### PR TITLE
move and rename filterbar story

### DIFF
--- a/packages/admin-stories/src/admin/table/filterbar/AllFiltersInFilterbar.tsx
+++ b/packages/admin-stories/src/admin/table/filterbar/AllFiltersInFilterbar.tsx
@@ -184,7 +184,7 @@ function Story({ tableData }: StoryProps) {
     );
 }
 
-storiesOf("@comet/admin/table", module).add("Table with Filterbar", () => {
+storiesOf("@comet/admin/table/filterbar", module).add("Filterbar with all kinds of Filters", () => {
     const randomTableData = Array.from(Array(30).keys()).map((i): IExampleRow => {
         return {
             id: i,


### PR DESCRIPTION
move and rename to keep table stories with filter a bit more sorted