### PR TITLE
Skip DirtyHandler when RouterTabs are used beneath a Form

### DIFF
--- a/packages/admin-stories/src/admin/form/RouterTabs.tsx
+++ b/packages/admin-stories/src/admin/form/RouterTabs.tsx
@@ -1,0 +1,53 @@
+import { Field, FinalForm, FinalFormInput, RouterTab, RouterTabs, Stack } from "@comet/admin";
+import { Card, CardContent } from "@material-ui/core";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+function Story() {
+    return (
+        <Stack topLevelTitle="Root Stack">
+            <RouterTabs>
+                <RouterTab label="Top 1" path="">
+                    <FinalForm
+                        mode="edit"
+                        onSubmit={(values: any) => {
+                            alert(JSON.stringify(values));
+                        }}
+                        initialValues={{
+                            foo: "foo",
+                            bar: "bar",
+                        }}
+                    >
+                        <RouterTabs>
+                            <RouterTab label="Form 1" path="">
+                                <Card variant="outlined">
+                                    <CardContent>
+                                        <Field label="Foo" name="foo" component={FinalFormInput} />
+                                    </CardContent>
+                                </Card>
+                            </RouterTab>
+                            <RouterTab label="Form 2" path="/form2">
+                                <Card variant="outlined">
+                                    <CardContent>
+                                        <Field label="Bar" name="bar" component={FinalFormInput} />
+                                    </CardContent>
+                                </Card>
+                            </RouterTab>
+                        </RouterTabs>
+                    </FinalForm>
+                </RouterTab>
+                <RouterTab label="Top 2" path="/top2">
+                    <Card variant="outlined">
+                        <CardContent>Top2</CardContent>
+                    </Card>
+                </RouterTab>
+            </RouterTabs>
+        </Stack>
+    );
+}
+
+storiesOf("@comet/admin/form", module)
+    .addDecorator(storyRouterDecorator())
+    .add("RouterTabs with forms", () => <Story />);

--- a/packages/admin/src/DirtyHandler.tsx
+++ b/packages/admin/src/DirtyHandler.tsx
@@ -1,3 +1,4 @@
+import { Location } from "history";
 import * as React from "react";
 import { defineMessages, useIntl, WrappedComponentProps } from "react-intl";
 
@@ -86,18 +87,18 @@ class DirtyHandlerComponent extends React.Component<IProps & WrappedComponentPro
         return false;
     };
 
-    private promptMessage = (): string | boolean => {
-        if (!this.isBindingDirty()) {
+    private promptMessage = (location?: Location): string | boolean => {
+        if (!this.isBindingDirty(location)) {
             return true;
         } else {
             return this.props.intl.formatMessage(messages.saveChanges);
         }
     };
 
-    private isBindingDirty() {
+    private isBindingDirty(location?: Location) {
         return this.bindings
             .map((binding) => {
-                return binding.binding.isDirty();
+                return binding.binding.isDirty(location);
             })
             .reduce((accumulator, currentValue) => accumulator || currentValue, false);
     }

--- a/packages/admin/src/DirtyHandler.tsx
+++ b/packages/admin/src/DirtyHandler.tsx
@@ -88,17 +88,17 @@ class DirtyHandlerComponent extends React.Component<IProps & WrappedComponentPro
     };
 
     private promptMessage = (location?: Location): string | boolean => {
-        if (!this.isBindingDirty(location)) {
+        if (!this.isBindingDirty(location?.state)) {
             return true;
         } else {
             return this.props.intl.formatMessage(messages.saveChanges);
         }
     };
 
-    private isBindingDirty(location?: Location) {
+    private isBindingDirty(state?: unknown) {
         return this.bindings
             .map((binding) => {
-                return binding.binding.isDirty(location);
+                return binding.binding.isDirty(state);
             })
             .reduce((accumulator, currentValue) => accumulator || currentValue, false);
     }

--- a/packages/admin/src/DirtyHandlerApiContext.tsx
+++ b/packages/admin/src/DirtyHandlerApiContext.tsx
@@ -1,10 +1,9 @@
-import { Location } from "history";
 import * as React from "react";
 
 import { SubmitResult } from "./form/SubmitResult";
 
 export interface IDirtyHandlerApiBinding {
-    isDirty: (location?: Location) => boolean;
+    isDirty: (state: unknown) => boolean; // state might contain data which could be relevant for the isDirty-state
     submit: () => Promise<SubmitResult | void>;
     reset: () => void;
 }

--- a/packages/admin/src/DirtyHandlerApiContext.tsx
+++ b/packages/admin/src/DirtyHandlerApiContext.tsx
@@ -1,9 +1,10 @@
+import { Location } from "history";
 import * as React from "react";
 
 import { SubmitResult } from "./form/SubmitResult";
 
 export interface IDirtyHandlerApiBinding {
-    isDirty: () => boolean;
+    isDirty: (location?: Location) => boolean;
     submit: () => Promise<SubmitResult | void>;
     reset: () => void;
 }

--- a/packages/admin/src/FinalForm.tsx
+++ b/packages/admin/src/FinalForm.tsx
@@ -2,7 +2,6 @@ import { useApolloClient } from "@apollo/client";
 import { CircularProgress } from "@material-ui/core";
 import { FORM_ERROR, FormApi, Mutator, SubmissionErrors, ValidationErrors } from "final-form";
 import setFieldData from "final-form-set-field-data";
-import { Location } from "history";
 import * as React from "react";
 import { AnyObject, Form, FormProps, FormRenderProps } from "react-final-form";
 import useConstant from "use-constant";
@@ -87,9 +86,9 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
         React.useEffect(() => {
             if (dirtyHandler) {
                 dirtyHandler.registerBinding(ref, {
-                    isDirty: (location?: Location) => {
-                        const state = location?.state as { parentFormId: string };
-                        if (state.parentFormId === formId) {
+                    isDirty: (state?: unknown) => {
+                        const data = state as { parentFormId: string };
+                        if (data.parentFormId === formId) {
                             return false;
                         }
                         return formRenderProps.form.getState().dirty;

--- a/packages/admin/src/form/FinalFormContextProvider.tsx
+++ b/packages/admin/src/form/FinalFormContextProvider.tsx
@@ -5,6 +5,7 @@ export interface FinalFormContext {
     shouldScrollToField: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
     shouldShowFieldError: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
     shouldShowFieldWarning: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
+    formId?: string;
 }
 
 const defaultFinalFormContext: FinalFormContext = {

--- a/packages/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/src/tabs/RouterTabs.tsx
@@ -5,6 +5,7 @@ import { withStyles } from "@material-ui/styles";
 import * as React from "react";
 import { Route, RouteComponentProps, Switch, withRouter } from "react-router-dom";
 
+import { useFinalFormContext } from "../form/FinalFormContextProvider";
 import { StackApiContext } from "../stack/Api";
 import { StackBreadcrumb } from "../stack/Breadcrumb";
 import { StackSwitchApiContext } from "../stack/Switch";
@@ -33,12 +34,15 @@ function RouterTabsComponent({
     classes,
 }: Props & WithStyles<typeof styles>) {
     const childrenArr = React.Children.toArray(children);
+    const finalFormContext = useFinalFormContext();
 
     const handleChange = (event: {}, value: number) => {
         const paths = childrenArr.map((child) => {
             return React.isValidElement<TabProps>(child) ? child.props.path : null;
         });
-        history.push(match.url + paths[value]);
+        history.push(match.url + paths[value], {
+            parentFormId: finalFormContext.formId,
+        });
     };
 
     const paths = childrenArr.map((child) => {


### PR DESCRIPTION
Add a somewhat fancy mechanism to store the parentFormId in the Location-Object
which is then used to skip the isDirty-Check in a FinalForm

https://user-images.githubusercontent.com/1013756/142583291-e99a6c33-cb18-4073-9c18-f970a9c8cfb1.mp4
