### PR TITLE
Temporarily fix @comet/blocks-admin peer dependency for @comet/cms-admin

### DIFF
--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -69,7 +69,7 @@
         "@comet/admin-react-select": "^2.0.0",
         "@comet/admin-rte": "^2.0.0",
         "@comet/admin-theme": "^2.0.0",
-        "@comet/blocks-admin": "^2.0.0",
+        "@comet/blocks-admin": "*",
         "@comet/react-app-auth": "^1.0.0",
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3786,7 +3786,7 @@ __metadata:
     "@comet/admin-react-select": ^2.0.0
     "@comet/admin-rte": ^2.0.0
     "@comet/admin-theme": ^2.0.0
-    "@comet/blocks-admin": ^2.0.0
+    "@comet/blocks-admin": "*"
     "@comet/react-app-auth": ^1.0.0
     "@emotion/react": ^11.0.0
     "@emotion/styled": ^11.0.0


### PR DESCRIPTION
The @comet/cms-admin package requires @comet/blocks-admin ^2.0.0 as peer dependency. This causes an error during installation, as the @comet/blocks-admin package has never been published in v2, and will only be published starting with v3 onwards. To fix the issue, we temporarily widen the peer dependency version in @comet/cms-admin.