### PR TITLE
Dynamic block display names

### DIFF
--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
@@ -465,7 +465,7 @@ export function createBlocksBlock({
                                                         return (
                                                             <HoverPreviewComponent key={data.key} componentSlug={`${data.key}/blocks`}>
                                                                 <BlockRow
-                                                                    name={block.displayName}
+                                                                    name={block.dynamicDisplayName?.(data.props) ?? block.displayName}
                                                                     id={data.key}
                                                                     previewContent={block.previewContent(data.props, blockContext)}
                                                                     index={blockIndex}

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -226,7 +226,7 @@ export function createListBlock<T extends BlockInterface>({
                                                             return (
                                                                 <HoverPreviewComponent key={data.key} componentSlug={`${data.key}/edit`}>
                                                                     <BlockRow
-                                                                        name={block.displayName}
+                                                                        name={block.dynamicDisplayName?.(data.props) ?? block.displayName}
                                                                         id={data.key}
                                                                         previewContent={block.previewContent(data.props, blockContext)}
                                                                         index={blockIndex}

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -392,6 +392,16 @@ IBlockFactoryOptions): BlockInterface<OneOfBlockFragment, OneOfBlockState, any, 
                 return [];
             }
         },
+
+        dynamicDisplayName: (state) => {
+            const { block } = getActiveBlock(state);
+
+            if (block != null) {
+                return block.displayName;
+            } else {
+                return displayName;
+            }
+        },
     };
     return OneOfBlock;
 };

--- a/packages/admin/blocks-admin/src/blocks/types.tsx
+++ b/packages/admin/blocks-admin/src/blocks/types.tsx
@@ -74,6 +74,7 @@ export interface BlockMethods<
     isValid: (state: State) => Promise<boolean> | boolean;
     childBlockCount?: (state: State) => number;
     previewContent: (state: State, context?: BlockContext) => PreviewContent[];
+    dynamicDisplayName?: (state: State) => React.ReactNode;
 }
 
 export interface AnonymousBlockInterface<

--- a/packages/admin/cms-admin/src/blocks/createTextLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createTextLinkBlock.tsx
@@ -65,6 +65,8 @@ export function createTextLinkBlock({ link: LinkBlock }: CreateTextLinkBlockOpti
         },
 
         previewContent: (state) => [{ type: "text", content: state.text }],
+
+        dynamicDisplayName: (state) => LinkBlock.dynamicDisplayName?.(state.link),
     };
 
     return TextLinkBlock;


### PR DESCRIPTION
This change introduces the option to change a block's display name based on its current state. This is especially useful when creating a one-of-block: The display name of the active block is more informative than the display name of the one-of-block itself.

Before: Default display names

<img width="456" alt="default_display_names" src="https://user-images.githubusercontent.com/48853629/177295411-e6cfd1bb-6bf3-4788-8701-a84a85726953.png">


After: Dynamic display names

<img width="456" alt="dynamic_display_names" src="https://user-images.githubusercontent.com/48853629/177295435-a3989cdc-e9da-4eb7-8ed8-7b4d5d1d253f.png">

