### PR TITLE
Fix root lint-staged config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
             - name: Lint
               run: |
-                  yarn exec prettier -c .
+                  yarn exec prettier --check "./*.{js,json,md,yml}"
                   yarn lint:lib
 
             - name: Test

--- a/.prettierignore
+++ b/.prettierignore
@@ -18,6 +18,4 @@ storybook-static
 schema.graphql
 block-meta.json
 *.generated.ts
-demo/
-packages/
 .yarn/

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-    "*": () => "npx yarn exec prettier -c .",
+    "./*{js,json,md,yml}": "npx yarn exec prettier --check",
 };


### PR DESCRIPTION
The root lint-staged config contained a command that performed a Prettier check on all (!) files in the repository. This caused issues with Prettier checking files that are ignored by Git. The command has been changed to only check files that are directly located in the root directory and supported by Prettier.