### PR TITLE
Fix page tree node category type issues

### DIFF
--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -79,6 +79,10 @@ const categories: AllCategories = [
         category: "MainNavigation",
         label: <FormattedMessage id="comet.menu.pageTree.mainNavigation" defaultMessage="Main navigation" />,
     },
+    {
+        category: "TopMenu",
+        label: <FormattedMessage id="comet.menu.pageTree.topMenu" defaultMessage="Top menu" />,
+    },
 ];
 
 const pageTreeDocumentTypes = {
@@ -146,8 +150,9 @@ class App extends React.Component {
                                                                                                 path={`${match.path}/project-snips/main-menu`}
                                                                                                 component={MainMenu}
                                                                                             />
+
                                                                                             <Route
-                                                                                                path={`${match.path}/pages/pagetree/:category`}
+                                                                                                path={`${match.path}/pages/pagetree/main-navigation`}
                                                                                                 render={() => (
                                                                                                     <PagesPage
                                                                                                         path="/pages/pagetree/main-navigation"
@@ -155,6 +160,19 @@ class App extends React.Component {
                                                                                                         documentTypes={pageTreeDocumentTypes}
                                                                                                         editPageNode={EditPageNode}
                                                                                                         category="MainNavigation"
+                                                                                                    />
+                                                                                                )}
+                                                                                            />
+
+                                                                                            <Route
+                                                                                                path={`${match.path}/pages/pagetree/top-menu`}
+                                                                                                render={() => (
+                                                                                                    <PagesPage
+                                                                                                        path="/pages/pagetree/top-menu"
+                                                                                                        allCategories={categories}
+                                                                                                        documentTypes={pageTreeDocumentTypes}
+                                                                                                        editPageNode={EditPageNode}
+                                                                                                        category="TopMenu"
                                                                                                     />
                                                                                                 )}
                                                                                             />

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -30,11 +30,17 @@ const MasterMenu: React.FC = () => {
                 icon={<Dashboard />}
                 to={`${match.url}/dashboard`}
             />
-            <MenuItemRouterLink
-                primary={intl.formatMessage({ id: "comet.menu.pageTree", defaultMessage: "Page tree" })}
-                icon={<PageTree />}
-                to={`${match.url}/pages/pagetree/main-navigation`}
-            />
+            <MenuCollapsibleItem primary={intl.formatMessage({ id: "comet.menu.pageTree", defaultMessage: "Page tree" })} icon={<PageTree />}>
+                <MenuItemRouterLink
+                    primary={intl.formatMessage({ id: "comet.menu.pageTree", defaultMessage: "Main menu" })}
+                    to={`${match.url}/pages/pagetree/main-navigation`}
+                />
+                <MenuItemRouterLink
+                    primary={intl.formatMessage({ id: "comet.menu.pageTree", defaultMessage: "Top menu" })}
+                    to={`${match.url}/pages/pagetree/top-menu`}
+                />
+            </MenuCollapsibleItem>
+
             <MenuCollapsibleItem
                 primary={intl.formatMessage({ id: "comet.menu.structuredContent", defaultMessage: "Structured Content" })}
                 icon={<Data />}

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -175,6 +175,7 @@ enum PageTreeNodeVisibility {
 
 enum PageTreeNodeCategory {
   MainNavigation
+  TopMenu
 }
 
 enum PageTreeNodeUserGroup {
@@ -275,7 +276,7 @@ type Query {
   autoBuildStatus: AutoBuildStatus!
   pageTreeNode(id: ID!): PageTreeNode
   pageTreeNodeByPath(scope: PageTreeNodeScopeInput!, path: String!): PageTreeNode
-  pageTreeNodeList(category: PageTreeNodeCategory, scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
+  pageTreeNodeList(category: String, scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
   pageTreeNodeSlugAvailable(slug: String!, parentId: ID, scope: PageTreeNodeScopeInput!): SlugAvailability!
   redirects(query: String, type: RedirectGenerationType, active: Boolean): [Redirect!]!
   redirect(id: ID!): Redirect!
@@ -289,6 +290,7 @@ type Query {
   newsBySlug(slug: String!): News
   newsList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, query: String, category: NewsCategory, scope: NewsContentScopeInput!): PaginatedNews!
   mainMenu(scope: PageTreeNodeScopeInput!): MainMenu!
+  topMenu(scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
   mainMenuItem(pageTreeNodeId: ID!): MainMenuItem!
   footer(scope: FooterContentScopeInput!): Footer
   predefinedPage(id: ID!): PredefinedPage
@@ -323,8 +325,8 @@ type Mutation {
   deletePageTreeNode(id: ID!): Boolean!
   updatePageTreeNodeVisibility(input: PageTreeNodeUpdateVisibilityInput!, id: ID!): PageTreeNode!
   updatePageTreeNodePosition(input: PageTreeNodeUpdatePositionInput!, id: ID!): PageTreeNode!
-  updatePageTreeNodeCategory(category: PageTreeNodeCategory!, id: ID!): PageTreeNode!
-  createPageTreeNode(category: PageTreeNodeCategory!, scope: PageTreeNodeScopeInput!, input: PageTreeNodeCreateInput!): PageTreeNode!
+  updatePageTreeNodeCategory(category: String!, id: ID!): PageTreeNode!
+  createPageTreeNode(category: String!, scope: PageTreeNodeScopeInput!, input: PageTreeNodeCreateInput!): PageTreeNode!
   createRedirect(input: CreateRedirectInput!): Redirect!
   updateRedirect(lastUpdatedAt: DateTime, input: UpdateRedirectInput!, id: ID!): Redirect!
   updateRedirectActiveness(input: RedirectUpdateActivenessInput!, id: ID!): Redirect!

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -32,7 +32,6 @@ import { NewsModule } from "./news/news.module";
 import { PageTreeNodeCreateInput, PageTreeNodeUpdateInput } from "./page-tree/dto/page-tree-node.input";
 import { PageTreeNodeScope } from "./page-tree/dto/page-tree-node-scope";
 import { PageTreeNode } from "./page-tree/entities/page-tree-node.entity";
-import { PageTreeNodeCategory } from "./page-tree/page-tree-node-category";
 import { Page } from "./pages/entities/page.entity";
 import { PredefinedPageModule } from "./predefined-page/predefined-page.module";
 
@@ -100,7 +99,6 @@ import { PredefinedPageModule } from "./predefined-page/predefined-page.module";
             PageTreeNodeUpdateInput: PageTreeNodeUpdateInput,
             Documents: [Page, Link, PredefinedPage],
             Scope: PageTreeNodeScope,
-            Category: PageTreeNodeCategory,
             reservedPaths: ["/events"],
         }),
         RedirectsModule.register({ PageTreeNode: PageTreeNode }),

--- a/demo/api/src/db/migrations/Migration20220705125401.ts
+++ b/demo/api/src/db/migrations/Migration20220705125401.ts
@@ -1,0 +1,18 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20220705125401 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "PageTreeNode" drop constraint if exists "PageTreeNode_category_check";');
+    this.addSql('UPDATE "PageTreeNode" SET category=\'MainNavigation\' WHERE category=\'main-navigation\'')
+    this.addSql('alter table "PageTreeNode" add constraint "PageTreeNode_category_check" check ("category" in (\'MainNavigation\', \'TopMenu\'));');
+    this.addSql('alter table "PageTreeNode" alter column "category" set default \'MainNavigation\';');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "PageTreeNode" drop constraint if exists "PageTreeNode_category_check";');
+    this.addSql('alter table "PageTreeNode" add constraint "PageTreeNode_category_check" check ("category" in (\'main-navigation\'));');
+    this.addSql('alter table "PageTreeNode" alter column "category" set default \'main-navigation\';');
+  }
+
+}

--- a/demo/api/src/menus/menus.resolver.ts
+++ b/demo/api/src/menus/menus.resolver.ts
@@ -1,4 +1,4 @@
-import { PageTreeNodeVisibility, PageTreeService, PublicApi } from "@comet/cms-api";
+import { PageTreeNodeInterface, PageTreeNodeVisibility, PageTreeService, PublicApi, RequestContext, RequestContextInterface } from "@comet/cms-api";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
 import { Args, Query, Resolver } from "@nestjs/graphql";
@@ -43,5 +43,17 @@ export class MenusResolver {
         return {
             items,
         };
+    }
+
+    @Query(() => [PageTreeNode])
+    async topMenu(
+        @Args("scope", { type: () => PageTreeNodeScope }) scope: PageTreeNodeScope,
+        @RequestContext() { includeInvisiblePages }: RequestContextInterface,
+    ): Promise<PageTreeNodeInterface[]> {
+        return this.pageTreeService
+            .createReadApi({
+                visibility: [PageTreeNodeVisibility.Published, ...(includeInvisiblePages || [])],
+            })
+            .pageTreeRootNodeList({ scope, category: PageTreeNodeCategory.TopMenu, excludeHiddenInMenu: true });
     }
 }

--- a/demo/api/src/page-tree/page-tree-node-category.ts
+++ b/demo/api/src/page-tree/page-tree-node-category.ts
@@ -1,7 +1,8 @@
 import { registerEnumType } from "@nestjs/graphql";
 
 export enum PageTreeNodeCategory {
-    MainNavigation = "main-navigation",
+    MainNavigation = "MainNavigation",
+    TopMenu = "TopMenu",
 }
 
 registerEnumType(PageTreeNodeCategory, { name: "PageTreeNodeCategory" });

--- a/demo/site/src/pageTypes/Page.tsx
+++ b/demo/site/src/pageTypes/Page.tsx
@@ -3,6 +3,7 @@ import SeoBlock from "@src/blocks/seo/SeoBlock";
 import Breadcrumbs, { breadcrumbsFragment } from "@src/components/Breadcrumbs";
 import { GQLPageQuery } from "@src/graphql.generated";
 import { Header, headerFragment } from "@src/header/Header";
+import { topMenuPageTreeNodeFragment, TopNavigation } from "@src/topNavigation/TopNavigation";
 import { gql } from "graphql-request";
 import Head from "next/head";
 import * as React from "react";
@@ -24,14 +25,20 @@ export const pageQuery = gql`
         header: mainMenu(scope: { domain: $domain, language: $language }) {
             ...Header
         }
+
+        topMenu(scope: { domain: $domain, language: $language }) {
+            ...TopMenuPageTreeNode
+        }
     }
 
     ${breadcrumbsFragment}
     ${headerFragment}
+    ${topMenuPageTreeNodeFragment}
 `;
 
 export default function Page(props: GQLPageQuery): JSX.Element {
     const document = props.pageContent?.document;
+
     return (
         <>
             <Head>
@@ -44,6 +51,7 @@ export default function Page(props: GQLPageQuery): JSX.Element {
                     canonicalUrl={`${process.env.SITE_URL}${props.pageContent?.path}`}
                 />
             )}
+            <TopNavigation data={props.topMenu} />
             <Header header={props.header} />
             {props.pageContent && <Breadcrumbs {...props.pageContent} />}
             {document && document.__typename === "Page" ? (

--- a/demo/site/src/topNavigation/TopNavigation.tsx
+++ b/demo/site/src/topNavigation/TopNavigation.tsx
@@ -1,0 +1,83 @@
+import { PageLink } from "@src/header/PageLink";
+import { gql } from "graphql-request";
+import styled from "styled-components";
+
+interface Props {
+    data: any;
+}
+
+export function TopNavigation({ data }: Props): JSX.Element {
+    return (
+        <TopLevelNavigation>
+            {data.map((item) => (
+                <TopLevelLinkContainer key={item.id}>
+                    <PageLink page={item}>{(active) => <Link $active={active}>{item.name}</Link>}</PageLink>
+                    {item.childNodes.length > 0 && (
+                        <SubLevelNavigation>
+                            {item.childNodes.map((node) => (
+                                <li key={node.id}>
+                                    <PageLink page={node}>{(active) => <Link $active={active}>{node.name}</Link>}</PageLink>
+                                </li>
+                            ))}
+                        </SubLevelNavigation>
+                    )}
+                </TopLevelLinkContainer>
+            ))}
+        </TopLevelNavigation>
+    );
+}
+
+export const topMenuPageTreeNodeFragment = gql`
+    fragment TopMenuPageTreeNode on PageTreeNode {
+        id
+        name
+        ...PageLink
+
+        childNodes {
+            id
+            name
+            ...PageLink
+        }
+    }
+`;
+
+const TopLevelNavigation = styled.ol`
+    display: flex;
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    background-color: ${({ theme }) => theme.colors.primary};
+`;
+
+const SubLevelNavigation = styled.ol`
+    display: none;
+    position: absolute;
+    min-width: 100px;
+    list-style-type: none;
+    padding: 5px;
+    background-color: ${({ theme }) => theme.colors.primary};
+    box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
+`;
+
+const TopLevelLinkContainer = styled.li`
+    position: relative;
+
+    &:hover {
+        text-decoration: underline;
+
+        & > ${SubLevelNavigation} {
+            display: block;
+        }
+    }
+`;
+
+const Link = styled.a<{ $active: boolean }>`
+    text-decoration: none;
+    padding: 5px 10px;
+    color: ${({ $active, theme }) => ($active ? theme.colors.white : theme.colors.n200)};
+    font-size: 12px;
+
+    &:hover {
+        text-decoration: underline;
+    }
+`;

--- a/packages/admin/cms-admin/src/documents/types.ts
+++ b/packages/admin/cms-admin/src/documents/types.ts
@@ -2,7 +2,7 @@ import { TypedDocumentNode } from "@apollo/client";
 import { SvgIconProps } from "@mui/material";
 import { DocumentNode } from "graphql";
 
-import { GQLDocumentInterface, GQLPageTreeNodeCategory, Maybe } from "../graphql.generated";
+import { GQLDocumentInterface, Maybe } from "../graphql.generated";
 
 export type DocumentType = string;
 
@@ -39,7 +39,7 @@ export interface DocumentInterface<
 > {
     displayName: React.ReactNode;
     getQuery?: TypedDocumentNode<GQLPageQuery, GQLPageQueryVariables>; // TODO better typing (see createUsePage.tsx)
-    editComponent?: React.ComponentType<{ id: string; category: GQLPageTreeNodeCategory }>;
+    editComponent?: React.ComponentType<{ id: string; category: string }>;
     updateMutation?: TypedDocumentNode<GQLUpdatePageMutation, GQLUpdatePageMutationVariables<DocumentInput>>;
     inputToOutput?: (input: DocumentInput, context: { idsMap: IdsMap }) => DocumentOutput;
     menuIcon: (props: SvgIconProps<"svg">) => JSX.Element;

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -22,7 +22,6 @@ import {
     GQLEditPageParentNodeQueryVariables,
     GQLIsPathAvailableQuery,
     GQLIsPathAvailableQueryVariables,
-    GQLPageTreeNodeCategory,
     GQLSlugAvailability,
     GQLUpdatePageNodeMutation,
     GQLUpdatePageNodeMutationVariables,
@@ -46,7 +45,7 @@ interface CreateEditPageNodeProps {
 export interface EditPageNodeProps {
     id: null | SerializedInitialValues | string; // when mode is add: SerializedInitialValues is expected
     mode: "add" | "edit";
-    category: GQLPageTreeNodeCategory;
+    category: string;
     documentTypes: Record<DocumentType, DocumentInterface>;
 }
 
@@ -387,7 +386,7 @@ const editPageParentNodeQuery = gql`
 `;
 
 const createPageNodeMutation = gql`
-    mutation CreatePageNode($input: PageTreeNodeCreateInput!, $contentScope: PageTreeNodeScopeInput!, $category: PageTreeNodeCategory!) {
+    mutation CreatePageNode($input: PageTreeNodeCreateInput!, $contentScope: PageTreeNodeScopeInput!, $category: String!) {
         createPageTreeNode(input: $input, scope: $contentScope, category: $category) {
             id
         }

--- a/packages/admin/cms-admin/src/pages/pageTree/MovePageMenuItem.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/MovePageMenuItem.tsx
@@ -5,11 +5,7 @@ import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { useContentScope } from "../../contentScope/Provider";
-import {
-    GQLPageTreeNodeCategory,
-    GQLUpdatePageTreeNodeCategoryMutation,
-    GQLUpdatePageTreeNodeCategoryMutationVariables,
-} from "../../graphql.generated";
+import { GQLUpdatePageTreeNodeCategoryMutation, GQLUpdatePageTreeNodeCategoryMutationVariables } from "../../graphql.generated";
 import { PageTreePage } from "./usePageTree";
 import { usePageTreeContext } from "./usePageTreeContext";
 
@@ -24,7 +20,7 @@ function MovePageMenuItem({ page, onClose }: Props): React.ReactElement | null {
         GQLUpdatePageTreeNodeCategoryMutation,
         GQLUpdatePageTreeNodeCategoryMutationVariables
     >(gql`
-        mutation UpdatePageTreeNodeCategory($id: ID!, $category: PageTreeNodeCategory!) {
+        mutation UpdatePageTreeNodeCategory($id: ID!, $category: String!) {
             updatePageTreeNodeCategory(id: $id, category: $category) {
                 id
                 category
@@ -47,7 +43,7 @@ function MovePageMenuItem({ page, onClose }: Props): React.ReactElement | null {
         onClose();
     };
 
-    const handleSubMenuItemClick = async (category: GQLPageTreeNodeCategory) => {
+    const handleSubMenuItemClick = async (category: string) => {
         const refetchQueries = [
             { query, variables: { contentScope: scope, category } },
             { query, variables: { contentScope: scope, category: page.category } },

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
@@ -14,7 +14,6 @@ import { useContentScope } from "../../contentScope/Provider";
 import {
     GQLPagesCacheQuery,
     GQLPagesCacheQueryVariables,
-    GQLPageTreeNodeCategory,
     GQLUpdatePageTreeNodePositionMutation,
     GQLUpdatePageTreeNodePositionMutationVariables,
 } from "../../graphql.generated";
@@ -28,7 +27,7 @@ interface PageTreeProps {
     editDialogApi: IEditDialogApi;
     toggleExpand: (pageId: string) => void;
     onSelectChanged: (pageId: string, value: boolean) => void;
-    category: GQLPageTreeNodeCategory;
+    category: string;
     siteUrl: string;
 }
 
@@ -45,7 +44,7 @@ const UPDATE_PAGE_TREE_NODE_POSITION = gql`
 `;
 
 const PAGES_CACHE_QUERY = gql`
-    query PagesCache($contentScope: PageTreeNodeScopeInput!, $category: PageTreeNodeCategory!) {
+    query PagesCache($contentScope: PageTreeNodeScopeInput!, $category: String!) {
         pages: pageTreeNodeList(scope: $contentScope, category: $category) {
             id
             parentId

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTreeContext.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTreeContext.ts
@@ -2,10 +2,10 @@ import { DocumentNode } from "graphql";
 import * as React from "react";
 
 import { DocumentInterface, DocumentType } from "../../documents/types";
-import { GQLPageTreeNodeCategory, GQLPageTreePageFragment } from "../../graphql.generated";
+import { GQLPageTreePageFragment } from "../../graphql.generated";
 import { TreeMap } from "./treemap/TreeMapUtils";
 
-export type AllCategories = Array<{ category: GQLPageTreeNodeCategory; label: React.ReactNode }>;
+export type AllCategories = Array<{ category: string; label: React.ReactNode }>;
 
 export interface PageTreeContext {
     allCategories: AllCategories;

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages.tsx
@@ -25,7 +25,7 @@ const slugAvailableQuery = gql`
 `;
 
 const createPageNodeMutation = gql`
-    mutation CreatePageNode($input: PageTreeNodeCreateInput!, $contentScope: PageTreeNodeScopeInput!, $category: PageTreeNodeCategory!) {
+    mutation CreatePageNode($input: PageTreeNodeCreateInput!, $contentScope: PageTreeNodeScopeInput!, $category: String!) {
         createPageTreeNode(input: $input, scope: $contentScope, category: $category) {
             id
         }

--- a/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
@@ -10,13 +10,7 @@ import { FixedSizeList as List } from "react-window";
 
 import { useCmsBlockContext } from "../../blocks/useCmsBlockContext";
 import { useContentScope } from "../../contentScope/Provider";
-import {
-    GQLPagesQuery,
-    GQLPagesQueryVariables,
-    GQLPageTreeNodeCategory,
-    GQLPageTreePageFragment,
-    GQLSelectedPageFragment,
-} from "../../graphql.generated";
+import { GQLPagesQuery, GQLPagesQueryVariables, GQLPageTreePageFragment, GQLSelectedPageFragment } from "../../graphql.generated";
 import { PageSearch } from "../pageSearch/PageSearch";
 import { usePageSearch } from "../pageSearch/usePageSearch";
 import { createPagesQuery } from "../pagesPage/createPagesQuery";
@@ -64,7 +58,7 @@ interface PageTreeSelectProps {
     onChange: (newValue: GQLSelectedPageFragment | null) => void;
     open: boolean;
     onClose: () => void;
-    defaultCategory: GQLPageTreeNodeCategory;
+    defaultCategory: string;
 }
 
 const useStyles = makeStyles({
@@ -77,7 +71,7 @@ const useStyles = makeStyles({
 export default function PageTreeSelectDialog({ value, onChange, open, onClose, defaultCategory }: PageTreeSelectProps): JSX.Element {
     const { pageTreeCategories, pageTreeDocumentTypes } = useCmsBlockContext();
     const { scope } = useContentScope();
-    const [category, setCategory] = React.useState<GQLPageTreeNodeCategory>(defaultCategory);
+    const [category, setCategory] = React.useState<string>(defaultCategory);
     const refList = React.useRef<List>(null);
     const [height, setHeight] = React.useState(200);
     const refDialogContent = React.useRef<HTMLDivElement>(null);
@@ -179,7 +173,7 @@ export default function PageTreeSelectDialog({ value, onChange, open, onClose, d
                         <Select
                             value={category}
                             onChange={(event) => {
-                                setCategory(event.target.value as GQLPageTreeNodeCategory);
+                                setCategory(event.target.value as string);
                             }}
                         >
                             {pageTreeCategories.map(({ category, label }) => (

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -11,7 +11,7 @@ import { ContentScopeIndicator, createEditPageNode } from "../..";
 import { useContentScope } from "../../contentScope/Provider";
 import { useContentScopeConfig } from "../../contentScope/useContentScopeConfig";
 import { DocumentInterface, DocumentType } from "../../documents/types";
-import { GQLPagesQuery, GQLPagesQueryVariables, GQLPageTreeNodeCategory, GQLPageTreePageFragment } from "../../graphql.generated";
+import { GQLPagesQuery, GQLPagesQueryVariables, GQLPageTreePageFragment } from "../../graphql.generated";
 import { useSiteConfig } from "../../sitesConfig/useSiteConfig";
 import { EditPageNodeProps } from "../createEditPageNode";
 import { PageSearch } from "../pageSearch/PageSearch";
@@ -42,7 +42,7 @@ const ScopeIndicatorLabel = styled(Typography)`
     }
 `;
 interface Props {
-    category: GQLPageTreeNodeCategory;
+    category: string;
     path: string;
     allCategories: AllCategories;
     documentTypes: Record<DocumentType, DocumentInterface>;

--- a/packages/admin/cms-admin/src/pages/pagesPage/createPagesQuery.ts
+++ b/packages/admin/cms-admin/src/pages/pagesPage/createPagesQuery.ts
@@ -23,7 +23,7 @@ export const createPagesQuery = (props?: CreatePagesQueryOptions): DocumentNode 
     });
 
     return gql`
-        query Pages($contentScope: PageTreeNodeScopeInput!, $category: PageTreeNodeCategory!) {
+        query Pages($contentScope: PageTreeNodeScopeInput!, $category: String!) {
             pages: pageTreeNodeList(scope: $contentScope, category: $category) {
                 id
                 ...PageTreePage

--- a/packages/api/cms-api/generate-schema.ts
+++ b/packages/api/cms-api/generate-schema.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from "@nestjs/core";
-import { Field, GraphQLSchemaBuilderModule, GraphQLSchemaFactory, ObjectType, registerEnumType } from "@nestjs/graphql";
+import { Field, GraphQLSchemaBuilderModule, GraphQLSchemaFactory, ObjectType } from "@nestjs/graphql";
 import { writeFile } from "fs/promises";
 import { printSchema } from "graphql";
 
@@ -12,19 +12,13 @@ import {
     FilesResolver,
     FoldersResolver,
     PageTreeNodeBase,
+    PageTreeNodeCategory,
 } from "./src";
-
-export enum ExamplePageTreeNodeCategory {
-    MainNavigation = "main-navigation",
-    Other = "other",
-}
-
-registerEnumType(ExamplePageTreeNodeCategory, { name: "PageTreeNodeCategory" });
 
 @ObjectType()
 class PageTreeNode extends PageTreeNodeBase {
-    @Field(() => ExamplePageTreeNodeCategory)
-    category: ExamplePageTreeNodeCategory;
+    @Field(() => String)
+    category: PageTreeNodeCategory;
 }
 
 @ObjectType({
@@ -47,7 +41,6 @@ async function generateSchema(): Promise<void> {
     const pageTreeResolver = createPageTreeResolver({
         PageTreeNode,
         Documents: [Page],
-        Category: ExamplePageTreeNodeCategory,
     }); // no scope
 
     const schema = await gqlSchemaFactory.create([

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -132,7 +132,7 @@ type PageTreeNode {
   visibility: PageTreeNodeVisibility!
   documentType: String!
   hideInMenu: Boolean!
-  category: PageTreeNodeCategory!
+  category: String!
   childNodes: [PageTreeNode!]!
   parentNode: PageTreeNode
   path: String!
@@ -144,11 +144,6 @@ enum PageTreeNodeVisibility {
   Published
   Unpublished
   Archived
-}
-
-enum PageTreeNodeCategory {
-  MainNavigation
-  Other
 }
 
 union PageContentUnion = Page
@@ -171,7 +166,7 @@ type Query {
   damFolderByNameAndParentId(name: String!, parentId: ID): DamFolder
   pageTreeNode(id: ID!): PageTreeNode
   pageTreeNodeByPath(scope: PageTreeNodeScopeInput!, path: String!): PageTreeNode
-  pageTreeNodeList(category: PageTreeNodeCategory, scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
+  pageTreeNodeList(category: String, scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
   pageTreeNodeSlugAvailable(slug: String!, parentId: ID, scope: PageTreeNodeScopeInput!): SlugAvailability!
 }
 
@@ -218,8 +213,8 @@ type Mutation {
   deletePageTreeNode(id: ID!): Boolean!
   updatePageTreeNodeVisibility(input: PageTreeNodeUpdateVisibilityInput!, id: ID!): PageTreeNode!
   updatePageTreeNodePosition(input: PageTreeNodeUpdatePositionInput!, id: ID!): PageTreeNode!
-  updatePageTreeNodeCategory(category: PageTreeNodeCategory!, id: ID!): PageTreeNode!
-  createPageTreeNode(category: PageTreeNodeCategory!, scope: PageTreeNodeScopeInput!, input: PageTreeNodeCreateInput!): PageTreeNode!
+  updatePageTreeNodeCategory(category: String!, id: ID!): PageTreeNode!
+  createPageTreeNode(category: String!, scope: PageTreeNodeScopeInput!, input: PageTreeNodeCreateInput!): PageTreeNode!
 }
 
 input CreateRedirectInput {

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -36,14 +36,12 @@ export function createPageTreeResolver({
     PageTreeNodeUpdateInput = DefaultPageTreeNodeUpdateInput,
     Documents,
     Scope: PassedScope,
-    Category,
 }: {
     PageTreeNode: Type<PageTreeNodeInterface>;
     PageTreeNodeCreateInput?: Type<PageTreeNodeCreateInputInterface>;
     PageTreeNodeUpdateInput?: Type<PageTreeNodeUpdateInputInterface>;
     Documents: Type<DocumentInterface>[];
     Scope?: Type<ScopeInterface>;
-    Category: unknown;
 }): Type<unknown> {
     const Scope = PassedScope || EmptyPageTreeNodeScope;
 
@@ -92,7 +90,7 @@ export function createPageTreeResolver({
         @Query(() => [PageTreeNode])
         async pageTreeNodeList(
             @Args("scope", { type: () => Scope }) scope: ScopeInterface,
-            @Args("category", { type: () => Category, nullable: true }) category: PageTreeNodeCategory,
+            @Args("category", { type: () => String, nullable: true }) category: PageTreeNodeCategory,
             @Context() context: PageTreeGQLContext,
         ): Promise<PageTreeNodeInterface[]> {
             const result = await this.pageTreeReadApi.getNodes({ scope: nonEmptyScopeOrNothing(scope), category });
@@ -225,7 +223,7 @@ export function createPageTreeResolver({
         @Mutation(() => PageTreeNode)
         async updatePageTreeNodeCategory(
             @Args("id", { type: () => ID }) id: string,
-            @Args("category", { type: () => Category }) category: PageTreeNodeCategory,
+            @Args("category", { type: () => String }) category: PageTreeNodeCategory,
         ): Promise<PageTreeNodeInterface> {
             // Archived pages cannot be updated
             const pageTreeReadApi = this.pageTreeService.createReadApi({
@@ -244,7 +242,7 @@ export function createPageTreeResolver({
         async createPageTreeNode(
             @Args("input", { type: () => PageTreeNodeCreateInput }) input: PageTreeNodeCreateInputInterface,
             @Args("scope", { type: () => Scope }) scope: ScopeInterface,
-            @Args("category", { type: () => Category }) category: PageTreeNodeCategory,
+            @Args("category", { type: () => String }) category: PageTreeNodeCategory,
         ): Promise<PageTreeNodeInterface> {
             // Can not add a subpage under an archived page
             if (input.parentId) {

--- a/packages/api/cms-api/src/page-tree/page-tree.module.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.module.ts
@@ -21,7 +21,6 @@ interface PageTreeModuleOptions {
     PageTreeNodeUpdateInput?: Type<PageTreeNodeBaseUpdateInput>;
     Documents: Type<DocumentInterface>[];
     Scope?: Type<ScopeInterface>;
-    Category?: unknown;
     reservedPaths?: string[];
 }
 
@@ -29,12 +28,11 @@ interface PageTreeModuleOptions {
 @Module({})
 export class PageTreeModule {
     static forRoot(options: PageTreeModuleOptions): DynamicModule {
-        const { Documents, Scope, PageTreeNode, PageTreeNodeCreateInput, PageTreeNodeUpdateInput, Category, reservedPaths } = options;
+        const { Documents, Scope, PageTreeNode, PageTreeNodeCreateInput, PageTreeNodeUpdateInput, reservedPaths } = options;
         const pageTreeResolver = createPageTreeResolver({
             PageTreeNode,
             Documents,
-            Scope: Scope,
-            Category,
+            Scope,
             PageTreeNodeCreateInput,
             PageTreeNodeUpdateInput,
         });


### PR DESCRIPTION
depends on !665

I changes the types from the PageTreeNodeCategory to string.
The type was used in the admin with GQLPageTreeNodeCategory, and when adding custom types it lead to type errors.

furthermore, I added a second page tree to the demo application. I think it makes sense to have a second page tree in the demo project. Fixtures would be good too, but I want to add them in another PR, since I plan on changing the fixture generation in general.

Admin
![image](https://user-images.githubusercontent.com/44967610/177333497-4a8f23c5-2bba-422f-ac07-f359c9944bbb.png)

Site:
![Screenshot from 2022-07-05 15-03-06](https://user-images.githubusercontent.com/44967610/177334158-26028ae0-b76b-41b9-abea-39558df7b8ce.jpg)