### PR TITLE
set the debug mode in the ormconfig to false

### DIFF
--- a/demo/api/src/db/ormconfig.ts
+++ b/demo/api/src/db/ormconfig.ts
@@ -15,7 +15,7 @@ const config = createOrmConfig({
         connection: { ssl: process.env.POSTGRESQL_USE_SSL === "true" },
     },
     namingStrategy: EntityCaseNamingStrategy,
-    debug: process.env.NODE_ENV !== "production",
+    debug: false,
     migrations: {
         tableName: "Migrations",
         //  `path` is only used to tell MikroORM where to place newly generated migrations. Available migrations are defined using `migrationsList`.


### PR DESCRIPTION
mikro-orm spams the console with all executed sql queries when the debug mode is set to true, which makes it hard to find custom logs.

example:
![image](https://user-images.githubusercontent.com/44967610/177335757-e579b12d-07ce-48d8-bb95-aa6150335863.png)
