### PR TITLE
DAM: Don't show File Upload Dialog on Asset click

### DIFF
--- a/packages/admin/cms-admin/src/dam/Table/FolderTable.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/FolderTable.tsx
@@ -266,6 +266,12 @@ const FolderTable = ({
 
     const damMultiselectApi = useDamMultiselect({ totalItemCount: tableData?.totalCount ?? 0 });
 
+    const fileRootProps = getFileRootProps({
+        onClick: (event) => {
+            event.stopPropagation();
+        },
+    });
+
     return (
         <DamMultiselectContext.Provider value={damMultiselectApi}>
             <TableContainer>
@@ -295,7 +301,7 @@ const FolderTable = ({
                                 }}
                             />
 
-                            <sc.FilesTableWrapper className="CometFilesTableWrapper-root" {...getFileRootProps()}>
+                            <sc.FilesTableWrapper className="CometFilesTableWrapper-root" {...fileRootProps}>
                                 <Table<GQLDamFileTableFragment>
                                     hideTableHead
                                     totalCount={filesTableData?.length ?? 0}


### PR DESCRIPTION
Now:

- no file upload dialog is opened on click

Previous behavior:

- when clicking on an asset, a file upload dialog is opened
- must be a bug introduced by the react-dropzone update. I don't know why I didn't notice this earlier 🤔


https://user-images.githubusercontent.com/13380047/178289918-a5827532-31e8-48aa-83cc-7b816cd4bff8.mov


