### PR TITLE
Fix SVG image block dimensions type

### DIFF
--- a/packages/site/cms-site/src/blocks/SvgImageBlock.tsx
+++ b/packages/site/cms-site/src/blocks/SvgImageBlock.tsx
@@ -6,8 +6,8 @@ import { PreviewSkeleton } from "../previewskeleton/PreviewSkeleton";
 import { PropsWithData } from "./PropsWithData";
 
 interface SvgImageBlockProps extends PropsWithData<SvgImageBlockData> {
-    width?: string | "auto";
-    height?: string | "auto";
+    width?: string | number | "auto";
+    height?: string | number | "auto";
 }
 
 export const SvgImageBlock = withPreview(


### PR DESCRIPTION
The `width` and `height` props of the SVG image block did not support `number`.