### PR TITLE
Add error handler to custom server

### DIFF
--- a/demo/site/server.js
+++ b/demo/site/server.js
@@ -5,40 +5,50 @@ const next = require("next");
 const fs = require("fs");
 
 const dev = process.env.NODE_ENV !== "production";
+const hostname = "localhost";
 const port = process.env.APP_PORT ?? 3000;
 const cdnEnabled = process.env.CDN_ENABLED === "true";
 const cdnOriginHeader = process.env.CDN_ORIGIN_HEADER;
 
-const app = next({ dev });
+// when using middleware `hostname` and `port` must be provided below
+const app = next({ dev, hostname, port });
 const handle = app.getRequestHandler();
 
-app.prepare().then(() => {
-    createServer((req, res) => {
-        // Be sure to pass `true` as the second argument to `url.parse`.
-        // This tells it to parse the query portion of the URL.
-        const parsedUrl = parse(req.url, true);
+app.prepare()
+    .then(() => {
+        createServer(async (req, res) => {
+            try {
+                // Be sure to pass `true` as the second argument to `url.parse`.
+                // This tells it to parse the query portion of the URL.
+                const parsedUrl = parse(req.url, true);
 
-        if (cdnEnabled) {
-            const incomingCdnOriginHeader = req.headers["x-cdn-origin-check"];
-            if (cdnOriginHeader !== incomingCdnOriginHeader) {
-                res.statusCode = 403;
-                res.end();
-                return;
+                if (cdnEnabled) {
+                    const incomingCdnOriginHeader = req.headers["x-cdn-origin-check"];
+                    if (cdnOriginHeader !== incomingCdnOriginHeader) {
+                        res.statusCode = 403;
+                        res.end();
+                        return;
+                    }
+                }
+                if (parsedUrl.pathname === "/access-token-service-worker.js") {
+                    const filename = require.resolve("@comet/cms-site/access-token-service-worker.ejs");
+                    const { mtime } = fs.statSync(filename);
+                    res.setHeader("Cache-Control", "public, max-age=0");
+                    res.setHeader("Content-Type", "application/javascript; charset=UTF-8");
+                    res.setHeader("Last-Modified", mtime.toUTCString());
+                    const str = fs.readFileSync(filename).toString();
+                    res.end(str.replace(/<%= API_URL %>/g, process.env.API_URL));
+                } else {
+                    await handle(req, res, parsedUrl);
+                }
+            } catch (err) {
+                console.error("Error occurred handling", req.url, err);
+                res.statusCode = 500;
+                res.end("internal server error");
             }
-        }
-        if (parsedUrl.pathname === "/access-token-service-worker.js") {
-            const filename = require.resolve("@comet/cms-site/access-token-service-worker.ejs");
-            const { mtime } = fs.statSync(filename);
-            res.setHeader("Cache-Control", "public, max-age=0");
-            res.setHeader("Content-Type", "application/javascript; charset=UTF-8");
-            res.setHeader("Last-Modified", mtime.toUTCString());
-            const str = fs.readFileSync(filename).toString();
-            res.end(str.replace(/<%= API_URL %>/g, process.env.API_URL));
-        } else {
-            handle(req, res, parsedUrl);
-        }
-    }).listen(port, (err) => {
-        if (err) throw err;
-        console.log(`> Ready on http://localhost:${port}`);
-    });
-});
+        }).listen(port, (err) => {
+            if (err) throw err;
+            console.log(`> Ready on http://localhost:${port}`);
+        });
+    })
+    .catch((error) => console.error(error));


### PR DESCRIPTION
additionally adapt custom server to template from latest [docs](https://nextjs.org/docs/advanced-features/custom-server) version

e.g. the following error when starting an next 11 build with next 12 was hidden:
```
Error: Cannot find module '/opt/app-root/src/.next/server/middleware-manifest.json'
Require stack:
- /opt/app-root/src/node_modules/next/dist/server/next-server.js
- /opt/app-root/src/node_modules/next/dist/server/next.js
- /opt/app-root/src/server.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.mod._resolveFilename (/opt/app-root/src/node_modules/next/dist/build/webpack/require-hook.js:182:28)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at NextNodeServer.getMiddlewareManifest (/opt/app-root/src/node_modules/next/dist/server/next-server.js:635:26)
    at NextNodeServer.getMiddleware (/opt/app-root/src/node_modules/next/dist/server/next-server.js:643:31)
    at NextNodeServer.generateCatchAllMiddlewareRoute (/opt/app-root/src/node_modules/next/dist/server/next-server.js:991:22)
    at NextNodeServer.generateRoutes (/opt/app-root/src/node_modules/next/dist/server/base-server.js:473:41)
    at new Server (/opt/app-root/src/node_modules/next/dist/server/base-server.js:109:48) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/opt/app-root/src/node_modules/next/dist/server/next-server.js',
    '/opt/app-root/src/node_modules/next/dist/server/next.js',
    '/opt/app-root/src/server.js'
  ]
}
```