### PR TITLE
Fix mapping between page tree node category and URL param

### DIFF
--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -45,6 +45,7 @@ import { Link } from "./links/Link";
 import News from "./news/News";
 import MainMenu from "./pages/mainMenu/MainMenu";
 import { Page } from "./pages/Page";
+import { urlParamToCategory } from "./utils/pageTreeNodeCategoryMapping";
 
 const GlobalStyle = () => (
     <Global
@@ -150,33 +151,30 @@ class App extends React.Component {
                                                                                                 path={`${match.path}/project-snips/main-menu`}
                                                                                                 component={MainMenu}
                                                                                             />
-
                                                                                             <Route
-                                                                                                path={`${match.path}/pages/pagetree/main-navigation`}
-                                                                                                render={() => (
-                                                                                                    <PagesPage
-                                                                                                        path="/pages/pagetree/main-navigation"
-                                                                                                        allCategories={categories}
-                                                                                                        documentTypes={pageTreeDocumentTypes}
-                                                                                                        editPageNode={EditPageNode}
-                                                                                                        category="MainNavigation"
-                                                                                                    />
-                                                                                                )}
-                                                                                            />
+                                                                                                path={`${match.path}/pages/pagetree/:category`}
+                                                                                                render={({ match: { params } }) => {
+                                                                                                    const category = urlParamToCategory(
+                                                                                                        params.category,
+                                                                                                    );
 
-                                                                                            <Route
-                                                                                                path={`${match.path}/pages/pagetree/top-menu`}
-                                                                                                render={() => (
-                                                                                                    <PagesPage
-                                                                                                        path="/pages/pagetree/top-menu"
-                                                                                                        allCategories={categories}
-                                                                                                        documentTypes={pageTreeDocumentTypes}
-                                                                                                        editPageNode={EditPageNode}
-                                                                                                        category="TopMenu"
-                                                                                                    />
-                                                                                                )}
-                                                                                            />
+                                                                                                    if (category === undefined) {
+                                                                                                        return (
+                                                                                                            <Redirect to={`${match.url}/dashboard`} />
+                                                                                                        );
+                                                                                                    }
 
+                                                                                                    return (
+                                                                                                        <PagesPage
+                                                                                                            path={`/pages/pagetree/${params.category}`}
+                                                                                                            allCategories={categories}
+                                                                                                            documentTypes={pageTreeDocumentTypes}
+                                                                                                            editPageNode={EditPageNode}
+                                                                                                            category={category}
+                                                                                                        />
+                                                                                                    );
+                                                                                                }}
+                                                                                            />
                                                                                             <RouteWithErrorBoundary
                                                                                                 path={`${match.path}/structured-content/news`}
                                                                                                 component={News}

--- a/demo/admin/src/utils/pageTreeNodeCategoryMapping.ts
+++ b/demo/admin/src/utils/pageTreeNodeCategoryMapping.ts
@@ -2,17 +2,20 @@ import { GQLPageTreeNodeCategory } from "@src/graphql.generated";
 
 function categoryToUrlParam(category: GQLPageTreeNodeCategory): string {
     switch (category) {
+        case "TopMenu":
+            return "top-menu";
         case "MainNavigation":
+        default:
             return "main-navigation";
     }
 }
 
-function urlParamToCategory(param: string | undefined): GQLPageTreeNodeCategory | null {
+function urlParamToCategory(param: string | undefined): GQLPageTreeNodeCategory | undefined {
     switch (param) {
+        case "top-menu":
+            return "TopMenu";
         case "main-navigation":
             return "MainNavigation";
-        default:
-            return null;
     }
 }
 


### PR DESCRIPTION
The `TopMenu` category was missing from the mapping between page tree node category and URL param, which is used for navigation in the Admin application.