### PR TITLE
Add DAM image block

### DIFF
--- a/demo/admin/src/pages/PageContentBlock.tsx
+++ b/demo/admin/src/pages/PageContentBlock.tsx
@@ -1,5 +1,5 @@
 import { createBlocksBlock, Space as SpaceBlock, YouTubeVideoBlock } from "@comet/blocks-admin";
-import { DamVideoBlock } from "@comet/cms-admin";
+import { DamImageBlock, DamVideoBlock } from "@comet/cms-admin";
 import { ImageBlock } from "@src/common/blocks/ImageBlock";
 import { LinkListBlock } from "@src/common/blocks/LinkListBlock";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
@@ -16,6 +16,7 @@ export const PageContentBlock = createBlocksBlock({
         headline: HeadlineBlock,
         image: ImageBlock,
         textImage: TextImageBlock,
+        damImage: DamImageBlock,
         damVideo: DamVideoBlock,
         youTubeVideo: YouTubeVideoBlock,
         linkList: LinkListBlock,

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -122,7 +122,7 @@
                             "nullable": false
                         },
                         {
-                            "name": "type",
+                            "name": "mimetype",
                             "kind": "String",
                             "nullable": false
                         },
@@ -439,7 +439,7 @@
                             "nullable": false
                         },
                         {
-                            "name": "type",
+                            "name": "mimetype",
                             "kind": "String",
                             "nullable": false
                         },
@@ -483,6 +483,69 @@
                 "name": "damFileId",
                 "kind": "String",
                 "nullable": true
+            }
+        ]
+    },
+    {
+        "name": "DamImage",
+        "fields": [
+            {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": [
+                                "PixelImage",
+                                "SvgImage"
+                            ],
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
+            {
+                "name": "activeType",
+                "kind": "String",
+                "nullable": true
+            },
+            {
+                "name": "block",
+                "kind": "NestedObject",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": [
+                                "PixelImage",
+                                "SvgImage"
+                            ],
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": true
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "activeType",
+                "kind": "String",
+                "nullable": false
             }
         ]
     },
@@ -1138,6 +1201,7 @@
                                 "Headline",
                                 "Image",
                                 "TextImage",
+                                "DamImage",
                                 "DamVideo",
                                 "YouTubeVideo",
                                 "LinkList",

--- a/demo/api/src/pages/blocks/PageContentBlock.ts
+++ b/demo/api/src/pages/blocks/PageContentBlock.ts
@@ -1,5 +1,5 @@
 import { createBlocksBlock, SpaceBlock, YouTubeVideoBlock } from "@comet/blocks-api";
-import { DamVideoBlock } from "@comet/cms-api";
+import { DamImageBlock, DamVideoBlock } from "@comet/cms-api";
 import { LinkListBlock } from "@src/common/blocks/link-list.block";
 import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 
@@ -16,6 +16,7 @@ export const PageContentBlock = createBlocksBlock(
             headline: HeadlineBlock,
             image: ImageBlock,
             textImage: TextImageBlock,
+            damImage: DamImageBlock,
             damVideo: DamVideoBlock,
             youTubeVideo: YouTubeVideoBlock,
             linkList: LinkListBlock,

--- a/demo/site/src/blocks/DamImageBlock.tsx
+++ b/demo/site/src/blocks/DamImageBlock.tsx
@@ -1,0 +1,15 @@
+import { OneOfBlock, PixelImageBlock, PropsWithData, SupportedBlocks, SvgImageBlock, withPreview } from "@comet/cms-site";
+import { DamImageBlockData } from "@src/blocks.generated";
+import * as React from "react";
+
+const supportedBlocks: SupportedBlocks = {
+    pixelImage: (props) => <PixelImageBlock data={props} layout="intrinsic" />,
+    svgImage: (props) => <SvgImageBlock data={props} />,
+};
+
+export const DamImageBlock = withPreview(
+    ({ data }: PropsWithData<DamImageBlockData>) => {
+        return <OneOfBlock data={data} supportedBlocks={supportedBlocks} />;
+    },
+    { label: "Image" },
+);

--- a/demo/site/src/blocks/PageContentBlock.tsx
+++ b/demo/site/src/blocks/PageContentBlock.tsx
@@ -2,6 +2,7 @@ import { BlocksBlock, PropsWithData, SupportedBlocks } from "@comet/cms-site";
 import { PageContentBlockData } from "@src/blocks.generated";
 import * as React from "react";
 
+import { DamImageBlock } from "./DamImageBlock";
 import DamVideoBlock from "./DamVideoBlock";
 import { FullWidthImageBlock } from "./FullWidthImageBlock";
 import { HeadlineBlock } from "./HeadlineBlock";
@@ -18,6 +19,7 @@ const supportedBlocks: SupportedBlocks = {
     headline: (props) => <HeadlineBlock data={props} />,
     image: (props) => <ImageBlock data={props} />,
     textImage: (props) => <TextImageBlock data={props} />,
+    damImage: (props) => <DamImageBlock data={props} />,
     damVideo: (props) => <DamVideoBlock data={props} />,
     youTubeVideo: (props) => <YouTubeVideoBlock data={props} />,
     linkList: (props) => <LinkListBlock data={props} />,

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -34,7 +34,7 @@ export interface OneOfBlockFragment {
     activeType: string | null;
 }
 
-interface PreviewState extends PreviewStateInterface {
+export interface OneOfBlockPreviewState extends PreviewStateInterface {
     block?: {
         type: string;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -60,7 +60,7 @@ export const createOneOfBlock = ({
     variant = "select",
     allowEmpty = true,
 }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-IBlockFactoryOptions): BlockInterface<OneOfBlockFragment, OneOfBlockState, any, PreviewState> => {
+IBlockFactoryOptions): BlockInterface<OneOfBlockFragment, OneOfBlockState, any, OneOfBlockPreviewState> => {
     function blockForType(type: string): BlockInterface | null {
         return supportedBlocks[type] ?? null;
     }
@@ -98,7 +98,7 @@ IBlockFactoryOptions): BlockInterface<OneOfBlockFragment, OneOfBlockState, any, 
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const OneOfBlock: BlockInterface<OneOfBlockFragment, OneOfBlockState, any, PreviewState> = {
+    const OneOfBlock: BlockInterface<OneOfBlockFragment, OneOfBlockState, any, OneOfBlockPreviewState> = {
         ...createBlockSkeleton(),
 
         name,

--- a/packages/admin/cms-admin/src/blocks/SvgImageBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/SvgImageBlock.tsx
@@ -11,7 +11,7 @@ import {
     IPreviewContext,
     SelectPreviewComponent,
 } from "@comet/blocks-admin";
-import { Divider, Grid, Typography } from "@mui/material";
+import { Box, Divider, Grid, Typography } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -104,15 +104,17 @@ export const SvgImageBlock: BlockInterface<SvgImageBlockData, SvgImageBlockState
                 {state.damFile ? (
                     <>
                         <AdminComponentPaper disablePadding>
-                            <Grid container alignItems="center" spacing={3}>
-                                <Grid item>{previewUrl && <img src={previewUrl} width="70" height="70" />}</Grid>
-                                <Grid item xs>
-                                    <Typography variant="subtitle1">{state.damFile.name}</Typography>
-                                    <Typography variant="body1" color="textSecondary">
-                                        {state.damFile.damPath}
-                                    </Typography>
+                            <Box padding={3}>
+                                <Grid container alignItems="center" spacing={3}>
+                                    <Grid item>{previewUrl && <img src={previewUrl} width="70" height="70" />}</Grid>
+                                    <Grid item xs>
+                                        <Typography variant="subtitle1">{state.damFile.name}</Typography>
+                                        <Typography variant="body1" color="textSecondary">
+                                            {state.damFile.damPath}
+                                        </Typography>
+                                    </Grid>
                                 </Grid>
-                            </Grid>
+                            </Box>
                             <Divider />
                             <AdminComponentButton startIcon={<Delete />} onClick={() => updateState({ damFile: undefined })}>
                                 <FormattedMessage id="comet.blocks.image.empty" defaultMessage="Empty" />

--- a/packages/admin/cms-admin/src/dam/blocks/DamImageBlock.tsx
+++ b/packages/admin/cms-admin/src/dam/blocks/DamImageBlock.tsx
@@ -1,0 +1,101 @@
+import { Field } from "@comet/admin";
+import { BlockCategory, BlockInterface, BlocksFinalForm, createOneOfBlock, resolveNewState } from "@comet/blocks-admin";
+import * as React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { PixelImageBlockData, SvgImageBlockData } from "../../blocks.generated";
+import { PixelImageBlock } from "../../blocks/PixelImageBlock";
+import { SvgImageBlock } from "../../blocks/SvgImageBlock";
+import { FileField } from "../../form/file/FileField";
+import { GQLDamFileFieldFileFragment } from "../../graphql.generated";
+import { useDamAcceptedMimeTypes } from "../config/useDamAcceptedMimeTypes";
+
+const supportedBlocks: Record<string, BlockInterface> = {
+    pixelImage: PixelImageBlock,
+    svgImage: SvgImageBlock,
+};
+
+const DamImageBlock = createOneOfBlock({
+    name: "DamImage",
+    displayName: <FormattedMessage id="comet.blocks.damImage" defaultMessage="Image" />,
+    category: BlockCategory.Media,
+    supportedBlocks,
+    allowEmpty: false,
+});
+
+// Custom Admin component to improve the image selection UX.
+// Allows selecting both pixel and SVG images and "chooses" the correct supported block.
+DamImageBlock.AdminComponent = function AdminComponent({ state, updateState }) {
+    const { filteredAcceptedMimeTypes } = useDamAcceptedMimeTypes();
+
+    if (state.activeType === null) {
+        throw new Error("No active type");
+    }
+
+    const activeBlock = state.attachedBlocks.find((block) => block.type === state.activeType);
+
+    if (activeBlock === undefined) {
+        throw new Error(`No block found for type ${state.activeType}`);
+    }
+
+    const isEmpty = (activeBlock.props as PixelImageBlockData | SvgImageBlockData).damFile === undefined;
+
+    if (isEmpty) {
+        return (
+            <BlocksFinalForm<{ damFile?: GQLDamFileFieldFileFragment }>
+                onSubmit={({ damFile }) => {
+                    if (damFile === undefined) {
+                        return;
+                    }
+
+                    const type = filteredAcceptedMimeTypes.pixelImage.includes(damFile.mimetype) ? "pixelImage" : "svgImage";
+
+                    updateState({
+                        attachedBlocks: [
+                            {
+                                type,
+                                props: {
+                                    damFile,
+                                },
+                            },
+                        ],
+                        activeType: type,
+                    });
+                }}
+                initialValues={{}}
+            >
+                <Field
+                    name="damFile"
+                    component={FileField}
+                    fullWidth
+                    buttonText={<FormattedMessage id="comet.blocks.image.chooseImage" defaultMessage="Choose image" />}
+                    allowedMimetypes={[...filteredAcceptedMimeTypes.pixelImage, ...filteredAcceptedMimeTypes.svgImage]}
+                />
+            </BlocksFinalForm>
+        );
+    } else {
+        const AdminComponent = supportedBlocks[state.activeType].AdminComponent;
+
+        return (
+            <AdminComponent
+                state={activeBlock.props}
+                updateState={(setStateAction) => {
+                    updateState({
+                        attachedBlocks: [
+                            {
+                                type: activeBlock.type,
+                                props: resolveNewState({ prevState: activeBlock.props, setStateAction }),
+                            },
+                        ],
+                        activeType: activeBlock.type,
+                    });
+                }}
+            />
+        );
+    }
+};
+
+// Disable dynamic display name. Would display "SVG" for a selected SVG image, but we want to always display "Image".
+DamImageBlock.dynamicDisplayName = undefined;
+
+export { DamImageBlock };

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -35,6 +35,7 @@ export type { ContentScopeInterface, ContentScopeProviderProps, ContentScopeValu
 export { ContentScopeProvider, useContentScope } from "./contentScope/Provider";
 export type { ContentScopeConfigProps } from "./contentScope/useContentScopeConfig";
 export { useContentScopeConfig } from "./contentScope/useContentScopeConfig";
+export { DamImageBlock } from "./dam/blocks/DamImageBlock";
 export { DamConfigProvider } from "./dam/config/DamConfigProvider";
 export { damDefaultAcceptedMimeTypes } from "./dam/config/damDefaultAcceptedMimeTypes";
 export { useDamAcceptedMimeTypes } from "./dam/config/useDamAcceptedMimeTypes";

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -122,7 +122,7 @@
                             "nullable": false
                         },
                         {
-                            "name": "type",
+                            "name": "mimetype",
                             "kind": "String",
                             "nullable": false
                         },
@@ -439,7 +439,7 @@
                             "nullable": false
                         },
                         {
-                            "name": "type",
+                            "name": "mimetype",
                             "kind": "String",
                             "nullable": false
                         },
@@ -483,6 +483,69 @@
                 "name": "damFileId",
                 "kind": "String",
                 "nullable": true
+            }
+        ]
+    },
+    {
+        "name": "DamImage",
+        "fields": [
+            {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": [
+                                "PixelImage",
+                                "SvgImage"
+                            ],
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
+            {
+                "name": "activeType",
+                "kind": "String",
+                "nullable": true
+            },
+            {
+                "name": "block",
+                "kind": "NestedObject",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": [
+                                "PixelImage",
+                                "SvgImage"
+                            ],
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": true
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "activeType",
+                "kind": "String",
+                "nullable": false
             }
         ]
     },

--- a/packages/api/cms-api/src/blocks/PixelImageBlock.ts
+++ b/packages/api/cms-api/src/blocks/PixelImageBlock.ts
@@ -128,7 +128,7 @@ class Meta extends AnnotationBlockMeta {
                             nullable: false,
                         },
                         {
-                            name: "type",
+                            name: "mimetype",
                             kind: BlockMetaFieldKind.String,
                             nullable: false,
                         },

--- a/packages/api/cms-api/src/blocks/SvgImageBlock.ts
+++ b/packages/api/cms-api/src/blocks/SvgImageBlock.ts
@@ -88,7 +88,7 @@ class Meta extends AnnotationBlockMeta {
                         nullable: false,
                     },
                     {
-                        name: "type",
+                        name: "mimetype",
                         kind: BlockMetaFieldKind.String,
                         nullable: false,
                     },

--- a/packages/api/cms-api/src/dam/blocks/dam-image.block.ts
+++ b/packages/api/cms-api/src/dam/blocks/dam-image.block.ts
@@ -1,0 +1,17 @@
+import { createOneOfBlock, OneOfBlock } from "@comet/blocks-api";
+
+import { PixelImageBlock } from "../../blocks/PixelImageBlock";
+import { SvgImageBlock } from "../../blocks/SvgImageBlock";
+
+const DamImageBlock: OneOfBlock<{ pixelImage: typeof PixelImageBlock; svgImage: typeof SvgImageBlock }> = createOneOfBlock(
+    {
+        supportedBlocks: {
+            pixelImage: PixelImageBlock,
+            svgImage: SvgImageBlock,
+        },
+        allowEmpty: false,
+    },
+    "DamImage",
+);
+
+export { DamImageBlock };

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -51,6 +51,7 @@ export { PaginatedResponseFactory } from "./common/pagination/paginated-response
 export { SortArgs } from "./common/sorting/sort.args";
 export { SortDirection } from "./common/sorting/sort-direction.enum";
 export { IsSlug } from "./common/validators/is-slug";
+export { DamImageBlock } from "./dam/blocks/dam-image.block";
 export { ScaledImagesCacheService } from "./dam/cache/scaled-images-cache.service";
 export { FocalPoint } from "./dam/common/enums/focal-point.enum";
 export { CometImageResolutionException } from "./dam/common/errors/image-resolution.exception";


### PR DESCRIPTION
We usually use a `OneOfBlock` to create an image block that supports both pixel and SVG images. This lead to UX problems when using the image block, for instance SVGs could only be selected when the SVG image block was active. This change introduces a special DAM image block to resolve the UX problems. The block uses a `OneOfBlock` under the hood but provides a custom Admin component which allows users to choose any image when empty, and renders the respective child block's Admin component based on the selected file.

**Before**

https://user-images.githubusercontent.com/48853629/178985551-46baa71c-378e-437d-b7a4-b5b4da02a872.mov

**After**

https://user-images.githubusercontent.com/48853629/178987123-d9dd27dd-cd0d-4bab-bc7c-3d1f3119dc52.mov



