### PR TITLE
Fix z-index of header in MasterLayout

### DIFF
--- a/packages/admin/admin-theme/src/componentsTheme/MuiDrawer.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDrawer.ts
@@ -3,11 +3,11 @@ import { Components } from "@mui/material/styles/components";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDrawer: GetMuiComponentTheme<"MuiDrawer"> = (component, { palette }): Components["MuiDrawer"] => ({
+export const getMuiDrawer: GetMuiComponentTheme<"MuiDrawer"> = (component, { palette, zIndex }): Components["MuiDrawer"] => ({
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiDrawer">(component?.styleOverrides, {
         root: {
-            zIndex: 1250, // Between AppBar (1200) and Modal (1300)
+            zIndex: zIndex.drawer + 50, // Between AppBar (1200) and Modal (1300)
         },
         paper: {
             backgroundColor: palette.grey[50],

--- a/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
@@ -1,6 +1,7 @@
 import { ComponentNameToClassKey, ThemeOptions } from "@mui/material";
 import { Components, Palette } from "@mui/material/styles";
 import { Typography } from "@mui/material/styles/createTypography";
+import { ZIndex } from "@mui/material/styles/zIndex";
 import { Spacing } from "@mui/system";
 
 import { getMuiAppBar } from "./MuiAppBar";
@@ -41,6 +42,7 @@ type ThemeData = {
     palette: Palette;
     typography: Typography;
     spacing: Spacing;
+    zIndex: ZIndex;
 };
 
 export type GetMuiComponentTheme<ClassesName extends keyof ComponentNameToClassKey> = (

--- a/packages/admin/admin-theme/src/createCometTheme.ts
+++ b/packages/admin/admin-theme/src/createCometTheme.ts
@@ -1,6 +1,7 @@
 import { createTheme, Theme, ThemeOptions } from "@mui/material";
 import createPalette, { PaletteOptions } from "@mui/material/styles/createPalette";
 import createTypography, { TypographyOptions } from "@mui/material/styles/createTypography";
+import muiDefaultZIndex from "@mui/material/styles/zIndex";
 import { createSpacing } from "@mui/system";
 import { deepmerge } from "@mui/utils";
 
@@ -14,6 +15,7 @@ export const createCometTheme = ({
     typography: passedTypographyOptions = {},
     spacing: passedSpacingOptions = 5,
     components: passedComponentsOptions = {},
+    zIndex: passedZIndexOptions = {},
     ...restPassedOptions
 }: ThemeOptions | undefined = {}): Theme => {
     const paletteOptions: PaletteOptions = deepmerge<PaletteOptions>(cometPaletteOptions, passedPaletteOptions);
@@ -26,6 +28,11 @@ export const createCometTheme = ({
 
     const spacing = createSpacing(passedSpacingOptions);
 
+    const zIndex = {
+        ...muiDefaultZIndex,
+        ...passedZIndexOptions,
+    };
+
     const cometThemeOptions: ThemeOptions = {
         spacing: passedSpacingOptions,
         palette: paletteOptions,
@@ -34,7 +41,8 @@ export const createCometTheme = ({
             borderRadius: 2,
         },
         shadows,
-        components: getComponentsTheme(passedComponentsOptions, { palette, typography, spacing }),
+        zIndex,
+        components: getComponentsTheme(passedComponentsOptions, { palette, typography, spacing, zIndex }),
     };
 
     const themeOptions = deepmerge<ThemeOptions>(cometThemeOptions, restPassedOptions);

--- a/packages/admin/admin/src/appHeader/AppHeader.tsx
+++ b/packages/admin/admin/src/appHeader/AppHeader.tsx
@@ -14,7 +14,7 @@ interface AppHeaderProps extends AppBarProps {
 
 export type AppHeaderClassKey = AppBarClassKey;
 
-const styles = ({ palette }: Theme) => {
+const styles = ({ palette, zIndex }: Theme) => {
     return createStyles<AppHeaderClassKey, AppHeaderProps>({
         root: {
             backgroundColor: palette.grey["A400"],

--- a/packages/admin/admin/src/mui/MasterLayout.styles.tsx
+++ b/packages/admin/admin/src/mui/MasterLayout.styles.tsx
@@ -12,7 +12,7 @@ export const styles = ({ zIndex }: Theme) => {
             flexWrap: "nowrap",
         },
         header: {
-            zIndex: zIndex.drawer + 1,
+            zIndex: zIndex.drawer + 51, // Above the MuiDrawer-root / CometAdminAppHeader-root
         },
         contentWrapper: {
             flexGrow: 1,


### PR DESCRIPTION
It should be above the drawer of CometAdminMenu, so the content inside the AppHeader (e.g., the MenuButton) is clickable.