### PR TITLE
Scrollable tabs

### DIFF
--- a/packages/admin/blocks-admin/src/blocks/common/AdminTabs.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminTabs.tsx
@@ -23,7 +23,7 @@ export function AdminTabs({ children }: AdminTabsProps): JSX.Element | null {
     const selectedTab = children.find((tab) => tab.key === selected) ? selected : firstTab.key; //fall back to first, as <Switch> does
     return (
         <Root key="tabs">
-            <Tabs value={selectedTab}>
+            <Tabs value={selectedTab} variant="scrollable" scrollButtons>
                 {children.map((tab, index) => {
                     const url = index === 0 ? match.url : `${match.url}/${tab.key}`;
                     return <Tab key={tab.key} value={tab.key} label={tab.label} component={Link} to={url} />;
@@ -53,6 +53,7 @@ const Root = styled("div")`
 
 const Tabs = styled(MuiTabs)`
     background-color: ${({ theme }) => theme.palette.background.default};
+    max-width: 640px;
 `;
 
 const Tab = styled(MuiTab)<TabProps & LinkProps>`

--- a/packages/admin/blocks-admin/src/blocks/common/AdminTabs.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminTabs.tsx
@@ -53,7 +53,6 @@ const Root = styled("div")`
 
 const Tabs = styled(MuiTabs)`
     background-color: ${({ theme }) => theme.palette.background.default};
-    max-width: 640px;
 `;
 
 const Tab = styled(MuiTab)<TabProps & LinkProps>`


### PR DESCRIPTION

https://user-images.githubusercontent.com/12232983/179454910-515da48c-15fe-4de9-953b-773565a4b069.mov

Old tabs, not scrollable:
<img width="635" alt="Screen Shot 2022-07-15 at 15 08 47 PM" src="https://user-images.githubusercontent.com/12232983/179454955-37506c4c-e974-4d35-8345-60447ffd4a76.png">

New, scrollable tabs
<img width="579" alt="Screen Shot 2022-07-15 at 15 08 58 PM" src="https://user-images.githubusercontent.com/12232983/179454959-36f433e5-7a7d-4352-869c-3bd34f09ce11.png">
