### PR TITLE
Fix z-index issues of MasterLayout & MuiDrawer

### DIFF
--- a/packages/admin/admin-stories/src/docs/components/Master/Master.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/components/Master/Master.stories.tsx
@@ -12,9 +12,12 @@ import {
     ToolbarTitleItem,
 } from "@comet/admin";
 import { Dashboard, Wrench } from "@comet/admin-icons";
-import { Card, CardContent, Typography } from "@mui/material";
+import { AppBar, Box, Card, CardContent, Drawer, Toolbar as MuiToolbar, Typography } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
+
+const loremIpsumText =
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Maecenas sed diam eget risus varius blandit sit amet non magna.";
 
 storiesOf("stories/components/Master", module)
     .addParameters({
@@ -33,12 +36,31 @@ storiesOf("stories/components/Master", module)
         }
 
         function MasterHeader() {
+            const [showDrawer, setShowDrawer] = React.useState<boolean>(false);
             return (
-                <AppHeader>
-                    <AppHeaderMenuButton />
-                    <AppHeaderFillSpace />
-                    <AppHeaderButton startIcon={<Wrench />}>AppHeader button</AppHeaderButton>
-                </AppHeader>
+                <>
+                    <AppHeader>
+                        <AppHeaderMenuButton />
+                        <AppHeaderFillSpace />
+                        <AppHeaderButton startIcon={<Wrench />} onClick={() => setShowDrawer(true)}>
+                            Open drawer
+                        </AppHeaderButton>
+                    </AppHeader>
+                    <Drawer anchor="right" open={showDrawer} onClose={() => setShowDrawer(false)}>
+                        <Box sx={{ width: 300 }}>
+                            <AppBar position="relative">
+                                <MuiToolbar>
+                                    <Typography variant="h6">Drawer</Typography>
+                                </MuiToolbar>
+                            </AppBar>
+                            <Box p={4}>
+                                <Typography paragraph>{loremIpsumText}</Typography>
+                                <Typography paragraph>{loremIpsumText}</Typography>
+                                <Typography>{loremIpsumText}</Typography>
+                            </Box>
+                        </Box>
+                    </Drawer>
+                </>
             );
         }
 
@@ -49,11 +71,7 @@ storiesOf("stories/components/Master", module)
                         <Typography variant="h1" gutterBottom>
                             App content
                         </Typography>
-                        <Typography>
-                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante venenatis dapibus posuere velit
-                            aliquet. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Maecenas
-                            sed diam eget risus varius blandit sit amet non magna.
-                        </Typography>
+                        <Typography>{loremIpsumText}</Typography>
                     </CardContent>
                 </Card>
             );

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDrawer.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDrawer.ts
@@ -6,9 +6,6 @@ import { GetMuiComponentTheme } from "./getComponentsTheme";
 export const getMuiDrawer: GetMuiComponentTheme<"MuiDrawer"> = (component, { palette, zIndex }): Components["MuiDrawer"] => ({
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiDrawer">(component?.styleOverrides, {
-        root: {
-            zIndex: zIndex.drawer + 50, // Between AppBar (1200) and Modal (1300)
-        },
         paper: {
             backgroundColor: palette.grey[50],
         },

--- a/packages/admin/admin/src/mui/MasterLayout.styles.tsx
+++ b/packages/admin/admin/src/mui/MasterLayout.styles.tsx
@@ -12,7 +12,7 @@ export const styles = ({ zIndex }: Theme) => {
             flexWrap: "nowrap",
         },
         header: {
-            zIndex: zIndex.drawer + 51, // Above the MuiDrawer-root / CometAdminAppHeader-root
+            zIndex: zIndex.drawer - 10,
         },
         contentWrapper: {
             flexGrow: 1,


### PR DESCRIPTION
The header inside MasterLayout needs to be above the menu to prevent the content, e.g., MenuButton in the header, from being overlayed and therefore not clickable. This was fixed in #694, which then caused the MasterLayout-header to overlay all drawers (MuiDrawer).

Also, MuiDrawer-root should not always have a z-index, as it is not always rendered as a modal, e.g., when using the variant "permanent".

By not using a custom theme value for the z-index of MuiDrawer-root and instead only changing the z-index of components directly used inside MasterLayout, these problems should be fixed permanently.