### PR TITLE
Support React nodes in page tree node info tag

### DIFF
--- a/packages/admin/cms-admin/src/documents/types.ts
+++ b/packages/admin/cms-admin/src/documents/types.ts
@@ -45,5 +45,5 @@ export interface DocumentInterface<
     menuIcon: (props: SvgIconProps<"svg">) => JSX.Element;
     hideInMenuIcon?: (props: SvgIconProps<"svg">) => JSX.Element;
     additionalDocumentFragment?: { name: string; fragment: DocumentNode };
-    infoTag?: (document: GQLDocument) => string | undefined;
+    infoTag?: (document: GQLDocument) => React.ReactNode | undefined;
 }


### PR DESCRIPTION
Previously, only `string` was supported. To support translated labels, we need to support `React.ReactNode` as well, so that we can use `<FormattedMessage ... />`.