### PR TITLE
Fix Styling of ChooseFileDialog

### DIFF
--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -95,6 +95,7 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
                         <ToolbarActions>
                             <Button
                                 variant="text"
+                                color="inherit"
                                 startIcon={<AddFolderIcon />}
                                 onClick={() => {
                                     editDialogApi.openAddDialog(id);

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -19,12 +19,10 @@ const FixedHeightDialog = styled(Dialog)`
 `;
 
 const StyledDialogTitle = styled(DialogTitle)`
-    & > .MuiTypography-root {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        width: 100%;
-    }
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
 `;
 
 const CloseButton = styled(IconButton)`
@@ -35,6 +33,7 @@ const CloseButton = styled(IconButton)`
 const TableRowButton = styled(Button)`
     padding: 0;
     justify-content: left;
+    color: ${({ theme }) => theme.palette.grey[600]};
 
     &:hover {
         background-color: transparent;


### PR DESCRIPTION
- fix styling after Mui v3 update

Before:
<img width="1947" alt="Screen Shot 2022-07-05 at 08 45 38" src="https://user-images.githubusercontent.com/13380047/179506344-f235e8f1-6ade-4982-bff1-e7c5272859d7.png">


Now:
<img width="1636" alt="Bildschirmfoto 2022-07-18 um 13 56 50" src="https://user-images.githubusercontent.com/13380047/179506357-ec414759-10b9-4054-b974-b4a976186fee.png">

