### PR TITLE
Time Range Picker

### DIFF
--- a/packages/admin/admin-date-time/src/FinalFormTimeRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/FinalFormTimeRangePicker.tsx
@@ -1,0 +1,10 @@
+import * as React from "react";
+import { FieldRenderProps } from "react-final-form";
+
+import { TimeRange, TimeRangePicker, TimeRangePickerProps } from "./TimeRangePicker";
+
+export type FinalFormTimeRangePickerProps = TimeRangePickerProps & FieldRenderProps<TimeRange, HTMLInputElement | HTMLTextAreaElement>;
+
+export const FinalFormTimeRangePicker = ({ meta, input, ...restProps }: FinalFormTimeRangePickerProps): React.ReactElement => {
+    return <TimeRangePicker {...input} {...restProps} />;
+};

--- a/packages/admin/admin-date-time/src/TimeRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/TimeRangePicker.tsx
@@ -1,0 +1,134 @@
+import { ComponentsOverrides, Theme, Typography } from "@mui/material";
+import { createStyles, WithStyles, withStyles } from "@mui/styles";
+import clsx from "clsx";
+import * as React from "react";
+import { FormatDateOptions, FormattedMessage } from "react-intl";
+
+import { TimePicker, TimePickerProps } from "./TimePicker";
+
+export type TimeRange = {
+    start: string;
+    end: string;
+};
+
+export type TimeRangePickerIndividualPickerProps = Omit<TimePickerProps, "onChange" | "onBlur" | "value" | "className" | "inputRef">;
+
+export interface TimeRangePickerComponentsProps {
+    startPicker?: TimeRangePickerIndividualPickerProps;
+    endPicker?: TimeRangePickerIndividualPickerProps;
+}
+
+export interface TimeRangePickerProps {
+    onChange?: (timeRange?: TimeRange) => void;
+    value?: TimeRange;
+    formatOptions?: FormatDateOptions;
+    minuteStep?: number;
+    min?: string;
+    max?: string;
+    clearable?: boolean;
+    separatorText?: React.ReactNode;
+    componentsProps?: TimeRangePickerComponentsProps;
+}
+
+type IndividualTimeValue = string | undefined;
+
+function TimeRangePicker({
+    classes,
+    onChange,
+    value,
+    separatorText = <FormattedMessage id="cometAdmin.dateTime.fromToSeparatorText" defaultMessage="to" />,
+    componentsProps = {},
+    ...propsForBothTimePickers
+}: TimeRangePickerProps & WithStyles<typeof styles>) {
+    const [startTime, setStartTime] = React.useState<IndividualTimeValue>(value?.start);
+    const [endTime, setEndTime] = React.useState<IndividualTimeValue>(value?.end);
+
+    const startPickerRef = React.useRef<HTMLElement>(null);
+    const endPickerRef = React.useRef<HTMLElement>(null);
+
+    React.useEffect(() => {
+        if (startTime && endTime) {
+            onChange?.({ start: startTime, end: endTime });
+        } else if (startTime === undefined && endTime === undefined) {
+            onChange?.(undefined);
+        }
+    }, [startTime, endTime, onChange]);
+
+    const onChangeTimeValue = (newTimeValue: IndividualTimeValue, type: "start" | "end") => {
+        const otherTimeValue = type === "start" ? endTime : startTime;
+        const setNewTimeValue = type === "start" ? setStartTime : setEndTime;
+        const setOtherTimeValue = type === "start" ? setEndTime : setStartTime;
+        const otherTimeInputRef = type === "start" ? endPickerRef : startPickerRef;
+
+        setNewTimeValue(newTimeValue);
+
+        if (newTimeValue === undefined) {
+            setOtherTimeValue(undefined);
+        } else if (otherTimeInputRef.current && otherTimeValue === undefined) {
+            otherTimeInputRef.current.focus();
+        }
+    };
+
+    return (
+        <div className={classes.root}>
+            <TimePicker
+                inputRef={startPickerRef}
+                value={startTime}
+                className={clsx(classes.timePicker, classes.startTimePicker)}
+                onChange={(time) => onChangeTimeValue(time, "start")}
+                {...propsForBothTimePickers}
+                {...componentsProps.startPicker}
+            />
+            <Typography className={classes.separator}>{separatorText}</Typography>
+            <TimePicker
+                inputRef={endPickerRef}
+                value={endTime}
+                className={clsx(classes.timePicker, classes.endTimePicker)}
+                onChange={(time) => onChangeTimeValue(time, "end")}
+                {...propsForBothTimePickers}
+                {...componentsProps.endPicker}
+            />
+        </div>
+    );
+}
+
+export type TimeRangePickerClassKey = "root" | "timePicker" | "startTimePicker" | "endTimePicker" | "separator";
+
+export const styles = ({ spacing }: Theme) =>
+    createStyles<TimeRangePickerClassKey, TimeRangePickerProps>({
+        root: {
+            display: "flex",
+            alignItems: "center",
+        },
+        timePicker: {
+            flexGrow: 1,
+            flexBasis: "100%",
+        },
+        startTimePicker: {},
+        endTimePicker: {},
+        separator: {
+            marginLeft: spacing(2),
+            marginRight: spacing(2),
+        },
+    });
+
+const TimeRangePickerWithStyles = withStyles(styles, { name: "CometAdminTimeRangePicker" })(TimeRangePicker);
+
+export { TimeRangePickerWithStyles as TimeRangePicker };
+
+declare module "@mui/material/styles" {
+    interface ComponentNameToClassKey {
+        CometAdminTimeRangePicker: TimeRangePickerClassKey;
+    }
+
+    interface ComponentsPropsList {
+        CometAdminTimeRangePicker: TimeRangePickerProps;
+    }
+
+    interface Components {
+        CometAdminTimeRangePicker?: {
+            defaultProps?: ComponentsPropsList["CometAdminTimeRangePicker"];
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTimeRangePicker"];
+        };
+    }
+}

--- a/packages/admin/admin-date-time/src/index.ts
+++ b/packages/admin/admin-date-time/src/index.ts
@@ -3,5 +3,13 @@ export { DateRange, DateRangePicker, DateRangePickerProps } from "./DateRangePic
 export { FinalFormDatePicker, FinalFormDatePickerProps } from "./FinalFormDatePicker";
 export { FinalFormDateRangePicker, FinalFormDateRangePickerProps } from "./FinalFormDateRangePicker";
 export { FinalFormTimePicker } from "./FinalFormTimePicker";
+export { FinalFormTimeRangePicker, FinalFormTimeRangePickerProps } from "./FinalFormTimeRangePicker";
 export { DateFnsLocaleContext, DateFnsLocaleProvider, useDateFnsLocale } from "./helpers/DateFnsLocaleProvider";
 export { TimePicker, TimePickerProps } from "./TimePicker";
+export {
+    TimeRange,
+    TimeRangePicker,
+    TimeRangePickerComponentsProps,
+    TimeRangePickerIndividualPickerProps,
+    TimeRangePickerProps,
+} from "./TimeRangePicker";

--- a/packages/admin/admin-stories/src/admin-date-time/TimeRangePicker.tsx
+++ b/packages/admin/admin-stories/src/admin-date-time/TimeRangePicker.tsx
@@ -1,0 +1,53 @@
+import { Field } from "@comet/admin";
+import { FinalFormTimeRangePicker, TimeRange } from "@comet/admin-date-time";
+import { Time } from "@comet/admin-icons";
+import { Card, CardContent, InputAdornment } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { Form } from "react-final-form";
+
+const Story = () => {
+    interface Values {
+        timeRangeOne?: TimeRange;
+        timeRangeTwo?: TimeRange;
+    }
+
+    const initialValues: Partial<Values> = {
+        timeRangeOne: undefined,
+        timeRangeTwo: {
+            start: "11:30",
+            end: "12:30",
+        },
+    };
+
+    return (
+        <div style={{ width: 500 }}>
+            <Form<Values> onSubmit={() => {}} initialValues={initialValues}>
+                {({ values }) => (
+                    <form>
+                        <Card>
+                            <CardContent>
+                                <Field name="timeRangeOne" label="Time range" fullWidth component={FinalFormTimeRangePicker} />
+                                <Field
+                                    name="timeRangeTwo"
+                                    label="Clearable time range with icon"
+                                    fullWidth
+                                    clearable
+                                    component={FinalFormTimeRangePicker}
+                                    startAdornment={
+                                        <InputAdornment position="start">
+                                            <Time />
+                                        </InputAdornment>
+                                    }
+                                />
+                            </CardContent>
+                        </Card>
+                        <pre>{JSON.stringify(values, null, 4)}</pre>
+                    </form>
+                )}
+            </Form>
+        </div>
+    );
+};
+
+storiesOf("@comet/admin-date-time", module).add("Time Range Picker", () => <Story />);

--- a/packages/admin/admin/src/inputWithPopper/InputWithPopper.tsx
+++ b/packages/admin/admin/src/inputWithPopper/InputWithPopper.tsx
@@ -18,12 +18,13 @@ export type InputWithPopperComponents = InputBaseProps["components"] & {
 
 type ClosePopper = (focusInput?: boolean) => void;
 
-export interface InputWithPopperProps extends Omit<InputBaseProps, "componentsProps" | "components"> {
+export interface InputWithPopperProps extends Omit<InputBaseProps, "componentsProps" | "components" | "inputRef"> {
     children: ((closePopper: ClosePopper) => React.ReactNode) | React.ReactNode;
     componentsProps?: InputWithPopperComponentsProps;
     components?: InputWithPopperComponents;
     onOpenPopper?: () => void;
     onClosePopper?: () => void;
+    inputRef?: React.RefObject<HTMLElement>;
 }
 
 function InputWithPopper({
@@ -34,13 +35,16 @@ function InputWithPopper({
     onOpenPopper,
     onClosePopper,
     components = {},
+    inputRef: inputRefProp,
     ...inputBaseProps
 }: InputWithPopperProps & WithStyles<typeof styles>): React.ReactElement {
     const { Transition = Grow, ...inputBaseComponents } = components;
 
     const rootRef = React.useRef<HTMLDivElement>(null);
-    const inputRef = React.useRef<HTMLInputElement>(null);
+    const ownInputRef = React.useRef<HTMLElement>(null);
     const [showPopper, setShowPopper] = React.useState<boolean>(false);
+
+    const inputRef = inputRefProp ?? ownInputRef;
 
     const closePopper: ClosePopper = React.useCallback(
         (focusInput) => {


### PR DESCRIPTION
### TODO
- [ ] Set both values the same if all poppers are permanently closed and one value is undefined (maybe by tracking, wich poppers are currently open, using `onOpenPopper` & `onClosePopper`?)
- [ ] Validate order of values (start <= end)
- [ ] Set min/max values, depending on the other value, to prevent invalid order (while respecting min/max prop-values)
- [ ] Only set focus styling on single picker, but keep on fieldLabel
- [ ] Fix `fullWidth` styling in story & check if width behavior is generally as intended