### PR TITLE
Set DAM uploads max file size via config

### DIFF
--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -144,6 +144,7 @@ import { PredefinedPageModule } from "./predefined-page/predefined-page.module";
                     allowedAspectRatios: config.DAM_ALLOWED_IMAGE_ASPECT_RATIOS,
                     filesDirectory: `${config.BLOB_STORAGE_DIRECTORY_PREFIX}-files`,
                     cacheDirectory: `${config.BLOB_STORAGE_DIRECTORY_PREFIX}-cache`,
+                    maxFileSize: config.DAM_UPLOADS_MAX_FILE_SIZE,
                 },
                 imgproxyConfig: {
                     url: config.IMGPROXY_URL,

--- a/demo/api/src/config/config.namespace.ts
+++ b/demo/api/src/config/config.namespace.ts
@@ -75,6 +75,10 @@ export class EnvironmentVariables {
     @IsString()
     DAM_ALLOWED_IMAGE_ASPECT_RATIOS: string;
 
+    @Type(() => Number)
+    @IsInt()
+    DAM_UPLOADS_MAX_FILE_SIZE: number;
+
     @IsString()
     BLOB_STORAGE_DRIVER: BlobStorageConfig["backend"]["driver"];
 

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -22,7 +22,7 @@ type DamFileImage {
   exif: JSONObject
   dominantColor: String
   cropArea: ImageCropArea!
-  url(height: Int!, width: Int!): String
+  url(width: Int!, height: Int!): String
 }
 
 """
@@ -152,14 +152,14 @@ type Query {
   redirect(id: ID!): Redirect!
   damFilesList(sortColumnName: String, sortDirection: SortDirection = ASC, folderId: ID, includeArchived: Boolean = false, filter: FileFilterInput): [DamFile!]!
   damFile(id: ID!): DamFile!
-  damFilenameAlreadyExists(folderId: String, filename: String!): Boolean!
+  damFilenameAlreadyExists(filename: String!, folderId: String): Boolean!
   damFoldersList(sortColumnName: String, sortDirection: SortDirection = ASC, parentId: ID, includeArchived: Boolean, filter: FolderFilterInput): [DamFolder!]!
   damFolder(id: ID!): DamFolder!
   damFolderByNameAndParentId(name: String!, parentId: ID): DamFolder
   pageTreeNode(id: ID!): PageTreeNode
-  pageTreeNodeByPath(scope: PageTreeNodeScopeInput!, path: String!): PageTreeNode
-  pageTreeNodeList(category: String, scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
-  pageTreeNodeSlugAvailable(slug: String!, parentId: ID, scope: PageTreeNodeScopeInput!): SlugAvailability!
+  pageTreeNodeByPath(path: String!, scope: PageTreeNodeScopeInput!): PageTreeNode
+  pageTreeNodeList(scope: PageTreeNodeScopeInput!, category: String): [PageTreeNode!]!
+  pageTreeNodeSlugAvailable(scope: PageTreeNodeScopeInput!, parentId: ID, slug: String!): SlugAvailability!
 }
 
 enum SortDirection {
@@ -189,24 +189,24 @@ enum SlugAvailability {
 type Mutation {
   createBuild: Boolean!
   createRedirect(input: RedirectInput!): Redirect!
-  updateRedirect(lastUpdatedAt: DateTime, input: RedirectInput!, id: ID!): Redirect!
-  updateRedirectActiveness(input: RedirectUpdateActivenessInput!, id: ID!): Redirect!
+  updateRedirect(id: ID!, input: RedirectInput!, lastUpdatedAt: DateTime): Redirect!
+  updateRedirectActiveness(id: ID!, input: RedirectUpdateActivenessInput!): Redirect!
   deleteRedirect(id: ID!): Boolean!
-  updateDamFile(input: UpdateDamFileInput!, id: ID!): DamFile!
-  moveDamFiles(targetFolderId: ID, fileIds: [ID!]!): [DamFile!]!
+  updateDamFile(id: ID!, input: UpdateDamFileInput!): DamFile!
+  moveDamFiles(fileIds: [ID!]!, targetFolderId: ID): [DamFile!]!
   archiveDamFile(id: ID!): DamFile!
   restoreDamFile(id: ID!): DamFile!
   deleteDamFile(id: ID!): Boolean!
   createDamFolder(input: CreateDamFolderInput!): DamFolder!
-  updateDamFolder(input: UpdateDamFolderInput!, id: ID!): DamFolder!
-  moveDamFolders(targetFolderId: ID, folderIds: [ID!]!): [DamFolder!]!
+  updateDamFolder(id: ID!, input: UpdateDamFolderInput!): DamFolder!
+  moveDamFolders(folderIds: [ID!]!, targetFolderId: ID): [DamFolder!]!
   deleteDamFolder(id: ID!): Boolean!
-  updatePageTreeNode(input: PageTreeNodeUpdateInput!, id: ID!): PageTreeNode!
+  updatePageTreeNode(id: ID!, input: PageTreeNodeUpdateInput!): PageTreeNode!
   deletePageTreeNode(id: ID!): Boolean!
-  updatePageTreeNodeVisibility(input: PageTreeNodeUpdateVisibilityInput!, id: ID!): PageTreeNode!
-  updatePageTreeNodePosition(input: PageTreeNodeUpdatePositionInput!, id: ID!): PageTreeNode!
-  updatePageTreeNodeCategory(category: String!, id: ID!): PageTreeNode!
-  createPageTreeNode(category: String!, scope: PageTreeNodeScopeInput!, input: PageTreeNodeCreateInput!): PageTreeNode!
+  updatePageTreeNodeVisibility(id: ID!, input: PageTreeNodeUpdateVisibilityInput!): PageTreeNode!
+  updatePageTreeNodePosition(id: ID!, input: PageTreeNodeUpdatePositionInput!): PageTreeNode!
+  updatePageTreeNodeCategory(id: ID!, category: String!): PageTreeNode!
+  createPageTreeNode(input: PageTreeNodeCreateInput!, scope: PageTreeNodeScopeInput!, category: String!): PageTreeNode!
 }
 
 input RedirectInput {

--- a/packages/api/cms-api/src/dam/dam.config.ts
+++ b/packages/api/cms-api/src/dam/dam.config.ts
@@ -10,6 +10,7 @@ export interface DamConfig {
     filesDirectory: string;
     cacheDirectory: string;
     additionalMimeTypes?: string[];
+    maxFileSize: number;
 }
 
 export const CDN_ORIGIN_CHECK_HEADER = "x-cdn-origin-check";

--- a/packages/api/cms-api/src/dam/files/dam-upload-file.interceptor.ts
+++ b/packages/api/cms-api/src/dam/files/dam-upload-file.interceptor.ts
@@ -38,7 +38,7 @@ export function DamUploadFileInterceptor(fieldName: string): Type<NestIntercepto
                     },
                 }),
                 limits: {
-                    fileSize: Number(process.env.DAM_UPLOADS_MAX_FILE_SIZE) * 1024 * 1024,
+                    fileSize: config.maxFileSize * 1024 * 1024,
                 },
                 fileFilter: (req, file, cb) => {
                     const acceptedMimeTypes = [...defaultDamAcceptedMimetypes, ...(config.additionalMimeTypes ?? [])];


### PR DESCRIPTION
Previously, the max file size for DAM uploads was determined by directly using an environment variable. This lead to issues where the file upload would fail silently when the environment variable was not set. To resolve the issue, the max file size must now be set via config when registering the DAM module.