### PR TITLE
Fix duplicate ids for formatted messages

### DIFF
--- a/packages/admin/admin/src/router/ConfirmationDialog.tsx
+++ b/packages/admin/admin/src/router/ConfirmationDialog.tsx
@@ -39,7 +39,11 @@ export function InternalRouterConfirmationDialog({
                     <Warning className={classes.messageWarningIcon} />
                     <Typography className={classes.messageText}>
                         {message ?? (
-                            <FormattedMessage id="cometAdmin.generic.doYouWantToSaveYourChanges" defaultMessage="Do you want to save your changes?" />
+                            <FormattedMessage
+                                id="cometAdmin.generic.doYouWantToSaveYourChanges"
+                                defaultMessage="Do you want to save your changes?"
+                                description="Prompt to save unsaved changes"
+                            />
                         )}
                     </Typography>
                 </div>

--- a/packages/admin/blocks-admin/src/clipboard/CannotPasteBlockDialog.tsx
+++ b/packages/admin/blocks-admin/src/clipboard/CannotPasteBlockDialog.tsx
@@ -17,7 +17,7 @@ function CannotPasteBlockDialog({ open, onClose, error }: Props): React.ReactEle
             <DialogContent>{error}</DialogContent>
             <DialogActions>
                 <Button onClick={onClose} color="info">
-                    <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />
+                    <FormattedMessage id="comet.generic.ok" defaultMessage="Ok" />
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/admin/cms-admin/src/builds/PublishButton.tsx
+++ b/packages/admin/cms-admin/src/builds/PublishButton.tsx
@@ -71,7 +71,7 @@ export const PublishButton: React.FunctionComponent = () => {
                 fullWidth
             >
                 {hasStarted && <FormattedMessage id="comet.pages.publisher.buildStarted" defaultMessage="Build started" />}
-                {hasError && <FormattedMessage id="comet.pages.publisher.buildStarted" defaultMessage="Build start failed" />}
+                {hasError && <FormattedMessage id="comet.pages.publisher.buildStartFailed" defaultMessage="Starting build failed" />}
                 {!hasStarted && !hasError && <FormattedMessage id="comet.pages.publisher.build" defaultMessage="Start build" />}
             </Button>
             {loading && <CircularProgress size={24} className={classes.buttonProgress} />}


### PR DESCRIPTION
> [@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "cometAdmin.generic.doYouWantToSaveYourChanges", but the `description` and/or `defaultMessage` are different.[@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "comet.pages.publisher.buildStarted", but the `description` and/or `defaultMessage` are different.[@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "comet.generic.ok", but the `description` and/or `defaultMessage` are different.

I did a quick search, but I did not find any eslint plugin or formatjs-cli option to check for duplicate ids as part of linting.


Additionally we could consider to refactor the "generic" messages. Currently they have to be exactly duplicated for each occurrence. This makes them error prone and hard to find (what generic translations exist?). Maybe we should move them to a common place. 