### PR TITLE
Add check for duplicated ids of formatted messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
               run: |
                   yarn exec prettier --check "./*.{js,json,md,yml}"
                   yarn lint:lib
+                  # check for duplicate ids of formatted messages
+                  yarn intl:extract
 
             - name: Test
               run: yarn test:lib

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "test": "lerna run test --concurrency=1 --stream",
         "test:lib": "lerna run test --concurrency=1 --stream --no-private",
         "build:storybook": "yarn build && yarn workspace comet-admin-stories build-storybook",
-        "intl:extract": "formatjs extract './packages/admin/**/*.ts*' --out-file 'lang/en.json' --ignore './**.d.ts' --ignore './packages/admin/admin-stories/**/*' --format simple",
+        "intl:extract": "formatjs extract './packages/admin/**/*.ts*' --out-file 'lang/en.json' --ignore './**.d.ts' --ignore './packages/admin/admin-stories/**/*' --format simple --throws",
         "postinstall": "husky install"
     },
     "devDependencies": {


### PR DESCRIPTION
see https://github.com/vivid-planet/comet/pull/707#issuecomment-1191204763

It is not possible to detect this with lint-staged, as the closest lint-staged file is used (see https://github.com/okonet/lint-staged#how-to-use-lint-staged-in-a-multi-package-monorepo), but extracting happens at the root level.

Detecting it with the CI/CD works: https://github.com/vivid-planet/comet/runs/7445752404