### PR TITLE
integrate comet-lang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,15 +67,25 @@ jobs:
                   path: packages/**/junit.xml
                   reporter: jest-junit
 
+            - name: Clone translations
+              if: ${{ github.ref_name == 'next' }} # TODO: change me to main
+              uses: actions/checkout@v3
+              with:
+                  repository: vivid-planet/comet-lang
+                  token: ${{ secrets.GH_TOKEN }}
+                  path: "comet-lang"
+
             - name: Extract i18n strings
-              if: ${{ github.ref_name == 'main' }}
+              if: ${{ github.ref_name == 'next' }} # TODO: change me to main
               run: |
                   yarn intl:extract
-                  git clone https://github.com/vivid-planet/comet-lang.git
-                  cp -r lang/* comet-admin-lang/
-                  cd comet-admin-lang
-                  git add .
-                  if [[ `git status --porcelain` ]]; then git commit -m "add translatable strings for ${{ github.sha }}" && git remote rm origin && git remote add origin https://vivid-planet-bot:${{ secrets.GH_TOKEN }}@github.com/vivid-planet/comet-admin-lang.git && git push --set-upstream origin master; fi
+                  cp -r lang/* comet-lang/
+
+            - name: Update translateable strings
+              if: ${{ github.ref_name == 'next' }} # TODO: change me to main
+              uses: EndBug/add-and-commit@v9
+              with:
+                  cwd: "./comet-lang"
 
             - name: Publish premajor canary release
               if: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 **/.watchmanconfig
 /.docker-sync
 storybook-static/
-comet-admin-lang/
+comet-lang/
 lang/
 /.npm
 .pnp.*


### PR DESCRIPTION
- starting from v3, https://github.com/vivid-planet/comet-lang will be used for translation (https://github.com/vivid-planet/comet-admin-lang will stay as public archive for backwards compatibility)
- once v3 is released, the translation pipelines should run on main rather than next