### PR TITLE
Make all individual child-component props optional

### DIFF
--- a/packages/admin/admin/src/table/filterbar/filterBarPopoverFilter/FilterBarPopoverFilter.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarPopoverFilter/FilterBarPopoverFilter.tsx
@@ -14,9 +14,9 @@ export interface FilterBarPopoverFilterProps {
     label: string;
     dirtyFieldsBadge?: React.ComponentType<FilterBarActiveFilterBadgeProps>;
     calcNumberDirtyFields?: (values: Record<string, any>, registeredFields: string[]) => number;
-    submitButtonProps?: ButtonProps;
-    resetButtonProps?: ButtonProps;
-    filterBarButtonProps?: FilterBarButtonProps;
+    submitButtonProps?: Partial<ButtonProps>;
+    resetButtonProps?: Partial<ButtonProps>;
+    filterBarButtonProps?: Partial<FilterBarButtonProps>;
 }
 
 function PopoverFilter({


### PR DESCRIPTION
The required props are already set manually in the component's usage.