### PR TITLE
Fix RTE inline styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Next]
+
+## Bugfixes
+
+-   [RTE] Fix a bug were `setEditorState` was incorrectly assumed to be a React state setter function.
+
 # [2.2.0]
 
 ## Highlights

--- a/packages/admin-rte/src/core/Controls/useBlockTypes.tsx
+++ b/packages/admin-rte/src/core/Controls/useBlockTypes.tsx
@@ -7,7 +7,7 @@ import getCurrentBlock from "../utils/getCurrentBlock";
 
 interface IProps {
     editorState: EditorState;
-    setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
+    setEditorState: (editorState: EditorState) => void;
     supportedThings: SupportedThings[];
     blocktypeMap: IBlocktypeMap;
     editorRef: React.RefObject<Editor>;

--- a/packages/admin-rte/src/core/Controls/useHistory.ts
+++ b/packages/admin-rte/src/core/Controls/useHistory.ts
@@ -9,7 +9,7 @@ import { IFeatureConfig } from "../types";
 
 interface IProps {
     editorState: EditorState;
-    setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
+    setEditorState: (editorState: EditorState) => void;
     supportedThings: SupportedThings[];
 }
 

--- a/packages/admin-rte/src/core/Controls/useInlineStyleType.tsx
+++ b/packages/admin-rte/src/core/Controls/useInlineStyleType.tsx
@@ -16,7 +16,7 @@ const browser = detectBrowser.detect();
 
 interface IProps {
     editorState: EditorState;
-    setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
+    setEditorState: (editorState: EditorState) => void;
     supportedThings: SupportedThings[];
     editorRef: React.RefObject<Editor>;
     customInlineStyles?: CustomInlineStyles;
@@ -108,9 +108,9 @@ export default function useInlineStyleType({ editorState, setEditorState, suppor
     const handleInlineStyleButtonClick = React.useCallback(
         (draftInlineStyleType: InlineStyleType, e: React.MouseEvent) => {
             e.preventDefault();
-            setEditorState((previousEditorState) => RichUtils.toggleInlineStyle(previousEditorState, draftInlineStyleType));
+            setEditorState(RichUtils.toggleInlineStyle(editorState, draftInlineStyleType));
         },
-        [setEditorState],
+        [setEditorState, editorState],
     );
 
     const features: Array<IFeatureConfig<InlineStyleType>> = React.useMemo(

--- a/packages/admin-rte/src/core/Controls/useListIndent.ts
+++ b/packages/admin-rte/src/core/Controls/useListIndent.ts
@@ -63,7 +63,7 @@ function adjustBlockDepth(type: "increase" | "decrease", editorState: EditorStat
 
 interface IProps {
     editorState: EditorState;
-    setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
+    setEditorState: (editorState: EditorState) => void;
     supportedThings: SupportedThings[];
     listLevelMax?: number;
 }

--- a/packages/admin-rte/src/core/types.ts
+++ b/packages/admin-rte/src/core/types.ts
@@ -42,7 +42,7 @@ export type InlineStyleType = CustomInlineStyleType | DraftInlineStyleType;
 
 export interface IControlProps {
     editorState: EditorState;
-    setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
+    setEditorState: (editorState: EditorState) => void;
     options: IRteOptions;
     editorRef: React.RefObject<Editor>;
     disabled?: boolean;


### PR DESCRIPTION
The `setEditorState` function as incorrectly assumed to be a React state setter function. This lead to issues when the RTE's `onChange` handler was not a React state. To fix this, the typing and usage of the `setEditorState` function has been changed to a "regular" change handler.