### PR TITLE
Fix pasting external links into rich text block

### DIFF
--- a/demo/admin/src/common/blocks/LinkBlock.tsx
+++ b/demo/admin/src/common/blocks/LinkBlock.tsx
@@ -1,12 +1,6 @@
-import { BlockInterface, createOneOfBlock } from "@comet/blocks-admin";
-import { ExternalLinkBlock, InternalLinkBlock } from "@comet/cms-admin";
+import { createLinkBlock, ExternalLinkBlock, InternalLinkBlock } from "@comet/cms-admin";
 import { NewsLinkBlock } from "@src/news/blocks/NewsLinkBlock";
-import * as React from "react";
-import { FormattedMessage } from "react-intl";
 
-export const LinkBlock: BlockInterface = createOneOfBlock({
+export const LinkBlock = createLinkBlock({
     supportedBlocks: { internal: InternalLinkBlock, external: ExternalLinkBlock, news: NewsLinkBlock },
-    name: "Link",
-    displayName: <FormattedMessage id="comet.blocks.link" defaultMessage="Link" />,
-    allowEmpty: false,
 });

--- a/demo/admin/src/news/blocks/NewsLinkBlock.tsx
+++ b/demo/admin/src/news/blocks/NewsLinkBlock.tsx
@@ -1,9 +1,11 @@
 import { Field, FinalFormInput } from "@comet/admin";
-import { BlockInterface, BlocksFinalForm, createBlockSkeleton } from "@comet/blocks-admin";
+import { BlockInterface, BlocksFinalForm, createBlockSkeleton, LinkBlockInterface } from "@comet/blocks-admin";
 import { NewsLinkBlockData, NewsLinkBlockInput } from "@src/blocks.generated";
 import * as React from "react";
 
-const NewsLinkBlock: BlockInterface<NewsLinkBlockData, NewsLinkBlockData, NewsLinkBlockInput> = {
+type State = NewsLinkBlockData;
+
+const NewsLinkBlock: BlockInterface<NewsLinkBlockData, State, NewsLinkBlockInput> & LinkBlockInterface<State> = {
     ...createBlockSkeleton(),
 
     name: "NewsLink",

--- a/packages/admin/admin-rte/src/core/Rte.tsx
+++ b/packages/admin/admin-rte/src/core/Rte.tsx
@@ -13,7 +13,7 @@ import {
     getDefaultKeyBinding,
     RichUtils,
 } from "draft-js";
-import { handleDraftEditorPastedText, onDraftEditorCopy, onDraftEditorCut } from "draftjs-conductor";
+import { onDraftEditorCopy, onDraftEditorCut } from "draftjs-conductor";
 import * as React from "react";
 
 import Controls from "./Controls/Controls";
@@ -25,6 +25,7 @@ import removeBlocksExceedingBlockLimit from "./filterEditor/removeBlocksExceedin
 import { CustomInlineStyles, IBlocktypeMap, ICustomBlockTypeMap_Deprecated, ToolbarButtonComponent } from "./types";
 import createBlockRenderMap from "./utils/createBlockRenderMap";
 import getRteTheme from "./utils/getRteTheme";
+import { pasteAndFilterText } from "./utils/pasteAndFilterText";
 
 const mandatoryFilterEditorStateFn = composeFilterEditorFns([removeBlocksExceedingBlockLimit, manageDefaultBlockType]);
 
@@ -58,7 +59,15 @@ export interface IRteOptions {
     draftJsProps: Partial<
         Pick<
             DraftJsEditorProps,
-            "placeholder" | "autoComplete" | "autoCorrect" | "readOnly" | "spellCheck" | "stripPastedStyles" | "tabIndex" | "editorKey"
+            | "placeholder"
+            | "autoComplete"
+            | "autoCorrect"
+            | "readOnly"
+            | "spellCheck"
+            | "stripPastedStyles"
+            | "tabIndex"
+            | "editorKey"
+            | "handlePastedText"
         >
     >;
     filterEditorStateBeforeUpdate?: FilterEditorStateBeforeUpdateFn;
@@ -95,7 +104,7 @@ export interface RteProps {
     };
 }
 
-const defaultOptions: IRteOptions = {
+export const defaultOptions: IRteOptions = {
     supports: [
         "bold",
         "italic",
@@ -285,10 +294,9 @@ const Rte: React.RefForwardingComponent<any, RteProps & WithStyles<typeof styles
                     onCopy={onDraftEditorCopy}
                     onCut={onDraftEditorCut}
                     handlePastedText={(text: string, html: string | undefined, editorState: EditorState): DraftHandleValue => {
-                        let nextEditorState = handleDraftEditorPastedText(html, editorState);
+                        const nextEditorState = pasteAndFilterText(html, editorState, options);
 
                         if (nextEditorState) {
-                            nextEditorState = defaultFilterEditorStateBeforeUpdate(nextEditorState, options);
                             decoratedOnChange(nextEditorState);
                             return "handled";
                         }

--- a/packages/admin/admin-rte/src/core/utils/pasteAndFilterText.ts
+++ b/packages/admin/admin-rte/src/core/utils/pasteAndFilterText.ts
@@ -1,0 +1,21 @@
+import { EditorState } from "draft-js";
+import { handleDraftEditorPastedText } from "draftjs-conductor";
+
+import defaultFilterEditorStateBeforeUpdate from "../filterEditor/default";
+import { defaultOptions, IOptions } from "../Rte";
+
+function pasteAndFilterText(
+    html: string | undefined,
+    editorState: EditorState,
+    options: Pick<IOptions, "supports" | "listLevelMax" | "maxBlocks" | "standardBlockType">,
+): false | EditorState {
+    const nextEditorState = handleDraftEditorPastedText(html, editorState);
+
+    if (nextEditorState) {
+        return defaultFilterEditorStateBeforeUpdate(nextEditorState, { ...defaultOptions, ...options });
+    }
+
+    return false;
+}
+
+export { pasteAndFilterText };

--- a/packages/admin/admin-rte/src/index.ts
+++ b/packages/admin/admin-rte/src/index.ts
@@ -18,5 +18,6 @@ export { FilterEditorStateBeforeUpdateFn, IOptions as IRteOptions, IRteRef, defa
 export { IOptions as IRteReadOnlyOptions, IProps as IRteReadOnlyProps, default as RteReadOnly } from "./core/RteReadOnly";
 export { default as findEntityInCurrentSelection } from "./core/utils/findEntityInCurrentSelection";
 export { default as findTextInCurrentSelection } from "./core/utils/findTextInCurrentSelection";
+export { pasteAndFilterText } from "./core/utils/pasteAndFilterText";
 export { default as selectionIsInOneBlock } from "./core/utils/selectionIsInOneBlock";
 export { default as createFinalFormRte } from "./field/createFinalFormRte";

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -43,7 +43,7 @@ export interface OneOfBlockPreviewState extends PreviewStateInterface {
 }
 
 type BlockType = string;
-interface IBlockFactoryOptions {
+export interface CreateOneOfBlockOptions {
     name: string;
     displayName?: React.ReactNode;
     supportedBlocks: Record<BlockType, BlockInterface>;
@@ -60,7 +60,7 @@ export const createOneOfBlock = ({
     variant = "select",
     allowEmpty = true,
 }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-IBlockFactoryOptions): BlockInterface<OneOfBlockFragment, OneOfBlockState, any, OneOfBlockPreviewState> => {
+CreateOneOfBlockOptions): BlockInterface<OneOfBlockFragment, OneOfBlockState, any, OneOfBlockPreviewState> => {
     function blockForType(type: string): BlockInterface | null {
         return supportedBlocks[type] ?? null;
     }
@@ -207,19 +207,6 @@ IBlockFactoryOptions): BlockInterface<OneOfBlockFragment, OneOfBlockState, any, 
                 }
                 return await block.isValid(c.props);
             }),
-
-        fromRaw: (raw) => {
-            for (const [type, block] of Object.entries(supportedBlocks)) {
-                if (block.fromRaw?.(raw)) {
-                    return {
-                        attachedBlocks: [{ type, props: block.fromRaw(raw) }],
-                        activeType: type,
-                    };
-                }
-            }
-
-            return false;
-        },
 
         definesOwnPadding: true,
 

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -208,6 +208,19 @@ IBlockFactoryOptions): BlockInterface<OneOfBlockFragment, OneOfBlockState, any, 
                 return await block.isValid(c.props);
             }),
 
+        fromRaw: (raw) => {
+            for (const [type, block] of Object.entries(supportedBlocks)) {
+                if (block.fromRaw?.(raw)) {
+                    return {
+                        attachedBlocks: [{ type, props: block.fromRaw(raw) }],
+                        activeType: type,
+                    };
+                }
+            }
+
+            return false;
+        },
+
         definesOwnPadding: true,
 
         AdminComponent: ({ state, updateState }) => {

--- a/packages/admin/blocks-admin/src/blocks/types.tsx
+++ b/packages/admin/blocks-admin/src/blocks/types.tsx
@@ -75,6 +75,7 @@ export interface BlockMethods<
     childBlockCount?: (state: State) => number;
     previewContent: (state: State, context?: BlockContext) => PreviewContent[];
     dynamicDisplayName?: (state: State) => React.ReactNode;
+    fromRaw?: (raw: unknown) => State | false;
 }
 
 export interface AnonymousBlockInterface<

--- a/packages/admin/blocks-admin/src/blocks/types.tsx
+++ b/packages/admin/blocks-admin/src/blocks/types.tsx
@@ -75,7 +75,6 @@ export interface BlockMethods<
     childBlockCount?: (state: State) => number;
     previewContent: (state: State, context?: BlockContext) => PreviewContent[];
     dynamicDisplayName?: (state: State) => React.ReactNode;
-    fromRaw?: (raw: unknown) => State | false;
 }
 
 export interface AnonymousBlockInterface<
@@ -153,3 +152,10 @@ export const blockCategoryLabels = {
     [BlockCategory.Form]: <FormattedMessage id="comet.blocks.category.form" defaultMessage="Form" />,
     [BlockCategory.Other]: <FormattedMessage id="comet.blocks.category.other" defaultMessage="Other" />,
 };
+
+export interface LinkBlockInterface<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    State = any,
+> {
+    url2State?: (url: string) => State | false;
+}

--- a/packages/admin/blocks-admin/src/index.ts
+++ b/packages/admin/blocks-admin/src/index.ts
@@ -19,7 +19,7 @@ export { createColumnsBlock } from "./blocks/factories/createColumnsBlock";
 export { createCompositeBlock } from "./blocks/factories/createCompositeBlock";
 export type { ListBlockFragment, ListBlockState } from "./blocks/factories/createListBlock";
 export { createListBlock } from "./blocks/factories/createListBlock";
-export type { OneOfBlockFragment, OneOfBlockState } from "./blocks/factories/createOneOfBlock";
+export type { CreateOneOfBlockOptions, OneOfBlockFragment, OneOfBlockState } from "./blocks/factories/createOneOfBlock";
 export { createOneOfBlock } from "./blocks/factories/createOneOfBlock";
 export type { OptionalBlockDecoratorFragment, OptionalBlockState } from "./blocks/factories/createOptionalBlock";
 export { createOptionalBlock } from "./blocks/factories/createOptionalBlock";
@@ -41,6 +41,7 @@ export type {
     BlockState,
     DispatchSetStateAction,
     IPreviewContext,
+    LinkBlockInterface,
     PreviewStateInterface,
     RootBlockInterface,
     SetStateAction,

--- a/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
@@ -1,5 +1,5 @@
 import { Field, FinalFormCheckbox, FinalFormInput } from "@comet/admin";
-import { BlockCategory, BlockInterface, BlocksFinalForm, createBlockSkeleton, SelectPreviewComponent } from "@comet/blocks-admin";
+import { BlockCategory, BlockInterface, BlocksFinalForm, createBlockSkeleton, LinkBlockInterface, SelectPreviewComponent } from "@comet/blocks-admin";
 import { FormControlLabel } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
@@ -9,7 +9,7 @@ import { isHref } from "./externalLinkBlock/isHref";
 
 type State = ExternalLinkBlockData;
 
-export const ExternalLinkBlock: BlockInterface<ExternalLinkBlockData, State, ExternalLinkBlockInput> = {
+export const ExternalLinkBlock: BlockInterface<ExternalLinkBlockData, State, ExternalLinkBlockInput> & LinkBlockInterface<State> = {
     ...createBlockSkeleton(),
 
     name: "ExternalLink",
@@ -42,10 +42,10 @@ export const ExternalLinkBlock: BlockInterface<ExternalLinkBlockData, State, Ext
         return state.targetUrl ? isHref(state.targetUrl) : true;
     },
 
-    fromRaw: (raw) => {
-        if (typeof raw === "string" && isHref(raw)) {
+    url2State: (url) => {
+        if (isHref(url)) {
             return {
-                targetUrl: raw,
+                targetUrl: url,
                 openInNewWindow: false,
             };
         }

--- a/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
@@ -42,6 +42,17 @@ export const ExternalLinkBlock: BlockInterface<ExternalLinkBlockData, State, Ext
         return state.targetUrl ? isHref(state.targetUrl) : true;
     },
 
+    fromRaw: (raw) => {
+        if (typeof raw === "string" && isHref(raw)) {
+            return {
+                targetUrl: raw,
+                openInNewWindow: false,
+            };
+        }
+
+        return false;
+    },
+
     AdminComponent: ({ state, updateState }) => {
         return (
             <SelectPreviewComponent>

--- a/packages/admin/cms-admin/src/blocks/InternalLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/InternalLinkBlock.tsx
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 import { Field } from "@comet/admin";
-import { BlockCategory, BlockInterface, BlocksFinalForm, createBlockSkeleton, SelectPreviewComponent } from "@comet/blocks-admin";
+import { BlockCategory, BlockInterface, BlocksFinalForm, createBlockSkeleton, LinkBlockInterface, SelectPreviewComponent } from "@comet/blocks-admin";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -11,7 +11,7 @@ import { CmsBlockContext } from "./CmsBlockContextProvider";
 
 type State = InternalLinkBlockData;
 
-export const InternalLinkBlock: BlockInterface<InternalLinkBlockData, State, InternalLinkBlockInput> = {
+export const InternalLinkBlock: BlockInterface<InternalLinkBlockData, State, InternalLinkBlockInput> & LinkBlockInterface<State> = {
     ...createBlockSkeleton(),
 
     name: "InternalLink",

--- a/packages/admin/cms-admin/src/blocks/createLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createLinkBlock.tsx
@@ -1,0 +1,43 @@
+import { BlockInterface, createOneOfBlock, CreateOneOfBlockOptions, LinkBlockInterface } from "@comet/blocks-admin";
+import * as React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { ExternalLinkBlock } from "./ExternalLinkBlock";
+import { InternalLinkBlock } from "./InternalLinkBlock";
+
+interface CreateLinkBlockOptions extends Omit<CreateOneOfBlockOptions, "name" | "supportedBlocks"> {
+    name?: string;
+    supportedBlocks?: Record<string, BlockInterface & LinkBlockInterface>;
+}
+
+function createLinkBlock({
+    name = "Link",
+    displayName = <FormattedMessage id="comet.blocks.link" defaultMessage="Link" />,
+    supportedBlocks = { internal: InternalLinkBlock, external: ExternalLinkBlock },
+    allowEmpty = false,
+    ...oneOfBlockOptions
+}: CreateLinkBlockOptions): BlockInterface & LinkBlockInterface {
+    return {
+        ...createOneOfBlock({
+            name,
+            displayName,
+            supportedBlocks,
+            allowEmpty,
+            ...oneOfBlockOptions,
+        }),
+        url2State: (url) => {
+            for (const [type, block] of Object.entries(supportedBlocks)) {
+                if (block.url2State?.(url)) {
+                    return {
+                        attachedBlocks: [{ type, props: block.url2State(url) }],
+                        activeType: type,
+                    };
+                }
+            }
+
+            return false;
+        },
+    };
+}
+
+export { createLinkBlock };

--- a/packages/admin/cms-admin/src/blocks/createRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createRichTextBlock.tsx
@@ -1,6 +1,15 @@
-import { IRteOptions, makeRteApi, Rte } from "@comet/admin-rte";
+import { IRteOptions, makeRteApi, pasteAndFilterText, Rte } from "@comet/admin-rte";
 import { BlockCategory, BlockInterface, createBlockSkeleton, SelectPreviewComponent } from "@comet/blocks-admin";
-import { convertFromRaw, convertToRaw, EditorState, RawDraftContentState } from "draft-js";
+import {
+    BlockMapBuilder,
+    convertFromHTML,
+    convertFromRaw,
+    convertToRaw,
+    EditorState,
+    EntityInstance,
+    Modifier,
+    RawDraftContentState,
+} from "draft-js";
 import isEqual from "lodash.isequal";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
@@ -179,7 +188,54 @@ export const createRichTextBlock = (
                 <SelectPreviewComponent>
                     <Rte
                         minHeight={options.minHeight}
-                        options={rteOptions}
+                        options={{
+                            ...rteOptions,
+                            draftJsProps: {
+                                ...rteOptions.draftJsProps,
+                                handlePastedText: (text, html, editorState) => {
+                                    const nextEditorState = pasteAndFilterText(html, editorState, rteOptions);
+
+                                    if (nextEditorState) {
+                                        // Paste is from one Draft.js instance to another -> update directly
+                                        updateState({ editorState: nextEditorState });
+                                        return "handled";
+                                    }
+
+                                    // Pasted text comes from an external source, e.g. a Word document
+                                    if (html !== undefined) {
+                                        const { contentBlocks } = convertFromHTML(html);
+
+                                        let nextContent = Modifier.replaceWithFragment(
+                                            state.editorState.getCurrentContent(),
+                                            state.editorState.getSelection(),
+                                            BlockMapBuilder.createFromArray(contentBlocks),
+                                        );
+
+                                        const entities = (nextContent.getEntityMap().__getAll() as Immutable.Map<string, EntityInstance>).entries();
+
+                                        // @ts-expect-error Immutable.Map#entries is iterable, but missing [Symbol.iterator]()
+                                        for (const [key, entity] of entities) {
+                                            if (entity.getType() === "LINK") {
+                                                const data = entity.getData();
+
+                                                if (typeof data.url === "string") {
+                                                    const stateFromRaw = LinkBlock.fromRaw?.(data.url);
+
+                                                    nextContent = nextContent.replaceEntityData(key, stateFromRaw || LinkBlock.defaultValues());
+                                                }
+                                            }
+                                        }
+
+                                        const newEditorState = EditorState.push(state.editorState, nextContent, "insert-fragment");
+
+                                        updateState({ editorState: newEditorState });
+                                        return "handled";
+                                    }
+
+                                    return "not-handled";
+                                },
+                            },
+                        }}
                         value={state.editorState}
                         onChange={(c: EditorState) => {
                             updateState((prevState) => ({

--- a/packages/admin/cms-admin/src/blocks/createRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createRichTextBlock.tsx
@@ -1,5 +1,5 @@
 import { IRteOptions, makeRteApi, pasteAndFilterText, Rte } from "@comet/admin-rte";
-import { BlockCategory, BlockInterface, createBlockSkeleton, SelectPreviewComponent } from "@comet/blocks-admin";
+import { BlockCategory, BlockInterface, createBlockSkeleton, LinkBlockInterface, SelectPreviewComponent } from "@comet/blocks-admin";
 import {
     BlockMapBuilder,
     convertFromHTML,
@@ -90,7 +90,7 @@ async function mapLinkEntitiesDataAsync(rawContent: RawDraftContentState, fn: (l
 }
 
 export interface RichTextBlockFactoryOptions {
-    link: BlockInterface;
+    link: BlockInterface & LinkBlockInterface;
     rte?: IRteOptions;
     minHeight?: number;
 }
@@ -219,9 +219,10 @@ export const createRichTextBlock = (
                                                 const data = entity.getData();
 
                                                 if (typeof data.url === "string") {
-                                                    const stateFromRaw = LinkBlock.fromRaw?.(data.url);
-
-                                                    nextContent = nextContent.replaceEntityData(key, stateFromRaw || LinkBlock.defaultValues());
+                                                    nextContent = nextContent.replaceEntityData(
+                                                        key,
+                                                        LinkBlock.url2State?.(data.url) || LinkBlock.defaultValues(),
+                                                    );
                                                 }
                                             }
                                         }

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -1,5 +1,6 @@
 export { CmsBlockContext, CmsBlockContextProvider } from "./blocks/CmsBlockContextProvider";
 export { createImageLinkBlock } from "./blocks/createImageLinkBlock";
+export { createLinkBlock } from "./blocks/createLinkBlock";
 export type { RichTextBlockFactoryOptions } from "./blocks/createRichTextBlock";
 export { createRichTextBlock, isRichTextEmpty, isRichTextEqual } from "./blocks/createRichTextBlock";
 export { createSeoBlock } from "./blocks/createSeoBlock";


### PR DESCRIPTION
The rich text block would fail when a link is pasted from an external source (e.g. a Word document), because the pasted link does not match the link block's state. To fix this, we implement a custom paste handler that converts the "raw" external links into external link blocks.