### PR TITLE
Add idempotent copy and paste between RTEs

### DIFF
--- a/packages/admin/admin-rte/package.json
+++ b/packages/admin/admin-rte/package.json
@@ -12,7 +12,8 @@
         "directory": "packages/admin/admin-rte"
     },
     "dependencies": {
-        "detect-browser": "^5.2.1"
+        "detect-browser": "^5.2.1",
+        "draftjs-conductor": "^3.0.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.17.6",

--- a/packages/admin/admin-rte/src/core/Rte.tsx
+++ b/packages/admin/admin-rte/src/core/Rte.tsx
@@ -5,6 +5,7 @@ import { createStyles, WithStyles, withStyles } from "@mui/styles";
 import {
     DraftBlockType,
     DraftEditorCommand,
+    DraftHandleValue,
     DraftStyleMap,
     Editor as DraftJsEditor,
     EditorProps as DraftJsEditorProps,
@@ -12,6 +13,7 @@ import {
     getDefaultKeyBinding,
     RichUtils,
 } from "draft-js";
+import { handleDraftEditorPastedText, onDraftEditorCopy, onDraftEditorCut } from "draftjs-conductor";
 import * as React from "react";
 
 import Controls from "./Controls/Controls";
@@ -279,6 +281,20 @@ const Rte: React.RefForwardingComponent<any, RteProps & WithStyles<typeof styles
                     keyBindingFn={keyBindingFn}
                     customStyleMap={customStyleMap}
                     blockRenderMap={blockRenderMap}
+                    // @ts-expect-error the onCopy and onPaste APIs are not exposed publicly
+                    onCopy={onDraftEditorCopy}
+                    onCut={onDraftEditorCut}
+                    handlePastedText={(text: string, html: string | undefined, editorState: EditorState): DraftHandleValue => {
+                        let nextEditorState = handleDraftEditorPastedText(html, editorState);
+
+                        if (nextEditorState) {
+                            nextEditorState = defaultFilterEditorStateBeforeUpdate(nextEditorState, options);
+                            decoratedOnChange(nextEditorState);
+                            return "handled";
+                        }
+
+                        return "not-handled";
+                    }}
                     {...options.draftJsProps}
                 />
             </div>

--- a/packages/admin/admin-rte/src/core/filterEditor/default.ts
+++ b/packages/admin/admin-rte/src/core/filterEditor/default.ts
@@ -1,11 +1,17 @@
 import { FilterEditorStateBeforeUpdateFn } from "../Rte";
 import composeFilterEditorFns from "./composeFilterEditorFns";
+import removeBlocksExceedingBlockLimit from "./removeBlocksExceedingBlockLimit";
 import removeUnsupportedBlockTypes from "./removeUnsupportedBlockTypes";
 import removeUnsupportedEntities from "./removeUnsupportedEntities";
 import removeUnsupportedInlineStyles from "./removeUnsupportedInlineStyles";
 
 const defaultFilterEditorStateBeforeUpdate: FilterEditorStateBeforeUpdateFn = (newState, ctx) => {
-    const fns: FilterEditorStateBeforeUpdateFn[] = [removeUnsupportedEntities, removeUnsupportedBlockTypes, removeUnsupportedInlineStyles];
+    const fns: FilterEditorStateBeforeUpdateFn[] = [
+        removeUnsupportedEntities,
+        removeUnsupportedBlockTypes,
+        removeUnsupportedInlineStyles,
+        removeBlocksExceedingBlockLimit,
+    ];
 
     const shouldFilter = newState.getLastChangeType() === "insert-fragment";
     if (shouldFilter) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3485,6 +3485,7 @@ __metadata:
     "@types/draft-js": ^0.10.38
     "@types/immutable": ^3.8.7
     detect-browser: ^5.2.1
+    draftjs-conductor: ^3.0.0
     eslint: ^8.0.0
     prettier: ^2.0.0
     rimraf: ^3.0.2
@@ -16594,6 +16595,15 @@ __metadata:
     react: ">=0.14.0"
     react-dom: ">=0.14.0"
   checksum: b6d127a5e22838d3d43e736762c689c8d67dc632e9eb53b025c2d9504f892bcd0e05c8137f63051ae7b6ecb8b722c8f3923a13453583023e85b999cc0f6f93f7
+  languageName: node
+  linkType: hard
+
+"draftjs-conductor@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "draftjs-conductor@npm:3.0.0"
+  peerDependencies:
+    draft-js: ^0.10.4 || ^0.11.0 || ^0.12.0
+  checksum: e60aa32cce46a8104572d9508e2c07a7ffa2a5ebd00d8893b12ac0967677f7471e41a7fd6edea5235bf1792aada36ac2b7cef2e777ca03f9600850bcb89e7735
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Previously, some formatting and entities (e.g. a link) were lost when copying text between two RTEs. This is due to draft-js using a HTML representation of the content internally when copying and pasting. To enable idempotent copy and paste between RTEs, we now use the `draftjs-conductor` library that enhances the copied content to keep formatting and entities. Furthermore, we filter the pasted content to ensure that only supported features (styles and entities) are kept when pasting.

https://user-images.githubusercontent.com/48853629/182336578-774e73ad-237e-42bb-ab77-fc08ebe6e6a3.mov


