### PR TITLE
Set the default fontSize on fontSizeMedium

### DIFF
--- a/packages/admin/admin-theme/src/componentsTheme/MuiSvgIcon.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSvgIcon.ts
@@ -4,14 +4,15 @@ import { GetMuiComponentTheme } from "./getComponentsTheme";
 export const getMuiSvgIcon: GetMuiComponentTheme<"MuiSvgIcon"> = (component, { palette }) => ({
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiSvgIcon">(component?.styleOverrides, {
-        root: {
-            fontSize: 16,
-        },
+        root: {},
         colorDisabled: {
             color: palette.grey[200],
         },
         fontSizeSmall: {
             fontSize: 10,
+        },
+        fontSizeMedium: {
+            fontSize: 16,
         },
         fontSizeLarge: {
             fontSize: 20,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiSvgIcon.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSvgIcon.ts
@@ -11,6 +11,7 @@ export const getMuiSvgIcon: GetMuiComponentTheme<"MuiSvgIcon"> = (component, { p
         fontSizeSmall: {
             fontSize: 10,
         },
+        // @ts-expect-error The type for `fontSizeMedium` is missing, but the class exsits.
         fontSizeMedium: {
             fontSize: 16,
         },


### PR DESCRIPTION
This prevents overriding values from other classes, e.g. "fontSizeInherit".