### PR TITLE
fix spelling of acronyms

### DIFF
--- a/packages/admin/admin-rte/src/core/extension/Link/ToolbarButton.tsx
+++ b/packages/admin/admin-rte/src/core/extension/Link/ToolbarButton.tsx
@@ -100,7 +100,7 @@ function LinkDialog(props: {
             <DialogContent>
                 <FormControl fullWidth>
                     <FormLabel>
-                        <FormattedMessage id="comet.rte.extensions.link.url" defaultMessage="Url" />
+                        <FormattedMessage id="comet.rte.extensions.link.url" defaultMessage="URL" />
                     </FormLabel>
                     <InputBase
                         // autoFocus

--- a/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
+++ b/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
@@ -60,7 +60,7 @@ const styles = () => {
 };
 
 function OkayBtn({
-    children = <FormattedMessage id="comet.generic.ok" defaultMessage="Ok" />,
+    children = <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />,
     startIcon = <Check />,
     color = "primary",
     variant = "contained",

--- a/packages/admin/admin/src/error/errordialog/ErrorDialog.tsx
+++ b/packages/admin/admin/src/error/errordialog/ErrorDialog.tsx
@@ -65,7 +65,7 @@ export const ErrorDialog: React.FunctionComponent<ErrorDialogProps> = ({ show = 
             </DialogContent>
             <DialogActions>
                 <Button onClick={onCloseClicked} color="primary" variant="contained">
-                    <FormattedMessage id="comet.generic.ok" defaultMessage="Ok" />
+                    <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/admin/blocks-admin/src/clipboard/CannotPasteBlockDialog.tsx
+++ b/packages/admin/blocks-admin/src/clipboard/CannotPasteBlockDialog.tsx
@@ -17,7 +17,7 @@ function CannotPasteBlockDialog({ open, onClose, error }: Props): React.ReactEle
             <DialogContent>{error}</DialogContent>
             <DialogActions>
                 <Button onClick={onClose} color="info">
-                    <FormattedMessage id="comet.generic.ok" defaultMessage="Ok" />
+                    <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/admin/cms-admin/src/blocks/createSeoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createSeoBlock.tsx
@@ -51,7 +51,7 @@ export function createSeoBlock({ image = PixelImageBlock }: CreateSeoBlockOption
         ...block,
         name: "Seo",
 
-        displayName: <FormattedMessage id="comet.blocks.seo" defaultMessage="Seo" />,
+        displayName: <FormattedMessage id="comet.blocks.seo" defaultMessage="SEO" />,
 
         AdminComponent: ({ state, updateState }) => {
             const intl = useIntl();

--- a/packages/admin/cms-admin/src/blocks/rte/extension/CmsLink/createCmsLinkToolbarButton.tsx
+++ b/packages/admin/cms-admin/src/blocks/rte/extension/CmsLink/createCmsLinkToolbarButton.tsx
@@ -137,7 +137,7 @@ export function createCmsLinkToolbarButton({ link: LinkBlock }: CreateCmsLinkToo
                         </Button>
                     )}
                     <Button onClick={handleUpdate} color="primary">
-                        <FormattedMessage id="comet.generic.ok" defaultMessage="Ok" />
+                        <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />
                     </Button>
                     <Button onClick={handleClose} color="primary">
                         <FormattedMessage id="comet.generic.cancel" defaultMessage="Cancel" />

--- a/packages/admin/cms-admin/src/dam/Table/fileUpload/FileUploadErrorDialog.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/fileUpload/FileUploadErrorDialog.tsx
@@ -97,7 +97,7 @@ export const FileUploadErrorDialog = ({ open = false, onClose, validationErrors 
             </DialogContent>
             <DialogActions>
                 <Button variant="contained" color="primary" onClick={onClose}>
-                    <FormattedMessage id="comet.generic.ok" defaultMessage="Ok" />
+                    <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/admin/cms-admin/src/pages/pageTree/PageContextMenu.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageContextMenu.tsx
@@ -124,7 +124,7 @@ const PageContextMenu = (props: PageContextMenuProps): React.ReactElement => {
                         <ListItemIcon>
                             <Domain />
                         </ListItemIcon>
-                        <ListItemText primary={intl.formatMessage({ id: "comet.pages.pages.page.copyUrl", defaultMessage: "Copy Url" })} />
+                        <ListItemText primary={intl.formatMessage({ id: "comet.pages.pages.page.copyUrl", defaultMessage: "Copy URL" })} />
                     </MenuItem>,
                     <MenuItemSeparator key="separator2" />,
                     <MenuItem


### PR DESCRIPTION
- Acronyms should be spelled UPPERCASE (e.g. see https://www.grammarly.com/blog/abbreviations/)
- OK is the preferred spelling (https://en.wikipedia.org/wiki/OK#Computers)