### PR TITLE
Reset final-form to current (submitted) values to avoid dirty flag after submit

### DIFF
--- a/packages/admin/admin-stories/src/admin/form/DisabledSubmitIfNotDirty.tsx
+++ b/packages/admin/admin-stories/src/admin/form/DisabledSubmitIfNotDirty.tsx
@@ -1,0 +1,28 @@
+import { Field, FinalForm, FinalFormInput, FormSection, SaveButton } from "@comet/admin";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { apolloStoryDecorator } from "../../apollo-story.decorator";
+
+storiesOf("stories/form/FinalForm", module)
+    .addDecorator(apolloStoryDecorator())
+    .add("Disabled Submit If Not Dirty", () => {
+        return (
+            <FinalForm
+                mode="add"
+                onSubmit={async (values) => {
+                    window.alert(JSON.stringify(values));
+                }}
+            >
+                {({ dirty }) => (
+                    <>
+                        <FormSection>
+                            <Field label="First name" name="firstname" component={FinalFormInput} fullWidth />
+                            <Field label="Last name" name="lastname" component={FinalFormInput} fullWidth />
+                        </FormSection>
+                        <SaveButton type="submit" disabled={!dirty} />
+                    </>
+                )}
+            </FinalForm>
+        );
+    });

--- a/packages/admin/admin/src/FinalForm.tsx
+++ b/packages/admin/admin/src/FinalForm.tsx
@@ -183,8 +183,6 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                 // setTimeout is required because of https://github.com/final-form/final-form/pull/229
                 setTimeout(() => {
                     if (props.mode === "add") {
-                        form.reset(); // reset form to initial values so it is not dirty anymore (needed when adding)
-
                         if (tableQuery) {
                             // refetch TableQuery after adding
                             client.query({
@@ -203,6 +201,7 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                 (data) => {
                     // for final-form undefined means success, an obj means error
                     editDialogFormApi?.resetFormStatus();
+                    form.reset(values);
                     return undefined;
                 },
                 (error) => {


### PR DESCRIPTION
Needed if submit button should be disabled when form is not dirty