### PR TITLE
Add new sort api in demo that allows multiple sort fields and is typed 2/3

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -280,7 +280,7 @@ type Query {
   damFolderByNameAndParentId(name: String!, parentId: ID): DamFolder
   news(id: ID!): News
   newsBySlug(slug: String!): News
-  newsList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, query: String, category: NewsCategory, scope: NewsContentScopeInput!): PaginatedNews!
+  newsList(offset: Int = 0, limit: Int = 20, query: String, category: NewsCategory, scope: NewsContentScopeInput!, sort: [NewsSortField!]): PaginatedNews!
   mainMenu(scope: PageTreeNodeScopeInput!): MainMenu!
   topMenu(scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
   mainMenuItem(pageTreeNodeId: ID!): MainMenuItem!
@@ -307,6 +307,23 @@ input FileFilterInput {
 
 input FolderFilterInput {
   searchText: String
+}
+
+enum NewsSortField {
+  Title_ASC
+  Title_DESC
+  Slug_ASC
+  Slug_DESC
+  Category_ASC
+  Category_DESC
+  Date_ASC
+  Date_DESC
+  Visible_ASC
+  Visible_DESC
+  UpdatedAt_ASC
+  UpdatedAt_DESC
+  CreatedAt_ASC
+  CreatedAt_DESC
 }
 
 type Mutation {

--- a/demo/api/src/news/dto/news-list.args.ts
+++ b/demo/api/src/news/dto/news-list.args.ts
@@ -1,12 +1,32 @@
-import { OffsetBasedPaginationArgs, SortArgs } from "@comet/cms-api";
-import { ArgsType, Field, IntersectionType } from "@nestjs/graphql";
+import { OffsetBasedPaginationArgs } from "@comet/cms-api";
+import { ArgsType, Field, registerEnumType } from "@nestjs/graphql";
 import { Type } from "class-transformer";
 import { IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
 
 import { NewsCategory, NewsContentScope } from "../entities/news.entity";
 
+export enum NewsSortField {
+    Title_ASC = "Title_ASC",
+    Title_DESC = "Title_DESC",
+    Slug_ASC = "Slug_ASC",
+    Slug_DESC = "Slug_DESC",
+    Category_ASC = "Category_ASC",
+    Category_DESC = "Category_DESC",
+    Date_ASC = "Date_ASC",
+    Date_DESC = "Date_DESC",
+    Visible_ASC = "Visible_ASC",
+    Visible_DESC = "Visible_DESC",
+    UpdatedAt_ASC = "UpdatedAt_ASC",
+    UpdatedAt_DESC = "UpdatedAt_DESC",
+    CreatedAt_ASC = "CreatedAt_ASC",
+    CreatedAt_DESC = "CreatedAt_DESC",
+}
+registerEnumType(NewsSortField, {
+    name: "NewsSortField",
+});
+
 @ArgsType()
-export class NewsListArgs extends IntersectionType(OffsetBasedPaginationArgs, SortArgs) {
+export class NewsListArgs extends OffsetBasedPaginationArgs {
     @Field(() => String, { nullable: true })
     @IsString()
     @IsOptional()
@@ -21,4 +41,8 @@ export class NewsListArgs extends IntersectionType(OffsetBasedPaginationArgs, So
     @Type(() => NewsContentScope)
     @ValidateNested()
     scope: NewsContentScope;
+
+    @Field(() => [NewsSortField], { nullable: true })
+    @IsEnum(NewsSortField, { each: true })
+    sort: NewsSortField[];
 }

--- a/demo/api/src/news/news.resolver.ts
+++ b/demo/api/src/news/news.resolver.ts
@@ -29,12 +29,26 @@ export class NewsResolver {
 
     @Query(() => PaginatedNews)
     @PublicApi()
-    async newsList(@Args() { scope, query, category, offset, limit, sortColumnName, sortDirection, ...args }: NewsListArgs): Promise<PaginatedNews> {
+    async newsList(@Args() { scope, query, category, offset, limit, sort, ...args }: NewsListArgs): Promise<PaginatedNews> {
         const where: FilterQuery<News> = { scope };
         if (query) where.title = { $ilike: `%${query}%` };
         const options: FindOptions<News> = { offset, limit };
-        if (sortColumnName) {
-            options.orderBy = { [sortColumnName]: sortDirection };
+        if (sort) {
+            options.orderBy = sort.map((sortItem) => {
+                if (sortItem.endsWith("_ASC")) {
+                    const field = sortItem.charAt(0).toLowerCase() + sortItem.slice(1, -4);
+                    return {
+                        [field]: "ASC",
+                    };
+                } else if (sortItem.endsWith("_DESC")) {
+                    const field = sortItem.charAt(0).toLowerCase() + sortItem.slice(1, -5);
+                    return {
+                        [field]: "DESC",
+                    };
+                } else {
+                    return {};
+                }
+            });
         }
 
         if (category) where.category = category;


### PR DESCRIPTION
Alternative to #734 and #736

example query:
```
query {
  newsList(scope: { domain: "de", language: "de" }, sort: [ Visible_DESC ] ) {
    nodes {
      id
    }
  }
}
```