### PR TITLE
Add new sort api in demo that allows multiple sort fields and is typed 3/3

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -280,7 +280,7 @@ type Query {
   damFolderByNameAndParentId(name: String!, parentId: ID): DamFolder
   news(id: ID!): News
   newsBySlug(slug: String!): News
-  newsList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, query: String, category: NewsCategory, scope: NewsContentScopeInput!): PaginatedNews!
+  newsList(offset: Int = 0, limit: Int = 20, query: String, category: NewsCategory, scope: NewsContentScopeInput!, sort: [NewsSort!]): PaginatedNews!
   mainMenu(scope: PageTreeNodeScopeInput!): MainMenu!
   topMenu(scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
   mainMenuItem(pageTreeNodeId: ID!): MainMenuItem!
@@ -307,6 +307,16 @@ input FileFilterInput {
 
 input FolderFilterInput {
   searchText: String
+}
+
+input NewsSort {
+  title: SortDirection
+  slug: SortDirection
+  category: SortDirection
+  date: SortDirection
+  visible: SortDirection
+  updatedAt: SortDirection
+  createdAt: SortDirection
 }
 
 type Mutation {

--- a/demo/api/src/news/dto/news-list.args.ts
+++ b/demo/api/src/news/dto/news-list.args.ts
@@ -1,12 +1,50 @@
-import { OffsetBasedPaginationArgs, SortArgs } from "@comet/cms-api";
-import { ArgsType, Field, IntersectionType } from "@nestjs/graphql";
+import { OffsetBasedPaginationArgs, SortDirection } from "@comet/cms-api";
+import { ArgsType, Field, InputType } from "@nestjs/graphql";
 import { Type } from "class-transformer";
 import { IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
 
 import { NewsCategory, NewsContentScope } from "../entities/news.entity";
 
+@InputType()
+export class NewsSort {
+    @Field(() => SortDirection, { nullable: true })
+    @IsEnum(SortDirection)
+    @IsOptional()
+    title: SortDirection;
+
+    @Field(() => SortDirection, { nullable: true })
+    @IsEnum(SortDirection)
+    @IsOptional()
+    slug: SortDirection;
+
+    @Field(() => SortDirection, { nullable: true })
+    @IsEnum(SortDirection)
+    @IsOptional()
+    category: SortDirection;
+
+    @Field(() => SortDirection, { nullable: true })
+    @IsEnum(SortDirection)
+    @IsOptional()
+    date: SortDirection;
+
+    @Field(() => SortDirection, { nullable: true })
+    @IsEnum(SortDirection)
+    @IsOptional()
+    visible: SortDirection;
+
+    @Field(() => SortDirection, { nullable: true })
+    @IsEnum(SortDirection)
+    @IsOptional()
+    updatedAt: SortDirection;
+
+    @Field(() => SortDirection, { nullable: true })
+    @IsEnum(SortDirection)
+    @IsOptional()
+    createdAt: SortDirection;
+}
+
 @ArgsType()
-export class NewsListArgs extends IntersectionType(OffsetBasedPaginationArgs, SortArgs) {
+export class NewsListArgs extends OffsetBasedPaginationArgs {
     @Field(() => String, { nullable: true })
     @IsString()
     @IsOptional()
@@ -21,4 +59,9 @@ export class NewsListArgs extends IntersectionType(OffsetBasedPaginationArgs, So
     @Type(() => NewsContentScope)
     @ValidateNested()
     scope: NewsContentScope;
+
+    @Field(() => [NewsSort], { nullable: true })
+    @Type(() => NewsSort)
+    @ValidateNested({ each: true })
+    sort: NewsSort[];
 }

--- a/demo/api/src/news/news.resolver.ts
+++ b/demo/api/src/news/news.resolver.ts
@@ -29,12 +29,16 @@ export class NewsResolver {
 
     @Query(() => PaginatedNews)
     @PublicApi()
-    async newsList(@Args() { scope, query, category, offset, limit, sortColumnName, sortDirection, ...args }: NewsListArgs): Promise<PaginatedNews> {
+    async newsList(@Args() { scope, query, category, offset, limit, sort, ...args }: NewsListArgs): Promise<PaginatedNews> {
         const where: FilterQuery<News> = { scope };
         if (query) where.title = { $ilike: `%${query}%` };
         const options: FindOptions<News> = { offset, limit };
-        if (sortColumnName) {
-            options.orderBy = { [sortColumnName]: sortDirection };
+        if (sort) {
+            options.orderBy = sort.map((sortItem) => {
+                return Object.entries(sortItem).reduce((acc, [field, direction]) => {
+                    return { ...acc, [field]: direction };
+                }, {});
+            });
         }
 
         if (category) where.category = category;


### PR DESCRIPTION
Alternative to #734 and #735

example query:
```
query {
  newsList(scope: { domain: "de", language: "de" }, sort: [ {visible: DESC} ] ) {
    nodes {
      id
    }
  }
}
```