### PR TITLE
Make breadcrumbs responsive using an overflow menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Changes
 
--   EditDialog now displays loading and error states of a contained form automatically via its SaveButton
+-   EditDialog now displays loading and error states of a contained form automatically via its SaveButton.
+-   StackBreadcrumbs have a new design and show an overflow menu when the items don't fit into a single line.
 
 ### Incompatible Changes
 

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -20,6 +20,7 @@
         "lodash.debounce": "^4.0.8",
         "lodash.isequal": "^4.5.0",
         "query-string": "^6.8.1",
+        "react-resize-aware": "^3.1.1",
         "use-constant": "^1.0.0",
         "uuid": "^3.3.2"
     },

--- a/packages/admin/admin/src/stack/breadcrumbs/BreadcrumbLink.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/BreadcrumbLink.tsx
@@ -1,0 +1,6 @@
+import * as React from "react";
+import { Link as RouterLink, LinkProps as RouterLinkProps } from "react-router-dom";
+
+export const BreadcrumbLink = React.forwardRef<HTMLAnchorElement, RouterLinkProps>(({ href, to, ...rest }, ref) => (
+    <RouterLink innerRef={ref} to={to ?? href} {...rest} />
+));

--- a/packages/admin/admin/src/stack/breadcrumbs/BreadcrumbOverflow.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/BreadcrumbOverflow.tsx
@@ -1,0 +1,42 @@
+import { ChevronRight } from "@comet/admin-icons";
+import { Link, ListItemIcon, ListItemText, Menu, MenuItem } from "@mui/material";
+import { WithStyles } from "@mui/styles";
+import clsx from "clsx";
+import * as React from "react";
+
+import { BreadcrumbItem } from "../Stack";
+import { BreadcrumbLink } from "./BreadcrumbLink";
+import { styles } from "./StackBreadcrumbs.styles";
+
+interface Props {
+    items: BreadcrumbItem[];
+}
+
+// This must return an HTML element, as MuiBreadcrumbs cannot handle fragments.
+export const BreadcrumbOverflow = ({ items, classes }: Props & WithStyles<typeof styles>): React.ReactElement => {
+    const [showOverflowMenu, setShowOverflowMenu] = React.useState<boolean>(false);
+    const overflowLinkRef = React.useRef<HTMLAnchorElement>(null);
+
+    return (
+        <span>
+            <Link
+                ref={overflowLinkRef}
+                onClick={() => setShowOverflowMenu(true)}
+                className={clsx(classes.link, classes.overflowLink)}
+                variant="body2"
+            >
+                ...
+            </Link>
+            <Menu open={showOverflowMenu} onClose={() => setShowOverflowMenu(false)} anchorEl={overflowLinkRef.current}>
+                {items.map(({ id, url, title }) => (
+                    <MenuItem key={id} component={BreadcrumbLink} to={url} onClick={() => setShowOverflowMenu(false)}>
+                        <ListItemIcon>
+                            <ChevronRight />
+                        </ListItemIcon>
+                        <ListItemText primary={title} />
+                    </MenuItem>
+                ))}
+            </Menu>
+        </span>
+    );
+};

--- a/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.styles.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.styles.tsx
@@ -4,36 +4,60 @@ import { createStyles } from "@mui/styles";
 
 import { StackBreadcrumbsProps } from "./StackBreadcrumbs";
 
-export type StackBreadcrumbsClassKey = BreadcrumbsClassKey | "link" | "last";
+export type StackBreadcrumbsClassKey =
+    | BreadcrumbsClassKey
+    | "breadcrumbs"
+    | "backAndFirstLinkContainer"
+    | "backButton"
+    | "backButtonSeparator"
+    | "link"
+    | "overflowLink"
+    | "lastLink";
 
-export const styles = ({ palette }: Theme) => {
+export const styles = ({ palette, spacing, typography }: Theme) => {
     return createStyles<StackBreadcrumbsClassKey, StackBreadcrumbsProps>({
         root: {
-            paddingTop: 30,
-            paddingBottom: 30,
+            position: "relative",
         },
-        ol: {},
-        li: {},
+        breadcrumbs: {
+            height: 50,
+            borderBottom: `1px solid ${palette.divider}`,
+        },
+        backAndFirstLinkContainer: {
+            display: "flex",
+            alignItems: "center",
+        },
+        backButton: {},
+        backButtonSeparator: {
+            height: 30,
+            width: 1,
+            backgroundColor: palette.divider,
+            marginRight: spacing(2),
+        },
+        ol: {
+            flexWrap: "nowrap",
+            height: "100%",
+            overflowY: "auto", // Make the breadcrumbs scrollable, if they still take up too much space, when only the first, last & the overflow link are visible.
+        },
+        li: {
+            whiteSpace: "nowrap",
+        },
         separator: {
-            color: palette.grey[300],
-            "& [class*='MuiSvgIcon-root']": {
-                fontSize: 12,
-            },
-            link: {
-                color: palette.text.primary,
-                textDecoration: "underline",
-                "& [class*='MuiTypography']": {
-                    fontSize: 13,
-                    lineHeight: "14px",
-                },
-            },
+            fontSize: 12,
         },
-        link: {},
-        last: {
+        link: {
+            fontSize: 13,
+            lineHeight: "14px",
+            fontWeight: typography.fontWeightMedium,
+            color: palette.grey[600],
+            textDecorationColor: "currentColor",
+        },
+        overflowLink: {
+            cursor: "pointer",
+        },
+        lastLink: {
             color: palette.text.disabled,
-            "&, &:hover": {
-                textDecoration: "none",
-            },
+            textDecoration: "none",
         },
     });
 };

--- a/packages/admin/admin/src/stack/breadcrumbs/getBreadcrumbLinkNodes.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/getBreadcrumbLinkNodes.tsx
@@ -1,0 +1,43 @@
+import { LevelUp } from "@comet/admin-icons";
+import { ClassNameMap, IconButton, Link, Typography } from "@mui/material";
+import { ClassKeyOfStyles } from "@mui/styles";
+import clsx from "clsx";
+import * as React from "react";
+
+import { BreadcrumbItem } from "../Stack";
+import { BreadcrumbLink } from "./BreadcrumbLink";
+import { StackBreadcrumbsClassKey } from "./StackBreadcrumbs.styles";
+
+// This must return an array of nodes, as MuiBreadcrumbs cannot handle fragments.
+export const getBreadcrumbLinkNodes = (
+    items: BreadcrumbItem[],
+    preventLinkOnLastItem: boolean,
+    classes: ClassNameMap<ClassKeyOfStyles<StackBreadcrumbsClassKey>>,
+    backButtonUrl?: string,
+): React.ReactNode[] =>
+    items.map(({ id, url, title }, index) => {
+        const breadcrumbItem: React.ReactNode =
+            preventLinkOnLastItem && index === items.length - 1 ? (
+                <Typography key={id} className={clsx(classes.link, classes.lastLink)} variant="body2">
+                    {title}
+                </Typography>
+            ) : (
+                <Link key={id} to={url} component={BreadcrumbLink} className={classes.link} variant="body2">
+                    {title}
+                </Link>
+            );
+
+        if (index === 0 && backButtonUrl) {
+            return (
+                <div key={id} className={classes.backAndFirstLinkContainer}>
+                    <IconButton className={classes.backButton} component={BreadcrumbLink} to={backButtonUrl}>
+                        <LevelUp />
+                    </IconButton>
+                    <div className={classes.backButtonSeparator} />
+                    {breadcrumbItem}
+                </div>
+            );
+        }
+
+        return breadcrumbItem;
+    });

--- a/packages/admin/admin/src/stack/breadcrumbs/useNumberOfItemsToBeHidden.ts
+++ b/packages/admin/admin/src/stack/breadcrumbs/useNumberOfItemsToBeHidden.ts
@@ -1,0 +1,128 @@
+import { breadcrumbsClasses } from "@mui/material";
+import * as React from "react";
+
+const getElementOuterWidth = (element: HTMLElement): number =>
+    element.offsetWidth + parseFloat(getComputedStyle(element).marginLeft) + parseFloat(getComputedStyle(element).marginRight);
+
+const useSeparatorWidth = (breadcrumbsElement: HTMLElement | null): number | null => {
+    const [separatorWidth, setSeparatorWidth] = React.useState<number | null>(null);
+
+    React.useEffect(() => {
+        if (breadcrumbsElement) {
+            const breadcrumbsListElement = breadcrumbsElement.getElementsByClassName(breadcrumbsClasses.ol)[0];
+
+            if (separatorWidth === null) {
+                const separatorElements = breadcrumbsListElement.getElementsByClassName(
+                    breadcrumbsClasses.separator,
+                ) as HTMLCollectionOf<HTMLElement>;
+
+                if (separatorElements.length) {
+                    const newSeparatorWidth = getElementOuterWidth(separatorElements[0]);
+                    setSeparatorWidth(newSeparatorWidth);
+                }
+            }
+        }
+    }, [breadcrumbsElement, separatorWidth]);
+
+    return separatorWidth;
+};
+
+type LinkWidths = {
+    overflowLinkWidth: number | null;
+    breadcrumbItemWidths: number[];
+};
+
+const useLinkWidths = (breadcrumbsElement: HTMLElement | null, itemsBeforeCollapse: number): LinkWidths => {
+    const [breadcrumbItemWidths, setBreadcrumbItemWidths] = React.useState<number[]>([]);
+    const [overflowLinkWidth, setOverflowLinkWidth] = React.useState<number | null>(null);
+
+    React.useEffect(() => {
+        if (breadcrumbsElement) {
+            const breadcrumbsListElement = breadcrumbsElement.getElementsByClassName(breadcrumbsClasses.ol)[0];
+
+            if (breadcrumbItemWidths.length === 0 || overflowLinkWidth === null) {
+                const itemWidths: number[] = [];
+                const breadcrumbListItemElements = breadcrumbsListElement.getElementsByClassName(
+                    breadcrumbsClasses.li,
+                ) as HTMLCollectionOf<HTMLElement>;
+
+                Array.from(breadcrumbListItemElements).forEach((breadcrumbsItemElement, index) => {
+                    const itemWidth = getElementOuterWidth(breadcrumbsItemElement);
+
+                    if (index === itemsBeforeCollapse) {
+                        setOverflowLinkWidth(itemWidth);
+                    } else {
+                        itemWidths.push(itemWidth);
+                    }
+                });
+
+                if (itemWidths.length) {
+                    setBreadcrumbItemWidths(itemWidths);
+                }
+            }
+        }
+    }, [breadcrumbItemWidths.length, breadcrumbsElement, overflowLinkWidth, itemsBeforeCollapse]);
+
+    return {
+        overflowLinkWidth,
+        breadcrumbItemWidths,
+    };
+};
+
+export const useNumberOfItemsToBeHidden = (
+    breadcrumbsElement: HTMLElement | null,
+    breadcrumbsContainerWidth: number | null,
+    totalNumberOfItems: number,
+    itemsBeforeCollapse: number,
+): number | null => {
+    const separatorWidth = useSeparatorWidth(breadcrumbsElement);
+    const { overflowLinkWidth, breadcrumbItemWidths } = useLinkWidths(breadcrumbsElement, itemsBeforeCollapse);
+    const [numberOfItemsToBeHidden, setNumberOfItemsToBeHidden] = React.useState<number | null>(null);
+
+    const minimumNumberOfVisibleBreadcrumbItems = itemsBeforeCollapse + 2; // +2 for the last item and the overflow link
+    const maximumNumberOfHiddenBreadcrumbItems = totalNumberOfItems - minimumNumberOfVisibleBreadcrumbItems + 1; // +1 for the overflow link
+
+    React.useEffect(() => {
+        const allSizingInformationHasBeenSet =
+            breadcrumbsContainerWidth !== null && separatorWidth !== null && overflowLinkWidth !== null && breadcrumbItemWidths.length;
+
+        if (allSizingInformationHasBeenSet && breadcrumbsElement) {
+            let newNumberOfItemsToBeHidden = 0;
+            let allVisibleItemsFitIntoBreadcrumbs = false;
+
+            while (!allVisibleItemsFitIntoBreadcrumbs && newNumberOfItemsToBeHidden < maximumNumberOfHiddenBreadcrumbItems) {
+                const currentWidthOfOverflowLink = newNumberOfItemsToBeHidden === 0 ? 0 : overflowLinkWidth + separatorWidth;
+                let totalWidthOfItems = 0;
+                let numberOfItemsToBeHidden = 0;
+
+                breadcrumbItemWidths.forEach((itemWidth, index) => {
+                    const currentItemIsHidden = index >= itemsBeforeCollapse && numberOfItemsToBeHidden < newNumberOfItemsToBeHidden;
+
+                    if (currentItemIsHidden) {
+                        numberOfItemsToBeHidden++;
+                    } else {
+                        totalWidthOfItems += itemWidth + (index > 0 ? separatorWidth : 0);
+                    }
+                });
+
+                if (totalWidthOfItems + currentWidthOfOverflowLink > breadcrumbsContainerWidth) {
+                    newNumberOfItemsToBeHidden++;
+                } else {
+                    allVisibleItemsFitIntoBreadcrumbs = true;
+                }
+            }
+
+            setNumberOfItemsToBeHidden(newNumberOfItemsToBeHidden);
+        }
+    }, [
+        breadcrumbsElement,
+        breadcrumbsContainerWidth,
+        separatorWidth,
+        overflowLinkWidth,
+        breadcrumbItemWidths,
+        maximumNumberOfHiddenBreadcrumbItems,
+        itemsBeforeCollapse,
+    ]);
+
+    return numberOfItemsToBeHidden;
+};

--- a/packages/admin/blocks-admin/src/blocks/common/AdminTabs.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminTabs.tsx
@@ -53,6 +53,7 @@ const Root = styled("div")`
 
 const Tabs = styled(MuiTabs)`
     background-color: ${({ theme }) => theme.palette.background.default};
+    margin-bottom: 0;
 `;
 
 const Tab = styled(MuiTab)<TabProps & LinkProps>`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,6 +3553,7 @@ __metadata:
     lodash.isequal: ^4.5.0
     prettier: ^2.0.0
     query-string: ^6.8.1
+    react-resize-aware: ^3.1.1
     rimraf: ^3.0.2
     typescript: ^4.0.0
     use-constant: ^1.0.0
@@ -28500,6 +28501,15 @@ __metadata:
   version: 0.11.0
   resolution: "react-refresh@npm:0.11.0"
   checksum: 112178a05b1e0ffeaf5d9fb4e56b4410a34a73adeb04dbf13abdc50d9ac9df2ada83e81485156cca0b3fa296aa3612751b3d6cd13be4464642a43679b819cbc7
+  languageName: node
+  linkType: hard
+
+"react-resize-aware@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "react-resize-aware@npm:3.1.1"
+  peerDependencies:
+    react: ^16.8.0 || 17.x
+  checksum: 0088849e128403ea66f90d588379d9260089c6f218b46e6254da20fe5e4d39c8d13b64da1e6a24bacd0d808db8b7d26bf9dc72801c58606c0b26e9eb5da1bdc5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`react-resize-aware` is used to detect resizing of the breadcrumbs.
Listening only to window-resize is not an option, as the breadcrumbs could be used inside a split-view.

https://user-images.githubusercontent.com/6264317/185361566-bf726e2c-cf36-4955-ae6a-2f01ce177656.mov