### PR TITLE
Extract generic messages to messages.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Changes
 
+-   `comet.generic` messages are exposed as public API through `messages.ts` (this stops them from being translated for every application)
+
 ### Incompatible Changes
 
 -   Removed the `Select` component, use MUIs `Select` instead.
@@ -16,6 +18,31 @@ All notable changes to this project will be documented in this file. This projec
 
 -   close the EditDialog after submitting a contained form via ENTER click
 -   [RTE] Fix a bug were `setEditorState` was incorrectly assumed to be a React state setter function.
+
+### Migration Guide
+
+-   replace all occurrences of `<FormattedMessage id="comet.generic.XXX" />` and `intl.formatMessage({id: "comet.generic.XXX"})`
+
+    **before**
+
+    ```typescript jsx
+    <FormattedMessage id="comet.generic.globalContentScope" defaultMessage="Global Content" />;
+
+    intl.formatMessage({
+        id: "comet.generic.doYouWantToSaveYourChanges",
+        defaultMessage: "Do you want to save your changes?",
+    });
+    ```
+
+    **new**
+
+    ```typescript jsx
+    import { messages } from "@comet/admin";
+
+    <FormattedMessage {...messages.globalContentScope} />;
+
+    intl.formatMessage(messages.saveUnsavedChanges);
+    ```
 
 ## @comet/admin-theme
 

--- a/demo/admin/src/dashboard/Dashboard.tsx
+++ b/demo/admin/src/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { MainContent, Stack } from "@comet/admin";
+import { MainContent, messages, Stack } from "@comet/admin";
 import { Domain } from "@comet/admin-icons";
 import { ContentScopeIndicator } from "@comet/cms-admin";
 import { useUser } from "@comet/react-app-auth";
@@ -62,7 +62,7 @@ const Dashboard: React.FC = () => {
                     <ScopeIndicatorContent>
                         <Domain fontSize="small" />
                         <ScopeIndicatorLabelBold variant="body2">
-                            <FormattedMessage id="comet.generic.globalContentScope" defaultMessage="Global Content" />
+                            <FormattedMessage {...messages.globalContentScope} />
                         </ScopeIndicatorLabelBold>
                     </ScopeIndicatorContent>
                 </ContentScopeIndicator>

--- a/demo/admin/src/links/EditLink.tsx
+++ b/demo/admin/src/links/EditLink.tsx
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { MainContent, RouterPrompt, RouterTab, RouterTabs, Toolbar, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
+import { MainContent, messages, RouterPrompt, RouterTab, RouterTabs, Toolbar, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
 import { ArrowLeft } from "@comet/admin-icons";
 import { AdminComponentRoot } from "@comet/blocks-admin";
 import { createUsePage, EditPageLayout, PageName } from "@comet/cms-admin";
@@ -86,10 +86,7 @@ export const EditLink: React.FC<Props> = ({ id }) => {
             {hasChanges && (
                 <RouterPrompt
                     message={(location) => {
-                        return intl.formatMessage({
-                            id: "comet.generic.doYouWantToSaveYourChanges",
-                            defaultMessage: "Do you want to save your changes?",
-                        });
+                        return intl.formatMessage(messages.saveUnsavedChanges);
                     }}
                     saveAction={handleSaveAction}
                 />
@@ -106,7 +103,7 @@ export const EditLink: React.FC<Props> = ({ id }) => {
             </Toolbar>
             <MainContent>
                 <RouterTabs>
-                    <RouterTab label={intl.formatMessage({ id: "comet.generic.content", defaultMessage: "Content" })} path="">
+                    <RouterTab label={intl.formatMessage(messages.content)} path="">
                         <AdminComponentRoot>{rootBlocksApi.content.adminUI}</AdminComponentRoot>
                     </RouterTab>
                 </RouterTabs>

--- a/demo/admin/src/links/Link.tsx
+++ b/demo/admin/src/links/Link.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import { Link as LinkIcon } from "@comet/admin-icons";
 import { DocumentInterface, rewriteInternalLinks } from "@comet/cms-admin";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
@@ -8,7 +9,7 @@ import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 export const Link: DocumentInterface<Pick<GQLLink, "content">, GQLLinkInput> = {
-    displayName: <FormattedMessage id="comet.generic.link" defaultMessage="Link" />,
+    displayName: <FormattedMessage {...messages.link} />,
     editComponent: EditLink,
     getQuery: gql`
         query LinkDocument($id: ID!) {

--- a/demo/admin/src/news/Form.tsx
+++ b/demo/admin/src/news/Form.tsx
@@ -4,7 +4,9 @@ import {
     FinalForm,
     FinalFormInput,
     MainContent,
+    saveAndGoBackMessage,
     SaveButton,
+    saveMessage,
     SplitButton,
     Toolbar,
     ToolbarActions,
@@ -91,7 +93,7 @@ const NewsForm: React.FC<NewsFormProps> = ({ newsId }) => {
                         <ToolbarActions>
                             <SplitButton disabled={pristine || hasValidationErrors || submitting} localStorageKey="editInspirationSave">
                                 <SaveButton color="primary" variant="contained" hasErrors={hasSubmitErrors} type="submit">
-                                    <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
+                                    <FormattedMessage {...saveMessage} />
                                 </SaveButton>
                                 <SaveButton
                                     color="primary"
@@ -106,7 +108,7 @@ const NewsForm: React.FC<NewsFormProps> = ({ newsId }) => {
                                         }
                                     }}
                                 >
-                                    <FormattedMessage id="comet.generic.saveAndGoBack" defaultMessage="Save and go back" />
+                                    <FormattedMessage {...saveAndGoBackMessage} />
                                 </SaveButton>
                             </SplitButton>
                         </ToolbarActions>

--- a/demo/admin/src/news/Form.tsx
+++ b/demo/admin/src/news/Form.tsx
@@ -4,9 +4,8 @@ import {
     FinalForm,
     FinalFormInput,
     MainContent,
-    saveAndGoBackMessage,
+    messages,
     SaveButton,
-    saveMessage,
     SplitButton,
     Toolbar,
     ToolbarActions,
@@ -93,7 +92,7 @@ const NewsForm: React.FC<NewsFormProps> = ({ newsId }) => {
                         <ToolbarActions>
                             <SplitButton disabled={pristine || hasValidationErrors || submitting} localStorageKey="editInspirationSave">
                                 <SaveButton color="primary" variant="contained" hasErrors={hasSubmitErrors} type="submit">
-                                    <FormattedMessage {...saveMessage} />
+                                    <FormattedMessage {...messages.save} />
                                 </SaveButton>
                                 <SaveButton
                                     color="primary"
@@ -108,7 +107,7 @@ const NewsForm: React.FC<NewsFormProps> = ({ newsId }) => {
                                         }
                                     }}
                                 >
-                                    <FormattedMessage {...saveAndGoBackMessage} />
+                                    <FormattedMessage {...messages.saveAndGoBack} />
                                 </SaveButton>
                             </SplitButton>
                         </ToolbarActions>

--- a/demo/admin/src/pages/EditPage.tsx
+++ b/demo/admin/src/pages/EditPage.tsx
@@ -1,5 +1,14 @@
 import { gql } from "@apollo/client";
-import { MainContent as CometMainContent, RouterPrompt, Toolbar, ToolbarActions, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
+import {
+    MainContent as CometMainContent,
+    messages,
+    RouterPrompt,
+    Toolbar,
+    ToolbarActions,
+    ToolbarFillSpace,
+    ToolbarItem,
+    useStackApi,
+} from "@comet/admin";
 import { ArrowLeft, Preview } from "@comet/admin-icons";
 import { AdminComponentRoot, AdminTabLabel } from "@comet/blocks-admin";
 import {
@@ -129,10 +138,7 @@ export const EditPage: React.FC<Props> = ({ id, category }) => {
                 <RouterPrompt
                     message={(location) => {
                         if (location.pathname.startsWith(match.url)) return true; //we navigated within our self
-                        return intl.formatMessage({
-                            id: "comet.generic.doYouWantToSaveYourChanges",
-                            defaultMessage: "Do you want to save your changes?",
-                        });
+                        return intl.formatMessage(messages.saveUnsavedChanges);
                     }}
                     saveAction={handleSaveAction}
                 />

--- a/demo/admin/src/pages/mainMenu/components/EditMainMenuItem.tsx
+++ b/demo/admin/src/pages/mainMenu/components/EditMainMenuItem.tsx
@@ -2,7 +2,9 @@ import { gql, useMutation } from "@apollo/client";
 import {
     MainContent,
     RouterPrompt,
+    saveAndGoBackMessage,
     SaveButton,
+    saveMessage,
     SplitButton,
     Toolbar,
     ToolbarActions,
@@ -146,7 +148,7 @@ const EditMainMenuItem: React.FunctionComponent<EditMainMenuItemProps> = ({ item
                             variant="contained"
                             onClick={handleSaveClick}
                         >
-                            <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
+                            <FormattedMessage {...saveMessage} />
                         </SaveButton>
                         <SaveButton
                             startIcon={<Save />}
@@ -159,7 +161,7 @@ const EditMainMenuItem: React.FunctionComponent<EditMainMenuItemProps> = ({ item
                                 stackApi?.goBack();
                             }}
                         >
-                            <FormattedMessage id="comet.generic.saveAndGoBack" defaultMessage="Save and go back" />
+                            <FormattedMessage {...saveAndGoBackMessage} />
                         </SaveButton>
                     </SplitButton>
                 </ToolbarActions>

--- a/demo/admin/src/pages/mainMenu/components/EditMainMenuItem.tsx
+++ b/demo/admin/src/pages/mainMenu/components/EditMainMenuItem.tsx
@@ -1,10 +1,9 @@
 import { gql, useMutation } from "@apollo/client";
 import {
     MainContent,
+    messages,
     RouterPrompt,
-    saveAndGoBackMessage,
     SaveButton,
-    saveMessage,
     SplitButton,
     Toolbar,
     ToolbarActions,
@@ -148,7 +147,7 @@ const EditMainMenuItem: React.FunctionComponent<EditMainMenuItemProps> = ({ item
                             variant="contained"
                             onClick={handleSaveClick}
                         >
-                            <FormattedMessage {...saveMessage} />
+                            <FormattedMessage {...messages.save} />
                         </SaveButton>
                         <SaveButton
                             startIcon={<Save />}
@@ -161,7 +160,7 @@ const EditMainMenuItem: React.FunctionComponent<EditMainMenuItemProps> = ({ item
                                 stackApi?.goBack();
                             }}
                         >
-                            <FormattedMessage {...saveAndGoBackMessage} />
+                            <FormattedMessage {...messages.saveAndGoBack} />
                         </SaveButton>
                     </SplitButton>
                 </ToolbarActions>
@@ -170,10 +169,7 @@ const EditMainMenuItem: React.FunctionComponent<EditMainMenuItemProps> = ({ item
                 <RouterPrompt
                     message={(location) => {
                         if (location.pathname.startsWith(match.url)) return true; //we navigated within our self
-                        return intl.formatMessage({
-                            id: "comet.generic.doYouWantToSaveYourChanges",
-                            defaultMessage: "Do you want to save your changes?",
-                        });
+                        return intl.formatMessage(messages.saveUnsavedChanges);
                     }}
                     saveAction={handleSaveAction}
                 />

--- a/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
+++ b/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
@@ -4,7 +4,9 @@ import {
     FinalForm,
     FinalFormSelect,
     MainContent,
+    saveAndGoBackMessage,
     SaveButton,
+    saveMessage,
     SplitButton,
     Toolbar,
     ToolbarFillSpace,
@@ -96,7 +98,7 @@ export const EditPredefinedPage: React.FC<Props> = ({ id }) => {
                             <ToolbarItem>
                                 <SplitButton disabled={pristine || hasValidationErrors || submitting}>
                                     <SaveButton hasErrors={hasSubmitErrors} type="submit">
-                                        <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
+                                        <FormattedMessage {...saveMessage} />
                                     </SaveButton>
                                     <SaveButton
                                         saving={submitting}
@@ -109,7 +111,7 @@ export const EditPredefinedPage: React.FC<Props> = ({ id }) => {
                                             }
                                         }}
                                     >
-                                        <FormattedMessage id="comet.generic.saveAndGoBack" defaultMessage="Save and go back" />
+                                        <FormattedMessage {...saveAndGoBackMessage} />
                                     </SaveButton>
                                 </SplitButton>
                             </ToolbarItem>

--- a/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
+++ b/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
@@ -4,9 +4,8 @@ import {
     FinalForm,
     FinalFormSelect,
     MainContent,
-    saveAndGoBackMessage,
+    messages,
     SaveButton,
-    saveMessage,
     SplitButton,
     Toolbar,
     ToolbarFillSpace,
@@ -98,7 +97,7 @@ export const EditPredefinedPage: React.FC<Props> = ({ id }) => {
                             <ToolbarItem>
                                 <SplitButton disabled={pristine || hasValidationErrors || submitting}>
                                     <SaveButton hasErrors={hasSubmitErrors} type="submit">
-                                        <FormattedMessage {...saveMessage} />
+                                        <FormattedMessage {...messages.save} />
                                     </SaveButton>
                                     <SaveButton
                                         saving={submitting}
@@ -111,7 +110,7 @@ export const EditPredefinedPage: React.FC<Props> = ({ id }) => {
                                             }
                                         }}
                                     >
-                                        <FormattedMessage {...saveAndGoBackMessage} />
+                                        <FormattedMessage {...messages.saveAndGoBack} />
                                     </SaveButton>
                                 </SplitButton>
                             </ToolbarItem>

--- a/packages/admin/admin-rte/src/core/extension/Link/ToolbarButton.tsx
+++ b/packages/admin/admin-rte/src/core/extension/Link/ToolbarButton.tsx
@@ -113,6 +113,7 @@ function LinkDialog(props: {
             </DialogContent>
             <DialogActions>
                 <Button onClick={handleClose} startIcon={<Clear />}>
+                    {/** Same as in @comet/admin/messages.ts, not referenced as no dependency specified */}
                     <FormattedMessage id="comet.generic.cancel" defaultMessage="Cancel" />
                 </Button>
                 <div>
@@ -120,12 +121,14 @@ function LinkDialog(props: {
                         {linkData && (
                             <Grid item>
                                 <Button variant="contained" startIcon={<Delete />} onClick={handleRemove}>
+                                    {/** Same as in @comet/admin/messages.ts, not referenced as no dependency specified */}
                                     <FormattedMessage id="comet.generic.delete" defaultMessage="Delete" />
                                 </Button>
                             </Grid>
                         )}
                         <Grid item>
                             <Button variant="contained" color="primary" startIcon={<Check />} onClick={handleUpdate} disabled={!newUrl}>
+                                {/** Same as in @comet/admin/messages.ts, not referenced as no dependency specified */}
                                 <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
                             </Button>
                         </Grid>

--- a/packages/admin/admin/src/DirtyHandler.tsx
+++ b/packages/admin/admin/src/DirtyHandler.tsx
@@ -3,7 +3,7 @@ import { useIntl, WrappedComponentProps } from "react-intl";
 
 import { DirtyHandlerApiContext, IDirtyHandlerApi, IDirtyHandlerApiBinding } from "./DirtyHandlerApiContext";
 import { SubmitResult } from "./form/SubmitResult";
-import { saveUnsavedChangesMessage } from "./messages";
+import { messages } from "./messages";
 import { RouterPrompt } from "./router/Prompt";
 
 interface IProps {
@@ -77,7 +77,7 @@ class DirtyHandlerComponent extends React.Component<IProps & WrappedComponentPro
         if (!this.isBindingDirty()) {
             return true;
         } else {
-            return this.props.intl.formatMessage(saveUnsavedChangesMessage);
+            return this.props.intl.formatMessage(messages.saveUnsavedChanges);
         }
     };
 

--- a/packages/admin/admin/src/DirtyHandler.tsx
+++ b/packages/admin/admin/src/DirtyHandler.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import { defineMessages, useIntl, WrappedComponentProps } from "react-intl";
+import { useIntl, WrappedComponentProps } from "react-intl";
 
 import { DirtyHandlerApiContext, IDirtyHandlerApi, IDirtyHandlerApiBinding } from "./DirtyHandlerApiContext";
 import { SubmitResult } from "./form/SubmitResult";
+import { saveUnsavedChangesMessage } from "./messages";
 import { RouterPrompt } from "./router/Prompt";
 
 interface IProps {
@@ -15,13 +16,6 @@ interface IBinding {
 }
 type Bindings = IBinding[];
 
-const messages = defineMessages({
-    saveChanges: {
-        id: "comet.generic.doYouWantToSaveYourChanges",
-        defaultMessage: "Do you want to save your changes?",
-        description: "Prompt to save unsaved changes",
-    },
-});
 class DirtyHandlerComponent extends React.Component<IProps & WrappedComponentProps> {
     public static contextType = DirtyHandlerApiContext;
 
@@ -83,7 +77,7 @@ class DirtyHandlerComponent extends React.Component<IProps & WrappedComponentPro
         if (!this.isBindingDirty()) {
             return true;
         } else {
-            return this.props.intl.formatMessage(messages.saveChanges);
+            return this.props.intl.formatMessage(saveUnsavedChangesMessage);
         }
     };
 

--- a/packages/admin/admin/src/EditDialog.tsx
+++ b/packages/admin/admin/src/EditDialog.tsx
@@ -9,7 +9,7 @@ import { DirtyHandlerApiContext, IDirtyHandlerApi } from "./DirtyHandlerApiConte
 import { CloseDialogOptions, EditDialogApiContext, IEditDialogApi } from "./EditDialogApiContext";
 import { EditDialogFormApiProvider, useEditDialogFormApi } from "./EditDialogFormApiContext";
 import { SubmitResult } from "./form/SubmitResult";
-import { addMessage, editMessage, saveMessage } from "./messages";
+import { messages } from "./messages";
 import { ISelectionApi } from "./SelectionApi";
 import { useSelectionRoute } from "./SelectionRoute";
 
@@ -92,8 +92,8 @@ const EditDialogInner: React.FunctionComponent<IProps & IHookProps> = ({ selecti
     const editDialogFormApi = useEditDialogFormApi();
 
     const title = maybeTitle ?? {
-        edit: intl.formatMessage(editMessage),
-        add: intl.formatMessage(addMessage),
+        edit: intl.formatMessage(messages.edit),
+        add: intl.formatMessage(messages.add),
     };
 
     let dirtyHandlerApi: IDirtyHandlerApi | undefined;
@@ -139,7 +139,7 @@ const EditDialogInner: React.FunctionComponent<IProps & IHookProps> = ({ selecti
                                             hasErrors={editDialogFormApi?.hasErrors}
                                             onClick={handleSaveClick}
                                         >
-                                            <FormattedMessage {...saveMessage} />
+                                            <FormattedMessage {...messages.save} />
                                         </SaveButton>
                                     );
                                 }}

--- a/packages/admin/admin/src/EditDialog.tsx
+++ b/packages/admin/admin/src/EditDialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
 import * as React from "react";
-import { defineMessages, FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { CancelButton } from "./common/buttons/cancel/CancelButton";
 import { SaveButton } from "./common/buttons/save/SaveButton";
@@ -9,6 +9,7 @@ import { DirtyHandlerApiContext, IDirtyHandlerApi } from "./DirtyHandlerApiConte
 import { CloseDialogOptions, EditDialogApiContext, IEditDialogApi } from "./EditDialogApiContext";
 import { EditDialogFormApiProvider, useEditDialogFormApi } from "./EditDialogFormApiContext";
 import { SubmitResult } from "./form/SubmitResult";
+import { addMessage, editMessage, saveMessage } from "./messages";
 import { ISelectionApi } from "./SelectionApi";
 import { useSelectionRoute } from "./SelectionRoute";
 
@@ -20,18 +21,6 @@ interface ITitle {
 interface IProps {
     title?: ITitle | string;
 }
-
-const messages = defineMessages({
-    edit: {
-        id: "comet.generic.edit",
-        defaultMessage: "Edit",
-    },
-
-    add: {
-        id: "comet.generic.add",
-        defaultMessage: "Add",
-    },
-});
 
 export function useEditDialog(): [React.ComponentType<IProps>, { id?: string; mode?: "edit" | "add" }, IEditDialogApi, ISelectionApi] {
     const [Selection, selection, selectionApi] = useSelectionRoute();
@@ -103,8 +92,8 @@ const EditDialogInner: React.FunctionComponent<IProps & IHookProps> = ({ selecti
     const editDialogFormApi = useEditDialogFormApi();
 
     const title = maybeTitle ?? {
-        edit: intl.formatMessage(messages.edit),
-        add: intl.formatMessage(messages.add),
+        edit: intl.formatMessage(editMessage),
+        add: intl.formatMessage(addMessage),
     };
 
     let dirtyHandlerApi: IDirtyHandlerApi | undefined;
@@ -150,7 +139,7 @@ const EditDialogInner: React.FunctionComponent<IProps & IHookProps> = ({ selecti
                                             hasErrors={editDialogFormApi?.hasErrors}
                                             onClick={handleSaveClick}
                                         >
-                                            <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
+                                            <FormattedMessage {...saveMessage} />
                                         </SaveButton>
                                     );
                                 }}

--- a/packages/admin/admin/src/FinalFormSaveSplitButton.tsx
+++ b/packages/admin/admin/src/FinalFormSaveSplitButton.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage } from "react-intl";
 
 import { SaveButton } from "./common/buttons/save/SaveButton";
 import { SplitButton } from "./common/buttons/split/SplitButton";
-import { saveAndGoBackMessage, saveMessage } from "./messages";
+import { messages } from "./messages";
 import { useStackApi } from "./stack/Api";
 
 export interface FormSaveButtonProps {
@@ -28,7 +28,7 @@ export const FinalFormSaveSplitButton = ({ localStorageKey }: PropsWithChildren<
                     form.submit();
                 }}
             >
-                <FormattedMessage {...saveMessage} />
+                <FormattedMessage {...messages.save} />
             </SaveButton>
             <SaveButton
                 color="primary"
@@ -43,7 +43,7 @@ export const FinalFormSaveSplitButton = ({ localStorageKey }: PropsWithChildren<
                     }
                 }}
             >
-                <FormattedMessage {...saveAndGoBackMessage} />
+                <FormattedMessage {...messages.saveAndGoBack} />
             </SaveButton>
         </SplitButton>
     );

--- a/packages/admin/admin/src/FinalFormSaveSplitButton.tsx
+++ b/packages/admin/admin/src/FinalFormSaveSplitButton.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage } from "react-intl";
 
 import { SaveButton } from "./common/buttons/save/SaveButton";
 import { SplitButton } from "./common/buttons/split/SplitButton";
+import { saveAndGoBackMessage, saveMessage } from "./messages";
 import { useStackApi } from "./stack/Api";
 
 export interface FormSaveButtonProps {
@@ -27,7 +28,7 @@ export const FinalFormSaveSplitButton = ({ localStorageKey }: PropsWithChildren<
                     form.submit();
                 }}
             >
-                <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
+                <FormattedMessage {...saveMessage} />
             </SaveButton>
             <SaveButton
                 color="primary"
@@ -42,7 +43,7 @@ export const FinalFormSaveSplitButton = ({ localStorageKey }: PropsWithChildren<
                     }
                 }}
             >
-                <FormattedMessage id="comet.generic.saveAndGoBack" defaultMessage="Save and go back" />
+                <FormattedMessage {...saveAndGoBackMessage} />
             </SaveButton>
         </SplitButton>
     );

--- a/packages/admin/admin/src/common/buttons/cancel/CancelButton.tsx
+++ b/packages/admin/admin/src/common/buttons/cancel/CancelButton.tsx
@@ -6,6 +6,8 @@ import { createStyles, WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { cancelMessage } from "../../../messages";
+
 export type CancelButtonProps = ButtonProps;
 export type CancelButtonClassKey = ButtonClassKey;
 
@@ -63,7 +65,7 @@ const styles = () => {
 };
 
 function CancelBtn({
-    children = <FormattedMessage id="comet.generic.cancel" defaultMessage="Cancel" />,
+    children = <FormattedMessage {...cancelMessage} />,
     startIcon = <Clear />,
     ...restProps
 }: CancelButtonProps & WithStyles<typeof styles>) {

--- a/packages/admin/admin/src/common/buttons/cancel/CancelButton.tsx
+++ b/packages/admin/admin/src/common/buttons/cancel/CancelButton.tsx
@@ -6,7 +6,7 @@ import { createStyles, WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { cancelMessage } from "../../../messages";
+import { messages } from "../../../messages";
 
 export type CancelButtonProps = ButtonProps;
 export type CancelButtonClassKey = ButtonClassKey;
@@ -65,7 +65,7 @@ const styles = () => {
 };
 
 function CancelBtn({
-    children = <FormattedMessage {...cancelMessage} />,
+    children = <FormattedMessage {...messages.cancel} />,
     startIcon = <Clear />,
     ...restProps
 }: CancelButtonProps & WithStyles<typeof styles>) {

--- a/packages/admin/admin/src/common/buttons/delete/DeleteButton.tsx
+++ b/packages/admin/admin/src/common/buttons/delete/DeleteButton.tsx
@@ -4,7 +4,7 @@ import { createStyles, WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { deleteMessage } from "../../../messages";
+import { messages } from "../../../messages";
 
 export type DeleteButtonClassKey = ButtonClassKey;
 export type DeleteButtonProps = ButtonProps;
@@ -69,7 +69,7 @@ const styles = ({ palette }: Theme) => {
 };
 
 function DeleteBtn({
-    children = <FormattedMessage {...deleteMessage} />,
+    children = <FormattedMessage {...messages.delete} />,
     startIcon = <Delete />,
     ...restProps
 }: ButtonProps & WithStyles<typeof styles>) {

--- a/packages/admin/admin/src/common/buttons/delete/DeleteButton.tsx
+++ b/packages/admin/admin/src/common/buttons/delete/DeleteButton.tsx
@@ -4,6 +4,8 @@ import { createStyles, WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { deleteMessage } from "../../../messages";
+
 export type DeleteButtonClassKey = ButtonClassKey;
 export type DeleteButtonProps = ButtonProps;
 
@@ -67,7 +69,7 @@ const styles = ({ palette }: Theme) => {
 };
 
 function DeleteBtn({
-    children = <FormattedMessage id="comet.generic.delete" defaultMessage="Delete" />,
+    children = <FormattedMessage {...deleteMessage} />,
     startIcon = <Delete />,
     ...restProps
 }: ButtonProps & WithStyles<typeof styles>) {

--- a/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
+++ b/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
@@ -4,6 +4,8 @@ import { createStyles, WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { okMessage } from "../../../messages";
+
 export type OkayButtonClassKey = ButtonClassKey;
 export type OkayButtonProps = ButtonProps;
 
@@ -60,7 +62,7 @@ const styles = () => {
 };
 
 function OkayBtn({
-    children = <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />,
+    children = <FormattedMessage {...okMessage} />,
     startIcon = <Check />,
     color = "primary",
     variant = "contained",

--- a/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
+++ b/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
@@ -4,7 +4,7 @@ import { createStyles, WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { okMessage } from "../../../messages";
+import { messages } from "../../../messages";
 
 export type OkayButtonClassKey = ButtonClassKey;
 export type OkayButtonProps = ButtonProps;
@@ -62,7 +62,7 @@ const styles = () => {
 };
 
 function OkayBtn({
-    children = <FormattedMessage {...okMessage} />,
+    children = <FormattedMessage {...messages.ok} />,
     startIcon = <Check />,
     color = "primary",
     variant = "contained",

--- a/packages/admin/admin/src/common/buttons/save/SaveButton.tsx
+++ b/packages/admin/admin/src/common/buttons/save/SaveButton.tsx
@@ -6,7 +6,7 @@ import { ClassNameMap } from "@mui/styles/withStyles/withStyles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { saveMessage } from "../../../messages";
+import { messages } from "../../../messages";
 import { useSplitButtonContext } from "../split/useSplitButtonContext";
 import { SaveButtonClassKey, styles } from "./SaveButton.styles";
 
@@ -27,7 +27,7 @@ export type SaveButtonDisplayState = "idle" | "saving" | "success" | "error";
 const SaveBtn = ({
     saving = false,
     hasErrors = false,
-    children = <FormattedMessage {...saveMessage} />,
+    children = <FormattedMessage {...messages.save} />,
     savingItem = <FormattedMessage id="comet.saveButton.savingItem.title" defaultMessage="Saving" />,
     successItem = <FormattedMessage id="comet.saveButton.successItem.title" defaultMessage="Successfully Saved" />,
     errorItem = <FormattedMessage id="comet.saveButton.errorItem.title" defaultMessage="Save Error" />,

--- a/packages/admin/admin/src/common/buttons/save/SaveButton.tsx
+++ b/packages/admin/admin/src/common/buttons/save/SaveButton.tsx
@@ -6,6 +6,7 @@ import { ClassNameMap } from "@mui/styles/withStyles/withStyles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { saveMessage } from "../../../messages";
 import { useSplitButtonContext } from "../split/useSplitButtonContext";
 import { SaveButtonClassKey, styles } from "./SaveButton.styles";
 
@@ -26,7 +27,7 @@ export type SaveButtonDisplayState = "idle" | "saving" | "success" | "error";
 const SaveBtn = ({
     saving = false,
     hasErrors = false,
-    children = <FormattedMessage id="comet.generic.save" defaultMessage="Save" />,
+    children = <FormattedMessage {...saveMessage} />,
     savingItem = <FormattedMessage id="comet.saveButton.savingItem.title" defaultMessage="Saving" />,
     successItem = <FormattedMessage id="comet.saveButton.successItem.title" defaultMessage="Successfully Saved" />,
     errorItem = <FormattedMessage id="comet.saveButton.errorItem.title" defaultMessage="Save Error" />,

--- a/packages/admin/admin/src/error/errordialog/ErrorDialog.tsx
+++ b/packages/admin/admin/src/error/errordialog/ErrorDialog.tsx
@@ -13,7 +13,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { okMessage } from "../../messages";
+import { messages } from "../../messages";
 
 export interface ErrorDialogOptions {
     error: string;
@@ -67,7 +67,7 @@ export const ErrorDialog: React.FunctionComponent<ErrorDialogProps> = ({ show = 
             </DialogContent>
             <DialogActions>
                 <Button onClick={onCloseClicked} color="primary" variant="contained">
-                    <FormattedMessage {...okMessage} />
+                    <FormattedMessage {...messages.ok} />
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/admin/admin/src/error/errordialog/ErrorDialog.tsx
+++ b/packages/admin/admin/src/error/errordialog/ErrorDialog.tsx
@@ -13,6 +13,8 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { okMessage } from "../../messages";
+
 export interface ErrorDialogOptions {
     error: string;
     title?: React.ReactNode;
@@ -65,7 +67,7 @@ export const ErrorDialog: React.FunctionComponent<ErrorDialogProps> = ({ show = 
             </DialogContent>
             <DialogActions>
                 <Button onClick={onCloseClicked} color="primary" variant="contained">
-                    <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />
+                    <FormattedMessage {...okMessage} />
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -73,7 +73,7 @@ export { AsyncOptionsProps, useAsyncOptionsProps } from "./hooks/useAsyncOptions
 export { useStoredState } from "./hooks/useStoredState";
 export { InputWithPopper, InputWithPopperComponents, InputWithPopperComponentsProps, InputWithPopperProps } from "./inputWithPopper/InputWithPopper";
 export { InputWithPopperClassKey } from "./inputWithPopper/InputWithPopper.styles";
-export * from "./messages";
+export { messages } from "./messages";
 export { MainContent, MainContentClassKey, MainContentProps } from "./mui/MainContent";
 export { MasterLayout, MasterLayoutProps } from "./mui/MasterLayout";
 export { MasterLayoutClassKey } from "./mui/MasterLayout.styles";

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -73,6 +73,7 @@ export { AsyncOptionsProps, useAsyncOptionsProps } from "./hooks/useAsyncOptions
 export { useStoredState } from "./hooks/useStoredState";
 export { InputWithPopper, InputWithPopperComponents, InputWithPopperComponentsProps, InputWithPopperProps } from "./inputWithPopper/InputWithPopper";
 export { InputWithPopperClassKey } from "./inputWithPopper/InputWithPopper.styles";
+export * from "./messages";
 export { MainContent, MainContentClassKey, MainContentProps } from "./mui/MainContent";
 export { MasterLayout, MasterLayoutProps } from "./mui/MasterLayout";
 export { MasterLayoutClassKey } from "./mui/MasterLayout.styles";

--- a/packages/admin/admin/src/messages.ts
+++ b/packages/admin/admin/src/messages.ts
@@ -12,7 +12,7 @@ export const messages = defineMessages({
     saveAndGoBack: { id: "comet.generic.saveAndGoBack", defaultMessage: "Save and go back" },
     cancel: { id: "comet.generic.cancel", defaultMessage: "Cancel" },
     delete: { id: "comet.generic.delete", defaultMessage: "Delete" },
-    ok: { id: "comet.generic.ok", defaultMessage: "Ok" },
+    ok: { id: "comet.generic.ok", defaultMessage: "OK" },
     unsavedChanges: { id: "comet.generic.unsavedChanges", defaultMessage: "Unsaved Changes" },
     discard: { id: "comet.generic.discard", defaultMessage: "Discard" },
     undo: { id: "comet.generic.undo", defaultMessage: "Undo" },

--- a/packages/admin/admin/src/messages.ts
+++ b/packages/admin/admin/src/messages.ts
@@ -1,39 +1,46 @@
-import { defineMessage } from "react-intl";
+import { defineMessages } from "react-intl";
 
-export const editMessage = defineMessage({
-    id: "comet.generic.edit",
-    defaultMessage: "Edit",
+export const messages = defineMessages({
+    edit: { id: "comet.generic.edit", defaultMessage: "Edit" },
+    add: { id: "comet.generic.add", defaultMessage: "Add" },
+    saveUnsavedChanges: {
+        id: "comet.generic.doYouWantToSaveYourChanges",
+        defaultMessage: "Do you want to save your changes?",
+        description: "Prompt to save unsaved changes",
+    },
+    save: { id: "comet.generic.save", defaultMessage: "Save" },
+    saveAndGoBack: { id: "comet.generic.saveAndGoBack", defaultMessage: "Save and go back" },
+    cancel: { id: "comet.generic.cancel", defaultMessage: "Cancel" },
+    delete: { id: "comet.generic.delete", defaultMessage: "Delete" },
+    ok: { id: "comet.generic.ok", defaultMessage: "Ok" },
+    unsavedChanges: { id: "comet.generic.unsavedChanges", defaultMessage: "Unsaved Changes" },
+    discard: { id: "comet.generic.discard", defaultMessage: "Discard" },
+    undo: { id: "comet.generic.undo", defaultMessage: "Undo" },
+    back: { id: "comet.generic.back", defaultMessage: "Back" },
+    reset: { id: "comet.generic.reset", defaultMessage: "Reset" },
+    apply: { id: "comet.generic.apply", defaultMessage: "Apply" },
+    copy: { id: "comet.generic.copy", defaultMessage: "Copy" },
+    paste: { id: "comet.generic.paste", defaultMessage: "Paste" },
+    left: { id: "comet.generic.left", defaultMessage: "Left" },
+    right: { id: "comet.generic.right", defaultMessage: "Right" },
+    link: { id: "comet.generic.link", defaultMessage: "Link" },
+    text: { id: "comet.generic.text", defaultMessage: "Text" },
+    file: { id: "comet.generic.file", defaultMessage: "File" },
+    yes: { id: "comet.generic.yes", defaultMessage: "Yes" },
+    no: { id: "comet.generic.no", defaultMessage: "No" },
+    globalContentScope: { id: "comet.generic.globalContentScope", defaultMessage: "Global Content" },
+    invalidData: { id: "comet.generic.invalidData", defaultMessage: "Invalid Data" },
+    saveConflict: { id: "comet.generic.saveConflict", defaultMessage: "Save Conflict" },
+    retry: { id: "comet.generic.retry", defaultMessage: "Retry" },
+    networkError: {
+        id: "comet.generic.errors.networkError",
+        defaultMessage: "<strong>Could not connect to server.</strong> Please check your internet connection.",
+    },
+    unknownError: {
+        id: "comet.generic.errors.unknownError",
+        defaultMessage: "<strong>Something went wrong.</strong> Please try again later.",
+    },
+    warning: { id: "comet.generic.warning", defaultMessage: "Warning" },
+    content: { id: "comet.generic.content", defaultMessage: "Content" },
+    close: { id: "comet.generic.close", defaultMessage: "Close" },
 });
-
-export const addMessage = defineMessage({
-    id: "comet.generic.add",
-    defaultMessage: "Add",
-});
-
-export const saveUnsavedChangesMessage = defineMessage({
-    id: "comet.generic.doYouWantToSaveYourChanges",
-    defaultMessage: "Do you want to save your changes??????",
-    description: "Prompt to save unsaved changes",
-});
-
-export const saveMessage = defineMessage({ id: "comet.generic.save", defaultMessage: "Save" });
-
-export const saveAndGoBackMessage = defineMessage({ id: "comet.generic.saveAndGoBack", defaultMessage: "Save and go back" });
-
-export const cancelMessage = defineMessage({ id: "comet.generic.cancel", defaultMessage: "Cancel" });
-
-export const deleteMessage = defineMessage({ id: "comet.generic.delete", defaultMessage: "Delete" });
-
-export const okMessage = defineMessage({ id: "comet.generic.ok", defaultMessage: "Ok" });
-
-export const unsavedChangesMessage = defineMessage({ id: "comet.generic.unsavedChanges", defaultMessage: "Unsaved Changes" });
-
-export const discardMessage = defineMessage({ id: "comet.generic.discard", defaultMessage: "Discard" });
-
-export const undoMessage = defineMessage({ id: "comet.generic.undo", defaultMessage: "Undo" });
-
-export const backMessage = defineMessage({ id: "comet.generic.back", defaultMessage: "Back" });
-
-export const resetMessage = defineMessage({ id: "comet.generic.reset", defaultMessage: "Reset" });
-
-export const applyMessage = defineMessage({ id: "comet.generic.apply", defaultMessage: "Apply" });

--- a/packages/admin/admin/src/messages.ts
+++ b/packages/admin/admin/src/messages.ts
@@ -1,0 +1,39 @@
+import { defineMessage } from "react-intl";
+
+export const editMessage = defineMessage({
+    id: "comet.generic.edit",
+    defaultMessage: "Edit",
+});
+
+export const addMessage = defineMessage({
+    id: "comet.generic.add",
+    defaultMessage: "Add",
+});
+
+export const saveUnsavedChangesMessage = defineMessage({
+    id: "comet.generic.doYouWantToSaveYourChanges",
+    defaultMessage: "Do you want to save your changes??????",
+    description: "Prompt to save unsaved changes",
+});
+
+export const saveMessage = defineMessage({ id: "comet.generic.save", defaultMessage: "Save" });
+
+export const saveAndGoBackMessage = defineMessage({ id: "comet.generic.saveAndGoBack", defaultMessage: "Save and go back" });
+
+export const cancelMessage = defineMessage({ id: "comet.generic.cancel", defaultMessage: "Cancel" });
+
+export const deleteMessage = defineMessage({ id: "comet.generic.delete", defaultMessage: "Delete" });
+
+export const okMessage = defineMessage({ id: "comet.generic.ok", defaultMessage: "Ok" });
+
+export const unsavedChangesMessage = defineMessage({ id: "comet.generic.unsavedChanges", defaultMessage: "Unsaved Changes" });
+
+export const discardMessage = defineMessage({ id: "comet.generic.discard", defaultMessage: "Discard" });
+
+export const undoMessage = defineMessage({ id: "comet.generic.undo", defaultMessage: "Undo" });
+
+export const backMessage = defineMessage({ id: "comet.generic.back", defaultMessage: "Back" });
+
+export const resetMessage = defineMessage({ id: "comet.generic.reset", defaultMessage: "Reset" });
+
+export const applyMessage = defineMessage({ id: "comet.generic.apply", defaultMessage: "Apply" });

--- a/packages/admin/admin/src/router/ConfirmationDialog.tsx
+++ b/packages/admin/admin/src/router/ConfirmationDialog.tsx
@@ -4,7 +4,7 @@ import { WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { discardMessage, saveMessage, saveUnsavedChangesMessage, unsavedChangesMessage } from "../messages";
+import { messages } from "../messages";
 import { RouterConfirmationDialogClassKey, styles } from "./ConfirmationDialog.styles";
 
 export enum PromptAction {
@@ -30,7 +30,7 @@ export function InternalRouterConfirmationDialog({
     return (
         <Dialog open={isOpen} onClose={() => handleClose(PromptAction.Cancel)} maxWidth="sm" className={classes.root}>
             <DialogTitle>
-                <FormattedMessage {...unsavedChangesMessage} />
+                <FormattedMessage {...messages.saveUnsavedChanges} />
                 <IconButton onClick={() => handleClose(PromptAction.Cancel)} className={classes.closeButton}>
                     <Close />
                 </IconButton>
@@ -38,7 +38,7 @@ export function InternalRouterConfirmationDialog({
             <DialogContent>
                 <div className={classes.messageWrapper}>
                     <Warning className={classes.messageWarningIcon} />
-                    <Typography className={classes.messageText}>{message ?? <FormattedMessage {...saveUnsavedChangesMessage} />}</Typography>
+                    <Typography className={classes.messageText}>{message ?? <FormattedMessage {...messages.saveUnsavedChanges} />}</Typography>
                 </div>
             </DialogContent>
             <DialogActions>
@@ -49,7 +49,7 @@ export function InternalRouterConfirmationDialog({
                     onClick={() => handleClose(PromptAction.Discard)}
                     className={`${classes.actionButton} ${classes.discardButton}`}
                 >
-                    <FormattedMessage {...discardMessage} />
+                    <FormattedMessage {...messages.discard} />
                 </Button>
                 {showSaveButton && (
                     <Button
@@ -59,7 +59,7 @@ export function InternalRouterConfirmationDialog({
                         onClick={() => handleClose(PromptAction.Save)}
                         className={`${classes.actionButton} ${classes.saveButton}`}
                     >
-                        <FormattedMessage {...saveMessage} />
+                        <FormattedMessage {...messages.save} />
                     </Button>
                 )}
             </DialogActions>

--- a/packages/admin/admin/src/router/ConfirmationDialog.tsx
+++ b/packages/admin/admin/src/router/ConfirmationDialog.tsx
@@ -4,6 +4,7 @@ import { WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { discardMessage, saveMessage, saveUnsavedChangesMessage, unsavedChangesMessage } from "../messages";
 import { RouterConfirmationDialogClassKey, styles } from "./ConfirmationDialog.styles";
 
 export enum PromptAction {
@@ -29,7 +30,7 @@ export function InternalRouterConfirmationDialog({
     return (
         <Dialog open={isOpen} onClose={() => handleClose(PromptAction.Cancel)} maxWidth="sm" className={classes.root}>
             <DialogTitle>
-                <FormattedMessage id="comet.generic.unsavedChanges" defaultMessage="Unsaved Changes" />
+                <FormattedMessage {...unsavedChangesMessage} />
                 <IconButton onClick={() => handleClose(PromptAction.Cancel)} className={classes.closeButton}>
                     <Close />
                 </IconButton>
@@ -37,15 +38,7 @@ export function InternalRouterConfirmationDialog({
             <DialogContent>
                 <div className={classes.messageWrapper}>
                     <Warning className={classes.messageWarningIcon} />
-                    <Typography className={classes.messageText}>
-                        {message ?? (
-                            <FormattedMessage
-                                id="comet.generic.doYouWantToSaveYourChanges"
-                                defaultMessage="Do you want to save your changes?"
-                                description="Prompt to save unsaved changes"
-                            />
-                        )}
-                    </Typography>
+                    <Typography className={classes.messageText}>{message ?? <FormattedMessage {...saveUnsavedChangesMessage} />}</Typography>
                 </div>
             </DialogContent>
             <DialogActions>
@@ -56,7 +49,7 @@ export function InternalRouterConfirmationDialog({
                     onClick={() => handleClose(PromptAction.Discard)}
                     className={`${classes.actionButton} ${classes.discardButton}`}
                 >
-                    <FormattedMessage id="comet.generic.discard" defaultMessage="Discard" />
+                    <FormattedMessage {...discardMessage} />
                 </Button>
                 {showSaveButton && (
                     <Button
@@ -66,7 +59,7 @@ export function InternalRouterConfirmationDialog({
                         onClick={() => handleClose(PromptAction.Save)}
                         className={`${classes.actionButton} ${classes.saveButton}`}
                     >
-                        <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
+                        <FormattedMessage {...saveMessage} />
                     </Button>
                 )}
             </DialogActions>

--- a/packages/admin/admin/src/snackbar/UndoSnackbar.tsx
+++ b/packages/admin/admin/src/snackbar/UndoSnackbar.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { FormattedMessage } from "react-intl";
 import * as UUID from "uuid";
 
+import { undoMessage } from "../messages";
 import { useSnackbarApi } from "./SnackbarProvider";
 
 export interface UndoSnackbarProps<Payload> extends Omit<SnackbarProps, "action"> {
@@ -28,7 +29,7 @@ export const UndoSnackbar = <Payload,>({ onUndoClick, payload, ...props }: UndoS
             autoHideDuration={5000}
             action={
                 <Button color="secondary" size="small" onClick={onClick}>
-                    <FormattedMessage id="comet.generic.undo" defaultMessage="Undo" />
+                    <FormattedMessage {...undoMessage} />
                 </Button>
             }
             TransitionComponent={(props: SlideProps) => <Slide {...props} direction="right" />}

--- a/packages/admin/admin/src/snackbar/UndoSnackbar.tsx
+++ b/packages/admin/admin/src/snackbar/UndoSnackbar.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { FormattedMessage } from "react-intl";
 import * as UUID from "uuid";
 
-import { undoMessage } from "../messages";
+import { messages } from "../messages";
 import { useSnackbarApi } from "./SnackbarProvider";
 
 export interface UndoSnackbarProps<Payload> extends Omit<SnackbarProps, "action"> {
@@ -29,7 +29,7 @@ export const UndoSnackbar = <Payload,>({ onUndoClick, payload, ...props }: UndoS
             autoHideDuration={5000}
             action={
                 <Button color="secondary" size="small" onClick={onClick}>
-                    <FormattedMessage {...undoMessage} />
+                    <FormattedMessage {...messages.undo} />
                 </Button>
             }
             TransitionComponent={(props: SlideProps) => <Slide {...props} direction="right" />}

--- a/packages/admin/admin/src/stack/backbutton/StackBackButton.tsx
+++ b/packages/admin/admin/src/stack/backbutton/StackBackButton.tsx
@@ -4,6 +4,7 @@ import { WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { backMessage } from "../../messages";
 import { StackApiContext } from "../Api";
 import { StackBackButtonClassKey, styles } from "./StackBackButton.styles";
 
@@ -20,7 +21,7 @@ const StackBackBtn = ({ startIcon = <ArrowBack />, ...restProps }: StackBackButt
                         startIcon={startIcon}
                         {...restProps}
                     >
-                        <FormattedMessage id="comet.generic.back" defaultMessage="Back" />
+                        <FormattedMessage {...backMessage} />
                     </Button>
                 );
             }}

--- a/packages/admin/admin/src/stack/backbutton/StackBackButton.tsx
+++ b/packages/admin/admin/src/stack/backbutton/StackBackButton.tsx
@@ -4,7 +4,7 @@ import { WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { backMessage } from "../../messages";
+import { messages } from "../../messages";
 import { StackApiContext } from "../Api";
 import { StackBackButtonClassKey, styles } from "./StackBackButton.styles";
 
@@ -21,7 +21,7 @@ const StackBackBtn = ({ startIcon = <ArrowBack />, ...restProps }: StackBackButt
                         startIcon={startIcon}
                         {...restProps}
                     >
-                        <FormattedMessage {...backMessage} />
+                        <FormattedMessage {...messages.back} />
                     </Button>
                 );
             }}

--- a/packages/admin/admin/src/table/AddButton.tsx
+++ b/packages/admin/admin/src/table/AddButton.tsx
@@ -3,6 +3,7 @@ import { Button } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { addMessage } from "../messages";
 import { ISelectionApi } from "../SelectionApi";
 
 interface IProps {
@@ -13,7 +14,7 @@ export class TableAddButton extends React.Component<IProps> {
     public render() {
         return (
             <Button onClick={this.handleAddClick} startIcon={<AddIcon />}>
-                <FormattedMessage id="comet.generic.add" defaultMessage="Add" />
+                <FormattedMessage {...addMessage} />
             </Button>
         );
     }

--- a/packages/admin/admin/src/table/AddButton.tsx
+++ b/packages/admin/admin/src/table/AddButton.tsx
@@ -3,7 +3,7 @@ import { Button } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { addMessage } from "../messages";
+import { messages } from "../messages";
 import { ISelectionApi } from "../SelectionApi";
 
 interface IProps {
@@ -14,7 +14,7 @@ export class TableAddButton extends React.Component<IProps> {
     public render() {
         return (
             <Button onClick={this.handleAddClick} startIcon={<AddIcon />}>
-                <FormattedMessage {...addMessage} />
+                <FormattedMessage {...messages.add} />
             </Button>
         );
     }

--- a/packages/admin/admin/src/table/DeleteButton.tsx
+++ b/packages/admin/admin/src/table/DeleteButton.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { DeleteMutation } from "../DeleteMutation";
-import { deleteMessage } from "../messages";
+import { messages } from "../messages";
 
 interface IProps {
     selectedId?: string;
@@ -18,7 +18,7 @@ interface IProps {
     refetchQueries?: Array<string | PureQueryOptions>;
 }
 
-const DeleteMessage = () => <FormattedMessage {...deleteMessage} />;
+const DeleteMessage = () => <FormattedMessage {...messages.delete} />;
 
 export class TableDeleteButton extends React.Component<IProps> {
     public render() {

--- a/packages/admin/admin/src/table/DeleteButton.tsx
+++ b/packages/admin/admin/src/table/DeleteButton.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { DeleteMutation } from "../DeleteMutation";
+import { deleteMessage } from "../messages";
 
 interface IProps {
     selectedId?: string;
@@ -17,7 +18,7 @@ interface IProps {
     refetchQueries?: Array<string | PureQueryOptions>;
 }
 
-const DeleteMessage = () => <FormattedMessage id="comet.generic.delete" defaultMessage="Delete" />;
+const DeleteMessage = () => <FormattedMessage {...deleteMessage} />;
 
 export class TableDeleteButton extends React.Component<IProps> {
     public render() {

--- a/packages/admin/admin/src/table/filterbar/filterBarMoreFilters/FilterBarMoreFilters.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarMoreFilters/FilterBarMoreFilters.tsx
@@ -22,7 +22,7 @@ export function MoreFilters({
                 {icon}
                 <div className={classes.textWrapper}>
                     <Typography variant="body1">
-                        <FormattedMessage id="comet.generic.moreFilter" defaultMessage="More Filter" />
+                        <FormattedMessage id="comet.filterbar.moreFilter" defaultMessage="More Filter" />
                     </Typography>
                 </div>
             </div>

--- a/packages/admin/admin/src/table/filterbar/filterBarPopoverFilter/FilterBarPopoverFilter.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarPopoverFilter/FilterBarPopoverFilter.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { Form, useForm } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
-import { applyMessage, resetMessage } from "../../../messages";
+import { messages } from "../../../messages";
 import { dirtyFieldsCount } from "../dirtyFieldsCount";
 import { FilterBarActiveFilterBadgeProps } from "../filterBarActiveFilterBadge/FilterBarActiveFilterBadge";
 import { FilterBarButton, FilterBarButtonProps } from "../filterBarButton/FilterBarButton";
@@ -96,7 +96,7 @@ function PopoverFilter({
                                             startIcon={<Reset />}
                                             {...resetButtonProps}
                                         >
-                                            <FormattedMessage {...resetMessage} />
+                                            <FormattedMessage {...messages.reset} />
                                         </Button>
 
                                         <Button
@@ -111,7 +111,7 @@ function PopoverFilter({
                                             disabled={Object.values(dirtyFields).length === 0}
                                             {...submitButtonProps}
                                         >
-                                            <FormattedMessage {...applyMessage} />
+                                            <FormattedMessage {...messages.apply} />
                                         </Button>
                                     </div>
                                 </div>

--- a/packages/admin/admin/src/table/filterbar/filterBarPopoverFilter/FilterBarPopoverFilter.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarPopoverFilter/FilterBarPopoverFilter.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { Form, useForm } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
+import { applyMessage, resetMessage } from "../../../messages";
 import { dirtyFieldsCount } from "../dirtyFieldsCount";
 import { FilterBarActiveFilterBadgeProps } from "../filterBarActiveFilterBadge/FilterBarActiveFilterBadge";
 import { FilterBarButton, FilterBarButtonProps } from "../filterBarButton/FilterBarButton";
@@ -95,7 +96,7 @@ function PopoverFilter({
                                             startIcon={<Reset />}
                                             {...resetButtonProps}
                                         >
-                                            <FormattedMessage id="comet.generic.resetButton" defaultMessage="Reset" />
+                                            <FormattedMessage {...resetMessage} />
                                         </Button>
 
                                         <Button
@@ -110,7 +111,7 @@ function PopoverFilter({
                                             disabled={Object.values(dirtyFields).length === 0}
                                             {...submitButtonProps}
                                         >
-                                            <FormattedMessage id="comet.generic.applyButton" defaultMessage="Apply" />
+                                            <FormattedMessage {...applyMessage} />
                                         </Button>
                                     </div>
                                 </div>

--- a/packages/admin/blocks-admin/src/blocks/common/blockRow/BlockRow.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/blockRow/BlockRow.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import { Copy, Delete, Drag, MoreVertical, Paste, Warning } from "@comet/admin-icons";
 import { Checkbox, IconButton, ListItemIcon, Menu, MenuItem } from "@mui/material";
 import * as React from "react";
@@ -195,19 +196,19 @@ export function BlockRow(props: BlockRowProps): JSX.Element {
                         <ListItemIcon>
                             <Copy />
                         </ListItemIcon>
-                        <FormattedMessage id="comet.generic.copy" defaultMessage="Copy" />
+                        <FormattedMessage {...messages.copy} />
                     </MenuItem>
                     <MenuItem onClick={handlePasteClick}>
                         <ListItemIcon>
                             <Paste />
                         </ListItemIcon>
-                        <FormattedMessage id="comet.generic.paste" defaultMessage="Paste" />
+                        <FormattedMessage {...messages.paste} />
                     </MenuItem>
                     <MenuItem onClick={handleDeleteClick}>
                         <ListItemIcon>
                             <Delete />
                         </ListItemIcon>
-                        <FormattedMessage id="comet.generic.delete" defaultMessage="Delete" />
+                        <FormattedMessage {...messages.delete} />
                     </MenuItem>
                 </Menu>
             </sc.Root>

--- a/packages/admin/blocks-admin/src/clipboard/CannotPasteBlockDialog.tsx
+++ b/packages/admin/blocks-admin/src/clipboard/CannotPasteBlockDialog.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
@@ -17,7 +18,7 @@ function CannotPasteBlockDialog({ open, onClose, error }: Props): React.ReactEle
             <DialogContent>{error}</DialogContent>
             <DialogActions>
                 <Button onClick={onClose} color="info">
-                    <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />
+                    <FormattedMessage {...messages.ok} />
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { Field, FieldContainer, FinalFormSwitch } from "@comet/admin";
+import { Field, FieldContainer, FinalFormSwitch, messages } from "@comet/admin";
 import { Delete, Video } from "@comet/admin-icons";
 import { AdminComponentButton, AdminComponentPaper, BlockCategory, BlockInterface, BlocksFinalForm, createBlockSkeleton } from "@comet/blocks-admin";
 import { Box, Divider, Grid, Typography } from "@mui/material";
@@ -79,7 +79,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                 initialValues={state}
             >
                 {state.damFile ? (
-                    <FieldContainer label={<FormattedMessage id="comet.generic.file" defaultMessage="File" />} fullWidth>
+                    <FieldContainer label={<FormattedMessage {...messages.file} />} fullWidth>
                         <AdminComponentPaper disablePadding>
                             <Box padding={3}>
                                 <Grid container alignItems="center" spacing={3}>
@@ -104,7 +104,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                 ) : (
                     <Field
                         name="damFile"
-                        label={<FormattedMessage id="comet.generic.file" defaultMessage="File" />}
+                        label={<FormattedMessage {...messages.file} />}
                         component={FileField}
                         fullWidth
                         allowedMimetypes={["video/mp4"]}

--- a/packages/admin/cms-admin/src/blocks/createTextImageBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createTextImageBlock.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import {
     AdminComponentPaper,
     AdminComponentSection,
@@ -78,16 +79,8 @@ const createTextImageBlock = ({
                                 }));
                             }}
                         >
-                            <FormControlLabel
-                                value="left"
-                                control={<Radio />}
-                                label={<FormattedMessage id="comet.generic.left" defaultMessage="Left" />}
-                            />
-                            <FormControlLabel
-                                value="right"
-                                control={<Radio />}
-                                label={<FormattedMessage id="comet.generic.right" defaultMessage="Right" />}
-                            />
+                            <FormControlLabel value="left" control={<Radio />} label={<FormattedMessage {...messages.left} />} />
+                            <FormControlLabel value="right" control={<Radio />} label={<FormattedMessage {...messages.right} />} />
                         </RadioGroup>
                     </AdminComponentSection>
                     <AdminComponentSection

--- a/packages/admin/cms-admin/src/blocks/createTextLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createTextLinkBlock.tsx
@@ -1,4 +1,4 @@
-import { Field, FinalFormInput } from "@comet/admin";
+import { Field, FinalFormInput, messages } from "@comet/admin";
 import {
     AdminComponentPaper,
     BlockCategory,
@@ -33,7 +33,7 @@ export function createTextLinkBlock({ link: LinkBlock }: CreateTextLinkBlockOpti
 
         name: "TextLink",
 
-        displayName: <FormattedMessage id="comet.generic.link" defaultMessage="Link" />,
+        displayName: <FormattedMessage {...messages.link} />,
 
         category: BlockCategory.Navigation,
 
@@ -51,12 +51,7 @@ export function createTextLinkBlock({ link: LinkBlock }: CreateTextLinkBlockOpti
                             }}
                             initialValues={{ text: state.text }}
                         >
-                            <Field
-                                label={<FormattedMessage id="comet.generic.text" defaultMessage="Text" />}
-                                name="text"
-                                component={FinalFormInput}
-                                fullWidth
-                            />
+                            <Field label={<FormattedMessage {...messages.text} />} name="text" component={FinalFormInput} fullWidth />
                         </BlocksFinalForm>
                     </Box>
                     {link}

--- a/packages/admin/cms-admin/src/blocks/image/EditImageDialog.tsx
+++ b/packages/admin/cms-admin/src/blocks/image/EditImageDialog.tsx
@@ -1,6 +1,6 @@
 import "react-image-crop/dist/ReactCrop.css";
 
-import { CancelButton, Field, FormSection, SaveButton } from "@comet/admin";
+import { CancelButton, Field, FormSection, messages, SaveButton } from "@comet/admin";
 import {
     Box,
     Dialog,
@@ -196,13 +196,7 @@ const YesNoSwitch = ({ checked, onChange }: YesNoSwitchProps): React.ReactElemen
     return (
         <FormControlLabel
             control={<Switch checked={checked} onChange={onChange} />}
-            label={
-                checked ? (
-                    <FormattedMessage id="comet.generic.yes" defaultMessage="Yes" />
-                ) : (
-                    <FormattedMessage id="comet.generic.no" defaultMessage="No" />
-                )
-            }
+            label={checked ? <FormattedMessage {...messages.yes} /> : <FormattedMessage {...messages.no} />}
         />
     );
 };

--- a/packages/admin/cms-admin/src/blocks/rte/extension/CmsLink/createCmsLinkToolbarButton.tsx
+++ b/packages/admin/cms-admin/src/blocks/rte/extension/CmsLink/createCmsLinkToolbarButton.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import { Link } from "@comet/admin-icons";
 import { ControlButton, findEntityInCurrentSelection, findTextInCurrentSelection, selectionIsInOneBlock } from "@comet/admin-rte";
 import { BlockInterface, BlockState } from "@comet/blocks-admin";
@@ -137,10 +138,10 @@ export function createCmsLinkToolbarButton({ link: LinkBlock }: CreateCmsLinkToo
                         </Button>
                     )}
                     <Button onClick={handleUpdate} color="primary">
-                        <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />
+                        <FormattedMessage {...messages.ok} />
                     </Button>
                     <Button onClick={handleClose} color="primary">
-                        <FormattedMessage id="comet.generic.cancel" defaultMessage="Cancel" />
+                        <FormattedMessage {...messages.cancel} />
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/packages/admin/cms-admin/src/builds/Publisher.tsx
+++ b/packages/admin/cms-admin/src/builds/Publisher.tsx
@@ -2,6 +2,7 @@ import { gql } from "@apollo/client";
 import {
     LocalErrorScopeApolloContext,
     MainContent,
+    messages,
     Stack,
     Table,
     TableQuery,
@@ -66,7 +67,7 @@ export function Publisher(): React.ReactElement {
                 <ScopeIndicatorContent>
                     <Domain fontSize="small" />
                     <ScopeIndicatorLabelBold variant="body2">
-                        <FormattedMessage id="comet.generic.globalContentScope" defaultMessage="Global Content" />
+                        <FormattedMessage {...messages.globalContentScope} />
                     </ScopeIndicatorLabelBold>
                 </ScopeIndicatorContent>
             </ContentScopeIndicator>

--- a/packages/admin/cms-admin/src/common/PageList.tsx
+++ b/packages/admin/cms-admin/src/common/PageList.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import { ArrowLeft, File, Folder } from "@comet/admin-icons";
 import { List, ListItem, ListItemIcon } from "@mui/material";
 import { styled } from "@mui/material/styles";
@@ -28,7 +29,7 @@ export function PageList({ items, showBackButton, onItemClick, onBackClick, site
                     <ListItemIcon>
                         <ArrowLeft />
                     </ListItemIcon>
-                    <FormattedMessage id="comet.generic.back" defaultMessage="Back" />
+                    <FormattedMessage {...messages.back} />
                 </ListItem>
             )}
             <ScrollableListSection>

--- a/packages/admin/cms-admin/src/common/errors/AuthorizationErrorPage.tsx
+++ b/packages/admin/cms-admin/src/common/errors/AuthorizationErrorPage.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import { Button, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import * as React from "react";
@@ -40,7 +41,7 @@ export const AuthorizationErrorPage: React.FunctionComponent<AuthorizationErrorP
         <Root>
             <Message align="center">{JSON.stringify(error)}</Message>
             <Button variant="contained" onClick={onRetry}>
-                <FormattedMessage id="comet.generic.retry" defaultMessage="Retry" />
+                <FormattedMessage {...messages.retry} />
             </Button>
             <CometLogo src={cometLogoUrl} alt="Comet Logo" />
         </Root>

--- a/packages/admin/cms-admin/src/common/errors/errorMessages.tsx
+++ b/packages/admin/cms-admin/src/common/errors/errorMessages.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -5,8 +6,7 @@ export const formatStrong = (chunks: string): React.ReactElement => <strong>{chu
 
 export const NetworkError = (): React.ReactElement => (
     <FormattedMessage
-        id="comet.generic.errors.networkError"
-        defaultMessage="<strong>Could not connect to server.</strong> Please check your internet connection."
+        {...messages.networkError}
         values={{
             strong: formatStrong,
         }}
@@ -15,8 +15,7 @@ export const NetworkError = (): React.ReactElement => (
 
 export const UnknownError = (): React.ReactElement => (
     <FormattedMessage
-        id="comet.generic.errors.unknownError"
-        defaultMessage="<strong>Something went wrong.</strong> Please try again later."
+        {...messages.unknownError}
         values={{
             strong: formatStrong,
         }}

--- a/packages/admin/cms-admin/src/common/useSaveState.tsx
+++ b/packages/admin/cms-admin/src/common/useSaveState.tsx
@@ -1,4 +1,4 @@
-import { SaveButton, SaveButtonProps, SplitButton, useStackApi } from "@comet/admin";
+import { messages, SaveButton, SaveButtonProps, SplitButton, useStackApi } from "@comet/admin";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -118,16 +118,16 @@ export function SaveStateSaveButton({
         saving: saving || validating || checkingSaveConflict,
         hasErrors: !!saveError || !valid || hasConflict,
         errorItem: !valid ? (
-            <FormattedMessage id="comet.generic.invalidData" defaultMessage="Invalid Data" />
+            <FormattedMessage {...messages.invalidData} />
         ) : hasConflict ? (
-            <FormattedMessage id="comet.generic.saveConflict" defaultMessage="Save Conflict" />
+            <FormattedMessage {...messages.saveConflict} />
         ) : undefined,
     };
 
     return (
         <SplitButton localStorageKey="SaveStateSaveButton" disabled={!hasChanges}>
             <SaveButton onClick={() => handleSaveClick(true)} {...saveButtonProps}>
-                <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
+                <FormattedMessage {...messages.save} />
             </SaveButton>
             <SaveButton
                 onClick={async () => {
@@ -136,7 +136,7 @@ export function SaveStateSaveButton({
                 }}
                 {...saveButtonProps}
             >
-                <FormattedMessage id="comet.generic.saveAndGoBack" defaultMessage="Save and go back" />
+                <FormattedMessage {...messages.saveAndGoBack} />
             </SaveButton>
         </SplitButton>
     );

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -3,6 +3,7 @@ import {
     EditDialogApiContext,
     IFilterApi,
     ISortInformation,
+    messages,
     SortDirection,
     Stack,
     StackPage,
@@ -81,7 +82,7 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
                             <ScopeIndicatorContent>
                                 <Domain fontSize="small" />
                                 <ScopeIndicatorLabelBold variant="body2">
-                                    <FormattedMessage id="comet.generic.globalContentScope" defaultMessage="Global Content" />
+                                    <FormattedMessage {...messages.globalContentScope} />
                                 </ScopeIndicatorLabelBold>
                             </ScopeIndicatorContent>
                         </ContentScopeIndicator>

--- a/packages/admin/cms-admin/src/dam/FileActions/ConfirmDeleteDialog.tsx
+++ b/packages/admin/cms-admin/src/dam/FileActions/ConfirmDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import { CancelButton } from "@comet/admin";
+import { CancelButton, messages } from "@comet/admin";
 import { Delete } from "@comet/admin-icons";
 import { Button, Dialog, DialogActions, DialogTitle } from "@mui/material";
 import React from "react";
@@ -25,7 +25,7 @@ export const ConfirmDeleteDialog = ({ open, onCloseDialog, name, itemType }: Con
                     <sc.WarningIcon />
                     <sc.WarningTextWrapper>
                         <sc.WarningHeading>
-                            <FormattedMessage id="comet.generic.warning" defaultMessage="Warning" />
+                            <FormattedMessage {...messages.warning} />
                         </sc.WarningHeading>
                         <sc.WarningText>
                             {itemType === "file" && (

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -3,6 +3,7 @@ import {
     FinalForm,
     LocalErrorScopeApolloContext,
     MainContent,
+    messages,
     RouterTab,
     RouterTabs,
     SaveButton,
@@ -200,7 +201,7 @@ const EditFileInner = ({ file, id }: EditFileInnerProps) => {
                                         await handleSubmit();
                                     }}
                                 >
-                                    <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
+                                    <FormattedMessage {...messages.save} />
                                 </SaveButton>
                                 <SaveButton
                                     color="primary"
@@ -215,7 +216,7 @@ const EditFileInner = ({ file, id }: EditFileInnerProps) => {
                                         }
                                     }}
                                 >
-                                    <FormattedMessage id="comet.generic.saveAndGoBack" defaultMessage="Save and go back" />
+                                    <FormattedMessage {...messages.saveAndGoBack} />
                                 </SaveButton>
                             </SplitButton>
                         </ToolbarActions>

--- a/packages/admin/cms-admin/src/dam/Table/fileUpload/FileUploadErrorDialog.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/fileUpload/FileUploadErrorDialog.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import {
     Button,
     Dialog,
@@ -97,7 +98,7 @@ export const FileUploadErrorDialog = ({ open = false, onClose, validationErrors 
             </DialogContent>
             <DialogActions>
                 <Button variant="contained" color="primary" onClick={onClose}>
-                    <FormattedMessage id="comet.generic.ok" defaultMessage="OK" />
+                    <FormattedMessage {...messages.ok} />
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/admin/cms-admin/src/pages/SaveConflictDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/SaveConflictDialog.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import { Clear, Delete, OpenNewTab, Warning } from "@comet/admin-icons";
 import { fontWeights } from "@comet/admin-theme";
 import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from "@mui/material";
@@ -57,7 +58,7 @@ function SaveConflictDialog({ open, onClosePressed, onDiscardChangesPressed }: S
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClosePressed} startIcon={<Clear />} color="info">
-                    <FormattedMessage id="comet.generic.cancel" defaultMessage="Cancel" />
+                    <FormattedMessage {...messages.cancel} />
                 </Button>
                 <div className={styles.fillSpace} />
                 <Button

--- a/packages/admin/cms-admin/src/pages/createUsePage.tsx
+++ b/packages/admin/cms-admin/src/pages/createUsePage.tsx
@@ -1,6 +1,6 @@
 import { gql, TypedDocumentNode, useMutation, useQuery } from "@apollo/client";
 import { ApolloError } from "@apollo/client/errors";
-import { SaveButton, SaveButtonProps, SplitButton, useStackApi } from "@comet/admin";
+import { messages, SaveButton, SaveButtonProps, SplitButton, useStackApi } from "@comet/admin";
 import {
     BindBlockAdminComponent,
     BlockInterface,
@@ -448,16 +448,16 @@ function PageSaveButton({
         saving: saving || validating || checkingSaveConflict,
         hasErrors: saveError != null || !valid || hasSaveConflict,
         errorItem: !valid ? (
-            <FormattedMessage id="comet.generic.invalidData" defaultMessage="Invalid Data" />
+            <FormattedMessage {...messages.invalidData} />
         ) : hasSaveConflict ? (
-            <FormattedMessage id="comet.generic.saveConflict" defaultMessage="Save Conflict" />
+            <FormattedMessage {...messages.saveConflict} />
         ) : undefined,
     };
 
     return (
         <SplitButton localStorageKey="EditPageSave" disabled={!hasChanges}>
             <SaveButton onClick={handleSavePage} {...saveButtonProps}>
-                <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
+                <FormattedMessage {...messages.save} />
             </SaveButton>
             <SaveButton
                 onClick={async () => {
@@ -466,7 +466,7 @@ function PageSaveButton({
                 }}
                 {...saveButtonProps}
             >
-                <FormattedMessage id="comet.generic.saveAndGoBack" defaultMessage="Save and go back" />
+                <FormattedMessage {...messages.saveAndGoBack} />
             </SaveButton>
         </SplitButton>
     );

--- a/packages/admin/cms-admin/src/pages/pageTree/BottomAddLink.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/BottomAddLink.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import { Add } from "@comet/admin-icons";
 import { Button, Divider } from "@mui/material";
 import { styled } from "@mui/material/styles";
@@ -13,7 +14,7 @@ export default function BottomAddLink({ onClick }: Props): React.ReactElement {
         <>
             <Divider />
             <AddButton color="primary" onClick={onClick} startIcon={<Add />} fullWidth>
-                <FormattedMessage id="comet.generic.add" defaultMessage="Add" />
+                <FormattedMessage {...messages.add} />
             </AddButton>
         </>
     );

--- a/packages/admin/cms-admin/src/pages/pageTree/PageContextMenu.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useApolloClient } from "@apollo/client";
-import { IEditDialogApi, StackSwitchApiContext } from "@comet/admin";
+import { IEditDialogApi, messages, StackSwitchApiContext } from "@comet/admin";
 import { Add, Copy, Delete, Domain, Edit, MoreVertical, Paste, Settings, ThreeDotSaving } from "@comet/admin-icons";
 import { writeClipboard } from "@comet/blocks-admin";
 import { IconButton, ListItemIcon, ListItemText, Menu as MUIMenu, MenuItem } from "@mui/material";
@@ -100,7 +100,7 @@ const PageContextMenu = (props: PageContextMenuProps): React.ReactElement => {
                         <ListItemIcon>
                             <Edit />
                         </ListItemIcon>
-                        <ListItemText primary={intl.formatMessage({ id: "comet.generic.content", defaultMessage: "Content" })} />
+                        <ListItemText primary={<FormattedMessage {...messages.content} />} />
                     </MenuItem>,
                     <MenuItem
                         key="editPageProperties"

--- a/packages/admin/cms-admin/src/pages/pageTree/PageDeleteDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import { DeleteButton } from "@comet/admin";
+import { DeleteButton, messages } from "@comet/admin";
 import { ArrowRight, Delete } from "@comet/admin-icons";
 import { AdminComponentPaper } from "@comet/blocks-admin";
 import { Cancel } from "@mui/icons-material";
@@ -139,7 +139,7 @@ export const PageDeleteDialog: React.FC<PageDeleteDialogProps> = (props) => {
             </DialogContent>
             <DialogActions>
                 <Button onClick={handleCancelClick} color="inherit" startIcon={<Cancel />}>
-                    <FormattedMessage id="comet.generic.cancel" defaultMessage="Cancel" />
+                    <FormattedMessage {...messages.cancel} />
                 </Button>
 
                 <DeleteButton onClick={handleDeleteClick}>

--- a/packages/admin/cms-admin/src/pages/pagesPage/PageCanNotDeleteDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PageCanNotDeleteDialog.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
@@ -23,7 +24,7 @@ export const PageCanNotDeleteDialog: React.FunctionComponent<PageCanNotDeleteDia
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClosePressed} color="primary">
-                    <FormattedMessage id="comet.generic.close" defaultMessage="Close" />
+                    <FormattedMessage {...messages.close} />
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@apollo/client";
-import { MainContent, Stack, StackPage, StackSwitch, Toolbar, ToolbarActions, useEditDialog, useStoredState } from "@comet/admin";
+import { MainContent, messages, Stack, StackPage, StackSwitch, Toolbar, ToolbarActions, useEditDialog, useStoredState } from "@comet/admin";
 import { Add, Domain } from "@comet/admin-icons";
 import { Box, Button, CircularProgress, FormControlLabel, Paper, Switch, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
@@ -137,7 +137,7 @@ export function PagesPage({
                                     editDialogApi.openAddDialog();
                                 }}
                             >
-                                <FormattedMessage id="comet.generic.add" defaultMessage="Add" />
+                                <FormattedMessage {...messages.add} />
                             </Button>
                         </ToolbarActions>
                     </Toolbar>

--- a/packages/admin/cms-admin/src/preview/OpenLinkDialog.tsx
+++ b/packages/admin/cms-admin/src/preview/OpenLinkDialog.tsx
@@ -1,3 +1,4 @@
+import { messages } from "@comet/admin";
 import { Domain } from "@comet/admin-icons";
 import { Dialog, DialogContent, DialogTitle, Grid, Typography } from "@mui/material";
 import Button from "@mui/material/Button";
@@ -47,7 +48,7 @@ function OpenLinkDialog({ open, onClose, link }: OpenLinkDialogProps): React.Rea
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClose} color="info">
-                    <FormattedMessage id="comet.generic.cancel" defaultMessage="Cancel" />
+                    <FormattedMessage {...messages.cancel} />
                 </Button>
 
                 <Button

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -5,6 +5,7 @@ import {
     FinalFormInput,
     FinalFormSelect,
     MainContent,
+    messages,
     SaveButton,
     SplitButton,
     Toolbar,
@@ -139,7 +140,7 @@ export const RedirectForm = ({ mode, id, linkBlock }: Props): JSX.Element => {
                         <ToolbarActions>
                             <SplitButton disabled={pristine || hasValidationErrors || submitting} localStorageKey="editRedirectSave">
                                 <SaveButton color="primary" variant="contained" saving={saving} hasErrors={saveError != null} type="submit">
-                                    <FormattedMessage id="comet.generic.save" defaultMessage="Save" />
+                                    <FormattedMessage {...messages.save} />
                                 </SaveButton>
 
                                 <SaveButton
@@ -155,7 +156,7 @@ export const RedirectForm = ({ mode, id, linkBlock }: Props): JSX.Element => {
                                         }
                                     }}
                                 >
-                                    <FormattedMessage id="comet.generic.saveAndGoBack" defaultMessage="Save and go back" />
+                                    <FormattedMessage {...messages.saveAndGoBack} />
                                 </SaveButton>
                             </SplitButton>
                         </ToolbarActions>


### PR DESCRIPTION
This PR tackles the problems described in https://github.com/vivid-planet/comet/pull/721

--------------

- Adds a SSOT for all comet.generic messages (messages.ts). This makes it easier to know which ones are existing.
- Makes comet.generic messages easier to use inside app code (see demo/admin/src/news/Form.tsx)
- Prevents comet.generic messages from being extracted by app code

Messages from the library outside of comet.generic should not be used in app code as they are subject of change.