### PR TITLE
Small CMS styling fixes

### DIFF
--- a/demo/admin/src/dashboard/LatestContentUpdates.tsx
+++ b/demo/admin/src/dashboard/LatestContentUpdates.tsx
@@ -1,6 +1,7 @@
 import { gql } from "@apollo/client";
 import { Table, TableQuery, useTableQuery } from "@comet/admin";
 import { ArrowRight } from "@comet/admin-icons";
+import { IconButton } from "@mui/material";
 import { GQLLatestContentUpdatesQuery, GQLLatestContentUpdatesQueryVariables } from "@src/graphql.generated";
 import { categoryToUrlParam } from "@src/utils/pageTreeNodeCategoryMapping";
 import * as React from "react";
@@ -71,19 +72,21 @@ export const LatestContentUpdates: React.FC = () => {
                             },
                             {
                                 name: "jumpTo",
+                                cellProps: { align: "right" },
                                 render: (row) => {
                                     if (!row.pageTreeNode) {
                                         return null;
                                     }
 
                                     return (
-                                        <Link
+                                        <IconButton
+                                            component={Link}
                                             to={`/${row.pageTreeNode.scope.domain}/${
                                                 row.pageTreeNode.scope.language
                                             }/pages/pagetree/${categoryToUrlParam(row.pageTreeNode.category)}/${row.pageTreeNode.id}/edit`}
                                         >
                                             <ArrowRight />
-                                        </Link>
+                                        </IconButton>
                                     );
                                 },
                             },

--- a/packages/admin/cms-admin/src/dam/Table/fileUpload/UploadSplitButton.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/fileUpload/UploadSplitButton.tsx
@@ -48,7 +48,6 @@ export const UploadSplitButton = ({ folderId, filter }: UploadSplitButtonProps):
                     variant="contained"
                     color="primary"
                     startIcon={<Upload />}
-                    component="label"
                     onClick={() => {
                         // Add explicit onClick to make it work in SplitButton
                         fileInputRef.current?.click();
@@ -60,7 +59,6 @@ export const UploadSplitButton = ({ folderId, filter }: UploadSplitButtonProps):
                     variant="contained"
                     color="primary"
                     startIcon={<Upload />}
-                    component="label"
                     onClick={() => {
                         // Add explicit onClick to make it work in SplitButton
                         folderInputRef.current?.click();

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -26,8 +26,8 @@ const StyledDialogTitle = styled(DialogTitle)`
 `;
 
 const CloseButton = styled(IconButton)`
-    color: inherit;
-    padding: 0;
+    position: absolute;
+    right: ${({ theme }) => theme.spacing(2)};
 `;
 
 const TableRowButton = styled(Button)`
@@ -70,8 +70,8 @@ export const ChooseFileDialog = ({ open, onClose, onChooseFile, allowedMimetypes
         <FixedHeightDialog open={open} onClose={onClose} fullWidth maxWidth="xl">
             <StyledDialogTitle>
                 <FormattedMessage id="comet.form.file.selectFile" defaultMessage="Select file from DAM" />
-                <CloseButton onClick={(event) => onClose(event, "backdropClick")}>
-                    <Close fontSize="medium" />
+                <CloseButton onClick={(event) => onClose(event, "backdropClick")} color="inherit">
+                    <Close />
                 </CloseButton>
             </StyledDialogTitle>
             <MemoryRouter>

--- a/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
@@ -32,12 +32,15 @@ export const selectedPageFragment = gql`
 `;
 
 const StyledDialogTitle = styled(DialogTitle)`
-    & > .MuiTypography-root {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        width: 100%;
-    }
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+`;
+
+const CloseButton = styled(IconButton)`
+    position: absolute;
+    right: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledDialogAction = styled(DialogActions)`
@@ -181,9 +184,9 @@ export default function PageTreeSelectDialog({ value, onChange, open, onClose, d
         >
             <StyledDialogTitle>
                 <FormattedMessage id="comet.pages.pageTreeSelect.label" defaultMessage="Select Page" />
-                <IconButton onClick={onClose} color="inherit" size="large">
-                    <Close fontSize="medium" />
-                </IconButton>
+                <CloseButton onClick={onClose} color="inherit">
+                    <Close />
+                </CloseButton>
             </StyledDialogTitle>
             <Toolbar>
                 <ToolbarActions>


### PR DESCRIPTION
 - [Fix icon-link color & align as last item](https://github.com/vivid-planet/comet/commit/16c68a23bb312e9d2a2fcd4be6d6984c7dbeced3)
 - [Don't set the button's component to label](https://github.com/vivid-planet/comet/commit/2e18641bc6882f6943ef418a55e7f293c56ffdae)
This broke the styling of the SplitButton and just looked like two separate buttons next to each other without any spacing.
 - [Make the close button look the same in both dialogs](https://github.com/vivid-planet/comet/commit/3214d62e8c7cef86b896fed9d68d50cf5e7145f7)