### PR TITLE
DAM: File Not Found Error State

### DIFF
--- a/packages/admin/cms-admin/src/common/image/ImageCrop.tsx
+++ b/packages/admin/cms-admin/src/common/image/ImageCrop.tsx
@@ -9,7 +9,7 @@ import * as sc from "./ImageCrop.sc";
 
 const focalPoints: GQLFocalPoint[] = ["CENTER", "NORTHEAST", "NORTHWEST", "SOUTHEAST", "SOUTHWEST"];
 
-type ImageCropProps = Pick<ReactCropProps, "src" | "imageStyle" | "disabled">;
+type ImageCropProps = Pick<ReactCropProps, "src" | "imageStyle" | "disabled" | "onImageError">;
 
 export const ImageCrop = (props: ImageCropProps): React.ReactElement => {
     const form = useForm<EditImageFormValues>();

--- a/packages/admin/cms-admin/src/dam/FileForm/previews/AudioPreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/previews/AudioPreview.tsx
@@ -46,9 +46,10 @@ const StyledAudio = styled("audio")`
 
 interface AudioPreviewProps {
     file: GQLDamFileDetailFragment;
+    onError?: (event: React.SyntheticEvent<HTMLSourceElement, Event>) => void;
 }
 
-export const AudioPreview = ({ file }: AudioPreviewProps): React.ReactElement => {
+export const AudioPreview = ({ file, onError }: AudioPreviewProps): React.ReactElement => {
     return (
         <AudioPreviewWrapper>
             <MusicIconContainer>
@@ -57,7 +58,7 @@ export const AudioPreview = ({ file }: AudioPreviewProps): React.ReactElement =>
                 </MusicIconWrapper>
             </MusicIconContainer>
             <StyledAudio controls>
-                <source src={file.fileUrl} type={file.mimetype} />
+                <source src={file.fileUrl} type={file.mimetype} onError={onError} />
             </StyledAudio>
         </AudioPreviewWrapper>
     );

--- a/packages/admin/cms-admin/src/dam/FileForm/previews/FileNotFound.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/previews/FileNotFound.tsx
@@ -1,0 +1,48 @@
+import { Error } from "@comet/admin-icons";
+import { Box, Typography } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+const FileNotFoundWrapper = styled("div")`
+    width: 100%;
+    min-height: 400px;
+    background-color: ${({ theme }) => theme.palette.grey[50]};
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`;
+
+const InnerWrapper = styled(Box)`
+    height: 150px;
+    background: white;
+    padding: 0 20px;
+    border: ${({ theme }) => theme.palette.error.main} solid 2px;
+    border-radius: 10px;
+
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    align-items: center;
+    box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.1);
+`;
+
+const ErrorIcon = styled(Error)`
+    color: ${({ theme }) => theme.palette.error.main};
+    width: 54px;
+    height: 72px;
+`;
+
+export const FileNotFound = (): React.ReactElement => {
+    return (
+        <FileNotFoundWrapper>
+            <InnerWrapper>
+                <ErrorIcon />
+                <Typography variant="h3" component="p">
+                    <FormattedMessage id="comet.dam.filePreview.error" defaultMessage="File not found" />
+                </Typography>
+            </InnerWrapper>
+        </FileNotFoundWrapper>
+    );
+};

--- a/packages/admin/cms-admin/src/dam/FileForm/previews/ImagePreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/previews/ImagePreview.tsx
@@ -7,8 +7,9 @@ const imageStyle = { maxWidth: "100%", maxHeight: "75vh" };
 
 interface Props {
     file: GQLDamFileDetailFragment;
+    onError?: (event: React.SyntheticEvent<HTMLImageElement, Event>) => void;
 }
 
-export function ImagePreview({ file }: Props): JSX.Element {
-    return <ImageCrop src={file.fileUrl} imageStyle={imageStyle} />;
+export function ImagePreview({ file, onError }: Props): JSX.Element {
+    return <ImageCrop src={file.fileUrl} imageStyle={imageStyle} onImageError={onError} />;
 }

--- a/packages/admin/cms-admin/src/dam/FileForm/previews/PdfPreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/previews/PdfPreview.tsx
@@ -16,12 +16,13 @@ const PdfPreviewIFrame = styled("iframe")`
 
 interface PdfPreviewProps {
     file: GQLDamFileDetailFragment;
+    onError?: (event: React.SyntheticEvent<HTMLIFrameElement, Event>) => void;
 }
 
-export const PdfPreview = ({ file }: PdfPreviewProps): React.ReactElement => {
+export const PdfPreview = ({ file, onError }: PdfPreviewProps): React.ReactElement => {
     return (
         <PdfPreviewWrapper>
-            <PdfPreviewIFrame src={file.fileUrl} />
+            <PdfPreviewIFrame src={file.fileUrl} onError={onError} />
         </PdfPreviewWrapper>
     );
 };

--- a/packages/admin/cms-admin/src/dam/FileForm/previews/VideoPreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/previews/VideoPreview.tsx
@@ -19,12 +19,13 @@ const StyledVideo = styled("video")`
 
 interface VideoPreviewProps {
     file: GQLDamFileDetailFragment;
+    onError?: (event: React.SyntheticEvent<HTMLVideoElement, Event>) => void;
 }
 
-export const VideoPreview = ({ file }: VideoPreviewProps): React.ReactElement => {
+export const VideoPreview = ({ file, onError }: VideoPreviewProps): React.ReactElement => {
     return (
         <VideoPreviewWrapper>
-            <StyledVideo controls src={file.fileUrl}>
+            <StyledVideo controls src={file.fileUrl} onError={onError}>
                 <FormattedMessage
                     id="comet.dam.file.unsupportedVideoTag"
                     defaultMessage="Your browser does not support the video element. Please use another browser."

--- a/packages/api/cms-api/src/blob-storage/backends/file/blob-storage-file.storage.ts
+++ b/packages/api/cms-api/src/blob-storage/backends/file/blob-storage-file.storage.ts
@@ -76,10 +76,18 @@ export class BlobStorageFileStorage implements BlobStorageBackendInterface {
     }
 
     async getFile(folderName: string, fileName: string): Promise<NodeJS.ReadableStream> {
+        if (!(await this.fileExists(folderName, fileName))) {
+            throw new Error(`File does not exist: ${path}`);
+        }
+
         return fs.createReadStream(`${this.path}/${folderName}/${fileName}`);
     }
 
     async getPartialFile(folderName: string, fileName: string, offset: number, length: number): Promise<NodeJS.ReadableStream> {
+        if (!(await this.fileExists(folderName, fileName))) {
+            throw new Error(`File does not exist: ${path}`);
+        }
+
         return fs.createReadStream(`${this.path}/${folderName}/${fileName}`, {
             start: offset,
             end: offset + length - 1,


### PR DESCRIPTION
- check if file exists before returning it in `BlobStorageFileStorage` (previously the API server would crash if the file didn't exist on disk)
- open error dialog if file doesn't exist on disk (only in DB)
- show error message in file preview if file doesn't exist on disk (only in DB)

### Open Question:

- Is this the right way to handle an error like this?
- This error is non-recoverable since the physical file disappeared from disk but the DB entry still exists
- This should NEVER happen in normal operation
- The file can be repaired by uploading the same file again
- Possibility: automatically archive the file to prevent further use

### Screencast:

https://user-images.githubusercontent.com/13380047/186102863-a590c898-f36e-4a11-b0c8-8dc38668e02f.mov


