### PR TITLE
Simplify useSaveConflict hook by making it query independent

### DIFF
--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -60,6 +60,7 @@ export type { AllCategories } from "./pages/pageTree/PageTreeContext";
 export { useCopyPastePages } from "./pages/pageTree/useCopyPastePages";
 export { resolveHasSaveConflict } from "./pages/resolveHasSaveConflict";
 export { useSaveConflict } from "./pages/useSaveConflict";
+export { useSaveConflictQuery } from "./pages/useSaveConflictQuery";
 export { BlockPreview } from "./preview/BlockPreview";
 export { BlockPreviewWithTabs } from "./preview/BlockPreviewWithTabs";
 export { openPreviewWindow } from "./preview/openPreviewWindow";

--- a/packages/admin/cms-admin/src/pages/createUsePage.tsx
+++ b/packages/admin/cms-admin/src/pages/createUsePage.tsx
@@ -16,7 +16,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { GQLCheckForChangesQuery, GQLCheckForChangesQueryVariables, GQLDocumentInterface } from "../graphql.generated";
 import { resolveHasSaveConflict } from "./resolveHasSaveConflict";
-import { useSaveConflict } from "./useSaveConflict";
+import { useSaveConflictQuery } from "./useSaveConflictQuery";
 
 type Output = Record<string, unknown>;
 // dictionary of all root-blocks connected to a page
@@ -217,7 +217,7 @@ export const createUsePage: CreateUsePage =
                 dialogs,
                 checkForConflicts: checkForSaveConflict,
                 hasConflict,
-            } = useSaveConflict<GQLCheckForChangesQuery, GQLCheckForChangesQueryVariables>(
+            } = useSaveConflictQuery<GQLCheckForChangesQuery, GQLCheckForChangesQueryVariables>(
                 checkForChangesQuery,
                 {
                     variables: {

--- a/packages/admin/cms-admin/src/pages/useSaveConflict.tsx
+++ b/packages/admin/cms-admin/src/pages/useSaveConflict.tsx
@@ -1,114 +1,71 @@
-import { useLazyQuery } from "@apollo/client";
-import { LazyQueryHookOptions } from "@apollo/client/react/types/types";
 import { useSnackbarApi } from "@comet/admin";
-import { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { Alert, Snackbar } from "@mui/material";
-import { DocumentNode } from "graphql";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { SaveConflictDialog } from "./SaveConflictDialog";
 
-interface SaveConflictHookOptions<TData, TVariables> extends LazyQueryHookOptions<TData, TVariables> {
-    resolveHasConflict: (query: TData) => boolean;
-    skip?: boolean;
-}
-
-interface SaveConflictDialogOptions {
-    hasChanges: boolean;
+export interface SaveConflictOptions {
+    checkConflict: () => Promise<boolean>;
+    hasChanges: () => boolean;
     loadLatestVersion: () => Promise<void>;
     onDiscardButtonPressed: () => Promise<void>;
 }
 
-interface SaveConflictHookReturn {
+export interface SaveConflictHookReturn {
     hasConflict: boolean;
     loading: boolean;
     dialogs: React.ReactNode;
     checkForConflicts: () => Promise<boolean>;
 }
 
-export function useSaveConflict<TData, TVariables>(
-    query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-    options: SaveConflictHookOptions<TData, TVariables>,
-    dialogOptions: SaveConflictDialogOptions,
-): SaveConflictHookReturn {
-    const { hasChanges, loadLatestVersion, onDiscardButtonPressed } = dialogOptions;
-    const { resolveHasConflict, ...restOptions } = options;
+export function useSaveConflict(options: SaveConflictOptions): SaveConflictHookReturn {
+    const { checkConflict, hasChanges, loadLatestVersion, onDiscardButtonPressed } = options;
     const snackbarApi = useSnackbarApi();
 
     const [loading, setLoading] = React.useState(false);
     const [showDialog, setShowDialog] = React.useState(false);
     const [hasConflict, setHasConflict] = React.useState(false);
 
-    const [lazyQuery, { data, refetch: checkForChangeRefetch }] = useLazyQuery<TData, TVariables>(query, {
-        ...restOptions,
-        fetchPolicy: "no-cache",
-    });
-
-    const loadLatestVersionAsync = React.useCallback(async () => {
-        await loadLatestVersion();
-        snackbarApi.showSnackbar(
-            <Snackbar anchorOrigin={{ vertical: "bottom", horizontal: "left" }} autoHideDuration={5000}>
-                <Alert severity="success">
-                    <FormattedMessage
-                        id="comet.saveConflict.autoReloadSuccessfull"
-                        defaultMessage="This content has changed. We've refreshed the page for you."
-                    />
-                </Alert>
-            </Snackbar>,
-        );
-    }, [loadLatestVersion, snackbarApi]);
-
     React.useEffect(() => {
-        if (hasConflict) {
-            // No local changes, server changes available
-            if (!hasChanges) {
-                loadLatestVersionAsync();
+        const interval = setInterval(async () => {
+            const newHasConflict = await checkConflict();
+            //we don't need setHasConflict as that is used during save only
+            if (newHasConflict) {
+                if (!hasChanges()) {
+                    // No local changes, server changes available
+                    await loadLatestVersion();
+                    snackbarApi.showSnackbar(
+                        <Snackbar anchorOrigin={{ vertical: "bottom", horizontal: "left" }} autoHideDuration={5000}>
+                            <Alert severity="success">
+                                <FormattedMessage
+                                    id="comet.saveConflict.autoReloadSuccessfull"
+                                    defaultMessage="This content has changed. We've refreshed the page for you."
+                                />
+                            </Alert>
+                        </Snackbar>,
+                    );
+                } else {
+                    // local changes, and server changes available: ask user what to do
+                    setShowDialog(true);
+                }
+            } else {
+                setShowDialog(false);
             }
-            // local changes, and serve changes available
-            else {
-                setShowDialog(true);
-            }
-        } else {
-            setShowDialog(false);
-        }
-    }, [hasChanges, hasConflict, loadLatestVersionAsync]);
-
-    React.useEffect(() => {
-        if (data != null) {
-            const resolvedHasConflict = resolveHasConflict(data);
-            if (resolvedHasConflict != hasConflict) {
-                setHasConflict(resolvedHasConflict);
-            }
-        }
-    }, [hasConflict, data, resolveHasConflict]);
-
-    React.useEffect(() => {
-        if (!options.skip) {
-            const interval = setInterval(async () => {
-                await lazyQuery();
-            }, 10000);
-            return () => {
-                clearInterval(interval);
-            };
-        }
-    }, [lazyQuery, options.skip]);
+        }, 10000);
+        return () => {
+            clearInterval(interval);
+        };
+    }, [checkConflict, snackbarApi, loadLatestVersion, hasChanges]);
 
     const checkForConflicts = React.useCallback(async () => {
         setLoading(true);
         setHasConflict(false);
-        const result = await checkForChangeRefetch?.();
+        const newHasConflict = await checkConflict();
+        setHasConflict(newHasConflict);
         setLoading(false);
-
-        if (result?.data != null) {
-            const resolvedConflict = resolveHasConflict(result.data);
-            if (resolvedConflict != hasConflict) {
-                setHasConflict(resolvedConflict);
-            }
-            return resolvedConflict;
-        }
-        return false;
-    }, [checkForChangeRefetch, hasConflict, resolveHasConflict]);
+        return newHasConflict;
+    }, [checkConflict]);
     return {
         hasConflict,
         loading,

--- a/packages/admin/cms-admin/src/pages/useSaveConflictQuery.tsx
+++ b/packages/admin/cms-admin/src/pages/useSaveConflictQuery.tsx
@@ -1,0 +1,32 @@
+import { DocumentNode, QueryOptions, TypedDocumentNode, useApolloClient } from "@apollo/client";
+
+import { SaveConflictHookReturn, useSaveConflict } from "./useSaveConflict";
+
+interface SaveConflictQueryHookOptions<TData, TVariables> extends Omit<QueryOptions<TVariables, TData>, "query"> {
+    resolveHasConflict: (query: TData) => boolean;
+    skip?: boolean;
+}
+interface SaveConflictDialogOptions {
+    hasChanges: boolean;
+    loadLatestVersion: () => Promise<void>;
+    onDiscardButtonPressed: () => Promise<void>;
+}
+export function useSaveConflictQuery<TData, TVariables>(
+    query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+    options: SaveConflictQueryHookOptions<TData, TVariables>,
+    dialogOptions: SaveConflictDialogOptions,
+): SaveConflictHookReturn {
+    const client = useApolloClient();
+    const { resolveHasConflict, skip, ...restOptions } = options;
+    const checkConflict = async () => {
+        if (skip) return false;
+        const { data, error } = await client.query({
+            query,
+            fetchPolicy: "no-cache",
+            ...restOptions,
+        });
+        if (error) return false;
+        return resolveHasConflict(data);
+    };
+    return useSaveConflict({ checkConflict, ...dialogOptions, hasChanges: () => dialogOptions.hasChanges });
+}


### PR DESCRIPTION
useSaveConflict previously made the query itself and was relative complicated to use (needed query+variables and a resolve function) and not very generic.

This refactoring makes useSaveConflict independent of apollo client, requiring simply a function that returns Promise<boolean>.

Incompatible change! For easy upgrading path the old version is still available as `useSaveConflictQuery` (internally using the new)

Old:
```
    const saveConflict = useSaveConflict<GQLCheckForChangesProductQuery, GQLCheckForChangesProductQueryVariables>(
        productCheckForChangesQuery,
        {
            variables: id ? { id } : undefined,
            resolveHasConflict: (data) => {
                return resolveHasSaveConflict(query.data?.product?.updatedAt, data?.product?.updatedAt);
            },
            skip: mode === "add",
        },
        {
            hasChanges,
            loadLatestVersion: async () => {
                await query.refetch();
            },
            onDiscardButtonPressed: async () => {
                await query.refetch();
            },
        },
    );
```

New:
```
    const saveConflict = useSaveConflict({
        checkConflict: async () => {
            if (!id) return false;
            const { data: hasConflictData } = await client.query<GQLCheckForChangesProductQuery, GQLCheckForChangesProductQueryVariables>({
                query: productCheckForChangesQuery,
                variables: { id },
                fetchPolicy: "no-cache",
            });

            return resolveHasSaveConflict(data?.product.updatedAt, hasConflictData.product.updatedAt);
        },
        hasChanges: () => hasChanges, //this also changed into a callback (for more flexibility)
        loadLatestVersion: async () => {
            await query.refetch();
        },
        onDiscardButtonPressed: async () => {
            await query.refetch();
        },
    });
```