### PR TITLE
Remove ForkTsCheckerWebpackPlugin from webpack config

### DIFF
--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -126,7 +126,6 @@
         "dotenv-cli": "^4.0.0",
         "eslint": "^8.0.0",
         "fast-xml-parser": "^3.0.0",
-        "fork-ts-checker-webpack-plugin": "^7.0.0",
         "graphql-request": "^3.0.0",
         "html-webpack-plugin": "^5.0.0",
         "pascal-case": "^3.0.0",

--- a/demo/admin/webpack.config.ts
+++ b/demo/admin/webpack.config.ts
@@ -1,6 +1,5 @@
 import "webpack-dev-server";
 
-import ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 import * as fs from "fs";
 import * as HtmlWebpackPlugin from "html-webpack-plugin";
 import * as path from "path";
@@ -43,8 +42,6 @@ const config = ({ production }: IEnvironment): webpack.Configuration => {
                 "process.env.NODE_ENV": JSON.stringify("production"),
             }),
         );
-    } else {
-        plugins.push(new ForkTsCheckerWebpackPlugin());
     }
 
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15576,7 +15576,6 @@ __metadata:
     final-form: ^4.0.0
     final-form-arrays: ^3.0.0
     final-form-set-field-touched: ^1.0.0
-    fork-ts-checker-webpack-plugin: ^7.0.0
     graphql: ^15.0.0
     graphql-anywhere: ^4.0.0
     graphql-request: ^3.0.0
@@ -19751,33 +19750,6 @@ __metadata:
     vue-template-compiler:
       optional: true
   checksum: c823de02ee258a26ea5c0c488b2f1825b941f72292417478689862468a9140b209ad7df52f67bd134228fe9f40e9115b604fc8f88a69338929fe52be869469b6
-  languageName: node
-  linkType: hard
-
-"fork-ts-checker-webpack-plugin@npm:^7.0.0":
-  version: 7.2.13
-  resolution: "fork-ts-checker-webpack-plugin@npm:7.2.13"
-  dependencies:
-    "@babel/code-frame": ^7.16.7
-    chalk: ^4.1.2
-    chokidar: ^3.5.3
-    cosmiconfig: ^7.0.1
-    deepmerge: ^4.2.2
-    fs-extra: ^10.0.0
-    memfs: ^3.4.1
-    minimatch: ^3.0.4
-    node-abort-controller: ^3.0.1
-    schema-utils: ^3.1.1
-    semver: ^7.3.5
-    tapable: ^2.2.1
-  peerDependencies:
-    typescript: ">3.6.0"
-    vue-template-compiler: "*"
-    webpack: ^5.11.0
-  peerDependenciesMeta:
-    vue-template-compiler:
-      optional: true
-  checksum: 3d4694c6fee4b8b2f213d0d10a3f40da770ca0ed3aa2a3dc8d1e701ad1ecaed3a1507f77a1b0cea6ef80539b04d8e5f5f02560e688d310bcb9e8c81f684d2950
   languageName: node
   linkType: hard
 
@@ -26261,13 +26233,6 @@ __metadata:
     lower-case: ^2.0.2
     tslib: ^2.0.3
   checksum: 0b2ebc113dfcf737d48dde49cfebf3ad2d82a8c3188e7100c6f375e30eafbef9e9124aadc3becef237b042fd5eb0aad2fd78669c20972d045bbe7fea8ba0be5c
-  languageName: node
-  linkType: hard
-
-"node-abort-controller@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "node-abort-controller@npm:3.0.1"
-  checksum: 2b3d75c65249fea99e8ba22da3a8bc553f034f44dd12f5f4b38b520f718b01c88718c978f0c24c2a460fc01de9a80b567028f547b94440cb47adeacfeb82c2ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Doesn't log eslint/tsc errors in browser anymore, as I find that non helpful and spams the console only.
The IDE should be used for that.

And for cicd and production we have a dedicated lint pipeline (and this plugin was not used before)

(TODO: change that also in starter)