### PR TITLE
FinalForm based edit of Products with blocks

### DIFF
--- a/demo/admin/src/products/ProductForm.gql.ts
+++ b/demo/admin/src/products/ProductForm.gql.ts
@@ -7,21 +7,34 @@ export const productFormFragment = gql`
         description
         price
         inStock
+        image
     }
 `;
 
 export const productQuery = gql`
     query Product($id: ID!) {
         product(id: $id) {
+            id
+            updatedAt
             ...ProductForm
         }
     }
     ${productFormFragment}
 `;
 
+export const productCheckForChangesQuery = gql`
+    query CheckForChangesProduct($id: ID!) {
+        product(id: $id) {
+            updatedAt
+        }
+    }
+`;
+
 export const createProductMutation = gql`
     mutation ProductFormCreateProduct($input: ProductInput!) {
         createProduct(input: $input) {
+            id
+            updatedAt
             ...ProductForm
         }
     }
@@ -29,8 +42,10 @@ export const createProductMutation = gql`
 `;
 
 export const updateProductMutation = gql`
-    mutation ProductFormUpdateProduct($id: ID!, $input: ProductInput!) {
-        updateProduct(id: $id, input: $input) {
+    mutation ProductFormUpdateProduct($id: ID!, $input: ProductInput!, $lastUpdatedAt: DateTime) {
+        updateProduct(id: $id, input: $input, lastUpdatedAt: $lastUpdatedAt) {
+            id
+            updatedAt
             ...ProductForm
         }
     }

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -4,21 +4,24 @@ import {
     FinalForm,
     FinalFormCheckbox,
     FinalFormInput,
+    FinalFormSaveSplitButton,
     MainContent,
-    messages,
-    SaveButton,
-    SplitButton,
     Toolbar,
     ToolbarActions,
     ToolbarFillSpace,
     ToolbarItem,
     ToolbarTitleItem,
+    useFormApiRef,
     useStackApi,
+    useStackSwitchApi,
 } from "@comet/admin";
 import { ArrowLeft } from "@comet/admin-icons";
-import { EditPageLayout } from "@comet/cms-admin";
+import { BlockState, createFinalFormBlock } from "@comet/blocks-admin";
+import { DamImageBlock, EditPageLayout, resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
 import { CircularProgress, FormControlLabel, IconButton } from "@mui/material";
 import {
+    GQLCheckForChangesProductQuery,
+    GQLCheckForChangesProductQueryVariables,
     GQLProductFormCreateProductMutation,
     GQLProductFormCreateProductMutationVariables,
     GQLProductFormFragment,
@@ -27,49 +30,89 @@ import {
     GQLProductQuery,
     GQLProductQueryVariables,
 } from "@src/graphql.generated";
-import { FORM_ERROR } from "final-form";
 import { filter } from "graphql-anywhere";
+import isEqual from "lodash.isequal";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 
-import { createProductMutation, productFormFragment, productQuery, updateProductMutation } from "./ProductForm.gql";
+import { createProductMutation, productCheckForChangesQuery, productFormFragment, productQuery, updateProductMutation } from "./ProductForm.gql";
 
 interface FormProps {
     id?: string;
 }
 
+const rootBlocks = {
+    image: DamImageBlock,
+};
+
 type FormState = Omit<GQLProductFormFragment, "price"> & {
     price: string;
+    image: BlockState<typeof rootBlocks.image>;
 };
 
 function ProductForm({ id }: FormProps): React.ReactElement {
-    const intl = useIntl();
     const stackApi = useStackApi();
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
+    const formApiRef = useFormApiRef<FormState>();
+    const stackSwitchApi = useStackSwitchApi();
+    const createMutationResponseRef = React.useRef<GQLProductFormCreateProductMutation>();
+
+    const { data, error, loading, refetch } = useQuery<GQLProductQuery, GQLProductQueryVariables>(
+        productQuery,
+        id ? { variables: { id } } : { skip: true },
+    );
+
+    const initialValues: Partial<FormState> = data?.product
+        ? {
+              ...filter<GQLProductFormFragment>(productFormFragment, data.product),
+              price: String(data.product.price),
+              image: rootBlocks.image.input2State(data.product.image),
+          }
+        : {
+              image: rootBlocks.image.defaultValues(),
+          };
+
+    const saveConflict = useFormSaveConflict({
+        checkConflict: async () => {
+            if (!id) return false;
+            const { data: hasConflictData } = await client.query<GQLCheckForChangesProductQuery, GQLCheckForChangesProductQueryVariables>({
+                query: productCheckForChangesQuery,
+                variables: { id },
+                fetchPolicy: "no-cache",
+            });
+            return resolveHasSaveConflict(data?.product.updatedAt, hasConflictData.product.updatedAt);
+        },
+        formApiRef,
+        loadLatestVersion: async () => {
+            await refetch();
+        },
+    });
 
     const handleSubmit = async (formState: FormState) => {
-        const input = {
+        if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");
+        createMutationResponseRef.current = undefined;
+        const output = {
             ...formState,
             price: parseFloat(formState.price),
+            image: rootBlocks.image.state2Output(formState.image),
         };
         if (mode === "edit") {
             if (!id) throw new Error();
             await client.mutate<GQLProductFormUpdateProductMutation, GQLProductFormUpdateProductMutationVariables>({
                 mutation: updateProductMutation,
-                variables: { id, input },
+                variables: { id, input: output, lastUpdatedAt: data?.product.updatedAt },
             });
         } else {
-            await client.mutate<GQLProductFormCreateProductMutation, GQLProductFormCreateProductMutationVariables>({
+            const { data: mutationReponse } = await client.mutate<GQLProductFormCreateProductMutation, GQLProductFormCreateProductMutationVariables>({
                 mutation: createProductMutation,
-                variables: { input },
+                variables: { input: output },
             });
+            if (mutationReponse) {
+                createMutationResponseRef.current = mutationReponse;
+            }
         }
     };
-
-    const { data, error, loading } = useQuery<GQLProductQuery, GQLProductQueryVariables>(productQuery, id ? { variables: { id } } : { skip: true });
-
-    const initialValues = data?.product ? filter(productFormFragment, data.product) : {};
 
     if (error) {
         return <FormattedMessage id="demo.common.error" defaultMessage="Ein Fehler ist aufgetreten. Bitte versuchen Sie es später noch einmal." />;
@@ -81,16 +124,18 @@ function ProductForm({ id }: FormProps): React.ReactElement {
 
     return (
         <FinalForm<FormState>
+            apiRef={formApiRef}
             onSubmit={handleSubmit}
             mode={mode}
             initialValues={initialValues}
-            renderButtons={() => null}
+            initialValuesEqual={isEqual} //required to compare block data correctly
             onAfterSubmit={(values, form) => {
                 //don't go back automatically
             }}
         >
-            {({ values, pristine, hasValidationErrors, submitting, handleSubmit, hasSubmitErrors }) => (
+            {({ values }) => (
                 <EditPageLayout>
+                    {saveConflict.dialogs}
                     <Toolbar>
                         <ToolbarItem>
                             <IconButton onClick={stackApi?.goBack}>
@@ -102,26 +147,14 @@ function ProductForm({ id }: FormProps): React.ReactElement {
                         </ToolbarTitleItem>
                         <ToolbarFillSpace />
                         <ToolbarActions>
-                            <SplitButton disabled={pristine || hasValidationErrors || submitting} localStorageKey="editInspirationSave">
-                                <SaveButton color="primary" variant="contained" hasErrors={hasSubmitErrors} type="submit">
-                                    <FormattedMessage {...messages.save} />
-                                </SaveButton>
-                                <SaveButton
-                                    color="primary"
-                                    variant="contained"
-                                    saving={submitting}
-                                    hasErrors={hasSubmitErrors}
-                                    onClick={async () => {
-                                        const submitResult = await handleSubmit();
-                                        const error = submitResult?.[FORM_ERROR];
-                                        if (!error) {
-                                            stackApi?.goBack();
-                                        }
-                                    }}
-                                >
-                                    <FormattedMessage {...messages.saveAndGoBack} />
-                                </SaveButton>
-                            </SplitButton>
+                            <FinalFormSaveSplitButton
+                                onNavigateToEditPage={() => {
+                                    const id = createMutationResponseRef.current?.createProduct.id;
+                                    if (mode == "add" && id) {
+                                        stackSwitchApi.activatePage(`edit`, id);
+                                    }
+                                }}
+                            />
                         </ToolbarActions>
                     </Toolbar>
                     <MainContent>
@@ -130,14 +163,14 @@ function ProductForm({ id }: FormProps): React.ReactElement {
                             fullWidth
                             name="title"
                             component={FinalFormInput}
-                            label={intl.formatMessage({ id: "demo.product.title", defaultMessage: "Titel" })}
+                            label={<FormattedMessage id="demo.product.title" defaultMessage="Titel" />}
                         />
                         <Field
                             required
                             fullWidth
                             name="slug"
                             component={FinalFormInput}
-                            label={intl.formatMessage({ id: "demo.product.slug", defaultMessage: "Slug" })}
+                            label={<FormattedMessage id="demo.product.slug" defaultMessage="Slug" />}
                         />
                         <Field
                             required
@@ -146,22 +179,25 @@ function ProductForm({ id }: FormProps): React.ReactElement {
                             rows={5}
                             name="description"
                             component={FinalFormInput}
-                            label={intl.formatMessage({ id: "demo.product.description", defaultMessage: "Beschreibung" })}
+                            label={<FormattedMessage id="demo.product.description" defaultMessage="Beschreibung" />}
                         />
                         <Field
                             fullWidth
                             name="price"
                             component={FinalFormInput}
                             inputProps={{ type: "number" }}
-                            label={intl.formatMessage({ id: "demo.product.description", defaultMessage: "Preis" })}
+                            label={<FormattedMessage id="demo.product.price" defaultMessage="Preis" />}
                         />
                         <Field name="inStock" label="" type="checkbox" fullWidth>
                             {(props) => (
                                 <FormControlLabel
-                                    label={intl.formatMessage({ id: "demo.product.inStock", defaultMessage: "Auf Lager" })}
+                                    label={<FormattedMessage id="demo.product.inStock" defaultMessage="Auf Lager" />}
                                     control={<FinalFormCheckbox {...props} />}
                                 />
                             )}
+                        </Field>
+                        <Field name="image" isEqual={isEqual}>
+                            {createFinalFormBlock(rootBlocks.image)}
                         </Field>
                     </MainContent>
                 </EditPageLayout>

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -304,6 +304,7 @@ type Product implements DocumentInterface {
   description: String!
   price: Float
   inStock: Boolean!
+  image: JSONObject
   createdAt: DateTime!
 }
 

--- a/demo/api/src/db/migrations/Migration20230221101720.ts
+++ b/demo/api/src/db/migrations/Migration20230221101720.ts
@@ -1,0 +1,8 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20230221101720 extends Migration {
+    async up(): Promise<void> {
+        this.addSql('truncate table "Product";');
+        this.addSql('alter table "Product" add column "image" json not null;');
+    }
+}

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -1,4 +1,5 @@
-import { CrudField, CrudGenerator, DocumentInterface } from "@comet/cms-api";
+import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
+import { CrudField, CrudGenerator, DamImageBlock, DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import { BaseEntity, Entity, OptionalProps, PrimaryKey, Property, types } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
@@ -7,6 +8,7 @@ import { v4 as uuid } from "uuid";
     implements: () => [DocumentInterface],
 })
 @Entity()
+@RootBlockEntity()
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/` })
 export class Product extends BaseEntity<Product, "id"> implements DocumentInterface {
     [OptionalProps]?: "createdAt" | "updatedAt";
@@ -41,6 +43,11 @@ export class Product extends BaseEntity<Product, "id"> implements DocumentInterf
     @Property({ type: types.boolean })
     @Field()
     inStock: boolean = true;
+
+    @Property({ customType: new RootBlockType(DamImageBlock) })
+    @Field(() => RootBlockDataScalar(DamImageBlock))
+    @RootBlock(DamImageBlock)
+    image: BlockDataInterface;
 
     @Property()
     @Field()

--- a/packages/admin/admin/src/FinalFormSaveSplitButton.tsx
+++ b/packages/admin/admin/src/FinalFormSaveSplitButton.tsx
@@ -10,9 +10,10 @@ import { useStackApi } from "./stack/Api";
 
 export interface FormSaveButtonProps {
     localStorageKey?: string;
+    onNavigateToEditPage?: () => void;
 }
 
-export const FinalFormSaveSplitButton = ({ localStorageKey = "SaveSplitButton" }: PropsWithChildren<FormSaveButtonProps>) => {
+export const FinalFormSaveSplitButton = ({ localStorageKey = "SaveSplitButton", onNavigateToEditPage }: PropsWithChildren<FormSaveButtonProps>) => {
     const stackApi = useStackApi();
     const form = useForm();
     const { pristine, hasValidationErrors, submitting, hasSubmitErrors } = useFormState();
@@ -24,8 +25,14 @@ export const FinalFormSaveSplitButton = ({ localStorageKey = "SaveSplitButton" }
                 variant="contained"
                 saving={submitting}
                 hasErrors={hasSubmitErrors}
-                onClick={() => {
-                    form.submit();
+                onClick={async () => {
+                    const submitReturn = await form.submit();
+                    const successful = submitReturn === undefined || Object.keys(submitReturn).length == 0;
+                    if (successful && onNavigateToEditPage) {
+                        setTimeout(() => {
+                            onNavigateToEditPage();
+                        });
+                    }
                 }}
             >
                 <FormattedMessage {...messages.save} />
@@ -36,9 +43,9 @@ export const FinalFormSaveSplitButton = ({ localStorageKey = "SaveSplitButton" }
                 saving={submitting}
                 hasErrors={hasSubmitErrors}
                 onClick={async () => {
-                    const submitResult = await form.submit();
-                    const error = submitResult !== undefined;
-                    if (!error) {
+                    const submitReturn = await form.submit();
+                    const successful = submitReturn === undefined || Object.keys(submitReturn).length == 0;
+                    if (successful) {
                         stackApi?.goBack();
                     }
                 }}

--- a/packages/admin/cms-admin/src/form/useFormSaveConflict.tsx
+++ b/packages/admin/cms-admin/src/form/useFormSaveConflict.tsx
@@ -1,0 +1,32 @@
+import { FormApi } from "final-form";
+import React from "react";
+
+import { useSaveConflict } from "../pages/useSaveConflict";
+
+export interface FormSaveConflictOptions<FormValues, InitialFormValues> {
+    checkConflict: () => Promise<boolean>;
+    formApiRef: React.MutableRefObject<FormApi<FormValues, InitialFormValues> | undefined>;
+    loadLatestVersion: () => Promise<void>;
+}
+
+export function useFormSaveConflict<FormValues, InitialFormValues>({
+    checkConflict,
+    formApiRef,
+    loadLatestVersion,
+}: FormSaveConflictOptions<FormValues, InitialFormValues>) {
+    const ret = useSaveConflict({
+        checkConflict,
+        hasChanges: () => {
+            return formApiRef.current?.getState().dirty ?? false;
+        },
+        onDiscardButtonPressed: async () => {
+            await loadLatestVersion();
+            formApiRef.current?.reset();
+        },
+        loadLatestVersion: async () => {
+            await loadLatestVersion();
+            formApiRef.current?.reset();
+        },
+    });
+    return ret;
+}

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -52,6 +52,7 @@ export { FileField } from "./form/file/FileField";
 export { FinalFormToggleButtonGroup } from "./form/FinalFormToggleButtonGroup";
 export { serializeInitialValues } from "./form/serializeInitialValues";
 export { SyncFields } from "./form/SyncFields";
+export { useFormSaveConflict } from "./form/useFormSaveConflict";
 export { createHttpClient } from "./http/createHttpClient";
 export { LocaleProvider } from "./locale/LocaleProvider";
 export { useLocale } from "./locale/useLocale";


### PR DESCRIPTION
This adds a demo for a form that edits PIM data with blocks.

Changed in library:
- new useFormSaveConflict helper for easier implementation of conflicts for FinalForms
- extend FinalFormSaveSplitButton to support navigating to edit page after add

Features of product form demo:
- conflicts (like we do for page content)
- image block inside FinalForm (not the other way around - where we used useSaveState and auto-submitting BlocksFinalForm once there was a block needed in a form)
- no more initial validation on add
- correctly goi to edit page after add

TODO?? (out of scope)
- [ ] auto generate check for updates mutation?
- [ ] find better alternative for `createMutationResponseRef`
- [ ] helper for blocks to avoid listing them 4 times

https://user-images.githubusercontent.com/50764/186620205-8ddf096e-7bd5-44a8-8bd1-cfb941f2c4ec.mp4


