### PR TITLE
Demo: Fix duplicate message cometDemo.menu.pageTree

### DIFF
--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -32,11 +32,11 @@ const MasterMenu: React.FC = () => {
             />
             <MenuCollapsibleItem primary={intl.formatMessage({ id: "cometDemo.menu.pageTree", defaultMessage: "Page tree" })} icon={<PageTree />}>
                 <MenuItemRouterLink
-                    primary={intl.formatMessage({ id: "cometDemo.menu.pageTree", defaultMessage: "Main menu" })}
+                    primary={intl.formatMessage({ id: "cometDemo.menu.pageTree.mainNavigation", defaultMessage: "Main navigation" })}
                     to={`${match.url}/pages/pagetree/main-navigation`}
                 />
                 <MenuItemRouterLink
-                    primary={intl.formatMessage({ id: "cometDemo.menu.pageTree", defaultMessage: "Top menu" })}
+                    primary={intl.formatMessage({ id: "cometDemo.menu.pageTree.topMenu", defaultMessage: "Top menu" })}
                     to={`${match.url}/pages/pagetree/top-menu`}
                 />
             </MenuCollapsibleItem>


### PR DESCRIPTION
```
➜  ~/ws/comet/demo/admin git:(next) yarn intl:extract
warning [FormatJS CLI] Duplicate message id: "cometDemo.menu.pageTree", but the `description` and/or `defaultMessage` are different.
```