### PR TITLE
Remove "potentially unsafe" pseudo-classes

### DIFF
--- a/packages/admin/admin-theme/src/componentsTheme/MuiButton.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiButton.ts
@@ -99,7 +99,7 @@ export const getMuiButton: GetMuiComponentTheme<"MuiButton"> = (component, { pal
             position: "relative",
             top: -1,
 
-            [`&.${buttonClasses.iconSizeMedium} > *:first-child`]: {
+            [`&.${buttonClasses.iconSizeMedium} > *:first-of-type`]: {
                 fontSize: 16,
             },
         },
@@ -108,7 +108,7 @@ export const getMuiButton: GetMuiComponentTheme<"MuiButton"> = (component, { pal
             position: "relative",
             top: -1,
 
-            [`&.${buttonClasses.iconSizeMedium} > *:first-child`]: {
+            [`&.${buttonClasses.iconSizeMedium} > *:first-of-type`]: {
                 fontSize: 16,
             },
         },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiButtonGroup.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiButtonGroup.ts
@@ -14,7 +14,7 @@ export const getMuiButtonGroup: GetMuiComponentTheme<"MuiButtonGroup"> = (compon
             border: "none",
         },
         groupedContained: ({ ownerState }) => ({
-            "&:not(:first-child)": {
+            "&:not(:first-of-type)": {
                 borderLeftWidth: 0,
             },
 

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogActions.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogActions.ts
@@ -9,7 +9,7 @@ export const getMuiDialogActions: GetMuiComponentTheme<"MuiDialogActions"> = (co
             padding: 20,
             justifyContent: "space-between",
 
-            "&>:first-child:last-child": {
+            "&>:first-of-type:last-child": {
                 marginLeft: "auto",
             },
         },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTableCell.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTableCell.ts
@@ -25,7 +25,7 @@ export const getMuiTableCell: GetMuiComponentTheme<"MuiTableCell"> = (component,
             lineHeight: "20px",
             fontWeight: typography.fontWeightMedium,
 
-            "&:not(:first-child):not(:empty):before": {
+            "&:not(:first-of-type):not(:empty):before": {
                 content: "''",
                 position: "absolute",
                 top: 15,

--- a/packages/admin/cms-admin/src/dam/Table/fileUpload/FileUploadErrorDialog.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/fileUpload/FileUploadErrorDialog.tsx
@@ -25,7 +25,7 @@ const Path = styled(Typography)`
 `;
 
 const TableHeadCell = styled(TableCell)`
-    &.MuiTableCell-head:not(:first-child):not(:empty):before {
+    &.MuiTableCell-head:not(:first-of-type):not(:empty):before {
         background-color: transparent;
     }
 `;

--- a/packages/admin/cms-admin/src/form/FinalFormToggleButtonGroup.tsx
+++ b/packages/admin/cms-admin/src/form/FinalFormToggleButtonGroup.tsx
@@ -58,24 +58,24 @@ const StyledToggleButton = styled(ToggleButton)<{ $optionsPerRow?: number }>`
                 border-left: 1px solid ${neutrals[100]};
 
                 // first row
-                &:nth-child(-n + ${$optionsPerRow}) {
+                &:nth-of-type(-n + ${$optionsPerRow}) {
                     border-top: 1px solid ${neutrals[100]};
                 }
 
                 // last column
-                &:nth-child(${$optionsPerRow}n) {
+                &:nth-of-type(${$optionsPerRow}n) {
                     border-right: 1px solid ${neutrals[100]};
                 }
 
-                &:first-child {
+                &:first-of-type {
                     border-top-left-radius: 2px;
                 }
 
-                &:nth-child(${$optionsPerRow}) {
+                &:nth-of-type(${$optionsPerRow}) {
                     border-top-right-radius: 2px;
                 }
 
-                &:nth-last-child(${$optionsPerRow}) {
+                &:nth-last-of-type(${$optionsPerRow}) {
                     border-bottom-left-radius: 2px;
                 }
 

--- a/packages/admin/cms-admin/src/pages/pageTree/PageDeleteDialog.sc.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageDeleteDialog.sc.tsx
@@ -22,7 +22,7 @@ export const PageVisibility = styled("div")`
     align-items: center;
     flex: 1;
 
-    & :first-child {
+    & :first-of-type {
         margin-right: 5px;
     }
 `;

--- a/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
@@ -44,7 +44,7 @@ const CloseButton = styled(IconButton)`
 `;
 
 const StyledDialogAction = styled(DialogActions)`
-    & > :first-child:last-child {
+    & > :first-of-type:last-child {
         margin-left: initial;
     }
 `;
@@ -247,7 +247,7 @@ export default function PageTreeSelectDialog({ value, onChange, open, onClose, d
 
 const PageVisibility = styled("div")`
     display: flex;
-    & :first-child {
+    & :first-of-type {
         margin-right: 5px;
     }
     align-items: center;


### PR DESCRIPTION
This is to suppress irrelevant but annoying error messages in the
console about potential issues with server-side rendering with emotion.

There is no other way to disable these error messages, even though we
only use client-side rendering: https://github.com/emotion-js/emotion/issues/1105.