### PR TITLE
Make builds module global

### DIFF
--- a/packages/api/cms-api/src/builds/builds.module.ts
+++ b/packages/api/cms-api/src/builds/builds.module.ts
@@ -1,5 +1,5 @@
 import { MikroOrmModule } from "@mikro-orm/nestjs";
-import { DynamicModule, Module, ModuleMetadata } from "@nestjs/common";
+import { DynamicModule, Global, Module, ModuleMetadata } from "@nestjs/common";
 
 import { BuildTemplatesResolver } from "./build-templates.resolver";
 import { BuildTemplatesService } from "./build-templates.service";
@@ -27,6 +27,7 @@ interface BuildsModuleAsyncOptions extends Pick<ModuleMetadata, "imports"> {
 }
 
 @Module({})
+@Global()
 export class BuildsModule {
     static registerAsync(options: BuildsModuleAsyncOptions): DynamicModule {
         const optionsProvider = {


### PR DESCRIPTION
The builds module has been changed to a dynamic module recently. This change requires every module that wants to use the builds service to dynamically initialize the builds module. To reduce the amount of necessary boilerplate we decided to make the builds module global, as it should only be initialized once in an application