### PR TITLE
Fix styling of FinalFormToggleButtonGroup

### DIFF
--- a/packages/admin/cms-admin/src/form/FinalFormToggleButtonGroup.tsx
+++ b/packages/admin/cms-admin/src/form/FinalFormToggleButtonGroup.tsx
@@ -1,6 +1,5 @@
-import { neutrals } from "@comet/admin-theme";
-import { css, ToggleButton, ToggleButtonGroup } from "@mui/material";
-import { styled } from "@mui/material/styles";
+import { ButtonBase } from "@mui/material";
+import { css, styled } from "@mui/material/styles";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
@@ -15,28 +14,24 @@ export function FinalFormToggleButtonGroup<FieldValue = unknown>({
     optionsPerRow,
 }: Props<FieldValue>): React.ReactElement {
     return (
-        <StyledToggleButtonGroup
-            exclusive
-            value={value}
-            onChange={(event, value: FieldValue | null) => {
-                if (value === null) {
-                    return;
-                }
-
-                onChange(value);
-            }}
-            $optionsPerRow={optionsPerRow}
-        >
-            {options.map(({ value, icon }, index) => (
-                <StyledToggleButton key={index} value={value} $optionsPerRow={optionsPerRow}>
+        <Root $optionsPerRow={optionsPerRow}>
+            {options.map(({ value: optionValue, icon }, index) => (
+                <Button key={index} $selected={value === optionValue} onClick={() => onChange(optionValue)} focusRipple>
                     {icon}
-                </StyledToggleButton>
+                </Button>
             ))}
-        </StyledToggleButtonGroup>
+        </Root>
     );
 }
 
-const StyledToggleButtonGroup = styled(ToggleButtonGroup)<{ $optionsPerRow?: number }>`
+const Root = styled("div")<{ $optionsPerRow?: number }>`
+    display: inline-flex;
+    border: 1px solid ${({ theme }) => theme.palette.divider};
+    background-color: ${({ theme }) => theme.palette.divider};
+    border-radius: 2px;
+    overflow: hidden;
+    gap: 1px;
+
     ${({ $optionsPerRow }) =>
         $optionsPerRow &&
         css`
@@ -45,43 +40,28 @@ const StyledToggleButtonGroup = styled(ToggleButtonGroup)<{ $optionsPerRow?: num
         `}
 `;
 
-const StyledToggleButton = styled(ToggleButton)<{ $optionsPerRow?: number }>`
-    ${({ $optionsPerRow }) =>
-        $optionsPerRow &&
+const Button = styled(ButtonBase)<{ $selected?: boolean }>`
+    width: 46px;
+    height: 46px;
+    background-color: ${({ theme }) => theme.palette.background.paper};
+
+    :hover {
+        background-color: ${({ theme }) => theme.palette.grey[50]};
+    }
+
+    ${({ $selected, theme }) =>
+        $selected &&
         css`
-            && {
-                margin-left: 0;
-                border-radius: 0;
-                border-top: none;
-                border-right: none;
-                border-bottom: 1px solid ${neutrals[100]};
-                border-left: 1px solid ${neutrals[100]};
+            color: ${theme.palette.primary.main};
 
-                // first row
-                &:nth-of-type(-n + ${$optionsPerRow}) {
-                    border-top: 1px solid ${neutrals[100]};
-                }
-
-                // last column
-                &:nth-of-type(${$optionsPerRow}n) {
-                    border-right: 1px solid ${neutrals[100]};
-                }
-
-                &:first-of-type {
-                    border-top-left-radius: 2px;
-                }
-
-                &:nth-of-type(${$optionsPerRow}) {
-                    border-top-right-radius: 2px;
-                }
-
-                &:nth-last-of-type(${$optionsPerRow}) {
-                    border-bottom-left-radius: 2px;
-                }
-
-                &:last-child {
-                    border-bottom-right-radius: 2px;
-                }
+            :before {
+                content: "";
+                position: absolute;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                height: 2px;
+                background-color: ${theme.palette.primary.main};
             }
         `}
 `;


### PR DESCRIPTION
Don't use MUIs ToggleButton components as a base. 
They add difficult-to-override styles like borders & negative margins that cause issues when trying to achieve a multi-row layout, which doesn't seem to be intended by MUI.

| Previously              | Now          |
|------------------|----------------|
|<img width="270" alt="Screen Shot 2022-09-08 at 10 17 31" src="https://user-images.githubusercontent.com/6264317/189072216-38437156-c789-4606-be8a-d2130464de27.png"> | <img width="270" alt="Screen Shot 2022-09-08 at 10 16 55" src="https://user-images.githubusercontent.com/6264317/189072207-0378ad78-c0a1-4548-ab9b-e883d06c078d.png"> | 





