### PR TITLE
Don't forward props on `styled()` to dom

### DIFF
--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentSection.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentSection.tsx
@@ -26,7 +26,7 @@ export function AdminComponentSection({ children, title, disableBottomMargin }: 
     return <Root disableBottomMargin={disableBottomMargin}>{children}</Root>;
 }
 
-const Root = styled("div")<Pick<Props, "variant" | "disableBottomMargin">>`
+const Root = styled("div", { shouldForwardProp: (prop) => prop !== "disableBottomMargin" })<Pick<Props, "variant" | "disableBottomMargin">>`
     ${({ disableBottomMargin, variant, theme }) =>
         !disableBottomMargin &&
         css`

--- a/packages/admin/blocks-admin/src/blocks/common/blockRow/BlockRow.sc.ts
+++ b/packages/admin/blocks-admin/src/blocks/common/blockRow/BlockRow.sc.ts
@@ -33,7 +33,7 @@ export const BlockWrapper = styled("div")`
     }
 `;
 
-export const Root = styled("div")<RootStyleProps>`
+export const Root = styled("div", { shouldForwardProp: (prop) => prop !== "isMouseHover" && prop !== "slideIn" })<RootStyleProps>`
     position: relative;
     display: flex;
     border-bottom: 1px solid ${({ theme }) => theme.palette.divider};

--- a/packages/admin/blocks-admin/src/iframebridge/HoverPreviewComponent.sc.ts
+++ b/packages/admin/blocks-admin/src/iframebridge/HoverPreviewComponent.sc.ts
@@ -13,7 +13,8 @@ export const Children = styled("div")`
 interface HoverProps {
     isHovered: boolean;
 }
-export const Hover = styled("div")<HoverProps>`
+
+export const Hover = styled("div", { shouldForwardProp: (prop) => prop !== "isHovered" })<HoverProps>`
     ${(props) => {
         if (props.isHovered) {
             return css`

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
@@ -21,7 +21,7 @@ interface ScopeIndicatorProps {
     global: boolean;
 }
 
-const ScopeIndicator = styled("div")<ScopeIndicatorProps>`
+const ScopeIndicator = styled("div", { shouldForwardProp: (prop) => prop !== "global" })<ScopeIndicatorProps>`
     position: ${({ variant }) => (variant === "toolbar" ? "fixed" : "absolute")};
     top: -12px;
     left: 0;
@@ -54,13 +54,13 @@ const ScopeIndicator = styled("div")<ScopeIndicatorProps>`
         `}
 `;
 
-const ToolbarIndicator = styled("div")<{ global: boolean }>`
+const ToolbarIndicator = styled("div", { shouldForwardProp: (prop) => prop !== "global" })<{ global: boolean }>`
     width: 4px;
     height: 100%;
     background-color: ${({ theme, global }) => (global ? theme.palette.primary.main : "#596980")};
 `;
 
-const Content = styled("div")<{ global: boolean }>`
+const Content = styled("div", { shouldForwardProp: (prop) => prop !== "global" })<{ global: boolean }>`
     background: ${({ theme, global }) => (global ? theme.palette.primary.main : "#596980")};
     border-top-left-radius: 12px;
     border-bottom-right-radius: 12px;

--- a/packages/admin/cms-admin/src/dam/Table/FolderTable.sc.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/FolderTable.sc.tsx
@@ -18,7 +18,7 @@ interface TableHoverHighlightProps {
     $isHovered?: boolean;
 }
 
-export const TableHoverHighlight = styled("div")<TableHoverHighlightProps>`
+export const TableHoverHighlight = styled("div", { shouldForwardProp: (prop) => prop !== "$isHovered" })<TableHoverHighlightProps>`
     flex-grow: 1;
 
     display: flex;

--- a/packages/admin/cms-admin/src/dam/Table/FolderTableRow.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/FolderTableRow.tsx
@@ -37,7 +37,9 @@ export interface DamDragObject {
     item: GQLDamFileTableFragment | GQLDamFolderTableFragment;
 }
 
-const StyledFolderTableRow = styled(TableBodyRow)<TableBodyRowProps & { $activeHoverStyle: boolean; $archived: boolean; $highlightAsNew: boolean }>`
+const StyledFolderTableRow = styled(TableBodyRow, {
+    shouldForwardProp: (prop) => prop !== "$activeHoverStyle" && prop !== "$archived" && prop !== "$highlightAsNew",
+})<TableBodyRowProps & { $activeHoverStyle: boolean; $archived: boolean; $highlightAsNew: boolean }>`
     height: 58px;
     position: relative;
     z-index: 0;

--- a/packages/admin/cms-admin/src/dam/Table/breadcrumbs/FolderBreadcrumbs.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/breadcrumbs/FolderBreadcrumbs.tsx
@@ -26,7 +26,7 @@ interface FolderBreadcrumbsProps {
     loading?: boolean;
 }
 
-const FolderBreadcrumbWrapper = styled("div")<{ $isHovered: boolean }>`
+const FolderBreadcrumbWrapper = styled("div", { shouldForwardProp: (prop) => prop !== "$isHovered" })<{ $isHovered: boolean }>`
     font-weight: 500;
     padding: 6px;
     outline: ${({ theme, $isHovered }) => ($isHovered ? `solid 1px ${theme.palette.primary.main}` : "none")};

--- a/packages/admin/cms-admin/src/dam/Table/filter/DamSortPopover.sc.ts
+++ b/packages/admin/cms-admin/src/dam/Table/filter/DamSortPopover.sc.ts
@@ -5,7 +5,7 @@ interface WrapperProps {
     $active: boolean;
 }
 
-export const Wrapper = styled("div")<WrapperProps>`
+export const Wrapper = styled("div", { shouldForwardProp: (prop) => prop !== "$active" })<WrapperProps>`
     width: fit-content;
     position: relative;
     border: 1px solid ${({ theme, $active }) => ($active ? theme.palette.grey[400] : theme.palette.grey[100])};

--- a/packages/admin/cms-admin/src/form/FinalFormToggleButtonGroup.tsx
+++ b/packages/admin/cms-admin/src/form/FinalFormToggleButtonGroup.tsx
@@ -24,7 +24,7 @@ export function FinalFormToggleButtonGroup<FieldValue = unknown>({
     );
 }
 
-const Root = styled("div")<{ $optionsPerRow?: number }>`
+const Root = styled("div", { shouldForwardProp: (prop) => prop !== "$optionsPerRow" })<{ $optionsPerRow?: number }>`
     display: inline-flex;
     border: 1px solid ${({ theme }) => theme.palette.divider};
     background-color: ${({ theme }) => theme.palette.divider};
@@ -40,7 +40,7 @@ const Root = styled("div")<{ $optionsPerRow?: number }>`
         `}
 `;
 
-const Button = styled(ButtonBase)<{ $selected?: boolean }>`
+const Button = styled(ButtonBase, { shouldForwardProp: (prop) => prop !== "$selected" })<{ $selected?: boolean }>`
     width: 46px;
     height: 46px;
     background-color: ${({ theme }) => theme.palette.background.paper};

--- a/packages/admin/cms-admin/src/pages/pageTree/common/PageTreeTableRow.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/common/PageTreeTableRow.tsx
@@ -41,7 +41,16 @@ export const PageTreeTableRow: React.FC<Props> = ({ children, clickable, disable
     );
 };
 
-const Root = styled(TableRow)<Props>`
+const Root = styled(TableRow, {
+    shouldForwardProp: (prop) =>
+        prop !== "isDragHovered" &&
+        prop !== "isMouseHovered" &&
+        prop !== "isArchived" &&
+        prop !== "isSelected" &&
+        prop !== "clickable" &&
+        prop !== "disabled" &&
+        prop !== "slideIn",
+})<Props>`
     scroll-margin-top: 160px;
     scroll-snap-margin-top: 160px; // Safari
     box-sizing: border-box;
@@ -97,7 +106,7 @@ interface SideBorderHightlightsProps {
     horizontal: boolean;
 }
 
-const BorderHightlights = styled("div")<SideBorderHightlightsProps>`
+const BorderHightlights = styled("div", { shouldForwardProp: (prop) => prop !== "vertical" && prop !== "horizontal" })<SideBorderHightlightsProps>`
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
Prevents the console error: "Warning: React does not recognize the {propName} prop on a DOM element..."