### PR TITLE
Add new sort api in demo that allows multiple sort fields and is typed 1a/3

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -315,13 +315,13 @@ input NewsSort {
 }
 
 enum NewsSortField {
-  Title
-  Slug
-  Category
-  Date
-  Visible
-  UpdatedAt
-  CreatedAt
+  title
+  slug
+  category
+  date
+  visible
+  updatedAt
+  createdAt
 }
 
 type Mutation {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -280,7 +280,7 @@ type Query {
   damFolderByNameAndParentId(name: String!, parentId: ID): DamFolder
   news(id: ID!): News
   newsBySlug(slug: String!): News
-  newsList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, query: String, category: NewsCategory, scope: NewsContentScopeInput!): PaginatedNews!
+  newsList(offset: Int = 0, limit: Int = 20, query: String, category: NewsCategory, scope: NewsContentScopeInput!, sort: [NewsSort!]): PaginatedNews!
   mainMenu(scope: PageTreeNodeScopeInput!): MainMenu!
   topMenu(scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
   mainMenuItem(pageTreeNodeId: ID!): MainMenuItem!
@@ -307,6 +307,21 @@ input FileFilterInput {
 
 input FolderFilterInput {
   searchText: String
+}
+
+input NewsSort {
+  field: NewsSortField!
+  direction: SortDirection = ASC
+}
+
+enum NewsSortField {
+  Title
+  Slug
+  Category
+  Date
+  Visible
+  UpdatedAt
+  CreatedAt
 }
 
 type Mutation {

--- a/demo/api/src/news/dto/news-list.args.ts
+++ b/demo/api/src/news/dto/news-list.args.ts
@@ -6,13 +6,13 @@ import { IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
 import { NewsCategory, NewsContentScope } from "../entities/news.entity";
 
 export enum NewsSortField {
-    Title = "Title",
-    Slug = "Slug",
-    Category = "Category",
-    Date = "Date",
-    Visible = "Visible",
-    UpdatedAt = "UpdatedAt",
-    CreatedAt = "CreatedAt",
+    title = "title",
+    slug = "slug",
+    category = "category",
+    date = "date",
+    visible = "visible",
+    updatedAt = "updatedAt",
+    createdAt = "createdAt",
 }
 registerEnumType(NewsSortField, {
     name: "NewsSortField",

--- a/demo/api/src/news/dto/news-list.args.ts
+++ b/demo/api/src/news/dto/news-list.args.ts
@@ -1,12 +1,36 @@
-import { OffsetBasedPaginationArgs, SortArgs } from "@comet/cms-api";
-import { ArgsType, Field, IntersectionType } from "@nestjs/graphql";
+import { OffsetBasedPaginationArgs, SortDirection } from "@comet/cms-api";
+import { ArgsType, Field, InputType, registerEnumType } from "@nestjs/graphql";
 import { Type } from "class-transformer";
 import { IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
 
 import { NewsCategory, NewsContentScope } from "../entities/news.entity";
 
+export enum NewsSortField {
+    Title = "Title",
+    Slug = "Slug",
+    Category = "Category",
+    Date = "Date",
+    Visible = "Visible",
+    UpdatedAt = "UpdatedAt",
+    CreatedAt = "CreatedAt",
+}
+registerEnumType(NewsSortField, {
+    name: "NewsSortField",
+});
+
+@InputType()
+export class NewsSort {
+    @Field(() => NewsSortField)
+    @IsEnum(NewsSortField)
+    field: NewsSortField;
+
+    @Field(() => SortDirection, { defaultValue: SortDirection.ASC })
+    @IsEnum(SortDirection)
+    direction: SortDirection = SortDirection.ASC;
+}
+
 @ArgsType()
-export class NewsListArgs extends IntersectionType(OffsetBasedPaginationArgs, SortArgs) {
+export class NewsListArgs extends OffsetBasedPaginationArgs {
     @Field(() => String, { nullable: true })
     @IsString()
     @IsOptional()
@@ -21,4 +45,9 @@ export class NewsListArgs extends IntersectionType(OffsetBasedPaginationArgs, So
     @Type(() => NewsContentScope)
     @ValidateNested()
     scope: NewsContentScope;
+
+    @Field(() => [NewsSort], { nullable: true })
+    @Type(() => NewsSort)
+    @ValidateNested({ each: true })
+    sort: NewsSort[];
 }

--- a/demo/api/src/news/news.resolver.ts
+++ b/demo/api/src/news/news.resolver.ts
@@ -35,9 +35,8 @@ export class NewsResolver {
         const options: FindOptions<News> = { offset, limit };
         if (sort) {
             options.orderBy = sort.map((sortItem) => {
-                const field = sortItem.field.charAt(0).toLowerCase() + sortItem.field.slice(1); //lowercase first char to turn enum names into column names
                 return {
-                    [field]: sortItem.direction,
+                    [sortItem.field]: sortItem.direction,
                 };
             });
         }

--- a/demo/api/src/news/news.resolver.ts
+++ b/demo/api/src/news/news.resolver.ts
@@ -29,12 +29,17 @@ export class NewsResolver {
 
     @Query(() => PaginatedNews)
     @PublicApi()
-    async newsList(@Args() { scope, query, category, offset, limit, sortColumnName, sortDirection, ...args }: NewsListArgs): Promise<PaginatedNews> {
+    async newsList(@Args() { scope, query, category, offset, limit, sort, ...args }: NewsListArgs): Promise<PaginatedNews> {
         const where: FilterQuery<News> = { scope };
         if (query) where.title = { $ilike: `%${query}%` };
         const options: FindOptions<News> = { offset, limit };
-        if (sortColumnName) {
-            options.orderBy = { [sortColumnName]: sortDirection };
+        if (sort) {
+            options.orderBy = sort.map((sortItem) => {
+                const field = sortItem.field.charAt(0).toLowerCase() + sortItem.field.slice(1); //lowercase first char to turn enum names into column names
+                return {
+                    [field]: sortItem.direction,
+                };
+            });
         }
 
         if (category) where.category = category;


### PR DESCRIPTION
Like #734 but with lower cased enum, matching the field casing

example query:
```
query {
  newsList(scope: { domain: "de", language: "de" }, sort: [ { field: visible, direction: DESC } ] ) {
    nodes {
      id
    }
  }
}
```