### PR TITLE
Fix additional item fields not being copied

### DIFF
--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
@@ -368,6 +368,7 @@ export function createBlocksBlock({
                             visible: block.visible,
                             props: block.state,
                             slideIn: true,
+                            ...block.additionalFields,
                         };
                     });
 
@@ -428,6 +429,7 @@ export function createBlocksBlock({
                             name: blockInterface.name,
                             visible: block.visible,
                             state: block.props,
+                            additionalFields: Object.keys(additionalItemFields).reduce((fields, field) => ({ ...fields, [field]: block[field] }), {}),
                         };
                     });
 
@@ -524,6 +526,10 @@ export function createBlocksBlock({
                                                                                 name: block.name,
                                                                                 visible: data.visible,
                                                                                 state: data.props,
+                                                                                additionalFields: Object.keys(additionalItemFields).reduce(
+                                                                                    (fields, field) => ({ ...fields, [field]: data[field] }),
+                                                                                    {},
+                                                                                ),
                                                                             },
                                                                         ]);
                                                                     }}

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -307,6 +307,10 @@ export function createListBlock<T extends BlockInterface>({
                                                                                     name: block.name,
                                                                                     visible: data.visible,
                                                                                     state: data.props,
+                                                                                    additionalFields: Object.keys(additionalItemFields).reduce(
+                                                                                        (fields, field) => ({ ...fields, [field]: data[field] }),
+                                                                                        {},
+                                                                                    ),
                                                                                 },
                                                                             ]);
                                                                         }}

--- a/packages/admin/blocks-admin/src/blocks/factories/listBlock/createUseAdminComponent.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/listBlock/createUseAdminComponent.tsx
@@ -206,6 +206,7 @@ export function createUseAdminComponent<T extends BlockInterface>({
                         props: block.state,
                         selected: false,
                         slideIn: true,
+                        ...block.additionalFields,
                     };
                 });
 
@@ -250,6 +251,7 @@ export function createUseAdminComponent<T extends BlockInterface>({
                     name: block.name,
                     visible: item.visible,
                     state: item.props,
+                    additionalFields: Object.keys(additionalItemFields).reduce((fields, field) => ({ ...fields, [field]: item[field] }), {}),
                 }));
 
             updateClipboardContent(blocksToCopy);

--- a/packages/admin/blocks-admin/src/clipboard/useBlockClipboard.tsx
+++ b/packages/admin/blocks-admin/src/clipboard/useBlockClipboard.tsx
@@ -10,6 +10,7 @@ interface ClipboardBlock {
     name: string;
     visible: boolean;
     state: BlockState<BlockInterface>;
+    additionalFields?: Record<string, unknown>;
 }
 
 type ClipboardContent = ClipboardBlock[];
@@ -18,6 +19,7 @@ interface TransformedClipboardBlock {
     name: string;
     visible: boolean;
     output: BlockOutputApi<BlockInterface>;
+    additionalFields?: Record<string, unknown>;
 }
 
 type TransformedClipboardContent = TransformedClipboardBlock[];
@@ -49,7 +51,7 @@ function useBlockClipboard({ supports }: UseBlockClipboardOptions): BlockClipboa
     };
 
     const updateClipboardContent = async (content: ClipboardContent) => {
-        const blocks = content.map((block) => {
+        const blocks = content.map<TransformedClipboardBlock>((block) => {
             const blockInterface = findBlockInterfaceForClipboardBlock(block);
 
             if (!blockInterface) {
@@ -60,6 +62,7 @@ function useBlockClipboard({ supports }: UseBlockClipboardOptions): BlockClipboa
                 name: block.name,
                 visible: block.visible,
                 output: blockInterface.state2Output(block.state),
+                additionalFields: block.additionalFields,
             };
         });
 
@@ -137,7 +140,7 @@ function useBlockClipboard({ supports }: UseBlockClipboardOptions): BlockClipboa
                 };
             }
 
-            blocks.push({ name: clipboardBlock.name, visible: clipboardBlock.visible, state });
+            blocks.push({ name: clipboardBlock.name, visible: clipboardBlock.visible, state, additionalFields: clipboardBlock.additionalFields });
         }
 
         return { canPaste: true, content: blocks };


### PR DESCRIPTION
The additional fields were not included when writing a block to the clipboard. Consequently, the fields were not assigned correctly when pasting the clipboard content. The issue is resolved by writing the additional fields to the clipboard.