### PR TITLE
mikro-orm migrations: Fix detection of .ts files when .snapshot-main.json exists

### DIFF
--- a/demo/api/src/db/ormconfig.ts
+++ b/demo/api/src/db/ormconfig.ts
@@ -22,6 +22,7 @@ const config = createOrmConfig({
         path: "./src/db/migrations",
         migrationsList: createMigrationsList(path.resolve(__dirname, "migrations")),
         disableForeignKeys: false,
+        snapshot: false,
     },
 });
 

--- a/packages/api/cms-api/src/mikro-orm/mikro-orm.module.ts
+++ b/packages/api/cms-api/src/mikro-orm/mikro-orm.module.ts
@@ -21,7 +21,7 @@ export function createMigrationsList(migrationsDir: string): MigrationObject[] {
     // loaded from the source directory (typically `src/`) and have a ".ts" extension. In production migrations are loaded from the output directory
     // (typically `dist/` or `lib/`) and may either have a ".js", a ".js.map" or a ".d.ts" extensions (we are only interested in ".js" files). We
     // therefore assume to be in the development setup when all files in the migration directory have a ".ts" file extension.
-    const isInSourceDirectory = files.every((file) => file.endsWith(".ts"));
+    const isInSourceDirectory = files.filter((file) => file != ".snapshot-main.json").every((file) => file.endsWith(".ts"));
     const fileExtension = isInSourceDirectory ? ".ts" : ".js";
 
     return files


### PR DESCRIPTION
TODO: evaluate if we should use the snapshot feature (if yes: add snapshot to git, if no: disable snapshot generation)