### PR TITLE
Fix scrolling in AdminTabs

### DIFF
--- a/packages/admin/blocks-admin/src/blocks/common/AdminTabs.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminTabs.tsx
@@ -48,11 +48,12 @@ export function AdminTabs({ children }: AdminTabsProps): JSX.Element | null {
 const Root = styled("div")`
     display: flex;
     flex-direction: column;
-    min-height: 100%;
+    height: 100%;
 `;
 
 const Tabs = styled(MuiTabs)`
     background-color: ${({ theme }) => theme.palette.background.default};
+    flex-shrink: 0;
 `;
 
 const Tab = styled(MuiTab)<TabProps & LinkProps>`


### PR DESCRIPTION
Changing `height` to `min-height` (in 665b19a90a7d34829c989cb4debf4965bae64b58) was done to prevent the height of the tabs from changing depending on the tab's content height.

This had the side effect of causing the entire page to be scrollable instead of just the sidebar.