### PR TITLE
Style redirect columns

### DIFF
--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
@@ -19,6 +19,7 @@ import {
 import { Add as AddIcon, Delete as DeleteIcon, Edit } from "@comet/admin-icons";
 import { BlockInterface, BlockPreview } from "@comet/blocks-admin";
 import { Button, IconButton, MenuItem, Typography } from "@mui/material";
+import { styled } from "@mui/material/styles";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -186,16 +187,21 @@ export function RedirectsTable({ linkBlock }: Props): JSX.Element {
                                     render: (row: GQLRedirectTableFragment) => {
                                         const state = linkBlock.input2State(row.target);
                                         return (
-                                            <BlockPreview
-                                                title={linkBlock.dynamicDisplayName?.(state) ?? linkBlock.displayName}
-                                                content={linkBlock.previewContent(state)}
-                                            />
+                                            <TargetWrapper>
+                                                <BlockPreview
+                                                    title={linkBlock.dynamicDisplayName?.(state) ?? linkBlock.displayName}
+                                                    content={linkBlock.previewContent(state)}
+                                                />
+                                            </TargetWrapper>
                                         );
                                     },
                                 },
                                 {
                                     name: "comment",
                                     header: intl.formatMessage({ id: "comet.pages.redirects.redirect.comment", defaultMessage: "Comment" }),
+                                    render: ({ comment }) => {
+                                        return <div>{comment}</div>;
+                                    },
                                 },
                                 {
                                     name: "generationType",
@@ -256,3 +262,7 @@ export function RedirectsTable({ linkBlock }: Props): JSX.Element {
         </TableFilterFinalForm>
     );
 }
+
+const TargetWrapper = styled("div")`
+    max-width: 25vw;
+`;

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
@@ -236,7 +236,7 @@ export function RedirectsTable({ linkBlock }: Props): JSX.Element {
                                     name: "actions",
                                     header: "",
                                     render: (row: GQLRedirectTableFragment) => (
-                                        <>
+                                        <IconWrapper>
                                             <IconButton
                                                 onClick={() => {
                                                     stackApi.activatePage("edit", row.id);
@@ -251,7 +251,7 @@ export function RedirectsTable({ linkBlock }: Props): JSX.Element {
                                                 selectedId={row.id}
                                                 text=""
                                             />
-                                        </>
+                                        </IconWrapper>
                                     ),
                                 },
                             ]}
@@ -265,4 +265,9 @@ export function RedirectsTable({ linkBlock }: Props): JSX.Element {
 
 const TargetWrapper = styled("div")`
     max-width: 25vw;
+`;
+
+const IconWrapper = styled("div")`
+    display: flex;
+    flex-direction: row;
 `;

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
@@ -17,7 +17,6 @@ import {
     useTableQueryFilter,
 } from "@comet/admin";
 import { Add as AddIcon, Delete as DeleteIcon, Edit } from "@comet/admin-icons";
-import { FinalFormReactSelectStaticOptions } from "@comet/admin-react-select";
 import { BlockInterface, BlockPreview } from "@comet/blocks-admin";
 import { Button, IconButton, MenuItem, Typography } from "@mui/material";
 import * as React from "react";
@@ -35,7 +34,7 @@ import { deleteRedirectMutation, redirectsQuery } from "./RedirectsTable.gql";
 
 interface Filter extends Omit<GQLRedirectsQueryVariables, "active" | "type"> {
     type?: "all" | GQLRedirectGenerationType;
-    active?: "all" | boolean;
+    active?: "all" | "activated" | "deactivated";
 }
 
 interface Props {
@@ -82,14 +81,14 @@ export function RedirectsTable({ linkBlock }: Props): JSX.Element {
                 id: "comet.redirects.redirect.active.activated",
                 defaultMessage: "activated",
             }),
-            value: true,
+            value: "activated",
         },
         {
             label: intl.formatMessage({
                 id: "comet.redirects.redirect.active.deactivated",
                 defaultMessage: "deactivated",
             }),
-            value: false,
+            value: "deactivated",
         },
     ];
 
@@ -99,7 +98,7 @@ export function RedirectsTable({ linkBlock }: Props): JSX.Element {
     const { tableData, api, loading, error } = useTableQuery<GQLRedirectsQuery, GQLRedirectsQueryVariables>()(redirectsQuery, {
         variables: {
             type: filterApi.current.type !== "all" ? filterApi.current.type : undefined,
-            active: filterApi.current.active !== "all" ? filterApi.current.active : undefined,
+            active: filterApi.current.active !== "all" ? filterApi.current.active === "activated" : undefined,
             query: filterApi.current.query ?? undefined,
         },
         resolveTableData: ({ redirects }) => {
@@ -138,18 +137,24 @@ export function RedirectsTable({ linkBlock }: Props): JSX.Element {
                     </Field>
                 </ToolbarItem>
                 <ToolbarItem>
-                    {/* TODO: Replace with FinalFormSelect when boolean-values have been changed to strings */}
                     <Field
                         name="active"
-                        defaultValue="all"
                         label={intl.formatMessage({
                             id: "comet.redirects.redirect.activation.title",
                             defaultMessage: "Activation",
                         })}
-                        component={FinalFormReactSelectStaticOptions}
-                        options={activeOptions}
-                        isSearchable={false}
-                    />
+                        fullWidth
+                    >
+                        {(props) => (
+                            <FinalFormSelect {...props} fullWidth>
+                                {activeOptions.map((option) => (
+                                    <MenuItem value={option.value} key={option.value}>
+                                        {option.label}
+                                    </MenuItem>
+                                ))}
+                            </FinalFormSelect>
+                        )}
+                    </Field>
                 </ToolbarItem>
                 <ToolbarFillSpace />
                 <ToolbarActions>


### PR DESCRIPTION
Fix for: 
- https://app-eu.wrike.com/open.htm?id=961790915
- https://app-eu.wrike.com/open.htm?id=961790247

The redirect table was restyled to avoid the "target" columns' width being too large.