### PR TITLE
Outsource the ContentScopeIndicator Component

### DIFF
--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -7,10 +7,12 @@ import "typeface-open-sans";
 
 import { ApolloProvider } from "@apollo/client";
 import { ErrorDialogHandler, MasterLayout, MuiThemeProvider, RouterBrowserRouter, RouteWithErrorBoundary, SnackbarProvider } from "@comet/admin";
+import { Domain } from "@comet/admin-icons";
 import {
     AllCategories,
     AuthorizationErrorPage,
     CmsBlockContextProvider,
+    ContentScopeIndicator,
     createHttpClient,
     createRedirectsPage,
     DamConfigProvider,
@@ -25,6 +27,7 @@ import {
 import { AuthConfiguration, AuthorizationGate, AuthorizationProvider, createAuthorizationManager, createRefreshHandler } from "@comet/react-app-auth";
 import { css, Global } from "@emotion/react";
 import { createApolloClient } from "@src/common/apollo/createApolloClient";
+import { ScopeIndicatorContent, ScopeIndicatorLabel, ScopeIndicatorLabelBold } from "@src/common/ContentScopeIndicatorStyles";
 import ContentScopeProvider, { ContentScope } from "@src/common/ContentScopeProvider";
 import { EditPageNode } from "@src/common/EditPageNode";
 import MasterHeader from "@src/common/MasterHeader";
@@ -175,6 +178,22 @@ class App extends React.Component {
                                                                                                             documentTypes={pageTreeDocumentTypes}
                                                                                                             editPageNode={EditPageNode}
                                                                                                             category={category}
+                                                                                                            renderContentScopeIndicator={(scope) => {
+                                                                                                                return (
+                                                                                                                    <ContentScopeIndicator variant="toolbar">
+                                                                                                                        <ScopeIndicatorContent>
+                                                                                                                            <Domain fontSize="small" />
+                                                                                                                            <ScopeIndicatorLabelBold variant="body2">
+                                                                                                                                {scope.domain}
+                                                                                                                            </ScopeIndicatorLabelBold>
+                                                                                                                        </ScopeIndicatorContent>
+                                                                                                                        {` | `}
+                                                                                                                        <ScopeIndicatorLabel variant="body2">
+                                                                                                                            {scope.language}
+                                                                                                                        </ScopeIndicatorLabel>
+                                                                                                                    </ContentScopeIndicator>
+                                                                                                                );
+                                                                                                            }}
                                                                                                         />
                                                                                                     );
                                                                                                 }}

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -6,7 +6,7 @@ import withStyles from "@mui/styles/withStyles";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { createEditPageNode } from "../..";
+import { ContentScopeInterface, createEditPageNode } from "../..";
 import { useContentScope } from "../../contentScope/Provider";
 import { useContentScopeConfig } from "../../contentScope/useContentScopeConfig";
 import { DocumentInterface, DocumentType } from "../../documents/types";

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -1,13 +1,12 @@
 import { useQuery } from "@apollo/client";
 import { MainContent, messages, Stack, StackPage, StackSwitch, Toolbar, ToolbarActions, useEditDialog, useStoredState } from "@comet/admin";
-import { Add, Domain } from "@comet/admin-icons";
-import { Box, Button, CircularProgress, FormControlLabel, Paper, Switch, Typography } from "@mui/material";
-import { styled } from "@mui/material/styles";
+import { Add } from "@comet/admin-icons";
+import { Box, Button, CircularProgress, FormControlLabel, Paper, Switch } from "@mui/material";
 import withStyles from "@mui/styles/withStyles";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { ContentScopeIndicator, createEditPageNode } from "../..";
+import { createEditPageNode } from "../..";
 import { useContentScope } from "../../contentScope/Provider";
 import { useContentScopeConfig } from "../../contentScope/useContentScopeConfig";
 import { DocumentInterface, DocumentType } from "../../documents/types";
@@ -22,31 +21,13 @@ import { usePageTree } from "../pageTree/usePageTree";
 import { PagesPageActionToolbar } from "./PagesPageActionToolbar";
 import { pagesQuery } from "./pagesQuery";
 
-const ScopeIndicatorLabelBold = styled(Typography)`
-    && {
-        font-weight: 400;
-        padding: 0 8px 0 4px;
-        text-transform: uppercase;
-    }
-`;
-
-const ScopeIndicatorContent = styled("div")`
-    display: flex;
-    align-items: center;
-`;
-
-const ScopeIndicatorLabel = styled(Typography)`
-    && {
-        padding-left: 8px;
-        text-transform: uppercase;
-    }
-`;
 interface Props {
     category: string;
     path: string;
     allCategories: AllCategories;
     documentTypes: Record<DocumentType, DocumentInterface>;
     editPageNode?: React.ComponentType<EditPageNodeProps>;
+    renderContentScopeIndicator: (scope: ContentScopeInterface) => React.ReactNode;
 }
 
 const DefaultEditPageNode = createEditPageNode({});
@@ -57,6 +38,7 @@ export function PagesPage({
     allCategories,
     documentTypes,
     editPageNode: EditPageNode = DefaultEditPageNode,
+    renderContentScopeIndicator,
 }: Props): React.ReactElement {
     const intl = useIntl();
     const { scope, setRedirectPathAfterChange } = useContentScope();
@@ -113,14 +95,7 @@ export function PagesPage({
         <Stack topLevelTitle={intl.formatMessage({ id: "comet.pages.pages", defaultMessage: "Pages" })}>
             <StackSwitch>
                 <StackPage name="table">
-                    <ContentScopeIndicator variant="toolbar">
-                        <ScopeIndicatorContent>
-                            <Domain fontSize="small" />
-                            <ScopeIndicatorLabelBold variant="body2">{scope.domain}</ScopeIndicatorLabelBold>
-                        </ScopeIndicatorContent>
-                        {` | `}
-                        <ScopeIndicatorLabel variant="body2">{scope.language}</ScopeIndicatorLabel>
-                    </ContentScopeIndicator>
+                    {renderContentScopeIndicator(scope)}
                     <Toolbar>
                         <PageSearch query={query} onQueryChange={setQuery} pageSearchApi={pageSearchApi} />
                         <FormControlLabel


### PR DESCRIPTION
**Problem:** Some customers do not define an explicit language for their CMS. This causes the ContentScopeIndicator-Component, which expects the scope to have a language and a domain, to show a pipe symbol that is not used:  

<img width="1021" alt="190410285-a4a6b2df-9064-4871-aa68-7e59cf9fe384" src="https://user-images.githubusercontent.com/48853629/190956731-7c11365c-f43c-4c12-8b6a-3661fbbcc826.png">

**Solution:** In order to solve this problem the ContentScopeIndicator-Component is replaced by a renderContentScopeIndicator function, which returns the Components to be rendered.  Now customers are able and required to create an individual ContentScopeIndicator.