### PR TITLE
Add ScopeGuard to support users with restricted content scopes

### DIFF
--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -64,7 +64,7 @@ const authorizationConfig: AuthConfiguration = {
     clientId: config.IDP_CLIENT_ID,
     redirectUrl: `${config.ADMIN_URL}/process-token`,
     responseType: "code",
-    scope: "offline openid profile email",
+    scope: "offline openid profile email role",
     usePKCE: true,
 };
 

--- a/demo/admin/src/links/EditLink.tsx
+++ b/demo/admin/src/links/EditLink.tsx
@@ -36,7 +36,7 @@ const usePage = createUsePage({
         }
     `,
     updateMutation: gql`
-        mutation UpdateLink($pageId: ID!, $input: LinkInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID) {
+        mutation UpdateLink($pageId: ID!, $input: LinkInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID!) {
             saveLink(linkId: $pageId, input: $input, lastUpdatedAt: $lastUpdatedAt, attachedPageTreeNodeId: $attachedPageTreeNodeId) {
                 id
                 content

--- a/demo/admin/src/links/Link.tsx
+++ b/demo/admin/src/links/Link.tsx
@@ -32,7 +32,7 @@ export const Link: DocumentInterface<Pick<GQLLink, "content">, GQLLinkInput> = {
         }
     `,
     updateMutation: gql`
-        mutation UpdateLink($pageId: ID!, $input: LinkInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID) {
+        mutation UpdateLink($pageId: ID!, $input: LinkInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID!) {
             saveLink(linkId: $pageId, input: $input, lastUpdatedAt: $lastUpdatedAt, attachedPageTreeNodeId: $attachedPageTreeNodeId) {
                 id
                 content

--- a/demo/admin/src/pages/EditPage.tsx
+++ b/demo/admin/src/pages/EditPage.tsx
@@ -70,7 +70,7 @@ const usePage = createUsePage({
         }
     `,
     updateMutation: gql`
-        mutation UpdatePage($pageId: ID!, $input: PageInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID) {
+        mutation UpdatePage($pageId: ID!, $input: PageInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID!) {
             savePage(pageId: $pageId, input: $input, lastUpdatedAt: $lastUpdatedAt, attachedPageTreeNodeId: $attachedPageTreeNodeId) {
                 id
                 content

--- a/demo/admin/src/pages/Page.tsx
+++ b/demo/admin/src/pages/Page.tsx
@@ -33,7 +33,7 @@ export const Page: DocumentInterface<Pick<GQLPage, "content" | "seo">, GQLPageIn
         }
     `,
     updateMutation: gql`
-        mutation UpdatePage($pageId: ID!, $input: PageInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID) {
+        mutation UpdatePage($pageId: ID!, $input: PageInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID!) {
             savePage(pageId: $pageId, input: $input, lastUpdatedAt: $lastUpdatedAt, attachedPageTreeNodeId: $attachedPageTreeNodeId) {
                 id
                 content

--- a/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
+++ b/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
@@ -48,7 +48,7 @@ const getQuery = gql`
 `;
 
 const updateMutation = gql`
-    mutation UpdatePredefinedPage($pageId: ID!, $input: PredefinedPageInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID) {
+    mutation UpdatePredefinedPage($pageId: ID!, $input: PredefinedPageInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID!) {
         savePredefinedPage(id: $pageId, input: $input, lastUpdatedAt: $lastUpdatedAt, attachedPageTreeNodeId: $attachedPageTreeNodeId) {
             id
             type

--- a/demo/admin/src/predefinedPage/PredefinedPage.tsx
+++ b/demo/admin/src/predefinedPage/PredefinedPage.tsx
@@ -46,7 +46,7 @@ export const PredefinedPage: DocumentInterface<Pick<GQLPredefinedPage, "type">, 
         }
     `,
     updateMutation: gql`
-        mutation UpdatePredefinedPageDocument($pageId: ID!, $input: PredefinedPageInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID) {
+        mutation UpdatePredefinedPageDocument($pageId: ID!, $input: PredefinedPageInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID!) {
             savePredefinedPage(id: $pageId, input: $input, lastUpdatedAt: $lastUpdatedAt, attachedPageTreeNodeId: $attachedPageTreeNodeId) {
                 id
                 type

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -328,8 +328,8 @@ input FolderFilterInput {
 }
 
 type Mutation {
-  savePage(pageId: ID!, input: PageInput!, lastUpdatedAt: DateTime, attachedPageTreeNodeId: ID): Page!
-  saveLink(linkId: ID!, input: LinkInput!, lastUpdatedAt: DateTime, attachedPageTreeNodeId: ID): Link!
+  savePage(pageId: ID!, input: PageInput!, attachedPageTreeNodeId: ID!, lastUpdatedAt: DateTime): Page!
+  saveLink(linkId: ID!, input: LinkInput!, attachedPageTreeNodeId: ID!, lastUpdatedAt: DateTime): Link!
   createBuilds(input: CreateBuildsInput!): Boolean!
   updatePageTreeNode(id: ID!, input: PageTreeNodeUpdateInput!): PageTreeNode!
   deletePageTreeNode(id: ID!): Boolean!
@@ -356,7 +356,7 @@ type Mutation {
   deleteNews(id: ID!): Boolean!
   updateMainMenuItem(pageTreeNodeId: ID!, input: MainMenuItemInput!, lastUpdatedAt: DateTime): MainMenuItem!
   saveFooter(input: FooterInput!, lastUpdatedAt: DateTime): Footer!
-  savePredefinedPage(id: ID!, input: PredefinedPageInput!, lastUpdatedAt: DateTime, attachedPageTreeNodeId: ID): PredefinedPage!
+  savePredefinedPage(id: ID!, input: PredefinedPageInput!, attachedPageTreeNodeId: ID!, lastUpdatedAt: DateTime): PredefinedPage!
 }
 
 input PageInput {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -354,7 +354,7 @@ type Mutation {
   updateNewsVisibility(id: ID!, visible: Boolean!): News!
   deleteNews(id: ID!): Boolean!
   updateMainMenuItem(pageTreeNodeId: ID!, input: MainMenuItemInput!, lastUpdatedAt: DateTime): MainMenuItem!
-  saveFooter(input: FooterInput!, lastUpdatedAt: DateTime): Footer!
+  saveFooter(scope: FooterContentScopeInput!, input: FooterInput!, lastUpdatedAt: DateTime): Footer!
   savePredefinedPage(id: ID!, input: PredefinedPageInput!, attachedPageTreeNodeId: ID!, lastUpdatedAt: DateTime): PredefinedPage!
 }
 
@@ -463,7 +463,6 @@ input MainMenuItemInput {
 
 input FooterInput {
   content: JSONObject!
-  scope: FooterContentScopeInput!
 }
 
 input PredefinedPageInput {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -205,6 +205,13 @@ type MainMenu {
   items: [MainMenuItem!]!
 }
 
+type NewsComment implements DocumentInterface {
+  id: ID!
+  updatedAt: DateTime!
+  comment: String!
+  createdAt: DateTime!
+}
+
 type NewsContentScope {
   domain: String!
   language: String!
@@ -222,6 +229,7 @@ type News implements DocumentInterface {
   image: JSONObject!
   content: JSONObject!
   createdAt: DateTime!
+  comments: [NewsComment!]!
 }
 
 enum NewsCategory {
@@ -353,6 +361,9 @@ type Mutation {
   updateNews(id: ID!, input: NewsInput!, lastUpdatedAt: DateTime): News!
   updateNewsVisibility(id: ID!, visible: Boolean!): News!
   deleteNews(id: ID!): Boolean!
+  createNewsComment(newsId: ID!, input: NewsCommentInput!): NewsComment!
+  updateNewsComment(id: ID!, input: NewsCommentInput!, lastUpdatedAt: DateTime): NewsComment!
+  deleteNewsComment(id: ID!): Boolean!
   updateMainMenuItem(pageTreeNodeId: ID!, input: MainMenuItemInput!, lastUpdatedAt: DateTime): MainMenuItem!
   saveFooter(scope: FooterContentScopeInput!, input: FooterInput!, lastUpdatedAt: DateTime): Footer!
   savePredefinedPage(id: ID!, input: PredefinedPageInput!, attachedPageTreeNodeId: ID!, lastUpdatedAt: DateTime): PredefinedPage!
@@ -455,6 +466,10 @@ input NewsInput {
   category: NewsCategory!
   image: JSONObject!
   content: JSONObject!
+}
+
+input NewsCommentInput {
+  comment: String!
 }
 
 input MainMenuItemInput {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -272,7 +272,6 @@ input NewsContentScopeInput {
 }
 
 type Query {
-  page(pageId: ID!): Page
   pages(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC): PaginatedPages!
   link(linkId: ID!): Link
   buildTemplates: [BuildTemplate!]!

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -291,7 +291,7 @@ type Query {
   damFolder(id: ID!): DamFolder!
   damFolderByNameAndParentId(name: String!, parentId: ID): DamFolder
   news(id: ID!): News
-  newsBySlug(slug: String!): News
+  newsBySlug(scope: NewsContentScopeInput!, slug: String!): News
   newsList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, query: String, category: NewsCategory, scope: NewsContentScopeInput!): PaginatedNews!
   mainMenu(scope: PageTreeNodeScopeInput!): MainMenu!
   topMenu(scope: PageTreeNodeScopeInput!): [PageTreeNode!]!

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -6,8 +6,8 @@ import {
     BlocksTransformerMiddlewareFactory,
     BlocksTransformerService,
     BuildsModule,
+    ContentScope,
     ContentScopeModule,
-    CurrentUser,
     DamModule,
     FilesService,
     GlobalAuthGuard,
@@ -80,7 +80,10 @@ import { PredefinedPageModule } from "./predefined-page/predefined-page.module";
             currentUserLoaderService: CurrentUserLoaderService,
         }),
         ContentScopeModule.forRoot({
-            contentScopesFromUser: (user: CurrentUser) => user.contentScopes,
+            canAccessScope(requestScope: ContentScope, user) {
+                if (!user.domains) return true; //all domains
+                return user.domains.includes(requestScope.domain);
+            },
         }),
         BlocksModule.forRootAsync({
             imports: [PagesModule],

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -8,6 +8,7 @@ import {
     BuildsModule,
     DamModule,
     FilesService,
+    GlobalAuthGuard,
     ImagesService,
     PageTreeModule,
     PageTreeService,
@@ -17,6 +18,7 @@ import {
 import { ApolloDriver } from "@nestjs/apollo";
 import { Module } from "@nestjs/common";
 import { ConfigType } from "@nestjs/config";
+import { APP_GUARD } from "@nestjs/core";
 import { GraphQLModule } from "@nestjs/graphql";
 import { ConfigModule } from "@src/config/config.module";
 import { configNS } from "@src/config/config.namespace";
@@ -27,6 +29,7 @@ import { PredefinedPage } from "@src/predefined-page/entities/predefined-page.en
 import { Request } from "express";
 
 import { CurrentUserLoaderService } from "./auth/current-user-loader.service";
+import { GlobalScopeGuard } from "./auth/scope.guard";
 import { FooterModule } from "./footer/footer.module";
 import { Link } from "./links/entities/link.entity";
 import { MenusModule } from "./menus/menus.module";
@@ -181,6 +184,10 @@ import { PredefinedPageModule } from "./predefined-page/predefined-page.module";
         MenusModule,
         FooterModule,
         PredefinedPageModule,
+    ],
+    providers: [
+        { provide: APP_GUARD, useClass: GlobalAuthGuard },
+        { provide: APP_GUARD, useClass: GlobalScopeGuard },
     ],
 })
 export class AppModule {}

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -26,6 +26,7 @@ import { PagesModule } from "@src/pages/pages.module";
 import { PredefinedPage } from "@src/predefined-page/entities/predefined-page.entity";
 import { Request } from "express";
 
+import { CurrentUserLoaderService } from "./auth/current-user-loader.service";
 import { FooterModule } from "./footer/footer.module";
 import { Link } from "./links/entities/link.entity";
 import { MenusModule } from "./menus/menus.module";
@@ -72,6 +73,7 @@ import { PredefinedPageModule } from "./predefined-page/predefined-page.module";
                 },
             }),
             inject: [configNS.KEY],
+            currentUserLoaderService: CurrentUserLoaderService,
         }),
         BlocksModule.forRootAsync({
             imports: [PagesModule],

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -6,6 +6,8 @@ import {
     BlocksTransformerMiddlewareFactory,
     BlocksTransformerService,
     BuildsModule,
+    ContentScopeModule,
+    CurrentUser,
     DamModule,
     FilesService,
     GlobalAuthGuard,
@@ -29,7 +31,6 @@ import { PredefinedPage } from "@src/predefined-page/entities/predefined-page.en
 import { Request } from "express";
 
 import { CurrentUserLoaderService } from "./auth/current-user-loader.service";
-import { GlobalScopeGuard } from "./auth/scope.guard";
 import { FooterModule } from "./footer/footer.module";
 import { Link } from "./links/entities/link.entity";
 import { MenusModule } from "./menus/menus.module";
@@ -77,6 +78,9 @@ import { PredefinedPageModule } from "./predefined-page/predefined-page.module";
             }),
             inject: [configNS.KEY],
             currentUserLoaderService: CurrentUserLoaderService,
+        }),
+        ContentScopeModule.forRoot({
+            contentScopesFromUser: (user: CurrentUser) => user.contentScopes,
         }),
         BlocksModule.forRootAsync({
             imports: [PagesModule],
@@ -185,9 +189,6 @@ import { PredefinedPageModule } from "./predefined-page/predefined-page.module";
         FooterModule,
         PredefinedPageModule,
     ],
-    providers: [
-        { provide: APP_GUARD, useClass: GlobalAuthGuard },
-        { provide: APP_GUARD, useClass: GlobalScopeGuard },
-    ],
+    providers: [{ provide: APP_GUARD, useClass: GlobalAuthGuard }],
 })
 export class AppModule {}

--- a/demo/api/src/auth/current-user-loader.service.ts
+++ b/demo/api/src/auth/current-user-loader.service.ts
@@ -1,0 +1,19 @@
+import { CurrentUser, CurrentUserLoaderInterface } from "@comet/cms-api";
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class CurrentUserLoaderService implements CurrentUserLoaderInterface {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async load(token: string, data: any): Promise<CurrentUser> {
+        const user = {
+            id: data.sub,
+            role: data.ext?.role,
+            contentScopes: data.ext?.domain.map((domain: string) => {
+                return {
+                    domain,
+                };
+            }),
+        };
+        return user;
+    }
+}

--- a/demo/api/src/auth/current-user-loader.service.ts
+++ b/demo/api/src/auth/current-user-loader.service.ts
@@ -8,11 +8,7 @@ export class CurrentUserLoaderService implements CurrentUserLoaderInterface {
         const user = {
             id: data.sub,
             role: data.ext?.role,
-            contentScopes: data.ext?.domain.map((domain: string) => {
-                return {
-                    domain,
-                };
-            }),
+            domains: data.ext?.domain,
         };
         return user;
     }

--- a/demo/api/src/auth/current-user.interface.ts
+++ b/demo/api/src/auth/current-user.interface.ts
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports
+import { CurrentUser } from "@comet/cms-api";
+
+declare module "@comet/cms-api" {
+    interface CurrentUser {
+        contentScopes?: Array<Record<string, string>>;
+    }
+    /*
+    contentScrops: [
+        {
+            domain: "at",
+        }
+    ]
+    */
+}

--- a/demo/api/src/auth/current-user.interface.ts
+++ b/demo/api/src/auth/current-user.interface.ts
@@ -3,13 +3,6 @@ import { CurrentUser } from "@comet/cms-api";
 
 declare module "@comet/cms-api" {
     interface CurrentUser {
-        contentScopes?: Array<Record<string, string>>;
+        domains?: Array<"main" | "secondary">;
     }
-    /*
-    contentScrops: [
-        {
-            domain: "at",
-        }
-    ]
-    */
 }

--- a/demo/api/src/auth/scope.guard.ts
+++ b/demo/api/src/auth/scope.guard.ts
@@ -1,4 +1,4 @@
-import { CurrentUser, PageTreeService, ScopedMeta, SubjectEntityMeta } from "@comet/cms-api";
+import { CurrentUser, PageTreeService, ScopedEntityMeta, SubjectEntityMeta } from "@comet/cms-api";
 import { EntityClass, MikroORM } from "@mikro-orm/core";
 import { CanActivate, ExecutionContext, HttpException, Injectable } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
@@ -49,7 +49,7 @@ export class GlobalScopeGuard extends AuthGuard(["bearer", "basic"]) implements 
                         subjectScope = row.scope;
                     } else {
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        const scoped = this.reflector.getAllAndOverride<ScopedMeta>("scoped", [subjectEntity.entity as EntityClass<any>]);
+                        const scoped = this.reflector.getAllAndOverride<ScopedEntityMeta>("scoped", [subjectEntity.entity as EntityClass<any>]);
                         subjectScope = await scoped.fn(row);
                     }
                 } else if (subjectEntity.options.pageTreeNodeIdArg && args[subjectEntity.options.pageTreeNodeIdArg]) {
@@ -62,8 +62,8 @@ export class GlobalScopeGuard extends AuthGuard(["bearer", "basic"]) implements 
                     if (!node) throw new Error("Can't find pageTreeNode");
                     subjectScope = node.scope;
                 } else {
-                    // TODO implement something more flexible that supports something like that: @SubjectEntity(Product, EntityLoader)
-                    throw new Error("not yet implemented");
+                    // TODO implement something more flexible that supports something like that: @SubjectEntity(Product, ProductEntityLoader)
+                    throw new Error("idArg or pageTreeNodeIdArg is required");
                 }
                 if (subjectScope === undefined) throw new Error("Scope not found");
                 if (args.scope) {

--- a/demo/api/src/auth/scope.guard.ts
+++ b/demo/api/src/auth/scope.guard.ts
@@ -27,7 +27,7 @@ export class GlobalScopeGuard implements CanActivate {
                         subjectScope = row.scope;
                     } else {
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        const scoped = this.reflector.getAllAndOverride<ScopedEntityMeta>("scoped", [subjectEntity.entity as EntityClass<any>]);
+                        const scoped = this.reflector.getAllAndOverride<ScopedEntityMeta>("scopedEntity", [subjectEntity.entity as EntityClass<any>]);
                         subjectScope = await scoped.fn(row);
                     }
                 } else if (subjectEntity.options.pageTreeNodeIdArg && args[subjectEntity.options.pageTreeNodeIdArg]) {

--- a/demo/api/src/content-scope/content-scope.interface.ts
+++ b/demo/api/src/content-scope/content-scope.interface.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports
+import { ContentScope } from "@comet/cms-api";
+
+declare module "@comet/cms-api" {
+    interface ContentScope {
+        domain: "main" | "secondary";
+        language: string;
+    }
+}

--- a/demo/api/src/db/migrations/Migration20220916095617.ts
+++ b/demo/api/src/db/migrations/Migration20220916095617.ts
@@ -1,0 +1,18 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20220916095617 extends Migration {
+    async up(): Promise<void> {
+        this.addSql(
+            'create table "NewsComment" ("id" uuid not null, "news" uuid not null, "comment" varchar(255) not null, "createdAt" timestamp with time zone not null, "updatedAt" timestamp with time zone not null);',
+        );
+        this.addSql('alter table "NewsComment" add constraint "NewsComment_pkey" primary key ("id");');
+
+        this.addSql(
+            'alter table "NewsComment" add constraint "NewsComment_news_foreign" foreign key ("news") references "News" ("id") on update cascade;',
+        );
+    }
+
+    async down(): Promise<void> {
+        this.addSql('drop table if exists "NewsComment" cascade;');
+    }
+}

--- a/demo/api/src/footer/dto/footer.input.ts
+++ b/demo/api/src/footer/dto/footer.input.ts
@@ -1,11 +1,10 @@
 import { BlockInputInterface } from "@comet/blocks-api";
 import { Field, InputType } from "@nestjs/graphql";
-import { Transform, Type } from "class-transformer";
+import { Transform } from "class-transformer";
 import { ValidateNested } from "class-validator";
 import { GraphQLJSONObject } from "graphql-type-json";
 
 import { FooterContentBlock } from "../blocks/footer-content.block";
-import { FooterContentScope } from "../entities/footer-content-scope.entity";
 
 @InputType()
 export class FooterInput {
@@ -13,9 +12,4 @@ export class FooterInput {
     @Transform((value) => FooterContentBlock.blockInputFactory(value), { toClassOnly: true })
     @ValidateNested()
     content: BlockInputInterface;
-
-    @Field(() => FooterContentScope)
-    @Type(() => FooterContentScope)
-    @ValidateNested()
-    scope: FooterContentScope;
 }

--- a/demo/api/src/footer/footer.resolver.ts
+++ b/demo/api/src/footer/footer.resolver.ts
@@ -24,15 +24,15 @@ export class FootersResolver {
     }
 
     @Mutation(() => Footer)
-    //TODO move scope out of input into own arg (so it can be validated)
     async saveFooter(
+        @Args("scope", { type: () => FooterContentScope }) scope: FooterContentScope,
         @Args("input", { type: () => FooterInput }) input: FooterInput,
         @Args("lastUpdatedAt", { type: () => Date, nullable: true }) lastUpdatedAt?: Date,
     ): Promise<Footer> {
-        let footer = await this.footersRepository.findOne({ scope: input.scope });
+        let footer = await this.footersRepository.findOne({ scope });
 
         if (!footer) {
-            footer = this.footersRepository.create({ ...input, content: input.content.transformToBlockData() });
+            footer = this.footersRepository.create({ scope, ...input, content: input.content.transformToBlockData() });
         } else if (lastUpdatedAt) {
             validateNotModified(footer, lastUpdatedAt);
 

--- a/demo/api/src/footer/footer.resolver.ts
+++ b/demo/api/src/footer/footer.resolver.ts
@@ -24,6 +24,7 @@ export class FootersResolver {
     }
 
     @Mutation(() => Footer)
+    //TODO move scope out of input into own arg (so it can be validated)
     async saveFooter(
         @Args("input", { type: () => FooterInput }) input: FooterInput,
         @Args("lastUpdatedAt", { type: () => Date, nullable: true }) lastUpdatedAt?: Date,

--- a/demo/api/src/links/links.resolver.ts
+++ b/demo/api/src/links/links.resolver.ts
@@ -1,4 +1,4 @@
-import { PageTreeNodeVisibility, PageTreeService, validateNotModified } from "@comet/cms-api";
+import { PageTreeNodeVisibility, PageTreeService, SubjectEntity, validateNotModified } from "@comet/cms-api";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
 import { UnauthorizedException } from "@nestjs/common";
@@ -12,24 +12,24 @@ export class LinksResolver {
     constructor(@InjectRepository(Link) readonly repository: EntityRepository<Link>, private readonly pageTreeService: PageTreeService) {}
 
     @Query(() => Link, { nullable: true })
+    @SubjectEntity(Link, { idArg: "linkId" })
     async link(@Args("linkId", { type: () => ID }) linkId: string): Promise<Link | null> {
         return this.repository.findOne(linkId);
     }
 
     @Mutation(() => Link)
+    @SubjectEntity(Link, { pageTreeNodeIdArg: "attachedPageTreeNodeId" })
     async saveLink(
         @Args("linkId", { type: () => ID }) linkId: string,
         @Args("input", { type: () => LinkInput }) input: LinkInput,
+        @Args("attachedPageTreeNodeId", { type: () => ID }) attachedPageTreeNodeId: string,
         @Args("lastUpdatedAt", { type: () => Date, nullable: true }) lastUpdatedAt?: Date,
-        @Args("attachedPageTreeNodeId", { nullable: true, type: () => ID }) attachedPageTreeNodeId?: string,
     ): Promise<Link | null> {
         // all pageTypes need this is-archived-page-check
         // TODO: maybe implemented in a base-(document|page)-service which lives in @comet/cms-api
-        if (attachedPageTreeNodeId) {
-            const pageTreeNode = await this.pageTreeService.createReadApi({ visibility: "all" }).getNodeOrFail(attachedPageTreeNodeId);
-            if (pageTreeNode.visibility === PageTreeNodeVisibility.Archived) {
-                throw new UnauthorizedException("Archived Links cannot be updated");
-            }
+        const pageTreeNode = await this.pageTreeService.createReadApi({ visibility: "all" }).getNodeOrFail(attachedPageTreeNodeId);
+        if (pageTreeNode.visibility === PageTreeNodeVisibility.Archived) {
+            throw new UnauthorizedException("Archived Links cannot be updated");
         }
 
         let link = await this.repository.findOne(linkId);
@@ -49,9 +49,7 @@ export class LinksResolver {
             this.repository.persist(link);
         }
 
-        if (attachedPageTreeNodeId) {
-            await this.pageTreeService.attachDocument({ id: linkId, type: "Link" }, attachedPageTreeNodeId);
-        }
+        await this.pageTreeService.attachDocument({ id: linkId, type: "Link" }, attachedPageTreeNodeId);
 
         await this.repository.flush();
 

--- a/demo/api/src/main.ts
+++ b/demo/api/src/main.ts
@@ -14,7 +14,8 @@ require("elastic-apm-node").start({
     active: !!process.env.API_ENABLE_APM,
 });
 
-import { ExceptionInterceptor, GlobalAuthGuard, ValidationExceptionFactory } from "@comet/cms-api";
+import { ExceptionInterceptor, GlobalAuthGuard, PageTreeService, ValidationExceptionFactory } from "@comet/cms-api";
+import { MikroORM } from "@mikro-orm/core";
 import { ValidationPipe } from "@nestjs/common";
 import { ConfigType } from "@nestjs/config";
 import { NestFactory, Reflector } from "@nestjs/core";
@@ -24,6 +25,8 @@ import { configNS } from "@src/config/config.namespace";
 import { useContainer } from "class-validator";
 import compression from "compression";
 import cookieParser from "cookie-parser";
+
+import { GlobalScopeGuard } from "./auth/scope.guard";
 
 async function bootstrap(): Promise<void> {
     const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -50,6 +53,7 @@ async function bootstrap(): Promise<void> {
     );
 
     app.useGlobalGuards(new GlobalAuthGuard(app.get(Reflector)));
+    app.useGlobalGuards(new GlobalScopeGuard(app.get(Reflector), app.get(MikroORM), app.get(PageTreeService)));
     app.use(compression());
     app.use(cookieParser());
 

--- a/demo/api/src/main.ts
+++ b/demo/api/src/main.ts
@@ -14,19 +14,16 @@ require("elastic-apm-node").start({
     active: !!process.env.API_ENABLE_APM,
 });
 
-import { ExceptionInterceptor, GlobalAuthGuard, PageTreeService, ValidationExceptionFactory } from "@comet/cms-api";
-import { MikroORM } from "@mikro-orm/core";
+import { ExceptionInterceptor, ValidationExceptionFactory } from "@comet/cms-api";
 import { ValidationPipe } from "@nestjs/common";
 import { ConfigType } from "@nestjs/config";
-import { NestFactory, Reflector } from "@nestjs/core";
+import { NestFactory } from "@nestjs/core";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { AppModule } from "@src/app.module";
 import { configNS } from "@src/config/config.namespace";
 import { useContainer } from "class-validator";
 import compression from "compression";
 import cookieParser from "cookie-parser";
-
-import { GlobalScopeGuard } from "./auth/scope.guard";
 
 async function bootstrap(): Promise<void> {
     const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -52,8 +49,6 @@ async function bootstrap(): Promise<void> {
         }),
     );
 
-    app.useGlobalGuards(new GlobalAuthGuard(app.get(Reflector)));
-    app.useGlobalGuards(new GlobalScopeGuard(app.get(Reflector), app.get(MikroORM), app.get(PageTreeService)));
     app.use(compression());
     app.use(cookieParser());
 

--- a/demo/api/src/news/dto/news-comment.input.ts
+++ b/demo/api/src/news/dto/news-comment.input.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from "@nestjs/graphql";
+import { IsNotEmpty, IsString } from "class-validator";
+
+@InputType()
+export class NewsCommentInput {
+    @Field()
+    @IsString()
+    @IsNotEmpty()
+    comment: string;
+}

--- a/demo/api/src/news/entities/news-comment.entity.ts
+++ b/demo/api/src/news/entities/news-comment.entity.ts
@@ -1,4 +1,4 @@
-import { DocumentInterface, Scoped } from "@comet/cms-api";
+import { DocumentInterface, ScopedEntity } from "@comet/cms-api";
 import { BaseEntity, Entity, ManyToOne, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
@@ -9,7 +9,7 @@ import { News } from "./news.entity";
 @ObjectType({
     implements: () => [DocumentInterface],
 })
-@Scoped(async (newsComment: NewsComment) => {
+@ScopedEntity(async (newsComment: NewsComment) => {
     return (await newsComment.news.init()).scope as unknown as Record<string, string>; // TODO typings
 })
 export class NewsComment extends BaseEntity<NewsComment, "id"> implements DocumentInterface {

--- a/demo/api/src/news/entities/news-comment.entity.ts
+++ b/demo/api/src/news/entities/news-comment.entity.ts
@@ -10,7 +10,7 @@ import { News } from "./news.entity";
     implements: () => [DocumentInterface],
 })
 @ScopedEntity(async (newsComment: NewsComment) => {
-    return (await newsComment.news.init()).scope as unknown as Record<string, string>; // TODO typings
+    return (await newsComment.news.init()).scope;
 })
 export class NewsComment extends BaseEntity<NewsComment, "id"> implements DocumentInterface {
     [OptionalProps]?: "createdAt" | "updatedAt";

--- a/demo/api/src/news/entities/news-comment.entity.ts
+++ b/demo/api/src/news/entities/news-comment.entity.ts
@@ -1,0 +1,38 @@
+import { DocumentInterface, Scoped } from "@comet/cms-api";
+import { BaseEntity, Entity, ManyToOne, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
+import { Field, ID, ObjectType } from "@nestjs/graphql";
+import { v4 as uuid } from "uuid";
+
+import { News } from "./news.entity";
+
+@Entity()
+@ObjectType({
+    implements: () => [DocumentInterface],
+})
+@Scoped(async (newsComment: NewsComment) => {
+    return (await newsComment.news.init()).scope as unknown as Record<string, string>; // TODO typings
+})
+export class NewsComment extends BaseEntity<NewsComment, "id"> implements DocumentInterface {
+    [OptionalProps]?: "createdAt" | "updatedAt";
+
+    @PrimaryKey({ type: "uuid" })
+    @Field(() => ID)
+    id: string = uuid();
+
+    @ManyToOne(() => News)
+    news!: News;
+
+    @Property()
+    @Field()
+    comment: string;
+
+    @Property({
+        columnType: "timestamp with time zone",
+    })
+    @Field()
+    createdAt: Date = new Date();
+
+    @Property({ onUpdate: () => new Date(), columnType: "timestamp with time zone" })
+    @Field()
+    updatedAt: Date = new Date();
+}

--- a/demo/api/src/news/entities/news-comment.entity.ts
+++ b/demo/api/src/news/entities/news-comment.entity.ts
@@ -10,7 +10,11 @@ import { News } from "./news.entity";
     implements: () => [DocumentInterface],
 })
 @ScopedEntity(async (newsComment: NewsComment) => {
-    return (await newsComment.news.init()).scope;
+    const scope = (await newsComment.news.init()).scope;
+    return {
+        domain: scope.domain as "main" | "secondary",
+        language: scope.language,
+    };
 })
 export class NewsComment extends BaseEntity<NewsComment, "id"> implements DocumentInterface {
     [OptionalProps]?: "createdAt" | "updatedAt";

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -1,12 +1,13 @@
 import { BlockDataInterface, RootBlockEntity } from "@comet/blocks-api";
 import { DamImageBlock, DocumentInterface, RootBlockType } from "@comet/cms-api";
-import { BaseEntity, Embeddable, Embedded, Entity, Enum, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
+import { BaseEntity, Collection, Embeddable, Embedded, Entity, Enum, OneToMany, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, InputType, ObjectType, registerEnumType } from "@nestjs/graphql";
 import { IsString } from "class-validator";
 import { GraphQLJSONObject } from "graphql-type-json";
 import { v4 } from "uuid";
 
 import { NewsContentBlock } from "../blocks/news-content.block";
+import { NewsComment } from "./news-comment.entity";
 
 export enum NewsCategory {
     Events = "Events",
@@ -75,6 +76,9 @@ export class News extends BaseEntity<News, "id"> implements DocumentInterface {
     @Property({ customType: new RootBlockType(NewsContentBlock) })
     @Field(() => GraphQLJSONObject)
     content: BlockDataInterface;
+
+    @OneToMany(() => NewsComment, (newsComment) => newsComment.news)
+    comments = new Collection<NewsComment>(this);
 
     @Property({
         columnType: "timestamp with time zone",

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -31,6 +31,8 @@ export class NewsContentScope {
     @Field()
     @IsString()
     language: string;
+
+    [key: string]: string;
 }
 
 @RootBlockEntity()

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -31,8 +31,6 @@ export class NewsContentScope {
     @Field()
     @IsString()
     language: string;
-
-    [key: string]: string;
 }
 
 @RootBlockEntity()

--- a/demo/api/src/news/news-comment.resolver.ts
+++ b/demo/api/src/news/news-comment.resolver.ts
@@ -1,0 +1,62 @@
+import { SubjectEntity } from "@comet/cms-api";
+import { InjectRepository } from "@mikro-orm/nestjs";
+import { EntityRepository } from "@mikro-orm/postgresql";
+import { Args, ID, Mutation, Resolver } from "@nestjs/graphql";
+
+import { NewsCommentInput } from "./dto/news-comment.input";
+import { News } from "./entities/news.entity";
+import { NewsComment } from "./entities/news-comment.entity";
+
+@Resolver(() => NewsComment)
+export class NewsCommentResolver {
+    constructor(
+        @InjectRepository(NewsComment) private readonly newsCommentRepository: EntityRepository<NewsComment>,
+        @InjectRepository(News) private readonly newsRepository: EntityRepository<News>,
+    ) {}
+
+    @Mutation(() => NewsComment)
+    @SubjectEntity(News, { idArg: "newsId" })
+    async createNewsComment(
+        @Args("newsId", { type: () => ID }) newsId: string,
+        @Args("input", { type: () => NewsCommentInput }) input: NewsCommentInput,
+    ): Promise<NewsComment> {
+        const news = await this.newsRepository.findOneOrFail(newsId);
+
+        const newsComment = this.newsCommentRepository.create({
+            ...input,
+            news,
+        });
+
+        await this.newsCommentRepository.persistAndFlush(newsComment);
+        return newsComment;
+    }
+
+    @Mutation(() => NewsComment)
+    @SubjectEntity(NewsComment)
+    async updateNewsComment(
+        @Args("id", { type: () => ID }) id: string,
+        @Args("input", { type: () => NewsCommentInput }) input: NewsCommentInput,
+        @Args("lastUpdatedAt", { type: () => Date, nullable: true }) lastUpdatedAt?: Date,
+    ): Promise<NewsComment> {
+        const newsComment = await this.newsCommentRepository.findOneOrFail(id);
+        console.log(lastUpdatedAt);
+        if (lastUpdatedAt) {
+            //validateNotModified(newsComment, lastUpdatedAt);
+        }
+        newsComment.assign({
+            ...input,
+        });
+
+        await this.newsCommentRepository.flush();
+
+        return newsComment;
+    }
+
+    @Mutation(() => Boolean)
+    @SubjectEntity(NewsComment)
+    async deleteNewsComment(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
+        await this.newsCommentRepository.removeAndFlush({ id });
+
+        return true;
+    }
+}

--- a/demo/api/src/news/news.module.ts
+++ b/demo/api/src/news/news.module.ts
@@ -2,11 +2,13 @@ import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { Module } from "@nestjs/common";
 import { News, NewsContentScope } from "@src/news/entities/news.entity";
 
+import { NewsComment } from "./entities/news-comment.entity";
 import { NewsResolver } from "./news.resolver";
+import { NewsCommentResolver } from "./news-comment.resolver";
 
 @Module({
-    imports: [MikroOrmModule.forFeature([News, NewsContentScope])],
-    providers: [NewsResolver],
+    imports: [MikroOrmModule.forFeature([News, NewsComment, NewsContentScope])],
+    providers: [NewsResolver, NewsCommentResolver],
     exports: [],
 })
 export class NewsModule {}

--- a/demo/api/src/news/news.resolver.ts
+++ b/demo/api/src/news/news.resolver.ts
@@ -22,9 +22,8 @@ export class NewsResolver {
     }
 
     @Query(() => News, { nullable: true })
-    //TODO add scope argument
-    async newsBySlug(@Args("slug") slug: string): Promise<News | null> {
-        const news = await this.newsRepository.findOne({ slug });
+    async newsBySlug(@Args("scope", { type: () => NewsContentScope }) scope: NewsContentScope, @Args("slug") slug: string): Promise<News | null> {
+        const news = await this.newsRepository.findOne({ scope, slug });
 
         return news ?? null;
     }

--- a/demo/api/src/news/news.resolver.ts
+++ b/demo/api/src/news/news.resolver.ts
@@ -2,12 +2,13 @@ import { PublicApi, SubjectEntity, validateNotModified } from "@comet/cms-api";
 import { FilterQuery, FindOptions } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
-import { Args, ID, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { NewsInput } from "@src/news/dto/news.input";
 
 import { NewsListArgs } from "./dto/news-list.args";
 import { PaginatedNews } from "./dto/paginated-news";
 import { News, NewsContentScope } from "./entities/news.entity";
+import { NewsComment } from "./entities/news-comment.entity";
 
 @Resolver(() => News)
 export class NewsResolver {
@@ -107,5 +108,10 @@ export class NewsResolver {
         await this.newsRepository.removeAndFlush({ id });
 
         return true;
+    }
+
+    @ResolveField(() => [NewsComment])
+    async comments(@Parent() news: News): Promise<NewsComment[]> {
+        return news.comments.loadItems();
     }
 }

--- a/demo/api/src/news/news.resolver.ts
+++ b/demo/api/src/news/news.resolver.ts
@@ -1,4 +1,4 @@
-import { PublicApi, validateNotModified } from "@comet/cms-api";
+import { PublicApi, SubjectEntity, validateNotModified } from "@comet/cms-api";
 import { FilterQuery, FindOptions } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
@@ -13,6 +13,7 @@ import { News, NewsContentScope } from "./entities/news.entity";
 export class NewsResolver {
     constructor(@InjectRepository(News) private readonly newsRepository: EntityRepository<News>) {}
 
+    @SubjectEntity(News)
     @Query(() => News, { nullable: true })
     async news(@Args("id", { type: () => ID }) id: string): Promise<News | null> {
         const news = await this.newsRepository.findOne(id);
@@ -21,6 +22,7 @@ export class NewsResolver {
     }
 
     @Query(() => News, { nullable: true })
+    //TODO add scope argument
     async newsBySlug(@Args("slug") slug: string): Promise<News | null> {
         const news = await this.newsRepository.findOne({ slug });
 
@@ -62,6 +64,7 @@ export class NewsResolver {
     }
 
     @Mutation(() => News)
+    @SubjectEntity(News)
     async updateNews(
         @Args("id", { type: () => ID }) id: string,
         @Args("input", { type: () => NewsInput }) input: NewsInput,
@@ -84,6 +87,7 @@ export class NewsResolver {
     }
 
     @Mutation(() => News)
+    @SubjectEntity(News)
     async updateNewsVisibility(
         @Args("id", { type: () => ID }) id: string,
         @Args("visible", { type: () => Boolean }) visible: boolean,
@@ -99,6 +103,7 @@ export class NewsResolver {
     }
 
     @Mutation(() => Boolean)
+    @SubjectEntity(News)
     async deleteNews(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
         await this.newsRepository.removeAndFlush({ id });
 

--- a/demo/api/src/page-tree/dto/page-tree-node-scope.ts
+++ b/demo/api/src/page-tree/dto/page-tree-node-scope.ts
@@ -16,6 +16,4 @@ export class PageTreeNodeScope {
     @Field()
     @IsString()
     language: string;
-
-    [key: string]: string;
 }

--- a/demo/api/src/page-tree/dto/page-tree-node-scope.ts
+++ b/demo/api/src/page-tree/dto/page-tree-node-scope.ts
@@ -16,4 +16,6 @@ export class PageTreeNodeScope {
     @Field()
     @IsString()
     language: string;
+
+    [key: string]: string;
 }

--- a/demo/api/src/pages/pages.resolver.ts
+++ b/demo/api/src/pages/pages.resolver.ts
@@ -25,12 +25,6 @@ export class PagesArgs extends IntersectionType(OffsetBasedPaginationArgs, SortA
 export class PagesResolver {
     constructor(@InjectRepository(Page) private readonly repository: EntityRepository<Page>, private readonly pageTreeService: PageTreeService) {}
 
-    @Query(() => Page, { nullable: true })
-    @SubjectEntity(Page, { idArg: "pageId" }) //TODO this doesn't work, as it has no relation to pageTreeNode
-    async page(@Args("pageId", { type: () => ID }) pageId: string): Promise<Page | null> {
-        return this.repository.findOne(pageId);
-    }
-
     // TODO add scope argument (who uses this anyway? probably dashboard)
     @Query(() => PaginatedPages)
     async pages(@Args() { offset, limit, sortColumnName, sortDirection }: PagesArgs): Promise<PaginatedPages> {

--- a/demo/site/src/pages/api/auth/[...nextauth].ts
+++ b/demo/site/src/pages/api/auth/[...nextauth].ts
@@ -47,7 +47,7 @@ const options: NextAuthOptions = {
             version: "2.0",
             clientId: process.env.IDP_CLIENT_ID as string,
             clientSecret: "",
-            scope: "offline openid profile email",
+            scope: "offline openid profile email role",
             params: { grant_type: "authorization_code" },
             accessTokenUrl: `${process.env.IDP_URL}/oauth2/token`,
             authorizationUrl: `${process.env.IDP_URL}/oauth2/auth?response_type=code`,

--- a/packages/api/cms-api/src/auth/auth.constants.ts
+++ b/packages/api/cms-api/src/auth/auth.constants.ts
@@ -1,2 +1,3 @@
 export const AUTH_MODULE_OPTIONS = "auth-module-options";
 export const AUTH_CONFIG = "auth-config";
+export const AUTH_CURRENT_USER_LOADER = "auth-current-user-loader";

--- a/packages/api/cms-api/src/auth/default-current-user-loader.service.ts
+++ b/packages/api/cms-api/src/auth/default-current-user-loader.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from "@nestjs/common";
+
+import { CurrentUser } from "./dto/current-user";
+import { CurrentUserLoaderInterface } from "./interfaces/current-user-loader.interface";
+
+@Injectable()
+export class DefaultCurrentUserLoaderService implements CurrentUserLoaderInterface {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async load(token: string, data: any): Promise<CurrentUser> {
+        const user = {
+            id: data.sub,
+            role: data.ext?.role,
+        };
+        return user;
+    }
+}

--- a/packages/api/cms-api/src/auth/dto/current-user.ts
+++ b/packages/api/cms-api/src/auth/dto/current-user.ts
@@ -1,4 +1,4 @@
-export class CurrentUser {
+export interface CurrentUser {
     id: string;
     role: string | undefined;
     contentScopes?: Array<Record<string, string>>;

--- a/packages/api/cms-api/src/auth/dto/current-user.ts
+++ b/packages/api/cms-api/src/auth/dto/current-user.ts
@@ -1,13 +1,4 @@
 export interface CurrentUser {
     id: string;
     role: string | undefined;
-    contentScopes?: Array<Record<string, string>>;
 }
-
-/*
-contentScrops: [
-    {
-        domain: "at",
-    }
-]
-*/

--- a/packages/api/cms-api/src/auth/dto/current-user.ts
+++ b/packages/api/cms-api/src/auth/dto/current-user.ts
@@ -1,4 +1,13 @@
 export class CurrentUser {
     id: string;
     role: string | undefined;
+    contentScopes?: Array<Record<string, string>>;
 }
+
+/*
+contentScrops: [
+    {
+        domain: "at",
+    }
+]
+*/

--- a/packages/api/cms-api/src/auth/interfaces/current-user-loader.interface.ts
+++ b/packages/api/cms-api/src/auth/interfaces/current-user-loader.interface.ts
@@ -1,0 +1,6 @@
+import { CurrentUser } from "../dto/current-user";
+
+export interface CurrentUserLoaderInterface {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    load: (token: string, data: any) => Promise<CurrentUser>;
+}

--- a/packages/api/cms-api/src/auth/strategies/bearer-token.strategy.ts
+++ b/packages/api/cms-api/src/auth/strategies/bearer-token.strategy.ts
@@ -56,6 +56,11 @@ export class BearerTokenStrategy extends PassportStrategy(Strategy) {
         const user = new CurrentUser();
         user.id = data.sub;
         user.role = data.ext?.role;
+        user.contentScopes = data.ext?.domain.map((domain: string) => {
+            return {
+                domain,
+            };
+        });
         return user;
     }
 }

--- a/packages/api/cms-api/src/common/decorators/content-scope.interface.ts
+++ b/packages/api/cms-api/src/common/decorators/content-scope.interface.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContentScope {}

--- a/packages/api/cms-api/src/common/decorators/scoped-entity.decorator.ts
+++ b/packages/api/cms-api/src/common/decorators/scoped-entity.decorator.ts
@@ -1,11 +1,11 @@
 import { CustomDecorator, SetMetadata } from "@nestjs/common";
 
-export interface ScopedMeta {
+export interface ScopedEntityMeta {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fn: (entity: any) => Promise<Record<string, string>>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const Scoped = (fn: (entity: any) => Promise<Record<string, string>>): CustomDecorator<string> => {
+export const ScopedEntity = (fn: (entity: any) => Promise<Record<string, string>>): CustomDecorator<string> => {
     return SetMetadata("scoped", { fn });
 };

--- a/packages/api/cms-api/src/common/decorators/scoped-entity.decorator.ts
+++ b/packages/api/cms-api/src/common/decorators/scoped-entity.decorator.ts
@@ -1,11 +1,13 @@
 import { CustomDecorator, SetMetadata } from "@nestjs/common";
 
+import { ContentScope } from "./content-scope.interface";
+
 export interface ScopedEntityMeta {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fn: (entity: any) => Promise<Record<string, string>>;
+    fn: (entity: any) => Promise<ContentScope>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const ScopedEntity = (fn: (entity: any) => Promise<Record<string, string>>): CustomDecorator<string> => {
+export const ScopedEntity = (fn: (entity: any) => Promise<ContentScope>): CustomDecorator<string> => {
     return SetMetadata("scopedEntity", { fn });
 };

--- a/packages/api/cms-api/src/common/decorators/scoped-entity.decorator.ts
+++ b/packages/api/cms-api/src/common/decorators/scoped-entity.decorator.ts
@@ -7,5 +7,5 @@ export interface ScopedEntityMeta {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const ScopedEntity = (fn: (entity: any) => Promise<Record<string, string>>): CustomDecorator<string> => {
-    return SetMetadata("scoped", { fn });
+    return SetMetadata("scopedEntity", { fn });
 };

--- a/packages/api/cms-api/src/common/decorators/scoped.decorator.ts
+++ b/packages/api/cms-api/src/common/decorators/scoped.decorator.ts
@@ -1,0 +1,11 @@
+import { CustomDecorator, SetMetadata } from "@nestjs/common";
+
+export interface ScopedMeta {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fn: (entity: any) => Promise<Record<string, string>>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const Scoped = (fn: (entity: any) => Promise<Record<string, string>>): CustomDecorator<string> => {
+    return SetMetadata("scoped", { fn });
+};

--- a/packages/api/cms-api/src/common/decorators/subject-entity.decorator.ts
+++ b/packages/api/cms-api/src/common/decorators/subject-entity.decorator.ts
@@ -1,0 +1,13 @@
+import { CustomDecorator, SetMetadata } from "@nestjs/common";
+
+export interface SubjectEntityOptions {
+    idArg?: string;
+    pageTreeNodeIdArg?: string;
+}
+export interface SubjectEntityMeta {
+    entity: any; //TODO
+    options: SubjectEntityOptions;
+}
+export const SubjectEntity = (entity: any, { idArg, pageTreeNodeIdArg }: SubjectEntityOptions = { idArg: "id" }): CustomDecorator<string> => {
+    return SetMetadata("subjectEntity", { entity, options: { idArg, pageTreeNodeIdArg } });
+};

--- a/packages/api/cms-api/src/common/decorators/subject-entity.decorator.ts
+++ b/packages/api/cms-api/src/common/decorators/subject-entity.decorator.ts
@@ -1,3 +1,4 @@
+import { EntityName } from "@mikro-orm/core";
 import { CustomDecorator, SetMetadata } from "@nestjs/common";
 
 export interface SubjectEntityOptions {
@@ -5,9 +6,15 @@ export interface SubjectEntityOptions {
     pageTreeNodeIdArg?: string;
 }
 export interface SubjectEntityMeta {
-    entity: any; //TODO
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entity: EntityName<any>; //TODO
     options: SubjectEntityOptions;
 }
-export const SubjectEntity = (entity: any, { idArg, pageTreeNodeIdArg }: SubjectEntityOptions = { idArg: "id" }): CustomDecorator<string> => {
+
+export const SubjectEntity = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entity: EntityName<any>,
+    { idArg, pageTreeNodeIdArg }: SubjectEntityOptions = { idArg: "id" },
+): CustomDecorator<string> => {
     return SetMetadata("subjectEntity", { entity, options: { idArg, pageTreeNodeIdArg } });
 };

--- a/packages/api/cms-api/src/content-scope/conent-scope.constants.ts
+++ b/packages/api/cms-api/src/content-scope/conent-scope.constants.ts
@@ -1,0 +1,1 @@
+export const CONTENT_SCOPES_FROM_USER = "content-scopes-from-user";

--- a/packages/api/cms-api/src/content-scope/conent-scope.constants.ts
+++ b/packages/api/cms-api/src/content-scope/conent-scope.constants.ts
@@ -1,1 +1,1 @@
-export const CONTENT_SCOPES_FROM_USER = "content-scopes-from-user";
+export const CAN_ACCESS_SCOPE = "can-access-scope";

--- a/packages/api/cms-api/src/content-scope/content-scope.module.ts
+++ b/packages/api/cms-api/src/content-scope/content-scope.module.ts
@@ -1,0 +1,26 @@
+import { DynamicModule, Module } from "@nestjs/common";
+import { APP_GUARD } from "@nestjs/core";
+
+import { CurrentUser } from "../auth/dto/current-user";
+import { CONTENT_SCOPES_FROM_USER } from "./conent-scope.constants";
+import { ScopeGuard } from "./scope.guard";
+
+interface ContentScopeModuleOptions {
+    contentScopesFromUser: (user: CurrentUser) => Array<Record<string, string>> | undefined;
+}
+
+@Module({})
+export class ContentScopeModule {
+    static forRoot(options: ContentScopeModuleOptions): DynamicModule {
+        const { contentScopesFromUser } = options;
+        return {
+            module: ContentScopeModule,
+            imports: [],
+            providers: [
+                { provide: APP_GUARD, useClass: ScopeGuard },
+                { provide: CONTENT_SCOPES_FROM_USER, useValue: contentScopesFromUser },
+            ],
+            exports: [],
+        };
+    }
+}

--- a/packages/api/cms-api/src/content-scope/content-scope.module.ts
+++ b/packages/api/cms-api/src/content-scope/content-scope.module.ts
@@ -1,24 +1,25 @@
 import { DynamicModule, Module } from "@nestjs/common";
 import { APP_GUARD } from "@nestjs/core";
+import { ContentScope } from "src/common/decorators/content-scope.interface";
 
 import { CurrentUser } from "../auth/dto/current-user";
-import { CONTENT_SCOPES_FROM_USER } from "./conent-scope.constants";
+import { CAN_ACCESS_SCOPE } from "./conent-scope.constants";
 import { ScopeGuard } from "./scope.guard";
 
 interface ContentScopeModuleOptions {
-    contentScopesFromUser: (user: CurrentUser) => Array<Record<string, string>> | undefined;
+    canAccessScope: (requestScope: ContentScope, user: CurrentUser) => boolean;
 }
 
 @Module({})
 export class ContentScopeModule {
     static forRoot(options: ContentScopeModuleOptions): DynamicModule {
-        const { contentScopesFromUser } = options;
+        const { canAccessScope } = options;
         return {
             module: ContentScopeModule,
             imports: [],
             providers: [
                 { provide: APP_GUARD, useClass: ScopeGuard },
-                { provide: CONTENT_SCOPES_FROM_USER, useValue: contentScopesFromUser },
+                { provide: CAN_ACCESS_SCOPE, useValue: canAccessScope },
             ],
             exports: [],
         };

--- a/packages/api/cms-api/src/content-scope/scope.guard.ts
+++ b/packages/api/cms-api/src/content-scope/scope.guard.ts
@@ -87,9 +87,7 @@ export class ScopeGuard implements CanActivate {
 
         const requestScope = await this.inferScopeFromRequest(context);
         if (requestScope) {
-            const canAccessScope = this.canAccessScope(user, requestScope);
-            // console.log(user, requestScope, canAccessScope);
-            return canAccessScope;
+            return this.canAccessScope(user, requestScope);
         } else {
             //not a scoped request, open to anyone
         }

--- a/packages/api/cms-api/src/content-scope/scope.guard.ts
+++ b/packages/api/cms-api/src/content-scope/scope.guard.ts
@@ -102,7 +102,7 @@ export class ScopeGuard implements CanActivate {
         if (userScopes === undefined) return true; //user has no contentScope restriction
         return userScopes.some((userScopes) => {
             return Object.entries(userScopes).every(([scopeKey, scopeValue]) => {
-                return !requestScope[scopeKey] || requestScope[scopeKey] == scopeValue;
+                return !requestScope[scopeKey] || requestScope[scopeKey] === scopeValue;
             });
         });
     }

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -41,7 +41,7 @@ export { JobStatus } from "./builds/job-status.enum";
 export { SKIP_BUILD_METADATA_KEY, SkipBuild } from "./builds/skip-build.decorator";
 export { SkipBuildInterceptor } from "./builds/skip-build.interceptor";
 export { getRequestContextHeadersFromRequest, RequestContext, RequestContextInterface } from "./common/decorators/request-context.decorator";
-export { Scoped, ScopedMeta } from "./common/decorators/scoped.decorator";
+export { ScopedEntity, ScopedEntityMeta } from "./common/decorators/scoped-entity.decorator";
 export { SubjectEntity, SubjectEntityMeta, SubjectEntityOptions } from "./common/decorators/subject-entity.decorator";
 export { getRequestFromExecutionContext } from "./common/decorators/utils";
 export { CometException } from "./common/errors/comet.exception";

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -41,6 +41,7 @@ export { JobStatus } from "./builds/job-status.enum";
 export { SKIP_BUILD_METADATA_KEY, SkipBuild } from "./builds/skip-build.decorator";
 export { SkipBuildInterceptor } from "./builds/skip-build.interceptor";
 export { getRequestContextHeadersFromRequest, RequestContext, RequestContextInterface } from "./common/decorators/request-context.decorator";
+export { SubjectEntity, SubjectEntityMeta, SubjectEntityOptions } from "./common/decorators/subject-entity.decorator";
 export { getRequestFromExecutionContext } from "./common/decorators/utils";
 export { CometException } from "./common/errors/comet.exception";
 export { CometEntityNotFoundException } from "./common/errors/entity-not-found.exception";

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 
-export { AUTH_CONFIG, AUTH_MODULE_OPTIONS } from "./auth/auth.constants";
+export { AUTH_CONFIG, AUTH_CURRENT_USER_LOADER, AUTH_MODULE_OPTIONS } from "./auth/auth.constants";
 export { AuthModule } from "./auth/auth.module";
 export { AllowForRole } from "./auth/decorators/allow-for-role.decorator";
 export { GetCurrentUser } from "./auth/decorators/get-current-user.decorator";
@@ -8,6 +8,7 @@ export { DisableGlobalGuard } from "./auth/decorators/global-guard-disable.decor
 export { PublicApi } from "./auth/decorators/public-api.decorator";
 export { CurrentUser } from "./auth/dto/current-user";
 export { GlobalAuthGuard } from "./auth/guards/global.guard";
+export { CurrentUserLoaderInterface } from "./auth/interfaces/current-user-loader.interface";
 export { BasicAuthStrategy } from "./auth/strategies/basic-auth.strategy";
 export { BearerTokenStrategy } from "./auth/strategies/bearer-token.strategy";
 export { BlobStorageAzureConfig } from "./blob-storage/backends/azure/blob-storage-azure.config";

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -55,6 +55,7 @@ export { PaginatedResponseFactory } from "./common/pagination/paginated-response
 export { SortArgs } from "./common/sorting/sort.args";
 export { SortDirection } from "./common/sorting/sort-direction.enum";
 export { IsSlug } from "./common/validators/is-slug";
+export { ContentScopeModule } from "./content-scope/content-scope.module";
 export { DamImageBlock } from "./dam/blocks/dam-image.block";
 export { ScaledImagesCacheService } from "./dam/cache/scaled-images-cache.service";
 export { FocalPoint } from "./dam/common/enums/focal-point.enum";

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -41,6 +41,7 @@ export { ChangesSinceLastBuild } from "./builds/entities/changes-since-last-buil
 export { JobStatus } from "./builds/job-status.enum";
 export { SKIP_BUILD_METADATA_KEY, SkipBuild } from "./builds/skip-build.decorator";
 export { SkipBuildInterceptor } from "./builds/skip-build.interceptor";
+export { ContentScope } from "./common/decorators/content-scope.interface";
 export { getRequestContextHeadersFromRequest, RequestContext, RequestContextInterface } from "./common/decorators/request-context.decorator";
 export { ScopedEntity, ScopedEntityMeta } from "./common/decorators/scoped-entity.decorator";
 export { SubjectEntity, SubjectEntityMeta, SubjectEntityOptions } from "./common/decorators/subject-entity.decorator";

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -41,6 +41,7 @@ export { JobStatus } from "./builds/job-status.enum";
 export { SKIP_BUILD_METADATA_KEY, SkipBuild } from "./builds/skip-build.decorator";
 export { SkipBuildInterceptor } from "./builds/skip-build.interceptor";
 export { getRequestContextHeadersFromRequest, RequestContext, RequestContextInterface } from "./common/decorators/request-context.decorator";
+export { Scoped, ScopedMeta } from "./common/decorators/scoped.decorator";
 export { SubjectEntity, SubjectEntityMeta, SubjectEntityOptions } from "./common/decorators/subject-entity.decorator";
 export { getRequestFromExecutionContext } from "./common/decorators/utils";
 export { CometException } from "./common/errors/comet.exception";

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -4,6 +4,7 @@ import { Request } from "express";
 import { GraphQLError } from "graphql";
 
 import { getRequestContextHeadersFromRequest } from "../common/decorators/request-context.decorator";
+import { SubjectEntity } from "../common/decorators/subject-entity.decorator";
 import { DocumentInterface } from "../document/dto/document-interface";
 import { EmptyPageTreeNodeScope } from "./dto/empty-page-tree-node-scope";
 import {
@@ -76,6 +77,7 @@ export function createPageTreeResolver({
         }
 
         @Query(() => PageTreeNode, { nullable: true })
+        @SubjectEntity(PageTreeNode)
         async pageTreeNode(@Args("id", { type: () => ID }) id: string): Promise<PageTreeNodeInterface> {
             return this.pageTreeReadApi.getNodeOrFail(id);
         }
@@ -157,6 +159,7 @@ export function createPageTreeResolver({
         }
 
         @Mutation(() => PageTreeNode)
+        @SubjectEntity(PageTreeNode)
         async updatePageTreeNode(
             @Args("id", { type: () => ID }) id: string,
             @Args("input", { type: () => PageTreeNodeUpdateInput }) input: PageTreeNodeUpdateInputInterface,
@@ -174,6 +177,7 @@ export function createPageTreeResolver({
         }
 
         @Mutation(() => Boolean)
+        @SubjectEntity(PageTreeNode)
         async deletePageTreeNode(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
             const pageTreeReadApi = this.pageTreeService.createReadApi({
                 visibility: "all",
@@ -184,6 +188,7 @@ export function createPageTreeResolver({
         }
 
         @Mutation(() => PageTreeNode)
+        @SubjectEntity(PageTreeNode)
         async updatePageTreeNodeVisibility(
             @Args("id", { type: () => ID }) id: string,
             @Args("input", { type: () => PageTreeNodeUpdateVisibilityInput }) input: PageTreeNodeUpdateVisibilityInput,
@@ -199,6 +204,7 @@ export function createPageTreeResolver({
         }
 
         @Mutation(() => PageTreeNode)
+        @SubjectEntity(PageTreeNode)
         async updatePageTreeNodePosition(
             @Args("id", { type: () => ID }) id: string,
             @Args("input", { type: () => PageTreeNodeUpdatePositionInput }) input: PageTreeNodeUpdatePositionInput,
@@ -221,6 +227,7 @@ export function createPageTreeResolver({
         }
 
         @Mutation(() => PageTreeNode)
+        @SubjectEntity(PageTreeNode)
         async updatePageTreeNodeCategory(
             @Args("id", { type: () => ID }) id: string,
             @Args("category", { type: () => String }) category: PageTreeNodeCategory,

--- a/packages/api/cms-api/src/page-tree/page-tree.module.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.module.ts
@@ -56,7 +56,19 @@ export class PageTreeModule {
         return {
             module: PageTreeModule,
             imports: [MikroOrmModule.forFeature([AttachedDocument, PageTreeNode, ...(Scope ? [Scope] : [])])],
-            providers: [PageTreeService, pageTreeResolver, repositoryProvider, pageTreeConfigProvider, PageExistsConstraint],
+            providers: [
+                PageTreeService,
+                pageTreeResolver,
+                repositoryProvider,
+                pageTreeConfigProvider,
+                {
+                    provide: PageExistsConstraint,
+                    useFactory: (pageTreeService: PageTreeService) => {
+                        new PageExistsConstraint(pageTreeService);
+                    },
+                    inject: [PageTreeService],
+                },
+            ],
             exports: [PageTreeService],
         };
     }


### PR DESCRIPTION
attachedPageTreeNodeId is not a required parameter, so it can be validated.

The `SubjectEntity` decorator is ment to be used for other use cases as well:

- scope dependent build trigger (to rebuild only affected scope)
- user action log

TODO: 

- [x] page query: this doesn't work, as it has no relation to pageTreeNode (is this query used anywhere?)
- [x] saveFooter mutation: move scope out of input into own arg (so it can be validated)
- [x] newsBySlug query: add scope argument
- [x] SubjectEntity decorator: type entity better
- [x] Add scope guard into library
- [x] get scope from parent row using something like `@Scoped(entity => entity.parent.scope)` (at entity class)
- [x] `@Scoped` fix typings (don't use ` as unknown as Record<string, string>`)
- [x] convert CurrentUser to an interface
- [x] think about an application specific CurrentUser
- [x] BearerTokenStrategy: allow idp user -> CurrentUser conversion application specific override
- [x] find a way to avoid manual DI in main.ts (where ScopeGuard is instanciated)
- [x] (?) Don't use `Record<string, string>` for scope, use `Record<string, unknown>` or so, let the application decide what's in there

---

Later, not in this PR:

- [x] implement admin side (to only show possible scopes to the user)
- [ ] implement something more flexible that supports something like that: `@SubjectEntity(Product, EntityLoader)`
- [ ] pages query: add scope argument (used in dashboard - dashboard should get scoped)
