### PR TITLE
Add option to override site preview icon

### DIFF
--- a/packages/admin/cms-admin/src/preview/SitePreview.sc.tsx
+++ b/packages/admin/cms-admin/src/preview/SitePreview.sc.tsx
@@ -1,6 +1,5 @@
 import { Button, Link } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { makeStyles } from "@mui/styles";
 
 export const Root = styled("div")`
     display: flex;
@@ -18,32 +17,31 @@ export const StyledButton = styled(Button)`
     color: ${({ theme }) => theme.palette.common.white};
 `;
 
-export const CometLogoWrapper = styled("div")`
+export const SiteInformation = styled("div")`
     display: flex;
     align-items: center;
     color: ${({ theme }) => theme.palette.common.white};
-    text-transform: uppercase;
+    padding: 0 6px;
+    gap: 20px;
 `;
 
-export const CometSiteLinkWrapper = styled("div")`
-    margin-left: 20px;
-    display: flex;
+export const LogoWrapper = styled("div")`
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
 `;
 
-export const CometSiteLink = styled(Link)`
-    margin-left: 6px;
+export const SiteLinkWrapper = styled("div")`
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+`;
+
+export const SiteLink = styled(Link)`
     color: ${({ theme }) => theme.palette.common.white};
-    text-transform: none;
+    text-decoration-color: ${({ theme }) => theme.palette.common.white};
 `;
 
 export const ActionsContainer = styled("div")`
     background-color: ${({ theme }) => theme.palette.grey["A400"]};
 `;
-
-export const useStyles = makeStyles({
-    cometIcon: {
-        fontSize: 32,
-        height: "auto",
-        padding: 6,
-    },
-});

--- a/packages/admin/cms-admin/src/preview/SitePreview.sc.tsx
+++ b/packages/admin/cms-admin/src/preview/SitePreview.sc.tsx
@@ -39,7 +39,7 @@ export const SiteLinkWrapper = styled("div")`
 
 export const SiteLink = styled(Link)`
     color: ${({ theme }) => theme.palette.common.white};
-    text-decoration-color: ${({ theme }) => theme.palette.common.white};
+    text-decoration-color: currentColor;
 `;
 
 export const ActionsContainer = styled("div")`

--- a/packages/admin/cms-admin/src/preview/SitePreview.tsx
+++ b/packages/admin/cms-admin/src/preview/SitePreview.tsx
@@ -13,7 +13,7 @@ import { buildPreviewUrl } from "./buildPreviewUrl";
 import { DeviceToggle } from "./DeviceToggle";
 import { IFrameViewer } from "./IFrameViewer";
 import { OpenLinkDialog } from "./OpenLinkDialog";
-import { ActionsContainer, CometLogoWrapper, CometSiteLink, CometSiteLinkWrapper, Root, useStyles } from "./SitePreview.sc";
+import { ActionsContainer, LogoWrapper, Root, SiteInformation, SiteLink, SiteLinkWrapper } from "./SitePreview.sc";
 import { Device } from "./types";
 import { VisibilityToggle } from "./VisibilityToggle";
 
@@ -23,9 +23,10 @@ interface SiteState {
 
 interface Props extends RouteComponentProps {
     resolvePath?: (path: string, scope: ContentScopeInterface) => string;
+    logo?: React.ReactNode;
 }
 
-function SitePreview({ location, resolvePath }: Props): React.ReactElement {
+function SitePreview({ location, resolvePath, logo = <CometColor sx={{ fontSize: 32 }} /> }: Props): React.ReactElement {
     const queryParams = new URLSearchParams(location.search);
 
     const [previewPath, setPreviewPath] = React.useState<string>(queryParams.get("path") || "");
@@ -65,8 +66,6 @@ function SitePreview({ location, resolvePath }: Props): React.ReactElement {
         // the src-value is just the default value, the iframe keeps its own src-state (by clicking links inside the iframe)
         setInitialPageUrl(buildPreviewUrl(siteConfig.previewUrl, previewPath, formattedSiteState));
     }, [formattedSiteState]); // eslint-disable-line react-hooks/exhaustive-deps
-
-    const classes = useStyles();
 
     const history = useHistory();
     const intl = useIntl();
@@ -131,12 +130,14 @@ function SitePreview({ location, resolvePath }: Props): React.ReactElement {
                 <ActionsContainer>
                     <Grid container justifyContent="space-between" alignItems="center" wrap="nowrap">
                         <Grid item>
-                            <CometLogoWrapper>
-                                <CometColor className={classes.cometIcon} />
-                                <Typography>
-                                    <FormattedMessage defaultMessage="Preview" id="comet.sitePreview.preview" />
-                                </Typography>
-                                <CometSiteLinkWrapper>
+                            <SiteInformation>
+                                <LogoWrapper>
+                                    {logo}
+                                    <Typography textTransform="uppercase" color="white">
+                                        <FormattedMessage defaultMessage="Preview" id="comet.sitePreview.preview" />
+                                    </Typography>
+                                </LogoWrapper>
+                                <SiteLinkWrapper>
                                     {siteConfig.preloginEnabled ? (
                                         <Tooltip
                                             title={intl.formatMessage({
@@ -149,11 +150,11 @@ function SitePreview({ location, resolvePath }: Props): React.ReactElement {
                                     ) : (
                                         <Public />
                                     )}
-                                    <CometSiteLink variant="body1" href={siteLink} target="_blank">
+                                    <SiteLink variant="body1" href={siteLink} target="_blank">
                                         {siteLink}
-                                    </CometSiteLink>
-                                </CometSiteLinkWrapper>
-                            </CometLogoWrapper>
+                                    </SiteLink>
+                                </SiteLinkWrapper>
+                            </SiteInformation>
                         </Grid>
                         <Grid item>
                             <DeviceToggle device={device} onChange={handleDeviceChange} />


### PR DESCRIPTION
In some projects we want to use a custom icon instead of the Comet icon in the bottom left corner of the site preview. This is now possible by using the `icon` prop in the `SitePreview` component.