### PR TITLE
Improve input validation of redirect form

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -282,8 +282,9 @@ type Query {
   pageTreeNodeByPath(path: String!, scope: PageTreeNodeScopeInput!): PageTreeNode
   pageTreeNodeList(scope: PageTreeNodeScopeInput!, category: String): [PageTreeNode!]!
   pageTreeNodeSlugAvailable(scope: PageTreeNodeScopeInput!, parentId: ID, slug: String!): SlugAvailability!
-  redirects(query: String, type: RedirectGenerationType, active: Boolean): [Redirect!]!
+  redirects(sortColumnName: String, sortDirection: SortDirection = ASC, query: String, type: RedirectGenerationType, active: Boolean): [Redirect!]!
   redirect(id: ID!): Redirect!
+  redirectSourceAvailable(source: String!): Boolean!
   damFilesList(sortColumnName: String, sortDirection: SortDirection = ASC, folderId: ID, includeArchived: Boolean = false, filter: FileFilterInput): [DamFile!]!
   damFile(id: ID!): DamFile!
   damIsFilenameOccupied(filename: String!, folderId: String): Boolean!

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@apollo/client";
+import { gql, useApolloClient, useQuery } from "@apollo/client";
 import {
     Field,
     FinalForm,
@@ -15,6 +15,7 @@ import {
     ToolbarTitleItem,
     useStackApi,
 } from "@comet/admin";
+import { useStackSwitchApi } from "@comet/admin/lib/stack/Switch";
 import { BlockInterface, BlockState, createFinalFormBlock, isValidUrl } from "@comet/blocks-admin";
 import { Card, CardContent, CircularProgress, Grid, MenuItem } from "@mui/material";
 import { FORM_ERROR } from "final-form";
@@ -22,9 +23,12 @@ import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import {
+    GQLCreateRedirectMutation,
     GQLRedirectDetailFragment,
     GQLRedirectDetailQuery,
     GQLRedirectDetailQueryVariables,
+    GQLRedirectSourceAvailableQuery,
+    GQLRedirectSourceAvailableQueryVariables,
     GQLRedirectSourceTypeValues,
 } from "../graphql.generated";
 import { redirectDetailQuery } from "./RedirectForm.gql";
@@ -78,6 +82,7 @@ export const RedirectForm = ({ mode, id, linkBlock }: Props): JSX.Element => {
     const intl = useIntl();
     const initialValues = useInitialValues(id, linkBlock);
     const targetInput = React.useMemo(() => createFinalFormBlock(linkBlock), [linkBlock]);
+    const client = useApolloClient();
 
     const sourceTypeOptions = [
         {
@@ -90,17 +95,40 @@ export const RedirectForm = ({ mode, id, linkBlock }: Props): JSX.Element => {
     ];
 
     const stackApi = useStackApi();
+    const stackSwitchApi = useStackSwitchApi();
 
     const [submit, { loading: saving, error: saveError }] = useSubmitMutation(mode, id, linkBlock);
+    const newlyCreatedRedirectId = React.useRef<string>();
 
     if (mode === "edit" && initialValues === undefined) {
         return <CircularProgress />;
     }
 
-    const validateSourceType = (value: string, allValues: GQLRedirectDetailFragment) => {
+    const validateSource = async (value: string, allValues: GQLRedirectDetailFragment) => {
         if (allValues.sourceType === "path") {
             if (!value.startsWith("/")) {
                 return intl.formatMessage({ id: "comet.pages.redirects.validate.path.error", defaultMessage: "Needs to start with /" });
+            }
+
+            const { data } = await client.query<GQLRedirectSourceAvailableQuery, GQLRedirectSourceAvailableQueryVariables>({
+                query: gql`
+                    query RedirectSourceAvailable($source: String!) {
+                        redirectSourceAvailable(source: $source)
+                    }
+                `,
+                variables: {
+                    source: value,
+                },
+            });
+
+            if (!data.redirectSourceAvailable && initialValues?.source !== undefined && initialValues.source !== value) {
+                return (
+                    <FormattedMessage
+                        id="comet.redirects.form.validation.sourceTaken"
+                        defaultMessage="Source {source} is not available"
+                        values={{ source: value }}
+                    />
+                );
             }
         } else {
             return validateDomain(value);
@@ -115,8 +143,14 @@ export const RedirectForm = ({ mode, id, linkBlock }: Props): JSX.Element => {
             });
         }
     };
-    const handleSaveClick = (values: FormValues) => {
-        return submit(values);
+
+    const handleSaveClick = async (values: FormValues) => {
+        const response = await submit(values);
+
+        if (response.data && "createRedirect" in response.data) {
+            // console.log((response.data as GQLCreateRedirectMutation).createRedirect.id);
+            newlyCreatedRedirectId.current = (response.data as GQLCreateRedirectMutation).createRedirect.id;
+        }
     };
 
     return (
@@ -129,7 +163,7 @@ export const RedirectForm = ({ mode, id, linkBlock }: Props): JSX.Element => {
                 form.reset(values);
             }}
         >
-            {({ values, pristine, hasValidationErrors, submitting, handleSubmit }) => (
+            {({ values, pristine, hasValidationErrors, submitting, handleSubmit, validating }) => (
                 <>
                     <Toolbar>
                         <ToolbarBackButton />
@@ -138,8 +172,21 @@ export const RedirectForm = ({ mode, id, linkBlock }: Props): JSX.Element => {
                         </ToolbarTitleItem>
                         <ToolbarFillSpace />
                         <ToolbarActions>
-                            <SplitButton disabled={pristine || hasValidationErrors || submitting} localStorageKey="editRedirectSave">
-                                <SaveButton color="primary" variant="contained" saving={saving} hasErrors={saveError != null} type="submit">
+                            <SplitButton disabled={pristine || hasValidationErrors || submitting || validating} localStorageKey="editRedirectSave">
+                                <SaveButton
+                                    color="primary"
+                                    variant="contained"
+                                    saving={saving}
+                                    hasErrors={saveError != null}
+                                    type="submit"
+                                    onClick={async () => {
+                                        const submitResult = await handleSubmit();
+                                        const error = submitResult?.[FORM_ERROR];
+                                        if (!error && mode === "add" && newlyCreatedRedirectId.current) {
+                                            stackSwitchApi.activatePage("edit", newlyCreatedRedirectId.current);
+                                        }
+                                    }}
+                                >
                                     <FormattedMessage {...messages.save} />
                                 </SaveButton>
 
@@ -195,7 +242,7 @@ export const RedirectForm = ({ mode, id, linkBlock }: Props): JSX.Element => {
                                             // @TODO: FIX ts-type here: https://github.com/vivid-planet/comet-admin/blob/next/packages/admin/src/form/Field.tsx#L18
                                             // type object doesnt work with "strict"
                                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                            validate={validateSourceType as any}
+                                            validate={validateSource as any}
                                             fullWidth
                                         />
                                     </Grid>

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -148,7 +148,6 @@ export const RedirectForm = ({ mode, id, linkBlock }: Props): JSX.Element => {
         const response = await submit(values);
 
         if (response.data && "createRedirect" in response.data) {
-            // console.log((response.data as GQLCreateRedirectMutation).createRedirect.id);
             newlyCreatedRedirectId.current = (response.data as GQLCreateRedirectMutation).createRedirect.id;
         }
     };

--- a/packages/admin/cms-admin/src/redirects/submitMutation.ts
+++ b/packages/admin/cms-admin/src/redirects/submitMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@apollo/client";
 import { ApolloError } from "@apollo/client/errors";
+import { FetchResult } from "@apollo/client/link/core";
 import { BlockInterface } from "@comet/blocks-admin";
 
 import { GQLCreateRedirectMutation, GQLRedirectInput, GQLUpdateRedirectMutation } from "../graphql.generated";
@@ -23,7 +24,10 @@ export const useSubmitMutation = (
     mode: "edit" | "add",
     id: string | undefined,
     linkBlock: BlockInterface,
-): [(values: FormValues) => void, { loading: boolean; error: ApolloError | undefined }] => {
+): [
+    (values: FormValues) => Promise<FetchResult<GQLCreateRedirectMutation | GQLUpdateRedirectMutation>>,
+    { loading: boolean; error: ApolloError | undefined },
+] => {
     const [create, { loading: createLoading, error: createError }] = useMutation<GQLCreateRedirectMutation>(createRedirectMutation);
     const [update, { loading: updateLoading, error: updateError }] = useMutation<GQLUpdateRedirectMutation>(updateRedirectMutation);
     const loading = mode === "edit" ? updateLoading : createLoading;

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -162,6 +162,7 @@ type Query {
   buildTemplates: [BuildTemplate!]!
   redirects(sortColumnName: String, sortDirection: SortDirection = ASC, query: String, type: RedirectGenerationType, active: Boolean): [Redirect!]!
   redirect(id: ID!): Redirect!
+  redirectSourceAvailable(source: String!): Boolean!
   damFilesList(sortColumnName: String, sortDirection: SortDirection = ASC, folderId: ID, includeArchived: Boolean = false, filter: FileFilterInput): [DamFile!]!
   damFile(id: ID!): DamFile!
   damIsFilenameOccupied(filename: String!, folderId: String): Boolean!

--- a/packages/api/cms-api/src/redirects/redirects.resolver.ts
+++ b/packages/api/cms-api/src/redirects/redirects.resolver.ts
@@ -53,6 +53,12 @@ export function createRedirectsResolver(Redirect: Type<RedirectInterface>, Redir
             return redirect ?? null;
         }
 
+        @Query(() => Boolean)
+        async redirectSourceAvailable(@Args("source", { type: () => String }) source: string): Promise<boolean> {
+            const redirect = await this.repository.findOne({ source });
+            return redirect === null;
+        }
+
         @Mutation(() => Redirect)
         async createRedirect(@Args("input", { type: () => RedirectInput }) input: RedirectInputInterface): Promise<RedirectInterface> {
             const tranformedInput = plainToClass(RedirectInput, input);


### PR DESCRIPTION
**Problem:** 
1) Editing a redirect directly after creating it could cause it to be duplicated. 
2) Furthermore, no checks for duplicated elements were executed. Therefore it was possible to create an already existing redirect.

**Solution:** 
1) After adding a new redirect, the mode is now automatically changed form "add" to "edit" which prevents the duplication.
2) A function that checks a redirect's inimitability was implemented. 