### PR TITLE
Prevent invalid dom nesting of 'div' inside 'p'

### DIFF
--- a/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
@@ -26,6 +26,7 @@ const PageLabel: React.FunctionComponent<PageLabelProps> = ({ page, disabled, on
                 <MarkedMatches text={page.name} matches={page.matches} />
                 {page.visibility === "Archived" && (
                     <ArchivedChip
+                        component="span"
                         label={<FormattedMessage id="comet.pages.pages.archived" defaultMessage="Archived" />}
                         color="primary"
                         clickable={false}
@@ -59,4 +60,4 @@ const LinkText = styled(Typography)`
 const ArchivedChip = styled(Chip)`
     margin-left: ${({ theme }) => theme.spacing(2)};
     cursor: inherit;
-`;
+` as typeof Chip;


### PR DESCRIPTION
And manually set type to prevent TS error when using the 'component' prop on a `styled()` component: https://github.com/mui/material-ui/issues/15759/#issuecomment-493994852