### PR TITLE
DND table drag-handle icon & styling adjustments

### DIFF
--- a/packages/admin/admin/src/table/Table.tsx
+++ b/packages/admin/admin/src/table/Table.tsx
@@ -123,6 +123,7 @@ export interface ITableProps<TRow extends IRow> {
     sortApi?: ISortApi;
     paginationPosition?: "bottom" | "top" | "both";
     exportApis?: Array<IExportApi<TRow>>;
+    className?: string;
 }
 
 function DefaultTableRow<TRow extends IRow>({ columns, row, rowProps }: ITableRowProps<TRow>) {
@@ -157,7 +158,7 @@ export class Table<TRow extends IRow> extends React.Component<ITableProps<TRow>>
         const shouldRenderBottomPagination = paginationPosition === "bottom" || paginationPosition === "both";
 
         return (
-            <MuiTable ref={this.domRef}>
+            <MuiTable ref={this.domRef} className={this.props.className}>
                 {!this.props.hideTableHead && (
                     <TableHead>
                         {this.props.pagingInfo && shouldRenderTopPagination && (

--- a/packages/admin/admin/src/table/TableDndOrder.tsx
+++ b/packages/admin/admin/src/table/TableDndOrder.tsx
@@ -1,5 +1,7 @@
+import { DragHandle } from "@comet/admin-icons";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
+import { ClassKeyOfStyles, ClassNameMap, createStyles, WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { DropTargetMonitor, useDrag, useDrop, XYCoord } from "react-dnd";
 
@@ -9,6 +11,8 @@ import { TableBodyRow } from "./TableBodyRow";
 interface IDndOrderRowProps<TRow extends IRow> extends ITableRowProps<TRow> {
     moveRow: (dragIndex: number, hoverIndex: number) => void;
     onDragEnd?: () => void;
+    dragHandleIcon: React.ReactNode;
+    classes: ClassNameMap<ClassKeyOfStyles<typeof styles>>;
 }
 
 interface DragItem {
@@ -17,9 +21,9 @@ interface DragItem {
 }
 
 function DndOrderRow<TRow extends IRow>(props: IDndOrderRowProps<TRow>) {
-    const { columns, row, rowProps } = props;
+    const { columns, row, rowProps, classes } = props;
 
-    const refDragHandle = React.useRef<HTMLSpanElement>(null);
+    const refDragHandle = React.useRef<HTMLTableCellElement>(null);
     const refRow = React.useRef<HTMLTableRowElement>(null);
 
     const [{ isDragging }, drag, dragPreview] = useDrag({
@@ -99,22 +103,27 @@ function DndOrderRow<TRow extends IRow>(props: IDndOrderRowProps<TRow>) {
 
     return (
         <TableBodyRow ref={refRow} {...rowProps} style={{ opacity }}>
-            <TableCell>
-                <span ref={refDragHandle} style={{ padding: 5, cursor: "grab" }}>
-                    ::
-                </span>
+            <TableCell ref={refDragHandle} className={classes.dragCell}>
+                <div className={classes.dragIconContainer}>{props.dragHandleIcon}</div>
             </TableCell>
             <TableColumns columns={columns} row={row} />
         </TableBodyRow>
     );
 }
 
-interface IProps<TRow extends IRow> extends ITableProps<TRow> {
+interface TableDndOrderProps<TRow extends IRow> extends ITableProps<TRow> {
     moveRow: (dragIndex: number, hoverIndex: number) => void;
     onDragEnd?: () => void;
+    dragHandleIcon?: React.ReactNode;
 }
 
-export function TableDndOrder<TRow extends IRow>({ moveRow, onDragEnd, ...rest }: IProps<TRow>): JSX.Element {
+function TableDndOrder<TRow extends IRow>({
+    moveRow,
+    onDragEnd,
+    dragHandleIcon = <DragHandle />,
+    classes,
+    ...rest
+}: TableDndOrderProps<TRow> & WithStyles<typeof styles>): JSX.Element {
     const renderHeadTableRow = React.useCallback<NonNullable<ITableProps<TRow>["renderHeadTableRow"]>>((ownProps) => {
         return (
             <TableRow>
@@ -125,9 +134,9 @@ export function TableDndOrder<TRow extends IRow>({ moveRow, onDragEnd, ...rest }
     }, []);
     const renderTableRow = React.useCallback<NonNullable<ITableProps<TRow>["renderTableRow"]>>(
         (ownProps) => {
-            return <DndOrderRow moveRow={moveRow} onDragEnd={onDragEnd} {...ownProps} />;
+            return <DndOrderRow moveRow={moveRow} onDragEnd={onDragEnd} dragHandleIcon={dragHandleIcon} classes={classes} {...ownProps} />;
         },
-        [moveRow, onDragEnd],
+        [moveRow, onDragEnd, dragHandleIcon, classes],
     );
 
     const tableProps: ITableProps<TRow> = {
@@ -136,5 +145,53 @@ export function TableDndOrder<TRow extends IRow>({ moveRow, onDragEnd, ...rest }
         renderHeadTableRow,
     };
 
-    return <Table {...tableProps} />;
+    return <Table className={classes.root} {...tableProps} />;
+}
+
+export type TableDndOrderClassKey = "root" | "dragCell" | "dragIconContainer";
+
+const styles = () =>
+    createStyles<TableDndOrderClassKey, TableDndOrderProps<IRow>>({
+        root: {},
+        dragCell: {
+            cursor: "grab",
+            width: 20,
+            paddingRight: 0,
+        },
+        dragIconContainer: {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+
+            "&:after": {
+                // Increase clickable area to include the padding-left of the next cell.
+                content: '""',
+                position: "absolute",
+                zIndex: 1,
+                top: 0,
+                right: -20,
+                bottom: 0,
+                left: 0,
+            },
+        },
+    });
+
+const TableDndOrderWithStyles = withStyles(styles, { name: "CometAdminTableDndOrder" })(TableDndOrder);
+export { TableDndOrderWithStyles as TableDndOrder };
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminTableDndOrder: TableDndOrderProps<IRow>;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminTableDndOrder: TableDndOrderClassKey;
+    }
+
+    interface Components {
+        CometAdminTableDndOrder?: {
+            defaultProps?: ComponentsPropsList["CometAdminTableDndOrder"];
+            styleOverrides?: ComponentNameToClassKey["CometAdminTableDndOrder"];
+        };
+    }
 }


### PR DESCRIPTION
### Previously
<img width="920" alt="DND table previously" src="https://user-images.githubusercontent.com/6264317/192732616-8c9b84a6-ea10-4abe-af67-881d447a05d3.png">

### Now
<img width="920" alt="DND table now" src="https://user-images.githubusercontent.com/6264317/192732623-a1f19dfc-d2ae-4e5f-a47c-2147a5ddff42.png">

