### PR TITLE
Reformat changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,517 +2,246 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Next]
+## [Next]
 
-## Bugfixes
+### @comet/admin-rte
 
--   [RTE] Fix a bug were `setEditorState` was incorrectly assumed to be a React state setter function.
+-   Fix a bug where `setEditorState` was incorrectly assumed to be a React state setter function
 
-# [2.2.0]
+## 2.2.0
 
-## Highlights
+_Jun 30, 2022_
 
--   `EditDialog` now displays loading and error states of a contained form automatically via its `SaveButton`
+### @comet/admin
 
-## Bugfixes
-
--   `EditDialog` closes when a contained form is submitted via `Enter` key press
+-   Display loading and error states of a contained form in `EditDialog` via its `SaveButton`
+-   Close `EditDialog` when a contained form is submitted via `Enter` key press
 -   Fix `FinalFormSelect` value generic to allow simple select values such as `string`
 
-# [2.1.0]
+## 2.1.0
 
-## Highlights:
+_Jun 20, 2022_
 
--   Add FinalFormAutocomplete (see Story "Autocomplete / Async Select")
--   Add useAsyncOptionsProps-Hook to allow async loading of options in FinalFormAutocomplete and FinalFormSelect
--   Add support to pass options directly via props in FinalFormSelect (they are rendered automatically)
--   [RTE] Add custom inline styles (see story "Custom inline styles")
+### Highlights
 
-## Changes
+-   Add `FinalFormAutocomplete` component (see [story](https://comet-admin.netlify.app/?path=/story/comet-admin-form--autocomplete-async-select))
 
--   [RTE] add MacOS specific shortcut tooltips
+### @comet/admin
 
-# [2.0.0]
+-   Add `useAsyncOptionsProps` hook to allow async loading of options in `FinalFormAutocomplete` and `FinalFormSelect`
+-   Add support to pass options directly via props in `FinalFormSelect (they are rendered automatically)
 
-## Highlights:
+### @comet/admin-rte
 
--   Added package @comet/admin-icons
--   Added a standard toolbar that can be used as an application wide element with consistent styling containing navigation, action buttons and filters
--   Added the ability to customize components, similar to material-ui components (either globally through [theme-overrides](https://v4.mui.com/customization/globals/#css) and [theme-props](https://v4.mui.com/customization/globals/#default-props) or individually with [classes](https://v4.mui.com/customization/components/#overriding-styles-with-class-names))
--   Started docs of components and general information about development of Comet Admin
--   Implemented [ErrorBoundaries](https://reactjs.org/docs/error-boundaries.html) that catch errors in the component tree without crashing the application
+-   Add support for custom inline styles (see [story](https://comet-admin.netlify.app/?path=/story/comet-admin-rte--custom-inline-styles))
+-   Show OS-specific shortcut tooltips on MacOS
 
-## @comet/admin
+## 2.0.0
 
-### Incompatible Changes
+_Nov 3, 2021_
 
--   `createMuiTheme` has been removed from `@comet/admin` in favour of `createTheme` from `@material-ui/core`
--   Removed `VPAdminInputBase` and `getDefaultVPAdminInputStyles`, in favour of InputBase from Material-UI
--   Removed FinalFormTextField in favour of FinalFormInput
-    -   MuiTextField should not be used inside comet-admin projects, it's design is not compatible with the comet-ci.
--   Usage and default layout of `Field` has changed
-    -   The `fieldContainer` prop has been removed, in favour of a `variant` prop
-    -   Removed `FieldContainerLabelAbove` component (the new default looks like this)
-    -   The old default layout of `Field` can be restored by adding the following to the theme:
-        ```js
-        {
-            props: {
-                CometAdminFormFieldContainer: {
-                    variant: 'horizontal'
-                }
-            },
-            overrides: {
-                CometAdminFormFieldContainer: {
-                    horizontal: {
-                        "& $label": {
-                            width: `${100 / 3}%`
-                        },
-                        "& $inputContainer": {
-                            width: `${200 / 3}%`
-                        }
+### Highlights
+
+-   Add package @comet/admin-icons
+-   Add a standard `Toolbar` that can be used as an application-wide element with consistent styling containing navigation, action buttons, and filters
+-   Add the ability to customize components, similar to Material UI components. Customization can be done either globally through theme [overrides](https://v4.mui.com/customization/globals/#css) and [props](https://v4.mui.com/customization/globals/#default-props) or individually with [classes](https://v4.mui.com/customization/components/#overriding-styles-with-class-names)
+-   Start docs of components and general information about the development of Comet Admin
+-   Implement [Error Boundaries](https://reactjs.org/docs/error-boundaries.html) that catch errors in the component tree without crashing the application
+
+### Migration Guide
+
+1. Install jscodeshift in your project
+
+    ```bash
+    npm install --save-dev jscodeshift
+    ```
+
+2. Clone this repository into your project repository. If you have a monorepo, clone it into the correct subfolder
+3. Run codemods depending on usage
+
+    **Remove `renderButtons` and `components` from `FinalForm`**
+
+    ```bash
+    npx jscodeshift --extensions=ts,tsx --parser=tsx -t comet-admin/codemods/2.0.0/final-form-dissolve-final-form-save-cancel-buttons.ts src/
+    ```
+
+    **Remove `showBreadcrumbs` from `Stack`**
+
+    ```bash
+    npx jscodeshift --extensions=ts,tsx --parser=tsx -t comet-admin/codemods/2.0.0/stack-dissolve-breadcrumbs.ts src/
+    ```
+
+    **Remove `showBackButton` from `Stack`**
+
+    ```bash
+    npx jscodeshift --extensions=ts,tsx --parser=tsx -t comet-admin/codemods/2.0.0/stack-dissolve-backbutton.ts  src/
+    ```
+
+    **Update theme**
+
+    ```bash
+    npx jscodeshift --extensions=ts,tsx --parser=tsx -t comet-admin/codemods/2.0.0/update-theme.ts src/
+    ```
+
+See an example migration [here](https://github.com/vivid-planet/comet-admin-starter/pull/36).
+
+### @comet/admin
+
+#### Breaking changes
+
+-   Remove `createMuiTheme` in favor of `createTheme` from `@material-ui/core`
+-   Remove `VPAdminInputBase` and `getDefaultVPAdminInputStyles`, in favor of [InputBase](https://v4.mui.com/api/input-base/) from Material UI
+-   Remove `renderButtons` and `components` props from `FinalForm` (handled by codemods)
+-   Remove `FinalFormTextField` in favor of `FinalFormInput`. Material UI's [TextField](https://v4.mui.com/components/text-fields/#textfield) component should not be used in Comet Admin projects as its design is incompatible with the Comet CI
+-   Remove `fieldContainer` prop from `Field` in favor of a new `variant` prop
+-   Remove `FieldContainerLabelAbove` component in favor of the default `vertical` variant. Restore the previous default layout of `Field` by adding the following to the theme:
+    ```js
+    {
+        props: {
+            CometAdminFormFieldContainer: {
+                variant: 'horizontal'
+            }
+        },
+        overrides: {
+            CometAdminFormFieldContainer: {
+                horizontal: {
+                    "& $label": {
+                        width: `${100 / 3}%`
+                    },
+                    "& $inputContainer": {
+                        width: `${200 / 3}%`
                     }
                 }
             }
         }
-        ```
--   Changes to Menu component
-    -   Removed default styling in favour of the ability to style the component using the theme without the need to override these default styles
-    -   Removed the `permanentMenuMinWidth` prop, now `variant` can be passed instead
-        -   This allows for more control, like giving certain pages more width by always using the temporary variant on those pages
-    -   Allows maximum item-nesting of two levels
--   Changes to Stack
-    -   Removed prop `components.breadcrumbsContainer` in favour of a div that can be customized through the theme and classes
--   Removed component `FixedLeftRightLayout`
--   Removed FormPaper, the same effect can be accomplished with a CardContent within a Card.
--   Changes to MasterLayout
-    -   The default values for content-spacing and header-height have changed slightly
-    -   When adding a custom `headerComponent`, the component should now be built using the `AppHeader` system (see docs).
-    -   Removed prop `hideToolbarMenuIcon`, it is no longer necessary when building a custom header using the `AppHeader` system.
-    -   The html tag `<main>` was removed from the `MasterTemplate` and a new component `MainContent` is introduced
-        -   The best way to handle this change is to wrap your main content with the `MainContent` component
--   Changes to Tabs & RouterTabs
-    -   Removed `AppBar` from Tabs, you can style `CometAdminTabs-root` to bring back the previous appearance, if necessary
-    -   Removed `tabLabel` prop, use `label` instead
-    -   In `RouterTabs`, the props `variant` and `indicatorColor` now need to be set in the `tabsProps` prop
+    }
+    ```
+-   Remove default styling from `Menu` component in favor of styling the component via the theme
+-   Remove `permanentMenuMinWidth` prop from `Menu` in favor of a new `variant` prop, which allows for more control. For instance, variant `temporary` can be used to give some pages more space
+-   Remove `components.breadcrumbsContainer` prop form `Stack` in favor of a div that can be customized via the theme
+-   Remove `FixedLeftRightLayout` component
+-   Remove `FormPaper` component in favor of Material UI's [Card](https://v4.mui.com/components/cards/#card) component
+-   Change default content spacing and header height of `MasterLayout`
+-   Custom `headerComponent` of `MasterLayout` expects a component built using the `AppHeader` system (see [docs](https://comet-admin.netlify.app/?path=/story/docs-components-appheader--page))
+-   Remove `hideToolbarMenuIcon` prop from `MasterLayout` as it is no longer necessary when building a custom header using the `AppHeader` system
+-   Remove `<main>` HTML tag from `MasterLayout` in favor of new `MainContent` component
+    ```js
+    <MasterLayout headerComponent={AppHeader} menuComponent={AppMenu}>
+        <Toolbar />
+        <MainContent>
+        /* Main content goes here */
+        </MainContent>
+    </MasterLayout
+    ```
+-   Remove `AppBar` inside `Tabs`. Restore the previous appearance by overriding the `CometAdminTabs-root` class
+-   Remove `tabLabel` prop from `Tabs`. Use `label` instead
+-   `RouterTabs` do not inherit Material UI's [Tabs props](https://v4.mui.com/api/tabs/#props) anymore. Use `tabsProps` prop to set `Tabs` props
+-   Remove `showBreadcrumbs` prop from `Stack`. `StackBreadcrumbs` has been added for compatibility. However, it is recommended to use the new `Toolbar` system (handled by codemods)
 
-```
-  <MasterLayout headerComponent={AppHeader} menuComponent={AppMenu}>
-    <Toolbar />
-    <MainContent>
-     /* You main content goes here*/
-    </MainContent>
-  </MasterLayout
-```
+    ```js
+    <Stack topLevelTitle="Stack Nested">
+        <StackBreadcrumbs />
+        <StackSwitch>
+            <StackPage name="page1">
+                <Page1 />
+            </StackPage>
+            <StackPage name="page2">page2-2</StackPage>
+        </StackSwitch>
+    </Stack>
+    ```
 
--   removed `showBreadcrumbs` Prop from Stack and added Breadcrumbs component for compatibility. It's recommended at all to use new Toolbar System
-    old:
+-   Remove `showBackButton` prop from `Stack` (handled by codemods)
+-   Remove alternating background color from body rows in `Table`. Restore the previous appearance by adding the following styles to `CometAdminTableBodyRow`:
 
-```
-   <Stack topLevelTitle="Stack Nested">
-       <StackSwitch>
-           <StackPage name="page1">
-               <Page1 />
-           </StackPage>
-           <StackPage name="page2">page2-2</StackPage>
-       </StackSwitch>
-   </Stack>
-```
+    ```js
+    odd: {
+        backgroundColor: neutrals[50],
+    }
+    ```
 
--   Changes to Table (CometAdminTable)
+-   Remove background color from table head in `Table`. Restore the previous appearance by adding the following styles to `MuiTableHead`:
 
-    -   Removed alternating background-color of body-rows in comet-theme, can be restored by adding the following styles to `CometAdminTableBodyRow`:
+    ```js
+    root: {
+        backgroundColor: neutrals[100],
+    }
+    ```
 
-        ```js
-        odd: {
-            backgroundColor: neutrals[50],
+-   `TableDndOrder` requires new peer dependencies and a `DndProvider` setup in the application
+
+    Install peer dependencies in your application
+
+    ```bash
+    npm install react-dnd@"~14" react-dnd-html5-backend@"~14"
+    ```
+
+    Wrap your application in a `DnDProvider`
+
+    ```js
+    import { DndProvider } from "react-dnd";
+    import { HTML5Backend } from "react-dnd-html5-backend";
+
+    export function App() {
+        return <DndProvider backend={HTML5Backend}>...</DndProvider>;
+    }
+    ```
+
+#### Changes
+
+-   Add `ClearInputButton` component, which can be used as an `endAdornment` to clear inputs
+-   Add `variant` prop to `Field` to control the positioning of label and input
+-   Add `headerHeight` prop to `MasterLayout` which child components can use to position themselves
+-   Add `onAfterSubmit` callback to `FinalForm`
+-   Add `useStoredState` hook to store state in local storage or session storage
+-   Add `FinalFormRangeInput` component
+-   Add `SplitButton` component to combine buttons in a button group
+-   Add `SaveButton` component, which handles and displays save state (idle, saving, success and error)
+-   Add `SnackbarProvider`, `useSnackbarApi` hook and `UndoSnackbar`
+-   Add `FinalFormSaveCancelButtonsLegacy` as drop-in replacement for removed cancel and save buttons in `FinalForm`
+-   Add `PrettyBytes`  component for formatting byte values, for instance, file sizes
+-   Add `validateWarning` validator to `Field` and `FinalForm`
+-   Add `open` and `onOpenChange` props to `AppHeaderDropdown` to control the open state
+-   Add `getTargetUrl()` to `StackSwitchApi`
+-   Add `StackLink` component for navigating within a `Stack` via hyperlinks
+-   Allow `boolean | undefined | null` as children of `RouterTabs`
+-   Expose `selectionApi` through `useEditDialog`
+
+### @comet/admin-color-picker
+
+#### Breaking changes
+
+-   Rename `VPAdminColorPicker` to `CometAdminColorPicker`
+-   Remove `clearButton` and `clearIcon` theme classes from the color picker in favor of a new `ClearInputButton` component
+-   The clear button is hidden by default
+
+#### Changes
+
+-   Allow custom icons/adornments for color input
+-   The clear button is now optional (using the `showClearButton` prop)
+
+### @comet/admin-react-select
+
+#### Breaking changes
+
+-   Rename theme key from `VPAdminSelect` to `CometAdminSelect`
+
+### @comet/admin-rte
+
+#### Breaking changes
+
+-   Removed `rte` key from theme. RTE colors should be defined using by overriding `CometAdminRte` instead
+    ```js
+    {
+        props: {
+            CometAdminRte: {
+                colors: {
+                    // Colors go here
+                }
+            }
         }
-        ```
+    }
+    ```
 
-    -   Removed background-color from TableHead, can be restored by adding the following styles to `MuiTableHead`:
+## Older versions
 
-        ```js
-        root: {
-            backgroundColor: neutrals[100],
-        }
-        ```
-
-new:
-
-```
-   <Stack topLevelTitle="Stack Nested">
-       <StackBreadcrumbs />
-       <StackSwitch>
-           <StackPage name="page1">
-               <Page1 />
-           </StackPage>
-           <StackPage name="page2">page2-2</StackPage>
-       </StackSwitch>
-   </Stack>
-```
-
--   Changes to DndOrderRow
-
-    DndOrderRow requires new peer dependencies and a DndProvider setup in the application.
-
-    -   Install peer dependencies in your application
-
-        ```bash
-        npm install react-dnd@"~14"
-        npm install react-dnd-html5-backend@"~14"
-        ```
-
-    -   Put your application code inside a DndProvider
-
-        ```
-        import { DndProvider } from "react-dnd";
-        import { HTML5Backend } from "react-dnd-html5-backend";
-
-        export function App() {
-            return (
-                <DndProvider backend={HTML5Backend}>
-                        ... your application code
-                </DndProvider>
-            )
-        }
-        ```
-
-### Migration Guide
-
-install jscodeshift in your project - otherwise you will get a lodash error
-
-    npm install jscodeshift --dev
-
-Clone this repository into your project repository. If you have a monorepo, you have to clone it into the right subfolder.
-
-An example can be found [here](https://github.com/vivid-planet/comet-admin-starter/pull/36).
-
-**Migrate FinalForm**
-
-Final Form: Following props have been removed: `renderButtons` and `components`
-
-```
-npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/2.0.0/final-form-dissolve-final-form-save-cancel-buttons.ts src/
-```
-
-**Migrate Stack**
-
-Follow props has been removed: `showBreadcrumbs`and `showBackButton`
-
-```
-npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/2.0.0/stack-dissolve-breadcrumbs.ts src/
-npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/2.0.0/stack-dissolve-backbutton.ts  src/
-```
-
-**Migrate Theme**
-
-Automatic migrations using codeshift are available (use -d for dry-run):
-
-```
-npx jscodeshift --extensions=ts --parser=ts -t comet-admin/codemods/2.0.0/update-theme.ts src/
-npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/2.0.0/update-theme.ts src/
-```
-
-### Other Notable Changes
-
--   Added `ClearInputButton`, this component can be used as `endAdornment`, to clear inputs
--   New methods of customization and default layout for `Field`
-    -   New `variant` prop to select between vertical and horizontal positioning of label and input
-    -   Label is now positioned above input by default (`variant={"vertical"}`)
--   Added a new `headerHeight` prop to MasterLayout, that child components (e.g. AppHeader & Menu) can use to position themselves without overlapping
--   add onAfterSubmit to FinalForm
--   add useStoredState() hook
--   Added a new FinalFormRangeInput Component
--   add SplitButton - combine multiple buttons behind one ButtonGroup
--   add SaveButton which handles and displays state(idle, saving, success and error)
--   add SnackbarProvider, useSnackbarApi() hook and UndoSnackbar
--   add `FinalFormSaveCancelButtonsLegacy` as drop in replacement for removed Cancel and Save Button in `FinalForm`.
--   add PrettyBytes component for formatting file sizes and other byte values
--   Add `validateWarning` validator to `Field` and `FinalForm`.
--   Add `open` and `onOpenChange` props to `AppHeaderDropdown` that allow replacing the internal open state with an external state
--   add `getTargetUrl()` to `StackSwitchApi`
--   add `StackLink` component for navigating within a `Stack` via hyperlinks
--   allow `boolean | undefined | null` as children of `RouterTabs`
--   expose `selectionApi` through `useEditDialog`
-
-## @comet/admin-color-picker
-
-### Incompatible Changes
-
--   Renamed `VPAdminColorPicker` to `CometAdminColorPicker`
--   Removed `clearButton` and `clearIcon` classes from color-picker and use the ClearInputButton component instead
--   The clear-button is no longer shown by default
-
-### Other Notable Changes
-
--   Allow custom icons/adornment for color-input
--   The clear-button is now optional (using the `showClearButton` prop)
-
-## @comet/admin-react-select
-
-### Incompatible Changes
-
--   Renamed theme-key from `VPAdminSelect` to `CometAdminSelect`
-
-## @comet/admin-rte
-
-### Incompatible Changes
-
--   Removed `rte` key from theme
-    -   The rte-colors should now be defined under `props` -> `CometAdminRte` -> `colors` instead of `rte` -> `colors`
-
------------------------------------- LEGACY DOCS WITH INDEPENDENT RELEASES ------------------------------------
-
-# @comet/admin
-
-## [1.3.0] - 4. March 2021
-
-This is a bugfix/maintenance release.
-
-### Bugfixes
-
--   Handle submit error in EditDialog (#209)
--   Pass `innerRef` from `TableBodyRow` to `sc.TableBodyRow`
-
-### Internal Changes
-
--   The `styled-components` peer dependency has been changed to `^4.0.0 || ^5.0.0` to include v5.
--   The `graphql` peer dependency has been changed to `^14.0.0 || ^15.0.0` to include v14.
-
-## [1.2.0] - 23. Feb 2021
-
-### Highlights
-
--   RouterPrompt: comet-admin's [react-router Prompt Component](https://reactrouter.com/core/api/Prompt) Wrapper (that adds support for multiple Prompt instances) adds missing message callback parameters for full react-router compatibility
-
-### Internal Changes
-
--   TotalCount of the tables Pagination is now formatted with FormattedNumber from react-intl.
--   switched from yarn to npm 7 (updated all dependencies)
-
-## [1.1.0] - 12. Jan 2021 - re-release under new name
-
-This package has been renamed to @comet/admin
-
-## [1.1.0] - 11. Jan 2021
-
-This is a bugfix/maintenance release.
-
-### Highlights
-
--   Added migration guide for 1.0 update https://github.com/vivid-planet/comet-admin/blob/master/CHANGELOG.md#migration-guide
-
-### Bugfixes
-
--   Render MenuItem in children of Route (#277)
--   Fix ability to open temporary menu (#279)
--   dependency-cleanup (#278)
-
-## [1.0.0] - 18. Dec 2020
-
-This version ist the first stable version.
-
-### Highlights
-
--   Renamed from react-admin to comet-admin (!!!)
--   Made comet-admin translatable with react-intl
--   Updated apollo
-
-### Incompatible Changes
-
--   Restructured packages:
-    -   Consolidated react-admin-core, fetch-provider, file-icons, react-admin-final-form-material-ui, react-admin-form, react-admin-layout and react-admin-mui into comet-admin
-    -   Moved react-select to own package comet-admin-react-select
--   Removed date-fns for date formatting in favor of react-intl
--   Removed exports for styled and css, use styled-components directly
--   FinalForm wrappers (e.g. Checkbox, Input, ...) are now prefixed with FinalForm
-
-### Internal Changes
-
--   Switched form TSLint to ESLint
-
-### Migration Guide
-
-Clone this repository into your project repository. If you have a monorepo, you have to clone it into the right subfolder.
-
-An example can be found [here](https://github.com/vivid-planet/comet-admin-starter/pull/36).
-
-**Package Renaming**
-
-Automatic migrations using codeshift are available (use -d for dry-run):
-
-```
-npx jscodeshift --extensions=ts --parser=ts -t comet-admin/codemods/1.0.0/package-renames.ts src/
-npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/1.0.0/package-renames.ts src/
-```
-
-**Styled Components**
-
-Automatic migrations using codeshift are available (use -d for dry-run):
-
-```
-npx jscodeshift --extensions=ts --parser=ts -t comet-admin/codemods/1.0.0/styled-components.ts src/
-npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/1.0.0/styled-components.ts src/
-```
-
-**Apollo-Client**
-
-Detailed instructions can be found [here](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration). Automatic migrations using codeshift are available (use -d for dry-run):
-
-```
-git clone https://github.com/apollographql/apollo-client.git
-npx jscodeshift -t apollo-client/scripts/codemods/ac2-to-ac3/imports.js --extensions ts --parser ts src/
-npx jscodeshift -t apollo-client/scripts/codemods/ac2-to-ac3/imports.js --extensions tsx --parser tsx src/
-```
-
-**Component-Renames**
-
-FinalForm fields are now prefixed with FinalForm. Automatic migrations using codeshift are available (use -d for dry-run):
-
-```
-npx jscodeshift --extensions=ts --parser=ts -t comet-admin/codemods/1.0.0/component-renames.ts src/
-npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/1.0.0/component-renames.ts src/
-```
-
-**FormatLocalized**
-
-`FormatLocalized` has been removed in favor of `FormattedDate` and `FormattedTime` of react-intl. An example migration can look like this:
-
-Before:
-
-```
-<FormatLocalized date={parseISO(publishDate)} format="dd.MM.yyyy - HH:mm" />
-```
-
-After:
-
-```
-<FormattedDate value={date} day="2-digit" month="2-digit" year="numeric" />
-{" - "}
-<FormattedTime value={date} />
-```
-
-As an alternative, FormatLocalized can be created inside the project by using:
-
-```
-import { format } from "date-fns";
-import * as React from "react";
-import { useIntl } from "react-intl";
-
-interface IProps {
-    format: string;
-    date: Date | number;
-}
-export const FormatLocalized: React.FunctionComponent<IProps> = ({ date, format: formatString }) => {
-    const intl = useIntl();
-    const locale = intl.locale;
-    return <>{format(date, formatString, { locale })}</>;
-};
-```
-
-However, imports need to be adjusted manually.
-
-**Internationalization**
-
-Strings are now prepared for internationalization. The default language is switched from German to English. A sample setup can be found [here](https://github.com/vivid-planet/comet-admin-starter/pull/36).
-
-**Fix Eslint Errors**
-
-```
-npx eslint --ext .ts,.tsx,.js,.jsx,.json,.md --fix src/
-```
-
-# @comet/admin-color-picker
-
-## [1.0.2] - 23. Feb 2021
-
-use fixed version of react-color
-switched from yarn to npm 7 (updated all dependencies)
-
-## [1.0.1] - 12. Jan 2021 - re-release under new name
-
-This package has been renamed to @comet/admin-color-picker
-
-## [1.0.1] - 11. Jan 2021
-
-This is a bugfix/maintenance release
-
-## [1.0.0] - 22. Dec 2020
-
-This version ist the first stable version.
-
-# @comet/admin-date-picker
-
-## [1.0.2] - 23. Feb 2021
-
-switched from yarn to npm 7 (updated all dependencies)
-
-## [1.0.1] - 12. Jan 2021 - re-release under new name
-
-This package has been renamed to @comet/admin-date-picker
-
-## [1.0.1] - 11. Jan 2021
-
-This is a bugfix/maintenance release
-
-## [1.0.0] - 22. Dec 2020
-
-This version ist the first stable version.
-
-# @comet/admin-react-select
-
-## [1.0.2] - 23. Feb 2021
-
-switched from yarn to npm 7 (updated all dependencies)
-
-## [1.0.1] - 12. Jan 2021 - re-release under new name
-
-This package has been renamed to @comet/admin-react-select
-
-## [1.0.1] - 11. Jan 2021
-
-This is a bugfix/maintenance release
-
-## [1.0.0] - 22. Dec 2020
-
-This version ist the first stable version.
-
-# @comet/admin-rte
-
-## [1.2.1] - 23. Feb 2021
-
-### Bugfixes
-
--   Make controls for RTE sticky
--   Use mui-grey-palette for default colors
--   Remove min-width of link buttons (MuiButtonGroup)
-
-### Internal Changes
-
--   switched from yarn to npm 7 (updated all dependencies)
-
-## [1.2.0] - 22. Jan 2021
-
-### Highlights
-
--   Add default styles (MUI) to built-in blocktypes
--   Make built-in blocktypes styleable
--   Supports disabled-attribute
-
-### Internal Changes
-
--   Rename prop-name "customBlockMap" to "blocktypeMap", deprecate prop-name "customBlockMap"
--   Rename prop-name "Icon" to "icon", deprecate prop-name "Icon"
-
-## [1.1.1] - 12. Jan 2021 - re-release under new name
-
-This package has been renamed to @comet/admin-rte
-
-## [1.1.1] - 11. Jan 2021
-
-This is a bugfix/maintenance release
-
-## [1.1.0] - 22. Dec 2020
-
-### Changes
-
--   Add `blockquote` support
+Changes before 2.x are listed in our [changelog for older versions](https://github.com/vivid-planet/comet/blob/main/CHANGELOG.old.md).

--- a/CHANGELOG.old.md
+++ b/CHANGELOG.old.md
@@ -1,0 +1,306 @@
+**Note: prior to 2.x, packages have been released independently, therefore having separate version numbers and changelogs**
+
+## @comet/admin
+
+### 1.3.0
+
+_Mar 4, 2021_
+
+This is a bugfix/maintenance release.
+
+#### Bugfixes
+
+-   Handle submit error in EditDialog (#209)
+-   Pass `innerRef` from `TableBodyRow` to `sc.TableBodyRow`
+
+#### Changes
+
+-   The `styled-components` peer dependency has been changed to `^4.0.0 || ^5.0.0` to include v5.
+-   The `graphql` peer dependency has been changed to `^14.0.0 || ^15.0.0` to include v14.
+
+### 1.2.0
+
+_Feb 23, 2021_
+
+#### Highlights
+
+-   RouterPrompt: comet-admin's [react-router Prompt Component](https://reactrouter.com/core/api/Prompt) Wrapper (that adds support for multiple Prompt instances) adds missing message callback parameters for full react-router compatibility
+
+#### Changes
+
+-   TotalCount of the tables Pagination is now formatted with FormattedNumber from react-intl.
+-   Switch from Yarn to NPM v7 (updated all dependencies)
+
+### 1.1.0 (re-release under new name)
+
+_Jan 12, 2021_
+
+This package has been renamed to @comet/admin
+
+### 1.1.0
+
+_Jan 11, 2021_
+
+This is a bugfix/maintenance release.
+
+#### Highlights
+
+-   Added migration guide for 1.0 update https://github.com/vivid-planet/comet-admin/blob/master/CHANGELOG.md#migration-guide
+
+#### Bugfixes
+
+-   Render MenuItem in children of Route (#277)
+-   Fix ability to open temporary menu (#279)
+-   dependency-cleanup (#278)
+
+### 1.0.0
+
+_Dec 18, 2020_
+
+This version is the first stable version.
+
+#### Highlights
+
+-   Renamed from react-admin to comet-admin (!!!)
+-   Made comet-admin translatable with react-intl
+-   Updated apollo
+
+#### Incompatible Changes
+
+-   Restructured packages:
+    -   Consolidated react-admin-core, fetch-provider, file-icons, react-admin-final-form-material-ui, react-admin-form, react-admin-layout and react-admin-mui into comet-admin
+    -   Moved react-select to own package comet-admin-react-select
+-   Removed date-fns for date formatting in favor of react-intl
+-   Removed exports for styled and css, use styled-components directly
+-   FinalForm wrappers (e.g. Checkbox, Input, ...) are now prefixed with FinalForm
+
+#### Changes
+
+-   Switched form TSLint to ESLint
+
+#### Migration Guide
+
+Clone this repository into your project repository. If you have a monorepo, you have to clone it into the right subfolder.
+
+An example can be found [here](https://github.com/vivid-planet/comet-admin-starter/pull/36).
+
+**Package Renaming**
+
+Automatic migrations using codeshift are available (use -d for dry-run):
+
+```
+npx jscodeshift --extensions=ts --parser=ts -t comet-admin/codemods/1.0.0/package-renames.ts src/
+npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/1.0.0/package-renames.ts src/
+```
+
+**Styled Components**
+
+Automatic migrations using codeshift are available (use -d for dry-run):
+
+```
+npx jscodeshift --extensions=ts --parser=ts -t comet-admin/codemods/1.0.0/styled-components.ts src/
+npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/1.0.0/styled-components.ts src/
+```
+
+**Apollo-Client**
+
+Detailed instructions can be found [here](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration). Automatic migrations using codeshift are available (use -d for dry-run):
+
+```
+git clone https://github.com/apollographql/apollo-client.git
+npx jscodeshift -t apollo-client/scripts/codemods/ac2-to-ac3/imports.js --extensions ts --parser ts src/
+npx jscodeshift -t apollo-client/scripts/codemods/ac2-to-ac3/imports.js --extensions tsx --parser tsx src/
+```
+
+**Component-Renames**
+
+FinalForm fields are now prefixed with FinalForm. Automatic migrations using codeshift are available (use -d for dry-run):
+
+```
+npx jscodeshift --extensions=ts --parser=ts -t comet-admin/codemods/1.0.0/component-renames.ts src/
+npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/1.0.0/component-renames.ts src/
+```
+
+**FormatLocalized**
+
+`FormatLocalized` has been removed in favor of `FormattedDate` and `FormattedTime` of react-intl. An example migration can look like this:
+
+Before:
+
+```
+<FormatLocalized date={parseISO(publishDate)} format="dd.MM.yyyy - HH:mm" />
+```
+
+After:
+
+```
+<FormattedDate value={date} day="2-digit" month="2-digit" year="numeric" />
+{" - "}
+<FormattedTime value={date} />
+```
+
+As an alternative, FormatLocalized can be created inside the project by using:
+
+```
+import { format } from "date-fns";
+import * as React from "react";
+import { useIntl } from "react-intl";
+
+interface IProps {
+    format: string;
+    date: Date | number;
+}
+export const FormatLocalized: React.FunctionComponent<IProps> = ({ date, format: formatString }) => {
+    const intl = useIntl();
+    const locale = intl.locale;
+    return <>{format(date, formatString, { locale })}</>;
+};
+```
+
+However, imports need to be adjusted manually.
+
+**Internationalization**
+
+Strings are now prepared for internationalization. The default language is switched from German to English. A sample setup can be found [here](https://github.com/vivid-planet/comet-admin-starter/pull/36).
+
+**Fix Eslint Errors**
+
+```
+npx eslint --ext .ts,.tsx,.js,.jsx,.json,.md --fix src/
+```
+
+## @comet/admin-color-picker
+
+### 1.0.2
+
+_Feb 23, 2021_
+
+use fixed version of react-color
+Switch from Yarn to NPM v7 (updated all dependencies)
+
+### 1.0.1 (re-release under new name)
+
+_Jan 12, 2021_
+
+This package has been renamed to @comet/admin-color-picker
+
+### 1.0.1
+
+_Jan 11, 2021_
+
+This is a bugfix/maintenance release
+
+### 1.0.0
+
+_Dec 18, 2020_
+
+This version is the first stable version.
+
+## @comet/admin-date-picker
+
+### 1.0.2
+
+_Feb 23, 2021_
+
+Switch from Yarn to NPM v7 (updated all dependencies)
+
+### 1.0.1 (re-release under new name)
+
+_Jan 12, 2021_
+
+This package has been renamed to @comet/admin-date-picker
+
+### 1.0.1
+
+_Jan 11, 2021_
+
+This is a bugfix/maintenance release
+
+### 1.0.0
+
+_Dec 18, 2020_
+
+This version is the first stable version.
+
+## @comet/admin-react-select
+
+### 1.0.2
+
+_Feb 23, 2021_
+
+Switch from Yarn to NPM v7 (updated all dependencies)
+
+### 1.0.1 (re-release under new name)
+
+_Jan 12, 2021_
+
+This package has been renamed to @comet/admin-react-select
+
+### 1.0.1
+
+_Jan 11, 2021_
+
+This is a bugfix/maintenance release
+
+### 1.0.0
+
+_Dec 18, 2020_
+
+This version is the first stable version.
+
+## @comet/admin-rte
+
+### 1.2.1
+
+_Feb 23, 2021_
+
+#### Bugfixes
+
+-   Make controls for RTE sticky
+-   Use mui-grey-palette for default colors
+-   Remove min-width of link buttons (MuiButtonGroup)
+
+#### Changes
+
+-   Switch from Yarn to NPM v7 (updated all dependencies)
+
+### 1.2.0
+
+_Jan 22, 2021_
+
+#### Highlights
+
+-   Add default styles (MUI) to built-in blocktypes
+-   Make built-in blocktypes styleable
+-   Supports disabled-attribute
+
+#### Changes
+
+-   Rename prop-name "customBlockMap" to "blocktypeMap", deprecate prop-name "customBlockMap"
+-   Rename prop-name "Icon" to "icon", deprecate prop-name "Icon"
+
+### 1.1.1 (re-release under new name)
+
+_Jan 12, 2021_
+
+This package has been renamed to @comet/admin-rte
+
+### 1.1.1
+
+_Jan 11, 2021_
+
+This is a bugfix/maintenance release
+
+### 1.1.0
+
+_Dec 22, 2020_
+
+#### Changes
+
+-   Add `blockquote` support
+
+### 1.0.0
+
+_Dec 18, 2020_
+
+This version is the first stable version.


### PR DESCRIPTION
The changelog for the 2.x releases of Comet Admin was rather messy: Code examples were in the wrong places, grammar was both present tense and past tense ("Added x", "Add y"), highlights, breaking changes etc. were not scoped correctly. This change improves the changelog by addressing these issues. Furthermore, the changelogs for the 1.x releases has been moved to a separate CHANGELOG.old.md file for better readability of the changelog.