### PR TITLE
PageTree: Multiselect Drag and Drop

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -445,7 +445,8 @@ type Mutation {
   updatePageTreeNode(id: ID!, input: PageTreeNodeUpdateInput!): PageTreeNode!
   deletePageTreeNode(id: ID!): Boolean!
   updatePageTreeNodeVisibility(id: ID!, input: PageTreeNodeUpdateVisibilityInput!): PageTreeNode!
-  movePageTreeNodes(ids: [ID!]!, input: MovePageTreeNodesInput!): [PageTreeNode!]!
+  movePageTreeNodesByPos(ids: [ID!]!, input: MovePageTreeNodesByPosInput!): [PageTreeNode!]!
+  movePageTreeNodesByNeighbour(ids: [ID!]!, input: MovePageTreeNodesByNeighbourInput!): [PageTreeNode!]!
   updatePageTreeNodeCategory(id: ID!, category: String!): PageTreeNode!
   createPageTreeNode(input: PageTreeNodeCreateInput!, scope: PageTreeNodeScopeInput!, category: String!): PageTreeNode!
   createRedirect(input: RedirectInput!): Redirect!
@@ -506,9 +507,15 @@ input PageTreeNodeUpdateVisibilityInput {
   visibility: PageTreeNodeVisibility!
 }
 
-input MovePageTreeNodesInput {
+input MovePageTreeNodesByPosInput {
   parentId: String
   pos: Int!
+}
+
+input MovePageTreeNodesByNeighbourInput {
+  parentId: String
+  afterId: String
+  beforeId: String
 }
 
 input PageTreeNodeCreateInput {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -445,7 +445,7 @@ type Mutation {
   updatePageTreeNode(id: ID!, input: PageTreeNodeUpdateInput!): PageTreeNode!
   deletePageTreeNode(id: ID!): Boolean!
   updatePageTreeNodeVisibility(id: ID!, input: PageTreeNodeUpdateVisibilityInput!): PageTreeNode!
-  updatePageTreeNodePosition(id: ID!, input: PageTreeNodeUpdatePositionInput!): PageTreeNode!
+  movePageTreeNodes(ids: [ID!]!, input: MovePageTreeNodesInput!): [PageTreeNode!]!
   updatePageTreeNodeCategory(id: ID!, category: String!): PageTreeNode!
   createPageTreeNode(input: PageTreeNodeCreateInput!, scope: PageTreeNodeScopeInput!, category: String!): PageTreeNode!
   createRedirect(input: RedirectInput!): Redirect!
@@ -506,7 +506,7 @@ input PageTreeNodeUpdateVisibilityInput {
   visibility: PageTreeNodeVisibility!
 }
 
-input PageTreeNodeUpdatePositionInput {
+input MovePageTreeNodesInput {
   parentId: String
   pos: Int!
 }

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
@@ -116,11 +116,18 @@ const PageTree: React.ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = 
         5,
     );
 
+    const [selectedPages, selectedPageIds] = React.useMemo(() => {
+        const selectedPages: PageTreePage[] = pages.filter((page) => page.selected);
+        const selectedPageIds: string[] = selectedPages.map((page) => page.id);
+
+        return [selectedPages, selectedPageIds];
+    }, [pages]);
+
     const moveRequest = React.useCallback(
         // @TODO: handle path collisions when moving pages
         async ({ id, parentId, position }: { id: string; parentId: string | null; position: number }) => {
-            const selectedPages: PageTreePage[] = pages.filter((page) => page.selected);
-            const selectedPageIds: string[] = selectedPages.map((page) => page.id);
+            // const selectedPages: PageTreePage[] = pages.filter((page) => page.selected);
+            // const selectedPageIds: string[] = selectedPages.map((page) => page.id);
 
             let idsToMove: string[];
             if (selectedPageIds.length === 0 || !selectedPageIds.includes(id)) {
@@ -189,7 +196,7 @@ const PageTree: React.ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = 
                 },
             });
         },
-        [pages, movePageTreeNodes, scope, category],
+        [selectedPageIds, movePageTreeNodes, selectedPages, scope, category],
     );
 
     const onDrop = React.useCallback(
@@ -235,7 +242,7 @@ const PageTree: React.ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = 
 
     return (
         <>
-            <PageTreeDragLayer />
+            <PageTreeDragLayer numberSelectedPages={selectedPages.length} />
             <Root>
                 <Divider />
                 <Table>

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTreeDragLayer.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTreeDragLayer.tsx
@@ -1,5 +1,7 @@
+import { Box } from "@mui/material";
 import React from "react";
 import { useDragLayer, XYCoord } from "react-dnd";
+import { FormattedMessage } from "react-intl/lib";
 
 import PageLabel from "./PageLabel";
 import * as sc from "./PageTreeDragLayer.sc";
@@ -18,7 +20,11 @@ function getItemStyles(initialOffset: XYCoord | null, currentOffset: XYCoord | n
     };
 }
 
-const PageTreeDragLayer = (): React.ReactElement | null => {
+interface PageTreeDragLayerProps {
+    numberSelectedPages: number;
+}
+
+const PageTreeDragLayer: React.VoidFunctionComponent<PageTreeDragLayerProps> = ({ numberSelectedPages }): React.ReactElement | null => {
     const { item, isAcceptedItemType, initialOffset, currentOffset, isDragging } = useDragLayer((monitor) => ({
         item: monitor.getItem() as PageTreePage,
         isAcceptedItemType: monitor.getItemType() === "row",
@@ -33,7 +39,17 @@ const PageTreeDragLayer = (): React.ReactElement | null => {
     return (
         <sc.PageTreeDragLayerWrapper>
             <sc.PageTreeDragLayerInner style={getItemStyles(initialOffset, currentOffset)}>
-                <PageLabel page={item} />
+                {!item.selected || numberSelectedPages === 1 ? (
+                    <PageLabel page={item} />
+                ) : (
+                    <Box pl={4}>
+                        <FormattedMessage
+                            id="comet.pagetree.dragLayer.numberDraggedPages"
+                            defaultMessage="{numItems} pages"
+                            values={{ numItems: numberSelectedPages }}
+                        />
+                    </Box>
+                )}
             </sc.PageTreeDragLayerInner>
         </sc.PageTreeDragLayerWrapper>
     );

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTreeRow.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTreeRow.tsx
@@ -36,6 +36,7 @@ interface PageTreeRowProps {
     siteUrl: string;
     virtualizedStyle?: React.CSSProperties;
     slideIn?: boolean;
+    selectedPages: PageTreePage[];
 }
 
 export interface PageTreeTableRowElement extends HTMLTableRowElement {
@@ -58,6 +59,7 @@ const PageTreeRow = ({
     siteUrl,
     virtualizedStyle,
     slideIn,
+    selectedPages,
 }: PageTreeRowProps): React.ReactElement => {
     const rowRef = React.useRef<PageTreeTableRowElement | null>(null);
     const [hover, setHover] = React.useState(false);
@@ -157,7 +159,15 @@ const PageTreeRow = ({
                 return false;
             }
 
-            return !!pageTreeService.dropAllowed(dragObject, dropTargetPage, dropInfo.dropTarget, dropInfo.targetLevel);
+            const selectedPageIds = selectedPages.map((page) => page.id);
+            let pagesToMove: PageTreePage[] = [];
+            if (selectedPageIds.includes(dragObject.id)) {
+                pagesToMove = selectedPages;
+            } else {
+                pagesToMove = [dragObject];
+            }
+
+            return !!pageTreeService.dropAllowed(pagesToMove, dropTargetPage, dropInfo.dropTarget, dropInfo.targetLevel);
         },
     });
 

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTreeService.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTreeService.ts
@@ -1,4 +1,4 @@
-import { DropTarget, DropTargetBeforeAfter, PageTreeDragObject } from "./PageTreeRow";
+import { DropTarget, DropTargetBeforeAfter } from "./PageTreeRow";
 import { PageTreePage } from "./usePageTree";
 
 export interface IPageTreeUpdateInfo {
@@ -92,22 +92,28 @@ class PageTreeService {
     // Returns an IPageTreeUpdateInfo object if drop is possible.
     // Otherwise returns false
     dropAllowed(
-        dragObject: PageTreeDragObject,
+        draggedPages: PageTreePage[],
         dropTargetPage: PageTreePage,
         dropTarget: DropTarget,
         targetLevel: number,
     ): IPageTreeUpdateInfo | false {
-        if (dragObject.slug === "home" && dropTarget === "ADD_AS_CHILD") {
-            return false;
-        }
-
         const updateInfo = this.getPageTreeNodeUpdateInfo(targetLevel, dropTargetPage, dropTarget);
 
-        if (
-            !updateInfo || // No fitting parent exists
-            updateInfo.parentId === dragObject.id || // Item cannot be its own parent
-            updateInfo.neighbourPage.ancestorIds.includes(dragObject.id) // Item cannot be its own subitem
-        ) {
+        for (const draggedPage of draggedPages) {
+            if (draggedPage.slug === "home" && dropTarget === "ADD_AS_CHILD") {
+                return false;
+            }
+
+            if (
+                !updateInfo || // No fitting parent exists
+                updateInfo.parentId === draggedPage.id || // Item cannot be its own parent
+                updateInfo.neighbourPage.ancestorIds.includes(draggedPage.id) // Item cannot be its own subitem
+            ) {
+                return false;
+            }
+        }
+
+        if (updateInfo === null) {
             return false;
         }
 

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -73,10 +73,6 @@ export function PagesPage({
         filter: ignorePages,
     });
 
-    // React.useEffect(() => {
-    //     console.log(tree);
-    // }, [tree]);
-
     const pageSearchApi = usePageSearch({
         tree,
         pagesToRender,

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -73,6 +73,10 @@ export function PagesPage({
         filter: ignorePages,
     });
 
+    // React.useEffect(() => {
+    //     console.log(tree);
+    // }, [tree]);
+
     const pageSearchApi = usePageSearch({
         tree,
         pagesToRender,

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -487,6 +487,42 @@
         ]
     },
     {
+        "name": "InternalLink",
+        "fields": [
+            {
+                "name": "targetPage",
+                "kind": "NestedObject",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "id",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "name",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "path",
+                            "kind": "String",
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": true
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "targetPageId",
+                "kind": "String",
+                "nullable": true
+            }
+        ]
+    },
+    {
         "name": "DamImage",
         "fields": [
             {
@@ -546,42 +582,6 @@
                 "name": "activeType",
                 "kind": "String",
                 "nullable": false
-            }
-        ]
-    },
-    {
-        "name": "InternalLink",
-        "fields": [
-            {
-                "name": "targetPage",
-                "kind": "NestedObject",
-                "object": {
-                    "fields": [
-                        {
-                            "name": "id",
-                            "kind": "String",
-                            "nullable": false
-                        },
-                        {
-                            "name": "name",
-                            "kind": "String",
-                            "nullable": false
-                        },
-                        {
-                            "name": "path",
-                            "kind": "String",
-                            "nullable": false
-                        }
-                    ]
-                },
-                "nullable": true
-            }
-        ],
-        "inputFields": [
-            {
-                "name": "targetPageId",
-                "kind": "String",
-                "nullable": true
             }
         ]
     },

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -246,7 +246,7 @@ type Mutation {
   updatePageTreeNode(id: ID!, input: PageTreeNodeUpdateInput!): PageTreeNode!
   deletePageTreeNode(id: ID!): Boolean!
   updatePageTreeNodeVisibility(id: ID!, input: PageTreeNodeUpdateVisibilityInput!): PageTreeNode!
-  updatePageTreeNodePosition(id: ID!, input: PageTreeNodeUpdatePositionInput!): PageTreeNode!
+  movePageTreeNodes(ids: [ID!]!, input: MovePageTreeNodesInput!): [PageTreeNode!]!
   updatePageTreeNodeCategory(id: ID!, category: String!): PageTreeNode!
   createPageTreeNode(input: PageTreeNodeCreateInput!, scope: PageTreeNodeScopeInput!, category: String!): PageTreeNode!
 }
@@ -315,7 +315,7 @@ input PageTreeNodeUpdateVisibilityInput {
   visibility: PageTreeNodeVisibility!
 }
 
-input PageTreeNodeUpdatePositionInput {
+input MovePageTreeNodesInput {
   parentId: String
   pos: Int!
 }

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -246,7 +246,8 @@ type Mutation {
   updatePageTreeNode(id: ID!, input: PageTreeNodeUpdateInput!): PageTreeNode!
   deletePageTreeNode(id: ID!): Boolean!
   updatePageTreeNodeVisibility(id: ID!, input: PageTreeNodeUpdateVisibilityInput!): PageTreeNode!
-  movePageTreeNodes(ids: [ID!]!, input: MovePageTreeNodesInput!): [PageTreeNode!]!
+  movePageTreeNodesByPos(ids: [ID!]!, input: MovePageTreeNodesByPosInput!): [PageTreeNode!]!
+  movePageTreeNodesByNeighbour(ids: [ID!]!, input: MovePageTreeNodesByNeighbourInput!): [PageTreeNode!]!
   updatePageTreeNodeCategory(id: ID!, category: String!): PageTreeNode!
   createPageTreeNode(input: PageTreeNodeCreateInput!, scope: PageTreeNodeScopeInput!, category: String!): PageTreeNode!
 }
@@ -315,9 +316,15 @@ input PageTreeNodeUpdateVisibilityInput {
   visibility: PageTreeNodeVisibility!
 }
 
-input MovePageTreeNodesInput {
+input MovePageTreeNodesByPosInput {
   parentId: String
   pos: Int!
+}
+
+input MovePageTreeNodesByNeighbourInput {
+  parentId: String
+  afterId: String
+  beforeId: String
 }
 
 input PageTreeNodeCreateInput {

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -114,7 +114,7 @@ export { createPageTreeResolver } from "./page-tree/createPageTreeResolver";
 export { AttachedDocumentInput, AttachedDocumentStrictInput } from "./page-tree/dto/attached-document.input";
 export { EmptyPageTreeNodeScope } from "./page-tree/dto/empty-page-tree-node-scope";
 export {
-    MovePageTreeNodesInput,
+    MovePageTreeNodesByPosInput,
     PageTreeNodeBaseCreateInput,
     PageTreeNodeBaseUpdateInput,
     PageTreeNodeUpdateVisibilityInput,

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -114,6 +114,7 @@ export { createPageTreeResolver } from "./page-tree/createPageTreeResolver";
 export { AttachedDocumentInput, AttachedDocumentStrictInput } from "./page-tree/dto/attached-document.input";
 export { EmptyPageTreeNodeScope } from "./page-tree/dto/empty-page-tree-node-scope";
 export {
+    MovePageTreeNodesByNeighbourInput,
     MovePageTreeNodesByPosInput,
     PageTreeNodeBaseCreateInput,
     PageTreeNodeBaseUpdateInput,

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -114,9 +114,9 @@ export { createPageTreeResolver } from "./page-tree/createPageTreeResolver";
 export { AttachedDocumentInput, AttachedDocumentStrictInput } from "./page-tree/dto/attached-document.input";
 export { EmptyPageTreeNodeScope } from "./page-tree/dto/empty-page-tree-node-scope";
 export {
+    MovePageTreeNodesInput,
     PageTreeNodeBaseCreateInput,
     PageTreeNodeBaseUpdateInput,
-    PageTreeNodeUpdatePositionInput,
     PageTreeNodeUpdateVisibilityInput,
 } from "./page-tree/dto/page-tree-node.input";
 export { AttachedDocument } from "./page-tree/entities/attached-document.entity";

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -221,7 +221,7 @@ export function createPageTreeResolver({
                 let parentId = newParentNode.parentId;
                 while (parentId !== null) {
                     if (ids.includes(parentId)) {
-                        throw new GraphQLError("Cannot make a page a child of its own child.");
+                        throw new GraphQLError("Cannot make a page its own child.");
                     }
 
                     const parentNode = await pageTreeReadApi.getNodeOrFail(parentId);

--- a/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
+++ b/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
@@ -79,13 +79,31 @@ export class PageTreeNodeUpdateVisibilityInput {
 }
 
 @InputType()
-export class MovePageTreeNodesInput {
+export class MovePageTreeNodesByPosInput {
     @Field(() => String, { nullable: true })
     @IsOptional()
-    // @IsUUID()
+    @IsUUID()
     parentId: string | null;
 
     @Field(() => Int)
     @IsInt()
     pos: number;
+}
+
+@InputType()
+export class MovePageTreeNodesByNeighbourInput {
+    @Field(() => String, { nullable: true })
+    @IsOptional()
+    @IsUUID()
+    parentId: string | null;
+
+    @Field(() => String, { nullable: true })
+    @IsOptional()
+    @IsUUID()
+    afterId: string | null;
+
+    @Field(() => String, { nullable: true })
+    @IsOptional()
+    @IsUUID()
+    beforeId: string | null;
 }

--- a/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
+++ b/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
@@ -79,10 +79,10 @@ export class PageTreeNodeUpdateVisibilityInput {
 }
 
 @InputType()
-export class PageTreeNodeUpdatePositionInput {
+export class MovePageTreeNodesInput {
     @Field(() => String, { nullable: true })
     @IsOptional()
-    @IsUUID()
+    // @IsUUID()
     parentId: string | null;
 
     @Field(() => Int)

--- a/packages/api/cms-api/src/page-tree/page-tree.service.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.ts
@@ -6,7 +6,7 @@ import { forwardRef, Inject, Injectable } from "@nestjs/common";
 import { CometValidationException } from "../common/errors/validation.exception";
 import { RedirectsService } from "../redirects/redirects.service";
 import { AttachedDocumentStrictInput } from "./dto/attached-document.input";
-import { MovePageTreeNodesInput, PageTreeNodeBaseCreateInput } from "./dto/page-tree-node.input";
+import { MovePageTreeNodesByPosInput, PageTreeNodeBaseCreateInput } from "./dto/page-tree-node.input";
 import { AttachedDocument } from "./entities/attached-document.entity";
 import { PAGE_TREE_CONFIG, PAGE_TREE_REPOSITORY } from "./page-tree.constants";
 import { PageTreeConfig } from "./page-tree.module";
@@ -197,7 +197,7 @@ export class PageTreeService {
             .execute();
     }
 
-    async updateNodePosition(id: string, input: MovePageTreeNodesInput): Promise<PageTreeNodeInterface> {
+    async updateNodePosition(id: string, input: MovePageTreeNodesByPosInput): Promise<PageTreeNodeInterface> {
         const readApi = this.createReadApi({ visibility: "all" });
         const existingNode = await readApi.getNodeOrFail(id);
         if (!existingNode) throw new Error("Can't find page-tree-node with id");

--- a/packages/api/cms-api/src/page-tree/page-tree.service.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.ts
@@ -6,7 +6,7 @@ import { forwardRef, Inject, Injectable } from "@nestjs/common";
 import { CometValidationException } from "../common/errors/validation.exception";
 import { RedirectsService } from "../redirects/redirects.service";
 import { AttachedDocumentStrictInput } from "./dto/attached-document.input";
-import { PageTreeNodeBaseCreateInput, PageTreeNodeUpdatePositionInput } from "./dto/page-tree-node.input";
+import { MovePageTreeNodesInput, PageTreeNodeBaseCreateInput } from "./dto/page-tree-node.input";
 import { AttachedDocument } from "./entities/attached-document.entity";
 import { PAGE_TREE_CONFIG, PAGE_TREE_REPOSITORY } from "./page-tree.constants";
 import { PageTreeConfig } from "./page-tree.module";
@@ -197,8 +197,9 @@ export class PageTreeService {
             .execute();
     }
 
-    async updateNodePosition(id: string, input: PageTreeNodeUpdatePositionInput): Promise<void> {
-        const existingNode = await this.createReadApi({ visibility: "all" }).getNodeOrFail(id);
+    async updateNodePosition(id: string, input: MovePageTreeNodesInput): Promise<PageTreeNodeInterface> {
+        const readApi = this.createReadApi({ visibility: "all" });
+        const existingNode = await readApi.getNodeOrFail(id);
         if (!existingNode) throw new Error("Can't find page-tree-node with id");
 
         const requestedPath = await this.pathForParentAndSlug(input.parentId, existingNode.slug);
@@ -238,6 +239,8 @@ export class PageTreeService {
             const nodesToIncrement = await qb.getResultList();
             await this.pageTreeRepository.persistAndFlush(nodesToIncrement.map((c) => c.assign({ pos: c.pos + 1 })));
         }
+
+        return await readApi.getNodeOrFail(existingNode.id);
     }
 
     async updateCategory(id: string, category: PageTreeNodeCategory): Promise<void> {


### PR DESCRIPTION
### API:
- add batch endpoint `movePageTreeNodesByPos` to move multiple PageTreeNodes simultaneously
- add batch endpoint `movePageTreeNodesByNeighbour` that allow moving PageTreeNodes by neighbour (instead of position like `movePageTreeNodesByPos`)

### Admin:
- allow moving multiple pages at once via dnd by selecting them
- show a custom DragLayer when moving multiple pages
- prevent making a page their own child when dragging multiple pages
- make Undo functionality work when moving multiple pages

### Note concerning moveByPos and moveByNeighbour:

moveByNeighbour is only used for undoing changes. That is because it is easy to figure out which neighbours a page had before their move. It is, however, hard to figure out a position that puts the page back to its old location if pages from multiple different parents were moved at once.

It's not ideal to have two different moving mechanisms. Maybe we could use moveByNeighbour for all moves in the future (that however makes client-side cache updates harder, that are used atm to make the move appear real-time).
At the moment, this solution works and there are other tasks with a higher priority.

### Demo:


https://user-images.githubusercontent.com/13380047/194822647-ba9401bd-5c29-4cd7-964e-8145d618b910.mov


