### PR TITLE
Fix UndoSnackbar

### DIFF
--- a/packages/admin/admin/src/snackbar/SnackbarProvider.tsx
+++ b/packages/admin/admin/src/snackbar/SnackbarProvider.tsx
@@ -27,8 +27,10 @@ type HandleClose = (event: SnackbarCloseEvent, reason: SnackbarCloseReason, onCl
 export const SnackbarProvider: React.FunctionComponent = ({ children }) => {
     const [open, setOpen] = React.useState<boolean>(false);
     const [snackbar, setSnackbar] = React.useState<React.ReactElement>();
+    const [key, setKey] = React.useState(UUID.v4());
 
     const updateSnackbar = (newSnackbar: React.ReactElement) => {
+        setKey(UUID.v4());
         setSnackbar(newSnackbar);
         if (newSnackbar !== undefined) {
             setOpen(true);
@@ -61,7 +63,7 @@ export const SnackbarProvider: React.FunctionComponent = ({ children }) => {
             {children}
             {snackbar !== undefined &&
                 React.cloneElement<SnackbarProps>(snackbar, {
-                    key: UUID.v4(),
+                    key,
                     open: open,
                     onClose: (event, reason) => handleClose(event, reason, snackbar?.props.onClose),
                 })}

--- a/packages/admin/admin/src/snackbar/SnackbarProvider.tsx
+++ b/packages/admin/admin/src/snackbar/SnackbarProvider.tsx
@@ -1,5 +1,6 @@
 import { SnackbarCloseReason, SnackbarProps } from "@mui/material";
 import * as React from "react";
+import * as UUID from "uuid";
 
 import { UndoSnackbarProps } from "./UndoSnackbar";
 
@@ -60,6 +61,7 @@ export const SnackbarProvider: React.FunctionComponent = ({ children }) => {
             {children}
             {snackbar !== undefined &&
                 React.cloneElement<SnackbarProps>(snackbar, {
+                    key: UUID.v4(),
                     open: open,
                     onClose: (event, reason) => handleClose(event, reason, snackbar?.props.onClose),
                 })}

--- a/packages/admin/admin/src/snackbar/UndoSnackbar.tsx
+++ b/packages/admin/admin/src/snackbar/UndoSnackbar.tsx
@@ -2,7 +2,6 @@ import { Button, Slide, Snackbar, SnackbarProps } from "@mui/material";
 import { SlideProps } from "@mui/material/Slide/Slide";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
-import * as UUID from "uuid";
 
 import { messages } from "../messages";
 import { useSnackbarApi } from "./SnackbarProvider";
@@ -15,7 +14,6 @@ export interface UndoSnackbarProps<Payload> extends Omit<SnackbarProps, "action"
 
 export const UndoSnackbar = <Payload,>({ onUndoClick, payload, ...props }: UndoSnackbarProps<Payload>) => {
     const snackbarApi = useSnackbarApi();
-    const uuid = React.useRef(UUID.v4());
 
     const onClick = () => {
         snackbarApi.hideSnackbar();
@@ -24,7 +22,6 @@ export const UndoSnackbar = <Payload,>({ onUndoClick, payload, ...props }: UndoS
 
     return (
         <Snackbar
-            key={uuid.current}
             anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
             autoHideDuration={5000}
             action={


### PR DESCRIPTION
Previously, subsequent UndoSnackbars shared their duration.

For example:
- `UndoSnackbar` 1 should be shown for 5 seconds
- It is replaced by `UndoSnackbar` 2 after 3 seconds
- `UndoSnackbar` 2 takes over the timer and is only shown for 2 seconds

Now a unique key is set when opening a new `UndoSnackbar` to avoid this issue