### PR TITLE
Fix PageTree Cache Watch

### DIFF
--- a/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
@@ -78,8 +78,8 @@ const PageTree: React.ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = 
                 variables: pagesQuery.variables,
                 callback: (newPagesQuery, previousPagesQuery) => {
                     if (newPagesQuery && previousPagesQuery) {
-                        const existingPageIds = previousPagesQuery.result?.pages.map((page) => page.id) ?? [];
-                        newPageIds.current = newPagesQuery.result?.pages.map((page) => page.id).filter((id) => !existingPageIds.includes(id)) ?? [];
+                        const existingPageIds = previousPagesQuery.result?.pages?.map((page) => page.id) ?? [];
+                        newPageIds.current = newPagesQuery.result?.pages?.map((page) => page.id).filter((id) => !existingPageIds.includes(id)) ?? [];
 
                         setTimeout(() => {
                             // reset newPageIds to prevent slideIn on every rerender


### PR DESCRIPTION
Fixes the `TypeError: Cannot read properties of undefined (reading 'map')` error

Usually, `pages` should never be undefined. For some reason, it still sometimes is undefined. 
However, I couldn't reproduce a situation where `pages` is undefined. Therefore, I don't really have an explanation as to why this happens. 

Adding optional chaining should solve it in any case. 
This logic is only used to scroll to new pages. That is not a vital feature and it's not that bad if it doesn't work sometimes.