### PR TITLE
Fix Link Validation

### DIFF
--- a/packages/api/cms-api/src/page-tree/page-tree.module.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.module.ts
@@ -64,7 +64,7 @@ export class PageTreeModule {
                 {
                     provide: PageExistsConstraint,
                     useFactory: (pageTreeService: PageTreeService) => {
-                        new PageExistsConstraint(pageTreeService);
+                        return new PageExistsConstraint(pageTreeService);
                     },
                     inject: [PageTreeService],
                 },


### PR DESCRIPTION
The `PageExists` validator was broken because the instance wasn't exported from the factory