### PR TITLE
Prevent flickering of StackBreadcrumbs

### DIFF
--- a/packages/admin/admin-stories/src/admin/stack/StackBreadcrumbs.tsx
+++ b/packages/admin/admin-stories/src/admin/stack/StackBreadcrumbs.tsx
@@ -1,0 +1,59 @@
+import { BreadcrumbItem, Stack, StackBreadcrumbs, useStackApi } from "@comet/admin";
+import { select } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+const singleItem: BreadcrumbItem[] = [{ id: "one", parentId: "", url: "/one", title: "Breadcrumb One", invisible: false }];
+const twoItems: BreadcrumbItem[] = [...singleItem, { id: "two", parentId: "one", url: "/two", title: "BC 2", invisible: false }];
+const threeItems: BreadcrumbItem[] = [...twoItems, { id: "three", parentId: "two", url: "/three", title: "BrdCrmb 3", invisible: false }];
+const fiveItems: BreadcrumbItem[] = [
+    ...threeItems,
+    { id: "four", parentId: "three", url: "/four", title: "Really long Breadcrumb Number Four", invisible: false },
+    { id: "five", parentId: "four", url: "/five", title: "Breadcrumb Five", invisible: false },
+];
+const eightItems: BreadcrumbItem[] = [
+    ...fiveItems,
+    { id: "six", parentId: "five", url: "/six", title: "Breadcrumb Six", invisible: false },
+    { id: "seven", parentId: "six", url: "/seven", title: "BrdCrmb 7", invisible: false },
+    { id: "eight", parentId: "seven", url: "/eight", title: "Breadcrumb Eight", invisible: false },
+];
+
+const allBradcrumbItemsGroupOne: Record<string, BreadcrumbItem[]> = {
+    Single: singleItem,
+    Two: twoItems,
+    Three: threeItems,
+    Five: fiveItems,
+    Eight: eightItems,
+};
+
+const allBradcrumbItemsGroupTwo: Record<string, BreadcrumbItem[]> = {
+    Single: singleItem.map((item) => ({ ...item, title: `${item.title} group 2` })),
+    Two: twoItems.map((item) => ({ ...item, title: `${item.title} group 2` })),
+    Three: threeItems.map((item) => ({ ...item, title: `${item.title} group 2` })),
+    Five: fiveItems.map((item) => ({ ...item, title: `${item.title} group 2` })),
+    Eight: eightItems.map((item) => ({ ...item, title: `${item.title} group 2` })),
+};
+
+const allBreadcrumbGroups: Record<string, Record<string, BreadcrumbItem[]>> = {
+    Normal: allBradcrumbItemsGroupOne,
+    "Increased length": allBradcrumbItemsGroupTwo,
+};
+
+function Story() {
+    const stackApi = useStackApi();
+    if (!stackApi) return null;
+    const selectedBreadcrumbsNumberKey = select("Number of items", Object.keys(allBradcrumbItemsGroupOne), "Three");
+    const selectedBreadcrumbsGroupKey = select("Item group", Object.keys(allBreadcrumbGroups), Object.keys(allBreadcrumbGroups)[0]);
+    stackApi.breadCrumbs = allBreadcrumbGroups[selectedBreadcrumbsGroupKey][selectedBreadcrumbsNumberKey];
+    return <StackBreadcrumbs />;
+}
+
+storiesOf("@comet/admin/stack", module)
+    .addDecorator(storyRouterDecorator())
+    .add("Stack Breadcrumbs", () => (
+        <Stack topLevelTitle="Stack">
+            <Story />
+        </Stack>
+    ));

--- a/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
@@ -25,10 +25,11 @@ const StackBreadcrumbsComponent = ({
     const [itemWidths, setItemWidths] = React.useState<number[] | undefined>();
 
     const breadcrumbItems = React.useMemo(() => stackApi?.breadCrumbs ?? [], [stackApi]);
+    const combinedTitlesOfBreadcrumbs = breadcrumbItems.map(({ title }) => title).join("");
 
     React.useEffect(() => {
         setItemWidths(undefined);
-    }, [breadcrumbItems]);
+    }, [breadcrumbItems?.length, combinedTitlesOfBreadcrumbs]);
 
     React.useEffect(() => {
         if (breadcrumbItems?.length && !itemWidths?.length) {
@@ -36,7 +37,7 @@ const StackBreadcrumbsComponent = ({
             const newItemWidths = listItems ? Object.values(listItems).map((listItem) => getElementOuterWidth(listItem)) : [];
             setItemWidths(newItemWidths);
         }
-    }, [breadcrumbItems, itemWidths, classes.listItem]);
+    }, [breadcrumbItems?.length, combinedTitlesOfBreadcrumbs, itemWidths, classes.listItem]);
 
     const backButtonUrl = breadcrumbItems.length > 1 ? breadcrumbItems[breadcrumbItems.length - 2].url : undefined;
     const itemsToRender = useItemsToRender(breadcrumbItems, containerWidth ?? 0, classes, itemWidths, overflowLinkText, backButtonUrl);


### PR DESCRIPTION
by only passing the breadcrumbs array's relevant values (as number & string) into useEffect's dependencies.

Previously the array was passed in directly, which caused a re-calculation of the item widths whenever the array was 
re-initialized, even when the values did not change. This is because JS compares the memory addresses instead of the values when comparing arrays & objects.

Also add a dev-story for debugging StackBreadcrumbs, with knobs for selecting different groups of breadcrumb items.