### PR TITLE
api generator: Make detail query non-nullable, throw an exception when id is not found

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -333,7 +333,7 @@ type Query {
   damFoldersList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, parentId: ID, includeArchived: Boolean, filter: FolderFilterInput): PaginatedDamFolders!
   damFolder(id: ID!): DamFolder!
   damFolderByNameAndParentId(name: String!, parentId: ID): DamFolder
-  news(id: ID!): News
+  news(id: ID!): News!
   newsBySlug(slug: String!): News
   newsList(scope: NewsContentScopeInput!, offset: Int = 0, limit: Int = 20, search: String, filter: NewsFilter, sort: [NewsSort!]): PaginatedNews!
   mainMenu(scope: PageTreeNodeScopeInput!): MainMenu!
@@ -342,7 +342,7 @@ type Query {
   footer(scope: FooterContentScopeInput!): Footer
   predefinedPage(id: ID!): PredefinedPage
   pageTreeNodeForPredefinedPage(type: String!, scope: PageTreeNodeScopeInput!): PageTreeNode
-  product(id: ID!): Product
+  product(id: ID!): Product!
   productBySlug(slug: String!): Product
   products(offset: Int = 0, limit: Int = 20, search: String, filter: ProductFilter, sort: [ProductSort!]): PaginatedProducts!
 }

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -268,12 +268,11 @@ export async function generateCrud(generatorOptions: CrudGeneratorOptions, metad
             @InjectRepository(${metadata.className}) private readonly repository: EntityRepository<${metadata.className}>
         ) {}
     
-        @Query(() => ${metadata.className}, { nullable: true })
+        @Query(() => ${metadata.className})
         @SubjectEntity(${metadata.className})
-        async ${instanceNameSingular}(@Args("id", { type: () => ID }) id: string): Promise<${metadata.className} | null> {
-            const ${instanceNameSingular} = await this.repository.findOne(id);
-    
-            return ${instanceNameSingular} ?? null;
+        async ${instanceNameSingular}(@Args("id", { type: () => ID }) id: string): Promise<${metadata.className}> {
+            const ${instanceNameSingular} = await this.repository.findOneOrFail(id);
+            return ${instanceNameSingular};
         }
     
         ${


### PR DESCRIPTION
This makes using the api easier as we don't have to take care about a null return

we also have this in starter: https://gitlab.vivid-planet.com/comet/starter/-/blob/main/api/src/products/products.resolver.ts#L32