### PR TITLE
Fix generated list query

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -344,7 +344,7 @@ type Query {
   damFolderByNameAndParentId(name: String!, parentId: ID): DamFolder
   news(id: ID!): News!
   newsBySlug(slug: String!): News
-  newsList(scope: NewsContentScopeInput!, offset: Int = 0, limit: Int = 20, search: String, filter: NewsFilter, sort: [NewsSort!]): PaginatedNews!
+  newsList(offset: Int = 0, limit: Int = 20, scope: NewsContentScopeInput!, search: String, filter: NewsFilter, sort: [NewsSort!]): PaginatedNews!
   mainMenu(scope: PageTreeNodeScopeInput!): MainMenu!
   topMenu(scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
   mainMenuItem(pageTreeNodeId: ID!): MainMenuItem!

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -158,9 +158,27 @@ export async function generateCrud(generatorOptions: CrudGeneratorOptions, metad
     import { OffsetBasedPaginationArgs } from "@comet/cms-api";
     import { ${classNameSingular}Filter } from "./${fileNameSingular}.filter";
     import { ${classNameSingular}Sort } from "./${fileNameSingular}.sort";
-    
+    ${
+        scopeProp && scopeProp.targetMeta
+            ? `import { ${scopeProp.targetMeta.className} } from "../${path
+                  .relative(generatorOptions.targetDirectory, scopeProp.targetMeta.path)
+                  .replace(/\.ts$/, "")}";`
+            : ""
+    }
+
     @ArgsType()
     export class ${argsClassName} extends OffsetBasedPaginationArgs {
+        ${
+            scopeProp
+                ? `
+        @Field(() => ${scopeProp.type})
+        @ValidateNested()
+        @Type(() => ${scopeProp.type})
+        scope: ${scopeProp.type};
+        `
+                : ""
+        }
+
         ${
             hasSearchArg
                 ? `
@@ -290,8 +308,9 @@ export async function generateCrud(generatorOptions: CrudGeneratorOptions, metad
     
         @Query(() => Paginated${classNamePlural})
         async ${instanceNameSingular != instanceNamePlural ? instanceNamePlural : `${instanceNamePlural}List`}(
-            ${scopeProp ? `@Args("scope", { type: () => ${scopeProp.type} }) scope: ${scopeProp.type},` : ""}
-            @Args() { ${hasSearchArg ? `search, ` : ""}${hasFilterArg ? `filter, ` : ""}${hasSortArg ? `sort, ` : ""}offset, limit }: ${argsClassName}
+            @Args() { ${scopeProp ? `scope, ` : ""}${hasSearchArg ? `search, ` : ""}${hasFilterArg ? `filter, ` : ""}${
+            hasSortArg ? `sort, ` : ""
+        }offset, limit }: ${argsClassName}
         ): Promise<Paginated${classNamePlural}> {
             const where = ${
                 hasSearchArg || hasFilterArg


### PR DESCRIPTION
The query would not work because of two `@Args()` arguments, one named (scope) and one unnamed. Nest adds all function arguments to the unnamed args class, causing a whitelist validation error. To fix this, we decided to move the named scope arg into the unnamed args class, thereby having only one `@Args()` argument.