### PR TITLE
Fix generated create mutation

### DIFF
--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -40,7 +40,7 @@ export class NewsContentScope {
 @Entity()
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/` })
 export class News extends BaseEntity<News, "id"> implements DocumentInterface {
-    [OptionalProps]?: "createdAt" | "updatedAt";
+    [OptionalProps]?: "createdAt" | "updatedAt" | "category"; // TODO remove "category" once CRUD generator supports enums
 
     @PrimaryKey({ type: "uuid" })
     @Field(() => ID)
@@ -64,7 +64,7 @@ export class News extends BaseEntity<News, "id"> implements DocumentInterface {
 
     @Enum({ items: () => NewsCategory })
     @Field(() => NewsCategory)
-    category: NewsCategory;
+    category: NewsCategory = NewsCategory.Awards; // TODO remove default value once CRUD generator supports enums
 
     @Property({ default: false })
     @Field()

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -1,5 +1,5 @@
 import { CrudField, CrudGenerator, DocumentInterface } from "@comet/cms-api";
-import { BaseEntity, Entity, PrimaryKey, Property, types } from "@mikro-orm/core";
+import { BaseEntity, Entity, OptionalProps, PrimaryKey, Property, types } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 } from "uuid";
 
@@ -9,6 +9,8 @@ import { v4 } from "uuid";
 @Entity()
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/` })
 export class Product extends BaseEntity<Product, "id"> implements DocumentInterface {
+    [OptionalProps]?: "createdAt" | "updatedAt";
+
     @PrimaryKey({ type: "uuid" })
     @Field(() => ID)
     id: string = v4();

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -323,8 +323,7 @@ export async function generateCrud(generatorOptions: CrudGeneratorOptions, metad
             ${scopeProp ? `@Args("scope", { type: () => ${scopeProp.type} }) scope: ${scopeProp.type},` : ""}
             @Args("input", { type: () => ${classNameSingular}Input }) input: ${classNameSingular}Input
         ): Promise<${metadata.className}> {
-            const ${instanceNameSingular} = new ${metadata.className}();
-            ${instanceNameSingular}.assign({
+            const ${instanceNameSingular} = this.repository.create({
                 ...input,
                 ${blockProps.length ? `${blockProps.map((prop) => `${prop.name}: input.${prop.name}.transformToBlockData()`).join(", ")}, ` : ""}
                 ${hasVisibleProp ? `visible: false,` : ""}


### PR DESCRIPTION
The `entity.assign()` call would not work as the entity is not managed yet (see [MikroORM docs](https://mikro-orm.io/docs/entity-helper#updating-entity-values-with-entityassign)). To fix this, one is supposed to explicitely pass the ORM's entity manager to the `wrap(entity)` call. However, as we normally create new entities using `repository.create()`, I've decided to use this approach instead.