### PR TITLE
Add check if lastUpdatedAt is a valid date

### DIFF
--- a/packages/api/cms-api/src/document/validateNotModified.ts
+++ b/packages/api/cms-api/src/document/validateNotModified.ts
@@ -1,8 +1,12 @@
-import { isEqual } from "date-fns";
+import { isEqual, isValid } from "date-fns";
 
 import { DocumentInterface } from "./dto/document-interface";
 
 export function validateNotModified(document: DocumentInterface, lastUpdatedAt: Date): void {
+    if (!isValid(lastUpdatedAt)) {
+        return;
+    }
+
     // only allow to save the document if it has not been modified
     if (document?.updatedAt && !isEqual(document.updatedAt, lastUpdatedAt)) {
         throw Error("Conflict: Document has been modified.");


### PR DESCRIPTION
Due to the nature of our setup the `lastUpdatedAt` arg of update mutations is transformed to an `Invalid Date` when it is `null` or `undefined` (see discussion [here](https://github.com/nestjs/graphql/issues/1145)). This caused false positives when checking if a document has been modified by another user. To fix this, we add a check if the provided `lastUpdatedAt` date is a valid date.