### PR TITLE
fix page tree click and fix page label styling

### DIFF
--- a/packages/admin/cms-admin/src/pages/pageTree/PageInfo.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageInfo.tsx
@@ -39,10 +39,12 @@ const Root = styled("div")`
 `;
 
 const ExpandIconWrapper = styled("div")`
+    pointer-events: auto;
     width: 44px;
     flex-shrink: 0;
 `;
 
 const ChildrenWrapper = styled("div")`
+    pointer-events: auto;
     min-width: 0;
 `;

--- a/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
@@ -45,8 +45,7 @@ const PageLabel: React.FunctionComponent<PageLabelProps> = ({ page, disabled, on
 export default PageLabel;
 
 const InfoPanel = styled(Chip)`
-    margin-left: auto;
-    margin-right: 10%;
+    margin-left: 20px;
 `;
 
 const Root = styled("div")`

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTreeRow.sc.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTreeRow.sc.tsx
@@ -24,6 +24,7 @@ export const PageInfoCell = styled(PageTreeCell)`
     padding-left: 0;
     padding-right: 0;
     overflow: hidden;
+    pointer-events: none;
 `;
 
 export const PageVisibilityCell = styled(PageTreeCell)`


### PR DESCRIPTION
Previous-Img:
![page-tree-prev](https://user-images.githubusercontent.com/44967610/200340354-7e900161-04fc-41b3-985c-b91c73c262a5.png)

After-Img:
![page-tree-after](https://user-images.githubusercontent.com/44967610/200340379-2216a300-24ef-4dd7-9553-a62ab8828704.png)


Previous-Video (clicks anywhere on the row do not work):

https://user-images.githubusercontent.com/44967610/200341454-64055f02-075a-4fef-a875-682e8ee2105f.mov

After-Video (clicks work):

https://user-images.githubusercontent.com/44967610/200341514-8cb51bd6-5049-41df-a298-761e3cec3c3e.mov



