### PR TITLE
Fix page label invalid child error

### DIFF
--- a/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
@@ -20,7 +20,6 @@ const PageLabel: React.FunctionComponent<PageLabelProps> = ({ page, disabled, on
 
     return (
         <Root onClick={onClick}>
-            {documentType.menuIcon}
             <PageTypeIcon page={page} disabled={disabled} />
             <LinkContent>
                 <LinkText color={page.visibility === "Unpublished" || disabled ? "textSecondary" : "textPrimary"}>


### PR DESCRIPTION
The PageLabel component produced the following error: `Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it.`. This was caused by directly rendering `documentType.menuIcon`. As the document's icon is determined in the PageTypeIcon component, this can be safely removed.