### PR TITLE
Add CI job to publish stable version on tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
         branches:
             - main
             - next
+    push:
+        tags:
+            - "v*"
 
 jobs:
     CI:
@@ -119,4 +122,9 @@ jobs:
               run: yarn publish:release preminor --no-push --no-git-tag-version --canary --preid=alpha.${{ github.run_number }} --dist-tag=alpha --yes
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+            - name: "Publish stable version"
+              if: startsWith(github.event.ref, 'refs/tags/v')
+              run: yarn publish:release from-git --yes
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
         "build:cms:site:skippable": "test -f packages/site/cms-site/lib/index.d.ts && echo 'Skipping CMS Site build' || yarn build:cms:site",
         "build:lib": "lerna run build --concurrency=1 --stream --no-private",
         "publish:release": "lerna publish --force-publish --no-private",
+        "publish:version": "lerna version --force-publish --no-private",
+        "version": "yarn install && git stage yarn.lock",
         "storybook": "yarn workspace comet-admin-stories storybook",
         "lint": "lerna run lint --concurrency=1 --stream",
         "lint:eslint": "lerna run lint:eslint --concurrency=1 --stream",


### PR DESCRIPTION
Publishing stable versions from a local machine introduces the case where a version may be published even if the packages have not been built. Therefore publishing using the CI pipeline is preferable. This change adds a CI job that publishes the current version upon tag push. The next version is determined by executing `yarn publish:version` locally. The `version` lifecycle script is added to update the yarn.lock accordingly after `lerna version` has been executed.