### PR TITLE
Pin react-resize-aware to v3.1.1

### DIFF
--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -20,7 +20,7 @@
         "lodash.debounce": "^4.0.8",
         "lodash.isequal": "^4.5.0",
         "query-string": "^6.8.1",
-        "react-resize-aware": "^3.1.1",
+        "react-resize-aware": "3.1.1",
         "use-constant": "^1.0.0",
         "uuid": "^9.0.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4682,7 +4682,7 @@ __metadata:
     lodash.isequal: ^4.5.0
     prettier: ^2.0.0
     query-string: ^6.8.1
-    react-resize-aware: ^3.1.1
+    react-resize-aware: 3.1.1
     rimraf: ^3.0.2
     typescript: ^4.0.0
     use-constant: ^1.0.0
@@ -30852,7 +30852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resize-aware@npm:^3.1.1":
+"react-resize-aware@npm:3.1.1":
   version: 3.1.1
   resolution: "react-resize-aware@npm:3.1.1"
   peerDependencies:


### PR DESCRIPTION
v3.1.2 introduces a `ReferenceError: jsx is not defined` error due to wrong configuration (see [issue](https://github.com/FezVrasta/react-resize-aware/issues/58)). We therefore pin the version for the time being.