### PR TITLE
Get breadcrumbs width using ResizeObserver

### DIFF
--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -20,7 +20,6 @@
         "lodash.debounce": "^4.0.8",
         "lodash.isequal": "^4.5.0",
         "query-string": "^6.8.1",
-        "react-resize-aware": "3.1.1",
         "use-constant": "^1.0.0",
         "uuid": "^9.0.0"
     },

--- a/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
@@ -2,11 +2,10 @@ import { ChevronRight } from "@comet/admin-icons";
 import { ComponentsOverrides, Theme, useTheme } from "@mui/material";
 import { WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
-import useResizeAware from "react-resize-aware";
 
 import { useStackApi } from "../Api";
 import { StackBreadcrumbsClassKey, styles } from "./StackBreadcrumbs.styles";
-import { getElementOuterWidth, useItemsToRender } from "./utils";
+import { getElementOuterWidth, useItemsToRender, useObservedWidth } from "./utils";
 
 export interface StackBreadcrumbsProps {
     separator?: React.ReactNode;
@@ -20,8 +19,8 @@ const StackBreadcrumbsComponent = ({
 }: StackBreadcrumbsProps & WithStyles<typeof styles>): React.ReactElement | null => {
     const stackApi = useStackApi();
     const { palette } = useTheme();
-    const [breadcrumbsResizeListener, { width: containerWidth }] = useResizeAware();
     const breadcrumbsRef = React.useRef<HTMLDivElement>(null);
+    const containerWidth = useObservedWidth(breadcrumbsRef);
     const [itemWidths, setItemWidths] = React.useState<number[] | undefined>();
 
     const breadcrumbItems = React.useMemo(() => stackApi?.breadCrumbs ?? [], [stackApi]);
@@ -46,7 +45,6 @@ const StackBreadcrumbsComponent = ({
 
     return (
         <div className={classes.root}>
-            {breadcrumbsResizeListener}
             <div className={classes.breadcrumbs} ref={breadcrumbsRef}>
                 {itemsToRender.map((item, index) => (
                     <div className={classes.listItem} key={index}>

--- a/packages/admin/admin/src/stack/breadcrumbs/utils.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/utils.tsx
@@ -1,11 +1,11 @@
 import { ClassKeyOfStyles, ClassNameMap } from "@mui/styles";
+import debounce from "lodash.debounce";
 import * as React from "react";
 
 import { BreadcrumbItem } from "../Stack";
 import { BreadcrumbsEntry } from "./BreadcrumbsEntry";
 import { BreadcrumbsOverflow } from "./BreadcrumbsOverflow";
 import { styles } from "./StackBreadcrumbs.styles";
-
 export const getElementOuterWidth = (element: Element): number =>
     element.clientWidth + parseFloat(getComputedStyle(element).marginLeft) + parseFloat(getComputedStyle(element).marginRight);
 
@@ -86,4 +86,29 @@ export const useItemsToRender = (
     ));
 
     return [firstItemWithBackButton, showOverflowMenu && overflowMenu, ...remainingItems].filter((item) => item !== false);
+};
+
+export const useObservedWidth = (ref: React.RefObject<HTMLElement>): number => {
+    const [containerWidth, setContainerWidth] = React.useState(ref.current?.clientWidth ?? 0);
+    const element = ref.current;
+
+    const elementObserver = React.useMemo(() => {
+        return new ResizeObserver(() => {
+            debounce(() => {
+                if (!element) return;
+                setContainerWidth(element.clientWidth);
+            }, 500)();
+        });
+    }, [element]);
+
+    React.useEffect(() => {
+        if (!element) return;
+        elementObserver.observe(element);
+
+        return () => {
+            elementObserver.unobserve(element);
+        };
+    }, [element, elementObserver]);
+
+    return containerWidth;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4682,7 +4682,6 @@ __metadata:
     lodash.isequal: ^4.5.0
     prettier: ^2.0.0
     query-string: ^6.8.1
-    react-resize-aware: 3.1.1
     rimraf: ^3.0.2
     typescript: ^4.0.0
     use-constant: ^1.0.0
@@ -30849,15 +30848,6 @@ __metadata:
   version: 0.11.0
   resolution: "react-refresh@npm:0.11.0"
   checksum: 112178a05b1e0ffeaf5d9fb4e56b4410a34a73adeb04dbf13abdc50d9ac9df2ada83e81485156cca0b3fa296aa3612751b3d6cd13be4464642a43679b819cbc7
-  languageName: node
-  linkType: hard
-
-"react-resize-aware@npm:3.1.1":
-  version: 3.1.1
-  resolution: "react-resize-aware@npm:3.1.1"
-  peerDependencies:
-    react: ^16.8.0 || 17.x
-  checksum: 0088849e128403ea66f90d588379d9260089c6f218b46e6254da20fe5e4d39c8d13b64da1e6a24bacd0d808db8b7d26bf9dc72801c58606c0b26e9eb5da1bdc5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removes dependency on react-resize-aware.