### PR TITLE
Make redirects scope support backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file. This projec
 
 -   Fix a bug where the pages query would query for a field `undefined` when no `additionalPageTreeNodeFragment` is set
 
+### @comet/cms-api
+
+-   Add default value `{}` for `RedirectScopeInput` when no explicit scope is set to make redirects scope support backwards compatible
+
 ## 3.1.0
 
 _Nov 15, 2022_

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -487,6 +487,42 @@
         ]
     },
     {
+        "name": "InternalLink",
+        "fields": [
+            {
+                "name": "targetPage",
+                "kind": "NestedObject",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "id",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "name",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "path",
+                            "kind": "String",
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": true
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "targetPageId",
+                "kind": "String",
+                "nullable": true
+            }
+        ]
+    },
+    {
         "name": "DamImage",
         "fields": [
             {
@@ -546,42 +582,6 @@
                 "name": "activeType",
                 "kind": "String",
                 "nullable": false
-            }
-        ]
-    },
-    {
-        "name": "InternalLink",
-        "fields": [
-            {
-                "name": "targetPage",
-                "kind": "NestedObject",
-                "object": {
-                    "fields": [
-                        {
-                            "name": "id",
-                            "kind": "String",
-                            "nullable": false
-                        },
-                        {
-                            "name": "name",
-                            "kind": "String",
-                            "nullable": false
-                        },
-                        {
-                            "name": "path",
-                            "kind": "String",
-                            "nullable": false
-                        }
-                    ]
-                },
-                "nullable": true
-            }
-        ],
-        "inputFields": [
-            {
-                "name": "targetPageId",
-                "kind": "String",
-                "nullable": true
             }
         ]
     },

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -177,9 +177,9 @@ type Query {
   builds(limit: Float): [Build!]!
   autoBuildStatus: AutoBuildStatus!
   buildTemplates: [BuildTemplate!]!
-  redirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]!
+  redirects(scope: RedirectScopeInput = {}, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]!
   redirect(id: ID!): Redirect!
-  redirectSourceAvailable(scope: RedirectScopeInput!, source: String!): Boolean!
+  redirectSourceAvailable(scope: RedirectScopeInput = {}, source: String!): Boolean!
   damFilesList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, folderId: ID, includeArchived: Boolean = false, filter: FileFilterInput): PaginatedDamFiles!
   damFile(id: ID!): DamFile!
   damIsFilenameOccupied(filename: String!, folderId: String): Boolean!
@@ -234,7 +234,7 @@ input DamItemFilterInput {
 
 type Mutation {
   createBuilds(input: CreateBuildsInput!): Boolean!
-  createRedirect(scope: RedirectScopeInput!, input: RedirectInput!): Redirect!
+  createRedirect(scope: RedirectScopeInput = {}, input: RedirectInput!): Redirect!
   updateRedirect(id: ID!, input: RedirectInput!, lastUpdatedAt: DateTime): Redirect!
   updateRedirectActiveness(id: ID!, input: RedirectUpdateActivenessInput!): Redirect!
   deleteRedirect(id: ID!): Boolean!

--- a/packages/api/cms-api/src/content-scope/decorators/scope-guard-active.decorator.ts
+++ b/packages/api/cms-api/src/content-scope/decorators/scope-guard-active.decorator.ts
@@ -1,0 +1,12 @@
+import { CustomDecorator, SetMetadata } from "@nestjs/common";
+
+const SCOPE_GUARD_ACTIVE_METADATA_KEY = "scopeGuardActive";
+
+type ScopeGuardActiveMetadataValue = boolean;
+
+const ScopeGuardActive = (active: boolean): CustomDecorator<string> => {
+    return SetMetadata(SCOPE_GUARD_ACTIVE_METADATA_KEY, active);
+};
+
+export { SCOPE_GUARD_ACTIVE_METADATA_KEY, ScopeGuardActive };
+export type { ScopeGuardActiveMetadataValue };

--- a/packages/api/cms-api/src/content-scope/scope.guard.ts
+++ b/packages/api/cms-api/src/content-scope/scope.guard.ts
@@ -10,6 +10,7 @@ import { ScopedEntityMeta } from "../common/decorators/scoped-entity.decorator";
 import { SubjectEntityMeta } from "../common/decorators/subject-entity.decorator";
 import { PageTreeService } from "../page-tree/page-tree.service";
 import { CAN_ACCESS_SCOPE } from "./conent-scope.constants";
+import { SCOPE_GUARD_ACTIVE_METADATA_KEY, ScopeGuardActiveMetadataValue } from "./decorators/scope-guard-active.decorator";
 
 @Injectable()
 export class ScopeGuard implements CanActivate {
@@ -77,6 +78,15 @@ export class ScopeGuard implements CanActivate {
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const isPublicApi = this.reflector.getAllAndOverride("publicApi", [context.getHandler(), context.getClass()]);
         if (isPublicApi) {
+            return true;
+        }
+
+        const scopeGuardActive = this.reflector.getAllAndOverride<ScopeGuardActiveMetadataValue | undefined>(SCOPE_GUARD_ACTIVE_METADATA_KEY, [
+            context.getHandler(),
+            context.getClass(),
+        ]);
+
+        if (scopeGuardActive === false) {
             return true;
         }
 

--- a/packages/api/cms-api/src/redirects/dto/redirects-args.factory.ts
+++ b/packages/api/cms-api/src/redirects/dto/redirects-args.factory.ts
@@ -7,6 +7,7 @@ import { SortArgs } from "../../common/sorting/sort.args";
 import { SortDirection } from "../../common/sorting/sort-direction.enum";
 import { RedirectGenerationType } from "../redirects.enum";
 import { RedirectScopeInterface } from "../types";
+import { EmptyRedirectScope } from "./empty-redirect-scope";
 
 export interface RedirectsArgsInterface {
     scope: RedirectScopeInterface;
@@ -21,7 +22,7 @@ export class RedirectsArgsFactory {
     static create({ Scope }: { Scope: Type<RedirectScopeInterface> }): Type<RedirectsArgsInterface> {
         @ArgsType()
         class RedirectsArgs extends SortArgs implements RedirectsArgsInterface {
-            @Field(() => Scope)
+            @Field(() => Scope, { defaultValue: Scope === EmptyRedirectScope ? {} : undefined })
             @TransformerType(() => Scope)
             @ValidateNested()
             scope: RedirectScopeInterface;

--- a/packages/api/cms-api/src/redirects/redirects.resolver.ts
+++ b/packages/api/cms-api/src/redirects/redirects.resolver.ts
@@ -10,6 +10,7 @@ import { Request } from "express";
 import { getRequestContextHeadersFromRequest } from "../common/decorators/request-context.decorator";
 import { SubjectEntity } from "../common/decorators/subject-entity.decorator";
 import { CometValidationException } from "../common/errors/validation.exception";
+import { ScopeGuardActive } from "../content-scope/decorators/scope-guard-active.decorator";
 import { validateNotModified } from "../document/validateNotModified";
 import { PageTreeReadApi, PageTreeService } from "../page-tree/page-tree.service";
 import { PageTreeNodeVisibility } from "../page-tree/types";
@@ -46,6 +47,7 @@ export function createRedirectsResolver({
     class RedirectsArgs extends RedirectsArgsFactory.create({ Scope }) {}
 
     @Resolver(() => Redirect)
+    @ScopeGuardActive(hasNonEmptyScope)
     class RedirectsResolver {
         protected pageTreeReadApi: PageTreeReadApi;
 
@@ -86,7 +88,7 @@ export function createRedirectsResolver({
 
         @Query(() => Boolean)
         async redirectSourceAvailable(
-            @Args("scope", { type: () => Scope }) scope: typeof Scope,
+            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
             @Args("source", { type: () => String }) source: string,
         ): Promise<boolean> {
             const redirect = await this.repository.findOne({ source, ...(hasNonEmptyScope ? { scope: nonEmptyScopeOrNothing(scope) } : {}) });
@@ -95,7 +97,7 @@ export function createRedirectsResolver({
 
         @Mutation(() => Redirect)
         async createRedirect(
-            @Args("scope", { type: () => Scope }) scope: typeof Scope,
+            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
             @Args("input", { type: () => RedirectInput }) input: RedirectInputInterface,
         ): Promise<RedirectInterface> {
             const tranformedInput = plainToInstance(RedirectInput, input);


### PR DESCRIPTION
The scope support introduced a breaking change where a `scope` argument has to be set for queries and mutations even if no scope is used. To fix this, we add a default value `{}` to the arguments when no explicit scope is set.