### PR TITLE
DAM: Fix broken Breadcrumbs in DAM-Dialog

### DIFF
--- a/packages/admin/cms-admin/src/dam/Table/breadcrumbs/FolderBreadcrumbs.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/breadcrumbs/FolderBreadcrumbs.tsx
@@ -97,7 +97,7 @@ const FolderBreadcrumbs = ({ breadcrumbs: stackBreadcrumbs, folderIds, loading }
             });
         } else {
             const prevUrl = damBreadcrumbs[damBreadcrumbs.length - 1].url;
-            const url = `${prevUrl}/${folderId}/folder`;
+            const url = `${prevUrl.endsWith("/") ? prevUrl.slice(0, -1) : prevUrl}/${folderId}/folder`;
 
             damBreadcrumbs.push({
                 id: folderId,


### PR DESCRIPTION
- remove trailing slash from prevUrl to prevent double slashes

Previously:

The FolderBreadcrumbs in the DAM-Dialog linked to URLs like `//223ea996-8642-44c8-8ab0-a98dd2b94456/folder`.
That broke the navigation:

https://user-images.githubusercontent.com/13380047/203014413-b6da3c20-c066-4c2b-ae72-dbdb96603a75.mov

Now:

FolderBreadcrumbs have the correct URL, e.g., `/223ea996-8642-44c8-8ab0-a98dd2b94456/folder`. Navigation works as expected


