### PR TITLE
Fix Slug Collision Detection

### DIFF
--- a/packages/api/cms-api/src/page-tree/page-tree.service.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.ts
@@ -360,7 +360,12 @@ export class PageTreeService {
     public async pathForParentAndSlug(parentId: null | string, slug: string): Promise<string> {
         const readApi = this.createReadApi({ visibility: "all" });
 
-        const parentPath = parentId ? await readApi.nodePathById(parentId) : "";
+        let parentPath = parentId ? await readApi.nodePathById(parentId) : "";
+
+        if (parentPath === "/") {
+            parentPath = "/home";
+        }
+
         return `${parentPath}/${slug}`;
     }
 


### PR DESCRIPTION

Previously:

The home page could have multiple children with the same slug



https://user-images.githubusercontent.com/13380047/203063278-d84df274-ed35-4555-b33c-1d2547b12fc6.mov


Now:

Slug Collision recognizes duplicated slugs, also for children of home