### PR TITLE
Fix refetch of automatic redirects after chainging page properties

### DIFF
--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -71,7 +71,6 @@ export { SplitPreview } from "./preview/SplitPreview";
 export type { BlockPreviewApi } from "./preview/useBlockPreview";
 export { useBlockPreview } from "./preview/useBlockPreview";
 export { createRedirectsPage } from "./redirects/createRedirectsPage";
-export { automaticRedirectsRefetchQueryDescription as automaticRedirectsRefetchQueryDescription__temporary__export } from "./redirects/RedirectsTable.gql";
 export type { SiteConfig } from "./sitesConfig/SitesConfigContext";
 export { SitesConfigProvider } from "./sitesConfig/SitesConfigProvider";
 export { useSiteConfig } from "./sitesConfig/useSiteConfig";

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -28,7 +28,6 @@ import {
     namedOperations,
 } from "../graphql.generated";
 import { useLocale } from "../locale/useLocale";
-import { automaticRedirectsRefetchQueryDescription } from "../redirects/RedirectsTable.gql";
 
 type SerializedInitialValues = string;
 
@@ -228,7 +227,6 @@ export function createEditPageNode({
                                 context: {
                                     errorScope: ErrorScope.Local,
                                 },
-                                refetchQueries: [automaticRedirectsRefetchQueryDescription],
                             });
                         } else {
                             await apollo.mutate<GQLCreatePageNodeMutation, GQLCreatePageNodeMutationVariables>({

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.gql.ts
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.gql.ts
@@ -1,4 +1,4 @@
-import { gql, PureQueryOptions } from "@apollo/client";
+import { gql } from "@apollo/client";
 
 import { redirectActivenessFragment } from "./RedirectActiveness";
 
@@ -41,13 +41,6 @@ export const redirectsQuery = gql`
     }
     ${redirectTableFragment}
 `;
-
-export const automaticRedirectsRefetchQueryDescription: PureQueryOptions = {
-    query: redirectsQuery,
-    variables: {
-        type: "automatic",
-    },
-};
 
 export const deleteRedirectMutation = gql`
     mutation DeleteRedirect($id: ID!) {

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
@@ -113,6 +113,7 @@ export function RedirectsTable({ linkBlock, scope }: Props): JSX.Element {
             };
         },
         context: LocalErrorScopeApolloContext,
+        fetchPolicy: "cache-and-network",
     });
 
     return (


### PR DESCRIPTION
I decided to use a completely different - with the changed fetchPolicy a refetch is now simply done always.

Arguments for that:
- It is an anti pattern to reference another module (redirects) in pages
- The Bug (automatic redirect not shown) was only fixed for filters set to Type Automatic, not if search/activation filter is also used

This is a general problem and we could even change the fetchPolicy always like that