### PR TITLE
Copy scope from PTN when creating automatic redirect

### DIFF
--- a/packages/api/cms-api/src/redirects/redirects.service.ts
+++ b/packages/api/cms-api/src/redirects/redirects.service.ts
@@ -54,9 +54,9 @@ export class RedirectsService {
     async createAutomaticRedirects(node: PageTreeNodeInterface): Promise<void> {
         const readApi = this.pageTreeService.createReadApi({ visibility: "all" });
         const path = await readApi.nodePath(node);
-
         await this.repository.persistAndFlush(
             this.repository.create({
+                scope: node.scope,
                 sourceType: RedirectSourceTypeValues.path,
                 source: path,
                 target: this.linkBlock


### PR DESCRIPTION
Issue with this:
Both scopes aren't neccessarily equal, eg. a language might not exist for redirects. This doesn't cause a problem though, language is simply ignored.