### PR TITLE
Fix drag-and-drop in modals above preview-iFrame

### DIFF
--- a/packages/admin/cms-admin/src/preview/IFrameViewer.tsx
+++ b/packages/admin/cms-admin/src/preview/IFrameViewer.tsx
@@ -149,6 +149,15 @@ const IFrame = styled("iframe", { shouldForwardProp: (prop) => prop !== "deviceC
     width: 100%;
     height: 100%;
     background-color: ${({ theme }) => theme.palette.common.white};
+
+    ${OuterFrame}:not(:hover):not(:active) & {
+        /**
+        * Remove iFrame pointer-events while not interacting with the parent to fix a chrome-bug that prevents
+        * drag-and-drop from working in a modal over the iFrame when using an external URL as the source.
+        * Source: https://medium.com/@marcmintel/most-weird-bug-or-security-feature-with-iframes-and-native-drag-and-drop-13ffbc26107a
+        */
+        pointer-events: none;
+    }
 `;
 
 const DeviceFrameWrapper = styled("div")`


### PR DESCRIPTION
Chrome has a security feature that prevents drag-and-drop onto iFrames with external URLs. 
This feature has a bug that also prevents drag-and-drop inside elements positioned above the iFrame, like modals. 

By default, this is not reproducible locally, as the preview-iFrame's source has the same domain as the browser window. 
To reproduce this, manually set the source to an external URL:

```diff
- <IFrame ref={iFrameRef} src={iFrameUrl.toString()} deviceConfig={deviceConfig} />
+ <IFrame ref={iFrameRef} src="https://example.com/" deviceConfig={deviceConfig} />
```

When disabling the iFrame's pointer-events while not interacting with the parent, drag-and-drop works in the above elements, and the iFrame is still usable since the parent will always have a `:hover` or `:active` state when interacting with the iFrame. 

Source: https://medium.com/@marcmintel/most-weird-bug-or-security-feature-with-iframes-and-native-drag-and-drop-13ffbc26107a