### PR TITLE
Type root blocks in GraphQL schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. This projec
 ### @comet/cms-api
 
 -   Add default value `{}` for `RedirectScopeInput` when no explicit scope is set to make redirects scope support backwards compatible
+-   Add `RootBlockDataScalar` and `RootBlockInputScalar` to type root blocks in the GraphQL schema. See [page.entity.ts](/demo/api/src/pages/entities/page.entity.ts), [schema.gql](/demo/api/schema.gql), and [codegen.ts](demo/admin/codegen.ts) for an example on how to use
 
 ## 3.1.0
 

--- a/demo/admin/codegen.ts
+++ b/demo/admin/codegen.ts
@@ -1,4 +1,10 @@
 import { CodegenConfig } from "@graphql-codegen/cli";
+import { readFileSync } from "fs";
+import { buildSchema } from "graphql";
+
+const schema = buildSchema(readFileSync("./schema.gql").toString());
+
+const rootBlocks = Object.keys(schema.getTypeMap()).filter((type) => type.endsWith("BlockData") || type.endsWith("BlockInput"));
 
 const config: CodegenConfig = {
     schema: "schema.gql",
@@ -14,13 +20,19 @@ const config: CodegenConfig = {
             plugins: ["fragment-matcher"],
         },
         "./src/graphql.generated.ts": {
-            plugins: ["named-operations-object", "typescript", "typescript-operations"],
+            plugins: [
+                { add: { content: `import { ${rootBlocks.sort().join(", ")} } from "./blocks.generated";` } },
+                "named-operations-object",
+                "typescript",
+                "typescript-operations",
+            ],
             config: {
                 avoidOptionals: {
                     field: true,
                 },
                 enumsAsTypes: true,
                 namingConvention: "keep",
+                scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), {}),
                 typesPrefix: "GQL",
             },
         },

--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -92,6 +92,7 @@
         "@emotion/babel-plugin": "^11.0.0",
         "@formatjs/cli": "^2.0.0",
         "@gitbeaker/node": "^25.0.0",
+        "@graphql-codegen/add": "^3.0.0",
         "@graphql-codegen/cli": "^2.0.0",
         "@graphql-codegen/fragment-matcher": "^2.0.0",
         "@graphql-codegen/introspection": "^2.0.0",

--- a/demo/admin/src/links/Link.tsx
+++ b/demo/admin/src/links/Link.tsx
@@ -41,6 +41,7 @@ export const Link: DocumentInterface<Pick<GQLLink, "content">, GQLLinkInput> = {
             }
         }
     `,
+    // @ts-expect-error rewriteInternalLinks is insufficiently typed. As we plan to remove this method anyway, I did not invest more effort into it.
     inputToOutput: (input, { idsMap }) => {
         return {
             content: rewriteInternalLinks(LinkBlock.state2Output(LinkBlock.input2State(input.content)), idsMap),

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -124,7 +124,7 @@ type PaginatedDamFolders {
 type Link implements DocumentInterface {
   id: ID!
   updatedAt: DateTime!
-  content: JSONObject!
+  content: LinkBlockData!
   createdAt: DateTime!
 }
 
@@ -133,14 +133,23 @@ interface DocumentInterface {
   updatedAt: DateTime!
 }
 
+"""Link root block data"""
+scalar LinkBlockData
+
 type Page implements DocumentInterface {
   id: ID!
   updatedAt: DateTime!
-  content: JSONObject!
-  seo: JSONObject!
+  content: PageContentBlockData!
+  seo: SeoBlockData!
   createdAt: DateTime!
   pageTreeNode: PageTreeNode
 }
+
+"""PageContent root block data"""
+scalar PageContentBlockData
+
+"""Seo root block data"""
+scalar SeoBlockData
 
 type PageTreeNodeScope {
   domain: String!
@@ -205,18 +214,24 @@ type FooterContentScope {
 type Footer implements DocumentInterface {
   id: ID!
   updatedAt: DateTime!
-  content: JSONObject!
+  content: FooterContentBlockData!
   scope: FooterContentScope!
   createdAt: DateTime!
 }
 
+"""FooterContent root block data"""
+scalar FooterContentBlockData
+
 type MainMenuItem {
   id: ID!
   node: PageTreeNode!
-  content: JSONObject
+  content: RichTextBlockData
   createdAt: DateTime!
   updatedAt: DateTime!
 }
+
+"""RichText root block data"""
+scalar RichTextBlockData
 
 type MainMenu {
   items: [MainMenuItem!]!
@@ -243,8 +258,8 @@ type News implements DocumentInterface {
   date: DateTime!
   category: NewsCategory!
   visible: Boolean!
-  image: JSONObject!
-  content: JSONObject!
+  image: DamImageBlockData!
+  content: NewsContentBlockData!
   createdAt: DateTime!
   comments: [NewsComment!]!
 }
@@ -254,6 +269,12 @@ enum NewsCategory {
   Company
   Awards
 }
+
+"""DamImage root block data"""
+scalar DamImageBlockData
+
+"""NewsContent root block data"""
+scalar NewsContentBlockData
 
 type PaginatedNews {
   nodes: [News!]!
@@ -509,13 +530,22 @@ type Mutation {
 }
 
 input PageInput {
-  content: JSONObject!
-  seo: JSONObject!
+  content: PageContentBlockInput!
+  seo: SeoBlockInput!
 }
 
+"""PageContent root block input"""
+scalar PageContentBlockInput
+
+"""Seo root block input"""
+scalar SeoBlockInput
+
 input LinkInput {
-  content: JSONObject!
+  content: LinkBlockInput!
 }
+
+"""Link root block input"""
+scalar LinkBlockInput
 
 input CreateBuildsInput {
   names: [String!]!
@@ -609,21 +639,33 @@ input NewsInput {
   title: String!
   date: DateTime!
   visible: Boolean!
-  image: JSONObject!
-  content: JSONObject!
+  image: DamImageBlockInput!
+  content: NewsContentBlockInput!
 }
+
+"""DamImage root block input"""
+scalar DamImageBlockInput
+
+"""NewsContent root block input"""
+scalar NewsContentBlockInput
 
 input NewsCommentInput {
   comment: String!
 }
 
 input MainMenuItemInput {
-  content: JSONObject
+  content: RichTextBlockInput
 }
 
+"""RichText root block input"""
+scalar RichTextBlockInput
+
 input FooterInput {
-  content: JSONObject!
+  content: FooterContentBlockInput!
 }
+
+"""FooterContent root block input"""
+scalar FooterContentBlockInput
 
 input PredefinedPageInput {
   type: String

--- a/demo/api/src/footer/entities/footer.entity.ts
+++ b/demo/api/src/footer/entities/footer.entity.ts
@@ -1,8 +1,7 @@
 import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
-import { CrudSingleGenerator, DocumentInterface, RootBlockType } from "@comet/cms-api";
+import { CrudSingleGenerator, DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import { BaseEntity, Embedded, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
-import { GraphQLJSONObject } from "graphql-type-json";
 import { v4 as uuid } from "uuid";
 
 import { FooterContentBlock } from "../blocks/footer-content.block";
@@ -23,7 +22,7 @@ export class Footer extends BaseEntity<Footer, "id"> implements DocumentInterfac
 
     @RootBlock(FooterContentBlock)
     @Property({ customType: new RootBlockType(FooterContentBlock) })
-    @Field(() => GraphQLJSONObject)
+    @Field(() => RootBlockDataScalar(FooterContentBlock))
     content: BlockDataInterface;
 
     @Embedded(() => FooterContentScope)

--- a/demo/api/src/links/dto/link.input.ts
+++ b/demo/api/src/links/dto/link.input.ts
@@ -1,13 +1,13 @@
 import { BlockInputInterface } from "@comet/blocks-api";
+import { RootBlockInputScalar } from "@comet/cms-api";
 import { Field, InputType } from "@nestjs/graphql";
 import { LinkBlock } from "@src/common/blocks/linkBlock/link.block";
 import { Transform } from "class-transformer";
 import { ValidateNested } from "class-validator";
-import { GraphQLJSONObject } from "graphql-type-json";
 
 @InputType()
 export class LinkInput {
-    @Field(() => GraphQLJSONObject)
+    @Field(() => RootBlockInputScalar(LinkBlock))
     @Transform(({ value }) => LinkBlock.blockInputFactory(value), { toClassOnly: true })
     @ValidateNested()
     content: BlockInputInterface;

--- a/demo/api/src/links/entities/link.entity.ts
+++ b/demo/api/src/links/entities/link.entity.ts
@@ -1,9 +1,8 @@
 import { BlockDataInterface } from "@comet/blocks-api";
-import { DocumentInterface, RootBlockType } from "@comet/cms-api";
+import { DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import { BaseEntity, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { LinkBlock } from "@src/common/blocks/linkBlock/link.block";
-import { GraphQLJSONObject } from "graphql-type-json";
 import { v4 as uuid } from "uuid";
 
 @Entity()
@@ -18,7 +17,7 @@ export class Link extends BaseEntity<Link, "id"> implements DocumentInterface {
     id: string = uuid();
 
     @Property({ customType: new RootBlockType(LinkBlock) })
-    @Field(() => GraphQLJSONObject)
+    @Field(() => RootBlockDataScalar(LinkBlock))
     content: BlockDataInterface;
 
     @Property({

--- a/demo/api/src/menus/dto/main-menu-item.input.ts
+++ b/demo/api/src/menus/dto/main-menu-item.input.ts
@@ -1,13 +1,13 @@
 import { BlockInputInterface } from "@comet/blocks-api";
+import { RootBlockInputScalar } from "@comet/cms-api";
 import { Field, InputType } from "@nestjs/graphql";
 import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { Transform } from "class-transformer";
 import { IsOptional, ValidateNested } from "class-validator";
-import { GraphQLJSONObject } from "graphql-type-json";
 
 @InputType()
 export class MainMenuItemInput {
-    @Field(() => GraphQLJSONObject, { nullable: true })
+    @Field(() => RootBlockInputScalar(RichTextBlock), { nullable: true })
     @IsOptional()
     @Transform(({ value }) => RichTextBlock.blockInputFactory(value), { toClassOnly: true })
     @ValidateNested()

--- a/demo/api/src/menus/entities/main-menu-item.entity.ts
+++ b/demo/api/src/menus/entities/main-menu-item.entity.ts
@@ -1,10 +1,9 @@
 import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
-import { DocumentInterface, RootBlockType } from "@comet/cms-api";
+import { DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import { BaseEntity, Entity, OneToOne, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { PageTreeNode } from "@src/page-tree/entities/page-tree-node.entity";
-import { GraphQLJSONObject } from "graphql-type-json";
 import { v4 as uuid } from "uuid";
 
 @Entity()
@@ -23,7 +22,7 @@ export class MainMenuItem extends BaseEntity<MainMenuItem, "id"> implements Docu
 
     @Property({ customType: new RootBlockType(RichTextBlock), nullable: true })
     @RootBlock(RichTextBlock)
-    @Field(() => GraphQLJSONObject, { nullable: true })
+    @Field(() => RootBlockDataScalar(RichTextBlock), { nullable: true })
     content: BlockDataInterface | null;
 
     @Property({

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -1,9 +1,8 @@
 import { BlockDataInterface, RootBlockEntity } from "@comet/blocks-api";
-import { CrudGenerator, DamImageBlock, DocumentInterface, RootBlockType } from "@comet/cms-api";
+import { CrudGenerator, DamImageBlock, DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import { BaseEntity, Collection, Embeddable, Embedded, Entity, Enum, OneToMany, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, InputType, ObjectType, registerEnumType } from "@nestjs/graphql";
 import { IsString } from "class-validator";
-import { GraphQLJSONObject } from "graphql-type-json";
 import { v4 as uuid } from "uuid";
 
 import { NewsContentBlock } from "../blocks/news-content.block";
@@ -71,11 +70,11 @@ export class News extends BaseEntity<News, "id"> implements DocumentInterface {
     visible: boolean;
 
     @Property({ customType: new RootBlockType(DamImageBlock) })
-    @Field(() => GraphQLJSONObject)
+    @Field(() => RootBlockDataScalar(DamImageBlock))
     image: BlockDataInterface;
 
     @Property({ customType: new RootBlockType(NewsContentBlock) })
-    @Field(() => GraphQLJSONObject)
+    @Field(() => RootBlockDataScalar(NewsContentBlock))
     content: BlockDataInterface;
 
     @OneToMany(() => NewsComment, (newsComment) => newsComment.news)

--- a/demo/api/src/pages/dto/page.input.ts
+++ b/demo/api/src/pages/dto/page.input.ts
@@ -1,20 +1,20 @@
 import { BlockInputInterface } from "@comet/blocks-api";
+import { RootBlockInputScalar } from "@comet/cms-api";
 import { Field, InputType } from "@nestjs/graphql";
 import { Transform } from "class-transformer";
 import { ValidateNested } from "class-validator";
-import { GraphQLJSONObject } from "graphql-type-json";
 
 import { PageContentBlock } from "../blocks/PageContentBlock";
 import { SeoBlock } from "../blocks/seo.block";
 
 @InputType()
 export class PageInput {
-    @Field(() => GraphQLJSONObject)
+    @Field(() => RootBlockInputScalar(PageContentBlock))
     @Transform(({ value }) => PageContentBlock.blockInputFactory(value), { toClassOnly: true })
     @ValidateNested()
     content: BlockInputInterface;
 
-    @Field(() => GraphQLJSONObject)
+    @Field(() => RootBlockInputScalar(SeoBlock))
     @Transform(({ value }) => SeoBlock.blockInputFactory(value), { toClassOnly: true })
     @ValidateNested()
     seo: BlockInputInterface;

--- a/demo/api/src/pages/entities/page.entity.ts
+++ b/demo/api/src/pages/entities/page.entity.ts
@@ -1,8 +1,7 @@
 import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
-import { DocumentInterface, RootBlockType } from "@comet/cms-api";
+import { DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import { BaseEntity, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
-import { GraphQLJSONObject } from "graphql-type-json";
 import { v4 as uuid } from "uuid";
 
 import { PageContentBlock } from "../blocks/PageContentBlock";
@@ -22,11 +21,11 @@ export class Page extends BaseEntity<Page, "id"> implements DocumentInterface {
 
     @RootBlock(PageContentBlock)
     @Property({ customType: new RootBlockType(PageContentBlock) })
-    @Field(() => GraphQLJSONObject)
+    @Field(() => RootBlockDataScalar(PageContentBlock))
     content: BlockDataInterface;
 
     @Property({ customType: new RootBlockType(SeoBlock) })
-    @Field(() => GraphQLJSONObject)
+    @Field(() => RootBlockDataScalar(SeoBlock))
     seo: BlockDataInterface;
 
     @Property({

--- a/demo/site/codegen.ts
+++ b/demo/site/codegen.ts
@@ -1,17 +1,29 @@
 import { CodegenConfig } from "@graphql-codegen/cli";
+import { readFileSync } from "fs";
+import { buildSchema } from "graphql";
+
+const schema = buildSchema(readFileSync("./schema.gql").toString());
+
+const rootBlocks = Object.keys(schema.getTypeMap()).filter((type) => type.endsWith("BlockData"));
 
 const config: CodegenConfig = {
     schema: "schema.gql",
     documents: ["src/**/*.{ts,tsx}", "preBuild/src/**/*.{ts,tsx}"],
     generates: {
         "./src/graphql.generated.ts": {
-            plugins: ["named-operations-object", "typescript", "typescript-operations"],
+            plugins: [
+                { add: { content: `import { ${rootBlocks.sort().join(", ")} } from "./blocks.generated";` } },
+                "named-operations-object",
+                "typescript",
+                "typescript-operations",
+            ],
             config: {
                 avoidOptionals: {
                     field: true,
                 },
                 enumsAsTypes: true,
                 namingConvention: "keep",
+                scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), {}),
                 typesPrefix: "GQL",
             },
         },

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -50,6 +50,7 @@
     "devDependencies": {
         "@babel/core": "^7.16.0",
         "@comet/eslint-config": "^3.0.0",
+        "@graphql-codegen/add": "^3.0.0",
         "@graphql-codegen/cli": "^2.0.0",
         "@graphql-codegen/named-operations-object": "^2.0.0",
         "@graphql-codegen/typescript": "^2.0.0",

--- a/packages/api/cms-api/src/blocks/rootBlocks/root-block-data.scalar.ts
+++ b/packages/api/cms-api/src/blocks/rootBlocks/root-block-data.scalar.ts
@@ -1,0 +1,12 @@
+import { Block } from "@comet/blocks-api";
+import { GraphQLScalarType } from "graphql";
+import { GraphQLJSONObject } from "graphql-type-json";
+
+export function RootBlockDataScalar(block: Block): GraphQLScalarType {
+    return new GraphQLScalarType({
+        ...GraphQLJSONObject,
+        specifiedByUrl: undefined,
+        name: `${block.name}BlockData`,
+        description: `${block.name} root block data`,
+    });
+}

--- a/packages/api/cms-api/src/blocks/rootBlocks/root-block-input.scalar.ts
+++ b/packages/api/cms-api/src/blocks/rootBlocks/root-block-input.scalar.ts
@@ -1,0 +1,12 @@
+import { Block } from "@comet/blocks-api";
+import { GraphQLScalarType } from "graphql";
+import { GraphQLJSONObject } from "graphql-type-json";
+
+export function RootBlockInputScalar(block: Block): GraphQLScalarType {
+    return new GraphQLScalarType({
+        ...GraphQLJSONObject,
+        specifiedByUrl: undefined,
+        name: `${block.name}BlockInput`,
+        description: `${block.name} root block input`,
+    });
+}

--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -82,7 +82,7 @@ export async function generateCrudInput(generatorOptions: { targetDirectory: str
                     .replace(/\.ts$/, "")}";`;
             }
 
-            decorators.push(`@Field(() => GraphQLJSONObject${prop.nullable ? ", { nullable: true }" : ""})`);
+            decorators.push(`@Field(() => RootBlockInputScalar(${blockExportName})${prop.nullable ? ", { nullable: true }" : ""})`);
             decorators.push(
                 `@Transform(({ value }) => (isBlockInputInterface(value) ? value : ${blockExportName}.blockInputFactory(value)), { toClassOnly: true })`,
             );
@@ -100,7 +100,7 @@ export async function generateCrudInput(generatorOptions: { targetDirectory: str
     const inputOut = `import { Field, InputType } from "@nestjs/graphql";
 import { Transform } from "class-transformer";
 import { IsString, IsNotEmpty, ValidateNested, IsNumber, IsBoolean, IsDate } from "class-validator";
-import { IsSlug } from "@comet/cms-api";
+import { IsSlug, RootBlockInputScalar } from "@comet/cms-api";
 import { GraphQLJSONObject } from "graphql-type-json";
 import { BlockInputInterface, isBlockInputInterface } from "@comet/blocks-api";
 ${importsOut}

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -30,6 +30,8 @@ export { createTextImageBlock, ImagePosition } from "./blocks/createTextImageBlo
 export { DamVideoBlock } from "./blocks/dam-video.block";
 export { PixelImageBlock } from "./blocks/PixelImageBlock";
 export { RootBlockType } from "./blocks/root-block-type";
+export { RootBlockDataScalar } from "./blocks/rootBlocks/root-block-data.scalar";
+export { RootBlockInputScalar } from "./blocks/rootBlocks/root-block-input.scalar";
 export { SvgImageBlock } from "./blocks/SvgImageBlock";
 export { BUILDS_CONFIG, BUILDS_MODULE_OPTIONS } from "./builds/builds.constants";
 export { BuildsModule } from "./builds/builds.module";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5809,6 +5809,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-codegen/add@npm:^3.0.0":
+  version: 3.2.1
+  resolution: "@graphql-codegen/add@npm:3.2.1"
+  dependencies:
+    "@graphql-codegen/plugin-helpers": ^2.6.2
+    tslib: ~2.4.0
+  peerDependencies:
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: 4f9c645a3cf4b6e64c8ea5cbaba95075df2f485e3fea5b2c369bcf898272d0a6665b3eb0b541dc57d3d8400b23610848c8348a469e472db1a1c558d61580dca0
+  languageName: node
+  linkType: hard
+
 "@graphql-codegen/cli@npm:^2.0.0":
   version: 2.13.12
   resolution: "@graphql-codegen/cli@npm:2.13.12"
@@ -16625,6 +16637,7 @@ __metadata:
     "@fontsource/roboto": ^4.5.5
     "@formatjs/cli": ^2.0.0
     "@gitbeaker/node": ^25.0.0
+    "@graphql-codegen/add": ^3.0.0
     "@graphql-codegen/cli": ^2.0.0
     "@graphql-codegen/fragment-matcher": ^2.0.0
     "@graphql-codegen/introspection": ^2.0.0
@@ -16820,6 +16833,7 @@ __metadata:
     "@comet/eslint-config": ^3.0.0
     "@googlemaps/js-api-loader": ^1.0.0
     "@googlemaps/markerclustererplus": ^1.0.0
+    "@graphql-codegen/add": ^3.0.0
     "@graphql-codegen/cli": ^2.0.0
     "@graphql-codegen/named-operations-object": ^2.0.0
     "@graphql-codegen/typescript": ^2.0.0


### PR DESCRIPTION
Previously, we typed root blocks in the schema using the GraphQLJSONObject scalar. The GraphQL Code Generator interpreted the scalar `any`, which led to numerous bugs in our projects due to insufficient typing. We add two scalars to type root blocks in the GraphQL schema to fix this. The generator interprets these scalars as block types and adds the respective imports from blocks.generated.ts.