### PR TITLE
Fix RTE control buttons triggering outer form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. This projec
 
 ## NEXT
 
+### @comet/admin-rte
+
+#### Changes
+
+-   Fix a bug where control buttons in the toolbar would trigger submission when used in a form
+
 ### @comet/cms-admin
 
 -   Fix a bug where the pages query would query for a field `undefined` when no `additionalPageTreeNodeFragment` is set

--- a/packages/admin/admin-rte/src/core/Controls/ControlButton.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/ControlButton.tsx
@@ -32,7 +32,7 @@ function ControlButton({
     if (Icon) rootClasses.push(classes.renderAsIcon);
 
     return (
-        <button className={rootClasses.join(" ")} disabled={disabled} onMouseDown={onButtonClick}>
+        <button type="button" className={rootClasses.join(" ")} disabled={disabled} onMouseDown={onButtonClick}>
             {!!Icon && <Icon fontSize="inherit" color="inherit" />}
             {children}
         </button>

--- a/packages/admin/admin-stories/src/admin-rte/ToolbarButtonsSubmitForm.tsx
+++ b/packages/admin/admin-stories/src/admin-rte/ToolbarButtonsSubmitForm.tsx
@@ -1,0 +1,27 @@
+import { Field } from "@comet/admin";
+import { createFinalFormRte } from "@comet/admin-rte";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { Form } from "react-final-form";
+
+const { RteField } = createFinalFormRte();
+
+/**
+ * Dev story to fix a bug where buttons in the RTE's toolbar trigger submission when used in a form.
+ */
+function Story() {
+    return (
+        <>
+            <Form
+                onSubmit={() => alert("submit")}
+                render={({ handleSubmit }) => (
+                    <form onSubmit={handleSubmit}>
+                        <Field name="text" component={RteField} />
+                    </form>
+                )}
+            />
+        </>
+    );
+}
+
+storiesOf("@comet/admin-rte", module).add("Toolbar buttons submit form", () => <Story />);


### PR DESCRIPTION
Pressing a button in the RTE's toolbar triggered a submission when used in a form. To fix this, we add `type="button"` to the `button` element.