### PR TITLE
Fix zIndex of ContentScopeIndicator as it overlaps the Menu

### DIFF
--- a/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
@@ -25,7 +25,7 @@ const ScopeIndicator = styled("div", { shouldForwardProp: (prop) => prop !== "gl
     position: ${({ variant }) => (variant === "toolbar" ? "fixed" : "absolute")};
     top: -12px;
     left: 0;
-    z-index: 1201;
+    z-index: 1200;
     background: ${({ theme, global }) => (global ? theme.palette.primary.main : "#596980")};
     border-top-left-radius: 12px;
     border-bottom-right-radius: 12px;

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
@@ -25,7 +25,7 @@ const ScopeIndicator = styled("div", { shouldForwardProp: (prop) => prop !== "gl
     position: ${({ variant }) => (variant === "toolbar" ? "fixed" : "absolute")};
     top: -12px;
     left: 0;
-    z-index: 1200;
+    z-index: ${({ theme }) => theme.zIndex.drawer - 1};
     background: ${({ theme, global }) => (global ? theme.palette.primary.main : "#596980")};
     border-top-left-radius: 12px;
     border-bottom-right-radius: 12px;


### PR DESCRIPTION
The MainMenu was overlapped by the ContentScopeIndicator in Mobile Mode