### PR TITLE
Fix thumb styling on FinalFormRangeInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## NEXT
+
+### @comet/admin
+
+#### Changes
+
+-   Fix a bug where the slider thumbs are not visible when using FinalFormRangeInput.
+
 ## 3.2.0
 
 _Nov 29, 2022_

--- a/packages/admin/admin-stories/src/admin/form/RangeInput.tsx
+++ b/packages/admin/admin-stories/src/admin/form/RangeInput.tsx
@@ -1,21 +1,21 @@
 import { Field, FinalFormRangeInput, Toolbar, ToolbarTitleItem } from "@comet/admin";
-import { Box, Button, Card, CardContent, Typography } from "@mui/material";
+import { Box, Button, Card, CardContent, SliderThumb, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 import { Form } from "react-final-form";
 
-const Thumb = styled("div")`
+const Thumb = styled(SliderThumb)`
     && {
-        margin-top: -9px;
-        height: 20px;
-        width: 20px;
-
-        &:hover {
+        &:hover,
+        &.Mui-focusVisible {
             box-shadow: none;
         }
 
         &:after {
+            width: auto;
+            height: auto;
+            border-radius: 0;
             border: solid white;
             border-width: 0 2px 2px 0;
             transform: rotate(-45deg);
@@ -27,11 +27,9 @@ const Thumb = styled("div")`
             top: 0;
         }
 
-        &[data-index="1"] {
-            &:after {
-                transform: rotate(135deg);
-                left: 1px;
-            }
+        &[data-index="1"]:after {
+            transform: rotate(135deg);
+            left: 1px;
         }
     }
 `;
@@ -64,7 +62,7 @@ function Story() {
                                             min={0}
                                             max={100}
                                             endAdornment={<span>€</span>}
-                                            sliderProps={{ ThumbComponent: Thumb }}
+                                            sliderProps={{ components: { Thumb } }}
                                         />
                                         <Button
                                             variant="contained"
@@ -101,7 +99,7 @@ function Story() {
                                             min={0}
                                             max={150}
                                             endAdornment={<span>€</span>}
-                                            sliderProps={{ ThumbComponent: Thumb }}
+                                            sliderProps={{ components: { Thumb } }}
                                         />
                                         <Button
                                             variant="contained"
@@ -138,7 +136,7 @@ function Story() {
                                             min={20}
                                             max={150}
                                             endAdornment={<span>€</span>}
-                                            sliderProps={{ ThumbComponent: Thumb }}
+                                            sliderProps={{ components: { Thumb } }}
                                         />
                                         <Button
                                             variant="contained"

--- a/packages/admin/admin/src/form/FinalFormRangeInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormRangeInput.tsx
@@ -134,7 +134,6 @@ const FinalFormRangeInputComponent: React.FunctionComponent<WithStyles<typeof st
                     min={min}
                     max={max}
                     value={[fieldValue.min ? fieldValue.min : min, fieldValue.max ? fieldValue.max : max]}
-                    components={{ Thumb: sliderProps?.components?.Thumb ? sliderProps.components.Thumb : "span" }}
                     onChange={handleSliderChange}
                     {...sliderProps}
                 />


### PR DESCRIPTION
Passing an empty span as the thumb component, if no custom thumb is defined, causes MUI's default thumb styles to be missing since MUI 5.

By no longer setting a custom `components` prop, the default (correctly styled) thumb component is used, and the component can still be overridden using the `sliderProps`.

|              | Previously                                                                                                                                           | Now                                                                                                                                                 |
| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
| Default      | <img width="375" alt="prev default" src="https://user-images.githubusercontent.com/6264317/204771878-6f465c88-7ac1-45bf-a1cf-3993edb20ae1.png">      | <img width="375" alt="now default" src="https://user-images.githubusercontent.com/6264317/204771872-bcd8bd3e-59f4-4065-8785-a4605dfd1643.png">      |
| Custom thumb | <img width="375" alt="prev custom thumb" src="https://user-images.githubusercontent.com/6264317/204771876-225e6728-6ed1-462f-a1f7-1b16109d3a01.png"> | <img width="375" alt="now custom thumb" src="https://user-images.githubusercontent.com/6264317/204771866-57aa3adf-3f99-4cce-8a77-3e374726450b.png"> |






