### PR TITLE
Fix clipboard access in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## NEXT
+
+### @comet/admin
+
+#### Changes
+
+-   Fix `readClipboardText()` not working in Firefox by using local storage as a fallback
+
 ## 3.2.1
 
 _Dec 6, 2022_

--- a/packages/admin/admin/src/clipboard/readClipboardText.ts
+++ b/packages/admin/admin/src/clipboard/readClipboardText.ts
@@ -1,57 +1,19 @@
-let canReadClipboard: boolean;
-
 export async function readClipboardText(): Promise<string | undefined> {
-    if (!("clipboard" in navigator)) {
-        // eslint-disable-next-line no-console
-        console.warn("Browser doesn't support navigator.clipboard");
-        return undefined;
-    }
-
-    // Firefox does not support navigator.clipboard.readText() by default.
-    if (navigator.clipboard.readText === undefined) {
+    if (
+        !("clipboard" in navigator) || // Browser doesn't support navigator.clipboard
+        navigator.clipboard.readText === undefined // Firefox doesn't support navigator.clipboard.readText() by default
+    ) {
+        // Reading from clipboard isn't supported, fallback to local storage.
         return window.localStorage.getItem("comet_clipboard") ?? undefined;
     }
 
-    if (canReadClipboard === true) {
-        return navigator.clipboard.readText();
-    }
-
-    let permissionStatus: PermissionStatus;
-
     try {
-        permissionStatus = await navigator.permissions.query({ name: "clipboard-read" as PermissionName });
-    } catch (error) {
-        // Firefox with "dom.events.asyncClipboard.readText" enabled via about:config. navigator.clipboard.readText() is available, but permission
-        // 'clipboard-read' permission cannot be queried. We can still read the clipboard though.
-        if (
-            error instanceof TypeError &&
-            error.message === "'clipboard-read' (value of 'name' member of PermissionDescriptor) is not a valid value for enumeration PermissionName."
-        ) {
-            canReadClipboard = true;
-            return navigator.clipboard.readText();
-        }
-
-        throw error;
-    }
-
-    if (permissionStatus.state === "granted") {
-        canReadClipboard = true;
-        return navigator.clipboard.readText();
-    } else if (permissionStatus.state === "denied") {
-        // eslint-disable-next-line no-console
-        console.error("Clipboard access denied");
-        return undefined;
-    } else {
         // We need to show a prompt to ask for clipboard access. Reading the clipboard triggers the prompt. The result of the read operation can
         // be used to check if access to the clipboard was granted by the user.
-        try {
-            const data = await navigator.clipboard.readText();
-            canReadClipboard = true;
-            return data;
-        } catch {
-            // eslint-disable-next-line no-console
-            console.error("Clipboard access denied");
-            return undefined;
-        }
+        const data = await navigator.clipboard.readText();
+        return data;
+    } catch {
+        // Clipboard access denied, fallback to local storage.
+        return window.localStorage.getItem("comet_clipboard") ?? undefined;
     }
 }

--- a/packages/admin/admin/src/clipboard/readClipboardText.ts
+++ b/packages/admin/admin/src/clipboard/readClipboardText.ts
@@ -13,7 +13,7 @@ export async function readClipboardText(): Promise<string | undefined> {
         const data = await navigator.clipboard.readText();
         return data;
     } catch {
-        // Clipboard access denied, fallback to local storage.
+        console.warn("Clipboard access denied, fallback to local storage.");
         return window.localStorage.getItem("comet_clipboard") ?? undefined;
     }
 }

--- a/packages/admin/admin/src/clipboard/writeClipboardText.ts
+++ b/packages/admin/admin/src/clipboard/writeClipboardText.ts
@@ -1,13 +1,8 @@
 export async function writeClipboardText(data: string): Promise<void> {
-    if (!("clipboard" in navigator)) {
-        // eslint-disable-next-line no-console
-        console.warn("Browser doesn't support navigator.clipboard");
-        return;
-    }
+    // Always write to local storage, which is used as a fallback when reading from the clipboard is not supported/allowed.
+    window.localStorage.setItem("comet_clipboard", data);
 
-    // Firefox does not support navigator.clipboard.readText() by default.
-    if (navigator.clipboard.readText === undefined) {
-        window.localStorage.setItem("comet_clipboard", data);
+    if (!("clipboard" in navigator)) {
         return;
     }
 

--- a/packages/admin/admin/src/clipboard/writeClipboardText.ts
+++ b/packages/admin/admin/src/clipboard/writeClipboardText.ts
@@ -5,6 +5,12 @@ export async function writeClipboardText(data: string): Promise<void> {
         return;
     }
 
+    // Firefox does not support navigator.clipboard.readText() by default.
+    if (navigator.clipboard.readText === undefined) {
+        window.localStorage.setItem("comet_clipboard", data);
+        return;
+    }
+
     // The "clipboard-write" permission is granted automatically to pages when they are the active tab
     // (see https://web.dev/async-clipboard/#security-and-permissions).
     return navigator.clipboard.writeText(data);


### PR DESCRIPTION
Firefox does not support `navigator.clipboard.readText()` by default. We therefore add a fallback clipboard using local storage. Furthermore, if a user explicitly enables clipboard access in `about:config`, we use `navigator.clipboard.readText()` even when querying the `clipboard-read` permission fails.