### PR TITLE
cms-api: Remove apollo peerDependency

### DIFF
--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -42,7 +42,6 @@
         "@mikro-orm/migrations": "^5.0.4",
         "@mikro-orm/nestjs": "^5.1.0",
         "@mikro-orm/postgresql": "^5.0.4",
-        "@nestjs/apollo": "^10.0.0",
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/graphql": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4983,7 +4983,6 @@ __metadata:
     "@mikro-orm/migrations": ^5.0.4
     "@mikro-orm/nestjs": ^5.1.0
     "@mikro-orm/postgresql": ^5.0.4
-    "@nestjs/apollo": ^10.0.0
     "@nestjs/common": ^9.0.0
     "@nestjs/core": ^9.0.0
     "@nestjs/graphql": ^10.0.0


### PR DESCRIPTION
The lib has no direct dependency on it. This allows it to use alternative providers