### PR TITLE
Paginated Redirects

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -358,7 +358,7 @@ type Query {
   pageTreeNodeList(scope: PageTreeNodeScopeInput!, category: String): [PageTreeNode!]!
   pageTreeNodeSlugAvailable(scope: PageTreeNodeScopeInput!, parentId: ID, slug: String!): SlugAvailability!
   redirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]! @deprecated(reason: "Use paginatedRedirects instead. Will be removed in the next version.")
-  paginatedRedirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, sort: [RedirectSort!], offset: Int = 0, limit: Int = 20): PaginatedRedirects!
+  paginatedRedirects(scope: RedirectScopeInput!, search: String, filter: RedirectFilter, sort: [RedirectSort!], offset: Int = 0, limit: Int = 20): PaginatedRedirects!
   redirect(id: ID!): Redirect!
   redirectSourceAvailable(scope: RedirectScopeInput!, source: String!): Boolean!
   damItemsList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, folderId: ID, includeArchived: Boolean, filter: DamItemFilterInput): PaginatedDamItems!
@@ -392,6 +392,36 @@ enum SlugAvailability {
   Available
   Taken
   Reserved
+}
+
+input RedirectFilter {
+  generationType: StringFilter
+  active: BooleanFilter
+  createdAt: DateFilter
+  updatedAt: DateFilter
+  and: [RedirectFilter!]
+  or: [RedirectFilter!]
+}
+
+input StringFilter {
+  contains: String
+  startsWith: String
+  endsWith: String
+  equal: String
+  notEqual: String
+}
+
+input BooleanFilter {
+  equal: Boolean
+}
+
+input DateFilter {
+  equal: DateTime
+  lowerThan: DateTime
+  greaterThan: DateTime
+  lowerThanEqual: DateTime
+  greaterThanEqual: DateTime
+  notEqual: DateTime
 }
 
 input RedirectSort {
@@ -433,27 +463,6 @@ input NewsFilter {
   updatedAt: DateFilter
   and: [NewsFilter!]
   or: [NewsFilter!]
-}
-
-input StringFilter {
-  contains: String
-  startsWith: String
-  endsWith: String
-  equal: String
-  notEqual: String
-}
-
-input DateFilter {
-  equal: DateTime
-  lowerThan: DateTime
-  greaterThan: DateTime
-  lowerThanEqual: DateTime
-  greaterThanEqual: DateTime
-  notEqual: DateTime
-}
-
-input BooleanFilter {
-  equal: Boolean
 }
 
 input NewsSort {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -357,7 +357,7 @@ type Query {
   pageTreeNodeByPath(path: String!, scope: PageTreeNodeScopeInput!): PageTreeNode
   pageTreeNodeList(scope: PageTreeNodeScopeInput!, category: String): [PageTreeNode!]!
   pageTreeNodeSlugAvailable(scope: PageTreeNodeScopeInput!, parentId: ID, slug: String!): SlugAvailability!
-  redirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]!
+  redirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]! @deprecated(reason: "Use paginatedRedirects instead. Will be removed in the next version.")
   paginatedRedirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC): PaginatedRedirects!
   redirect(id: ID!): Redirect!
   redirectSourceAvailable(scope: RedirectScopeInput!, source: String!): Boolean!

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -358,7 +358,7 @@ type Query {
   pageTreeNodeList(scope: PageTreeNodeScopeInput!, category: String): [PageTreeNode!]!
   pageTreeNodeSlugAvailable(scope: PageTreeNodeScopeInput!, parentId: ID, slug: String!): SlugAvailability!
   redirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]! @deprecated(reason: "Use paginatedRedirects instead. Will be removed in the next version.")
-  paginatedRedirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC): PaginatedRedirects!
+  paginatedRedirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, sort: [RedirectSort!], offset: Int = 0, limit: Int = 20): PaginatedRedirects!
   redirect(id: ID!): Redirect!
   redirectSourceAvailable(scope: RedirectScopeInput!, source: String!): Boolean!
   damItemsList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, folderId: ID, includeArchived: Boolean, filter: DamItemFilterInput): PaginatedDamItems!
@@ -392,6 +392,17 @@ enum SlugAvailability {
   Available
   Taken
   Reserved
+}
+
+input RedirectSort {
+  field: RedirectSortField!
+  direction: SortDirection = ASC
+}
+
+enum RedirectSortField {
+  source
+  createdAt
+  updatedAt
 }
 
 input DamItemFilterInput {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -323,6 +323,11 @@ enum RedirectGenerationType {
   automatic
 }
 
+type PaginatedRedirects {
+  nodes: [Redirect!]!
+  totalCount: Int!
+}
+
 input PageTreeNodeScopeInput {
   domain: String!
   language: String!
@@ -353,6 +358,7 @@ type Query {
   pageTreeNodeList(scope: PageTreeNodeScopeInput!, category: String): [PageTreeNode!]!
   pageTreeNodeSlugAvailable(scope: PageTreeNodeScopeInput!, parentId: ID, slug: String!): SlugAvailability!
   redirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]!
+  paginatedRedirects(scope: RedirectScopeInput!, query: String, type: RedirectGenerationType, active: Boolean, offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC): PaginatedRedirects!
   redirect(id: ID!): Redirect!
   redirectSourceAvailable(scope: RedirectScopeInput!, source: String!): Boolean!
   damItemsList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, folderId: ID, includeArchived: Boolean, filter: DamItemFilterInput): PaginatedDamItems!

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
@@ -5,10 +5,6 @@ import { GetMuiComponentTheme } from "./getComponentsTheme";
 
 export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) => ({
     ...component,
-    defaultProps: {
-        disableElevation: true,
-        ...component?.defaultProps,
-    },
     styleOverrides: mergeOverrideStyles<"MuiDataGrid">(component?.styleOverrides, {
         root: {
             backgroundColor: "white",

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
@@ -24,7 +24,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) =
             padding: "0 10px",
         },
         cell: {
-            borderTop: "1px solid #D9D9D9",
+            borderTop: `1px solid ${palette.grey[100]}`,
             "&:focus": {
                 outline: "none",
             },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
@@ -33,7 +33,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) =
             },
         },
         iconSeparator: {
-            backgroundColor: "#D9D9D9",
+            backgroundColor: palette.grey[100],
             width: "2px",
             height: "20px",
             marginRight: "10px",

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
@@ -38,5 +38,34 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) =
             height: "20px",
             marginRight: "10px",
         },
+        filterForm: {
+            padding: 20,
+            "& .MuiInputLabel-root": {
+                display: "none",
+            },
+            "& .MuiInput-root": {
+                marginTop: 0,
+            },
+            "& .MuiInputAdornment-root": {
+                paddingRight: 5,
+            },
+        },
+        filterFormDeleteIcon: {
+            justifyContent: "center",
+            "& .MuiSvgIcon-root": {
+                width: 16,
+                height: 16,
+            },
+        },
+        filterFormColumnInput: {
+            marginRight: 20,
+            marginLeft: 20,
+        },
+        filterFormOperatorInput: {
+            marginRight: 20,
+        },
+        paper: {
+            boxShadow: "0 0 8px 0 rgb(0 0 0 / 10%)",
+        },
     }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
@@ -65,7 +65,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) =
             marginRight: 20,
         },
         paper: {
-            boxShadow: "0 0 8px 0 rgb(0 0 0 / 10%)",
+            boxShadow: shadows[1],
         },
     }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
@@ -1,0 +1,46 @@
+import type {} from "@mui/x-data-grid/themeAugmentation";
+
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) => ({
+    ...component,
+    defaultProps: {
+        disableElevation: true,
+        ...component?.defaultProps,
+    },
+    styleOverrides: mergeOverrideStyles<"MuiDataGrid">(component?.styleOverrides, {
+        root: {
+            backgroundColor: "white",
+        },
+        columnHeader: {
+            "&:focus": {
+                outline: "none",
+            },
+            "&:focus-within": {
+                outline: "none",
+            },
+        },
+        columnHeadersInner: {
+            padding: "0 10px",
+        },
+        row: {
+            padding: "0 10px",
+        },
+        cell: {
+            borderTop: "1px solid #D9D9D9",
+            "&:focus": {
+                outline: "none",
+            },
+            "&:focus-within": {
+                outline: "none",
+            },
+        },
+        iconSeparator: {
+            backgroundColor: "#D9D9D9",
+            width: "2px",
+            height: "20px",
+            marginRight: "10px",
+        },
+    }),
+});

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.ts
@@ -3,7 +3,7 @@ import type {} from "@mui/x-data-grid/themeAugmentation";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) => ({
+export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, { palette, shadows, spacing }) => ({
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiDataGrid">(component?.styleOverrides, {
         root: {
@@ -18,10 +18,10 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) =
             },
         },
         columnHeadersInner: {
-            padding: "0 10px",
+            padding: spacing(0, 2),
         },
         row: {
-            padding: "0 10px",
+            padding: spacing(0, 2),
         },
         cell: {
             borderTop: `1px solid ${palette.grey[100]}`,
@@ -39,7 +39,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) =
             marginRight: "10px",
         },
         filterForm: {
-            padding: 20,
+            padding: spacing(4),
             "& .MuiInputLabel-root": {
                 display: "none",
             },
@@ -47,7 +47,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) =
                 marginTop: 0,
             },
             "& .MuiInputAdornment-root": {
-                paddingRight: 5,
+                padding: spacing(0, 1, 0, 0),
             },
         },
         filterFormDeleteIcon: {
@@ -58,11 +58,10 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component) =
             },
         },
         filterFormColumnInput: {
-            marginRight: 20,
-            marginLeft: 20,
+            margin: spacing(0, 4),
         },
         filterFormOperatorInput: {
-            marginRight: 20,
+            margin: spacing(0, 4, 0, 0),
         },
         paper: {
             boxShadow: shadows[1],

--- a/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
@@ -11,6 +11,7 @@ import { getMuiButtonGroup } from "./MuiButtonGroup";
 import { getMuiCardContent } from "./MuiCardContent";
 import { getMuiCheckbox } from "./MuiCheckbox";
 import { getMuiChip } from "./MuiChip";
+import { getMuiDataGrid } from "./MuiDataGrid";
 import { getMuiDialog } from "./MuiDialog";
 import { getMuiDialogActions } from "./MuiDialogActions";
 import { getMuiDialogContent } from "./MuiDialogContent";
@@ -60,6 +61,7 @@ export const getComponentsTheme = (components: Components, themeData: ThemeData)
     MuiCardContent: getMuiCardContent(components.MuiCardContent, themeData),
     MuiCheckbox: getMuiCheckbox(components.MuiCheckbox, themeData),
     MuiChip: getMuiChip(components.MuiChip, themeData),
+    MuiDataGrid: getMuiDataGrid(components.MuiDataGrid, themeData),
     MuiDialog: getMuiDialog(components.MuiDialog, themeData),
     MuiDialogActions: getMuiDialogActions(components.MuiDialogActions, themeData),
     MuiDialogContent: getMuiDialogContent(components.MuiDialogContent, themeData),

--- a/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
@@ -1,6 +1,7 @@
 import { ComponentNameToClassKey, ThemeOptions } from "@mui/material";
 import { Components, Palette } from "@mui/material/styles";
 import { Typography } from "@mui/material/styles/createTypography";
+import { Shadows } from "@mui/material/styles/shadows";
 import { ZIndex } from "@mui/material/styles/zIndex";
 import { Spacing } from "@mui/system";
 
@@ -45,6 +46,7 @@ type ThemeData = {
     typography: Typography;
     spacing: Spacing;
     zIndex: ZIndex;
+    shadows: Shadows;
 };
 
 export type GetMuiComponentTheme<ClassesName extends keyof ComponentNameToClassKey> = (

--- a/packages/admin/admin-theme/src/createCometTheme.ts
+++ b/packages/admin/admin-theme/src/createCometTheme.ts
@@ -42,7 +42,7 @@ export const createCometTheme = ({
         },
         shadows,
         zIndex,
-        components: getComponentsTheme(passedComponentsOptions, { palette, typography, spacing, zIndex }),
+        components: getComponentsTheme(passedComponentsOptions, { palette, typography, spacing, zIndex, shadows }),
     };
 
     const themeOptions = deepmerge<ThemeOptions>(cometThemeOptions, restPassedOptions);

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.gql.ts
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.gql.ts
@@ -29,14 +29,13 @@ export const redirectTableFragment = gql`
 export const paginatedRedirectsQuery = gql`
     query PaginatedRedirects(
         $scope: RedirectScopeInput!
-        $type: RedirectGenerationType
-        $active: Boolean
-        $query: String
+        $filter: RedirectFilter
+        $search: String
         $sort: [RedirectSort!]
         $offset: Int
         $limit: Int
     ) {
-        paginatedRedirects(scope: $scope, type: $type, active: $active, query: $query, sort: $sort, offset: $offset, limit: $limit) {
+        paginatedRedirects(scope: $scope, filter: $filter, search: $search, sort: $sort, offset: $offset, limit: $limit) {
             nodes {
                 ...RedirectTable
             }

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.gql.ts
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.gql.ts
@@ -32,21 +32,11 @@ export const paginatedRedirectsQuery = gql`
         $type: RedirectGenerationType
         $active: Boolean
         $query: String
-        $sortDirection: SortDirection
-        $sortColumnName: String
+        $sort: [RedirectSort!]
         $offset: Int
         $limit: Int
     ) {
-        paginatedRedirects(
-            scope: $scope
-            type: $type
-            active: $active
-            query: $query
-            sortDirection: $sortDirection
-            sortColumnName: $sortColumnName
-            offset: $offset
-            limit: $limit
-        ) {
+        paginatedRedirects(scope: $scope, type: $type, active: $active, query: $query, sort: $sort, offset: $offset, limit: $limit) {
             nodes {
                 ...RedirectTable
             }

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.gql.ts
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.gql.ts
@@ -26,17 +26,31 @@ export const redirectTableFragment = gql`
     ${redirectActivenessFragment}
 `;
 
-export const redirectsQuery = gql`
-    query Redirects(
+export const paginatedRedirectsQuery = gql`
+    query PaginatedRedirects(
         $scope: RedirectScopeInput!
         $type: RedirectGenerationType
         $active: Boolean
         $query: String
         $sortDirection: SortDirection
         $sortColumnName: String
+        $offset: Int
+        $limit: Int
     ) {
-        redirects(scope: $scope, type: $type, active: $active, query: $query, sortDirection: $sortDirection, sortColumnName: $sortColumnName) {
-            ...RedirectTable
+        paginatedRedirects(
+            scope: $scope
+            type: $type
+            active: $active
+            query: $query
+            sortDirection: $sortDirection
+            sortColumnName: $sortColumnName
+            offset: $offset
+            limit: $limit
+        ) {
+            nodes {
+                ...RedirectTable
+            }
+            totalCount
         }
     }
     ${redirectTableFragment}

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
@@ -5,7 +5,6 @@ import {
     FinalFormSelect,
     LocalErrorScopeApolloContext,
     MainContent,
-    muiGridFilterToGql,
     muiGridSortToGql,
     StackSwitchApiContext,
     TableDeleteButton,
@@ -99,7 +98,7 @@ export function RedirectsTable({ linkBlock, scope }: Props): JSX.Element {
         {
             field: "source",
             headerName: intl.formatMessage({ id: "comet.pages.redirects.redirect.source", defaultMessage: "Source" }),
-            sortable: false,
+            sortable: true,
             flex: 1,
         },
         {
@@ -187,7 +186,6 @@ export function RedirectsTable({ linkBlock, scope }: Props): JSX.Element {
 
     const { data, loading, error } = useQuery<GQLPaginatedRedirectsQuery, GQLPaginatedRedirectsQueryVariables>(paginatedRedirectsQuery, {
         variables: {
-            ...muiGridFilterToGql(columns, dataGridProps.filterModel),
             scope,
             type: filterApi.current.type !== "all" ? filterApi.current.type : undefined,
             active: filterApi.current.active !== "all" ? filterApi.current.active === "activated" : undefined,
@@ -273,19 +271,7 @@ export function RedirectsTable({ linkBlock, scope }: Props): JSX.Element {
             </Toolbar>
             <MainContent>
                 <DataGridContainer>
-                    <DataGrid
-                        {...dataGridProps}
-                        rows={rows}
-                        rowCount={rowCount}
-                        columns={columns}
-                        loading={loading}
-                        error={error}
-                        initialState={{
-                            sorting: {
-                                sortModel: [{ field: "source", sort: "asc" }],
-                            },
-                        }}
-                    />
+                    <DataGrid {...dataGridProps} rows={rows} rowCount={rowCount} columns={columns} loading={loading} error={error} />
                 </DataGridContainer>
             </MainContent>
         </TableFilterFinalForm>

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
@@ -195,6 +195,7 @@ export function RedirectsTable({ linkBlock, scope }: Props): JSX.Element {
                 columns={columns}
                 loading={loading}
                 error={error}
+                disableSelectionOnClick
                 components={{ Toolbar: RedirectsTableToolbar }}
             />
         </DataGridContainer>

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
@@ -287,7 +287,7 @@ const IconWrapper = styled("div")`
     flex-direction: row;
 `;
 
-const DataGridContainer = styled("div")(() => ({
-    height: window.innerHeight - 200,
-    width: "100%",
-}));
+const DataGridContainer = styled("div")`
+    height: calc(100vh - 200px);
+    width: 100%;
+`;

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -183,7 +183,7 @@ type Query {
   autoBuildStatus: AutoBuildStatus!
   buildTemplates: [BuildTemplate!]!
   redirects(scope: RedirectScopeInput = {}, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]! @deprecated(reason: "Use paginatedRedirects instead. Will be removed in the next version.")
-  paginatedRedirects(scope: RedirectScopeInput = {}, query: String, type: RedirectGenerationType, active: Boolean, offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC): PaginatedRedirects!
+  paginatedRedirects(scope: RedirectScopeInput = {}, query: String, type: RedirectGenerationType, active: Boolean, sort: [RedirectSort!], offset: Int = 0, limit: Int = 20): PaginatedRedirects!
   redirect(id: ID!): Redirect!
   redirectSourceAvailable(scope: RedirectScopeInput = {}, source: String!): Boolean!
   damFilesList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, folderId: ID, includeArchived: Boolean = false, filter: FileFilterInput): PaginatedDamFiles!
@@ -207,6 +207,17 @@ input RedirectScopeInput {
 enum SortDirection {
   ASC
   DESC
+}
+
+input RedirectSort {
+  field: RedirectSortField!
+  direction: SortDirection = ASC
+}
+
+enum RedirectSortField {
+  source
+  createdAt
+  updatedAt
 }
 
 input FileFilterInput {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -183,7 +183,7 @@ type Query {
   autoBuildStatus: AutoBuildStatus!
   buildTemplates: [BuildTemplate!]!
   redirects(scope: RedirectScopeInput = {}, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]! @deprecated(reason: "Use paginatedRedirects instead. Will be removed in the next version.")
-  paginatedRedirects(scope: RedirectScopeInput = {}, query: String, type: RedirectGenerationType, active: Boolean, sort: [RedirectSort!], offset: Int = 0, limit: Int = 20): PaginatedRedirects!
+  paginatedRedirects(scope: RedirectScopeInput = {}, search: String, filter: RedirectFilter, sort: [RedirectSort!], offset: Int = 0, limit: Int = 20): PaginatedRedirects!
   redirect(id: ID!): Redirect!
   redirectSourceAvailable(scope: RedirectScopeInput = {}, source: String!): Boolean!
   damFilesList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, folderId: ID, includeArchived: Boolean = false, filter: FileFilterInput): PaginatedDamFiles!
@@ -207,6 +207,36 @@ input RedirectScopeInput {
 enum SortDirection {
   ASC
   DESC
+}
+
+input RedirectFilter {
+  generationType: StringFilter
+  active: BooleanFilter
+  createdAt: DateFilter
+  updatedAt: DateFilter
+  and: [RedirectFilter!]
+  or: [RedirectFilter!]
+}
+
+input StringFilter {
+  contains: String
+  startsWith: String
+  endsWith: String
+  equal: String
+  notEqual: String
+}
+
+input BooleanFilter {
+  equal: Boolean
+}
+
+input DateFilter {
+  equal: DateTime
+  lowerThan: DateTime
+  greaterThan: DateTime
+  lowerThanEqual: DateTime
+  greaterThanEqual: DateTime
+  notEqual: DateTime
 }
 
 input RedirectSort {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -173,11 +173,17 @@ enum RedirectGenerationType {
   automatic
 }
 
+type PaginatedRedirects {
+  nodes: [Redirect!]!
+  totalCount: Int!
+}
+
 type Query {
   builds(limit: Float): [Build!]!
   autoBuildStatus: AutoBuildStatus!
   buildTemplates: [BuildTemplate!]!
-  redirects(scope: RedirectScopeInput = {}, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]!
+  redirects(scope: RedirectScopeInput = {}, query: String, type: RedirectGenerationType, active: Boolean, sortColumnName: String, sortDirection: SortDirection = ASC): [Redirect!]! @deprecated(reason: "Use paginatedRedirects instead. Will be removed in the next version.")
+  paginatedRedirects(scope: RedirectScopeInput = {}, query: String, type: RedirectGenerationType, active: Boolean, offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC): PaginatedRedirects!
   redirect(id: ID!): Redirect!
   redirectSourceAvailable(scope: RedirectScopeInput = {}, source: String!): Boolean!
   damFilesList(offset: Int = 0, limit: Int = 20, sortColumnName: String, sortDirection: SortDirection = ASC, folderId: ID, includeArchived: Boolean = false, filter: FileFilterInput): PaginatedDamFiles!

--- a/packages/api/cms-api/src/redirects/dto/paginated-redirects-args.factory.ts
+++ b/packages/api/cms-api/src/redirects/dto/paginated-redirects-args.factory.ts
@@ -1,22 +1,20 @@
 import { Type } from "@nestjs/common";
-import { ArgsType, Field, IntersectionType } from "@nestjs/graphql";
+import { ArgsType, Field } from "@nestjs/graphql";
 import { Type as TransformerType } from "class-transformer";
 import { IsBoolean, IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
 
 import { OffsetBasedPaginationArgs } from "../../common/pagination/offset-based.args";
-import { SortArgs } from "../../common/sorting/sort.args";
-import { SortDirection } from "../../common/sorting/sort-direction.enum";
 import { RedirectGenerationType } from "../redirects.enum";
 import { RedirectScopeInterface } from "../types";
 import { EmptyRedirectScope } from "./empty-redirect-scope";
+import { RedirectSort } from "./redirect.sort";
 
 export interface PaginatedRedirectsArgsInterface {
     scope: RedirectScopeInterface;
     query?: string;
     type?: RedirectGenerationType;
     active?: boolean;
-    sortColumnName?: string;
-    sortDirection?: SortDirection;
+    sort?: RedirectSort[];
     offset: number;
     limit: number;
 }
@@ -24,7 +22,7 @@ export interface PaginatedRedirectsArgsInterface {
 export class PaginatedRedirectsArgsFactory {
     static create({ Scope }: { Scope: Type<RedirectScopeInterface> }): Type<PaginatedRedirectsArgsInterface> {
         @ArgsType()
-        class PaginatedRedirectsArgs extends IntersectionType(OffsetBasedPaginationArgs, SortArgs) implements PaginatedRedirectsArgsInterface {
+        class PaginatedRedirectsArgs extends OffsetBasedPaginationArgs implements PaginatedRedirectsArgsInterface {
             @Field(() => Scope, { defaultValue: Scope === EmptyRedirectScope ? {} : undefined })
             @TransformerType(() => Scope)
             @ValidateNested()
@@ -44,6 +42,11 @@ export class PaginatedRedirectsArgsFactory {
             @IsOptional()
             @IsBoolean()
             active?: boolean;
+
+            @Field(() => [RedirectSort], { nullable: true })
+            @ValidateNested({ each: true })
+            @TransformerType(() => RedirectSort)
+            sort?: RedirectSort[];
         }
         return PaginatedRedirectsArgs;
     }

--- a/packages/api/cms-api/src/redirects/dto/paginated-redirects-args.factory.ts
+++ b/packages/api/cms-api/src/redirects/dto/paginated-redirects-args.factory.ts
@@ -1,0 +1,50 @@
+import { Type } from "@nestjs/common";
+import { ArgsType, Field, IntersectionType } from "@nestjs/graphql";
+import { Type as TransformerType } from "class-transformer";
+import { IsBoolean, IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
+
+import { OffsetBasedPaginationArgs } from "../../common/pagination/offset-based.args";
+import { SortArgs } from "../../common/sorting/sort.args";
+import { SortDirection } from "../../common/sorting/sort-direction.enum";
+import { RedirectGenerationType } from "../redirects.enum";
+import { RedirectScopeInterface } from "../types";
+import { EmptyRedirectScope } from "./empty-redirect-scope";
+
+export interface PaginatedRedirectsArgsInterface {
+    scope: RedirectScopeInterface;
+    query?: string;
+    type?: RedirectGenerationType;
+    active?: boolean;
+    sortColumnName?: string;
+    sortDirection?: SortDirection;
+    offset: number;
+    limit: number;
+}
+
+export class PaginatedRedirectsArgsFactory {
+    static create({ Scope }: { Scope: Type<RedirectScopeInterface> }): Type<PaginatedRedirectsArgsInterface> {
+        @ArgsType()
+        class PaginatedRedirectsArgs extends IntersectionType(OffsetBasedPaginationArgs, SortArgs) implements PaginatedRedirectsArgsInterface {
+            @Field(() => Scope, { defaultValue: Scope === EmptyRedirectScope ? {} : undefined })
+            @TransformerType(() => Scope)
+            @ValidateNested()
+            scope: RedirectScopeInterface;
+
+            @Field({ nullable: true })
+            @IsOptional()
+            @IsString()
+            query?: string;
+
+            @Field(() => RedirectGenerationType, { nullable: true })
+            @IsOptional()
+            @IsEnum(RedirectGenerationType)
+            type?: RedirectGenerationType;
+
+            @Field({ nullable: true })
+            @IsOptional()
+            @IsBoolean()
+            active?: boolean;
+        }
+        return PaginatedRedirectsArgs;
+    }
+}

--- a/packages/api/cms-api/src/redirects/dto/paginated-redirects-args.factory.ts
+++ b/packages/api/cms-api/src/redirects/dto/paginated-redirects-args.factory.ts
@@ -1,19 +1,18 @@
 import { Type } from "@nestjs/common";
 import { ArgsType, Field } from "@nestjs/graphql";
 import { Type as TransformerType } from "class-transformer";
-import { IsBoolean, IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
+import { IsOptional, IsString, ValidateNested } from "class-validator";
 
 import { OffsetBasedPaginationArgs } from "../../common/pagination/offset-based.args";
-import { RedirectGenerationType } from "../redirects.enum";
 import { RedirectScopeInterface } from "../types";
 import { EmptyRedirectScope } from "./empty-redirect-scope";
 import { RedirectSort } from "./redirect.sort";
+import { RedirectFilter } from "./redirects.filter";
 
 export interface PaginatedRedirectsArgsInterface {
     scope: RedirectScopeInterface;
-    query?: string;
-    type?: RedirectGenerationType;
-    active?: boolean;
+    search?: string;
+    filter?: RedirectFilter;
     sort?: RedirectSort[];
     offset: number;
     limit: number;
@@ -31,17 +30,12 @@ export class PaginatedRedirectsArgsFactory {
             @Field({ nullable: true })
             @IsOptional()
             @IsString()
-            query?: string;
+            search?: string;
 
-            @Field(() => RedirectGenerationType, { nullable: true })
-            @IsOptional()
-            @IsEnum(RedirectGenerationType)
-            type?: RedirectGenerationType;
-
-            @Field({ nullable: true })
-            @IsOptional()
-            @IsBoolean()
-            active?: boolean;
+            @Field(() => RedirectFilter, { nullable: true })
+            @ValidateNested()
+            @TransformerType(() => RedirectFilter)
+            filter?: RedirectFilter;
 
             @Field(() => [RedirectSort], { nullable: true })
             @ValidateNested({ each: true })

--- a/packages/api/cms-api/src/redirects/dto/redirect.sort.ts
+++ b/packages/api/cms-api/src/redirects/dto/redirect.sort.ts
@@ -1,0 +1,24 @@
+import { Field, InputType, registerEnumType } from "@nestjs/graphql";
+import { IsEnum } from "class-validator";
+
+import { SortDirection } from "../../common/sorting/sort-direction.enum";
+
+export enum RedirectSortField {
+    source = "source",
+    createdAt = "createdAt",
+    updatedAt = "updatedAt",
+}
+registerEnumType(RedirectSortField, {
+    name: "RedirectSortField",
+});
+
+@InputType()
+export class RedirectSort {
+    @Field(() => RedirectSortField)
+    @IsEnum(RedirectSortField)
+    field: RedirectSortField;
+
+    @Field(() => SortDirection, { defaultValue: SortDirection.ASC })
+    @IsEnum(SortDirection)
+    direction: SortDirection = SortDirection.ASC;
+}

--- a/packages/api/cms-api/src/redirects/dto/redirects.filter.ts
+++ b/packages/api/cms-api/src/redirects/dto/redirects.filter.ts
@@ -1,0 +1,40 @@
+import { Field, InputType } from "@nestjs/graphql";
+import { Type } from "class-transformer";
+import { IsOptional, ValidateNested } from "class-validator";
+
+import { BooleanFilter } from "../../common/filter/boolean.filter";
+import { DateFilter } from "../../common/filter/date.filter";
+import { StringFilter } from "../../common/filter/string.filter";
+
+@InputType()
+export class RedirectFilter {
+    @Field(() => StringFilter, { nullable: true })
+    @IsOptional()
+    @Type(() => StringFilter)
+    generationType?: StringFilter;
+
+    @Field(() => BooleanFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => BooleanFilter)
+    active?: BooleanFilter;
+
+    @Field(() => DateFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => DateFilter)
+    createdAt?: DateFilter;
+
+    @Field(() => DateFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => DateFilter)
+    updatedAt?: DateFilter;
+
+    @Field(() => [RedirectFilter], { nullable: true })
+    @Type(() => RedirectFilter)
+    @ValidateNested({ each: true })
+    and?: RedirectFilter[];
+
+    @Field(() => [RedirectFilter], { nullable: true })
+    @Type(() => RedirectFilter)
+    @ValidateNested({ each: true })
+    or?: RedirectFilter[];
+}

--- a/packages/api/cms-api/src/redirects/redirects.resolver.ts
+++ b/packages/api/cms-api/src/redirects/redirects.resolver.ts
@@ -71,7 +71,7 @@ export function createRedirectsResolver({
             });
         }
 
-        @Query(() => [Redirect])
+        @Query(() => [Redirect], { deprecationReason: "Use paginatedRedirects instead. Will be removed in the next version." })
         async redirects(@Args() { scope, query, type, active, sortColumnName, sortDirection }: RedirectsArgs): Promise<RedirectInterface[]> {
             const where = this.redirectService.getFindCondition({ query, type, active });
             if (hasNonEmptyScope) {

--- a/packages/api/cms-api/src/redirects/redirects.resolver.ts
+++ b/packages/api/cms-api/src/redirects/redirects.resolver.ts
@@ -88,8 +88,8 @@ export function createRedirectsResolver({
         }
 
         @Query(() => PaginatedRedirects)
-        async paginatedRedirects(@Args() { scope, query, type, active, sort, offset, limit }: PaginatedRedirectsArgs): Promise<PaginatedRedirects> {
-            const where = this.redirectService.getFindCondition({ query, type, active });
+        async paginatedRedirects(@Args() { scope, search, filter, sort, offset, limit }: PaginatedRedirectsArgs): Promise<PaginatedRedirects> {
+            const where = this.redirectService.getFindConditionPaginatedRedirects({ search, filter });
             if (hasNonEmptyScope) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (where as any).scope = scope;

--- a/packages/api/cms-api/src/redirects/redirects.resolver.ts
+++ b/packages/api/cms-api/src/redirects/redirects.resolver.ts
@@ -88,9 +88,7 @@ export function createRedirectsResolver({
         }
 
         @Query(() => PaginatedRedirects)
-        async paginatedRedirects(
-            @Args() { scope, query, type, active, sortColumnName, sortDirection, offset, limit }: PaginatedRedirectsArgs,
-        ): Promise<PaginatedRedirects> {
+        async paginatedRedirects(@Args() { scope, query, type, active, sort, offset, limit }: PaginatedRedirectsArgs): Promise<PaginatedRedirects> {
             const where = this.redirectService.getFindCondition({ query, type, active });
             if (hasNonEmptyScope) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -99,8 +97,12 @@ export function createRedirectsResolver({
 
             const options: FindOptions<RedirectInterface> = { offset, limit };
 
-            if (sortColumnName) {
-                options.orderBy = { [sortColumnName]: sortDirection };
+            if (sort) {
+                options.orderBy = sort.map((sortItem) => {
+                    return {
+                        [sortItem.field]: sortItem.direction,
+                    };
+                });
             }
 
             const [entities, totalCount] = await this.repository.findAndCount(where, options);

--- a/packages/api/cms-api/src/redirects/redirects.service.ts
+++ b/packages/api/cms-api/src/redirects/redirects.service.ts
@@ -2,8 +2,10 @@ import { EntityRepository, FilterQuery } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { forwardRef, Inject, Injectable } from "@nestjs/common";
 
+import { filtersToMikroOrmQuery, searchToMikroOrmQuery } from "../common/filter/mikro-orm";
 import { PageTreeService } from "../page-tree/page-tree.service";
 import { PageTreeNodeInterface } from "../page-tree/types";
+import { RedirectFilter } from "./dto/redirects.filter";
 import { RedirectInterface } from "./entities/redirect-entity.factory";
 import { RedirectGenerationType, RedirectSourceTypeValues } from "./redirects.enum";
 import { REDIRECTS_LINK_BLOCK, RedirectsLinkBlock } from "./redirects.module";
@@ -49,6 +51,20 @@ export class RedirectsService {
         } else {
             return filterConditions;
         }
+    }
+
+    getFindConditionPaginatedRedirects(options: { search?: string; filter?: RedirectFilter }): FilterQuery<RedirectInterface> {
+        const andFilters = [];
+
+        if (options.search) {
+            andFilters.push(searchToMikroOrmQuery(options.search, ["source"]));
+        }
+
+        if (options.filter) {
+            andFilters.push(filtersToMikroOrmQuery(options.filter));
+        }
+
+        return andFilters.length > 0 ? { $and: andFilters } : {};
     }
 
     async createAutomaticRedirects(node: PageTreeNodeInterface): Promise<void> {


### PR DESCRIPTION
This adds pagination to the redirects to prevent long loading times in case of a large number of redirects. For compatibility, a new query `paginatedRedirects` was added and the old query `redirects` was marked as deprecated. Further, the table for the redirects in the demo was replaced by `DataGrid` and a basic `DataGrid` styling was added to the `admin-theme` package.

![Screenshot 2022-12-20 at 10 23 55](https://user-images.githubusercontent.com/24371358/208631347-66c15660-fd69-41a0-bc16-41543ae83f50.png)
![Screenshot 2022-12-20 at 10 23 42](https://user-images.githubusercontent.com/24371358/208631358-ad5c7b14-17ca-40ab-bb15-8c742fba346c.png)

