### PR TITLE
Make preview refactoring backwards compatible

### DIFF
--- a/packages/admin/blocks-admin/src/iframebridge/IFrameMessage.ts
+++ b/packages/admin/blocks-admin/src/iframebridge/IFrameMessage.ts
@@ -1,11 +1,20 @@
 // Same file in admin and site
 
 // Messages sent from iFrame -> Admin
+import { ExternalLinkBlockData } from "../blocks.generated";
 
 export enum IFrameMessageType {
     Ready = "Ready",
     SelectComponent = "SelectComponent",
     HoverComponent = "HoverComponent",
+    /**
+     * @deprecated Use SitePreviewIFrameMessageType.OpenLink instead
+     */
+    OpenLink = "OpenLink",
+    /**
+     * @deprecated Use SitePreviewIFrameMessageType.SitePreviewLocation instead
+     */
+    SitePreviewLocation = "SitePreviewLocation",
 }
 
 export interface IReadyIFrameMessage {
@@ -19,6 +28,24 @@ export interface IFrameSelectComponentMessage {
     };
 }
 
+/**
+ * @deprecated Use SitePreviewIFrameOpenLinkMessage instead
+ */
+export interface IFrameOpenLinkMessage {
+    cometType: IFrameMessageType.OpenLink;
+    data: {
+        link: ExternalLinkBlockData;
+    };
+}
+
+/**
+ * @deprecated Use SitePreviewIFrameLocationMessage instead
+ */
+export interface IFrameLocationMessage {
+    cometType: IFrameMessageType.SitePreviewLocation;
+    data: Pick<Location, "search" | "pathname">;
+}
+
 export interface IFrameHoverComponentMessage {
     cometType: IFrameMessageType.HoverComponent;
     data: {
@@ -26,7 +53,12 @@ export interface IFrameHoverComponentMessage {
     };
 }
 
-export type IFrameMessage = IReadyIFrameMessage | IFrameSelectComponentMessage | IFrameHoverComponentMessage;
+export type IFrameMessage =
+    | IReadyIFrameMessage
+    | IFrameSelectComponentMessage
+    | IFrameOpenLinkMessage
+    | IFrameLocationMessage
+    | IFrameHoverComponentMessage;
 
 // Messages sent from Admin -> iFrame
 export enum AdminMessageType {

--- a/packages/admin/blocks-admin/src/index.ts
+++ b/packages/admin/blocks-admin/src/index.ts
@@ -71,6 +71,7 @@ export type {
     IAdminBlockMessage,
     IAdminHoverComponentMessage,
     IAdminSelectComponentMessage,
+    IFrameLocationMessage,
     IFrameMessage,
     IFrameSelectComponentMessage,
     IReadyIFrameMessage,

--- a/packages/site/cms-site/src/iframebridge/IFrameBridge.tsx
+++ b/packages/site/cms-site/src/iframebridge/IFrameBridge.tsx
@@ -11,6 +11,10 @@ export interface IFrameBridgeContext {
     hoveredAdminRoute?: string;
     sendSelectComponent: (id: string) => void;
     sendHoverComponent: (route: string | null) => void;
+    /**
+     * @deprecated Use sendSitePreviewIFrameMessage instead
+     */
+    sendMessage: (message: IFrameMessage) => void;
     showOutlines: boolean;
 }
 
@@ -22,6 +26,9 @@ export const IFrameBridgeContext = React.createContext<IFrameBridgeContext>({
     },
     sendHoverComponent: () => {
         // empty
+    },
+    sendMessage: () => {
+        //empty
     },
 });
 
@@ -119,6 +126,7 @@ export const IFrameBridgeProvider: React.FunctionComponent = ({ children }) => {
                 sendHoverComponent: (route: string | null) => {
                     sendMessage({ cometType: IFrameMessageType.HoverComponent, data: { route } });
                 },
+                sendMessage,
             }}
         >
             <div

--- a/packages/site/cms-site/src/iframebridge/IFrameMessage.ts
+++ b/packages/site/cms-site/src/iframebridge/IFrameMessage.ts
@@ -1,11 +1,20 @@
 // Same file in admin and site
 
 // Messages sent from iFrame -> Admin
+import { ExternalLinkBlockData } from "../blocks.generated";
 
 export enum IFrameMessageType {
     Ready = "Ready",
     SelectComponent = "SelectComponent",
     HoverComponent = "HoverComponent",
+    /**
+     * @deprecated Use SitePreviewIFrameMessageType.OpenLink instead
+     */
+    OpenLink = "OpenLink",
+    /**
+     * @deprecated Use SitePreviewIFrameMessageType.SitePreviewLocation instead
+     */
+    SitePreviewLocation = "SitePreviewLocation",
 }
 
 export interface IReadyIFrameMessage {
@@ -19,6 +28,24 @@ export interface IFrameSelectComponentMessage {
     };
 }
 
+/**
+ * @deprecated Use SitePreviewIFrameOpenLinkMessage instead
+ */
+export interface IFrameOpenLinkMessage {
+    cometType: IFrameMessageType.OpenLink;
+    data: {
+        link: ExternalLinkBlockData;
+    };
+}
+
+/**
+ * @deprecated Use SitePreviewIFrameLocationMessage instead
+ */
+export interface IFrameLocationMessage {
+    cometType: IFrameMessageType.SitePreviewLocation;
+    data: Pick<Location, "search" | "pathname">;
+}
+
 export interface IFrameHoverComponentMessage {
     cometType: IFrameMessageType.HoverComponent;
     data: {
@@ -26,7 +53,12 @@ export interface IFrameHoverComponentMessage {
     };
 }
 
-export type IFrameMessage = IReadyIFrameMessage | IFrameSelectComponentMessage | IFrameHoverComponentMessage;
+export type IFrameMessage =
+    | IReadyIFrameMessage
+    | IFrameSelectComponentMessage
+    | IFrameOpenLinkMessage
+    | IFrameLocationMessage
+    | IFrameHoverComponentMessage;
 
 // Messages sent from Admin -> iFrame
 export enum AdminMessageType {

--- a/packages/site/cms-site/src/index.ts
+++ b/packages/site/cms-site/src/index.ts
@@ -22,6 +22,8 @@ export { /** @deprecated use parsePreviewState instead */ parsePreviewParams as 
 export { parsePreviewParams } from "./preview/utils";
 export { PreviewSkeleton } from "./previewskeleton/PreviewSkeleton";
 export { useRouter } from "./router/useRouter";
+export { sendSitePreviewIFrameMessage } from "./sitePreview/iframebridge/sendSitePreviewIFrameMessage";
+export { SitePreviewIFrameMessageType } from "./sitePreview/iframebridge/SitePreviewIFrameMessage";
 export { SitePreviewPage } from "./sitePreview/SitePreviewPage";
 export {
     /** @deprecated use SitePreviewPage instead */

--- a/packages/site/cms-site/src/sitePreview/SitePreviewPage.tsx
+++ b/packages/site/cms-site/src/sitePreview/SitePreviewPage.tsx
@@ -1,6 +1,7 @@
 import { signIn, useSession } from "next-auth/client";
 import * as React from "react";
 
+import { IFrameBridgeContext } from "../iframebridge/IFrameBridge";
 import { SitePreviewProvider } from "./SitePreviewProvider";
 
 interface SitePreviewPageProps {
@@ -59,5 +60,24 @@ export const SitePreviewPage: React.FunctionComponent<SitePreviewPageProps> = ({
         return <>{initializeServiceWorker}</>;
     }
 
-    return <SitePreviewProvider previewPath="/preview">{children}</SitePreviewProvider>;
+    return (
+        // Legacy context for deprecated IFrameBridge.sendMessage method. Remove in a future version.
+        <IFrameBridgeContext.Provider
+            value={{
+                hasBridge: true,
+                showOutlines: false,
+                sendSelectComponent: () => {
+                    // noop
+                },
+                sendHoverComponent: () => {
+                    // noop
+                },
+                sendMessage: (message) => {
+                    window.parent.postMessage(JSON.stringify(message), "*");
+                },
+            }}
+        >
+            <SitePreviewProvider previewPath="/preview">{children}</SitePreviewProvider>
+        </IFrameBridgeContext.Provider>
+    );
 };


### PR DESCRIPTION
The [preview refactoring](https://github.com/vivid-planet/comet/pull/884) removed some functionality from the public API that was used in some of our apps. This change re-introduces this functionality to allow updating without having to change application code.