### PR TITLE
Disable test report for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
             - name: Test Report
               uses: dorny/test-reporter@v1
-              if: success() || failure()
+              if: success() || failure() && ${{ github.actor != 'dependabot[bot]' }}
               with:
                   name: Tests
                   path: packages/**/junit.xml


### PR DESCRIPTION
The token used for Dependabot PRs is read-only (see discussion [here](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544)), which causes the creation of the test report checks to fail. We therefore disable the test report.