### PR TITLE
DAM: Explicitly handle application/x-zip-compressed Mimetype

### DIFF
--- a/packages/admin/cms-admin/src/dam/Table/fileUpload/useFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/fileUpload/useFileUpload.tsx
@@ -107,13 +107,17 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
         const acceptedMimetypes = options.acceptedMimetypes ?? allAcceptedMimeTypes;
 
         acceptedMimetypes.forEach((mimetype) => {
-            const extensions = mimedb[mimetype]?.extensions;
-            if (extensions) {
-                acceptObj[mimetype] = extensions.map((extension) => `.${extension}`);
+            let extensions: readonly string[] | undefined;
+            if (mimetype === "application/x-zip-compressed") {
+                // zip files in Windows, not supported by mime-db
+                // see https://github.com/jshttp/mime-db/issues/245
+                extensions = ["zip"];
+            } else {
+                extensions = mimedb[mimetype]?.extensions;
             }
 
-            if (mimetype === "application/x-zip-compressed") {
-                acceptObj[mimetype] = [".zip"];
+            if (extensions) {
+                acceptObj[mimetype] = extensions.map((extension) => `.${extension}`);
             }
         });
 

--- a/packages/admin/cms-admin/src/dam/Table/fileUpload/useFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/fileUpload/useFileUpload.tsx
@@ -111,6 +111,10 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
             if (extensions) {
                 acceptObj[mimetype] = extensions.map((extension) => `.${extension}`);
             }
+
+            if (mimetype === "application/x-zip-compressed") {
+                acceptObj[mimetype] = [".zip"];
+            }
         });
 
         return acceptObj;

--- a/packages/api/cms-api/src/dam/files/dam-upload-file.interceptor.ts
+++ b/packages/api/cms-api/src/dam/files/dam-upload-file.interceptor.ts
@@ -53,7 +53,10 @@ export function DamUploadFileInterceptor(fieldName: string): Type<NestIntercepto
                     }
 
                     const supportedExtensions = mimedb[file.mimetype]?.extensions;
-                    if (supportedExtensions === undefined || !supportedExtensions.includes(extension)) {
+                    if (
+                        (supportedExtensions === undefined || !supportedExtensions.includes(extension)) &&
+                        !(file.mimetype === "application/x-zip-compressed" && extension === "zip")
+                    ) {
                         return cb(
                             new CometValidationException(`File type and extension mismatch: .${extension} and ${file.mimetype} are incompatible`),
                             false,

--- a/packages/api/cms-api/src/dam/files/dam-upload-file.interceptor.ts
+++ b/packages/api/cms-api/src/dam/files/dam-upload-file.interceptor.ts
@@ -52,11 +52,16 @@ export function DamUploadFileInterceptor(fieldName: string): Type<NestIntercepto
                         return cb(new CometValidationException(`Invalid file name: Missing file extension`), false);
                     }
 
-                    const supportedExtensions = mimedb[file.mimetype]?.extensions;
-                    if (
-                        (supportedExtensions === undefined || !supportedExtensions.includes(extension)) &&
-                        !(file.mimetype === "application/x-zip-compressed" && extension === "zip")
-                    ) {
+                    let supportedExtensions: readonly string[] | undefined;
+                    if (file.mimetype === "application/x-zip-compressed") {
+                        // zip files in Windows, not supported by mime-db
+                        // see https://github.com/jshttp/mime-db/issues/245
+                        supportedExtensions = ["zip"];
+                    } else {
+                        supportedExtensions = mimedb[file.mimetype]?.extensions;
+                    }
+
+                    if (supportedExtensions === undefined || !supportedExtensions.includes(extension)) {
                         return cb(
                             new CometValidationException(`File type and extension mismatch: .${extension} and ${file.mimetype} are incompatible`),
                             false,

--- a/packages/api/cms-api/src/public-upload/public-upload-file.interceptor.ts
+++ b/packages/api/cms-api/src/public-upload/public-upload-file.interceptor.ts
@@ -49,11 +49,16 @@ export function PublicUploadFileInterceptor(fieldName: string): Type<NestInterce
                         return cb(new CometValidationException(`Invalid file name: Missing file extension`), false);
                     }
 
-                    const supportedExtensions = mimedb[file.mimetype]?.extensions;
-                    if (
-                        (supportedExtensions === undefined || !supportedExtensions.includes(extension)) &&
-                        !(file.mimetype === "application/x-zip-compressed" && extension === "zip")
-                    ) {
+                    let supportedExtensions: readonly string[] | undefined;
+                    if (file.mimetype === "application/x-zip-compressed") {
+                        // zip files in Windows, not supported by mime-db
+                        // see https://github.com/jshttp/mime-db/issues/245
+                        supportedExtensions = ["zip"];
+                    } else {
+                        supportedExtensions = mimedb[file.mimetype]?.extensions;
+                    }
+
+                    if (supportedExtensions === undefined || !supportedExtensions.includes(extension)) {
                         return cb(
                             new CometValidationException(`File type and extension mismatch: .${extension} and ${file.mimetype} are incompatible`),
                             false,

--- a/packages/api/cms-api/src/public-upload/public-upload-file.interceptor.ts
+++ b/packages/api/cms-api/src/public-upload/public-upload-file.interceptor.ts
@@ -50,7 +50,10 @@ export function PublicUploadFileInterceptor(fieldName: string): Type<NestInterce
                     }
 
                     const supportedExtensions = mimedb[file.mimetype]?.extensions;
-                    if (supportedExtensions === undefined || !supportedExtensions.includes(extension)) {
+                    if (
+                        (supportedExtensions === undefined || !supportedExtensions.includes(extension)) &&
+                        !(file.mimetype === "application/x-zip-compressed" && extension === "zip")
+                    ) {
                         return cb(
                             new CometValidationException(`File type and extension mismatch: .${extension} and ${file.mimetype} are incompatible`),
                             false,


### PR DESCRIPTION

- on Windows .zip Files have the mimetype `application/x-zip-compressed`. This type is not supported by mimedb (https://github.com/jshttp/mime-db/issues/245), therefore it must be handled explicitly.