### PR TITLE
Fix path to preview path conversion during SSR

### DIFF
--- a/packages/site/cms-site/src/preview/utils.spec.ts
+++ b/packages/site/cms-site/src/preview/utils.spec.ts
@@ -16,7 +16,7 @@ describe("Preview utils", () => {
     it("Should create preview path for string path", () => {
         const path = "/main";
 
-        const result = createPathToPreviewPath({ path, previewPath, previewParams, baseUrl: "https://admin.com" });
+        const result = createPathToPreviewPath({ path, previewPath, previewParams });
 
         expect(result).toEqual(`${previewPath}${path}?__preview=%7B%22includeInvisibleBlocks%22%3Afalse%7D`);
     });
@@ -24,7 +24,7 @@ describe("Preview utils", () => {
     it("Should create preview path for string path with query params", () => {
         const path = "/main?query=foo";
 
-        const result = createPathToPreviewPath({ path, previewPath, previewParams, baseUrl: "https://admin.com" });
+        const result = createPathToPreviewPath({ path, previewPath, previewParams });
 
         expect(result).toEqual(`${previewPath}${path}&__preview=%7B%22includeInvisibleBlocks%22%3Afalse%7D`);
     });
@@ -39,7 +39,7 @@ describe("Preview utils", () => {
             query,
         };
 
-        const result = createPathToPreviewPath({ path, previewPath, previewParams, baseUrl: "https://admin.com" });
+        const result = createPathToPreviewPath({ path, previewPath, previewParams });
 
         expect(result).toEqual({
             ...path,

--- a/packages/site/cms-site/src/preview/utils.ts
+++ b/packages/site/cms-site/src/preview/utils.ts
@@ -31,15 +31,14 @@ export function createPathToPreviewPath({
     path,
     previewPath,
     previewParams,
-    baseUrl,
 }: {
     path: Url;
     previewPath: string;
     previewParams: SitePreviewParams;
-    baseUrl: string;
 }): Url {
     if (typeof path === "string") {
-        const { pathname, searchParams } = new URL(`${previewPath}${path}`, baseUrl);
+        const [pathname, search] = `${previewPath}${path}`.split("?");
+        const searchParams = new URLSearchParams(search);
 
         searchParams.append("__preview", JSON.stringify(previewParams));
 

--- a/packages/site/cms-site/src/sitePreview/SitePreviewProvider.tsx
+++ b/packages/site/cms-site/src/sitePreview/SitePreviewProvider.tsx
@@ -37,30 +37,24 @@ export const SitePreviewProvider: React.FunctionComponent<Props> = ({ children, 
     // maps the original-path to the preview-path
     const pathToPreviewPath = React.useCallback(
         (path: Url) => {
-            return createPathToPreviewPath({ path, previewPath, previewParams, baseUrl: window.location.origin });
+            return createPathToPreviewPath({ path, previewPath, previewParams });
         },
         [previewPath, previewParams],
     );
     const previewPathToPath = React.useCallback(
         (previewUrl: string) => {
             // Parse url
-            const { pathname, searchParams } = new URL(previewUrl, window.location.origin);
+            const [pathname, search] = previewUrl.split("?");
 
             // remove previewPath Prefix e.g. '/preview' from path
-            const replaceRegex = new RegExp(`^${previewPath}`);
+            const newPathname = pathname.replace(new RegExp(`^${previewPath}`), "");
 
             // remove __preview query parameter from searchParams
-            searchParams.delete("__preview");
+            const newSearchParams = new URLSearchParams(search);
+            newSearchParams.delete("__preview");
+            const newSearch = newSearchParams.toString();
 
-            // Create new Url
-            const newUrl = new URL(pathname.replace(replaceRegex, ""), window.location.origin);
-
-            // copy search params to newUrl
-            searchParams.forEach((value, key) => {
-                newUrl.searchParams.set(key, value);
-            });
-
-            return `${newUrl.pathname}${newUrl.search}`;
+            return `${newPathname.length === 0 ? "/" : newPathname}${newSearch.length === 0 ? "" : `?${newSearch}`}`;
         },
         [previewPath],
     );


### PR DESCRIPTION
The `pathToPreviewPath` and `previewPathToPath` functions relied on the window object, which is not available during server-side rendering. We fix this by using `URLSearchParams` instead of `URL` (which does not support relative URLs) and building the URL ourselves.