### PR TITLE
Redirects: Add missing source field to filter

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -396,6 +396,7 @@ enum SlugAvailability {
 
 input RedirectFilter {
   generationType: StringFilter
+  source: StringFilter
   active: BooleanFilter
   createdAt: DateFilter
   updatedAt: DateFilter

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -211,6 +211,7 @@ enum SortDirection {
 
 input RedirectFilter {
   generationType: StringFilter
+  source: StringFilter
   active: BooleanFilter
   createdAt: DateFilter
   updatedAt: DateFilter

--- a/packages/api/cms-api/src/redirects/dto/redirects.filter.ts
+++ b/packages/api/cms-api/src/redirects/dto/redirects.filter.ts
@@ -13,6 +13,11 @@ export class RedirectFilter {
     @Type(() => StringFilter)
     generationType?: StringFilter;
 
+    @Field(() => StringFilter, { nullable: true })
+    @IsOptional()
+    @Type(() => StringFilter)
+    source?: StringFilter;
+
     @Field(() => BooleanFilter, { nullable: true })
     @ValidateNested()
     @Type(() => BooleanFilter)


### PR DESCRIPTION
Filtering for source at the redirects table caused an error as source was missing in the filter arguments.