### PR TITLE
Fix GraphQL Schema Generation

### DIFF
--- a/packages/api/cms-api/generate-schema.ts
+++ b/packages/api/cms-api/generate-schema.ts
@@ -6,6 +6,7 @@ import { printSchema } from "graphql";
 
 import {
     BuildsResolver,
+    createAuthResolver,
     createPageTreeResolver,
     createRedirectsResolver,
     CurrentUserInterface,
@@ -18,7 +19,6 @@ import {
     PageTreeNodeBase,
     PageTreeNodeCategory,
 } from "./src";
-import { createAuthResolver } from "./src/auth/auth.resolver";
 import { BuildTemplatesResolver } from "./src/builds/build-templates.resolver";
 import { DamItemsResolver } from "./src/dam/files/dam-items.resolver";
 import { RedirectInputFactory } from "./src/redirects/dto/redirect-input.factory";
@@ -82,7 +82,7 @@ async function generateSchema(): Promise<void> {
         PageTreeNode,
         Documents: [Page],
     }); // no scope
-    const AuthResolver = createAuthResolver(CurrentUser);
+    const AuthResolver = createAuthResolver({ currentUser: CurrentUser });
 
     const schema = await gqlSchemaFactory.create([
         BuildsResolver,


### PR DESCRIPTION
Previously:

Schema generation failed because import and usage of `createAuthResolver()` was wrong

<img width="1172" alt="Bildschirmfoto 2023-01-17 um 11 08 44" src="https://user-images.githubusercontent.com/13380047/212870612-d545c455-73aa-473c-b1d8-2eb62e9d5a38.png">


Now:

Schema generation works again

<img width="1006" alt="Bildschirmfoto 2023-01-17 um 11 10 05" src="https://user-images.githubusercontent.com/13380047/212870644-cb0e18a5-c534-4358-a0c4-317b5b3a5156.png">

