### PR TITLE
Redirects: Extend Validation

### DIFF
--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -108,7 +108,10 @@ export const RedirectForm = ({ mode, id, linkBlock, scope }: Props): JSX.Element
     const validateSource = async (value: string, allValues: GQLRedirectDetailFragment) => {
         if (allValues.sourceType === "path") {
             if (!value.startsWith("/")) {
-                return intl.formatMessage({ id: "comet.pages.redirects.validate.path.error", defaultMessage: "Needs to start with /" });
+                return <FormattedMessage id="comet.pages.redirects.validate.path.error" defaultMessage="Needs to start with /" />;
+            }
+            if (value.includes("?")) {
+                return <FormattedMessage id="comet.pages.redirects.validate.path.queryStringError" defaultMessage="Must not contain ?" />;
             }
 
             const { data } = await client.query<GQLRedirectSourceAvailableQuery, GQLRedirectSourceAvailableQueryVariables>({
@@ -121,6 +124,7 @@ export const RedirectForm = ({ mode, id, linkBlock, scope }: Props): JSX.Element
                     scope,
                     source: value,
                 },
+                fetchPolicy: "network-only",
             });
 
             if (!data.redirectSourceAvailable && initialValues?.source !== undefined && initialValues.source !== value) {

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -109,9 +109,10 @@ export const RedirectForm = ({ mode, id, linkBlock, scope }: Props): JSX.Element
         if (allValues.sourceType === "path") {
             if (!value.startsWith("/")) {
                 return <FormattedMessage id="comet.pages.redirects.validate.path.error" defaultMessage="Needs to start with /" />;
-            }
-            if (value.includes("?")) {
+            } else if (value.includes("?")) {
                 return <FormattedMessage id="comet.pages.redirects.validate.path.queryStringError" defaultMessage="Must not contain ?" />;
+            } else if (!/^\/([a-zA-Z0-9-._~/]|%[0-9a-fA-F]{2})+$/.test(value)) {
+                return <FormattedMessage id="comet.pages.redirects.validate.path.invalidPathError" defaultMessage="Invalid path" />;
             }
 
             const { data } = await client.query<GQLRedirectSourceAvailableQuery, GQLRedirectSourceAvailableQueryVariables>({

--- a/packages/api/cms-api/src/redirects/redirects.service.ts
+++ b/packages/api/cms-api/src/redirects/redirects.service.ts
@@ -9,6 +9,7 @@ import { RedirectFilter } from "./dto/redirects.filter";
 import { RedirectInterface } from "./entities/redirect-entity.factory";
 import { RedirectGenerationType, RedirectSourceTypeValues } from "./redirects.enum";
 import { REDIRECTS_LINK_BLOCK, RedirectsLinkBlock } from "./redirects.module";
+import { RedirectScopeInterface } from "./types";
 
 @Injectable()
 export class RedirectsService {
@@ -97,5 +98,10 @@ export class RedirectsService {
         for (const childNode of childNodes) {
             await this.createAutomaticRedirects(childNode);
         }
+    }
+
+    async isRedirectSourceAvailable(source: string, scope: RedirectScopeInterface | undefined, options?: { excludedId?: string }): Promise<boolean> {
+        const redirect = await this.repository.findOne({ source, scope, id: { $ne: options?.excludedId } });
+        return redirect === null;
     }
 }

--- a/packages/api/cms-api/src/redirects/validators/isValidRedirectSource.ts
+++ b/packages/api/cms-api/src/redirects/validators/isValidRedirectSource.ts
@@ -1,3 +1,4 @@
+import { Injectable } from "@nestjs/common";
 import { isURL, registerDecorator, ValidationOptions, ValidatorConstraint, ValidatorConstraintInterface } from "class-validator";
 
 import { RedirectValidationArguments } from "../dto/redirect-input.factory";
@@ -15,13 +16,14 @@ export const IsValidRedirectSource = (validationOptions?: ValidationOptions) => 
     };
 };
 
+@Injectable()
 @ValidatorConstraint({ name: "IsValidRedirectSource", async: true })
 export class IsValidRedirectSourceConstraint implements ValidatorConstraintInterface {
     async validate(value: string, validationArguments: RedirectValidationArguments): Promise<boolean> {
         const sourceType = validationArguments.object.sourceType;
 
         if (sourceType === RedirectSourceTypeValues.path) {
-            return value.startsWith("/");
+            return value.startsWith("/") && !value.includes("?");
         } else {
             return isURL(value);
         }

--- a/packages/api/cms-api/src/redirects/validators/isValidRedirectSource.ts
+++ b/packages/api/cms-api/src/redirects/validators/isValidRedirectSource.ts
@@ -23,7 +23,7 @@ export class IsValidRedirectSourceConstraint implements ValidatorConstraintInter
         const sourceType = validationArguments.object.sourceType;
 
         if (sourceType === RedirectSourceTypeValues.path) {
-            return value.startsWith("/") && !value.includes("?");
+            return /^\/([a-zA-Z0-9-._~/]|%[0-9a-fA-F]{2})+$/.test(value);
         } else {
             return isURL(value);
         }


### PR DESCRIPTION
- Prevent query strings (`?`) in redirect sources
- Prevent duplicate redirect sources on the server-side
- Set RedirectSourceAvailable fetchPolicy to `network-only` (otherwise it was possible to add two redirects with the same source after another)