### PR TITLE
Fix Type Incompatibility With @mui/material@5.11

### DIFF
--- a/packages/admin/cms-admin/src/documents/types.ts
+++ b/packages/admin/cms-admin/src/documents/types.ts
@@ -42,7 +42,7 @@ export interface DocumentInterface<
     editComponent?: React.ComponentType<{ id: string; category: string }>;
     updateMutation?: TypedDocumentNode<GQLUpdatePageMutation, GQLUpdatePageMutationVariables<DocumentInput>>;
     inputToOutput?: (input: DocumentInput, context: { idsMap: IdsMap }) => DocumentOutput;
-    menuIcon: (props: SvgIconProps<"svg">) => JSX.Element;
-    hideInMenuIcon?: (props: SvgIconProps<"svg">) => JSX.Element;
+    menuIcon: (props: SvgIconProps<"svg">) => JSX.Element | null;
+    hideInMenuIcon?: (props: SvgIconProps<"svg">) => JSX.Element | null;
     InfoTag?: React.ComponentType<{ page: PageTreePage }>;
 }

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTypeIcon.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTypeIcon.tsx
@@ -14,7 +14,7 @@ export function PageTypeIcon({ page, disabled }: PageTypeIconProps): JSX.Element
     let iconColor: SvgIconProps["color"] = "primary";
     const { documentTypes } = usePageTreeContext();
     const documentType = documentTypes[page.documentType];
-    let Icon: (props: SvgIconProps<"svg">) => JSX.Element;
+    let Icon: (props: SvgIconProps<"svg">) => JSX.Element | null;
 
     if (page.slug === "home") {
         Icon = Home;


### PR DESCRIPTION

In 5.11, Muis `OverridableComponent` is changed to allow returning `JSX.Element | null` (see https://github.com/mui/material-ui/pull/35311).
That lead to a compatibility issue with Comet's `DocumentInterface`.