### PR TITLE
DAM: Improve File Upload Performance

### DIFF
--- a/packages/admin/cms-admin/src/dam/Table/fileUpload/useFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/fileUpload/useFileUpload.tsx
@@ -228,11 +228,13 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
                     const parentId = folderIdMap.has(parentPath) ? folderIdMap.get(parentPath) : currFolderId;
 
                     if (!noLookup) {
-                        const id = lookupCache.has(`${folderName}:${parentId}`)
-                            ? lookupCache.get(`${folderName}:${parentId}`)
-                            : await lookupDamFolder(folderName, parentId);
-
-                        lookupCache.set(`${folderName}:${parentId}`, id);
+                        let id: string | undefined;
+                        if (lookupCache.has(`${folderName}:${parentId}`)) {
+                            id = lookupCache.get(`${folderName}:${parentId}`);
+                        } else {
+                            id = await lookupDamFolder(folderName, parentId);
+                            lookupCache.set(`${folderName}:${parentId}`, id);
+                        }
 
                         if (id === undefined) {
                             // paths are looked up hierarchically starting with the first folder e.g.

--- a/packages/admin/cms-admin/src/dam/Table/fileUpload/useFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/fileUpload/useFileUpload.tsx
@@ -174,7 +174,7 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
                     name: folderName,
                     parentId: parentId,
                 },
-                fetchPolicy: "no-cache",
+                fetchPolicy: "network-only",
             });
 
             return data.damFolder?.id;

--- a/packages/admin/cms-admin/src/dam/Table/fileUpload/useFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/fileUpload/useFileUpload.tsx
@@ -130,10 +130,10 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
     const [validationErrors, setValidationErrors] = React.useState<FileUploadValidationError[] | undefined>();
     const [errorDialogOpen, setErrorDialogOpen] = React.useState<boolean>(false);
     const [totalSizes, setTotalSizes] = React.useState<{ [key: string]: number }>({});
-    const [loadedSizes, setLoadedSizes] = React.useState<{ [key: string]: number }>({});
+    const [uploadedSizes, setUploadedSizes] = React.useState<{ [key: string]: number }>({});
 
     const totalSize = Object.values(totalSizes).length > 0 ? Object.values(totalSizes).reduce((prev, curr) => prev + curr, 0) : undefined;
-    const loadedSize = Object.values(loadedSizes).length > 0 ? Object.values(loadedSizes).reduce((prev, curr) => prev + curr, 0) : undefined;
+    const uploadedSize = Object.values(uploadedSizes).length > 0 ? Object.values(uploadedSizes).reduce((prev, curr) => prev + curr, 0) : undefined;
 
     const maxFileSizeInMegabytes = parseInt(context.damConfig.maxFileSize);
     const maxFileSizeInBytes = maxFileSizeInMegabytes * 1024 * 1024;
@@ -146,12 +146,8 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
         });
     };
 
-    const addTotalSize = (path: string, value: number) => {
-        setTotalSizes((prev) => ({ ...prev, [path]: value }));
-    };
-
     const updateLoadedSize = (path: string, value: number) => {
-        setLoadedSizes((prev) => ({ ...prev, [path]: value }));
+        setUploadedSizes((prev) => ({ ...prev, [path]: value }));
     };
 
     const generateValidationErrorsForRejectedFiles = React.useCallback(
@@ -208,6 +204,7 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
     const createInitialFolderIdMap = React.useCallback(
         async (files: FileWithFolderPath[], currFolderId?: string) => {
             const folderIdMap = new Map<string, string>();
+            const lookupCache = new Map<string, string | undefined>();
 
             for (const file of files) {
                 let noLookup = false;
@@ -231,8 +228,11 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
                     const parentId = folderIdMap.has(parentPath) ? folderIdMap.get(parentPath) : currFolderId;
 
                     if (!noLookup) {
-                        // parentId cannot be null because then noLookup would be true
-                        const id = await lookupDamFolder(folderName, parentId);
+                        const id = lookupCache.has(`${folderName}:${parentId}`)
+                            ? lookupCache.get(`${folderName}:${parentId}`)
+                            : await lookupDamFolder(folderName, parentId);
+
+                        lookupCache.set(`${folderName}:${parentId}`, id);
 
                         if (id === undefined) {
                             // paths are looked up hierarchically starting with the first folder e.g.
@@ -358,9 +358,11 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
             const filesWithFolderPaths = await addFolderPathToFiles(acceptedFiles);
             let folderIdMap = await createInitialFolderIdMap(filesWithFolderPaths, folderId);
 
+            const fileSizes: { [key: string]: number } = {};
             for (const file of filesWithFolderPaths) {
-                addTotalSize(file.path ?? "", file.size);
+                fileSizes[file.path ?? ""] = file.size;
             }
+            setTotalSizes(fileSizes);
 
             const filesToUpload = await handleDuplicatedFilenames(filesWithFolderPaths, folderId, folderIdMap);
 
@@ -418,7 +420,7 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
             setErrorDialogOpen(true);
         }
         setTotalSizes({});
-        setLoadedSizes({});
+        setUploadedSizes({});
         options.onAfterUpload?.(errorOccurred);
 
         addNewlyUploadedFileIds(uploadedFileIds);
@@ -438,7 +440,7 @@ export const useFileUpload = (options: UploadFileOptions): FileUploadApi => {
                         setErrorDialogOpen(false);
                     }}
                 />
-                <ProgressDialog open={progressDialogOpen} totalSize={totalSize} loadedSize={loadedSize} />
+                <ProgressDialog open={progressDialogOpen} totalSize={totalSize} loadedSize={uploadedSize} />
             </>
         ),
         dropzoneConfig: {


### PR DESCRIPTION
- add lookupCache to cache if folders already exists (the Apollo cache wasn't used because the query results should be as new as possible, meaning the results should only be cached within the `createInitialFolderIdMap()` function)
- generate a `fileSizes` object and save it to the state once (previously, the state was updated for every file resulting in long waiting time)
- rename `loadedSize` to `uploadedSize` because its more understandable