### PR TITLE
Pin class-validator to 0.13.2

### DIFF
--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -45,7 +45,7 @@
         "async": "^3.0.0",
         "base64url": "^3.0.0",
         "class-transformer": "^0.5.0",
-        "class-validator": "^0.14.0",
+        "class-validator": "0.13.2",
         "commander": "^8.0.0",
         "compression": "^1.0.0",
         "cookie-parser": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "@types/jscodeshift": "^0.11.4",
         "@types/uuid": "^8.3.0",
         "class-transformer": "^0.5.0",
-        "class-validator": "^0.14.0",
+        "class-validator": "0.13.2",
         "dotenv-cli": "^5.1.0",
         "exceljs": "^3.4.0",
         "express": "^4.0.0",

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -42,7 +42,7 @@
         "@comet/admin-theme": "^3.2.2",
         "@comet/blocks-admin": "^3.2.2",
         "@graphql-typed-document-node/core": "^3.1.1",
-        "class-validator": "^0.14.0",
+        "class-validator": "0.13.2",
         "clsx": "^1.1.1",
         "date-fns": "^2.0.0",
         "draft-js": "^0.11.7",

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -62,7 +62,7 @@
         "@nestjs/platform-express": "^9.0.0",
         "@types/get-image-colors": "^4.0.0",
         "base64url": "^3.0.0",
-        "class-validator": "^0.14.0",
+        "class-validator": "0.13.2",
         "commander": "^9.3.0",
         "cron-parser": "^3.0.0",
         "date-fns": "^2.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4852,7 +4852,7 @@ __metadata:
     "@types/react-router": ^5.0.0
     "@types/react-virtualized-auto-sizer": ^1.0.0
     "@types/react-window": ^1.0.0
-    class-validator: ^0.14.0
+    class-validator: 0.13.2
     clsx: ^1.1.1
     date-fns: ^2.0.0
     draft-js: ^0.11.7
@@ -4941,7 +4941,7 @@ __metadata:
     "@types/rimraf": ^3.0.0
     base64url: ^3.0.0
     chokidar-cli: ^2.0.0
-    class-validator: ^0.14.0
+    class-validator: 0.13.2
     commander: ^9.3.0
     cron-parser: ^3.0.0
     date-fns: ^2.28.0
@@ -12440,13 +12440,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/validator@npm:^13.7.10":
-  version: 13.7.10
-  resolution: "@types/validator@npm:13.7.10"
-  checksum: 7b142c08019f484d62c9f3074231f640c24311558f157dd253a60810dd0cb29e41ec64ca210a192b54f6de51f4fe016bfeb2c30f90fa49c9337ed54a9d8e02aa
-  languageName: node
-  linkType: hard
-
 "@types/webpack-env@npm:^1.0.0, @types/webpack-env@npm:^1.16.0":
   version: 1.17.0
   resolution: "@types/webpack-env@npm:1.17.0"
@@ -16211,14 +16204,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"class-validator@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "class-validator@npm:0.14.0"
+"class-validator@npm:0.13.2":
+  version: 0.13.2
+  resolution: "class-validator@npm:0.13.2"
   dependencies:
-    "@types/validator": ^13.7.10
-    libphonenumber-js: ^1.10.14
+    libphonenumber-js: ^1.9.43
     validator: ^13.7.0
-  checksum: f62e4a0ad24cee68f4b2bc70d32b96de90cb598f96bde362b4dbf4234151af8eb6ae225458312a38fc49fa3959844cf61c60e731a8205e9a570454cff8de2710
+  checksum: 0deb4c29faa18345f6989fd7eaaaa07b05caae5298603fcd6485531c6daad503e5d2b24cc1342e4fc88ae5ba0acffdc24d0fc333110ef3f21a667cd8a79e1258
   languageName: node
   linkType: hard
 
@@ -16826,7 +16818,7 @@ __metadata:
     async: ^3.0.0
     base64url: ^3.0.0
     class-transformer: ^0.5.0
-    class-validator: ^0.14.0
+    class-validator: 0.13.2
     commander: ^8.0.0
     compression: ^1.0.0
     cookie-parser: ^1.0.0
@@ -25828,7 +25820,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libphonenumber-js@npm:^1.10.14":
+"libphonenumber-js@npm:^1.9.43":
   version: 1.10.18
   resolution: "libphonenumber-js@npm:1.10.18"
   checksum: df0a4b8adfb79666636913f6da730ffc3bc037094e35be492d2f7a23ef26754d65a7afa5f64e04f5c5c2883193fa10bd4bea966fd28edcf0c72ddd13bd4b3625
@@ -32305,7 +32297,7 @@ __metadata:
     "@types/jscodeshift": ^0.11.4
     "@types/uuid": ^8.3.0
     class-transformer: ^0.5.0
-    class-validator: ^0.14.0
+    class-validator: 0.13.2
     dotenv-cli: ^5.1.0
     exceljs: ^3.4.0
     express: ^4.0.0


### PR DESCRIPTION
Version 0.14.0 introduces a breaking change (`forbidUnknownValues` is now `true` by default), which doesn't work with empty objects, for instance empty redirect scopes.