### PR TITLE
Fix createCompositeSetting when using an array value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ _tbd_
 
 -   Fix `createRedirect` mutation when no scoping is used
 
+### @comet/blocks-admin
+
+#### Changes
+
+-   Fix `createCompositeSetting` not working when using an array value
+
 ## 3.2.2
 
 _Jan 25, 2023_

--- a/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/createCompositeSetting.spec.ts
+++ b/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/createCompositeSetting.spec.ts
@@ -1,0 +1,14 @@
+import { createCompositeSetting } from "./createCompositeSetting";
+
+describe("createCompositeSetting", () => {
+    it("should work with an array value", () => {
+        const [block] = createCompositeSetting<string[]>({
+            defaultValue: [],
+            AdminComponent: () => {
+                return null;
+            },
+        });
+
+        expect(block.state2Output(["one", "two", "three"])).toEqual(["one", "two", "three"]);
+    });
+});

--- a/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/createSettingsBlock.ts
+++ b/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/createSettingsBlock.ts
@@ -37,7 +37,16 @@ export function createSettingsAnonymousBlock<State>({
     return AnonymousSettingsBlock;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function copy<T = any>(value: T): T {
-    return typeof value === "object" && value !== null ? { ...value } : value;
+function copy<T = unknown>(value: T): T {
+    if (typeof value === "object") {
+        if (value === null) {
+            return value;
+        } else if (Array.isArray(value)) {
+            return [...value] as unknown as T;
+        } else {
+            return { ...value };
+        }
+    } else {
+        return value;
+    }
 }


### PR DESCRIPTION
The `copy` function use for state/input/output transformations incorrectly converted the array to an object.