### PR TITLE
Ignore relation entities during CRUD generation

### DIFF
--- a/packages/api/cms-api/src/generator/generate.ts
+++ b/packages/api/cms-api/src/generator/generate.ts
@@ -12,6 +12,9 @@ const generate = new Command("generate").action(async (options) => {
 
     for (const name in entities) {
         const entity = entities[name];
+        if (!entity.class) {
+            continue;
+        }
         {
             const generatorOptions = Reflect.getMetadata(`data:crudGeneratorOptions`, entity.class) as CrudGeneratorOptions | undefined;
             if (generatorOptions) {

--- a/packages/api/cms-api/src/generator/generate.ts
+++ b/packages/api/cms-api/src/generator/generate.ts
@@ -13,6 +13,7 @@ const generate = new Command("generate").action(async (options) => {
     for (const name in entities) {
         const entity = entities[name];
         if (!entity.class) {
+            // Ignore e.g. relation entities that don't have a class
             continue;
         }
         {


### PR DESCRIPTION
The CRUD generator scans all MikroORM entities to search for eligible entities. MikroORM also provides "entities" for relations (e.g., News_comments), which doesn't have a class on their own. This caused the retrieval of the metadata to fail. To fix this, we add a check to ignore entities that don't have a `class` field.