### PR TITLE
Fix root block scalars for multiple instances of the same block

### DIFF
--- a/packages/api/cms-api/src/blocks/rootBlocks/root-block-data.scalar.spec.ts
+++ b/packages/api/cms-api/src/blocks/rootBlocks/root-block-data.scalar.spec.ts
@@ -1,0 +1,45 @@
+import { NestFactory } from "@nestjs/core";
+import { GraphQLSchemaBuilderModule, GraphQLSchemaFactory, Query } from "@nestjs/graphql";
+
+import { PixelImageBlock } from "../PixelImageBlock";
+import { RootBlockDataScalar } from "./root-block-data.scalar";
+
+let gqlSchemaFactory: GraphQLSchemaFactory;
+
+describe("RootBlockDataScalar", () => {
+    beforeEach(async () => {
+        const app = await NestFactory.create(GraphQLSchemaBuilderModule, { logger: false });
+        await app.init();
+
+        gqlSchemaFactory = app.get(GraphQLSchemaFactory);
+    });
+
+    it("should work", async () => {
+        class DemoResolver {
+            @Query(() => RootBlockDataScalar(PixelImageBlock))
+            image(): void {
+                // noop
+            }
+        }
+
+        const schema = await gqlSchemaFactory.create([DemoResolver]);
+        expect(schema.getType("PixelImageBlockData")).toBeTruthy();
+    });
+
+    it("should work with multiple instances of the same scalar", async () => {
+        class DemoResolver {
+            @Query(() => RootBlockDataScalar(PixelImageBlock))
+            image1(): void {
+                // noop
+            }
+
+            @Query(() => RootBlockDataScalar(PixelImageBlock))
+            image2(): void {
+                // noop
+            }
+        }
+
+        const schema = await gqlSchemaFactory.create([DemoResolver]);
+        expect(schema.getType("PixelImageBlockData")).toBeTruthy();
+    });
+});

--- a/packages/api/cms-api/src/blocks/rootBlocks/root-block-data.scalar.ts
+++ b/packages/api/cms-api/src/blocks/rootBlocks/root-block-data.scalar.ts
@@ -2,11 +2,23 @@ import { Block } from "@comet/blocks-api";
 import { GraphQLScalarType } from "graphql";
 import { GraphQLJSONObject } from "graphql-type-json";
 
+const rootBlockDataScalars = new Map<string, GraphQLScalarType>();
+
 export function RootBlockDataScalar(block: Block): GraphQLScalarType {
-    return new GraphQLScalarType({
+    let scalar = rootBlockDataScalars.get(block.name);
+
+    if (scalar !== undefined) {
+        return scalar;
+    }
+
+    scalar = new GraphQLScalarType({
         ...GraphQLJSONObject,
         specifiedByUrl: undefined,
         name: `${block.name}BlockData`,
         description: `${block.name} root block data`,
     });
+
+    rootBlockDataScalars.set(block.name, scalar);
+
+    return scalar;
 }

--- a/packages/api/cms-api/src/blocks/rootBlocks/root-block-input.scalar.spec.ts
+++ b/packages/api/cms-api/src/blocks/rootBlocks/root-block-input.scalar.spec.ts
@@ -1,0 +1,56 @@
+import { NestFactory } from "@nestjs/core";
+import { Args, GraphQLSchemaBuilderModule, GraphQLSchemaFactory, Mutation, Query } from "@nestjs/graphql";
+
+import { PixelImageBlock } from "../PixelImageBlock";
+import { RootBlockDataScalar } from "./root-block-data.scalar";
+import { RootBlockInputScalar } from "./root-block-input.scalar";
+
+let gqlSchemaFactory: GraphQLSchemaFactory;
+
+describe("RootBlockInputScalar", () => {
+    beforeEach(async () => {
+        const app = await NestFactory.create(GraphQLSchemaBuilderModule, { logger: false });
+        await app.init();
+
+        gqlSchemaFactory = app.get(GraphQLSchemaFactory);
+    });
+
+    it("should work", async () => {
+        class DemoResolver {
+            @Query(() => RootBlockDataScalar(PixelImageBlock))
+            image(): void {
+                // A query is needed for schema generation to work
+            }
+
+            @Mutation(() => Boolean)
+            createImage(@Args({ name: "image", type: () => RootBlockInputScalar(PixelImageBlock) }) image: unknown): void {
+                // noop
+            }
+        }
+
+        const schema = await gqlSchemaFactory.create([DemoResolver]);
+        expect(schema.getType("PixelImageBlockInput")).toBeTruthy();
+    });
+
+    it("should work with multiple instances of the same scalar", async () => {
+        class DemoResolver {
+            @Query(() => RootBlockDataScalar(PixelImageBlock))
+            image(): void {
+                // A query is needed for schema generation to work
+            }
+
+            @Mutation(() => Boolean)
+            createImage1(@Args({ name: "image", type: () => RootBlockInputScalar(PixelImageBlock) }) image: unknown): void {
+                // noop
+            }
+
+            @Mutation(() => Boolean)
+            createImage2(@Args({ name: "image", type: () => RootBlockInputScalar(PixelImageBlock) }) image: unknown): void {
+                // noop
+            }
+        }
+
+        const schema = await gqlSchemaFactory.create([DemoResolver]);
+        expect(schema.getType("PixelImageBlockInput")).toBeTruthy();
+    });
+});

--- a/packages/api/cms-api/src/blocks/rootBlocks/root-block-input.scalar.ts
+++ b/packages/api/cms-api/src/blocks/rootBlocks/root-block-input.scalar.ts
@@ -2,11 +2,23 @@ import { Block } from "@comet/blocks-api";
 import { GraphQLScalarType } from "graphql";
 import { GraphQLJSONObject } from "graphql-type-json";
 
+const rootBlockInputScalars = new Map<string, GraphQLScalarType>();
+
 export function RootBlockInputScalar(block: Block): GraphQLScalarType {
-    return new GraphQLScalarType({
+    let scalar = rootBlockInputScalars.get(block.name);
+
+    if (scalar !== undefined) {
+        return scalar;
+    }
+
+    scalar = new GraphQLScalarType({
         ...GraphQLJSONObject,
         specifiedByUrl: undefined,
         name: `${block.name}BlockInput`,
         description: `${block.name} root block input`,
     });
+
+    rootBlockInputScalars.set(block.name, scalar);
+
+    return scalar;
 }


### PR DESCRIPTION
The `RootBlockDataScalar` and `RootBlockInputScalar` created a new GraphQL scalar type upon each call. This caused multiple scalars with the same name to appear in the GraphQL schema, which caused an error when generating the schema. To fix this, we add a cache to the scalar generation to only create a scalar for a block once.