### PR TITLE
Performance: Remove damPath from block json

### DIFF
--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -251,11 +251,6 @@
                             "nullable": false
                         },
                         {
-                            "name": "damPath",
-                            "kind": "String",
-                            "nullable": false
-                        },
-                        {
                             "name": "fileUrl",
                             "kind": "String",
                             "nullable": false
@@ -1042,11 +1037,6 @@
                             "nullable": true
                         },
                         {
-                            "name": "damPath",
-                            "kind": "String",
-                            "nullable": false
-                        },
-                        {
                             "name": "fileUrl",
                             "kind": "String",
                             "nullable": false
@@ -1461,11 +1451,6 @@
                         {
                             "name": "archived",
                             "kind": "Boolean",
-                            "nullable": false
-                        },
-                        {
-                            "name": "damPath",
-                            "kind": "String",
                             "nullable": false
                         },
                         {

--- a/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { DamVideoBlockData, DamVideoBlockInput } from "../blocks.generated";
+import { DamPathLazy } from "../form/file/DamPathLazy";
 import { FileField } from "../form/file/FileField";
 import { GQLVideoBlockDamFileQuery, GQLVideoBlockDamFileQueryVariables } from "../graphql.generated";
 import { CmsBlockContext } from "./CmsBlockContextProvider";
@@ -50,7 +51,6 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                         title
                         altText
                         archived
-                        damPath
                         fileUrl
                     }
                 }
@@ -103,7 +103,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                                     <Grid item xs>
                                         <Typography variant="subtitle1">{state.damFile.name}</Typography>
                                         <Typography variant="body1" color="textSecondary">
-                                            {state.damFile.damPath}
+                                            <DamPathLazy fileId={state.damFile.id} />
                                         </Typography>
                                     </Grid>
                                 </Grid>

--- a/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
@@ -20,6 +20,7 @@ import { FormattedMessage } from "react-intl";
 import { FileField } from "..";
 import { PixelImageBlockData, PixelImageBlockInput } from "../blocks.generated";
 import { useDamAcceptedMimeTypes } from "../dam/config/useDamAcceptedMimeTypes";
+import { DamPathLazy } from "../form/file/DamPathLazy";
 import { GQLImageBlockDamFileQuery, GQLImageBlockDamFileQueryVariables } from "../graphql.generated";
 import { CmsBlockContext } from "./CmsBlockContextProvider";
 import { EditImageDialog } from "./image/EditImageDialog";
@@ -106,7 +107,6 @@ export const PixelImageBlock: BlockInterface<PixelImageBlockData, ImageBlockStat
                                 y
                             }
                         }
-                        damPath
                         fileUrl
                     }
                 }
@@ -159,7 +159,7 @@ export const PixelImageBlock: BlockInterface<PixelImageBlockData, ImageBlockStat
                                     <Grid item xs>
                                         <Typography variant="subtitle1">{state.damFile.name}</Typography>
                                         <Typography variant="body1" color="textSecondary">
-                                            {state.damFile.damPath}
+                                            <DamPathLazy fileId={state.damFile.id} />
                                         </Typography>
                                     </Grid>
                                     <Grid item>

--- a/packages/admin/cms-admin/src/blocks/SvgImageBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/SvgImageBlock.tsx
@@ -17,6 +17,7 @@ import { FormattedMessage } from "react-intl";
 
 import { FileField, useDamAcceptedMimeTypes } from "..";
 import { SvgImageBlockData, SvgImageBlockInput } from "../blocks.generated";
+import { DamPathLazy } from "../form/file/DamPathLazy";
 import { GQLSvgImageBlockDamFileQuery, GQLSvgImageBlockDamFileQueryVariables } from "../graphql.generated";
 import { CmsBlockContext } from "./CmsBlockContextProvider";
 import { useCmsBlockContext } from "./useCmsBlockContext";
@@ -75,7 +76,6 @@ export const SvgImageBlock: BlockInterface<SvgImageBlockData, SvgImageBlockState
                         title
                         altText
                         archived
-                        damPath
                         fileUrl
                     }
                 }
@@ -109,7 +109,7 @@ export const SvgImageBlock: BlockInterface<SvgImageBlockData, SvgImageBlockState
                                     <Grid item xs>
                                         <Typography variant="subtitle1">{state.damFile.name}</Typography>
                                         <Typography variant="body1" color="textSecondary">
-                                            {state.damFile.damPath}
+                                            <DamPathLazy fileId={state.damFile.id} />
                                         </Typography>
                                     </Grid>
                                 </Grid>

--- a/packages/admin/cms-admin/src/form/file/DamPathLazy.tsx
+++ b/packages/admin/cms-admin/src/form/file/DamPathLazy.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import { GQLDamPathLazyQuery, GQLDamPathLazyQueryVariables } from "../../graphql.generated";
 
-export const damPathLazyQuery = gql`
+const damPathLazyQuery = gql`
     query DamPathLazy($id: ID!) {
         damFile(id: $id) {
             damPath

--- a/packages/admin/cms-admin/src/form/file/DamPathLazy.tsx
+++ b/packages/admin/cms-admin/src/form/file/DamPathLazy.tsx
@@ -1,0 +1,23 @@
+import { gql, useQuery } from "@apollo/client";
+import React from "react";
+
+import { GQLDamPathLazyQuery, GQLDamPathLazyQueryVariables } from "../../graphql.generated";
+
+export const damPathLazyQuery = gql`
+    query DamPathLazy($id: ID!) {
+        damFile(id: $id) {
+            damPath
+        }
+    }
+`;
+
+interface DamPathLazyProps {
+    fileId: string;
+}
+export const DamPathLazy = ({ fileId }: DamPathLazyProps): React.ReactElement => {
+    const { data } = useQuery<GQLDamPathLazyQuery, GQLDamPathLazyQueryVariables>(damPathLazyQuery, { variables: { id: fileId } });
+    if (!data) {
+        return <> </>;
+    }
+    return <>data.damFile.damPath</>;
+};

--- a/packages/admin/cms-admin/src/form/file/FileField.gql.ts
+++ b/packages/admin/cms-admin/src/form/file/FileField.gql.ts
@@ -21,7 +21,6 @@ export const damFileFieldFragment = gql`
                 y
             }
         }
-        damPath
         fileUrl
     }
 `;

--- a/packages/api/cms-api/src/blocks/PixelImageBlock.ts
+++ b/packages/api/cms-api/src/blocks/PixelImageBlock.ts
@@ -54,7 +54,6 @@ class PixelImageBlockData extends BlockData {
                           dominantColor: file.image.dominantColor,
                       }
                     : undefined,
-                damPath: await filesService.getDamPath(file),
                 fileUrl: await filesService.createFileUrl(file, previewDamUrls),
             },
             cropArea: this.cropArea ? { ...this.cropArea } : undefined,
@@ -176,11 +175,6 @@ class Meta extends AnnotationBlockMeta {
                                 ],
                             },
                             nullable: true,
-                        },
-                        {
-                            name: "damPath",
-                            kind: BlockMetaFieldKind.String,
-                            nullable: false,
                         },
                         {
                             name: "fileUrl",

--- a/packages/api/cms-api/src/blocks/SvgImageBlock.ts
+++ b/packages/api/cms-api/src/blocks/SvgImageBlock.ts
@@ -39,7 +39,6 @@ class SvgImageBlockData extends BlockData {
             damFile: {
                 ...data,
                 image: {},
-                damPath: await filesService.getDamPath(file),
                 fileUrl: await filesService.createFileUrl(file, previewDamUrls),
             },
         };
@@ -110,11 +109,6 @@ class Meta extends AnnotationBlockMeta {
                     {
                         name: "archived",
                         kind: BlockMetaFieldKind.Boolean,
-                        nullable: false,
-                    },
-                    {
-                        name: "damPath",
-                        kind: BlockMetaFieldKind.String,
                         nullable: false,
                     },
                     {

--- a/packages/api/cms-api/src/blocks/dam-video.block.ts
+++ b/packages/api/cms-api/src/blocks/dam-video.block.ts
@@ -48,7 +48,6 @@ class DamVideoBlockData extends BlockData {
         return {
             damFile: {
                 ...data,
-                damPath: await filesService.getDamPath(file),
                 fileUrl: await filesService.createFileUrl(file, previewDamUrls),
             },
             autoplay: this.autoplay,
@@ -138,11 +137,6 @@ class Meta extends AnnotationBlockMeta {
                         {
                             name: "archived",
                             kind: BlockMetaFieldKind.Boolean,
-                            nullable: false,
-                        },
-                        {
-                            name: "damPath",
-                            kind: BlockMetaFieldKind.String,
                             nullable: false,
                         },
                         {


### PR DESCRIPTION
- damPath can be relatively expensive to generate (sql query per nested folder)
- used in admin only

Replace it by lazy loading component that does it's own query only in admin