### PR TITLE
Removal of rounding up the image size

### DIFF
--- a/packages/api/cms-api/src/dam/images/images.util.ts
+++ b/packages/api/cms-api/src/dam/images/images.util.ts
@@ -23,8 +23,8 @@ export function getMaxDimensionsFromArea(area: ImageDimensions, aspectRatio: num
     }
 
     return {
-        width: Math.ceil(width),
-        height: Math.ceil(height),
+        width,
+        height,
     };
 }
 

--- a/packages/api/cms-api/src/dam/images/images.util.ts
+++ b/packages/api/cms-api/src/dam/images/images.util.ts
@@ -23,8 +23,8 @@ export function getMaxDimensionsFromArea(area: ImageDimensions, aspectRatio: num
     }
 
     return {
-        width,
-        height,
+        width: Math.ceil(width),
+        height: Math.ceil(height),
     };
 }
 

--- a/packages/site/cms-site/src/image/Image.tsx
+++ b/packages/site/cms-site/src/image/Image.tsx
@@ -29,8 +29,8 @@ export function getMaxDimensionsFromArea(area: ImageDimensions, aspectRatio: num
     }
 
     return {
-        width: Math.ceil(width),
-        height: Math.ceil(height),
+        width,
+        height,
     };
 }
 


### PR DESCRIPTION
This removes the of rounding up in the image size, as this leads to an incorrect aspect ratio and as a result can lead to "bouncing" when swapping images.

