### PR TITLE
wip: work on a better go-to-edit-form-after-create implementation

### DIFF
--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -5,6 +5,7 @@ import {
     FinalFormCheckbox,
     FinalFormInput,
     FinalFormSaveSplitButton,
+    FinalFormSubmitEvent,
     MainContent,
     Toolbar,
     ToolbarActions,
@@ -30,6 +31,7 @@ import {
     GQLProductQuery,
     GQLProductQueryVariables,
 } from "@src/graphql.generated";
+import { FormApi } from "final-form";
 import { filter } from "graphql-anywhere";
 import isEqual from "lodash.isequal";
 import React from "react";
@@ -56,7 +58,6 @@ function ProductForm({ id }: FormProps): React.ReactElement {
     const mode = id ? "edit" : "add";
     const formApiRef = useFormApiRef<FormState>();
     const stackSwitchApi = useStackSwitchApi();
-    const createMutationResponseRef = React.useRef<GQLProductFormCreateProductMutation>();
 
     const { data, error, loading, refetch } = useQuery<GQLProductQuery, GQLProductQueryVariables>(
         productQuery,
@@ -89,9 +90,8 @@ function ProductForm({ id }: FormProps): React.ReactElement {
         },
     });
 
-    const handleSubmit = async (formState: FormState) => {
+    const handleSubmit = async (formState: FormState, form: FormApi<FormState>, event: FinalFormSubmitEvent) => {
         if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");
-        createMutationResponseRef.current = undefined;
         const output = {
             ...formState,
             price: parseFloat(formState.price),
@@ -108,8 +108,13 @@ function ProductForm({ id }: FormProps): React.ReactElement {
                 mutation: createProductMutation,
                 variables: { input: output },
             });
-            if (mutationReponse) {
-                createMutationResponseRef.current = mutationReponse;
+            if (!event?.navigatingBack) {
+                const id = mutationReponse?.createProduct.id;
+                if (id) {
+                    setTimeout(() => {
+                        stackSwitchApi.activatePage(`edit`, id);
+                    });
+                }
             }
         }
     };
@@ -130,7 +135,7 @@ function ProductForm({ id }: FormProps): React.ReactElement {
             initialValues={initialValues}
             initialValuesEqual={isEqual} //required to compare block data correctly
             onAfterSubmit={(values, form) => {
-                //don't go back automatically
+                //don't go back automatically TODO remove this automatismn
             }}
         >
             {({ values }) => (
@@ -147,14 +152,7 @@ function ProductForm({ id }: FormProps): React.ReactElement {
                         </ToolbarTitleItem>
                         <ToolbarFillSpace />
                         <ToolbarActions>
-                            <FinalFormSaveSplitButton
-                                onNavigateToEditPage={() => {
-                                    const id = createMutationResponseRef.current?.createProduct.id;
-                                    if (mode == "add" && id) {
-                                        stackSwitchApi.activatePage(`edit`, id);
-                                    }
-                                }}
-                            />
+                            <FinalFormSaveSplitButton />
                         </ToolbarActions>
                     </Toolbar>
                     <MainContent>

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -57,7 +57,7 @@ export { ErrorScope, errorScopeForOperationContext, LocalErrorScopeApolloContext
 export { useErrorDialog, UseErrorDialogReturn } from "./error/errordialog/useErrorDialog";
 export { createFetch, FetchContext, FetchProvider, useFetch } from "./fetchProvider/fetch";
 export { FileIcon } from "./fileIcons/FileIcon";
-export { FinalForm, useFormApiRef } from "./FinalForm";
+export { FinalForm, FinalFormSubmitEvent, useFormApiRef } from "./FinalForm";
 export {
     FinalFormSaveCancelButtonsLegacy,
     FinalFormSaveCancelButtonsLegacyClassKey,


### PR DESCRIPTION
incompatbile: this removes onNavigateToEditPage again (hopefully not too late before it gets stable)

This basically adds the possibility to final-form to include an event for submit. This is not directly possible to get into FormApi, so the implementation is ... a bit strange. But the result is important :)

this introduces a 3rd argument for onSubmit: event (attention: upstream final-form has callback as 3rd, we never had that)