### PR TITLE
Add an additional strategy for StaticAuthedUser

### DIFF
--- a/demo/api/src/auth/auth.module.ts
+++ b/demo/api/src/auth/auth.module.ts
@@ -1,21 +1,13 @@
-import { createAuthResolver, createCometAuthGuard, createStaticAuthedUserStrategy } from "@comet/cms-api";
+import { createAuthResolver, createCometAuthGuard } from "@comet/cms-api";
 import { Module } from "@nestjs/common";
 import { APP_GUARD } from "@nestjs/core";
 
+import { AuthStrategy } from "./auth.strategy";
 import { CurrentUser } from "./current-user";
 
 @Module({
     providers: [
-        createStaticAuthedUserStrategy({
-            staticAuthedUser: {
-                id: "1",
-                name: "Test Admin",
-                email: "demo@comet-dxp.com",
-                language: "en",
-                role: "admin",
-                domains: ["main", "secondary"],
-            },
-        }),
+        AuthStrategy,
         createAuthResolver({
             currentUser: CurrentUser,
         }),

--- a/demo/api/src/auth/auth.strategy.ts
+++ b/demo/api/src/auth/auth.strategy.ts
@@ -1,0 +1,32 @@
+import { createStaticAuthedLoadedUserStrategy, CurrentUserInterface } from "@comet/cms-api";
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class AuthStrategy extends createStaticAuthedLoadedUserStrategy({ userIdentifier: "admin" }) {
+    // You can use Dependency Injection here (e.g. injecting a repository from which the user will be loaded in validate())
+    constructor() {
+        super();
+    }
+
+    validate(userIdentifier: string): CurrentUserInterface | undefined {
+        const users = [
+            {
+                id: "admin",
+                name: "Test Admin",
+                email: "admin@comet-dxp.com",
+                language: "en",
+                role: "admin",
+                domains: ["main", "secondary"],
+            } as CurrentUserInterface,
+            {
+                id: "superuser",
+                name: "Test Superuser",
+                email: "superuser@comet-dxp.com",
+                language: "en",
+                role: "superuser",
+                domains: ["main"],
+            } as CurrentUserInterface,
+        ];
+        return users.find((user) => user.id === userIdentifier);
+    }
+}

--- a/packages/api/cms-api/src/auth/strategies/static-authed-loaded-user.strategy.ts
+++ b/packages/api/cms-api/src/auth/strategies/static-authed-loaded-user.strategy.ts
@@ -1,0 +1,22 @@
+import { Injectable } from "@nestjs/common";
+import { PassportStrategy, Type } from "@nestjs/passport";
+import jwt from "jsonwebtoken";
+import { ExtractJwt, Strategy } from "passport-jwt";
+
+interface StaticAuthedUserStrategyConfig {
+    userIdentifier: string;
+}
+
+export function createStaticAuthedLoadedUserStrategy(config: StaticAuthedUserStrategyConfig): Type {
+    @Injectable()
+    class StaticAuthedUserStrategy extends PassportStrategy(Strategy, "static-authed-user") {
+        constructor() {
+            const secretOrKey = "static";
+            super({
+                jwtFromRequest: ExtractJwt.fromExtractors([() => jwt.sign(config.userIdentifier, secretOrKey)]),
+                secretOrKey,
+            });
+        }
+    }
+    return StaticAuthedUserStrategy;
+}

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -8,6 +8,7 @@ export { PublicApi } from "./auth/decorators/public-api.decorator";
 export { createCometAuthGuard } from "./auth/guards/comet.guard";
 export { createAuthResolver } from "./auth/resolver/auth.resolver";
 export { createAuthProxyJwtStrategy } from "./auth/strategies/auth-proxy-jwt.strategy";
+export { createStaticAuthedLoadedUserStrategy } from "./auth/strategies/static-authed-loaded-user.strategy";
 export { createStaticAuthedUserStrategy } from "./auth/strategies/static-authed-user.strategy";
 export { createStaticCredentialsBasicStrategy } from "./auth/strategies/static-credentials-basic.strategy";
 export { BlobStorageAzureConfig } from "./blob-storage/backends/azure/blob-storage-azure.config";


### PR DESCRIPTION
    - Has to be extended to overwrite the validate-method
    - When overwriting DI in the constructor is possible
    - Allows loading the user-object in the validate-method
