### PR TITLE
DAM: Fix Search

### DIFF
--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -23,7 +23,6 @@ import { styled } from "@mui/material/styles";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { TextMatch } from "../common/MarkedMatches";
 import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
 import { GQLDamFileTableFragment, GQLDamFolderQuery, GQLDamFolderQueryVariables, GQLDamFolderTableFragment } from "../graphql.generated";
 import { ManualDuplicatedFilenamesHandlerContextProvider } from "./DataGrid/duplicatedFilenames/ManualDuplicatedFilenamesHandler";
@@ -32,6 +31,7 @@ import { UploadSplitButton } from "./DataGrid/fileUpload/UploadSplitButton";
 import { DamTableFilter } from "./DataGrid/filter/DamTableFilter";
 import FolderDataGrid from "./DataGrid/FolderDataGrid";
 import { damFolderQuery } from "./DataGrid/FolderDataGrid.gql";
+import { RenderDamLabelOptions } from "./DataGrid/label/DamItemLabelColumn";
 import { RedirectToPersistedDamLocation } from "./DataGrid/RedirectToPersistedDamLocation";
 import EditFile from "./FileForm/EditFile";
 
@@ -134,7 +134,7 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
 };
 
 export interface DamConfig {
-    renderDamLabel?: (row: GQLDamFileTableFragment | GQLDamFolderTableFragment, options: { matches?: TextMatch[] }) => React.ReactNode;
+    renderDamLabel?: (row: GQLDamFileTableFragment | GQLDamFolderTableFragment, options: RenderDamLabelOptions) => React.ReactNode;
     hideArchiveFilter?: boolean;
     hideContextMenu?: boolean;
     allowedMimetypes?: string[];

--- a/packages/admin/cms-admin/src/dam/DataGrid/label/DamItemLabelColumn.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/label/DamItemLabelColumn.tsx
@@ -28,9 +28,14 @@ const DamItemLabelWrapper = styled(Box, { shouldForwardProp: (prop) => prop !== 
     background-color: ${({ isHovered }) => (isHovered ? "rgba(41, 182, 246, 0.1)" : "transparent")};
 `;
 
+export interface RenderDamLabelOptions {
+    matches?: TextMatch[];
+    filterApi: IFilterApi<DamFilter>;
+}
+
 interface DamItemLabelColumnProps {
     item: GQLDamFileTableFragment | GQLDamFolderTableFragment;
-    renderDamLabel?: (row: GQLDamFileTableFragment | GQLDamFolderTableFragment, options: { matches?: TextMatch[] }) => React.ReactNode;
+    renderDamLabel?: (row: GQLDamFileTableFragment | GQLDamFolderTableFragment, options: RenderDamLabelOptions) => React.ReactNode;
     matches: DamItemMatches;
     isSearching: boolean;
     filterApi: IFilterApi<DamFilter>;
@@ -84,7 +89,7 @@ export const DamItemLabelColumn: React.VoidFunctionComponent<DamItemLabelColumnP
     return (
         <DamItemLabelWrapper isHovered={hoverApi.isHovered} {...(isFolder(item) && getFolderRootProps())}>
             {renderDamLabel ? (
-                renderDamLabel(item, { matches: matches.get(item.id) })
+                renderDamLabel(item, { matches: matches.get(item.id), filterApi })
             ) : (
                 <Link
                     underline="none"

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -6,9 +6,9 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 import { MemoryRouter } from "react-router";
 
-import { TextMatch } from "../../../common/MarkedMatches";
 import { DamTable } from "../../../dam/DamTable";
 import DamItemLabel from "../../../dam/DataGrid/label/DamItemLabel";
+import { RenderDamLabelOptions } from "../../../dam/DataGrid/label/DamItemLabelColumn";
 import { isFile } from "../../../dam/helpers/isFile";
 import { GQLDamFileTableFragment, GQLDamFolderTableFragment } from "../../../graphql.generated";
 
@@ -43,7 +43,7 @@ const TableRowButton = styled(Button)`
 const renderDamLabel = (
     row: GQLDamFileTableFragment | GQLDamFolderTableFragment,
     onChooseFile: (fileId: string) => void,
-    { matches }: { matches?: TextMatch[] },
+    { matches, filterApi }: RenderDamLabelOptions,
 ) => {
     return isFile(row) ? (
         <TableRowButton disableRipple={true} variant="text" onClick={() => onChooseFile(row.id)} fullWidth>
@@ -58,6 +58,9 @@ const renderDamLabel = (
             sx={{
                 width: "100%",
                 height: "100%",
+            }}
+            onClick={() => {
+                filterApi.formApi.change("searchText", undefined);
             }}
         >
             <DamItemLabel asset={row} matches={matches} />
@@ -83,7 +86,7 @@ export const ChooseFileDialog = ({ open, onClose, onChooseFile, allowedMimetypes
             </StyledDialogTitle>
             <MemoryRouter>
                 <DamTable
-                    renderDamLabel={(row, { matches }) => renderDamLabel(row, onChooseFile, { matches })}
+                    renderDamLabel={(row, { matches, filterApi }: RenderDamLabelOptions) => renderDamLabel(row, onChooseFile, { matches, filterApi })}
                     allowedMimetypes={allowedMimetypes}
                     damLocationStorageKey="choose-file-dam-location"
                     hideContextMenu={true}


### PR DESCRIPTION
Previously:
- when clicking on a folder while searching in the DAM Dialog, the search would not be resetted. Thus, the user couldn't see that they successfully navigated to a folder.


https://user-images.githubusercontent.com/13380047/221875727-c01f4f91-2a01-448b-8507-c65529bfc6cc.mov



Now: 
-  when clicking on a folder, the search is resetted


https://user-images.githubusercontent.com/13380047/221875750-ea866143-7762-4155-a290-68f94c6ae596.mov


