### PR TITLE
Fix block meta generation in `@comet/cms-api` package

### DIFF
--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -143,11 +143,6 @@
                             "nullable": false
                         },
                         {
-                            "name": "damPath",
-                            "kind": "String",
-                            "nullable": false
-                        },
-                        {
                             "name": "fileUrl",
                             "kind": "String",
                             "nullable": false
@@ -463,11 +458,6 @@
                                 ]
                             },
                             "nullable": true
-                        },
-                        {
-                            "name": "damPath",
-                            "kind": "String",
-                            "nullable": false
                         },
                         {
                             "name": "fileUrl",
@@ -819,11 +809,6 @@
                         {
                             "name": "archived",
                             "kind": "Boolean",
-                            "nullable": false
-                        },
-                        {
-                            "name": "damPath",
-                            "kind": "String",
                             "nullable": false
                         },
                         {

--- a/packages/api/cms-api/generate-block-meta.ts
+++ b/packages/api/cms-api/generate-block-meta.ts
@@ -1,7 +1,7 @@
-import { createOneOfBlock, createRichTextBlock, createTextLinkBlock, ExternalLinkBlock } from "@comet/blocks-api";
-import { NestFactory } from "@nestjs/core";
+import { createOneOfBlock, createRichTextBlock, createTextLinkBlock, ExternalLinkBlock, getBlocksMeta } from "@comet/blocks-api";
+import { promises as fs } from "fs";
 
-import { BlocksModule, createSeoBlock, createTextImageBlock, InternalLinkBlock } from "./src";
+import { createSeoBlock, createTextImageBlock, InternalLinkBlock } from "./src";
 
 async function generateBlockMeta(): Promise<void> {
     console.info("Generating block-meta.json...");
@@ -24,13 +24,8 @@ async function generateBlockMeta(): Promise<void> {
     // Create SeoBlock for block types generation in client libraries
     createSeoBlock();
 
-    const app = await NestFactory.create(
-        BlocksModule.forRoot({
-            withoutIndex: true,
-            useFactory: () => ({ transformerDependencies: {} }),
-        }),
-    );
-    await app.init();
+    const metaJson = getBlocksMeta();
+    await fs.writeFile("block-meta.json", JSON.stringify(metaJson, null, 4));
 
     console.info("Done!");
 }

--- a/packages/api/cms-api/src/blocks/blocks.module.ts
+++ b/packages/api/cms-api/src/blocks/blocks.module.ts
@@ -17,7 +17,6 @@ export interface BlocksModuleSyncOptions extends Pick<ModuleMetadata, "imports">
     useFactory: (...args: any[]) => BlocksModuleOptions;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     inject?: any[];
-    withoutIndex?: boolean;
 }
 
 @Global()
@@ -45,9 +44,12 @@ export class BlocksModule {
                 transformerDependenciesProvider,
                 BlocksTransformerService,
                 BlocksMetaService,
-                ...(!options.withoutIndex ? [DiscoverService, BlockIndexService, CommandsService, BlockMigrateService] : []),
+                DiscoverService,
+                BlockIndexService,
+                CommandsService,
+                BlockMigrateService,
             ],
-            exports: [BlocksTransformerService, BLOCKS_MODULE_TRANSFORMER_DEPENDENCIES, ...(!options.withoutIndex ? [BlockIndexService] : [])],
+            exports: [BlocksTransformerService, BLOCKS_MODULE_TRANSFORMER_DEPENDENCIES, BlockIndexService],
         };
     }
 }


### PR DESCRIPTION
The blocks module could not be initialized correctly anymore during block meta generation. To fix this, the module initialization was removed for the block meta generation altogether, as it isn't needed anyway. Instead, we now retrieve the meta with `getBlockMeta()` and write it to the file directly. This also removes the arbitrary `withoutIndex` option from the blocks module.