### PR TITLE
Fix Page Save

### DIFF
--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -158,7 +158,10 @@ export function createPageTreeResolver({
                                 selection.typeCondition &&
                                 selection.typeCondition.kind == "NamedType"
                             ) {
-                                if (selection.typeCondition.name.value === node.documentType) {
+                                if (
+                                    selection.typeCondition.name.value === node.documentType ||
+                                    selection.typeCondition.name.value === DocumentInterface.name
+                                ) {
                                     //documentType is matching, return full document (fall thru)
                                     return undefined;
                                 } else {


### PR DESCRIPTION
In the `usePage()` factory the CheckForChanges query looks like this:

https://github.com/vivid-planet/comet/blob/10dca33abd525eb270aa912fc9bc520d65aa70e4/packages/admin/cms-admin/src/pages/createUsePage.tsx#L417-L427

The document is loaded using the generic `DocumentInterface` (instead of `Link` or `Page`).

The usePage() hook is used in the `EditPage` and `EditLink` form.

### Previously:

In https://github.com/vivid-planet/comet/pull/921 a loader optimization was introduced that only loads the document in the field resolver if the selection name matches the documentType. That means that the document is not loaded when querying `DocumentInterface`, causing following error:

https://user-images.githubusercontent.com/13380047/222161426-8d7dbfb8-8412-48bc-a6ea-3a6306aa44f6.mov

### Now:

This PR always loads the document when `DocumentInterface` is queried.

https://user-images.githubusercontent.com/13380047/222161803-56b2e03c-bf66-444a-8737-a0536064bf6d.mov


