### PR TITLE
CRUD Generator: Enable optional input fields

### DIFF
--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -29,6 +29,8 @@ export async function generateCrudInput(generatorOptions: { targetDirectory: str
         const decorators = [] as Array<string>;
         if (!prop.nullable) {
             decorators.push("@IsNotEmpty()");
+        } else {
+            decorators.push("@IsOptional()");
         }
         if (prop.name === "id" || prop.name == "createdAt" || prop.name == "updatedAt") {
             //skip those (TODO find a non-magic solution?)
@@ -93,13 +95,13 @@ export async function generateCrudInput(generatorOptions: { targetDirectory: str
             continue;
         }
         fieldsOut += `${decorators.join("\n")}
-    ${prop.name}: ${type};
+    ${prop.name}${prop.nullable ? "?" : ""}: ${type};
     
     `;
     }
     const inputOut = `import { Field, InputType } from "@nestjs/graphql";
 import { Transform } from "class-transformer";
-import { IsString, IsNotEmpty, ValidateNested, IsNumber, IsBoolean, IsDate } from "class-validator";
+import { IsString, IsNotEmpty, ValidateNested, IsNumber, IsBoolean, IsDate, IsOptional } from "class-validator";
 import { IsSlug, RootBlockInputScalar } from "@comet/cms-api";
 import { GraphQLJSONObject } from "graphql-type-json";
 import { BlockInputInterface, isBlockInputInterface } from "@comet/blocks-api";


### PR DESCRIPTION
### Previously:

The CRUD generator did not mark optional input fields as optional.

```ts
@InputType()
export class ProductInput {

    // ...

    @IsNumber()
    @Field({ nullable: true })
    price: number;

    // ...
}
```

### Now:

Optional fields are annotated with `?` and the `@IsOptional()` decorator.

```ts
@InputType()
export class ProductInput {

    // ...

    @IsOptional()
    @IsNumber()
    @Field({ nullable: true })
    price?: number;

    // ...
}
```

----

### Background:

I took a look at the ProductForm (originally because of this unrelated pipeline fail https://github.com/vivid-planet/comet/actions/runs/4314124525) and realised that the price field is optional but causes a validation error if not set (`price must be a number conforming to the specified constraints`)

```json
{
    "errors": [
        {
            "message": "Validation failed",
            "extensions": {
                "code": "BAD_USER_INPUT",
                "response": {
                    "statusCode": 400,
                    "message": "Validation failed",
                    "error": "CometValidationException",
                    "validationErrors": [
                        {
                            "target": {
                                "title": "Title",
                                "slug": "slug",
                                "description": "Description",
                                "price": null,
                                "inStock": false
                            },
                            "value": null,
                            "property": "price",
                            "children": [],
                            "constraints": {
                                "isNumber": "price must be a number conforming to the specified constraints"
                            }
                        }
                    ]
                }
            }
        }
    ],
    "data": null
}
```