### PR TITLE
Visually separate delete-block from other items

### DIFF
--- a/packages/admin/blocks-admin/src/blocks/common/blockRow/BlockRow.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/blockRow/BlockRow.tsx
@@ -1,6 +1,6 @@
 import { messages } from "@comet/admin";
 import { Copy, Delete, Drag, MoreVertical, Paste, Warning } from "@comet/admin-icons";
-import { Checkbox, IconButton, ListItemIcon, Menu, MenuItem } from "@mui/material";
+import { Checkbox, Divider, IconButton, ListItemIcon, Menu, MenuItem } from "@mui/material";
 import * as React from "react";
 import { DropTargetMonitor, useDrag, useDrop, XYCoord } from "react-dnd";
 import { FormattedMessage } from "react-intl";
@@ -207,13 +207,14 @@ export function BlockRow(props: BlockRowProps): JSX.Element {
                         </ListItemIcon>
                         <FormattedMessage {...messages.paste} />
                     </MenuItem>
+                    {props.additionalMenuItems?.(handleMenuClose)}
+                    <Divider />
                     <MenuItem onClick={handleDeleteClick}>
                         <ListItemIcon>
                             <Delete />
                         </ListItemIcon>
                         <FormattedMessage {...messages.delete} />
                     </MenuItem>
-                    {props.additionalMenuItems?.(handleMenuClose)}
                 </Menu>
             </sc.Root>
         </sc.BlockWrapper>


### PR DESCRIPTION
This is to prevent the user from accidentally deleting a block when quickly copy-pasting a lot of blocks.

| Previously | Now |
| --- | --- |
| <img width="401" alt="Screenshot 2023-03-11 at 13 28 35" src="https://user-images.githubusercontent.com/6264317/224484576-3ddea004-5bc3-4908-b9d3-be677a06248d.png"> | <img width="401" alt="Screenshot 2023-03-11 at 13 28 21" src="https://user-images.githubusercontent.com/6264317/224484575-46a8e511-42c1-4f19-a451-a7673c96d898.png"> |
