### PR TITLE
Fix `router.push()` and `router.replace()` in site preview

### DIFF
--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -45,6 +45,7 @@
         "@comet/cli": "^4.0.0",
         "@comet/eslint-config": "^4.0.0",
         "@gitbeaker/node": "^34.0.0",
+        "@testing-library/react-hooks": "^8.0.0",
         "@types/jest": "^27.0.0",
         "@types/styled-components": "^5.0.0",
         "chokidar-cli": "^2.0.0",

--- a/packages/site/cms-site/src/router/useRouter.test.tsx
+++ b/packages/site/cms-site/src/router/useRouter.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook } from "@testing-library/react-hooks";
+
+import { Url } from "../preview/PreviewContext";
+import { useRouter } from "./useRouter";
+
+const push = jest.fn();
+const replace = jest.fn();
+
+jest.mock("next/router", () => ({
+    useRouter: () => ({
+        push,
+        replace,
+    }),
+}));
+
+jest.mock("../preview/usePreview", () => ({
+    usePreview: () => ({
+        previewPathToPath: jest.fn(),
+        pathToPreviewPath: (url: Url) => `/preview${url}`,
+    }),
+}));
+
+describe("useRouter", () => {
+    it("push", () => {
+        const { result } = renderHook(() => useRouter());
+        result.current.push("/test");
+
+        expect(push).toBeCalledWith("/preview/test", undefined, undefined);
+    });
+
+    it("replace", () => {
+        const { result } = renderHook(() => useRouter());
+        result.current.replace("/test");
+
+        expect(replace).toBeCalledWith("/preview/test", undefined, undefined);
+    });
+});

--- a/packages/site/cms-site/src/router/useRouter.tsx
+++ b/packages/site/cms-site/src/router/useRouter.tsx
@@ -3,7 +3,7 @@ import { NextRouter, useRouter as useNextRouter } from "next/router";
 import { usePreview } from "../preview/usePreview";
 
 export function useRouter(): NextRouter {
-    const { previewPathToPath } = usePreview();
+    const { previewPathToPath, pathToPreviewPath } = usePreview();
     const router = useNextRouter();
 
     return {
@@ -11,5 +11,7 @@ export function useRouter(): NextRouter {
         pathname: previewPathToPath(router.pathname),
         asPath: previewPathToPath(router.asPath),
         route: previewPathToPath(router.route),
+        push: (url, as, options) => router.push(pathToPreviewPath(url), as, options),
+        replace: (url, as, options) => router.replace(pathToPreviewPath(url), as, options),
     };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5008,6 +5008,7 @@ __metadata:
     "@comet/cli": ^4.0.0
     "@comet/eslint-config": ^4.0.0
     "@gitbeaker/node": ^34.0.0
+    "@testing-library/react-hooks": ^8.0.0
     "@types/jest": ^27.0.0
     "@types/jsonwebtoken": ^8.5.9
     "@types/styled-components": ^5.0.0
@@ -11988,6 +11989,28 @@ __metadata:
   dependencies:
     defer-to-connect: ^2.0.0
   checksum: c29df3bcec6fc3bdec2b17981d89d9c9fc9bd7d0c9bcfe92821dc533f4440bc890ccde79971838b4ceed1921d456973c4180d7175ee1d0023ad0562240a58d95
+  languageName: node
+  linkType: hard
+
+"@testing-library/react-hooks@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "@testing-library/react-hooks@npm:8.0.1"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    react-error-boundary: ^3.1.0
+  peerDependencies:
+    "@types/react": ^16.9.0 || ^17.0.0
+    react: ^16.9.0 || ^17.0.0
+    react-dom: ^16.9.0 || ^17.0.0
+    react-test-renderer: ^16.9.0 || ^17.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react-dom:
+      optional: true
+    react-test-renderer:
+      optional: true
+  checksum: 7fe44352e920deb5cb1876f80d64e48615232072c9d5382f1e0284b3aab46bb1c659a040b774c45cdf084a5257b8fe463f7e08695ad8480d8a15635d4d3d1f6d
   languageName: node
   linkType: hard
 
@@ -32532,6 +32555,17 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
   checksum: 42bcd4423f12e9ee21b2d3f0c2a28805ff4953bd82b6be4c1f5b5f9a371115aafa36a6f3d82726d43b4912179b79e99550c2b9a772c7fe6a5cd8f7e93ff34ceb
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^3.1.0":
+  version: 3.1.4
+  resolution: "react-error-boundary@npm:3.1.4"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: f36270a5d775a25c8920f854c0d91649ceea417b15b5bc51e270a959b0476647bb79abb4da3be7dd9a4597b029214e8fe43ea914a7f16fa7543c91f784977f1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Previously, these two functions didn't transform the provided path to the preview path.