### PR TITLE
Re-add default value for redirects module options

### DIFF
--- a/packages/api/cms-api/src/redirects/redirects.module.ts
+++ b/packages/api/cms-api/src/redirects/redirects.module.ts
@@ -24,7 +24,7 @@ interface Config {
 @Global()
 @Module({})
 export class RedirectsModule {
-    static register({ customTargets, Scope }: Config): DynamicModule {
+    static register({ customTargets, Scope }: Config = {}): DynamicModule {
         const linkBlock = createOneOfBlock(
             {
                 supportedBlocks: { internal: InternalLinkBlock, external: ExternalLinkBlock, ...customTargets },


### PR DESCRIPTION
The default value was incorrectly removed while developing the dependencies module.