### PR TITLE
Add function for calculation a file hash in FilesService

### DIFF
--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -181,6 +181,10 @@ export class FilesService {
         return withFilesSelect(this.selectQueryBuilder(), { contentHash }).getSingleResult();
     }
 
+    async calculateHashForFile(filePath: string): Promise<string> {
+        return hasha.fromFile(filePath, { algorithm: "md5" });
+    }
+
     async findOneByFilenameAndFolder(
         {
             filename,
@@ -269,7 +273,7 @@ export class FilesService {
     async upload({ file, folderId }: { file: FileUploadInterface; folderId?: string }, scope?: DamScopeInterface): Promise<FileInterface> {
         let result: FileInterface | undefined = undefined;
         try {
-            const contentHash = await hasha.fromFile(file.path, { algorithm: "md5" });
+            const contentHash = await this.calculateHashForFile(file.path);
             let image: probe.ProbeResult | undefined;
             try {
                 image = await probe(createReadStream(file.path));


### PR DESCRIPTION
If the service exposes a function findOneByHash() a function which calculates the hash should also be exposed.