### PR TITLE
add tooltip

### DIFF
--- a/demo/admin/src/products/ProductsTable.tsx
+++ b/demo/admin/src/products/ProductsTable.tsx
@@ -9,12 +9,13 @@ import {
     ToolbarAutomaticTitleItem,
     ToolbarFillSpace,
     ToolbarItem,
+    Tooltip,
     useBufferedRowCount,
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Add as AddIcon, Edit } from "@comet/admin-icons";
-import { Box, Button, IconButton } from "@mui/material";
+import { Add as AddIcon, Edit, Info } from "@comet/admin-icons";
+import { Box, Button, IconButton, Typography } from "@mui/material";
 import { DataGridPro, GridColDef, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import {
     GQLCreateProductMutation,
@@ -51,7 +52,26 @@ function ProductsTableToolbar() {
 }
 
 const columns: GridColDef<GQLProductsListFragment>[] = [
-    { field: "title", headerName: "Title", width: 150 },
+    {
+        field: "title",
+        headerName: "Title",
+        width: 150,
+        renderHeader: () => (
+            <div style={{ display: "flex", alignItems: "center" }}>
+                <Typography fontWeight={400} fontSize={14}>
+                    Title
+                </Typography>
+                <Tooltip
+                    trigger="click"
+                    title={<FormattedMessage id="comet.products.productTitle.info" defaultMessage="The title/name of the product" />}
+                >
+                    <IconButton>
+                        <Info />
+                    </IconButton>
+                </Tooltip>
+            </div>
+        ),
+    },
     { field: "description", headerName: "Description", width: 150 },
     { field: "price", headerName: "Price", width: 150, type: "number" },
     { field: "type", headerName: "Type", width: 150, type: "singleSelect", valueOptions: ["Cap", "Shirt", "Tie"] },

--- a/packages/admin/admin-stories/src/docs/components/Tooltip/Tooltip.stories.mdx
+++ b/packages/admin/admin-stories/src/docs/components/Tooltip/Tooltip.stories.mdx
@@ -10,11 +10,7 @@ import dedent from "ts-dedent";
 >
 > \- [MUI Docs](https://mui.com/material-ui/react-tooltip/)
 
-The Comet Admin `Tooltip` is based on [Material UI's `Tooltip`](https://mui.com/material-ui/react-tooltip) (`MuiTooltip`).
-
-## Tooltip
-
-The Tooltip component is a basic tooltip that can be triggered by hover, focus, or click events. The component is built using the Material UI Tooltip component and extends it with some additional props.
+The Comet Admin `Tooltip` extends [Material UI's `Tooltip`](https://mui.com/material-ui/react-tooltip) by adding a trigger prop that allows showing the Tooltip on focus/click without the need for `ClickAwayListener`.
 
 #### Props
 

--- a/packages/admin/admin-stories/src/docs/components/Tooltip/Tooltip.stories.mdx
+++ b/packages/admin/admin-stories/src/docs/components/Tooltip/Tooltip.stories.mdx
@@ -8,7 +8,7 @@ import dedent from "ts-dedent";
 
 > Tooltips display informative text when users hover over, focus on, or tap an element.
 >
-> \- [MUI Docs](https://mui.com/material-ui/react-tabs/)
+> \- [MUI Docs](https://mui.com/material-ui/react-tooltip/)
 
 The Comet Admin `Tooltip` is based on [Material UI's `Tooltip`](https://mui.com/material-ui/react-tooltip) (`MuiTooltip`).
 
@@ -20,9 +20,9 @@ The Tooltip component is a basic tooltip that can be triggered by hover, focus, 
 
 | Name              | Type   | Description                                                                      |
 | :---------------- | :----- | :------------------------------------------------------------------------------- |
-| trigger          | "hover", "focus", "click" (optional) | You can define the types of events that cause a tooltip to show. |
+| trigger          | "hover", "focus", "click" (optional) | Defines the type of event that causes a tooltip to show |
 
-In addition to the trigger prop, the Tooltip component also accepts all the props from the Material UI Tooltip component.
+In addition to its own props, the Tooltip component also accepts all props from the Material UI Tooltip component.
 
 #### Example
 

--- a/packages/admin/admin-stories/src/docs/components/Tooltip/Tooltip.stories.mdx
+++ b/packages/admin/admin-stories/src/docs/components/Tooltip/Tooltip.stories.mdx
@@ -1,0 +1,31 @@
+import { Canvas, Meta, Source, Story } from "@storybook/addon-docs";
+
+import dedent from "ts-dedent";
+
+<Meta title="Docs/Components/Tooltip" />
+
+# Tooltip
+
+> Tooltips display informative text when users hover over, focus on, or tap an element.
+>
+> \- [MUI Docs](https://mui.com/material-ui/react-tabs/)
+
+The Comet Admin `Tooltip` is based on [Material UI's `Tooltip`](https://mui.com/material-ui/react-tooltip) (`MuiTooltip`).
+
+## Tooltip
+
+The Tooltip component is a basic tooltip that can be triggered by hover, focus, or click events. The component is built using the Material UI Tooltip component and extends it with some additional props.
+
+#### Props
+
+| Name              | Type   | Description                                                                      |
+| :---------------- | :----- | :------------------------------------------------------------------------------- |
+| trigger          | "hover", "focus", "click" (optional) | You can define the types of events that cause a tooltip to show. |
+
+In addition to the trigger prop, the Tooltip component also accepts all the props from the Material UI Tooltip component.
+
+#### Example
+
+<Canvas>
+    <Story id="stories-components-tooltip--basictooltip" />
+</Canvas>

--- a/packages/admin/admin-stories/src/docs/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,39 @@
+import { Tooltip } from "@comet/admin";
+import { Info } from "@comet/admin-icons";
+import { Grid, IconButton } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+storiesOf("stories/components/Tooltip", module).add("BasicTooltip", () => {
+    return (
+        <Grid container justifyContent="center" spacing={4}>
+            <Grid item>
+                <Tooltip title="This is a basic tooltip">
+                    <div>Hover over me</div>
+                </Tooltip>
+            </Grid>
+            <Grid item>
+                <Tooltip title="This is a hover or touch tooltip" trigger="hover">
+                    <div>Hover over or touch me me</div>
+                </Tooltip>
+            </Grid>
+            <Grid item>
+                <Tooltip title="This is a focus or touch tooltip" trigger="focus">
+                    <div>Focus or touch</div>
+                </Tooltip>
+            </Grid>
+            <Grid item>
+                <Tooltip trigger="click" title="This is a clickable tooltip">
+                    <div>Click here to show tooltip</div>
+                </Tooltip>
+            </Grid>
+            <Grid item>
+                <Tooltip trigger="click" title="This is a clickable tooltip with an info icon">
+                    <IconButton>
+                        <Info />
+                    </IconButton>
+                </Tooltip>
+            </Grid>
+        </Grid>
+    );
+});

--- a/packages/admin/admin-stories/src/docs/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/components/Tooltip/Tooltip.stories.tsx
@@ -13,11 +13,6 @@ storiesOf("stories/components/Tooltip", module).add("BasicTooltip", () => {
                 </Tooltip>
             </Grid>
             <Grid item>
-                <Tooltip title="This is a hover or touch tooltip" trigger="hover">
-                    <div>Hover over or touch me me</div>
-                </Tooltip>
-            </Grid>
-            <Grid item>
                 <Tooltip title="This is a focus or touch tooltip" trigger="focus">
                     <div>Focus or touch</div>
                 </Tooltip>

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -5,7 +5,7 @@ interface TooltipProps extends MuiTooltipProps {
     trigger?: "hover" | "focus" | "click";
 }
 
-export const Tooltip = ({ trigger, children, ...props }: TooltipProps): JSX.Element => {
+export const Tooltip = ({ trigger = "hover", children, ...props }: TooltipProps): JSX.Element => {
     const [open, setOpen] = React.useState(false);
 
     const handleTooltipClose = () => {

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -1,0 +1,31 @@
+import { ClickAwayListener, Tooltip as MuiTooltip, TooltipProps as MuiTooltipProps } from "@mui/material";
+import React, { cloneElement } from "react";
+
+interface TooltipProps extends MuiTooltipProps {
+    trigger?: "hover" | "focus" | "click";
+}
+
+export const Tooltip = ({ trigger, children, ...props }: TooltipProps): JSX.Element => {
+    const [open, setOpen] = React.useState(false);
+
+    const handleTooltipClose = () => {
+        setOpen(false);
+    };
+
+    const toggleTooltip = (event: React.MouseEvent) => {
+        event.stopPropagation();
+        setOpen(!open);
+    };
+
+    return trigger === "click" ? (
+        <ClickAwayListener onClickAway={handleTooltipClose}>
+            <MuiTooltip onClose={handleTooltipClose} open={open} disableFocusListener disableHoverListener disableTouchListener {...props}>
+                {cloneElement(children, { onClick: toggleTooltip })}
+            </MuiTooltip>
+        </ClickAwayListener>
+    ) : (
+        <MuiTooltip disableFocusListener={trigger === "hover"} disableHoverListener={trigger === "focus"} {...props}>
+            {children}
+        </MuiTooltip>
+    );
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -36,6 +36,7 @@ export { ToolbarFillSpace, ToolbarFillSpaceClassKey, ToolbarFillSpaceProps } fro
 export { ToolbarItem, ToolbarItemClassKey, ToolbarItemProps } from "./common/toolbar/item/ToolbarItem";
 export { ToolbarTitleItem, ToolbarTitleItemClassKey, ToolbarTitleItemProps } from "./common/toolbar/titleitem/ToolbarTitleItem";
 export { Toolbar, ToolbarClassKey, ToolbarProps } from "./common/toolbar/Toolbar";
+export { Tooltip } from "./common/Tooltip";
 export { CrudContextMenu } from "./dataGrid/CrudContextMenu";
 export { GridFilterButton } from "./dataGrid/GridFilterButton";
 export { muiGridFilterToGql } from "./dataGrid/muiGridFilterToGql";


### PR DESCRIPTION
This PR adds two Tooltip Components to wrap the Mui Tooltip functionality and make it easier to use.

![Bildschirm­foto 2023-04-03 um 13 39 03](https://user-images.githubusercontent.com/34998750/229498688-e1bc40c8-2df8-4856-a60f-865fdaf3053e.png)

