### PR TITLE
Add support for multiple StackSwitch on one StackPage

### DIFF
--- a/.changeset/twenty-parents-behave.md
+++ b/.changeset/twenty-parents-behave.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": minor
+---
+
+Allow Composite block with multiple sub blocks that have their own subroutes (eg a list)

--- a/.changeset/warm-feet-flow.md
+++ b/.changeset/warm-feet-flow.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": minor
+---
+
+Add support for multiple StackSwitch on one StackPage
+
+Add a SubRoute wrapper for this case that needs to be added in front of the tested StckSwitch and do that
+for all composite blocks

--- a/demo/admin/src/pages/PageContentBlock.tsx
+++ b/demo/admin/src/pages/PageContentBlock.tsx
@@ -11,6 +11,7 @@ import { ColumnsBlock } from "./blocks/ColumnsBlock";
 import { FullWidthImageBlock } from "./blocks/FullWidthImageBlock";
 import { HeadlineBlock } from "./blocks/HeadlineBlock";
 import { TextImageBlock } from "./blocks/TextImageBlock";
+import { TwoListsBlock } from "./blocks/TwoListsBlock";
 
 export const PageContentBlock = createBlocksBlock({
     name: "PageContent",
@@ -26,6 +27,7 @@ export const PageContentBlock = createBlocksBlock({
         fullWidthImage: FullWidthImageBlock,
         columns: ColumnsBlock,
         anchor: AnchorBlock,
+        twoLists: TwoListsBlock,
     },
     additionalItemFields: {
         ...userGroupAdditionalItemFields,

--- a/demo/admin/src/pages/blocks/TwoListsBlock.tsx
+++ b/demo/admin/src/pages/blocks/TwoListsBlock.tsx
@@ -1,0 +1,23 @@
+import { createCompositeBlock, createListBlock } from "@comet/blocks-admin";
+
+import { HeadlineBlock } from "./HeadlineBlock";
+
+const TwoListsListBlock = createListBlock({
+    name: "TwoListsList",
+    block: HeadlineBlock,
+});
+
+export const TwoListsBlock = createCompositeBlock({
+    name: "TwoLists",
+    displayName: "Two Lists",
+    blocks: {
+        list1: {
+            block: TwoListsListBlock,
+            title: "List 1",
+        },
+        list2: {
+            block: TwoListsListBlock,
+            title: "List 2",
+        },
+    },
+});

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -930,7 +930,8 @@
                                 "LinkList",
                                 "FullWidthImage",
                                 "Columns",
-                                "Anchor"
+                                "Anchor",
+                                "TwoLists"
                             ],
                             "nullable": false
                         },
@@ -1583,6 +1584,94 @@
             {
                 "name": "imageAspectRatio",
                 "kind": "String",
+                "nullable": false
+            }
+        ]
+    },
+    {
+        "name": "TwoLists",
+        "fields": [
+            {
+                "name": "list1",
+                "kind": "Block",
+                "block": "TwoListsList",
+                "nullable": false
+            },
+            {
+                "name": "list2",
+                "kind": "Block",
+                "block": "TwoListsList",
+                "nullable": false
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "list1",
+                "kind": "Block",
+                "block": "TwoListsList",
+                "nullable": false
+            },
+            {
+                "name": "list2",
+                "kind": "Block",
+                "block": "TwoListsList",
+                "nullable": false
+            }
+        ]
+    },
+    {
+        "name": "TwoListsList",
+        "fields": [
+            {
+                "name": "blocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "key",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "visible",
+                            "kind": "Boolean",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "Block",
+                            "block": "Headline",
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "blocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "key",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "visible",
+                            "kind": "Boolean",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "Block",
+                            "block": "Headline",
+                            "nullable": false
+                        }
+                    ]
+                },
                 "nullable": false
             }
         ]

--- a/demo/api/src/pages/blocks/PageContentBlock.ts
+++ b/demo/api/src/pages/blocks/PageContentBlock.ts
@@ -9,6 +9,7 @@ import { ColumnsBlock } from "./columns.block";
 import { FullWidthImageBlock } from "./full-width-image.block";
 import { HeadlineBlock } from "./headline.block";
 import { TextImageBlock } from "./TextImageBlock";
+import { TwoListsBlock } from "./two-lists.block";
 
 const supportedBlocks = {
     space: SpaceBlock,
@@ -22,6 +23,7 @@ const supportedBlocks = {
     fullWidthImage: FullWidthImageBlock,
     columns: ColumnsBlock,
     anchor: AnchorBlock,
+    twoLists: TwoListsBlock,
 };
 
 class BlocksBlockItemData extends BaseBlocksBlockItemData(supportedBlocks) {

--- a/demo/api/src/pages/blocks/two-lists.block.ts
+++ b/demo/api/src/pages/blocks/two-lists.block.ts
@@ -1,0 +1,40 @@
+import {
+    BlockData,
+    BlockDataInterface,
+    BlockInput,
+    ChildBlock,
+    ChildBlockInput,
+    createBlock,
+    createListBlock,
+    ExtractBlockData,
+    inputToData,
+} from "@comet/blocks-api";
+import { ValidateNested } from "class-validator";
+
+import { HeadlineBlock } from "./headline.block";
+
+const TwoListsList = createListBlock({ block: HeadlineBlock }, "TwoListsList");
+
+class TwoListsBlockData extends BlockData {
+    @ChildBlock(TwoListsList)
+    list1: ExtractBlockData<typeof TwoListsList>;
+
+    @ChildBlock(TwoListsList)
+    list2: ExtractBlockData<typeof TwoListsList>;
+}
+
+class TwoListsBlockInput extends BlockInput {
+    @ChildBlockInput(TwoListsList)
+    @ValidateNested()
+    list1: ExtractBlockData<typeof TwoListsList>;
+
+    @ChildBlockInput(TwoListsList)
+    @ValidateNested()
+    list2: ExtractBlockData<typeof TwoListsList>;
+
+    transformToBlockData(): BlockDataInterface {
+        return inputToData(TwoListsBlockData, this);
+    }
+}
+
+export const TwoListsBlock = createBlock(TwoListsBlockData, TwoListsBlockInput, "TwoLists");

--- a/packages/admin/admin-stories/src/admin/router/SubRoute.tsx
+++ b/packages/admin/admin-stories/src/admin/router/SubRoute.tsx
@@ -1,0 +1,105 @@
+import { SubRoute, SubRouteIndexRoute, useSubRoutePrefix } from "@comet/admin";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { Redirect, Route, Switch, useLocation, useRouteMatch } from "react-router";
+import { Link } from "react-router-dom";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+function Cmp1() {
+    const urlPrefix = useSubRoutePrefix();
+    return (
+        <>
+            <Switch>
+                <Route path={`${urlPrefix}/sub`}>
+                    <div>Cmp1 Sub</div>
+                </Route>
+                <SubRouteIndexRoute>
+                    <div>
+                        <Link to={`${urlPrefix}/sub`}>Cmp1 SubLink</Link>
+                    </div>
+                </SubRouteIndexRoute>
+            </Switch>
+        </>
+    );
+}
+
+function Cmp2() {
+    const urlPrefix = useSubRoutePrefix();
+    return (
+        <>
+            <Switch>
+                <Route path={`${urlPrefix}/sub`}>
+                    <div>
+                        <Link to={`${urlPrefix}/sub`}>Sub</Link>
+                        <br />
+                        <Link to={`${urlPrefix}/sub/sub2`}>Sub2</Link>
+                    </div>
+                    <Switch>
+                        <Route path={`${urlPrefix}/sub/sub2`}>
+                            <div>Cmp2 Sub2</div>
+                        </Route>
+                        <Route>
+                            <div>Cmp2 Sub</div>
+                        </Route>
+                    </Switch>
+                </Route>
+                <SubRouteIndexRoute>
+                    <div>
+                        <Link to={`${urlPrefix}/sub`}>Cmp2 SubLink</Link>
+                    </div>
+                </SubRouteIndexRoute>
+            </Switch>
+        </>
+    );
+}
+
+function Story() {
+    const match = useRouteMatch();
+    return (
+        <div>
+            <SubRoute path={`${match.url}/cmp1`}>
+                <div>
+                    <Cmp1 />
+                </div>
+            </SubRoute>
+            <SubRoute path={`${match.url}/cmp2`}>
+                <div>
+                    <Cmp2 />
+                </div>
+            </SubRoute>
+        </div>
+    );
+}
+
+function Path() {
+    const location = useLocation();
+    const [, rerender] = React.useState(0);
+    React.useEffect(() => {
+        const timer = setTimeout(() => {
+            rerender(new Date().getTime());
+        }, 1000);
+        return () => clearTimeout(timer);
+    }, []);
+    return <div>{location.pathname}</div>;
+}
+
+function App() {
+    return (
+        <>
+            <Path />
+            <Switch>
+                <Route exact path="/">
+                    <Redirect to="/foo" />
+                </Route>
+                <Route path="/foo">
+                    <Story />
+                </Route>
+            </Switch>
+        </>
+    );
+}
+
+storiesOf("@comet/admin/stack", module)
+    .addDecorator(storyRouterDecorator())
+    .add("Subroute", () => <App />);

--- a/packages/admin/admin-stories/src/admin/stack/StackNestedOneStack.tsx
+++ b/packages/admin/admin-stories/src/admin/stack/StackNestedOneStack.tsx
@@ -1,0 +1,69 @@
+import { Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch, SubRoute, useSubRoutePrefix } from "@comet/admin";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { Redirect, Route, Switch, useLocation } from "react-router";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+function Story() {
+    const urlPrefix = useSubRoutePrefix();
+    return (
+        <Stack topLevelTitle="Stack">
+            <StackBreadcrumbs />
+            <SubRoute path={`${urlPrefix}/first`}>
+                <StackSwitch>
+                    <StackPage name="page1">
+                        <p>First Page1</p>
+                        <StackLink pageName="page2" payload="test">
+                            activate page2
+                        </StackLink>
+                    </StackPage>
+                    <StackPage name="page2">First Page2</StackPage>
+                </StackSwitch>
+            </SubRoute>
+            <SubRoute path={`${urlPrefix}/second`}>
+                <StackSwitch>
+                    <StackPage name="page1">
+                        <p>Second Page1</p>
+                        <StackLink pageName="page2" payload="test">
+                            activate page2
+                        </StackLink>
+                    </StackPage>
+                    <StackPage name="page2">Second Page2</StackPage>
+                </StackSwitch>
+            </SubRoute>
+        </Stack>
+    );
+}
+
+function Path() {
+    const location = useLocation();
+    const [, rerender] = React.useState(0);
+    React.useEffect(() => {
+        const timer = setTimeout(() => {
+            rerender(new Date().getTime());
+        }, 100);
+        return () => clearTimeout(timer);
+    }, []);
+    return <div>{location.pathname}</div>;
+}
+
+function App() {
+    return (
+        <>
+            <Path />
+            <Switch>
+                <Route exact path="/">
+                    <Redirect to="/foo" />
+                </Route>
+                <Route path="/foo">
+                    <Story />
+                </Route>
+            </Switch>
+        </>
+    );
+}
+
+storiesOf("@comet/admin/stack", module)
+    .addDecorator(storyRouterDecorator())
+    .add("Stack Nested one Stack", () => <App />);

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -102,6 +102,7 @@ export { RouterContext } from "./router/Context";
 export { RouterMemoryRouter } from "./router/MemoryRouter";
 export { RouterPrompt } from "./router/Prompt";
 export { RouterPromptHandler, SaveAction } from "./router/PromptHandler";
+export { SubRoute, SubRouteIndexRoute, useSubRoutePrefix } from "./router/SubRoute";
 export { RowActionsItem, RowActionsItemProps } from "./rowActions/RowActionsItem";
 export { RowActionsMenu, RowActionsMenuProps } from "./rowActions/RowActionsMenu";
 export { Selected } from "./Selected";

--- a/packages/admin/admin/src/router/SubRoute.test.tsx
+++ b/packages/admin/admin/src/router/SubRoute.test.tsx
@@ -1,0 +1,186 @@
+/* eslint-disable @calm/react-intl/missing-formatted-message */
+import { createTheme } from "@mui/material/styles";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import * as React from "react";
+import { Route, Router, Switch, useRouteMatch } from "react-router";
+import { Link } from "react-router-dom";
+
+import { MuiThemeProvider } from "../mui/ThemeProvider";
+import { SubRoute, SubRouteIndexRoute, useSubRoutePrefix } from "../router/SubRoute";
+
+test("Subrote other route hidden", async () => {
+    function Cmp1() {
+        const urlPrefix = useSubRoutePrefix();
+        return (
+            <>
+                <Switch>
+                    <Route path={`${urlPrefix}/sub`}>
+                        <div>Cmp1 Sub</div>
+                    </Route>
+                    <SubRouteIndexRoute>
+                        <div>
+                            <Link to={`${urlPrefix}/sub`}>Cmp1 SubLink</Link>
+                        </div>
+                    </SubRouteIndexRoute>
+                </Switch>
+            </>
+        );
+    }
+
+    function Cmp2() {
+        const urlPrefix = useSubRoutePrefix();
+        return (
+            <>
+                <Switch>
+                    <Route path={`${urlPrefix}/sub`}>
+                        <div>
+                            <Link to={`${urlPrefix}/sub`}>Sub</Link>
+                            <br />
+                            <Link to={`${urlPrefix}/sub/sub2`}>Sub2</Link>
+                        </div>
+                        <Switch>
+                            <Route path={`${urlPrefix}/sub/sub2`}>
+                                <div>Cmp2 Sub2</div>
+                            </Route>
+                            <Route>
+                                <div>Cmp2 Sub</div>
+                            </Route>
+                        </Switch>
+                    </Route>
+                    <SubRouteIndexRoute>
+                        <div>
+                            <Link to={`${urlPrefix}/sub`}>Cmp2 SubLink</Link>
+                        </div>
+                    </SubRouteIndexRoute>
+                </Switch>
+            </>
+        );
+    }
+
+    function Story() {
+        const match = useRouteMatch();
+        return (
+            <div>
+                <SubRoute path={`${match.url}/cmp1`}>
+                    <div>
+                        <Cmp1 />
+                    </div>
+                </SubRoute>
+                <SubRoute path={`${match.url}/cmp2`}>
+                    <div>
+                        <Cmp2 />
+                    </div>
+                </SubRoute>
+            </div>
+        );
+    }
+
+    const history = createMemoryHistory();
+
+    const rendered = render(
+        <MuiThemeProvider theme={createTheme()}>
+            <Router history={history}>
+                <Story />
+            </Router>
+        </MuiThemeProvider>,
+    );
+
+    fireEvent.click(rendered.getByText("Cmp1 SubLink"));
+
+    await waitFor(() => {
+        expect(rendered.getByText("Cmp1 Sub")).toBeInTheDocument();
+    });
+    expect(rendered.queryByText("Cmp2 SubLink")).not.toBeInTheDocument();
+});
+
+test("Subrote other route hidden", async () => {
+    function Cmp1() {
+        const urlPrefix = useSubRoutePrefix();
+        return (
+            <>
+                <Switch>
+                    <Route path={`${urlPrefix}/sub`}>
+                        <div>Cmp1 Sub</div>
+                    </Route>
+                    <SubRouteIndexRoute>
+                        <div>
+                            <Link to={`${urlPrefix}/sub`}>Cmp1 SubLink</Link>
+                        </div>
+                    </SubRouteIndexRoute>
+                </Switch>
+            </>
+        );
+    }
+
+    function Cmp2() {
+        const urlPrefix = useSubRoutePrefix();
+        return (
+            <>
+                <Switch>
+                    <Route path={`${urlPrefix}/sub`}>
+                        <div>
+                            <Link to={`${urlPrefix}/sub`}>Sub</Link>
+                            <br />
+                            <Link to={`${urlPrefix}/sub/sub2`}>Sub2</Link>
+                        </div>
+                        <Switch>
+                            <Route path={`${urlPrefix}/sub/sub2`}>
+                                <div>Cmp2 Sub2</div>
+                            </Route>
+                            <Route>
+                                <div>Cmp2 Sub</div>
+                            </Route>
+                        </Switch>
+                    </Route>
+                    <SubRouteIndexRoute>
+                        <div>
+                            <Link to={`${urlPrefix}/sub`}>Cmp2 SubLink</Link>
+                        </div>
+                    </SubRouteIndexRoute>
+                </Switch>
+            </>
+        );
+    }
+
+    function Story() {
+        const match = useRouteMatch();
+        return (
+            <div>
+                <SubRoute path={`${match.url}/cmp1`}>
+                    <div>
+                        <Cmp1 />
+                    </div>
+                </SubRoute>
+                <SubRoute path={`${match.url}/cmp2`}>
+                    <div>
+                        <Cmp2 />
+                    </div>
+                </SubRoute>
+            </div>
+        );
+    }
+
+    const history = createMemoryHistory();
+
+    const rendered = render(
+        <MuiThemeProvider theme={createTheme()}>
+            <Router history={history}>
+                <Story />
+            </Router>
+        </MuiThemeProvider>,
+    );
+
+    fireEvent.click(rendered.getByText("Cmp2 SubLink"));
+
+    await waitFor(() => {
+        expect(rendered.getByText("Cmp2 Sub")).toBeInTheDocument();
+    });
+    expect(rendered.queryByText("Cmp1 SubLink")).not.toBeInTheDocument();
+    fireEvent.click(rendered.getByText("Sub2"));
+
+    await waitFor(() => {
+        expect(rendered.getByText("Cmp2 Sub2")).toBeInTheDocument();
+    });
+    expect(rendered.queryByText("Cmp2 Sub")).not.toBeInTheDocument();
+});

--- a/packages/admin/admin/src/router/SubRoute.tsx
+++ b/packages/admin/admin/src/router/SubRoute.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { matchPath, Route, useLocation, useRouteMatch } from "react-router";
+
+interface SubRoutesContext {
+    path: string;
+}
+const SubRoutesContext = React.createContext<SubRoutesContext | undefined>(undefined);
+
+export function SubRouteIndexRoute({ children }: { children: React.ReactNode }) {
+    const location = useLocation();
+    const match = useRouteMatch();
+    const subRoutesContext = React.useContext(SubRoutesContext);
+    const urlPrefix = subRoutesContext?.path || match.url;
+
+    const matchIndex = matchPath(location.pathname, { path: match.url, exact: true });
+    const routeProps = matchIndex ? { path: match.url, exact: true } : { path: urlPrefix };
+
+    return <Route {...routeProps}>{children}</Route>;
+}
+
+export function SubRoute({ children, path }: { children: React.ReactNode; path: string }) {
+    return <SubRoutesContext.Provider value={{ path }}>{children}</SubRoutesContext.Provider>;
+}
+
+export function useSubRoutePrefix() {
+    const match = useRouteMatch();
+    const subRoutesContext = React.useContext(SubRoutesContext);
+    return subRoutesContext?.path || match.url;
+}

--- a/packages/admin/admin/src/stack/Stack.multiple.test.tsx
+++ b/packages/admin/admin/src/stack/Stack.multiple.test.tsx
@@ -1,0 +1,65 @@
+/* eslint-disable @calm/react-intl/missing-formatted-message */
+import { createTheme } from "@mui/material/styles";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import * as React from "react";
+import { Router } from "react-router";
+
+import { MuiThemeProvider } from "../mui/ThemeProvider";
+import { SubRoute, useSubRoutePrefix } from "../router/SubRoute";
+import { StackBreadcrumbs } from "./breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "./Page";
+import { Stack } from "./Stack";
+import { StackLink } from "./StackLink";
+import { StackSwitch } from "./Switch";
+
+test("multiple stacks on same page", async () => {
+    function Story() {
+        const urlPrefix = useSubRoutePrefix();
+        return (
+            <Stack topLevelTitle="Stack">
+                <StackBreadcrumbs />
+                <SubRoute path={`${urlPrefix}/first`}>
+                    <StackSwitch>
+                        <StackPage name="page1">
+                            <p>First Page1</p>
+                            <StackLink pageName="page2" payload="test">
+                                activate First Page2
+                            </StackLink>
+                        </StackPage>
+                        <StackPage name="page2">First Page2</StackPage>
+                    </StackSwitch>
+                </SubRoute>
+                <SubRoute path={`${urlPrefix}/second`}>
+                    <StackSwitch>
+                        <StackPage name="page1">
+                            <p>Second Page1</p>
+                            <StackLink pageName="page2" payload="test">
+                                activate Second Page2
+                            </StackLink>
+                        </StackPage>
+                        <StackPage name="page2">Second Page2</StackPage>
+                    </StackSwitch>
+                </SubRoute>
+            </Stack>
+        );
+    }
+
+    const history = createMemoryHistory();
+
+    const rendered = render(
+        <MuiThemeProvider theme={createTheme()}>
+            <Router history={history}>
+                <Story />
+            </Router>
+        </MuiThemeProvider>,
+    );
+
+    fireEvent.click(rendered.getByText("activate First Page2"));
+
+    await waitFor(() => {
+        expect(rendered.getByText("First Page2")).toBeInTheDocument();
+    });
+    expect(rendered.queryByText("Second Page1")).not.toBeInTheDocument();
+    expect(rendered.queryByText("Second Page2")).not.toBeInTheDocument();
+});

--- a/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx
@@ -1,4 +1,4 @@
-import { StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
+import { StackPage, StackSwitch, StackSwitchApiContext, SubRoute, useSubRoutePrefix } from "@comet/admin";
 import { Divider } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
@@ -144,6 +144,7 @@ export const createCompositeBlock = <Options extends CreateCompositeBlockOptions
             return { ...(blockPreviewState as any), adminMeta: { route: previewContext.parentUrl } };
         },
         AdminComponent: ({ state, updateState }) => {
+            const urlPrefix = useSubRoutePrefix();
             const isInPaper = useAdminComponentPaper();
             const blockAdminComponents = adminComponents({ state, updateState });
             const blockPreviews = previews(state);
@@ -192,7 +193,7 @@ export const createCompositeBlock = <Options extends CreateCompositeBlockOptions
                 } else {
                     children = (
                         <HoverPreviewComponent key={blockKey} componentSlug={`#${blockKey}`}>
-                            {blockAdminComponents[blockKey]}
+                            <SubRoute path={`${urlPrefix}/${blockKey}`}>{blockAdminComponents[blockKey]}</SubRoute>
                         </HoverPreviewComponent>
                     );
                 }


### PR DESCRIPTION
depends on #1027 as that added tests

This allows having a Composite block with two sub blocks where each has it's own subroutes (eg a list)

Add a SubRoute wrapper for this case that needs to be added in front of the tested StckSwitch and do that
for all composite blocks
