### PR TITLE
Fix Router Prompt issue with subroutes

### DIFF
--- a/packages/admin/admin-stories/src/admin/form/RouterTabsInForm.tsx
+++ b/packages/admin/admin-stories/src/admin/form/RouterTabsInForm.tsx
@@ -1,0 +1,50 @@
+import { Field, FinalForm, FinalFormInput, RouterTab, RouterTabs } from "@comet/admin";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { useLocation } from "react-router";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+function Path() {
+    const location = useLocation();
+    const [, rerender] = React.useState(0);
+    React.useEffect(() => {
+        const timer = setTimeout(() => {
+            rerender(new Date().getTime());
+        }, 1000);
+        return () => clearTimeout(timer);
+    }, []);
+    return <div>{location.pathname}</div>;
+}
+
+function Story() {
+    return (
+        <>
+            <Path />
+            <FinalForm
+                mode="edit"
+                onSubmit={(values: any) => {
+                    alert(JSON.stringify(values));
+                }}
+                initialValues={{
+                    foo: "foo",
+                    bar: "bar",
+                }}
+            >
+                {() => (
+                    <RouterTabs>
+                        <RouterTab label="Form 1" path="" forceRender={true}>
+                            <Field label="Foo" name="foo" component={FinalFormInput} />
+                        </RouterTab>
+                        <RouterTab label="Form 2" path="/form2" forceRender={true}>
+                            <Field label="Bar" name="bar" component={FinalFormInput} />
+                        </RouterTab>
+                    </RouterTabs>
+                )}
+            </FinalForm>
+        </>
+    );
+}
+storiesOf("@comet/admin/form", module)
+    .addDecorator(storyRouterDecorator())
+    .add("RouterTabsInForm", () => <Story />);

--- a/packages/admin/admin-stories/src/admin/form/Tabs.tsx
+++ b/packages/admin/admin-stories/src/admin/form/Tabs.tsx
@@ -4,6 +4,7 @@ import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";
+import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Story() {
     const [showExample3, setShowExample3] = React.useState(false);
@@ -51,4 +52,5 @@ function Story() {
 
 storiesOf("@comet/admin/form", module)
     .addDecorator(apolloRestStoryDecorator())
+    .addDecorator(storyRouterDecorator())
     .add("Tabs", () => <Story />);

--- a/packages/admin/admin-stories/src/admin/router/Prompt.tsx
+++ b/packages/admin/admin-stories/src/admin/router/Prompt.tsx
@@ -1,0 +1,56 @@
+import { RouterPrompt } from "@comet/admin";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { Redirect, Route, Switch, useLocation } from "react-router";
+import { Link } from "react-router-dom";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+function Story() {
+    return (
+        <Switch>
+            <Route path="/foo">
+                <RouterPrompt
+                    message={() => {
+                        return "sure?";
+                    }}
+                    subRoutePath="/foo/s"
+                >
+                    <Link to="/foo/s/sub">subLink</Link>
+                    <Link to="/foo">fooLink</Link>
+                    <Route path="/foo">
+                        <div>foo</div>
+                    </Route>
+                    <Route path="/foo/s/sub">
+                        <div>sub</div>
+                    </Route>
+                </RouterPrompt>
+            </Route>
+            <Redirect to="/foo" />
+        </Switch>
+    );
+}
+
+function Path() {
+    const location = useLocation();
+    const [, rerender] = React.useState(0);
+    React.useEffect(() => {
+        const timer = setTimeout(() => {
+            rerender(new Date().getTime());
+        }, 1000);
+        return () => clearTimeout(timer);
+    }, []);
+    return <div>{location.pathname}</div>;
+}
+
+function App() {
+    return (
+        <>
+            <Path />
+            <Story />
+        </>
+    );
+}
+
+storiesOf("@comet/admin/router", module)
+    .addDecorator(storyRouterDecorator())
+    .add("Nested route with non-sub-path route in Prompt", () => <App />);

--- a/packages/admin/admin-stories/src/admin/router/SubRoute.tsx
+++ b/packages/admin/admin-stories/src/admin/router/SubRoute.tsx
@@ -100,6 +100,6 @@ function App() {
     );
 }
 
-storiesOf("@comet/admin/stack", module)
+storiesOf("@comet/admin/router", module)
     .addDecorator(storyRouterDecorator())
     .add("Subroute", () => <App />);

--- a/packages/admin/admin-stories/src/admin/tabs/RouterTabsInSubroute.tsx
+++ b/packages/admin/admin-stories/src/admin/tabs/RouterTabsInSubroute.tsx
@@ -1,0 +1,56 @@
+import { RouterTab, RouterTabs, SubRoute } from "@comet/admin";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { Redirect, Route, Switch, useLocation, useRouteMatch } from "react-router";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+function Story() {
+    const match = useRouteMatch();
+    return (
+        <div>
+            <SubRoute path={`${match.url}/cmp1`}>
+                <RouterTabs>
+                    <RouterTab label="Tab 1" path="">
+                        Tab 1 Content
+                    </RouterTab>
+                    <RouterTab label="Tab 2" path="/form2">
+                        Tab 2 Content
+                    </RouterTab>
+                </RouterTabs>
+            </SubRoute>
+        </div>
+    );
+}
+
+function Path() {
+    const location = useLocation();
+    const [, rerender] = React.useState(0);
+    React.useEffect(() => {
+        const timer = setTimeout(() => {
+            rerender(new Date().getTime());
+        }, 1000);
+        return () => clearTimeout(timer);
+    }, []);
+    return <div>{location.pathname}</div>;
+}
+
+function App() {
+    return (
+        <>
+            <Path />
+            <Switch>
+                <Route exact path="/">
+                    <Redirect to="/foo" />
+                </Route>
+                <Route path="/foo">
+                    <Story />
+                </Route>
+            </Switch>
+        </>
+    );
+}
+
+storiesOf("@comet/admin/tabs", module)
+    .addDecorator(storyRouterDecorator())
+    .add("Router Tabs in SubRoute", () => <App />);

--- a/packages/admin/admin/src/EditDialog.tsx
+++ b/packages/admin/admin/src/EditDialog.tsx
@@ -157,9 +157,9 @@ const EditDialogInner: React.FunctionComponent<EditDialogProps & IHookProps> = (
     return (
         <RouterContext.Provider
             value={{
-                register: ({ id, path, message, saveAction }) => {
+                register: ({ saveAction, ...args }) => {
                     saveActionRef.current = saveAction;
-                    parentRouterContext?.register({ id, path, message, saveAction });
+                    parentRouterContext?.register({ saveAction, ...args });
                 },
                 unregister: (id) => {
                     saveActionRef.current = undefined;

--- a/packages/admin/admin/src/FinalForm.InTabs.test.tsx
+++ b/packages/admin/admin/src/FinalForm.InTabs.test.tsx
@@ -101,13 +101,10 @@ test("Form DirtyPrompt for outer Tabs", async () => {
     fireEvent.change(input, { target: { value: "xxxx" } });
     fireEvent.click(rendered.getByText("Page 2"));
 
-    console.error("This test is currently failing as this feature is not yet implemented");
-    /*
     await waitFor(() => {
         const dirtyDialog = rendered.queryAllByText("Do you want to save your changes?");
         expect(dirtyDialog.length).toBe(2); // 2 because text is shown twice in dialog (title+content)
     });
-    */
 });
 
 test("Form DirtyPrompt for outer Stack", async () => {

--- a/packages/admin/admin/src/router/Context.tsx
+++ b/packages/admin/admin/src/router/Context.tsx
@@ -6,9 +6,10 @@ import { SaveAction } from "./PromptHandler";
 interface IContext {
     register: (options: {
         id: string;
-        path?: string;
         message: (location: History.Location, action: History.Action) => string | boolean;
         saveAction?: SaveAction;
+        path: string;
+        subRoutePath?: string;
     }) => void;
     unregister: (id: string) => void;
 }

--- a/packages/admin/admin/src/router/Prompt.tsx
+++ b/packages/admin/admin/src/router/Prompt.tsx
@@ -6,6 +6,7 @@ import { v4 as uuid } from "uuid";
 
 import { RouterContext } from "./Context";
 import { SaveAction } from "./PromptHandler";
+import { SubRoute } from "./SubRoute";
 
 // react-router Prompt doesn't support multiple Prompts, this one does
 interface IProps {
@@ -15,15 +16,16 @@ interface IProps {
      */
     message: (location: History.Location, action: History.Action) => boolean | string;
     saveAction?: SaveAction;
+    subRoutePath?: string;
 }
-export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, saveAction }) => {
+export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, saveAction, subRoutePath, children }) => {
     const id = useConstant<string>(() => uuid());
     const reactRouterContext = React.useContext(__RouterContext); // reactRouterContext can be undefined if no router is used, don't fail in that case
     const path: string | undefined = reactRouterContext?.match.path;
     const context = React.useContext(RouterContext);
     React.useEffect(() => {
         if (context) {
-            context.register({ id, message, saveAction, path });
+            context.register({ id, message, saveAction, path, subRoutePath });
         } else {
             console.error("Can't register RouterPrompt, missing <RouterPromptHandler>");
         }
@@ -33,6 +35,9 @@ export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, saveAct
             }
         };
     });
-
-    return null;
+    if (subRoutePath) {
+        return <SubRoute path={subRoutePath}>{children}</SubRoute>;
+    } else {
+        return <>{children}</>;
+    }
 };

--- a/packages/admin/admin/src/router/PromptHandler.test.tsx
+++ b/packages/admin/admin/src/router/PromptHandler.test.tsx
@@ -19,11 +19,13 @@ test("Nested route in Prompt", async () => {
                         message={() => {
                             return "sure?";
                         }}
-                    />
-                    <Link to="/foo/sub">subLink</Link>
-                    <Route path="/foo/sub">
-                        <div>sub</div>
-                    </Route>
+                        subRoutePath="/foo/s"
+                    >
+                        <Link to="/foo/s/sub">subLink</Link>
+                        <Route path="/foo/s/sub">
+                            <div>sub</div>
+                        </Route>
+                    </RouterPrompt>
                 </Route>
                 <Redirect to="/foo" />
             </Switch>
@@ -58,15 +60,17 @@ test("Nested route with non-sub-path route in Prompt", async () => {
                         message={() => {
                             return "sure?";
                         }}
-                    />
-                    <Link to="/foo/sub">subLink</Link>
-                    <Link to="/foo">fooLink</Link>
-                    <Route path="/foo">
-                        <div>foo</div>
-                    </Route>
-                    <Route path="/foo/sub">
-                        <div>sub</div>
-                    </Route>
+                        subRoutePath="/foo/s"
+                    >
+                        <Link to="/foo/s/sub">subLink</Link>
+                        <Link to="/foo">fooLink</Link>
+                        <Route path="/foo">
+                            <div>foo</div>
+                        </Route>
+                        <Route path="/foo/s/sub">
+                            <div>sub</div>
+                        </Route>
+                    </RouterPrompt>
                 </Route>
                 <Redirect to="/foo" />
             </Switch>
@@ -109,8 +113,10 @@ test("route outside Prompt", async () => {
                         message={() => {
                             return "sure?";
                         }}
-                    />
-                    <Link to="/bar">barLink</Link>
+                        subRoutePath="/s"
+                    >
+                        <Link to="/bar">barLink</Link>
+                    </RouterPrompt>
                 </Route>
                 <Route path="/bar">bar</Route>
             </Switch>

--- a/packages/admin/admin/src/router/PromptHandler.test.tsx
+++ b/packages/admin/admin/src/router/PromptHandler.test.tsx
@@ -135,8 +135,6 @@ test("route outside Prompt", async () => {
 
     fireEvent.click(rendered.getByText("barLink"));
 
-    console.error("This test is currently failing as this feature is not yet implemented");
-    /*
     // verify navigation to bar did get blocked
     await waitFor(() => {
         const sub = rendered.queryAllByText("bar");
@@ -148,5 +146,4 @@ test("route outside Prompt", async () => {
         const sub = rendered.queryAllByText("sure?");
         expect(sub.length).toBe(1);
     });
-    */
 });

--- a/packages/admin/admin/src/router/PromptHandler.tsx
+++ b/packages/admin/admin/src/router/PromptHandler.tsx
@@ -41,8 +41,9 @@ function InnerPromptHandler({
     const promptMessage = (location: History.Location, action: History.Action): boolean | string => {
         for (const id of Object.keys(registeredMessages.current)) {
             const path = registeredMessages.current[id].path;
+            const subRoutePath = registeredMessages.current[id].subRoutePath;
             // allow transition if location is below path where prompt was rendered
-            if (!(path && location.pathname.startsWith(path))) {
+            if (!((subRoutePath && location.pathname.startsWith(subRoutePath)) || location.pathname == path)) {
                 const message = registeredMessages.current[id].message(location, action);
                 if (message !== true) {
                     return message;
@@ -86,7 +87,8 @@ function InnerPromptHandler({
 interface PromptMessages {
     [id: string]: {
         message: (location: History.Location, action: History.Action) => boolean | string;
-        path?: string;
+        path: string;
+        subRoutePath?: string;
     };
 }
 interface Props {
@@ -106,16 +108,18 @@ export const RouterPromptHandler: React.FunctionComponent<Props> = ({ children, 
 
     const register = ({
         id,
-        path,
         message,
         saveAction,
+        path,
+        subRoutePath,
     }: {
         id: string;
-        path?: string;
         message: (location: History.Location, action: History.Action) => string | boolean;
         saveAction: SaveAction;
+        path: string;
+        subRoutePath?: string;
     }) => {
-        registeredMessages.current[id] = { message, path };
+        registeredMessages.current[id] = { message, path, subRoutePath };
         if (saveAction) {
             saveActions.current[id] = saveAction;
         }

--- a/packages/admin/admin/src/router/SubRoute.tsx
+++ b/packages/admin/admin/src/router/SubRoute.tsx
@@ -25,5 +25,7 @@ export function SubRoute({ children, path }: { children: React.ReactNode; path: 
 export function useSubRoutePrefix() {
     const match = useRouteMatch();
     const subRoutesContext = React.useContext(SubRoutesContext);
-    return subRoutesContext?.path || match.url;
+    let ret = subRoutesContext?.path || match.url;
+    ret = ret.replace(/\/$/, ""); //remove trailing slash
+    return ret;
 }

--- a/packages/admin/admin/src/table/TableLocalChanges.tsx
+++ b/packages/admin/admin/src/table/TableLocalChanges.tsx
@@ -96,13 +96,14 @@ export class TableLocalChanges<TData extends { id: string; [key: string]: any }>
                         });
                     }}
                     */
-                />
-                {this.props.children({
-                    tableLocalChangesApi: this.tableLocalChangesApi,
-                    localChangesCount: Object.keys(this.state.changes).length,
-                    data: patchedData,
-                    loading: this.state.loading,
-                })}
+                >
+                    {this.props.children({
+                        tableLocalChangesApi: this.tableLocalChangesApi,
+                        localChangesCount: Object.keys(this.state.changes).length,
+                        data: patchedData,
+                        loading: this.state.loading,
+                    })}
+                </RouterPrompt>
             </>
         );
     }


### PR DESCRIPTION
Fix the remaining issue of https://github.com/vivid-planet/comet/pull/1027 by:

- RouterPrompt now must wrap it's child components (with routes where the prompt should not be shown)
- RouterPrompt creates a SubRoute (new feature introduces in #1049) that gives child routes a prefix and we can ignore prompts for those

Not added to #1027 because it needs SubRoute from #1049