### PR TITLE
Fix demo/admin intl:update

### DIFF
--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -13,7 +13,7 @@
         "intl:compile:comet": "formatjs compile-folder --format simple --ast lang/comet-lang lang-compiled/comet-lang",
         "intl:compile:comet-demo": "formatjs compile-folder --format simple --ast lang/comet-demo-lang lang-compiled/comet-demo-lang",
         "intl:extract": "formatjs extract \"src/**/*.ts*\" --ignore ./**.d.ts --out-file lang-extracted/en.json --format simple",
-        "intl:update": "git --git-dir ./lang/comet-lang/.git pull && git --git-dir ./lang/comet-demo-lang/.git pull",
+        "intl:update": "git --work-tree ./lang/comet-lang pull && git --work-tree ./lang/comet-demo-lang pull",
         "lint": "run-s intl:update intl:compile && run-p gql:types generate-block-types && run-p lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0  --config ./.eslintrc.cli.js --ext .ts,.tsx,.js,.jsx,.json,.md src/",
         "lint:tsc": "tsc --project .",

--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -13,7 +13,7 @@
         "intl:compile:comet": "formatjs compile-folder --format simple --ast lang/comet-lang lang-compiled/comet-lang",
         "intl:compile:comet-demo": "formatjs compile-folder --format simple --ast lang/comet-demo-lang lang-compiled/comet-demo-lang",
         "intl:extract": "formatjs extract \"src/**/*.ts*\" --ignore ./**.d.ts --out-file lang-extracted/en.json --format simple",
-        "intl:update": "git --work-tree ./lang/comet-lang pull && git --work-tree ./lang/comet-demo-lang pull",
+        "intl:update": "cd ./lang/comet-lang && git pull && cd ../comet-demo-lang && git pull",
         "lint": "run-s intl:update intl:compile && run-p gql:types generate-block-types && run-p lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0  --config ./.eslintrc.cli.js --ext .ts,.tsx,.js,.jsx,.json,.md src/",
         "lint:tsc": "tsc --project .",


### PR DESCRIPTION
--git-dir only changes .git directory, not the loaction of the working copy. That always resulted in lang files in admin direcly that where not used and often caused errors because of changes.

--work-tree is what we need here (a simple cd would also have done the job)