### PR TITLE
Make attached document optional when updating a page tree node

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -858,7 +858,7 @@ scalar SeoBlockInput @specifiedBy(url: "http://www.ecma-international.org/public
 input PageTreeNodeUpdateInput {
   name: String!
   slug: String!
-  attachedDocument: AttachedDocumentInput!
+  attachedDocument: AttachedDocumentInput
   hideInMenu: Boolean
   createAutomaticRedirectsOnSlugChange: Boolean = true
   userGroup: UserGroup! = All

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -465,7 +465,7 @@ input UpdateDamFolderInput {
 input PageTreeNodeUpdateInput {
   name: String!
   slug: String!
-  attachedDocument: AttachedDocumentInput!
+  attachedDocument: AttachedDocumentInput
   hideInMenu: Boolean
   createAutomaticRedirectsOnSlugChange: Boolean = true
 }

--- a/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
+++ b/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
@@ -3,6 +3,7 @@ import { Type } from "class-transformer";
 import { IsBoolean, IsEnum, IsInt, IsNumber, IsOptional, IsString, IsUUID, ValidateNested } from "class-validator";
 
 import { IsSlug } from "../../common/validators/is-slug";
+import { IsUndefinable } from "../../common/validators/is-undefinable";
 import { PageTreeNodeVisibility } from "../types";
 import { AttachedDocumentInput } from "./attached-document.input";
 
@@ -45,8 +46,6 @@ export abstract class PageTreeNodeBaseCreateInput {
 @InputType("PageTreeNodeCreateInput")
 export class DefaultPageTreeNodeCreateInput extends PageTreeNodeBaseCreateInput {}
 
-// input and output type are the same now
-// @TODO refactor to only one inputType
 @InputType()
 export abstract class PageTreeNodeBaseUpdateInput {
     @Field()
@@ -57,10 +56,11 @@ export abstract class PageTreeNodeBaseUpdateInput {
     @IsSlug()
     slug: string;
 
-    @Field(() => AttachedDocumentInput)
+    @Field(() => AttachedDocumentInput, { nullable: true })
     @Type(() => AttachedDocumentInput)
+    @IsUndefinable()
     @ValidateNested()
-    attachedDocument: AttachedDocumentInput;
+    attachedDocument?: AttachedDocumentInput;
 
     @Field({ nullable: true })
     @IsOptional()


### PR DESCRIPTION
The attached document input is currently required, which is inconvenient when e.g. only an update of the name is needed