### PR TITLE
Add block meta information for alternative links in SEO block

### DIFF
--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -1332,7 +1332,21 @@
             },
             {
                 "name": "alternativeLinks",
-                "kind": "Json",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "code",
+                            "kind": "String",
+                            "nullable": true
+                        },
+                        {
+                            "name": "url",
+                            "kind": "String",
+                            "nullable": true
+                        }
+                    ]
+                },
                 "nullable": false
             }
         ],
@@ -1412,7 +1426,21 @@
             },
             {
                 "name": "alternativeLinks",
-                "kind": "Json",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "code",
+                            "kind": "String",
+                            "nullable": true
+                        },
+                        {
+                            "name": "url",
+                            "kind": "String",
+                            "nullable": true
+                        }
+                    ]
+                },
                 "nullable": false
             }
         ]

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -661,7 +661,21 @@
             },
             {
                 "name": "alternativeLinks",
-                "kind": "Json",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "code",
+                            "kind": "String",
+                            "nullable": true
+                        },
+                        {
+                            "name": "url",
+                            "kind": "String",
+                            "nullable": true
+                        }
+                    ]
+                },
                 "nullable": false
             }
         ],
@@ -741,7 +755,21 @@
             },
             {
                 "name": "alternativeLinks",
-                "kind": "Json",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "code",
+                            "kind": "String",
+                            "nullable": true
+                        },
+                        {
+                            "name": "url",
+                            "kind": "String",
+                            "nullable": true
+                        }
+                    ]
+                },
                 "nullable": false
             }
         ]

--- a/packages/api/cms-api/src/blocks/createSeoBlock.ts
+++ b/packages/api/cms-api/src/blocks/createSeoBlock.ts
@@ -1,10 +1,13 @@
 import {
+    AnnotationBlockMeta,
     Block,
     BlockData,
     BlockDataInterface,
     BlockField,
     BlockInput,
     BlockInputInterface,
+    BlockMetaField,
+    BlockMetaFieldKind,
     ChildBlock,
     ChildBlockInput,
     createBlock,
@@ -113,7 +116,6 @@ export function createSeoBlock<ImageBlock extends Block = typeof PixelImageBlock
         canonicalUrl?: string;
 
         //Alternate Hreflang
-        @BlockField({ type: "json" })
         alternativeLinks: AlternativeLink[] = [];
 
         async transformToPlain(): Promise<TraversableTransformResponse> {
@@ -192,7 +194,6 @@ export function createSeoBlock<ImageBlock extends Block = typeof PixelImageBlock
         canonicalUrl?: string;
 
         //Alternate Hreflang
-        @BlockField({ type: "json" }) // TODO support array types in block meta
         @Type(() => AlternativeLink)
         @ValidateNested({ each: true })
         alternativeLinks: AlternativeLink[] = [];
@@ -202,7 +203,7 @@ export function createSeoBlock<ImageBlock extends Block = typeof PixelImageBlock
         }
     }
 
-    return createBlock(SeoBlockData, SeoBlockInput, "Seo");
+    return createBlock(SeoBlockData, SeoBlockInput, { name: "Seo", blockMeta: new Meta(SeoBlockData), blockInputMeta: new InputMeta(SeoBlockData) });
 }
 
 class AlternativeLink {
@@ -216,4 +217,36 @@ class AlternativeLink {
     @IsOptional()
     @IsUrl()
     url?: string;
+}
+
+const alternativeLinksField: BlockMetaField = {
+    name: "alternativeLinks",
+    kind: BlockMetaFieldKind.NestedObjectList,
+    object: {
+        fields: [
+            {
+                name: "code",
+                kind: BlockMetaFieldKind.String,
+                nullable: true,
+            },
+            {
+                name: "url",
+                kind: BlockMetaFieldKind.String,
+                nullable: true,
+            },
+        ],
+    },
+    nullable: false,
+};
+
+class Meta extends AnnotationBlockMeta {
+    get fields(): BlockMetaField[] {
+        return [...super.fields, alternativeLinksField];
+    }
+}
+
+class InputMeta extends AnnotationBlockMeta {
+    get fields(): BlockMetaField[] {
+        return [...super.fields, alternativeLinksField];
+    }
 }


### PR DESCRIPTION
The alternative links were typed as JSON before, resulting in `unknown` in the generated block types. This was done due to lacking support for arrays in block meta. While we wait for an array support implementation, we provide the block meta information by using the `blockMeta` and `blockInputMeta` options.