### PR TITLE
Add spacing by default between Tabs and TabContent & set correct top position of sticky header

### DIFF
--- a/.changeset/moody-suns-wait.md
+++ b/.changeset/moody-suns-wait.md
@@ -1,0 +1,6 @@
+---
+"@comet/blocks-admin": patch
+"@comet/cms-admin": patch
+---
+
+Add spacing by default between the tabs and the tab content when using `AdminTabs` or `BlockPreviewWithTabs`. This may add unwanted additional spacing in cases where the spacing was added manually.

--- a/.changeset/swift-timers-complain.md
+++ b/.changeset/swift-timers-complain.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Prevent unintentional movement of sticky header when scrolling in Tabs.

--- a/demo/admin/src/pages/EditPage.tsx
+++ b/demo/admin/src/pages/EditPage.tsx
@@ -166,7 +166,7 @@ export const EditPage: React.FC<Props> = ({ id, category }) => {
                             key: "config",
                             label: (
                                 <AdminTabLabel isValid={rootBlocksApi.seo.isValid}>
-                                    <FormattedMessage id="pages.pages.page.edit.config" defaultMessage="Config" />{" "}
+                                    <FormattedMessage id="pages.pages.page.edit.config" defaultMessage="Config" />
                                 </AdminTabLabel>
                             ),
                             content: rootBlocksApi.seo.adminUI,

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
@@ -9,7 +9,7 @@ interface Props {
     title?: React.ReactNode;
 }
 
-const StackBreadcrumbs = withStyles(({ palette }) => ({
+const StackBreadcrumbs = withStyles(({ palette, spacing }) => ({
     root: {
         paddingTop: 0,
         paddingBottom: 20,
@@ -17,6 +17,7 @@ const StackBreadcrumbs = withStyles(({ palette }) => ({
         zIndex: 15,
         backgroundColor: palette.background.default,
         top: 0,
+        marginTop: spacing(-4),
     },
 }))(CometAdminStackBreadcrumbs);
 

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentStickyHeader.ts
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentStickyHeader.ts
@@ -2,7 +2,7 @@ import { styled } from "@mui/material/styles";
 
 export const AdminComponentStickyHeader = styled("div")`
     position: sticky;
-    top: 40px;
+    top: 70px;
     background-color: ${({ theme }) => theme.palette.background.paper};
     border-bottom: 1px solid ${({ theme }) => theme.palette.divider};
     z-index: 15;

--- a/packages/admin/blocks-admin/src/blocks/common/AdminTabsTabContent.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminTabsTabContent.tsx
@@ -13,7 +13,9 @@ export function TabContent({ children, selectedTab }: TabContentProps): React.Re
     const scrollRestoration = useScrollRestoration<HTMLDivElement>(`adminTabsTabContent-${selectedTab}`);
     return (
         <Root {...scrollRestoration}>
-            <Box marginBottom={4}>{children}</Box>
+            <Box marginBottom={4} marginTop={4}>
+                {children}
+            </Box>
         </Root>
     );
 }

--- a/packages/admin/cms-admin/src/blocks/createSeoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createSeoBlock.tsx
@@ -117,7 +117,7 @@ export function createSeoBlock({ image = PixelImageBlock }: CreateSeoBlockOption
                         }}
                     >
                         {/* Meta */}
-                        <Box marginTop={4} marginBottom={8}>
+                        <Box marginBottom={8}>
                             <Typography variant="h4" gutterBottom>
                                 <FormattedMessage id="comet.blocks.seo.meta.sectionTitle" defaultMessage="Meta Tags" />
                             </Typography>


### PR DESCRIPTION
### Add spacing by default between Tabs and TabContent
Previously the spacing would have to be added manually for every tab, which tended to be forgotten.
Now, with the default spacing, the tab content looks good automatically without needing to add additional styling.
The breadcrumbs are an exception, as, according to the design, they should be "stuck" to the tabs rather than be part of the tab content.

| Previous default behavior | New default behavior |
| --- | --- |
| <img width="410" alt="Screenshot 2023-04-20 at 12 45 28" src="https://user-images.githubusercontent.com/6264317/233343551-d16887b5-95cc-4bcf-bd5b-5628ff7e3c5f.png"/> | <img width="410" alt="Screenshot 2023-04-20 at 12 45 35" src="https://user-images.githubusercontent.com/6264317/233343557-3fa33cf9-c7c3-4228-983b-4927b5fc7207.png"/> |

### Set correct top position of sticky header
This prevents the header from overlaying the breadcrumbs and from moving unnecessarily 30 pixels before becoming sticky while scrolling.

https://user-images.githubusercontent.com/6264317/233347935-7ab4be2b-b60f-429f-997d-ddd5db6c2314.mov