### PR TITLE
Remove nestjs eslint @typescript-eslint/explicit-function-return-type

### DIFF
--- a/.changeset/funny-ghosts-carry.md
+++ b/.changeset/funny-ghosts-carry.md
@@ -1,0 +1,5 @@
+---
+"@comet/eslint-config": minor
+---
+
+Remove explicit-function-return-type rule for default nestjs eslint config

--- a/packages/eslint-config/nestjs.js
+++ b/packages/eslint-config/nestjs.js
@@ -5,12 +5,6 @@ module.exports = {
         jest: true,
     },
     rules: {
-        "@typescript-eslint/explicit-function-return-type": [
-            "error",
-            {
-                allowExpressions: true,
-            },
-        ],
         "@typescript-eslint/naming-convention": [
             "error",
             {


### PR DESCRIPTION
The in nestjs active rule [@typescript-eslint/explicit-function-return-type](https://typescript-eslint.io/rules/explicit-function-return-type/) requires an explicit return type for any function.

While I understand this rule can enforce better return types (as you have to think explicitly about the return type) it is sometimes also annoying as the return type would be inferred perfectly fine.

I'd propose to let the developer decide, like we do for non-nestjs environments.

Alternative rule [@typescript-eslint/explicit-module-boundary-types](https://typescript-eslint.io/rules/explicit-module-boundary-types) that requires this only for exported functions could be considered instead.

(this change is compatible as it only removes a rule)