### PR TITLE
Disable pre-commit hooks for changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,4 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  HUSKY: 0 # https://typicode.github.io/husky/#/?id=with-env-variables


### PR DESCRIPTION
The changesets action would run the pre-commit hooks when creating the "Version packages" PR. This is unnecessary and caused errors due to missing files.