### PR TITLE
Fix circular dependency for link block in rich text block

### DIFF
--- a/demo/api/src/news/blocks/news-link.block.ts
+++ b/demo/api/src/news/blocks/news-link.block.ts
@@ -1,5 +1,4 @@
 import { BlockData, BlockField, BlockIndexData, BlockInput, createBlock, inputToData } from "@comet/blocks-api";
-import { News } from "@src/news/entities/news.entity";
 import { IsOptional, IsUUID } from "class-validator";
 
 class NewsLinkBlockData extends BlockData {
@@ -14,7 +13,7 @@ class NewsLinkBlockData extends BlockData {
         return {
             dependencies: [
                 {
-                    targetEntityName: News.name,
+                    targetEntityName: "News",
                     id: this.id,
                 },
             ],


### PR DESCRIPTION
Using the `News` entity in the `NewsLinkBlock` caused the following circular dependency: `News -> NewsContentBlock -> RichTextBlock -> LinkBlock -> NewsLinkBlock -> News`. This caused the `LinkBlock` in the `RichTextBlock` to be `undefined`. To fix the issue, we replace the `News.name` access with `"News"` to remove the dependency on the `News` entity.