### PR TITLE
Change styling of FilterBarButton and FilterBarMoreFilters

### DIFF
--- a/.changeset/nice-cups-develop.md
+++ b/.changeset/nice-cups-develop.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": major
+---
+
+Change styling of FilterBar components to be more consistent with other form components. The classes of `FilterBarMoreFilters` have changed, which may cause custom styling of this component to break.

--- a/packages/admin/admin/src/table/filterbar/filterBarActiveFilterBadge/FilterBarActiveFilterBadge.styles.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarActiveFilterBadge/FilterBarActiveFilterBadge.styles.tsx
@@ -14,9 +14,10 @@ export const styles = ({ palette }: Theme) => {
             boxSizing: "border-box",
             textAlign: "center",
             borderRadius: "4px",
-            padding: "0 5px",
+            padding: "4px 5px",
+            marginTop: -4,
+            marginBottom: -4,
             fontSize: "12px",
-            height: "20px",
         },
     });
 };

--- a/packages/admin/admin/src/table/filterbar/filterBarButton/FilterBarButton.styles.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarButton/FilterBarButton.styles.tsx
@@ -1,4 +1,4 @@
-import { Theme } from "@mui/material";
+import { buttonClasses, svgIconClasses, Theme } from "@mui/material";
 import createStyles from "@mui/styles/createStyles";
 
 import { FilterBarButtonProps } from "./FilterBarButton";
@@ -8,42 +8,29 @@ export type FilterBarButtonClassKey = "root" | "open" | "hasDirtyFields" | "filt
 export const styles = (theme: Theme) => {
     return createStyles<FilterBarButtonClassKey, FilterBarButtonProps>({
         root: {
-            boxSizing: "border-box",
-            height: 42,
             position: "relative",
-            alignItems: "center",
-            paddingLeft: 15,
-            paddingRight: 15,
             cursor: "pointer",
             display: "flex",
+            backgroundColor: theme.palette.common.white,
             borderColor: theme.palette.grey[100],
-            textTransform: "none",
-            fontWeight: theme.typography.fontWeightRegular,
+            borderRadius: 2,
 
-            "& [class*='MuiSvgIcon-root']": {
+            [`& .${buttonClasses.startIcon} .${svgIconClasses.root}, & .${buttonClasses.endIcon} .${svgIconClasses.root}`]: {
                 fontSize: 12,
             },
 
-            "&:active": {
-                borderColor: theme.palette.grey[400],
-                backgroundColor: "transparent",
+            "&:hover": {
+                borderColor: theme.palette.grey[100],
+                backgroundColor: theme.palette.common.white,
             },
 
-            "&:hover, &:focus": {
+            "&:focus": {
                 borderColor: theme.palette.primary.main,
-                backgroundColor: "transparent",
-            },
-
-            "& [class*='MuiButton-startIcon']": {
-                marginRight: "6px",
-            },
-
-            "& [class*='MuiButton-endIcon']": {
-                marginLeft: "10px",
+                backgroundColor: theme.palette.common.white,
             },
         },
         open: {
-            borderColor: theme.palette.grey[400],
+            borderColor: theme.palette.primary.main,
         },
         hasDirtyFields: {
             borderColor: theme.palette.grey[400],
@@ -51,10 +38,6 @@ export const styles = (theme: Theme) => {
 
             "&:disabled": {
                 borderColor: theme.palette.grey[100],
-            },
-
-            "& [class*='MuiButton-endIcon']": {
-                marginLeft: "6px",
             },
         },
         filterBadge: {

--- a/packages/admin/admin/src/table/filterbar/filterBarButton/FilterBarButton.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarButton/FilterBarButton.tsx
@@ -12,7 +12,7 @@ import { FilterBarButtonClassKey, styles } from "./FilterBarButton.styles";
 export interface FilterBarButtonProps extends ButtonProps {
     dirtyFieldsBadge?: React.ComponentType<FilterBarActiveFilterBadgeProps>;
     numberDirtyFields?: number;
-    openPopover: boolean;
+    openPopover?: boolean;
 }
 
 const FilterBarButton = ({
@@ -21,7 +21,8 @@ const FilterBarButton = ({
     numberDirtyFields,
     openPopover,
     classes,
-    endIcon,
+    endIcon = <ChevronDown />,
+    className,
     ...buttonProps
 }: FilterBarButtonProps & WithStyles<typeof styles>): React.ReactElement => {
     const hasDirtyFields = !!(numberDirtyFields && numberDirtyFields > 0);
@@ -29,16 +30,16 @@ const FilterBarButton = ({
 
     return (
         <Button
-            className={clsx(classes.root, hasDirtyFields && classes.hasDirtyFields, openPopover && classes.open)}
+            className={clsx(className, classes.root, hasDirtyFields && classes.hasDirtyFields, openPopover && classes.open)}
             disableRipple
-            endIcon={endIcon ?? <ChevronDown />}
+            endIcon={endIcon}
             variant="outlined"
             {...buttonProps}
         >
             {children}
             {hasDirtyFields && (
                 <span className={classes.filterBadge}>
-                    <FilterBarActiveFilterBadgeComponent countValue={numberDirtyFields as number} />
+                    <FilterBarActiveFilterBadgeComponent countValue={numberDirtyFields} />
                 </span>
             )}
         </Button>

--- a/packages/admin/admin/src/table/filterbar/filterBarMoreFilters/FilterBarMoreFilters.styles.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarMoreFilters/FilterBarMoreFilters.styles.tsx
@@ -3,33 +3,16 @@ import { createStyles } from "@mui/styles";
 
 import { FilterBarMoreFiltersProps } from "./FilterBarMoreFilters";
 
-export type FilterBarMoveFilersClassKey = "root" | "textWrapper";
+export type FilterBarMoveFilersClassKey = "root" | "button";
 
-export const styles = ({ palette, typography }: Theme) => {
+export const styles = ({ typography }: Theme) => {
     return createStyles<FilterBarMoveFilersClassKey, FilterBarMoreFiltersProps>({
         root: {
-            backgroundColor: palette.common.white,
-            border: `1px solid ${palette.grey[300]}`,
-            justifyContent: "center",
-            padding: "10px 15px",
-            position: "relative",
-            marginBottom: "10px",
-            alignItems: "center",
-            marginRight: "10px",
-            borderRadius: "2px",
-            cursor: "pointer",
-            display: "flex",
-
-            "& [class*='MuiSvgIcon-root']": {
-                fontSize: 12,
-            },
+            marginBottom: 10,
+            marginRight: 6,
         },
-        textWrapper: {
-            marginLeft: "15px",
-
-            "& [class*='MuiTypography-body1']": {
-                fontWeight: typography.fontWeightBold,
-            },
+        button: {
+            fontWeight: typography.fontWeightBold,
         },
     });
 };

--- a/packages/admin/admin/src/table/filterbar/filterBarMoreFilters/FilterBarMoreFilters.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarMoreFilters/FilterBarMoreFilters.tsx
@@ -1,9 +1,10 @@
 import { Filter } from "@comet/admin-icons";
-import { ComponentsOverrides, Theme, Typography } from "@mui/material";
+import { ComponentsOverrides, Theme } from "@mui/material";
 import { WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { FilterBarButton } from "../filterBarButton/FilterBarButton";
 import { FilterBarMoveFilersClassKey, styles } from "./FilterBarMoreFilters.styles";
 
 export interface FilterBarMoreFiltersProps {
@@ -16,20 +17,18 @@ export function MoreFilters({
     classes,
 }: React.PropsWithChildren<FilterBarMoreFiltersProps> & WithStyles<typeof styles>): React.ReactElement {
     const [hasExtended, setHasExtended] = React.useState(false);
-    if (!hasExtended) {
-        return (
-            <div className={classes.root} onClick={() => setHasExtended(true)}>
-                {icon}
-                <div className={classes.textWrapper}>
-                    <Typography variant="body1">
-                        <FormattedMessage id="comet.filterbar.moreFilter" defaultMessage="More Filter" />
-                    </Typography>
-                </div>
-            </div>
-        );
-    } else {
+
+    if (hasExtended) {
         return <>{children}</>;
     }
+
+    return (
+        <div className={classes.root}>
+            <FilterBarButton className={classes.button} onClick={() => setHasExtended(true)} startIcon={icon} endIcon={null}>
+                <FormattedMessage id="comet.filterbar.moreFilter" defaultMessage="More Filter" />
+            </FilterBarButton>
+        </div>
+    );
 }
 
 export const FilterBarMoreFilters = withStyles(styles, { name: "CometAdminFilterBarMoreFilters" })(MoreFilters);


### PR DESCRIPTION
This makes the look and behavior of FilterBar components more consistent with form components, allowing FilterBar components to be used together with other form components without the styling looking broken and inconsistent between fields, as is currently the case with the DamTableFilter.

### Example of the change in DamTableFilter

| Previously | Now |
| --- | --- |
| <img width="408" alt="prev" src="https://user-images.githubusercontent.com/6264317/235139008-b7b1cc6b-5836-422f-8ea4-906b5bd9b6be.png"> | <img width="408" alt="now" src="https://user-images.githubusercontent.com/6264317/235139003-ef775e8c-967d-404f-8550-f1c2bbc9a5a6.png"> | 

### Example of the change of `FilterBarMoreFilters`

| Previously | Now |
| --- | --- |
| <img width="380" alt="prev" src="https://user-images.githubusercontent.com/6264317/235140173-ea1d92b0-a662-4e29-b7f4-6eec9b50c497.png"> | <img width="380" alt="now" src="https://user-images.githubusercontent.com/6264317/235140168-048927d5-db24-4901-af6b-d0e0778793a7.png">  | 