### PR TITLE
Remove GH_TOKEN secret

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -13,7 +13,7 @@ jobs:
 
             - uses: actions/checkout@v3
               with:
-                  token: ${{ secrets.GH_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
             - run: |
                   git config user.name github-actions
                   git config user.email github-actions@github.com
@@ -22,14 +22,14 @@ jobs:
               uses: actions/checkout@v3
               with:
                   repository: vivid-planet/comet-lang
-                  token: ${{ secrets.GH_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
                   path: "demo/admin/lang/comet-lang"
 
             - name: "Demo: Clone translations"
               uses: actions/checkout@v3
               with:
                   repository: vivid-planet/comet-demo-lang
-                  token: ${{ secrets.GH_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
                   path: "demo/admin/lang/comet-demo-lang"
 
             - uses: pnpm/action-setup@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
 
             - uses: actions/checkout@v3
               with:
-                  token: ${{ secrets.GH_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
             - run: |
                   git config user.name github-actions
                   git config user.email github-actions@github.com
@@ -33,14 +33,14 @@ jobs:
               uses: actions/checkout@v3
               with:
                   repository: vivid-planet/comet-lang
-                  token: ${{ secrets.GH_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
                   path: "demo/admin/lang/comet-lang"
 
             - name: "Demo: Clone translations"
               uses: actions/checkout@v3
               with:
                   repository: vivid-planet/comet-demo-lang
-                  token: ${{ secrets.GH_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
                   path: "demo/admin/lang/comet-demo-lang"
 
             - uses: pnpm/action-setup@v2


### PR DESCRIPTION
The secret was used to checkout the translation repositories in workflows. As secrets are not visible for workflows triggered by outside contributers (e.g. a pull request from a fork), using a custom secret caused those workflows to fail. To fix this, we now use the GITHUB_TOKEN variable instead, which is automatically generated upon the start of a workflow run (see [docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) for more information).