### PR TITLE
Add small helper function for writing eager loading resolvers

### DIFF
--- a/.changeset/forty-readers-brush.md
+++ b/.changeset/forty-readers-brush.md
@@ -1,0 +1,15 @@
+---
+"@comet/cms-api": minor
+---
+
+Add new extractGraphqlFields helper function that extracts requested fields from GraphQLResolveInfo
+
+Usage example:
+```
+async products(@Info() info: GraphQLResolveInfo): Promise<PaginatedProducts> {
+    const fields = extractGraphqlFields(info, { root: "nodes" });
+    const options: FindOptions<Product, any> = { };
+    if (fields.includes("category")) options.populate = ["category"];
+    //alternative if graphql structure completely matches entities: options.populate = fields;
+    const [entities, totalCount] = await this.repository.findAndCount({}, options);
+```

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -68,6 +68,7 @@
         "file-type": "^16.0.0",
         "get-image-colors": "^4.0.0",
         "got": "^11.8.0",
+        "graphql-parse-resolve-info": "^4.13.0",
         "graphql-type-json": "^0.3.2",
         "hasha": "^5.2.2",
         "jsonwebtoken": "^8.5.1",

--- a/packages/api/cms-api/src/common/graphql/extract-graphql-fields.ts
+++ b/packages/api/cms-api/src/common/graphql/extract-graphql-fields.ts
@@ -1,0 +1,26 @@
+import { GraphQLResolveInfo } from "graphql";
+import { parseResolveInfo, ResolveTree } from "graphql-parse-resolve-info";
+
+export function extractGraphqlFields(info: GraphQLResolveInfo, options: { root?: string } = {}): string[] {
+    const resolveTree = parseResolveInfo(info) as ResolveTree;
+    function treeToList(resolveTree: ResolveTree): string[] {
+        const ret = [];
+        for (const typeName in resolveTree.fieldsByTypeName) {
+            const fields = resolveTree.fieldsByTypeName[typeName];
+            for (const fieldName in fields) {
+                ret.push(fields[fieldName].name);
+                for (const i of treeToList(fields[fieldName])) {
+                    ret.push(`${fields[fieldName].name}.${i}`);
+                }
+            }
+        }
+        return ret;
+    }
+    return treeToList(resolveTree).reduce((acc, i) => {
+        if (!options.root) return [...acc, i];
+        if (!i.startsWith(`${options.root}.`)) {
+            return acc;
+        }
+        return [...acc, i.substring(options.root.length + 1)];
+    }, [] as string[]);
+}

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -56,6 +56,7 @@ export { createEnumFilter } from "./common/filter/enum.filter.factory";
 export { filtersToMikroOrmQuery, searchToMikroOrmQuery } from "./common/filter/mikro-orm";
 export { NumberFilter } from "./common/filter/number.filter";
 export { StringFilter } from "./common/filter/string.filter";
+export { extractGraphqlFields } from "./common/graphql/extract-graphql-fields";
 export { OffsetBasedPaginationArgs } from "./common/pagination/offset-based.args";
 export { PaginatedResponseFactory } from "./common/pagination/paginated-response.factory";
 export { SortArgs } from "./common/sorting/sort.args";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2208,6 +2208,9 @@ importers:
       got:
         specifier: ^11.8.0
         version: 11.8.6
+      graphql-parse-resolve-info:
+        specifier: ^4.13.0
+        version: 4.13.0(graphql@15.8.0)
       graphql-type-json:
         specifier: ^0.3.2
         version: 0.3.2(graphql@15.8.0)
@@ -17459,6 +17462,19 @@ packages:
     optionalDependencies:
       sinon: 9.2.4
     dev: true
+
+  /graphql-parse-resolve-info@4.13.0(graphql@15.8.0):
+    resolution: {integrity: sha512-VVJ1DdHYcR7hwOGQKNH+QTzuNgsLA8l/y436HtP9YHoX6nmwXRWq3xWthU3autMysXdm0fQUbhTZCx0W9ICozw==}
+    engines: {node: '>=8.6'}
+    peerDependencies:
+      graphql: '>=0.9 <0.14 || ^14.0.2 || ^15.4.0 || ^16.3.0'
+    dependencies:
+      debug: 4.3.4(supports-color@9.3.1)
+      graphql: 15.8.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /graphql-request@3.7.0(graphql@15.8.0):
     resolution: {integrity: sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==}


### PR DESCRIPTION
Uses graphql-parse-resolve-info which is quite popular https://npmtrends.com/graphql-fields-vs-graphql-fields-list-vs-graphql-list-fields-vs-graphql-parse-resolve-info

graphql-fields is deprecated (see https://github.com/robrichard/graphql-fields) and refers to graphql-parse-resolve-info

usage example:
```
        const options: FindOptions<Product, any> = { offset, limit };
        if (fields.includes("category")) options.populate = ["category"];
        const [entities, totalCount] = await this.repository.findAndCount(where, options);
```
