### PR TITLE
Add a new eslint rule that makes sure no private sibling imports are used

### DIFF
--- a/.changeset/rude-starfishes-greet.md
+++ b/.changeset/rude-starfishes-greet.md
@@ -1,0 +1,7 @@
+---
+"@comet/eslint-config": minor
+---
+
+Add a new eslint rule that makes sure no private sibling imports are used
+
+Sibling File is eg a Foo.gql.ts file that should be considered as private sibling of Foo.ts and not used (imported) by any other file

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     },
     "devDependencies": {
         "@comet/dev-process-manager": "^2.3.2",
+        "@comet/eslint-plugin": "workspace:^4.1.0",
         "@formatjs/cli": "^4.8.3",
         "@types/node": "^18.0.0",
         "dotenv-cli": "^5.1.0",

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -27,12 +27,12 @@ import { FileUploadContextProvider } from "./DataGrid/fileUpload/FileUploadConte
 import { UploadSplitButton } from "./DataGrid/fileUpload/UploadSplitButton";
 import { DamTableFilter } from "./DataGrid/filter/DamTableFilter";
 import FolderDataGrid, {
+    damFolderQuery,
     GQLDamFileTableFragment,
     GQLDamFolderQuery,
     GQLDamFolderQueryVariables,
     GQLDamFolderTableFragment,
 } from "./DataGrid/FolderDataGrid";
-import { damFolderQuery } from "./DataGrid/FolderDataGrid.gql";
 import { RenderDamLabelOptions } from "./DataGrid/label/DamItemLabelColumn";
 import { RedirectToPersistedDamLocation } from "./DataGrid/RedirectToPersistedDamLocation";
 import { DamMoreActions } from "./DataGrid/selection/DamMoreActions";

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.gql.ts
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.gql.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 
-import { damFileThumbnailFragment } from "./thumbnail/DamThumbnail.gql";
+import { damFileThumbnailFragment } from "./thumbnail/DamThumbnail";
 
 export const damFileTableFragment = gql`
     fragment DamFileTable on DamFile {

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -43,6 +43,8 @@ import { DamUploadFooter } from "./footer/UploadFooter";
 import { DamItemLabelColumn } from "./label/DamItemLabelColumn";
 import { useDamSelectionApi } from "./selection/DamSelectionContext";
 import { useDamSearchHighlighting } from "./useDamSearchHighlighting";
+export { damFolderQuery } from "./FolderDataGrid.gql";
+export { moveDamFilesMutation, moveDamFoldersMutation } from "./FolderDataGrid.gql";
 export {
     GQLDamFileTableFragment,
     GQLDamFolderQuery,

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderHead.gql.ts
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderHead.gql.ts
@@ -1,7 +1,5 @@
 import { gql } from "@apollo/client";
 
-export { GQLDamFolderMPathFragment, GQLDamFolderMPathQuery, GQLDamFolderMPathQueryVariables } from "./TableHead.generated";
-
 export const damFolderMPathFragment = gql`
     fragment DamFolderMPath on DamFolder {
         id

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderHead.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderHead.tsx
@@ -6,13 +6,9 @@ import { FormattedMessage } from "react-intl";
 
 import { useOptimisticQuery } from "../../common/useOptimisticQuery";
 import FolderBreadcrumbs from "./breadcrumbs/FolderBreadcrumbs";
-import {
-    damFolderMPathFragment,
-    damFolderMPathQuery,
-    GQLDamFolderMPathFragment,
-    GQLDamFolderMPathQuery,
-    GQLDamFolderMPathQueryVariables,
-} from "./TableHead";
+import { damFolderMPathFragment, damFolderMPathQuery } from "./FolderHead.gql";
+import { GQLDamFolderMPathFragment, GQLDamFolderMPathQuery, GQLDamFolderMPathQueryVariables } from "./FolderHead.gql.generated";
+export { GQLDamFolderMPathFragment, GQLDamFolderMPathQuery, GQLDamFolderMPathQueryVariables } from "./FolderHead.gql.generated";
 
 interface TableHeadProps {
     isSearching: boolean;

--- a/packages/admin/cms-admin/src/dam/DataGrid/thumbnail/DamThumbnail.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/thumbnail/DamThumbnail.tsx
@@ -6,6 +6,7 @@ import { GQLDamFile, GQLDamFolder } from "../../../graphql.generated";
 import { AudioThumbnail } from "./AudioThumbnail";
 import { GQLDamFileThumbnailFragment } from "./DamThumbnail.gql.generated";
 import { VideoThumbnail } from "./VideoThumbnail";
+export { damFileThumbnailFragment } from "./DamThumbnail.gql";
 
 const ThumbnailWrapper = styled("div")`
     display: flex;

--- a/packages/admin/cms-admin/src/dam/MoveDamItemDialog/ChooseFolder.tsx
+++ b/packages/admin/cms-admin/src/dam/MoveDamItemDialog/ChooseFolder.tsx
@@ -9,6 +9,7 @@ import { FixedSizeList as List } from "react-window";
 import { MarkedMatches } from "../../common/MarkedMatches";
 import { FolderTreeMap } from "./useFolderTree";
 import { FolderWithMatches } from "./useFolderTreeSearch";
+export { allFoldersQuery } from "./ChooseFolder.gql";
 export { GQLAllFoldersWithoutFiltersQuery, GQLAllFoldersWithoutFiltersQueryVariables } from "./ChooseFolder.gql.generated";
 
 interface ChooseFolderProps {

--- a/packages/admin/cms-admin/src/dam/MoveDamItemDialog/MoveDamItemDialog.tsx
+++ b/packages/admin/cms-admin/src/dam/MoveDamItemDialog/MoveDamItemDialog.tsx
@@ -15,11 +15,11 @@ import {
     GQLMoveDamFilesMutationVariables,
     GQLMoveDamFoldersMutation,
     GQLMoveDamFoldersMutationVariables,
+    moveDamFilesMutation,
+    moveDamFoldersMutation,
 } from "../DataGrid/FolderDataGrid";
-import { moveDamFilesMutation, moveDamFoldersMutation } from "../DataGrid/FolderDataGrid.gql";
 import { clearDamItemCache } from "../helpers/clearDamItemCache";
-import { ChooseFolder, GQLAllFoldersWithoutFiltersQuery, GQLAllFoldersWithoutFiltersQueryVariables } from "./ChooseFolder";
-import { allFoldersQuery } from "./ChooseFolder.gql";
+import { allFoldersQuery, ChooseFolder, GQLAllFoldersWithoutFiltersQuery, GQLAllFoldersWithoutFiltersQueryVariables } from "./ChooseFolder";
 import { useFolderTree } from "./useFolderTree";
 import { useFolderTreeSearch } from "./useFolderTreeSearch";
 

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -34,6 +34,7 @@ import {
 } from "./RedirectForm.gql.generated";
 import { useSubmitMutation } from "./submitMutation";
 export { GQLRedirectSourceAvailableQuery, GQLRedirectSourceAvailableQueryVariables } from "./RedirectForm.generated";
+export { createRedirectMutation, updateRedirectMutation } from "./RedirectForm.gql";
 export { GQLCreateRedirectMutation, GQLUpdateRedirectMutation } from "./RedirectForm.gql.generated";
 
 interface Props {

--- a/packages/admin/cms-admin/src/redirects/submitMutation.ts
+++ b/packages/admin/cms-admin/src/redirects/submitMutation.ts
@@ -4,8 +4,7 @@ import { FetchResult } from "@apollo/client/link/core";
 import { BlockInterface } from "@comet/blocks-admin";
 
 import { GQLRedirectInput } from "../graphql.generated";
-import { FormValues, GQLCreateRedirectMutation, GQLUpdateRedirectMutation } from "./RedirectForm";
-import { createRedirectMutation, updateRedirectMutation } from "./RedirectForm.gql";
+import { createRedirectMutation, FormValues, GQLCreateRedirectMutation, GQLUpdateRedirectMutation, updateRedirectMutation } from "./RedirectForm";
 
 const convertRedirectFormToApiInput = ({ sourceType, source, target, comment }: FormValues, linkBlock: BlockInterface): GQLRedirectInput => {
     const apiInput: GQLRedirectInput = {

--- a/packages/eslint-config/core-without-import.js
+++ b/packages/eslint-config/core-without-import.js
@@ -1,7 +1,6 @@
 module.exports = {
     extends: ["eslint:recommended", "plugin:prettier/recommended"],
-    plugins: ["simple-import-sort", "unused-imports", "json-files"],
-
+    plugins: ["simple-import-sort", "unused-imports", "json-files", "@comet"],
     rules: {
         "no-unused-vars": "off",
         "prefer-template": "error",

--- a/packages/eslint-config/core.js
+++ b/packages/eslint-config/core.js
@@ -5,6 +5,6 @@ module.exports = {
     plugins: [...core.plugins, "import"],
     rules: {
         "import/no-extraneous-dependencies": "error",
-        "import/no-duplicates": "error",
+        "import/no-duplicates": "error"
     },
 };

--- a/packages/eslint-config/nextjs.js
+++ b/packages/eslint-config/nextjs.js
@@ -5,5 +5,6 @@ module.exports = {
         "react/prop-types": "off",
         "react/self-closing-comp": "error",
         "import/no-extraneous-dependencies": "error",
+        "@comet/no-private-sibling-import": ["error", [ "gql", "sc"]]
     },
 };

--- a/packages/eslint-config/nextjs.js
+++ b/packages/eslint-config/nextjs.js
@@ -5,6 +5,6 @@ module.exports = {
         "react/prop-types": "off",
         "react/self-closing-comp": "error",
         "import/no-extraneous-dependencies": "error",
-        "@comet/no-private-sibling-import": ["error", [ "gql", "sc"]]
+        "@comet/no-private-sibling-import": ["error", ["gql", "sc", "gql.generated"]]
     },
 };

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,7 +22,8 @@
         "eslint-plugin-react": "^7.32.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-simple-import-sort": "^9.0.0",
-        "eslint-plugin-unused-imports": "^2.0.0"
+        "eslint-plugin-unused-imports": "^2.0.0",
+        "@comet/eslint-plugin": "workspace:^4.2.0"
     },
     "devDependencies": {
         "eslint": "^8.32.0",

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -37,6 +37,7 @@ module.exports = {
                 ],
             },
         ],
+        "@comet/no-private-sibling-import": ["error", [ "gql", "sc"]]
     },
     overrides: [
         {

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -37,7 +37,7 @@ module.exports = {
                 ],
             },
         ],
-        "@comet/no-private-sibling-import": ["error", [ "gql", "sc"]]
+        "@comet/no-private-sibling-import": ["error", ["gql", "sc", "gql.generated"]]
     },
     overrides: [
         {

--- a/packages/eslint-plugin/.eslintrc.json
+++ b/packages/eslint-plugin/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+    "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
+    "parser": "@typescript-eslint/parser",
+    "plugins": ["@typescript-eslint", "simple-import-sort", "unused-imports"],
+    "rules": {
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }],
+        "prefer-template": "error",
+        "simple-import-sort/exports": "error",
+        "simple-import-sort/imports": "error",
+        "unused-imports/no-unused-imports": "error",
+        "no-console": ["error", { "allow": ["warn", "error"] }],
+        "no-return-await": "error"
+    },
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {
+                "@typescript-eslint/no-unused-vars": ["error", { "args": "none", "ignoreRestSiblings": true }]
+            }
+        }
+    ],
+    "ignorePatterns": ["bin/", "lib/**"]
+}
+

--- a/packages/eslint-plugin/jest.config.js
+++ b/packages/eslint-plugin/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    testEnvironment: "node",
+    transform: { "^.+\\.tsx?$": "ts-jest" },
+    rootDir: "./src",
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "@comet/eslint-plugin",
+    "version": "4.2.0",
+    "main": "lib/index.js",
+    "scripts": {
+        "build": "$npm_execpath run clean && tsc",
+        "clean": "rimraf lib",
+        "dev": "tsc --watch",
+        "lint": "run-p lint:eslint lint:tsc",
+        "lint:eslint": "eslint --max-warnings 0 src/",
+        "lint:tsc": "tsc",
+        "test": "jest",
+        "test:watch": "jest --watch"
+    },
+    "dependencies": {
+    },
+    "devDependencies": {
+        "@types/eslint": "^8.37.0",
+        "@types/jest": "^27.0.2",
+        "eslint": "^8.36.0",
+        "jest": "^29.5.0",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.8.3",
+        "ts-jest": "^29.0.5",
+        "typescript": "^4.0.0"
+    },
+    "peerDependencies": {
+        "eslint": "8"
+    }
+}

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -12,8 +12,6 @@
         "test": "jest",
         "test:watch": "jest --watch"
     },
-    "dependencies": {
-    },
     "devDependencies": {
         "@types/eslint": "^8.37.0",
         "@types/jest": "^27.0.2",

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,0 +1,9 @@
+import noPrivateSiblingImport from "./rules/no-private-sibling-import";
+const plugin = {
+    rules: {
+        "no-private-sibling-import": noPrivateSiblingImport,
+    },
+};
+export type Plugin = typeof plugin;
+
+module.exports = plugin;

--- a/packages/eslint-plugin/src/rules/no-private-sibling-import.test.ts
+++ b/packages/eslint-plugin/src/rules/no-private-sibling-import.test.ts
@@ -1,0 +1,16 @@
+import { RuleTester } from "eslint";
+
+import noPrivateSiblingImport from "./no-private-sibling-import";
+
+const ruleTester = new RuleTester({
+    parser: require.resolve("@typescript-eslint/parser"),
+});
+
+const errors = [{ message: "Avoid private sibling import from other files" }];
+
+const options = [["gql", "sc"]];
+
+ruleTester.run("no-private-sibling-import", noPrivateSiblingImport, {
+    valid: [{ code: `import FooGql from "./Foo.gql";`, filename: "/path/to/Foo.ts", options }],
+    invalid: [{ code: `import BarGql from "./Bar.gql";`, filename: "/path/to/Foo.ts", options, errors }],
+});

--- a/packages/eslint-plugin/src/rules/no-private-sibling-import.test.ts
+++ b/packages/eslint-plugin/src/rules/no-private-sibling-import.test.ts
@@ -8,9 +8,14 @@ const ruleTester = new RuleTester({
 
 const errors = [{ message: "Avoid private sibling import from other files" }];
 
-const options = [["gql", "sc"]];
+const options = [["gql", "sc", "gql.generated"]];
 
 ruleTester.run("no-private-sibling-import", noPrivateSiblingImport, {
     valid: [{ code: `import FooGql from "./Foo.gql";`, filename: "/path/to/Foo.ts", options }],
     invalid: [{ code: `import BarGql from "./Bar.gql";`, filename: "/path/to/Foo.ts", options, errors }],
+});
+
+ruleTester.run("no-private-sibling-import", noPrivateSiblingImport, {
+    valid: [{ code: `import FooGql from "./Foo.gql.generated";`, filename: "/path/to/Foo.ts", options }],
+    invalid: [{ code: `import BarGql from "./Bar.gql.generated";`, filename: "/path/to/Foo.ts", options, errors }],
 });

--- a/packages/eslint-plugin/src/rules/no-private-sibling-import.ts
+++ b/packages/eslint-plugin/src/rules/no-private-sibling-import.ts
@@ -1,0 +1,42 @@
+import { Rule } from "eslint";
+import path from "path";
+
+export default {
+    meta: {
+        type: "suggestion",
+        schema: [
+            {
+                type: "array",
+                description: "List of private sibling file extensions, defaults to gql, sc",
+                items: {
+                    type: "string",
+                },
+            },
+        ],
+    },
+    create(context) {
+        return {
+            ImportDeclaration: function (node) {
+                const optionSiblingExtensions = context.options[0] ?? ["gql", "sc"];
+                const filePath = context.getPhysicalFilename ? context.getPhysicalFilename() : context.getFilename();
+                if (filePath == "<text>") return; // If the input is from stdin, this test can't fail
+                const isPrivateFileMatch = String(node.source.value).match(new RegExp(`^(.*)\\.(${optionSiblingExtensions.join("|")})$`));
+                if (isPrivateFileMatch) {
+                    if (!isPrivateFileMatch[1].startsWith("./")) {
+                        context.report({
+                            node,
+                            message: "Import private siblings always with relative imports",
+                        });
+                    } else {
+                        if (isPrivateFileMatch[1] != `./${path.basename(filePath).replace(/\.(.*)$/, "")}`) {
+                            context.report({
+                                node,
+                                message: "Avoid private sibling import from other files",
+                            });
+                        }
+                    }
+                }
+            },
+        };
+    },
+} as Rule.RuleModule;

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.core.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "rootDir": "src"
+    },
+    "include": ["./src"],
+    "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@comet/dev-process-manager':
         specifier: ^2.3.2
         version: 2.3.2
+      '@comet/eslint-plugin':
+        specifier: workspace:^4.1.0
+        version: link:packages/eslint-plugin
       '@formatjs/cli':
         specifier: ^4.8.3
         version: 4.8.4
@@ -2477,6 +2480,9 @@ importers:
       '@calm/eslint-plugin-react-intl':
         specifier: ^1.4.1
         version: 1.4.1
+      '@comet/eslint-plugin':
+        specifier: workspace:^4.2.0
+        version: link:../eslint-plugin
       '@next/eslint-plugin-next':
         specifier: ^12.0.0
         version: 12.3.4
@@ -2523,6 +2529,33 @@ importers:
       prettier:
         specifier: ^2.0.0
         version: 2.8.3
+      typescript:
+        specifier: ^4.0.0
+        version: 4.9.4
+
+  packages/eslint-plugin:
+    devDependencies:
+      '@types/eslint':
+        specifier: ^8.37.0
+        version: 8.37.0
+      '@types/jest':
+        specifier: ^27.0.2
+        version: 27.0.2
+      eslint:
+        specifier: ^8.36.0
+        version: 8.36.0
+      jest:
+        specifier: ^29.5.0
+        version: 29.5.0(@types/node@18.15.3)(ts-node@10.9.1)
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      prettier:
+        specifier: ^2.8.3
+        version: 2.8.3
+      ts-jest:
+        specifier: ^29.0.5
+        version: 29.0.5(@babel/core@7.20.12)(jest@29.5.0)(typescript@4.9.4)
       typescript:
         specifier: ^4.0.0
         version: 4.9.4
@@ -5651,13 +5684,28 @@ packages:
       - typescript
     dev: true
 
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.36.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.36.0
+      eslint-visitor-keys: 3.4.1
+    dev: true
+
+  /@eslint-community/regexpp@4.5.1:
+    resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
   /@eslint/eslintrc@1.4.1:
     resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4(supports-color@9.3.1)
-      espree: 9.4.1
+      espree: 9.5.2
       globals: 13.19.0
       ignore: 5.2.4
       import-fresh: 3.3.0
@@ -5666,6 +5714,28 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  /@eslint/eslintrc@2.0.3:
+    resolution: {integrity: sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4(supports-color@9.3.1)
+      espree: 9.5.2
+      globals: 13.19.0
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@eslint/js@8.36.0:
+    resolution: {integrity: sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
 
   /@faker-js/faker@7.6.0:
     resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
@@ -10875,14 +10945,21 @@ packages:
   /@types/eslint-scope@3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
-      '@types/eslint': 8.4.10
-      '@types/estree': 1.0.0
+      '@types/eslint': 8.37.0
+      '@types/estree': 0.0.51
+
+  /@types/eslint@8.37.0:
+    resolution: {integrity: sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==}
+    dependencies:
+      '@types/estree': 0.0.51
+      '@types/json-schema': 7.0.11
 
   /@types/eslint@8.4.10:
     resolution: {integrity: sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 0.0.51
       '@types/json-schema': 7.0.11
+    dev: false
 
   /@types/estree@0.0.50:
     resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
@@ -10890,9 +10967,6 @@ packages:
 
   /@types/estree@0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
-
-  /@types/estree@1.0.0:
-    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
 
   /@types/express-serve-static-core@4.17.31:
     resolution: {integrity: sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==}
@@ -11117,6 +11191,13 @@ packages:
     resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
+
+  /@types/jest@27.0.2:
+    resolution: {integrity: sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==}
+    dependencies:
+      jest-diff: 27.5.1
+      pretty-format: 27.5.1
+    dev: true
 
   /@types/jest@29.5.0:
     resolution: {integrity: sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==}
@@ -11844,7 +11925,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.49.0
-      eslint-visitor-keys: 3.3.0
+      eslint-visitor-keys: 3.4.1
     dev: false
 
   /@vue/compiler-core@3.2.45:
@@ -15238,6 +15319,11 @@ packages:
       streamsearch: 0.1.2
     dev: false
 
+  /diff-sequences@27.5.1:
+    resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
+
   /diff-sequences@29.4.3:
     resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -15954,8 +16040,8 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.49.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.32.0):
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.49.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.32.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -16041,7 +16127,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.32.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.49.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.32.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.49.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.32.0)
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -16212,6 +16298,10 @@ packages:
     resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  /eslint-visitor-keys@3.4.1:
+    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   /eslint@8.32.0:
     resolution: {integrity: sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -16259,6 +16349,55 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /eslint@8.36.0:
+    resolution: {integrity: sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.36.0)
+      '@eslint-community/regexpp': 4.5.1
+      '@eslint/eslintrc': 2.0.3
+      '@eslint/js': 8.36.0
+      '@humanwhocodes/config-array': 0.11.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4(supports-color@9.3.1)
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.1.1
+      eslint-visitor-keys: 3.4.1
+      espree: 9.5.2
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.19.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-sdsl: 4.3.0
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
@@ -16269,7 +16408,15 @@ packages:
     dependencies:
       acorn: 8.8.2
       acorn-jsx: 5.3.2(acorn@8.8.2)
-      eslint-visitor-keys: 3.3.0
+      eslint-visitor-keys: 3.4.1
+
+  /espree@9.5.2:
+    resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      acorn: 8.8.2
+      acorn-jsx: 5.3.2(acorn@8.8.2)
+      eslint-visitor-keys: 3.4.1
 
   /esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -16281,6 +16428,13 @@ packages:
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
+
+  /esquery@1.5.0:
+    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      estraverse: 5.3.0
+    dev: true
 
   /esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -19199,6 +19353,16 @@ packages:
       - supports-color
     dev: true
 
+  /jest-diff@27.5.1:
+    resolution: {integrity: sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 27.5.1
+      jest-get-type: 27.5.1
+      pretty-format: 27.5.1
+    dev: true
+
   /jest-diff@29.5.0:
     resolution: {integrity: sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -19260,6 +19424,11 @@ packages:
       '@types/node': 18.15.3
       jest-mock: 29.5.0
       jest-util: 29.5.0
+    dev: true
+
+  /jest-get-type@27.5.1:
+    resolution: {integrity: sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dev: true
 
   /jest-get-type@29.4.3:


### PR DESCRIPTION
Sibling File is eg a Foo.gql.ts file that should be considered as private sibling of Foo.ts and not used (imported) by any other file