### PR TITLE
Add support for Select multiple

### DIFF
--- a/.changeset/gorgeous-baboons-compete.md
+++ b/.changeset/gorgeous-baboons-compete.md
@@ -1,0 +1,9 @@
+---
+"@comet/admin": major
+---
+
+Add support for FinalFormSelect multiple
+
+Add a new getOptionValue prop that must be used to extract a unique string representation for a given option. Default implementation should work in most cases.
+    
+Remove getOptionSelected prop that is not needed anymore.

--- a/packages/admin/admin-stories/src/admin/form/Autocomplete.tsx
+++ b/packages/admin/admin-stories/src/admin/form/Autocomplete.tsx
@@ -20,6 +20,10 @@ const initialValues = {
     autocompleteAsync: { value: "strawberry", label: "Strawberry" },
     select: { value: "strawberry", label: "Strawberry" },
     selectAsync: { value: "strawberry", label: "Strawberry" },
+    selectAsyncMultiple: [
+        { value: "strawberry", label: "Strawberry" },
+        { value: "chocolate", label: "Chocolate" },
+    ],
 };
 
 function Story() {
@@ -27,6 +31,9 @@ function Story() {
         return new Promise((resolve) => setTimeout(() => resolve(options), 500));
     });
     const selectAsyncProps = useAsyncOptionsProps<Option>(async () => {
+        return new Promise((resolve) => setTimeout(() => resolve(options), 500));
+    });
+    const selectAsyncMultipleProps = useAsyncOptionsProps<Option>(async () => {
         return new Promise((resolve) => setTimeout(() => resolve(options), 500));
     });
     return (
@@ -87,6 +94,18 @@ function Story() {
                                 {...selectAsyncProps}
                                 name="selectAsync"
                                 label="SelectAsync"
+                                fullWidth
+                            />
+                            <Field
+                                component={FinalFormSelect}
+                                getOptionLabel={(option: Option) => option.label}
+                                getOptionSelected={(option: Option, value: Option) => {
+                                    return option.value === value.value;
+                                }}
+                                {...selectAsyncMultipleProps}
+                                name="selectAsyncMultiple"
+                                label="SelectAsyncMultiple"
+                                multiple
                                 fullWidth
                             />
                             <Button color="primary" variant="contained" type="submit">

--- a/packages/admin/admin-stories/src/docs/form/components/stories/FinalFormFields.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/form/components/stories/FinalFormFields.stories.tsx
@@ -141,6 +141,7 @@ storiesOf("stories/form/FinalForm Fields", module)
             () => ({
                 select: { value: "strawberry", label: "Strawberry" },
                 selectAsync: { value: "strawberry", label: "Strawberry" },
+                selectMultiple: [{ value: "strawberry", label: "Strawberry" }],
             }),
             [],
         );
@@ -177,6 +178,18 @@ storiesOf("stories/form/FinalForm Fields", module)
                     {...selectAsyncProps}
                     name="selectAsync"
                     label="SelectAsync"
+                    fullWidth
+                />
+                <Field
+                    component={FinalFormSelect}
+                    multiple
+                    getOptionLabel={(option: Option) => option.label}
+                    getOptionSelected={(option: Option, value: Option) => {
+                        return option.value === value.value;
+                    }}
+                    options={options}
+                    name="selectMultiple"
+                    label="Select multiple values"
                     fullWidth
                 />
                 <Button color="primary" variant="contained" type="submit">

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -79,17 +79,22 @@ export const FinalFormSelect = <T,>({
             onBlur={onBlur}
             multiple={multiple}
         >
+            {loading && (
+                <MenuItem value="">
+                    <CircularProgress size={20} />
+                </MenuItem>
+            )}
             {options.length === 0 &&
-                (loading || value) &&
+                value &&
                 (Array.isArray(value) ? (
                     value.map((v) => (
                         <MenuItem value={getOptionValue(v)} key={getOptionValue(v)}>
-                            {loading ? <CircularProgress size={20} /> : getOptionLabel(v)}
+                            {getOptionLabel(v)}
                         </MenuItem>
                     ))
                 ) : (
                     <MenuItem value={getOptionValue(value)} key={getOptionValue(value)}>
-                        {loading ? <CircularProgress size={20} /> : getOptionLabel(value)}
+                        {getOptionLabel(value)}
                     </MenuItem>
                 ))}
             {options.map((option: T) => (

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -1,6 +1,7 @@
-import { CircularProgress, MenuItem, Select, SelectProps } from "@mui/material";
+import { CircularProgress, InputAdornment, MenuItem, Select, SelectProps } from "@mui/material";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
+import { FormattedMessage } from "react-intl";
 
 import { ClearInputAdornment } from "../common/ClearInputAdornment";
 import { AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
@@ -64,7 +65,16 @@ export const FinalFormSelect = <T,>({
     return (
         <Select
             {...rest}
-            endAdornment={selectEndAdornment}
+            endAdornment={
+                <>
+                    {loading && (
+                        <InputAdornment position="end">
+                            <CircularProgress size={16} color="inherit" />
+                        </InputAdornment>
+                    )}
+                    {selectEndAdornment}
+                </>
+            }
             name={name}
             onChange={(event) => {
                 const value = event.target.value;
@@ -80,20 +90,21 @@ export const FinalFormSelect = <T,>({
             multiple={multiple}
         >
             {loading && (
-                <MenuItem value="">
-                    <CircularProgress size={20} />
+                <MenuItem value="" disabled>
+                    <FormattedMessage id="common.loading" defaultMessage="Loading ..." />
                 </MenuItem>
             )}
+
             {options.length === 0 &&
                 value &&
                 (Array.isArray(value) ? (
                     value.map((v) => (
-                        <MenuItem value={getOptionValue(v)} key={getOptionValue(v)}>
+                        <MenuItem value={getOptionValue(v)} key={getOptionValue(v)} sx={{ display: "none" }}>
                             {getOptionLabel(v)}
                         </MenuItem>
                     ))
                 ) : (
-                    <MenuItem value={getOptionValue(value)} key={getOptionValue(value)}>
+                    <MenuItem value={getOptionValue(value)} key={getOptionValue(value)} sx={{ display: "none" }}>
                         {getOptionLabel(value)}
                     </MenuItem>
                 ))}

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -6,14 +6,14 @@ import { ClearInputAdornment } from "../common/ClearInputAdornment";
 import { AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 
 export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> {
-    getOptionSelected?: (option: T, value: T) => boolean;
     getOptionLabel?: (option: T) => string;
+    getOptionValue?: (option: T) => string;
     children?: React.ReactNode;
     clearable?: boolean;
 }
 
 export const FinalFormSelect = <T,>({
-    input: { checked, value, name, onChange, onFocus, onBlur, ...restInput },
+    input: { checked, value, name, onChange, onFocus, onBlur, multiple, ...restInput },
     meta,
     isAsync = false,
     options = [],
@@ -25,9 +25,10 @@ export const FinalFormSelect = <T,>({
         }
         return "";
     },
-    getOptionSelected = (option: T, value: T) => {
-        if (!value) return false;
-        return option === value;
+    getOptionValue = (option: T) => {
+        if ((option as any).id) return String((option as any).id);
+        if ((option as any).value) return String((option as any).value);
+        return JSON.stringify(option);
     },
     children,
     endAdornment,
@@ -45,25 +46,54 @@ export const FinalFormSelect = <T,>({
 
     if (children) {
         return (
-            <Select {...rest} endAdornment={selectEndAdornment} name={name} onChange={onChange} value={value} onFocus={onFocus} onBlur={onBlur}>
+            <Select
+                {...rest}
+                endAdornment={selectEndAdornment}
+                name={name}
+                onChange={onChange}
+                value={value}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                multiple={multiple}
+            >
                 {children}
             </Select>
         );
     }
 
-    if (value && options) {
-        value = options.reduce((previousOption, option) => (getOptionSelected(option, value) ? option : previousOption), value);
-    }
-
     return (
-        <Select {...rest} endAdornment={selectEndAdornment} name={name} onChange={onChange} value={value} onFocus={onFocus} onBlur={onBlur}>
-            {options.length === 0 && (loading || value) && (
-                <MenuItem value={value as any} key={JSON.stringify(value)}>
-                    {loading ? <CircularProgress size={20} /> : getOptionLabel(value)}
-                </MenuItem>
-            )}
+        <Select
+            {...rest}
+            endAdornment={selectEndAdornment}
+            name={name}
+            onChange={(event) => {
+                const value = event.target.value;
+                onChange(
+                    Array.isArray(value)
+                        ? value.map((v) => options.find((i) => getOptionValue(i) == v))
+                        : options.find((i) => getOptionValue(i) == value),
+                );
+            }}
+            value={Array.isArray(value) ? value.map((i) => getOptionValue(i)) : getOptionValue(value)}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            multiple={multiple}
+        >
+            {options.length === 0 &&
+                (loading || value) &&
+                (Array.isArray(value) ? (
+                    value.map((v) => (
+                        <MenuItem value={getOptionValue(v)} key={getOptionValue(v)}>
+                            {loading ? <CircularProgress size={20} /> : getOptionLabel(v)}
+                        </MenuItem>
+                    ))
+                ) : (
+                    <MenuItem value={getOptionValue(value)} key={getOptionValue(value)}>
+                        {loading ? <CircularProgress size={20} /> : getOptionLabel(value)}
+                    </MenuItem>
+                ))}
             {options.map((option: T) => (
-                <MenuItem value={option as any} key={JSON.stringify(option)}>
+                <MenuItem value={getOptionValue(option)} key={getOptionValue(option)}>
                     {getOptionLabel(option)}
                 </MenuItem>
             ))}


### PR DESCRIPTION
- pass multiple prop correctly
- when using options prop handle object types correctly by not using that object directly as value (for mui select)

MenuItem value must be a string:

![Bildschirmfoto vom 2023-05-08 11-36-56](https://user-images.githubusercontent.com/50764/236790600-393c5903-be2d-427b-9f60-dc13fe92845b.png)

see also https://github.com/mui/material-ui/issues/16775

Adds a new getOptionValue prop that must be used to extract a unique string representation for a given option. Default implementation should work in most cases.

Remove getOptionSelected prop that is not needed anymore.