### PR TITLE
Change test report as recommended for public repositories

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,10 +72,9 @@ jobs:
             - name: Test
               run: pnpm run test
 
-            - name: Test Report
-              uses: dorny/test-reporter@v1
-              if: github.actor != 'dependabot[bot]' && (success() || failure())
+            - name: Upload test results
+              uses: actions/upload-artifact@v3
+              if: success() || failure()
               with:
-                  name: Tests
+                  name: test-results
                   path: packages/**/junit.xml
-                  reporter: jest-junit

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,16 @@
+name: "Test Report"
+on:
+    workflow_run:
+        workflows: ["Lint"]
+        types:
+            - completed
+jobs:
+    report:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: dorny/test-reporter@v1
+              with:
+                  artifact: test-results
+                  name: Tests
+                  path: packages/**/junit.xml
+                  reporter: jest-junit


### PR DESCRIPTION
The current test report job doesn't work for contributions coming from forks. We change it the [recommended setup for public repositories](https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories).