### PR TITLE
Disable "collapse all"-button when no collapsing is impossible

### DIFF
--- a/packages/admin/cms-admin/src/pages/pageTree/usePageTree.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/usePageTree.ts
@@ -42,6 +42,7 @@ interface UsePageTreeApi {
     tree: TreeMap<GQLPageTreePageFragment>;
     selectedTree: TreeMap<GQLPageTreePageFragment>;
     setExpandedIds: React.Dispatch<React.SetStateAction<string[]>>;
+    expandedIds: string[];
     toggleExpand: (pageId: string) => void;
     onSelectChanged: (pageId: string, value: boolean) => void;
     selectState: PageTreeSelectionState;
@@ -166,6 +167,7 @@ export function usePageTree({
         setExpandedIds,
         toggleExpand,
         expandPage,
+        expandedIds,
 
         /* selected */
         selectedTree,

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -87,10 +87,11 @@ export function PagesPage({
 
     const ignorePages = React.useCallback((page: GQLPageTreePageFragment) => (showArchive ? true : page.visibility !== "Archived"), [showArchive]);
 
-    const { tree, pagesToRender, setExpandedIds, toggleExpand, onSelectChanged, setSelectedIds, selectState, selectedTree } = usePageTree({
-        pages: data?.pages ?? [],
-        filter: ignorePages,
-    });
+    const { tree, pagesToRender, setExpandedIds, expandedIds, toggleExpand, onSelectChanged, setSelectedIds, selectState, selectedTree } =
+        usePageTree({
+            pages: data?.pages ?? [],
+            filter: ignorePages,
+        });
 
     const pageSearchApi = usePageSearch({
         tree,
@@ -151,12 +152,12 @@ export function PagesPage({
                                         }
                                     }}
                                     selectedTree={selectedTree}
+                                    collapseAllDisabled={!expandedIds.length}
                                     onCollapseAllPressed={() => {
                                         setExpandedIds([]);
                                     }}
                                 />
                             </ActionToolbarBox>
-
                             <FullHeightPaper variant="outlined">
                                 {loading && <CircularProgress />}
 

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPageActionToolbar.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPageActionToolbar.tsx
@@ -37,6 +37,7 @@ export interface PagesPageActionToolbarProps {
     selectedTree: TreeMap<GQLPageTreePageFragment>;
 
     /* Collapse Buttons*/
+    collapseAllDisabled: boolean;
     onCollapseAllPressed: () => void;
 }
 
@@ -44,6 +45,7 @@ export const PagesPageActionToolbar: React.FunctionComponent<PagesPageActionTool
     selectedState,
     selectedTree,
     onSelectAllPressed,
+    collapseAllDisabled,
     onCollapseAllPressed,
 }) => {
     const [showCanNotDeleteDialog, setShowCanNotDeleteDialog] = React.useState(false);
@@ -233,7 +235,7 @@ export const PagesPageActionToolbar: React.FunctionComponent<PagesPageActionTool
                     </Tooltip>
                 </Grid>
                 <Grid item>
-                    <Button startIcon={<TreeCollapseAll />} onClick={onCollapseAllPressed} size="small" color="info">
+                    <Button disabled={collapseAllDisabled} startIcon={<TreeCollapseAll />} onClick={onCollapseAllPressed} size="small" color="info">
                         <FormattedMessage id="comet.pages.pages.collapseAll" defaultMessage="Collapse all" />
                     </Button>
                 </Grid>


### PR DESCRIPTION
The "Collapse all"-button is disabled when:
- No pages exist
- No pages are collapsable 
- All pages are collapsed