### PR TITLE
Fix test report directory

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -12,5 +12,5 @@ jobs:
               with:
                   artifact: test-results
                   name: Tests
-                  path: packages/**/junit.xml
+                  path: "**/junit.xml"
                   reporter: jest-junit


### PR DESCRIPTION
For unknown reasons the enclosing packages/ folder is not included in the created artifact.