### PR TITLE
Remove unsupported list levels from RTE

### DIFF
--- a/.changeset/calm-sloths-fold.md
+++ b/.changeset/calm-sloths-fold.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-rte": patch
+---
+
+Remove unsupported list levels from RTE when using `listLevelMax`

--- a/packages/admin/admin-rte/src/core/filterEditor/default.ts
+++ b/packages/admin/admin-rte/src/core/filterEditor/default.ts
@@ -4,6 +4,7 @@ import removeBlocksExceedingBlockLimit from "./removeBlocksExceedingBlockLimit";
 import removeUnsupportedBlockTypes from "./removeUnsupportedBlockTypes";
 import removeUnsupportedEntities from "./removeUnsupportedEntities";
 import removeUnsupportedInlineStyles from "./removeUnsupportedInlineStyles";
+import removeUnsupportedListLevels from "./removeUnsupportedListLevels";
 
 const defaultFilterEditorStateBeforeUpdate: FilterEditorStateBeforeUpdateFn = (newState, ctx) => {
     const fns: FilterEditorStateBeforeUpdateFn[] = [
@@ -11,6 +12,7 @@ const defaultFilterEditorStateBeforeUpdate: FilterEditorStateBeforeUpdateFn = (n
         removeUnsupportedBlockTypes,
         removeUnsupportedInlineStyles,
         removeBlocksExceedingBlockLimit,
+        removeUnsupportedListLevels,
     ];
 
     const shouldFilter = newState.getLastChangeType() === "insert-fragment";

--- a/packages/admin/admin-rte/src/core/filterEditor/removeUnsupportedListLevels.ts
+++ b/packages/admin/admin-rte/src/core/filterEditor/removeUnsupportedListLevels.ts
@@ -1,0 +1,16 @@
+import { EditorState } from "draft-js";
+
+import { FilterEditorStateBeforeUpdateFn } from "../Rte";
+
+const removeUnsupportedListLevels: FilterEditorStateBeforeUpdateFn = (newState, { listLevelMax }) => {
+    const content = newState.getCurrentContent();
+    const blockMap = content.getBlockMap();
+
+    return EditorState.set(newState, {
+        currentContent: content.merge({
+            blockMap: blockMap.map((block) => block?.merge({ depth: Math.min(block.getDepth(), listLevelMax) })),
+        }),
+    });
+};
+
+export default removeUnsupportedListLevels;

--- a/packages/admin/admin-stories/src/admin-rte/MaxListLevel.tsx
+++ b/packages/admin/admin-stories/src/admin-rte/MaxListLevel.tsx
@@ -1,0 +1,136 @@
+import { IRteRef, makeRteApi, Rte } from "@comet/admin-rte";
+import { Box, Card, CardContent } from "@mui/material";
+import { number } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { PrintEditorState, useAutoFocus } from "./helper";
+
+const [useRteApi] = makeRteApi();
+
+/**
+ * Development story for testing the max list level option.
+ */
+function Story() {
+    const { editorState, setEditorState } = useRteApi({
+        defaultValue: JSON.stringify({
+            blocks: [
+                {
+                    key: "b3kag",
+                    text: "Level 0",
+                    type: "unordered-list-item",
+                    depth: 0,
+                    inlineStyleRanges: [],
+                    entityRanges: [],
+                    data: {},
+                },
+                {
+                    key: "c76pu",
+                    text: "Level 1",
+                    type: "unordered-list-item",
+                    depth: 1,
+                    inlineStyleRanges: [],
+                    entityRanges: [],
+                    data: {},
+                },
+                {
+                    key: "73ucq",
+                    text: "Level 2",
+                    type: "unordered-list-item",
+                    depth: 2,
+                    inlineStyleRanges: [],
+                    entityRanges: [],
+                    data: {},
+                },
+                {
+                    key: "66giv",
+                    text: "Level 3",
+                    type: "unordered-list-item",
+                    depth: 3,
+                    inlineStyleRanges: [],
+                    entityRanges: [],
+                    data: {},
+                },
+                {
+                    key: "bii9q",
+                    text: "Level 4",
+                    type: "unordered-list-item",
+                    depth: 4,
+                    inlineStyleRanges: [],
+                    entityRanges: [],
+                    data: {},
+                },
+                {
+                    key: "62g0n",
+                    text: "Level 0",
+                    type: "ordered-list-item",
+                    depth: 0,
+                    inlineStyleRanges: [],
+                    entityRanges: [],
+                    data: {},
+                },
+                {
+                    key: "drug5",
+                    text: "Level 1",
+                    type: "ordered-list-item",
+                    depth: 1,
+                    inlineStyleRanges: [],
+                    entityRanges: [],
+                    data: {},
+                },
+                {
+                    key: "8p2d7",
+                    text: "Level 2",
+                    type: "ordered-list-item",
+                    depth: 2,
+                    inlineStyleRanges: [],
+                    entityRanges: [],
+                    data: {},
+                },
+                {
+                    key: "82dql",
+                    text: "Level 3",
+                    type: "ordered-list-item",
+                    depth: 3,
+                    inlineStyleRanges: [],
+                    entityRanges: [],
+                    data: {},
+                },
+                {
+                    key: "4bk6s",
+                    text: "Level 4",
+                    type: "ordered-list-item",
+                    depth: 4,
+                    inlineStyleRanges: [],
+                    entityRanges: [],
+                    data: {},
+                },
+            ],
+            entityMap: {},
+        }),
+    });
+
+    // focus the editor to see the cursor immediately
+    const editorRef = React.useRef<IRteRef>();
+    useAutoFocus(editorRef);
+
+    return (
+        <>
+            <Box marginBottom={4}>
+                <Card variant="outlined">
+                    <CardContent>
+                        <Rte
+                            value={editorState}
+                            onChange={setEditorState}
+                            ref={editorRef}
+                            options={{ listLevelMax: number("Max list level", 4, { min: 0, max: 4 }) }}
+                        />
+                    </CardContent>
+                </Card>
+            </Box>
+            <PrintEditorState editorState={editorState} />
+        </>
+    );
+}
+
+storiesOf("@comet/admin-rte", module).add("Max list level", () => <Story />);


### PR DESCRIPTION
The `listLevelMax` option was not considered when pasting text from another source, for instance, a Word document. This is fixed by removing unsupported depths upon filtering the editor state.

https://github.com/vivid-planet/comet/assets/48853629/d4f13c28-6b12-4eb1-86d9-995ae7b06a78

