### PR TITLE
Change propagationPolicy for deleting jobs from default to Background

### DIFF
--- a/.changeset/twenty-ads-report.md
+++ b/.changeset/twenty-ads-report.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-api": patch
+---
+
+Change propagationPolicy for deleting jobs from default to Background
+
+Currently we use the default propagationPolicy for deleting jobs. This results in pods from jobs being deleted in k8s but not on OpenShift. With the value fixed to "Background", the jobs should get deleted on every system.
+Foreground would be blocking, so we use Background to be non blocking.

--- a/packages/api/cms-api/src/kubernetes/kubernetes.service.ts
+++ b/packages/api/cms-api/src/kubernetes/kubernetes.service.ts
@@ -68,7 +68,7 @@ export class KubernetesService {
     }
 
     async deleteJob(name: string): Promise<void> {
-        const { response } = await this.batchApi.deleteNamespacedJob(name, this.namespace);
+        const { response } = await this.batchApi.deleteNamespacedJob(name, this.namespace, undefined, undefined, undefined, undefined, "Background");
         if (response.statusCode !== 200) {
             throw new Error(`Error deleting Job "${name}"`);
         }


### PR DESCRIPTION
Currently we use the default propagationPolicy for deleting jobs. This results in pods from jobs being deleted in k8s but not on OpenShift. With the value fixed to "Background", the jobs should get deleted on every system.
Foreground would be blocking, so we use Background to be non blocking.