### PR TITLE
Fix changes checker for empty scope objects

### DIFF
--- a/packages/api/cms-api/src/builds/builds.service.ts
+++ b/packages/api/cms-api/src/builds/builds.service.ts
@@ -134,6 +134,12 @@ export class BuildsService {
     }
 
     async setChangesSinceLastBuild(scope: ContentScope | "all" = "all"): Promise<void> {
+        const isEmptyScope = scope !== "all" && Object.keys(scope).length === 0; // Caused by features with optional scoping, e.g. redirects
+
+        if (isEmptyScope) {
+            scope = "all";
+        }
+
         if ((await this.changesRepository.findOne({ scope })) === null) {
             await this.changesRepository.persistAndFlush(this.changesRepository.create({ scope }));
         }


### PR DESCRIPTION
When scoping is disabled for a feature with optional scoping (e.g. redirects), an empty scope object is used for the related mutations. This is done to keep the GraphQL schema the same, even if a feature doesn't support scoping. This empty scope object was not considered when tracking changes since last build. Empty scope objects should be treated as a global change.