### PR TITLE
Fix publish config for new `@comet/eslint-plugin`

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -24,5 +24,9 @@
     },
     "peerDependencies": {
         "eslint": "8"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org"
     }
 }


### PR DESCRIPTION
Scoped packages need to be marked as public.