### PR TITLE
Add human readable label for publisher (cron job and job)

### DIFF
--- a/.changeset/dry-dogs-fry.md
+++ b/.changeset/dry-dogs-fry.md
@@ -1,0 +1,6 @@
+---
+"@comet/cms-admin": minor
+"@comet/cms-api": minor
+---
+
+Add human readable label for publisher (cron jobs and jobs)

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -21,6 +21,11 @@ type Build {
   completionTime: DateTime
   estimatedCompletionTime: DateTime
   id: ID!
+
+  """
+  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  """
+  label: String
   name: String
   startTime: DateTime
   status: JobStatus!
@@ -29,6 +34,11 @@ type Build {
 
 type BuildTemplate {
   id: ID!
+
+  """
+  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  """
+  label: String
   name: String!
 }
 

--- a/packages/admin/cms-admin/src/builds/PublisherPage.tsx
+++ b/packages/admin/cms-admin/src/builds/PublisherPage.tsx
@@ -32,6 +32,7 @@ const buildsQuery = gql`
             id
             status
             name
+            label
             trigger
             startTime
             completionTime
@@ -81,6 +82,9 @@ export function PublisherPage(): React.ReactElement {
                             field: "name",
                             headerName: intl.formatMessage({ id: "comet.pages.publisher.name", defaultMessage: "Name" }),
                             flex: 2,
+                            renderCell: ({ row }) => {
+                                return row.label ?? row.name;
+                            },
                         },
                         {
                             field: "runtime",

--- a/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
+++ b/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
@@ -12,6 +12,7 @@ const buildTemplatesQuery = gql`
         buildTemplates {
             id
             name
+            label
         }
     }
 `;
@@ -66,6 +67,9 @@ export function StartBuildsDialog(props: StartBuildsDialogProps) {
                                 defaultMessage: "Name",
                             }),
                             flex: 1,
+                            renderCell: ({ row }) => {
+                                return row.label ?? row.name;
+                            },
                         },
                     ]}
                     checkboxSelection

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -92,6 +92,11 @@ type DamFile {
 type BuildTemplate {
   id: ID!
   name: String!
+
+  """
+  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  """
+  label: String
 }
 
 type AutoBuildStatus {
@@ -104,6 +109,11 @@ type Build {
   id: ID!
   status: JobStatus!
   name: String
+
+  """
+  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  """
+  label: String
   trigger: String
   startTime: DateTime
   completionTime: DateTime

--- a/packages/api/cms-api/src/builds/build-templates.resolver.ts
+++ b/packages/api/cms-api/src/builds/build-templates.resolver.ts
@@ -4,6 +4,7 @@ import { CurrentUserInterface } from "../auth/current-user/current-user";
 import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
 import { KubernetesService } from "../kubernetes/kubernetes.service";
 import { BuildTemplatesService } from "./build-templates.service";
+import { LABEL_ANNOTATION } from "./builds.constants";
 import { BuildTemplateObject } from "./dto/build-template.object";
 
 @Resolver(() => BuildTemplateObject)
@@ -17,6 +18,10 @@ export class BuildTemplatesResolver {
         }
 
         const builderCronJobs = await this.buildTemplatesService.getAllowedBuilderCronJobs(user);
-        return builderCronJobs.map((cronJob) => ({ id: cronJob.metadata?.uid as string, name: cronJob.metadata?.name as string }));
+        return builderCronJobs.map((cronJob) => ({
+            id: cronJob.metadata?.uid as string,
+            name: cronJob.metadata?.name as string,
+            label: cronJob.metadata?.annotations?.[LABEL_ANNOTATION],
+        }));
     }
 }

--- a/packages/api/cms-api/src/builds/builds.constants.ts
+++ b/packages/api/cms-api/src/builds/builds.constants.ts
@@ -7,6 +7,9 @@ export const BUILD_CHECKER_LABEL = "comet-dxp.com/build-checker";
 /** Annotation for the build Job: defines who triggered the build (CronJob, Manual, ChangesDetected) */
 export const TRIGGER_ANNOTATION = "comet-dxp.com/trigger";
 
+/** Annotation for the builder cron jobs and build jobs to provide a human readable name */
+export const LABEL_ANNOTATION = "comet-dxp.com/label";
+
 /** Label which identifies a build job */
 export const BUILDER_LABEL = "comet-dxp.com/builder";
 

--- a/packages/api/cms-api/src/builds/builds.service.ts
+++ b/packages/api/cms-api/src/builds/builds.service.ts
@@ -12,7 +12,7 @@ import { JobStatus } from "../kubernetes/job-status.enum";
 import { INSTANCE_LABEL, PARENT_CRON_JOB_LABEL } from "../kubernetes/kubernetes.constants";
 import { KubernetesService } from "../kubernetes/kubernetes.service";
 import { BuildTemplatesService } from "./build-templates.service";
-import { BUILDER_LABEL, TRIGGER_ANNOTATION } from "./builds.constants";
+import { BUILDER_LABEL, LABEL_ANNOTATION, TRIGGER_ANNOTATION } from "./builds.constants";
 import { AutoBuildStatus } from "./dto/auto-build-status.object";
 import { Build } from "./dto/build.object";
 import { ChangesSinceLastBuild } from "./entities/changes-since-last-build.entity";
@@ -107,6 +107,7 @@ export class BuildsService {
                         `${PARENT_CRON_JOB_LABEL} = ${job.metadata?.labels?.[PARENT_CRON_JOB_LABEL]}`,
                     ),
                     trigger: job.metadata?.annotations?.[TRIGGER_ANNOTATION],
+                    label: job.metadata?.annotations?.[LABEL_ANNOTATION],
                 };
             }),
         );

--- a/packages/api/cms-api/src/builds/dto/build-template.object.ts
+++ b/packages/api/cms-api/src/builds/dto/build-template.object.ts
@@ -1,5 +1,7 @@
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 
+import { LABEL_ANNOTATION } from "../builds.constants";
+
 @ObjectType("BuildTemplate")
 export class BuildTemplateObject {
     @Field(() => ID)
@@ -7,4 +9,7 @@ export class BuildTemplateObject {
 
     @Field()
     name: string;
+
+    @Field({ nullable: true, description: `Human readable label provided by ${LABEL_ANNOTATION} annotation. Use name as fallback if not present` })
+    label?: string;
 }

--- a/packages/api/cms-api/src/builds/dto/build.object.ts
+++ b/packages/api/cms-api/src/builds/dto/build.object.ts
@@ -1,6 +1,7 @@
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 
 import { JobStatus } from "../../kubernetes/job-status.enum";
+import { LABEL_ANNOTATION } from "../builds.constants";
 
 @ObjectType()
 export class Build {
@@ -12,6 +13,9 @@ export class Build {
 
     @Field({ nullable: true })
     name?: string;
+
+    @Field({ nullable: true, description: `Human readable label provided by ${LABEL_ANNOTATION} annotation. Use name as fallback if not present` })
+    label?: string;
 
     @Field({ nullable: true })
     trigger?: string;


### PR DESCRIPTION
Requested by customer: Exchange technical name from cron job/job with human readable name. Build time is redundant and thus not needed.

<img width="636" alt="Screenshot 2023-06-15 at 14 46 40" src="https://github.com/vivid-planet/comet/assets/10632685/87787611-2e4d-40d0-946a-4630d3cbd7b9">
