### PR TITLE
Silence polling errors in page tree

### DIFF
--- a/.changeset/chatty-days-deny.md
+++ b/.changeset/chatty-days-deny.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": minor
+---
+
+Silence polling errors in page tree
+
+Errors during polling (pages query, check for changes query) led to multiple consecutive error dialogs, which were irritating for our users. As these errors occurred randomly and would typically be resolved by the next poll, we decided to silence them altogether.

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -140,7 +140,7 @@ class App extends React.Component {
                                                                                         path={`${match.path}/project-snips/main-menu`}
                                                                                         component={MainMenu}
                                                                                     />
-                                                                                    <Route
+                                                                                    <RouteWithErrorBoundary
                                                                                         path={`${match.path}/pages/pagetree/:category`}
                                                                                         render={({ match: { params } }) => {
                                                                                             const category = urlParamToCategory(params.category);

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@apollo/client";
 import {
+    LocalErrorScopeApolloContext,
     MainContent,
     messages,
     Stack,
@@ -66,11 +67,13 @@ export function PagesPage({
         };
     }, [setRedirectPathAfterChange, path]);
 
-    const { loading, data, refetch, startPolling, stopPolling } = useQuery<GQLPagesQuery, GQLPagesQueryVariables>(pagesQuery, {
+    const { loading, data, error, refetch, startPolling, stopPolling } = useQuery<GQLPagesQuery, GQLPagesQueryVariables>(pagesQuery, {
+        fetchPolicy: "cache-and-network",
         variables: {
             contentScope: scope,
             category,
         },
+        context: LocalErrorScopeApolloContext,
     });
 
     useFocusAwarePolling({
@@ -79,6 +82,22 @@ export function PagesPage({
         startPolling,
         stopPolling,
     });
+
+    const isInitialLoad = React.useRef(true);
+
+    if (error) {
+        const isPollingError = !isInitialLoad.current;
+
+        if (isPollingError) {
+            // Ignore
+        } else {
+            throw error;
+        }
+    }
+
+    if (isInitialLoad.current && !loading) {
+        isInitialLoad.current = false;
+    }
 
     const [EditDialog, editDialogSelection, editDialogApi] = useEditDialog();
 


### PR DESCRIPTION
Errors during polling (pages query, check for changes query) led to multiple consecutive error dialogs, which were irritating for our users. As these errors occurred randomly and would typically be resolved by the next poll, we decided to silence them altogether.