### PR TITLE
Fix image download in fixtures

### DIFF
--- a/demo/api/src/db/fixtures/generators/unsplash-image-file.fixture.ts
+++ b/demo/api/src/db/fixtures/generators/unsplash-image-file.fixture.ts
@@ -14,7 +14,7 @@ export class UnsplashImageFileFixture {
             max: 3000,
         });
 
-        const imageUrl = `https://source.unsplash.com/random/${width}x${height}`;
+        const imageUrl = `https://source.unsplash.com/all/${width}x${height}`;
         console.log(`Downloading ${imageUrl}.`);
         const downloadedImage = await download(imageUrl);
         console.log(`Downloading ${imageUrl} done.`);


### PR DESCRIPTION
## Previously:

The URL https://source.unsplash.com/random/${width}x${height} didn't return actual images anymore. Only the error image as shown below.

<img width="1916" alt="Bildschirm­foto 2023-06-20 um 16 34 43" src="https://github.com/vivid-planet/comet/assets/13380047/cc02e51a-63b7-4bfd-89cb-624009aab955">

## Now:

Replaced the URL with https://source.unsplash.com/all/${width}x${height}. It returns actual images again.

<img width="1916" alt="Bildschirm­foto 2023-06-20 um 16 35 48" src="https://github.com/vivid-planet/comet/assets/13380047/1839ab8b-59cb-40fa-bc08-d0bb0ae85a9d">
