### PR TITLE
Opt-Out for Automatic Redirects When Changing Slug

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -797,7 +797,7 @@ input PageTreeNodeUpdateInput {
   slug: String!
   attachedDocument: AttachedDocumentInput!
   hideInMenu: Boolean
-  createAutomaticRedirectsOnSlugChange: Boolean = false
+  createAutomaticRedirectsOnSlugChange: Boolean = true
   userGroup: UserGroup! = All
 }
 

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -171,6 +171,7 @@ type PageTreeNode {
   category: PageTreeNodeCategory!
   userGroup: UserGroup!
   childNodes: [PageTreeNode!]!
+  numberOfDescendants: Float!
   parentNode: PageTreeNode
   path: String!
   parentNodes: [PageTreeNode!]!
@@ -796,6 +797,7 @@ input PageTreeNodeUpdateInput {
   slug: String!
   attachedDocument: AttachedDocumentInput!
   hideInMenu: Boolean
+  createRedirectFromOldToNewSlug: Boolean = false
   userGroup: UserGroup! = All
 }
 

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -797,7 +797,7 @@ input PageTreeNodeUpdateInput {
   slug: String!
   attachedDocument: AttachedDocumentInput!
   hideInMenu: Boolean
-  createRedirectFromOldToNewSlug: Boolean = false
+  createAutomaticRedirectsOnSlugChange: Boolean = false
   userGroup: UserGroup! = All
 }
 

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -361,8 +361,11 @@ export function createEditPageNode({
                                                                                 <Tooltip
                                                                                     title={
                                                                                         <FormattedMessage
-                                                                                            id="comet.pages.pages.page.createRedirectTooltip"
-                                                                                            defaultMessage="You should create the redirect(s) if the URL is known by users or search engines, so they can still find the page after renaming it. If the path is not known (e.g. newly created) you can skip it."
+                                                                                            id="comet.pages.pages.page.createAutomaticRedirects.tooltip"
+                                                                                            defaultMessage="You should create the {numberOfDescendants, plural, =0 {redirect} other {redirects}} if the URL is known by users or search engines, so they can still find the page after renaming it. If the path is not known (e.g. newly created) you can skip it."
+                                                                                            values={{
+                                                                                                numberOfDescendants,
+                                                                                            }}
                                                                                         />
                                                                                     }
                                                                                 >

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -325,7 +325,7 @@ export function createEditPageNode({
                                                 <>
                                                     <Typography>
                                                         {parentPath}
-                                                        <strong>/{slug}</strong>
+                                                        <strong>/{values.slug}</strong>
                                                     </Typography>
                                                     {mode === "edit" && dirtyFields.slug && (
                                                         <Box mt={3}>

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -324,61 +324,71 @@ export function createEditPageNode({
                                             return (
                                                 <>
                                                     <Typography>
-                                                        {parentPath}
-                                                        <strong>/{values.slug}</strong>
+                                                        {parentPath}/{values.slug}
                                                     </Typography>
                                                     {mode === "edit" && dirtyFields.slug && (
                                                         <Box mt={3}>
-                                                            <Field name="createAutomaticRedirectsOnSlugChange" type="checkbox">
-                                                                {(props) => (
-                                                                    <FormControlLabel
-                                                                        label={
-                                                                            <Typography display="flex" alignItems="center">
-                                                                                <div>
-                                                                                    <Typography variant="body1">
-                                                                                        <FormattedMessage
-                                                                                            tagName="span"
-                                                                                            id="comet.pages.pages.page.createAutomaticRedirects.fromOldToNewPath"
-                                                                                            defaultMessage="Create {numberOfDescendants, plural, =0 {a redirect} other {redirects}} from the old to the new path"
-                                                                                            values={{
-                                                                                                numberOfDescendants,
-                                                                                            }}
-                                                                                        />
-                                                                                    </Typography>
-                                                                                    {numberOfDescendants > 0 && (
-                                                                                        <Typography variant="body2" color="rgba(0, 0, 0, 0.6)">
+                                                            <FieldContainer
+                                                                label={
+                                                                    <>
+                                                                        <FormattedMessage
+                                                                            id="comet.pages.pages.page.createAutomaticRedirects.headline"
+                                                                            defaultMessage="Redirects"
+                                                                        />
+                                                                        <Tooltip
+                                                                            title={
+                                                                                <FormattedMessage
+                                                                                    id="comet.pages.pages.page.createAutomaticRedirects.tooltip"
+                                                                                    defaultMessage="A redirect will automatically send users and search engines to the correct page even if they visit the old path. So if you have already published or shared {numberOfDescendants, plural, =0 {this link} other {these links}}, check this box."
+                                                                                    values={{
+                                                                                        numberOfDescendants,
+                                                                                    }}
+                                                                                />
+                                                                            }
+                                                                        >
+                                                                            <IconButton>
+                                                                                <Info />
+                                                                            </IconButton>
+                                                                        </Tooltip>
+                                                                    </>
+                                                                }
+                                                            >
+                                                                <Field name="createAutomaticRedirectsOnSlugChange" type="checkbox">
+                                                                    {(props) => (
+                                                                        <FormControlLabel
+                                                                            label={
+                                                                                <Typography display="flex" alignItems="center">
+                                                                                    <div>
+                                                                                        <Typography variant="body1">
                                                                                             <FormattedMessage
                                                                                                 tagName="span"
-                                                                                                id="comet.pages.pages.page.createAutomaticRedirects.numberOfPages"
-                                                                                                defaultMessage="for this page and {numberOfDescendants} {numberOfDescendants, plural, one {subpage} other {subpages}}"
+                                                                                                id="comet.pages.pages.page.createAutomaticRedirects.label"
+                                                                                                defaultMessage="Create {numberOfDescendants, plural, =0 {a redirect} other {redirects}}"
                                                                                                 values={{
                                                                                                     numberOfDescendants,
                                                                                                 }}
                                                                                             />
                                                                                         </Typography>
-                                                                                    )}
-                                                                                </div>
-                                                                                <Tooltip
-                                                                                    title={
-                                                                                        <FormattedMessage
-                                                                                            id="comet.pages.pages.page.createAutomaticRedirects.tooltip"
-                                                                                            defaultMessage="You should create the {numberOfDescendants, plural, =0 {redirect} other {redirects}} if the URL is known by users or search engines, so they can still find the page after renaming it. If the path is not known (e.g. newly created) you can skip it."
-                                                                                            values={{
-                                                                                                numberOfDescendants,
-                                                                                            }}
-                                                                                        />
-                                                                                    }
-                                                                                >
-                                                                                    <IconButton>
-                                                                                        <Info />
-                                                                                    </IconButton>
-                                                                                </Tooltip>
-                                                                            </Typography>
-                                                                        }
-                                                                        control={<FinalFormCheckbox {...props} />}
-                                                                    />
-                                                                )}
-                                                            </Field>
+                                                                                        {numberOfDescendants > 0 && (
+                                                                                            <Typography variant="body2" color="rgba(0, 0, 0, 0.6)">
+                                                                                                <FormattedMessage
+                                                                                                    tagName="span"
+                                                                                                    id="comet.pages.pages.page.createAutomaticRedirects.labelSubline"
+                                                                                                    defaultMessage="for this page and all its child items"
+                                                                                                    values={{
+                                                                                                        numberOfDescendants,
+                                                                                                    }}
+                                                                                                />
+                                                                                            </Typography>
+                                                                                        )}
+                                                                                    </div>
+                                                                                </Typography>
+                                                                            }
+                                                                            control={<FinalFormCheckbox {...props} />}
+                                                                        />
+                                                                    )}
+                                                                </Field>
+                                                            </FieldContainer>
                                                         </Box>
                                                     )}
                                                 </>

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -204,7 +204,7 @@ export function createEditPageNode({
                             name: values.name,
                             slug: values.slug,
                             hideInMenu: values.hideInMenu,
-                            createRedirectFromOldToNewSlug: values.createRedirectFromOldToNewSlug,
+                            createAutomaticRedirectsOnSlugChange: values.createAutomaticRedirectsOnSlugChange,
                             attachedDocument: {
                                 id: values.documentType === data?.page?.documentType ? data?.page?.document?.id : undefined,
                                 type: values.documentType,
@@ -455,7 +455,7 @@ interface FormValues {
     path: string;
     documentType: string;
     hideInMenu: boolean;
-    createRedirectFromOldToNewSlug?: boolean;
+    createAutomaticRedirectsOnSlugChange?: boolean;
 }
 
 const transformToSlug = (name: string, locale: string) => {

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -63,6 +63,7 @@ export function createEditPageNode({
                 documentType
                 hideInMenu
                 parentId
+                numberOfDescendants
                 document {
                     ... on DocumentInterface {
                         id
@@ -318,39 +319,50 @@ export function createEditPageNode({
                                                 return <Typography>/</Typography>;
                                             }
 
-                                            function createCompletePath(slug: string) {
-                                                return (
-                                                    <>
-                                                        {parentPath ?? ""}
-                                                        <strong>/{slug}</strong>
-                                                    </>
-                                                );
-                                            }
+                                            const numberOfDescendants = data?.page?.numberOfDescendants ?? 0;
 
                                             return (
                                                 <>
-                                                    <Typography>{createCompletePath(values.slug)}</Typography>
+                                                    <Typography>
+                                                        {parentPath ?? ""}
+                                                        <strong>/{slug}</strong>
+                                                    </Typography>
                                                     {mode === "edit" && dirtyFields.slug && (
-                                                        <Box mt={2}>
-                                                            <Field name="createRedirectFromOldToNewSlug" type="checkbox">
+                                                        <Box mt={3}>
+                                                            <Field name="createAutomaticRedirectsOnSlugChange" type="checkbox">
                                                                 {(props) => (
                                                                     <FormControlLabel
                                                                         label={
                                                                             <Typography display="flex" alignItems="center">
-                                                                                <FormattedMessage
-                                                                                    tagName="span"
-                                                                                    id="comet.pages.pages.page.createRedirectFromOldToNewSlug"
-                                                                                    defaultMessage="Create redirect from {oldSlug} to {newSlug}"
-                                                                                    values={{
-                                                                                        oldSlug: createCompletePath(initialValues?.slug ?? ""),
-                                                                                        newSlug: createCompletePath(values.slug),
-                                                                                    }}
-                                                                                />
+                                                                                <div>
+                                                                                    <Typography variant="body1">
+                                                                                        <FormattedMessage
+                                                                                            tagName="span"
+                                                                                            id="comet.pages.pages.page.createAutomaticRedirects.fromOldToNewPath"
+                                                                                            defaultMessage="Create {numberOfDescendants, plural, =0 {a redirect} other {redirects}} from the old to the new path"
+                                                                                            values={{
+                                                                                                numberOfDescendants,
+                                                                                            }}
+                                                                                        />
+                                                                                    </Typography>
+                                                                                    {numberOfDescendants > 0 && (
+                                                                                        <Typography variant="body2" color="rgba(0, 0, 0, 0.6)">
+                                                                                            <FormattedMessage
+                                                                                                tagName="span"
+                                                                                                id="comet.pages.pages.page.createAutomaticRedirects.numberOfPages"
+                                                                                                defaultMessage="for this page and all {numberOfDescendants} descending pages"
+                                                                                                values={{
+                                                                                                    numberOfDescendants,
+                                                                                                }}
+                                                                                            />
+                                                                                        </Typography>
+                                                                                    )}
+                                                                                </div>
                                                                                 <Tooltip
                                                                                     title={
                                                                                         <FormattedMessage
                                                                                             id="comet.pages.pages.page.createRedirectTooltip"
-                                                                                            defaultMessage="You should create a redirect if the URL is known by users or search engines, so they can still find the page after renaming it. If this path is not known (e.g. newly created) you can skip it."
+                                                                                            defaultMessage="You should create the redirect(s) if the URL is known by users or search engines, so they can still find the page after renaming it. If the path is not known (e.g. newly created) you can skip it."
                                                                                         />
                                                                                     }
                                                                                 >

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -337,13 +337,25 @@ export function createEditPageNode({
                                                                         />
                                                                         <Tooltip
                                                                             title={
-                                                                                <FormattedMessage
-                                                                                    id="comet.pages.pages.page.createAutomaticRedirects.tooltip"
-                                                                                    defaultMessage="A redirect will automatically send users and search engines to the correct page even if they visit the old path. So if you have already published or shared {numberOfDescendants, plural, =0 {this link} other {these links}}, check this box."
-                                                                                    values={{
-                                                                                        numberOfDescendants,
-                                                                                    }}
-                                                                                />
+                                                                                <>
+                                                                                    <Typography variant="body2">
+                                                                                        <strong>
+                                                                                            <FormattedMessage
+                                                                                                id="comet.pages.pages.page.createAutomaticRedirects.tooltip.title"
+                                                                                                defaultMessage="Generate redirects"
+                                                                                            />
+                                                                                        </strong>
+                                                                                    </Typography>
+                                                                                    <Typography variant="body2">
+                                                                                        <FormattedMessage
+                                                                                            id="comet.pages.pages.page.createAutomaticRedirects.tooltip.text"
+                                                                                            defaultMessage="You have changed the slug, so redirects should be created so that users and search engines automatically land at the correct page, even if they visit the old path. So if you already have published or shared {numberOfDescendants, plural, =0 {this page} other {these pages}}, check this box."
+                                                                                            values={{
+                                                                                                numberOfDescendants,
+                                                                                            }}
+                                                                                        />
+                                                                                    </Typography>
+                                                                                </>
                                                                             }
                                                                         >
                                                                             <IconButton>
@@ -378,10 +390,7 @@ export function createEditPageNode({
                                                                                                 <FormattedMessage
                                                                                                     tagName="span"
                                                                                                     id="comet.pages.pages.page.createAutomaticRedirects.labelSubline"
-                                                                                                    defaultMessage="for this page and all its child items"
-                                                                                                    values={{
-                                                                                                        numberOfDescendants,
-                                                                                                    }}
+                                                                                                    defaultMessage="for this page and all its child pages"
                                                                                                 />
                                                                                             </Typography>
                                                                                         )}

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -350,7 +350,7 @@ export function createEditPageNode({
                                                                                             <FormattedMessage
                                                                                                 tagName="span"
                                                                                                 id="comet.pages.pages.page.createAutomaticRedirects.numberOfPages"
-                                                                                                defaultMessage="for this page and all {numberOfDescendants} descending pages"
+                                                                                                defaultMessage="for this page and {numberOfDescendants} {numberOfDescendants, plural, one {subpage} other {subpages}}"
                                                                                                 values={{
                                                                                                     numberOfDescendants,
                                                                                                 }}

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -353,7 +353,11 @@ export function createEditPageNode({
                                                                     </>
                                                                 }
                                                             >
-                                                                <Field name="createAutomaticRedirectsOnSlugChange" type="checkbox">
+                                                                <Field
+                                                                    name="createAutomaticRedirectsOnSlugChange"
+                                                                    type="checkbox"
+                                                                    initialValue={true}
+                                                                >
                                                                     {(props) => (
                                                                         <FormControlLabel
                                                                             label={

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -309,8 +309,8 @@ export function createEditPageNode({
                                         defaultMessage: "Complete Path",
                                     })}
                                 >
-                                    <FormSpy subscription={{ values: true, dirtyFields: true, initialValues: true }}>
-                                        {({ values, dirtyFields, initialValues }) => {
+                                    <FormSpy subscription={{ values: true, dirtyFields: true }}>
+                                        {({ values, dirtyFields }) => {
                                             if (!values.slug) {
                                                 return null;
                                             }

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -324,7 +324,7 @@ export function createEditPageNode({
                                             return (
                                                 <>
                                                     <Typography>
-                                                        {parentPath ?? ""}
+                                                        {parentPath}
                                                         <strong>/{slug}</strong>
                                                     </Typography>
                                                     {mode === "edit" && dirtyFields.slug && (

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -1,6 +1,7 @@
 import { gql, useApolloClient, useQuery } from "@apollo/client";
-import { ErrorScope, Field, FieldContainer, FinalForm, FinalFormCheckbox, FinalFormInput, FinalFormSelect } from "@comet/admin";
-import { Box, CircularProgress, FormControlLabel, MenuItem, Typography } from "@mui/material";
+import { ErrorScope, Field, FieldContainer, FinalForm, FinalFormCheckbox, FinalFormInput, FinalFormSelect, Tooltip } from "@comet/admin";
+import { Info } from "@comet/admin-icons";
+import { Box, CircularProgress, FormControlLabel, IconButton, MenuItem, Typography } from "@mui/material";
 import { Mutator } from "final-form";
 import setFieldTouched from "final-form-set-field-touched";
 import { DocumentNode } from "graphql";
@@ -335,14 +336,29 @@ export function createEditPageNode({
                                                                 {(props) => (
                                                                     <FormControlLabel
                                                                         label={
-                                                                            <FormattedMessage
-                                                                                id="comet.pages.pages.page.createRedirectFromOldToNewSlug"
-                                                                                defaultMessage="Create redirect from {oldSlug} to {newSlug}"
-                                                                                values={{
-                                                                                    oldSlug: createCompletePath(initialValues?.slug ?? ""),
-                                                                                    newSlug: createCompletePath(values.slug),
-                                                                                }}
-                                                                            />
+                                                                            <Typography display="flex" alignItems="center">
+                                                                                <FormattedMessage
+                                                                                    tagName="span"
+                                                                                    id="comet.pages.pages.page.createRedirectFromOldToNewSlug"
+                                                                                    defaultMessage="Create redirect from {oldSlug} to {newSlug}"
+                                                                                    values={{
+                                                                                        oldSlug: createCompletePath(initialValues?.slug ?? ""),
+                                                                                        newSlug: createCompletePath(values.slug),
+                                                                                    }}
+                                                                                />
+                                                                                <Tooltip
+                                                                                    title={
+                                                                                        <FormattedMessage
+                                                                                            id="comet.pages.pages.page.createRedirectTooltip"
+                                                                                            defaultMessage="You should create a redirect if the URL is known by users or search engines, so they can still find the page after renaming it. If this path is not known (e.g. newly created) you can skip it."
+                                                                                        />
+                                                                                    }
+                                                                                >
+                                                                                    <IconButton>
+                                                                                        <Info />
+                                                                                    </IconButton>
+                                                                                </Tooltip>
+                                                                            </Typography>
                                                                         }
                                                                         control={<FinalFormCheckbox {...props} />}
                                                                     />

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -57,6 +57,16 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 """
 scalar DateTime
 
+type Dependency {
+  rootId: String!
+  rootGraphqlObjectType: String!
+  rootColumnName: String!
+  jsonPath: String!
+  visible: Boolean!
+  targetGraphqlObjectType: String!
+  targetId: String!
+}
+
 type BuildTemplate {
   id: ID!
   name: String!
@@ -93,16 +103,6 @@ enum JobStatus {
   active
   succeeded
   failed
-}
-
-type Dependency {
-  rootId: String!
-  rootGraphqlObjectType: String!
-  rootColumnName: String!
-  jsonPath: String!
-  visible: Boolean!
-  targetGraphqlObjectType: String!
-  targetId: String!
 }
 
 type CronJob {
@@ -450,7 +450,7 @@ input PageTreeNodeUpdateInput {
   slug: String!
   attachedDocument: AttachedDocumentInput!
   hideInMenu: Boolean
-  createRedirectFromOldToNewSlug: Boolean = false
+  createAutomaticRedirectsOnSlugChange: Boolean = false
 }
 
 input AttachedDocumentInput {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -129,6 +129,7 @@ type PageTreeNode {
   hideInMenu: Boolean!
   category: String!
   childNodes: [PageTreeNode!]!
+  numberOfDescendants: Float!
   parentNode: PageTreeNode
   path: String!
   parentNodes: [PageTreeNode!]!

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -450,7 +450,7 @@ input PageTreeNodeUpdateInput {
   slug: String!
   attachedDocument: AttachedDocumentInput!
   hideInMenu: Boolean
-  createAutomaticRedirectsOnSlugChange: Boolean = false
+  createAutomaticRedirectsOnSlugChange: Boolean = true
 }
 
 input AttachedDocumentInput {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -449,6 +449,7 @@ input PageTreeNodeUpdateInput {
   slug: String!
   attachedDocument: AttachedDocumentInput!
   hideInMenu: Boolean
+  createRedirectFromOldToNewSlug: Boolean = false
 }
 
 input AttachedDocumentInput {

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -115,6 +115,18 @@ export function createPageTreeResolver({
             return this.pageTreeReadApi.getChildNodes(node);
         }
 
+        @ResolveField(() => Number)
+        async numberOfDescendants(@Parent() node: PageTreeNodeInterface): Promise<number> {
+            const childNodes = await this.pageTreeReadApi.getChildNodes(node);
+            let numberOfDescendants = childNodes.length;
+
+            for (const childNode of childNodes) {
+                numberOfDescendants += await this.numberOfDescendants(childNode);
+            }
+
+            return numberOfDescendants;
+        }
+
         @ResolveField(() => PageTreeNode, { nullable: true })
         async parentNode(@Parent() node: PageTreeNodeInterface): Promise<PageTreeNodeInterface | null> {
             return this.pageTreeReadApi.getParentNode(node);

--- a/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
+++ b/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
@@ -70,7 +70,7 @@ export abstract class PageTreeNodeBaseUpdateInput {
     @Field({ nullable: true, defaultValue: false })
     @IsOptional()
     @IsBoolean()
-    createRedirectFromOldToNewSlug: boolean;
+    createAutomaticRedirectsOnSlugChange: boolean;
 }
 
 @InputType("PageTreeNodeUpdateInput")

--- a/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
+++ b/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
@@ -67,7 +67,7 @@ export abstract class PageTreeNodeBaseUpdateInput {
     @IsBoolean()
     hideInMenu?: boolean;
 
-    @Field({ nullable: true, defaultValue: false })
+    @Field({ nullable: true, defaultValue: true })
     @IsOptional()
     @IsBoolean()
     createAutomaticRedirectsOnSlugChange: boolean;

--- a/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
+++ b/packages/api/cms-api/src/page-tree/dto/page-tree-node.input.ts
@@ -66,6 +66,11 @@ export abstract class PageTreeNodeBaseUpdateInput {
     @IsOptional()
     @IsBoolean()
     hideInMenu?: boolean;
+
+    @Field({ nullable: true, defaultValue: false })
+    @IsOptional()
+    @IsBoolean()
+    createRedirectFromOldToNewSlug: boolean;
 }
 
 @InputType("PageTreeNodeUpdateInput")

--- a/packages/api/cms-api/src/page-tree/page-tree.service.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.ts
@@ -90,7 +90,7 @@ export class PageTreeService {
         const existingNode = await readApi.getNodeOrFail(id);
         if (!existingNode) throw new Error("Can't find page-tree-node with id");
 
-        if (existingNode.slug != input.slug) {
+        if (input.createRedirectFromOldToNewSlug && existingNode.slug != input.slug) {
             await this.redirectsService.createAutomaticRedirects(existingNode);
         }
 

--- a/packages/api/cms-api/src/page-tree/page-tree.service.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.ts
@@ -90,7 +90,7 @@ export class PageTreeService {
         const existingNode = await readApi.getNodeOrFail(id);
         if (!existingNode) throw new Error("Can't find page-tree-node with id");
 
-        if (input.createRedirectFromOldToNewSlug && existingNode.slug != input.slug) {
+        if (input.createAutomaticRedirectsOnSlugChange && existingNode.slug != input.slug) {
             await this.redirectsService.createAutomaticRedirects(existingNode);
         }
 


### PR DESCRIPTION
Adds a checkbox to the EditPageNode form. Only if it's checked, a redirect is created.

Screencast:

https://github.com/vivid-planet/comet/assets/13380047/5cb5aadd-b4e7-4ac5-80fc-28c8d1918435

Screenshots:

Page without children:

<img width="614" alt="Bildschirm­foto 2023-07-13 um 10 56 10" src="https://github.com/vivid-planet/comet/assets/13380047/9570fa68-dd37-4a47-89f8-0139888b6c76">


Page with children:

<img width="614" alt="Bildschirm­foto 2023-07-13 um 10 56 44" src="https://github.com/vivid-planet/comet/assets/13380047/e37c84be-27b3-46e9-9f92-19aba9b9ed30">


Tooltip:

<img width="655" alt="Bildschirm­foto 2023-07-13 um 10 56 20" src="https://github.com/vivid-planet/comet/assets/13380047/7654d18d-315e-4468-9a64-c64e670bd13c">

