### PR TITLE
Always remove generated icons

### DIFF
--- a/packages/admin/admin-icons/generate-icons.ts
+++ b/packages/admin/admin-icons/generate-icons.ts
@@ -1,7 +1,7 @@
 import { Presets, SingleBar } from "cli-progress";
 import { ESLint } from "eslint";
 import { parse } from "fast-xml-parser";
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { pascalCase, pascalCaseTransformMerge } from "pascal-case";
 const eslint = new ESLint({ fix: true });
 
@@ -15,6 +15,10 @@ const main = async () => {
         Presets.shades_classic,
     );
     bar.start(files.length, 0);
+
+    if (existsSync("src/generated")) {
+        rmSync("src/generated", { recursive: true });
+    }
 
     mkdirSync("src/generated");
     await Promise.all(

--- a/packages/admin/admin-icons/package.json
+++ b/packages/admin/admin-icons/package.json
@@ -12,7 +12,7 @@
         "build": "run-s clean generate-icons && run-p build:babel build:types",
         "build:babel": "npx babel ./src -x \".ts,.tsx\" -d lib",
         "build:types": "tsc --project ./tsconfig.json --emitDeclarationOnly",
-        "clean": "rimraf lib && rimraf src/generated",
+        "clean": "rimraf lib",
         "generate-icons": "ts-node generate-icons.ts",
         "lint": "run-p lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0 src/ package.json",


### PR DESCRIPTION
The generated icons were removed before build, but not before start, causing `pnpm run start` to fail. To fix this, we now remove the generated icons in the generate-icons script in all cases.