### PR TITLE
Fix MUI error in page actions

### DIFF
--- a/packages/admin/cms-admin/src/pages/pageTree/PageActions.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageActions.tsx
@@ -64,74 +64,76 @@ export default function PageActions({ page, editDialog, children, siteUrl }: Pro
         <>
             <RowActionsMenu>
                 {children && children}
-                {page.visibility !== "Archived" && (
-                    <>
+                {page.visibility !== "Archived" && [
+                    <RowActionsItem
+                        key="edit"
+                        disabled={!isEditable}
+                        icon={<Edit />}
+                        onClick={() => {
+                            stackSwitchApi.activatePage("edit", String(page.id));
+                        }}
+                        componentsProps={{
+                            iconButton: {
+                                color: "primary",
+                            },
+                        }}
+                    >
+                        <FormattedMessage id="comet.pages.pages.page.editContent" defaultMessage="Edit content" />
+                    </RowActionsItem>,
+                    <RowActionsItem
+                        key="preview"
+                        icon={<Preview />}
+                        onClick={() => {
+                            openSitePreviewWindow(page.path, contentScopeMatch.url);
+                        }}
+                    >
+                        <FormattedMessage id="comet.pages.pages.page.openPreview" defaultMessage="Open preview" />
+                    </RowActionsItem>,
+                ]}
+                <RowActionsMenu>
+                    {page.visibility !== "Archived" && [
                         <RowActionsItem
-                            disabled={!isEditable}
+                            key="edit"
                             icon={<Edit />}
                             onClick={() => {
                                 stackSwitchApi.activatePage("edit", String(page.id));
                             }}
-                            componentsProps={{
-                                iconButton: {
-                                    color: "primary",
-                                },
-                            }}
                         >
                             <FormattedMessage id="comet.pages.pages.page.editContent" defaultMessage="Edit content" />
-                        </RowActionsItem>
+                        </RowActionsItem>,
                         <RowActionsItem
-                            icon={<Preview />}
+                            key="pageProperties"
+                            icon={<Settings />}
                             onClick={() => {
-                                openSitePreviewWindow(page.path, contentScopeMatch.url);
+                                editDialog?.openEditDialog(page.id);
                             }}
                         >
-                            <FormattedMessage id="comet.pages.pages.page.openPreview" defaultMessage="Open preview" />
-                        </RowActionsItem>
-                    </>
-                )}
-                <RowActionsMenu>
-                    {page.visibility !== "Archived" && (
-                        <>
-                            <RowActionsItem
-                                icon={<Edit />}
-                                onClick={() => {
-                                    stackSwitchApi.activatePage("edit", String(page.id));
-                                }}
-                            >
-                                <FormattedMessage id="comet.pages.pages.page.editContent" defaultMessage="Edit content" />
-                            </RowActionsItem>
-                            <RowActionsItem
-                                icon={<Settings />}
-                                onClick={() => {
-                                    editDialog?.openEditDialog(page.id);
-                                }}
-                            >
-                                <FormattedMessage id="comet.pages.pages.page.properties" defaultMessage="Page properties" />
-                            </RowActionsItem>
-                            <RowActionsItem
-                                icon={<Domain />}
-                                onClick={() => {
-                                    writeClipboard(`${siteUrl}${page.path}`);
-                                }}
-                            >
-                                <FormattedMessage id="comet.pages.pages.page.copyUrl" defaultMessage="Copy URL" />
-                            </RowActionsItem>
-                            <Divider />
-                            <RowActionsItem
-                                icon={<Add />}
-                                onClick={() => {
-                                    editDialog?.openAddDialog(serializeInitialValues({ parent: page.id }));
-                                }}
-                            >
-                                <FormattedMessage id="comet.pages.pages.page.newSubpage" defaultMessage="New subpage" />
-                            </RowActionsItem>
-                            <MovePageMenuItem page={page} />
-                            <Divider />
-                            <CopyPasteMenuItem page={page} />
-                            <Divider />
-                        </>
-                    )}
+                            <FormattedMessage id="comet.pages.pages.page.properties" defaultMessage="Page properties" />
+                        </RowActionsItem>,
+                        <RowActionsItem
+                            key="copyUrl"
+                            icon={<Domain />}
+                            onClick={() => {
+                                writeClipboard(`${siteUrl}${page.path}`);
+                            }}
+                        >
+                            <FormattedMessage id="comet.pages.pages.page.copyUrl" defaultMessage="Copy URL" />
+                        </RowActionsItem>,
+                        <Divider key="divider1" />,
+                        <RowActionsItem
+                            key="newSubpage"
+                            icon={<Add />}
+                            onClick={() => {
+                                editDialog?.openAddDialog(serializeInitialValues({ parent: page.id }));
+                            }}
+                        >
+                            <FormattedMessage id="comet.pages.pages.page.newSubpage" defaultMessage="New subpage" />
+                        </RowActionsItem>,
+                        <MovePageMenuItem key="movePage" page={page} />,
+                        <Divider key="divider2" />,
+                        <CopyPasteMenuItem key="copyPaste" page={page} />,
+                        <Divider key="divider3" />,
+                    ]}
                     <RowActionsItem
                         icon={<Delete />}
                         disabled={page.slug === "home"}


### PR DESCRIPTION
The MUI Menu component doesn't accept a fragment as a child. The error is resolved by using an array instead.

Before

<img width="1622" alt="before" src="https://github.com/vivid-planet/comet/assets/48853629/dc7b9615-6558-493b-8972-5d2ee6ee5621">

After

<img width="1622" alt="after" src="https://github.com/vivid-planet/comet/assets/48853629/c27d3a70-414a-4ffa-bfc8-c5f9863e5ed1">