### PR TITLE
Don't exclude test files in tsconfig.json, instead use a tsconfig.build.json

### DIFF
--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -15,7 +15,7 @@
     "scripts": {
         "build": "$npm_execpath run clean && run-p build:babel build:types",
         "build:babel": "npx babel ./src -x \".ts,.tsx\" -d lib",
-        "build:types": "tsc --project ./tsconfig.json --emitDeclarationOnly",
+        "build:types": "tsc --project ./tsconfig.build.json --emitDeclarationOnly",
         "clean": "rimraf lib",
         "lint": "run-p lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0 src/ package.json",

--- a/packages/admin/admin/tsconfig.build.json
+++ b/packages/admin/admin/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__/**"]
+}

--- a/packages/admin/admin/tsconfig.json
+++ b/packages/admin/admin/tsconfig.json
@@ -5,7 +5,5 @@
         "rootDir": "src"
     },
     "include": ["./src"],
-    "exclude": [
-        "**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__/**"
-    ]
+    "exclude": []
 }

--- a/packages/admin/blocks-admin/package.json
+++ b/packages/admin/blocks-admin/package.json
@@ -15,7 +15,7 @@
     "scripts": {
         "build": "$npm_execpath run clean && $npm_execpath generate-block-types && run-p build:babel build:types",
         "build:babel": "npx babel ./src -x \".ts,.tsx\" -d lib",
-        "build:types": "tsc --project ./tsconfig.json --emitDeclarationOnly",
+        "build:types": "tsc --project ./tsconfig.build.json --emitDeclarationOnly",
         "clean": "rimraf lib",
         "generate-block-types": "comet generate-block-types --inputs",
         "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",

--- a/packages/admin/blocks-admin/tsconfig.build.json
+++ b/packages/admin/blocks-admin/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__/**"]
+}

--- a/packages/admin/blocks-admin/tsconfig.json
+++ b/packages/admin/blocks-admin/tsconfig.json
@@ -5,5 +5,5 @@
         "rootDir": "src"
     },
     "include": ["./src"],
-    "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__/**"]
+    "exclude": []
 }

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -15,7 +15,7 @@
     "scripts": {
         "build": "$npm_execpath run clean && run-p generate-graphql-types generate-block-types && run-p build:babel build:types",
         "build:babel": "npx babel ./src -x \".ts,.tsx\" -d lib",
-        "build:types": "tsc --project ./tsconfig.json --emitDeclarationOnly",
+        "build:types": "tsc --project ./tsconfig.build.json --emitDeclarationOnly",
         "clean": "rimraf lib",
         "generate-block-types": "comet generate-block-types --inputs",
         "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",

--- a/packages/admin/cms-admin/tsconfig.build.json
+++ b/packages/admin/cms-admin/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__/**"]
+}

--- a/packages/admin/cms-admin/tsconfig.json
+++ b/packages/admin/cms-admin/tsconfig.json
@@ -6,5 +6,5 @@
         "strict": true
     },
     "include": ["./src"],
-    "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__/**"]
+    "exclude": []
 }

--- a/packages/api/blocks-api/package.json
+++ b/packages/api/blocks-api/package.json
@@ -13,9 +13,9 @@
         "lib/*"
     ],
     "scripts": {
-        "build": "$npm_execpath run clean && tsc",
+        "build": "$npm_execpath run clean && tsc -p tsconfig.build.json",
         "clean": "rimraf lib",
-        "dev": "tsc --watch --preserveWatchOutput",
+        "dev": "tsc --watch --preserveWatchOutput -p tsconfig.build.json",
         "generate-block-meta": "ts-node generate-block-meta.ts",
         "generate-block-meta:watch": "chokidar \"src/\" -c \"npm run generate-block-meta\"",
         "lint": "run-p lint:eslint lint:tsc",

--- a/packages/api/blocks-api/tsconfig.build.json
+++ b/packages/api/blocks-api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "lib", "**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__"]
+}

--- a/packages/api/blocks-api/tsconfig.json
+++ b/packages/api/blocks-api/tsconfig.json
@@ -5,5 +5,5 @@
         "baseUrl": "./"
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules", "lib", "**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__"]
+    "exclude": ["node_modules", "lib"]
 }

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -18,8 +18,8 @@
     ],
     "scripts": {
         "clean": "rimraf lib",
-        "build": "$npm_execpath run clean && tsc",
-        "dev": "tsc --watch --preserveWatchOutput",
+        "build": "$npm_execpath run clean && tsc -p tsconfig.build.json",
+        "dev": "tsc --watch --preserveWatchOutput -p tsconfig.build.json",
         "lint": "run-p lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0 src/ package.json",
         "lint:tsc": "tsc --noEmit",

--- a/packages/api/cms-api/tsconfig.build.json
+++ b/packages/api/cms-api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "lib", "**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__"]
+}

--- a/packages/api/cms-api/tsconfig.json
+++ b/packages/api/cms-api/tsconfig.json
@@ -5,5 +5,5 @@
         "baseUrl": "./"
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules", "lib", "**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__"]
+    "exclude": ["node_modules", "lib"]
 }

--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -13,9 +13,9 @@
         "lib/*"
     ],
     "scripts": {
-        "build": "$npm_execpath run clean && npm run generate-block-types && tsc",
+        "build": "$npm_execpath run clean && npm run generate-block-types && tsc --project tsconfig.build.json",
         "clean": "rimraf lib",
-        "dev": "$npm_execpath generate-block-types && tsc --watch --preserveWatchOutput",
+        "dev": "$npm_execpath generate-block-types && tsc --watch --preserveWatchOutput --project tsconfig.build.json",
         "generate-block-types": "comet generate-block-types",
         "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",
         "lint": "$npm_execpath generate-block-types && run-p lint:eslint lint:tsc",

--- a/packages/site/cms-site/tsconfig.build.json
+++ b/packages/site/cms-site/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__/**"]
+}

--- a/packages/site/cms-site/tsconfig.json
+++ b/packages/site/cms-site/tsconfig.json
@@ -4,5 +4,5 @@
         "outDir": "lib/"
     },
     "include": ["src/**/*"],
-    "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__"]
+    "exclude": []
 }


### PR DESCRIPTION
That previously resultet in no tsconfig being used for test files by TypeScript Language Server in the IDE. For tests using decorators with the new TS version the config didn't include experimentalDecorators and so the new non-experimental but incompatible decorator API was used resulting in "Unable to resolve signature of method decorator when called as an expression" error in the IDE.