### PR TITLE
DamFileDetails Type

### DIFF
--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -107,8 +107,10 @@ const EditFile = ({ id }: EditFormProps): React.ReactElement => {
     return <EditFileInner file={file} id={id} />;
 };
 
+export type DamFileDetails = GQLDamFileDetailFragment;
+
 interface EditFileInnerProps {
-    file: GQLDamFileDetailFragment;
+    file: DamFileDetails;
     id: string;
 }
 

--- a/packages/admin/cms-admin/src/dam/FileForm/FilePreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/FilePreview.tsx
@@ -9,7 +9,7 @@ import { FormattedMessage } from "react-intl";
 
 import { ConfirmDeleteDialog } from "../FileActions/ConfirmDeleteDialog";
 import { clearDamItemCache } from "../helpers/clearDamItemCache";
-import { GQLDamFileDetailFragment } from "./EditFile";
+import { DamFileDetails } from "./EditFile";
 import { archiveDamFileMutation, deleteDamFileMutation, restoreDamFileMutation } from "./FilePreview.gql";
 import {
     GQLArchiveFileMutation,
@@ -53,7 +53,7 @@ const ZipFileIcon = styled(ZipFile)`
 `;
 
 interface FilePreviewProps {
-    file: GQLDamFileDetailFragment;
+    file: DamFileDetails;
 }
 
 export const FilePreview = ({ file }: FilePreviewProps): React.ReactElement => {

--- a/packages/admin/cms-admin/src/dam/FileForm/previews/AudioPreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/previews/AudioPreview.tsx
@@ -2,7 +2,7 @@ import { Music } from "@comet/admin-icons";
 import { styled } from "@mui/material/styles";
 import React from "react";
 
-import { GQLDamFileDetailFragment } from "../EditFile";
+import { DamFileDetails } from "../EditFile";
 
 const AudioPreviewWrapper = styled("div")`
     width: 100%;
@@ -45,7 +45,7 @@ const StyledAudio = styled("audio")`
 `;
 
 interface AudioPreviewProps {
-    file: GQLDamFileDetailFragment;
+    file: DamFileDetails;
 }
 
 export const AudioPreview = ({ file }: AudioPreviewProps): React.ReactElement => {

--- a/packages/admin/cms-admin/src/dam/FileForm/previews/ImagePreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/previews/ImagePreview.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 
 import { ImageCrop } from "../../../common/image/ImageCrop";
-import { GQLDamFileDetailFragment } from "../EditFile";
+import { DamFileDetails } from "../EditFile";
 
 const imageStyle = { maxWidth: "100%", maxHeight: "75vh" };
 
 interface Props {
-    file: GQLDamFileDetailFragment;
+    file: DamFileDetails;
 }
 
 export function ImagePreview({ file }: Props): JSX.Element {

--- a/packages/admin/cms-admin/src/dam/FileForm/previews/PdfPreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/previews/PdfPreview.tsx
@@ -1,7 +1,7 @@
 import { styled } from "@mui/material/styles";
 import React from "react";
 
-import { GQLDamFileDetailFragment } from "../EditFile";
+import { DamFileDetails } from "../EditFile";
 const PdfPreviewWrapper = styled("div")`
     width: 100%;
     height: calc(100vh - 300px);
@@ -14,7 +14,7 @@ const PdfPreviewIFrame = styled("iframe")`
 `;
 
 interface PdfPreviewProps {
-    file: GQLDamFileDetailFragment;
+    file: DamFileDetails;
 }
 
 export const PdfPreview = ({ file }: PdfPreviewProps): React.ReactElement => {

--- a/packages/admin/cms-admin/src/dam/FileForm/previews/VideoPreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/previews/VideoPreview.tsx
@@ -2,7 +2,7 @@ import { styled } from "@mui/material/styles";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { GQLDamFileDetailFragment } from "../EditFile";
+import { DamFileDetails } from "../EditFile";
 
 const VideoPreviewWrapper = styled("div")`
     width: 100%;
@@ -18,7 +18,7 @@ const StyledVideo = styled("video")`
 `;
 
 interface VideoPreviewProps {
-    file: GQLDamFileDetailFragment;
+    file: DamFileDetails;
 }
 
 export const VideoPreview = ({ file }: VideoPreviewProps): React.ReactElement => {


### PR DESCRIPTION
Reexport `GQLDamFileDetailFragment` as `DamFileDetails` to adhere to the `no-private-sibling-import` rule