### PR TITLE
Comet Admin: Fix createOffsetLimitPagingAction

### DIFF
--- a/packages/admin/admin/src/table/paging/createOffsetLimitPagingAction.ts
+++ b/packages/admin/admin/src/table/paging/createOffsetLimitPagingAction.ts
@@ -10,8 +10,9 @@ export function createOffsetLimitPagingAction<TData extends OffsetLimitPagingDat
     { totalCount }: TData,
     limit: number,
 ): IPagingInfo {
-    const currentPage = pagingApi.currentPage ?? 1;
     const totalPages = Math.ceil(totalCount / limit);
+    const currentPage = Math.floor(pagingApi.current / limit) + 1;
+    pagingApi.changePage(currentPage);
 
     const createFetchNextPage = () => {
         const nextPage = currentPage + 1;


### PR DESCRIPTION
depends on https://github.com/vivid-planet/comet/pull/1146

only the last commit is relevant for this MR: https://github.com/vivid-planet/comet/pull/1147/commits/a0ae77c2a8b947cb0a9ae668e79de4b323f3a08d

## The problem

The `useTableQueryPaging()` hook accepts and `init` parameter and returns an instance of `PagingApi`. The hook is generic so that it can be used with any kind of pagination (e.g. Offset-based Pagination or Page-based Pagination). This means, the `init` argument can represent an offset, a page or something completely different.  
Consequently, `currentPage` (for the `PagingApi`) can't be calculated based on the `init` value because the hook doesn't know if the value represents an offset or a page. Instead, the currentPage is always set to 1.

https://github.com/vivid-planet/comet/blob/e10ad7533df3613ee9523896a975b8e95acc9032/packages/admin/admin/src/table/useTableQueryPaging.tsx#L17-L28

If you want to use offset-based pagination with another `init` value than 0 (e.g., 20), the `currentPage` is still 1. This means the items are displayed **starting with the 21st item but on page 1**. The **items 1 - 20 can't be viewed** by the user. And **the last pages are empty** (e.g., if there is a total of 100 items and 10 items per page, the last two pages are empty).

Screencast (with init = 80):

https://github.com/vivid-planet/comet/assets/13380047/2eca79bb-9c44-447e-ab7c-f8c08e15958d

## The fix

Since `useTableQueryPaging()` can be used for all kinds of pagination and it's never know what the init value represents, the `currentPage` can't be correctly calculated in the hook. Instead, I opted to recalculate the `currentPage` correctly in `createOffsetLimitPagingAction()`. So the offset and page are always in sync.

Screencast (with init = 80):

https://github.com/vivid-planet/comet/assets/13380047/389c4501-85dd-4f84-99a8-2851b003e7bf

## Question

Is this even a bug?

While writing this description, I started thinking that maybe I interpreted `init` wrong. Should it even be possible to use `init` for different starting points (like I do)? Or is it only configurable so it can be used with different kinds of pagination?

Also my "solution" feels more like a workaround.