### PR TITLE
Migration fix: drop index only if exists in database

### DIFF
--- a/packages/api/cms-api/src/mikro-orm/migrations/Migration20230209111818.ts
+++ b/packages/api/cms-api/src/mikro-orm/migrations/Migration20230209111818.ts
@@ -2,7 +2,7 @@ import { Migration } from "@mikro-orm/migrations";
 
 export class Migration20230209111818 extends Migration {
     async up(): Promise<void> {
-        this.addSql('drop index "unique_name_in_root_folder_index"');
-        this.addSql('drop index "unique_name_in_folder_index"');
+        this.addSql('drop index if exists "unique_name_in_root_folder_index";');
+        this.addSql('drop index if exists "unique_name_in_folder_index";');
     }
 }


### PR DESCRIPTION
Some projects may delete some Comet Tables, so it is essential to only drop an index if they exist.