### PR TITLE
DAM: Fix move folder mutation in MoveDamItemDialog

### DIFF
--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.gql.ts
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.gql.ts
@@ -104,8 +104,8 @@ export const moveDamFilesMutation = gql`
 `;
 
 export const moveDamFoldersMutation = gql`
-    mutation MoveDamFolders($folderIds: [ID!]!, $targetFolderId: ID) {
-        moveDamFolders(folderIds: $folderIds, targetFolderId: $targetFolderId) {
+    mutation MoveDamFolders($folderIds: [ID!]!, $targetFolderId: ID, $scope: DamScopeInput!) {
+        moveDamFolders(folderIds: $folderIds, targetFolderId: $targetFolderId, scope: $scope) {
             id
             mpath
         }

--- a/packages/admin/cms-admin/src/dam/MoveDamItemDialog/MoveDamItemDialog.tsx
+++ b/packages/admin/cms-admin/src/dam/MoveDamItemDialog/MoveDamItemDialog.tsx
@@ -116,6 +116,7 @@ export const MoveDamItemDialog = ({
                     variables: {
                         folderIds,
                         targetFolderId: selectedId,
+                        scope,
                     },
                     errorPolicy: "all",
                 }),
@@ -132,7 +133,7 @@ export const MoveDamItemDialog = ({
         }
 
         setMoving?.(false);
-    }, [apolloClient, damItemsToMove, handleHasErrors, selectedId, setMoving]);
+    }, [apolloClient, damItemsToMove, handleHasErrors, scope, selectedId, setMoving]);
 
     const handleClose = () => {
         setSelectedId(undefined);


### PR DESCRIPTION
The DAM scope was missing from the `moveDamFoldersMutation`. This lead to the following error message when trying to move a folder:

<img width="618" alt="Bildschirm­foto 2023-07-03 um 14 42 27" src="https://github.com/vivid-planet/comet/assets/13380047/e0845b1f-1449-4850-9c12-16adfa014316">
