### PR TITLE
Add the possibility to search for a path.

### DIFF
--- a/.changeset/sour-cheetahs-relax.md
+++ b/.changeset/sour-cheetahs-relax.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add the possibility to search for a path in PageSearch

--- a/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
+++ b/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
@@ -6,7 +6,7 @@ import { TextMatch } from "../../common/MarkedMatches";
 import { GQLPageSearchFragment } from "../../graphql.generated";
 import { PageTreePage } from "../pageTree/usePageTree";
 
-export type PageSearchMatch = TextMatch & { page: { id: string; ancestorIds: string[] } } & { where?: "name" | "path" };
+export type PageSearchMatch = TextMatch & { page: { id: string; ancestorIds: string[] }; where: "name" | "path" };
 
 export const pageSearchFragment = gql`
     fragment PageSearch on PageTreeNode {
@@ -102,7 +102,7 @@ const usePageSearch = ({ tree, domain, setExpandedIds, onUpdateCurrentMatch, pag
 
             if (pageExactMatch) {
                 const { id, name, ancestorIds } = pageExactMatch;
-                matches.push({ page: { id, ancestorIds }, start: 0, end: name.length - 1, focused: true });
+                matches.push({ page: { id, ancestorIds }, start: 0, end: name.length - 1, focused: true, where: "name" });
             }
         } catch {
             const regex = new RegExp(`(${escapeRegExp(query)})`, "gi");

--- a/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
+++ b/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
@@ -6,7 +6,7 @@ import { TextMatch } from "../../common/MarkedMatches";
 import { GQLPageSearchFragment } from "../../graphql.generated";
 import { PageTreePage } from "../pageTree/usePageTree";
 
-export type PageSearchMatch = TextMatch & { page: { id: string; ancestorIds: string[] } };
+export type PageSearchMatch = TextMatch & { page: { id: string; ancestorIds: string[] } } & { where?: "name" | "path" };
 
 export const pageSearchFragment = gql`
     fragment PageSearch on PageTreeNode {
@@ -109,14 +109,17 @@ const usePageSearch = ({ tree, domain, setExpandedIds, onUpdateCurrentMatch, pag
 
             inorderPages.forEach((page) => {
                 let match;
+                let nameMatch;
 
-                while ((match = regex.exec(page.name)) !== null) {
+                if ((nameMatch = (match = regex.exec(page.name)) !== null) || (match = regex.exec(page.path)) !== null) {
                     const { id, ancestorIds } = page;
+                    const where = nameMatch ? "name" : "path";
                     matches.push({
                         page: { id, ancestorIds },
                         start: match.index,
                         end: match.index + query.length - 1,
                         focused: matches.length === 0,
+                        where,
                     });
                 }
             });

--- a/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
+++ b/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
@@ -109,11 +109,23 @@ const usePageSearch = ({ tree, domain, setExpandedIds, onUpdateCurrentMatch, pag
 
             inorderPages.forEach((page) => {
                 let match;
-                let nameMatch;
 
-                if ((nameMatch = (match = regex.exec(page.name)) !== null) || (match = regex.exec(page.path)) !== null) {
+                while ((match = regex.exec(page.path)) !== null) {
                     const { id, ancestorIds } = page;
-                    const where = nameMatch ? "name" : "path";
+                    const where = "path";
+                    matches.push({
+                        page: { id, ancestorIds },
+                        start: match.index,
+                        end: match.index + query.length - 1,
+                        focused: matches.length === 0,
+                        where,
+                    });
+                }
+                regex.lastIndex = 0;
+
+                while ((match = regex.exec(page.name)) !== null) {
+                    const { id, ancestorIds } = page;
+                    const where = "name";
                     matches.push({
                         page: { id, ancestorIds },
                         start: match.index,

--- a/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
@@ -17,6 +17,7 @@ interface PageLabelProps {
 const PageLabel: React.FunctionComponent<PageLabelProps> = ({ page, disabled, onClick }) => {
     const { documentTypes } = usePageTreeContext();
     const documentType = documentTypes[page.documentType];
+    const pathMatches = page.matches.filter((match) => match.where === "path");
 
     return (
         <Root onClick={onClick}>
@@ -25,19 +26,21 @@ const PageLabel: React.FunctionComponent<PageLabelProps> = ({ page, disabled, on
                 <LinkText color={page.visibility === "Unpublished" || disabled ? "textSecondary" : "textPrimary"}>
                     <MarkedMatches text={page.name} matches={page.matches.filter((match) => match.where === "name")} />
                 </LinkText>
-                <LinkText color={page.visibility === "Unpublished" || disabled ? "textSecondary" : "textPrimary"}>
-                    <MarkedMatches text={page.name} matches={page.matches.filter((match) => match.where === "path")} />
-                </LinkText>
+                {pathMatches.length > 0 && (
+                    <LinkText color={page.visibility === "Unpublished" || disabled ? "textSecondary" : "textPrimary"}>
+                        <MarkedMatches text={page.path} matches={pathMatches} />
+                    </LinkText>
+                )}
+                {page.visibility === "Archived" && (
+                    <ArchivedChip
+                        component="span"
+                        label={<FormattedMessage id="comet.pages.pages.archived" defaultMessage="Archived" />}
+                        color="primary"
+                        clickable={false}
+                        size="small"
+                    />
+                )}
             </LinkContent>
-            {page.visibility === "Archived" && (
-                <ArchivedChip
-                    component="span"
-                    label={<FormattedMessage id="comet.pages.pages.archived" defaultMessage="Archived" />}
-                    color="primary"
-                    clickable={false}
-                    size="small"
-                />
-            )}
             {documentType.InfoTag !== undefined && (
                 <InfoPanel>
                     <documentType.InfoTag page={page} />

--- a/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
@@ -3,7 +3,7 @@ import { styled } from "@mui/material/styles";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { MarkedMatches, TextMatch } from "../../common/MarkedMatches";
+import { MarkedMatches } from "../../common/MarkedMatches";
 import { PageTypeIcon } from "./PageTypeIcon";
 import { PageTreePage } from "./usePageTree";
 import { usePageTreeContext } from "./usePageTreeContext";
@@ -14,38 +14,19 @@ interface PageLabelProps {
     onClick?: (e: React.MouseEvent) => void;
 }
 
-function createMatches(page: PageTreePage): {
-    pageMatches: TextMatch[];
-    pathMatches: TextMatch[];
-} {
-    const pageMatches: TextMatch[] = [];
-    const pathMatches: TextMatch[] = [];
-
-    page.matches.forEach((match) => {
-        if (match.where === "name") {
-            pageMatches.push(match);
-        } else if (match.where === "path") {
-            pathMatches.push(match);
-        }
-    });
-
-    return { pageMatches, pathMatches };
-}
-
 const PageLabel: React.FunctionComponent<PageLabelProps> = ({ page, disabled, onClick }) => {
     const { documentTypes } = usePageTreeContext();
     const documentType = documentTypes[page.documentType];
-    const { pageMatches, pathMatches } = createMatches(page);
 
     return (
         <Root onClick={onClick}>
             <PageTypeIcon page={page} disabled={disabled} />
             <LinkContent>
                 <LinkText color={page.visibility === "Unpublished" || disabled ? "textSecondary" : "textPrimary"}>
-                    <MarkedMatches text={page.name} matches={pageMatches} />
+                    <MarkedMatches text={page.name} matches={page.matches.filter((match) => match.where === "name")} />
                 </LinkText>
                 <LinkText color={page.visibility === "Unpublished" || disabled ? "textSecondary" : "textPrimary"}>
-                    <MarkedMatches text={page.path} matches={pathMatches} />
+                    <MarkedMatches text={page.name} matches={page.matches.filter((match) => match.where === "path")} />
                 </LinkText>
             </LinkContent>
             {page.visibility === "Archived" && (

--- a/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageLabel.tsx
@@ -3,7 +3,7 @@ import { styled } from "@mui/material/styles";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { MarkedMatches } from "../../common/MarkedMatches";
+import { MarkedMatches, TextMatch } from "../../common/MarkedMatches";
 import { PageTypeIcon } from "./PageTypeIcon";
 import { PageTreePage } from "./usePageTree";
 import { usePageTreeContext } from "./usePageTreeContext";
@@ -14,28 +14,49 @@ interface PageLabelProps {
     onClick?: (e: React.MouseEvent) => void;
 }
 
+function createMatches(page: PageTreePage): {
+    pageMatches: TextMatch[];
+    pathMatches: TextMatch[];
+} {
+    const pageMatches: TextMatch[] = [];
+    const pathMatches: TextMatch[] = [];
+
+    page.matches.forEach((match) => {
+        if (match.where === "name") {
+            pageMatches.push(match);
+        } else if (match.where === "path") {
+            pathMatches.push(match);
+        }
+    });
+
+    return { pageMatches, pathMatches };
+}
+
 const PageLabel: React.FunctionComponent<PageLabelProps> = ({ page, disabled, onClick }) => {
     const { documentTypes } = usePageTreeContext();
     const documentType = documentTypes[page.documentType];
+    const { pageMatches, pathMatches } = createMatches(page);
 
     return (
         <Root onClick={onClick}>
             <PageTypeIcon page={page} disabled={disabled} />
             <LinkContent>
                 <LinkText color={page.visibility === "Unpublished" || disabled ? "textSecondary" : "textPrimary"}>
-                    <MarkedMatches text={page.name} matches={page.matches} />
+                    <MarkedMatches text={page.name} matches={pageMatches} />
                 </LinkText>
-                {page.visibility === "Archived" && (
-                    <ArchivedChip
-                        component="span"
-                        label={<FormattedMessage id="comet.pages.pages.archived" defaultMessage="Archived" />}
-                        color="primary"
-                        clickable={false}
-                        size="small"
-                    />
-                )}
+                <LinkText color={page.visibility === "Unpublished" || disabled ? "textSecondary" : "textPrimary"}>
+                    <MarkedMatches text={page.path} matches={pathMatches} />
+                </LinkText>
             </LinkContent>
-
+            {page.visibility === "Archived" && (
+                <ArchivedChip
+                    component="span"
+                    label={<FormattedMessage id="comet.pages.pages.archived" defaultMessage="Archived" />}
+                    color="primary"
+                    clickable={false}
+                    size="small"
+                />
+            )}
             {documentType.InfoTag !== undefined && (
                 <InfoPanel>
                     <documentType.InfoTag page={page} />
@@ -60,6 +81,7 @@ const LinkContent = styled("div")`
     margin-left: ${({ theme }) => theme.spacing(2)};
     display: flex;
     min-width: 0;
+    flex-direction: column;
 `;
 
 const LinkText = styled(Typography)`


### PR DESCRIPTION
**This merge request adds the possibility to search for page-paths.** 

The matches are highlighted in the same way as RegEx-Textsearch matches, which means there is possibly more than one match per page in the page search. 

In addition, when searching for a path, the page-tree-row shows the matching path.

https://github.com/vivid-planet/comet/assets/67897480/bb84d2ca-510a-412e-99ac-f9c7d81677ae


