### PR TITLE
WIP: DAM: Redirect user to DAM root if folder doesn't exist

### DIFF
--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -4,6 +4,7 @@ import {
     EditDialog,
     IFilterApi,
     ISelectionApi,
+    LocalErrorScopeApolloContext,
     PrettyBytes,
     useDataGridRemote,
     useStackSwitchApi,
@@ -73,6 +74,7 @@ const FolderDataGrid = ({
     hideContextMenu,
     hideArchiveFilter,
     hideMultiselect,
+    showFolderNotFoundError,
     renderDamLabel,
     ...props
 }: FolderDataGridProps): React.ReactElement => {
@@ -102,6 +104,7 @@ const FolderDataGrid = ({
             id: currentFolderId!,
         },
         skip: currentFolderId === undefined,
+        context: showFolderNotFoundError ? undefined : LocalErrorScopeApolloContext,
     });
 
     const {
@@ -289,6 +292,7 @@ const FolderDataGrid = ({
                 numberItems={dataGridData?.damItemsList.totalCount ?? 0}
                 breadcrumbs={breadcrumbs}
                 folderId={currentFolderId}
+                showFolderNotFoundError={showFolderNotFoundError}
             />
             <sc.FolderOuterHoverHighlight isHovered={hoveredId === "root"} {...getFileRootProps()}>
                 <DataGrid

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderHead.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderHead.tsx
@@ -1,4 +1,4 @@
-import { BreadcrumbItem } from "@comet/admin";
+import { BreadcrumbItem, LocalErrorScopeApolloContext } from "@comet/admin";
 import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import * as React from "react";
@@ -15,6 +15,7 @@ interface TableHeadProps {
     numberItems?: number;
     breadcrumbs?: BreadcrumbItem[];
     folderId?: string;
+    showFolderNotFoundError?: boolean;
 }
 
 const TableHeadWrapper = styled("div")`
@@ -29,7 +30,7 @@ const BoldTypography = styled(Typography)`
     font-weight: 500;
 `;
 
-export const FolderHead = ({ isSearching, numberItems, breadcrumbs, folderId }: TableHeadProps): React.ReactElement => {
+export const FolderHead = ({ isSearching, numberItems, breadcrumbs, folderId, showFolderNotFoundError }: TableHeadProps): React.ReactElement => {
     let content: React.ReactNode = null;
 
     const { data, loading } = useOptimisticQuery<GQLDamFolderMPathQuery, GQLDamFolderMPathQueryVariables>(damFolderMPathQuery, {
@@ -47,6 +48,7 @@ export const FolderHead = ({ isSearching, numberItems, breadcrumbs, folderId }: 
 
             return fragment === null || Object.keys(fragment).length === 0 ? undefined : { damFolder: fragment };
         },
+        context: showFolderNotFoundError ? undefined : LocalErrorScopeApolloContext,
     });
 
     if (isSearching) {

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -105,6 +105,7 @@ export const ChooseFileDialog = ({ open, onClose, onChooseFile, allowedMimetypes
                         hideContextMenu={true}
                         hideMultiselect={true}
                         hideArchiveFilter={true}
+                        showFolderNotFoundError={false}
                     />
                 </MemoryRouter>
             </DamScopeProvider>


### PR DESCRIPTION
In the ChooseFileDialog, if the persisted DAM location is restored but the specified folder doesn't exist anymore, the user is automatically redirected to the DAM root without a (confusing) error message.



https://github.com/vivid-planet/comet/assets/13380047/a66aefe4-14e0-4c8a-a5d4-965f59ff5f7f

 (The folder specified in choose-file-dam-location doesn't exist anymore)

If the user navigates to a non-existing folder via URL, an error message is shown. However, the redirect does not work (yet) because of a bug in the breadcrumb generation that I couldn't fix yet. 