### PR TITLE
DAM: Disable License Feature per default

### DIFF
--- a/.changeset/hungry-laws-kneel.md
+++ b/.changeset/hungry-laws-kneel.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-admin": major
+---
+
+Disable the DAM license feature per default.
+
+The form fields to add license information to assets are now hidden per default. License warnings are not shown per default. 
+Setting the `enableLicenseFeature` option via the DamConfigProvider is now necessary to show the license fields and warnings.

--- a/packages/admin/cms-admin/src/dam/DataGrid/label/DamItemLabel.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/label/DamItemLabel.tsx
@@ -54,7 +54,7 @@ const getFolderPath = (folder: GQLDamFolderTableFragment) => {
     return `/${pathArr.join("/")}`;
 };
 
-const DamItemLabel = ({ asset, showPath = false, matches, showLicenseWarnings = true }: DamItemLabelProps): React.ReactElement => {
+const DamItemLabel = ({ asset, showPath = false, matches, showLicenseWarnings = false }: DamItemLabelProps): React.ReactElement => {
     return (
         <LabelWrapper>
             <DamThumbnail asset={asset} />

--- a/packages/admin/cms-admin/src/dam/DataGrid/label/DamItemLabelColumn.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/label/DamItemLabelColumn.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { FileRejection, useDropzone } from "react-dropzone";
 
 import { TextMatch } from "../../../common/MarkedMatches";
+import { useDamConfig } from "../../config/useDamConfig";
 import { DamFilter } from "../../DamTable";
 import { isFile } from "../../helpers/isFile";
 import { isFolder } from "../../helpers/isFolder";
@@ -31,6 +32,7 @@ const DamItemLabelWrapper = styled(Box, { shouldForwardProp: (prop) => prop !== 
 export interface RenderDamLabelOptions {
     matches?: TextMatch[];
     filterApi: IFilterApi<DamFilter>;
+    showLicenseWarnings?: boolean;
 }
 
 interface DamItemLabelColumnProps {
@@ -63,6 +65,7 @@ export const DamItemLabelColumn: React.VoidFunctionComponent<DamItemLabelColumnP
     hoverApi,
     scrollIntoView = false,
 }) => {
+    const damConfig = useDamConfig();
     const columnRef = React.useRef<HTMLDivElement>();
 
     React.useEffect(() => {
@@ -99,7 +102,7 @@ export const DamItemLabelColumn: React.VoidFunctionComponent<DamItemLabelColumnP
     return (
         <DamItemLabelWrapper ref={columnRef} isHovered={hoverApi.isHovered} {...(isFolder(item) && getFolderRootProps())}>
             {renderDamLabel ? (
-                renderDamLabel(item, { matches: matches.get(item.id), filterApi })
+                renderDamLabel(item, { matches: matches.get(item.id), filterApi, showLicenseWarnings: damConfig.enableLicenseFeature })
             ) : (
                 <Link
                     underline="none"
@@ -116,7 +119,12 @@ export const DamItemLabelColumn: React.VoidFunctionComponent<DamItemLabelColumnP
                         height: "100%",
                     }}
                 >
-                    <DamItemLabel asset={item} showPath={isSearching} matches={matches.get(item.id)} />
+                    <DamItemLabel
+                        asset={item}
+                        showPath={isSearching}
+                        matches={matches.get(item.id)}
+                        showLicenseWarnings={damConfig.enableLicenseFeature}
+                    />
                 </Link>
             )}
         </DamItemLabelWrapper>

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -27,6 +27,7 @@ import ReactSplit from "react-split";
 
 import { useContentScope } from "../../contentScope/Provider";
 import { GQLFocalPoint, GQLImageCropAreaInput, GQLLicenseInput } from "../../graphql.generated";
+import { useDamConfig } from "../config/useDamConfig";
 import { LicenseValidityTags } from "../DataGrid/tags/LicenseValidityTags";
 import Duplicates from "./Duplicates";
 import { damFileDetailQuery, updateDamFileMutation } from "./EditFile.gql";
@@ -117,6 +118,7 @@ interface EditFileInnerProps {
 const EditFileInner = ({ file, id }: EditFileInnerProps) => {
     const intl = useIntl();
     const stackApi = useStackApi();
+    const damConfig = useDamConfig();
 
     const [updateDamFile, { loading: saving, error: hasSaveErrors }] = useMutation<GQLUpdateFileMutation, GQLUpdateFileMutationVariables>(
         updateDamFileMutation,
@@ -199,16 +201,17 @@ const EditFileInner = ({ file, id }: EditFileInnerProps) => {
                     <Toolbar>
                         <ToolbarBackButton />
                         <ToolbarTitleItem>{file.name}</ToolbarTitleItem>
-                        {(file.license?.isNotValidYet || file.license?.expiresWithinThirtyDays || file.license?.hasExpired) && (
-                            <ToolbarItem>
-                                <LicenseValidityTags
-                                    expirationDate={file.license?.expirationDate ? new Date(file.license.expirationDate) : undefined}
-                                    isNotValidYet={file.license?.isNotValidYet}
-                                    expiresWithinThirtyDays={file.license?.expiresWithinThirtyDays}
-                                    hasExpired={file.license?.hasExpired}
-                                />
-                            </ToolbarItem>
-                        )}
+                        {damConfig.enableLicenseFeature &&
+                            (file.license?.isNotValidYet || file.license?.expiresWithinThirtyDays || file.license?.hasExpired) && (
+                                <ToolbarItem>
+                                    <LicenseValidityTags
+                                        expirationDate={file.license?.expirationDate ? new Date(file.license.expirationDate) : undefined}
+                                        isNotValidYet={file.license?.isNotValidYet}
+                                        expiresWithinThirtyDays={file.license?.expiresWithinThirtyDays}
+                                        hasExpired={file.license?.hasExpired}
+                                    />
+                                </ToolbarItem>
+                            )}
                         <ToolbarFillSpace />
                         <ToolbarActions>
                             <SplitButton disabled={pristine || hasValidationErrors || submitting} localStorageKey="editFileSave">

--- a/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
@@ -8,6 +8,7 @@ import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { GQLLicenseType } from "../../graphql.generated";
+import { useDamConfig } from "../config/useDamConfig";
 import { useDamScope } from "../config/useDamScope";
 import { CropSettingsFields } from "./CropSettingsFields";
 import { EditFileFormValues } from "./EditFile";
@@ -40,6 +41,7 @@ export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): Re
     const intl = useIntl();
     const apollo = useApolloClient();
     const scope = useDamScope();
+    const damConfig = useDamConfig();
     const damIsFilenameOccupied = React.useCallback(
         async (filename: string): Promise<boolean> => {
             const { data } = await apollo.query<GQLDamIsFilenameOccupiedQuery, GQLDamIsFilenameOccupiedQueryVariables>({
@@ -101,87 +103,89 @@ export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): Re
                     fullWidth
                 />
             </FormSection>
-            <FormSection title={<FormattedMessage id="comet.dam.file.licenseInformation" defaultMessage="License information" />}>
-                <Field
-                    component={FinalFormSelect}
-                    options={licenseTypeArray}
-                    getOptionLabel={(option: LicenseType) => licenseTypeLabels[option]}
-                    getOptionSelected={(option: LicenseType, selectedOption: LicenseType) => {
-                        return option === selectedOption;
-                    }}
-                    name="license.type"
-                    label={<FormattedMessage id="comet.dam.file.type" defaultMessage="Type" />}
-                    fullWidth
-                />
-                <Field name="license.type">
-                    {({ input: { value } }) => {
-                        return (
-                            <>
-                                <Field
-                                    label={<FormattedMessage id="comet.dam.file.licenseDetails" defaultMessage="License details" />}
-                                    name="license.details"
-                                    component={FinalFormInput}
-                                    multiline
-                                    minRows={3}
-                                    fullWidth
-                                    disabled={value === "NO_LICENSE"}
-                                />
-                                <Field
-                                    label={<FormattedMessage id="comet.dam.file.creatorOrAuthor" defaultMessage="Creator/Author" />}
-                                    name="license.author"
-                                    component={FinalFormInput}
-                                    fullWidth
-                                    disabled={value === "NO_LICENSE"}
-                                />
-                                <FieldContainer
-                                    label={<FormattedMessage id="comet.dam.file.licenseDuration" defaultMessage="License duration" />}
-                                    fullWidth
-                                    disabled={value === "NO_LICENSE"}
-                                >
-                                    <DurationFieldWrapper>
-                                        <Field
-                                            name="license.durationFrom"
-                                            placeholder="from"
-                                            component={FinalFormDatePicker}
-                                            clearable
-                                            startAdornment={null}
-                                            endAdornment={
-                                                <InputAdornment position="start">
-                                                    <Calendar />
-                                                </InputAdornment>
-                                            }
-                                            disabled={value === "NO_LICENSE"}
-                                        />
-                                        <Field
-                                            name="license.durationTo"
-                                            placeholder="to"
-                                            component={FinalFormDatePicker}
-                                            clearable
-                                            startAdornment={null}
-                                            endAdornment={
-                                                <InputAdornment position="start">
-                                                    <Calendar />
-                                                </InputAdornment>
-                                            }
-                                            validate={(value: Date | undefined, allValues) => {
-                                                if (value && allValues && value < (allValues as EditFileFormValues).license?.durationFrom) {
-                                                    return (
-                                                        <FormattedMessage
-                                                            id="comet.dam.file.error.durationTo"
-                                                            defaultMessage="The end date of the license must be after the start date"
-                                                        />
-                                                    );
+            {damConfig.enableLicenseFeature && (
+                <FormSection title={<FormattedMessage id="comet.dam.file.licenseInformation" defaultMessage="License information" />}>
+                    <Field
+                        component={FinalFormSelect}
+                        options={licenseTypeArray}
+                        getOptionLabel={(option: LicenseType) => licenseTypeLabels[option]}
+                        getOptionSelected={(option: LicenseType, selectedOption: LicenseType) => {
+                            return option === selectedOption;
+                        }}
+                        name="license.type"
+                        label={<FormattedMessage id="comet.dam.file.type" defaultMessage="Type" />}
+                        fullWidth
+                    />
+                    <Field name="license.type">
+                        {({ input: { value } }) => {
+                            return (
+                                <>
+                                    <Field
+                                        label={<FormattedMessage id="comet.dam.file.licenseDetails" defaultMessage="License details" />}
+                                        name="license.details"
+                                        component={FinalFormInput}
+                                        multiline
+                                        minRows={3}
+                                        fullWidth
+                                        disabled={value === "NO_LICENSE"}
+                                    />
+                                    <Field
+                                        label={<FormattedMessage id="comet.dam.file.creatorOrAuthor" defaultMessage="Creator/Author" />}
+                                        name="license.author"
+                                        component={FinalFormInput}
+                                        fullWidth
+                                        disabled={value === "NO_LICENSE"}
+                                    />
+                                    <FieldContainer
+                                        label={<FormattedMessage id="comet.dam.file.licenseDuration" defaultMessage="License duration" />}
+                                        fullWidth
+                                        disabled={value === "NO_LICENSE"}
+                                    >
+                                        <DurationFieldWrapper>
+                                            <Field
+                                                name="license.durationFrom"
+                                                placeholder="from"
+                                                component={FinalFormDatePicker}
+                                                clearable
+                                                startAdornment={null}
+                                                endAdornment={
+                                                    <InputAdornment position="start">
+                                                        <Calendar />
+                                                    </InputAdornment>
                                                 }
-                                            }}
-                                            disabled={value === "NO_LICENSE"}
-                                        />
-                                    </DurationFieldWrapper>
-                                </FieldContainer>
-                            </>
-                        );
-                    }}
-                </Field>
-            </FormSection>
+                                                disabled={value === "NO_LICENSE"}
+                                            />
+                                            <Field
+                                                name="license.durationTo"
+                                                placeholder="to"
+                                                component={FinalFormDatePicker}
+                                                clearable
+                                                startAdornment={null}
+                                                endAdornment={
+                                                    <InputAdornment position="start">
+                                                        <Calendar />
+                                                    </InputAdornment>
+                                                }
+                                                validate={(value: Date | undefined, allValues) => {
+                                                    if (value && allValues && value < (allValues as EditFileFormValues).license?.durationFrom) {
+                                                        return (
+                                                            <FormattedMessage
+                                                                id="comet.dam.file.error.durationTo"
+                                                                defaultMessage="The end date of the license must be after the start date"
+                                                            />
+                                                        );
+                                                    }
+                                                }}
+                                                disabled={value === "NO_LICENSE"}
+                                            />
+                                        </DurationFieldWrapper>
+                                    </FieldContainer>
+                                </>
+                            );
+                        }}
+                    </Field>
+                </FormSection>
+            )}
         </div>
     );
 };

--- a/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
+++ b/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 export interface DamConfig {
+    enableLicenseFeature?: boolean;
     additionalMimeTypes?: string[];
     scopeParts?: string[];
 }

--- a/packages/admin/cms-admin/src/dam/config/DamConfigProvider.tsx
+++ b/packages/admin/cms-admin/src/dam/config/DamConfigProvider.tsx
@@ -7,5 +7,5 @@ interface DamConfigProviderProps {
 }
 
 export const DamConfigProvider: React.FunctionComponent<DamConfigProviderProps> = ({ children, value }) => {
-    return <DamConfigContext.Provider value={value}>{children}</DamConfigContext.Provider>;
+    return <DamConfigContext.Provider value={{ enableLicenseFeature: false, ...value }}>{children}</DamConfigContext.Provider>;
 };

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -7,6 +7,7 @@ import { FormattedMessage } from "react-intl";
 import { MemoryRouter } from "react-router";
 
 import { DamScopeProvider } from "../../../dam/config/DamScopeProvider";
+import { useDamConfig } from "../../../dam/config/useDamConfig";
 import { useDamScope } from "../../../dam/config/useDamScope";
 import { DamTable } from "../../../dam/DamTable";
 import { GQLDamFileTableFragment, GQLDamFolderTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
@@ -46,11 +47,11 @@ const TableRowButton = styled(Button)`
 const renderDamLabel = (
     row: GQLDamFileTableFragment | GQLDamFolderTableFragment,
     onChooseFile: (fileId: string) => void,
-    { matches, filterApi }: RenderDamLabelOptions,
+    { matches, filterApi, showLicenseWarnings = false }: RenderDamLabelOptions,
 ) => {
     return isFile(row) ? (
         <TableRowButton disableRipple={true} variant="text" onClick={() => onChooseFile(row.id)} fullWidth>
-            <DamItemLabel asset={row} matches={matches} />
+            <DamItemLabel asset={row} matches={matches} showLicenseWarnings={showLicenseWarnings} />
         </TableRowButton>
     ) : (
         <Link
@@ -79,6 +80,7 @@ interface ChooseFileDialogProps {
 }
 
 export const ChooseFileDialog = ({ open, onClose, onChooseFile, allowedMimetypes }: ChooseFileDialogProps): React.ReactElement => {
+    const damConfig = useDamConfig();
     let stateKey = "choose-file-dam-location";
     const scope = useDamScope();
 
@@ -99,7 +101,7 @@ export const ChooseFileDialog = ({ open, onClose, onChooseFile, allowedMimetypes
                     <RedirectToPersistedDamLocation stateKey={stateKey} />
                     <DamTable
                         renderDamLabel={(row, { matches, filterApi }: RenderDamLabelOptions) =>
-                            renderDamLabel(row, onChooseFile, { matches, filterApi })
+                            renderDamLabel(row, onChooseFile, { matches, filterApi, showLicenseWarnings: damConfig.enableLicenseFeature })
                         }
                         allowedMimetypes={allowedMimetypes}
                         hideContextMenu={true}


### PR DESCRIPTION
Hides the DAM license form fields and warnings per default. The `enableLicenseFeature` option in the DamConfig has to be true to enable adding asset license information.

### Before:
<img width="771" alt="Bildschirm­foto 2023-07-06 um 10 35 04" src="https://github.com/vivid-planet/comet/assets/13380047/13260dbf-c092-4136-bbf0-e8f712d34369">

<img width="1608" alt="Bildschirm­foto 2023-07-06 um 10 35 16" src="https://github.com/vivid-planet/comet/assets/13380047/9d9a3811-d941-4a72-8678-bcda59aed4f8">

### Now:
<img width="781" alt="Bildschirm­foto 2023-07-06 um 10 36 27" src="https://github.com/vivid-planet/comet/assets/13380047/e2f8e0b9-5211-458b-9df1-e0a1f1b4df88">

<img width="1619" alt="Bildschirm­foto 2023-07-06 um 10 36 12" src="https://github.com/vivid-planet/comet/assets/13380047/d8128641-efde-4579-a716-c376aa02e4d6">
