### PR TITLE
DAM: Disable License Feature per default

### DIFF
--- a/.changeset/hungry-laws-kneel.md
+++ b/.changeset/hungry-laws-kneel.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-admin": patch
+---
+
+Disable the DAM license feature per default.
+
+The form fields to add license information to assets are now hidden per default. License warnings are not shown per default.
+Setting the `enableLicenseFeature` option via the DamConfigProvider is now necessary to show the license fields and warnings.

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -134,7 +134,10 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
 };
 
 export interface DamConfig {
-    renderDamLabel?: (row: GQLDamFileTableFragment | GQLDamFolderTableFragment, options: { matches?: TextMatch[] }) => React.ReactNode;
+    renderDamLabel?: (
+        row: GQLDamFileTableFragment | GQLDamFolderTableFragment,
+        options: { matches?: TextMatch[]; showLicenseWarnings?: boolean },
+    ) => React.ReactNode;
     TableContainer?: ({ children }: { children: React.ReactNode }) => React.ReactElement;
     hideArchiveFilter?: boolean;
     hideContextMenu?: boolean;

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -36,6 +36,7 @@ import {
     GQLUpdateFileMutation,
     GQLUpdateFileMutationVariables,
 } from "../../graphql.generated";
+import { useDamConfig } from "../config/useDamConfig";
 import { usePersistedDamLocation } from "../Table/RedirectToPersistedDamLocation";
 import { LicenseValidityTags } from "../Table/tags/LicenseValidityTags";
 import Duplicates from "./Duplicates";
@@ -121,6 +122,7 @@ interface EditFileInnerProps {
 const EditFileInner = ({ file, id }: EditFileInnerProps) => {
     const intl = useIntl();
     const stackApi = useStackApi();
+    const damConfig = useDamConfig();
 
     const [updateDamFile, { loading: saving, error: hasSaveErrors }] = useMutation<GQLUpdateFileMutation, GQLUpdateFileMutationVariables>(
         updateDamFileMutation,
@@ -203,16 +205,17 @@ const EditFileInner = ({ file, id }: EditFileInnerProps) => {
                     <Toolbar>
                         <ToolbarBackButton />
                         <ToolbarTitleItem>{file.name}</ToolbarTitleItem>
-                        {(file.license?.isNotValidYet || file.license?.expiresWithinThirtyDays || file.license?.hasExpired) && (
-                            <ToolbarItem>
-                                <LicenseValidityTags
-                                    expirationDate={file.license?.expirationDate ? new Date(file.license.expirationDate) : undefined}
-                                    isNotValidYet={file.license?.isNotValidYet}
-                                    expiresWithinThirtyDays={file.license?.expiresWithinThirtyDays}
-                                    hasExpired={file.license?.hasExpired}
-                                />
-                            </ToolbarItem>
-                        )}
+                        {damConfig.enableLicenseFeature &&
+                            (file.license?.isNotValidYet || file.license?.expiresWithinThirtyDays || file.license?.hasExpired) && (
+                                <ToolbarItem>
+                                    <LicenseValidityTags
+                                        expirationDate={file.license?.expirationDate ? new Date(file.license.expirationDate) : undefined}
+                                        isNotValidYet={file.license?.isNotValidYet}
+                                        expiresWithinThirtyDays={file.license?.expiresWithinThirtyDays}
+                                        hasExpired={file.license?.hasExpired}
+                                    />
+                                </ToolbarItem>
+                            )}
                         <ToolbarFillSpace />
                         <ToolbarActions>
                             <SplitButton disabled={pristine || hasValidationErrors || submitting} localStorageKey="editFileSave">

--- a/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
@@ -8,6 +8,7 @@ import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { GQLDamIsFilenameOccupiedQuery, GQLDamIsFilenameOccupiedQueryVariables, GQLLicenseType } from "../../graphql.generated";
+import { useDamConfig } from "../config/useDamConfig";
 import { CropSettingsFields } from "./CropSettingsFields";
 import { EditFileFormValues } from "./EditFile";
 
@@ -37,6 +38,7 @@ const licenseTypeLabels: { [key in LicenseType]: React.ReactNode } = {
 export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): React.ReactElement => {
     const intl = useIntl();
     const apollo = useApolloClient();
+    const damConfig = useDamConfig();
     const damIsFilenameOccupied = React.useCallback(
         async (filename: string): Promise<boolean> => {
             const { data } = await apollo.query<GQLDamIsFilenameOccupiedQuery, GQLDamIsFilenameOccupiedQueryVariables>({
@@ -97,87 +99,89 @@ export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): Re
                     fullWidth
                 />
             </FormSection>
-            <FormSection title={<FormattedMessage id="comet.dam.file.licenseInformation" defaultMessage="License information" />}>
-                <Field
-                    component={FinalFormSelect}
-                    options={licenseTypeArray}
-                    getOptionLabel={(option: LicenseType) => licenseTypeLabels[option]}
-                    getOptionSelected={(option: LicenseType, selectedOption: LicenseType) => {
-                        return option === selectedOption;
-                    }}
-                    name="license.type"
-                    label={<FormattedMessage id="comet.dam.file.type" defaultMessage="Type" />}
-                    fullWidth
-                />
-                <Field name="license.type">
-                    {({ input: { value } }) => {
-                        return (
-                            <>
-                                <Field
-                                    label={<FormattedMessage id="comet.dam.file.licenseDetails" defaultMessage="License details" />}
-                                    name="license.details"
-                                    component={FinalFormInput}
-                                    multiline
-                                    minRows={3}
-                                    fullWidth
-                                    disabled={value === "NO_LICENSE"}
-                                />
-                                <Field
-                                    label={<FormattedMessage id="comet.dam.file.creatorOrAuthor" defaultMessage="Creator/Author" />}
-                                    name="license.author"
-                                    component={FinalFormInput}
-                                    fullWidth
-                                    disabled={value === "NO_LICENSE"}
-                                />
-                                <FieldContainer
-                                    label={<FormattedMessage id="comet.dam.file.licenseDuration" defaultMessage="License duration" />}
-                                    fullWidth
-                                    disabled={value === "NO_LICENSE"}
-                                >
-                                    <DurationFieldWrapper>
-                                        <Field
-                                            name="license.durationFrom"
-                                            placeholder="from"
-                                            component={FinalFormDatePicker}
-                                            clearable
-                                            startAdornment={null}
-                                            endAdornment={
-                                                <InputAdornment position="start">
-                                                    <Calendar />
-                                                </InputAdornment>
-                                            }
-                                            disabled={value === "NO_LICENSE"}
-                                        />
-                                        <Field
-                                            name="license.durationTo"
-                                            placeholder="to"
-                                            component={FinalFormDatePicker}
-                                            clearable
-                                            startAdornment={null}
-                                            endAdornment={
-                                                <InputAdornment position="start">
-                                                    <Calendar />
-                                                </InputAdornment>
-                                            }
-                                            validate={(value: Date | undefined, allValues) => {
-                                                if (value && allValues && value < (allValues as EditFileFormValues).license?.durationFrom) {
-                                                    return (
-                                                        <FormattedMessage
-                                                            id="comet.dam.file.error.durationTo"
-                                                            defaultMessage="The end date of the license must be after the start date"
-                                                        />
-                                                    );
+            {damConfig.enableLicenseFeature && (
+                <FormSection title={<FormattedMessage id="comet.dam.file.licenseInformation" defaultMessage="License information" />}>
+                    <Field
+                        component={FinalFormSelect}
+                        options={licenseTypeArray}
+                        getOptionLabel={(option: LicenseType) => licenseTypeLabels[option]}
+                        getOptionSelected={(option: LicenseType, selectedOption: LicenseType) => {
+                            return option === selectedOption;
+                        }}
+                        name="license.type"
+                        label={<FormattedMessage id="comet.dam.file.type" defaultMessage="Type" />}
+                        fullWidth
+                    />
+                    <Field name="license.type">
+                        {({ input: { value } }) => {
+                            return (
+                                <>
+                                    <Field
+                                        label={<FormattedMessage id="comet.dam.file.licenseDetails" defaultMessage="License details" />}
+                                        name="license.details"
+                                        component={FinalFormInput}
+                                        multiline
+                                        minRows={3}
+                                        fullWidth
+                                        disabled={value === "NO_LICENSE"}
+                                    />
+                                    <Field
+                                        label={<FormattedMessage id="comet.dam.file.creatorOrAuthor" defaultMessage="Creator/Author" />}
+                                        name="license.author"
+                                        component={FinalFormInput}
+                                        fullWidth
+                                        disabled={value === "NO_LICENSE"}
+                                    />
+                                    <FieldContainer
+                                        label={<FormattedMessage id="comet.dam.file.licenseDuration" defaultMessage="License duration" />}
+                                        fullWidth
+                                        disabled={value === "NO_LICENSE"}
+                                    >
+                                        <DurationFieldWrapper>
+                                            <Field
+                                                name="license.durationFrom"
+                                                placeholder="from"
+                                                component={FinalFormDatePicker}
+                                                clearable
+                                                startAdornment={null}
+                                                endAdornment={
+                                                    <InputAdornment position="start">
+                                                        <Calendar />
+                                                    </InputAdornment>
                                                 }
-                                            }}
-                                            disabled={value === "NO_LICENSE"}
-                                        />
-                                    </DurationFieldWrapper>
-                                </FieldContainer>
-                            </>
-                        );
-                    }}
-                </Field>
-            </FormSection>
+                                                disabled={value === "NO_LICENSE"}
+                                            />
+                                            <Field
+                                                name="license.durationTo"
+                                                placeholder="to"
+                                                component={FinalFormDatePicker}
+                                                clearable
+                                                startAdornment={null}
+                                                endAdornment={
+                                                    <InputAdornment position="start">
+                                                        <Calendar />
+                                                    </InputAdornment>
+                                                }
+                                                validate={(value: Date | undefined, allValues) => {
+                                                    if (value && allValues && value < (allValues as EditFileFormValues).license?.durationFrom) {
+                                                        return (
+                                                            <FormattedMessage
+                                                                id="comet.dam.file.error.durationTo"
+                                                                defaultMessage="The end date of the license must be after the start date"
+                                                            />
+                                                        );
+                                                    }
+                                                }}
+                                                disabled={value === "NO_LICENSE"}
+                                            />
+                                        </DurationFieldWrapper>
+                                    </FieldContainer>
+                                </>
+                            );
+                        }}
+                    </Field>
+                </FormSection>
+            )}
         </div>
     );
 };

--- a/packages/admin/cms-admin/src/dam/Table/DamLabel.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/DamLabel.tsx
@@ -51,7 +51,7 @@ const getFolderPath = (folder: GQLDamFolderTableFragment) => {
     return `/${pathArr.join("/")}`;
 };
 
-const DamLabel = ({ asset, showPath = false, matches, showLicenseWarnings = true }: DamLabelProps): React.ReactElement => {
+const DamLabel = ({ asset, showPath = false, matches, showLicenseWarnings = false }: DamLabelProps): React.ReactElement => {
     return (
         <LabelWrapper>
             <DamThumbnail asset={asset} />

--- a/packages/admin/cms-admin/src/dam/Table/FolderTable.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/FolderTable.tsx
@@ -11,6 +11,7 @@ import { useDebouncedCallback, useThrottledCallback } from "use-debounce";
 
 import { GQLDamFileTableFragment, GQLDamFolderQuery, GQLDamFolderQueryVariables, GQLDamFolderTableFragment } from "../../graphql.generated";
 import { useDamAcceptedMimeTypes } from "../config/useDamAcceptedMimeTypes";
+import { useDamConfig } from "../config/useDamConfig";
 import { DamConfig, DamFilter } from "../DamTable";
 import AddFolder from "../FolderForm/AddFolder";
 import EditFolder from "../FolderForm/EditFolder";
@@ -50,6 +51,7 @@ const FolderTable = ({
     const client = useApolloClient();
     const intl = useIntl();
     const { allAcceptedMimeTypes } = useDamAcceptedMimeTypes();
+    const damConfig = useDamConfig();
 
     const [isHovered, setIsHovered] = React.useState<boolean>(false);
     const [footerType, setFooterType] = React.useState<FooterType>();
@@ -128,7 +130,7 @@ const FolderTable = ({
             cellProps: { style: { width: "100%" } },
             render: (row) => {
                 return renderDamLabel ? (
-                    renderDamLabel(row, { matches: matches.get(row.id) })
+                    renderDamLabel(row, { matches: matches.get(row.id), showLicenseWarnings: damConfig.enableLicenseFeature })
                 ) : (
                     <Link
                         underline="none"
@@ -141,7 +143,12 @@ const FolderTable = ({
                             }
                         }}
                     >
-                        <DamLabel asset={row} showPath={isSearching} matches={matches.get(row.id)} />
+                        <DamLabel
+                            asset={row}
+                            showPath={isSearching}
+                            matches={matches.get(row.id)}
+                            showLicenseWarnings={damConfig.enableLicenseFeature}
+                        />
                     </Link>
                 );
             },

--- a/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
+++ b/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 export interface DamConfig {
     additionalMimeTypes?: string[];
+    enableLicenseFeature?: boolean;
 }
 
 export const DamConfigContext = React.createContext<DamConfig | undefined>(undefined);

--- a/packages/admin/cms-admin/src/dam/config/DamConfigProvider.tsx
+++ b/packages/admin/cms-admin/src/dam/config/DamConfigProvider.tsx
@@ -7,5 +7,5 @@ interface DamConfigProviderProps {
 }
 
 export const DamConfigProvider: React.FunctionComponent<DamConfigProviderProps> = ({ children, value }) => {
-    return <DamConfigContext.Provider value={value}>{children}</DamConfigContext.Provider>;
+    return <DamConfigContext.Provider value={{ enableLicenseFeature: false, ...value }}>{children}</DamConfigContext.Provider>;
 };

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -7,6 +7,7 @@ import { FormattedMessage } from "react-intl";
 import { MemoryRouter } from "react-router";
 
 import { TextMatch } from "../../../common/MarkedMatches";
+import { useDamConfig } from "../../../dam/config/useDamConfig";
 import { DamTable } from "../../../dam/DamTable";
 import DamLabel from "../../../dam/Table/DamLabel";
 import { isFile } from "../../../dam/Table/FolderTableRow";
@@ -43,12 +44,12 @@ const TableRowButton = styled(Button)`
 const renderDamLabel = (
     row: GQLDamFileTableFragment | GQLDamFolderTableFragment,
     onChooseFile: (fileId: string) => void,
-    { matches }: { matches?: TextMatch[] },
+    { matches, showLicenseWarnings = false }: { matches?: TextMatch[]; showLicenseWarnings?: boolean },
 ) => {
     return isFile(row) ? (
         <div>
             <TableRowButton disableRipple={true} variant="text" onClick={() => onChooseFile(row.id)} fullWidth>
-                <DamLabel asset={row} matches={matches} />
+                <DamLabel asset={row} matches={matches} showLicenseWarnings={showLicenseWarnings} />
             </TableRowButton>
         </div>
     ) : (
@@ -66,6 +67,8 @@ interface ChooseFileDialogProps {
 }
 
 export const ChooseFileDialog = ({ open, onClose, onChooseFile, allowedMimetypes }: ChooseFileDialogProps): React.ReactElement => {
+    const damConfig = useDamConfig();
+
     return (
         <FixedHeightDialog open={open} onClose={onClose} fullWidth maxWidth="xl">
             <StyledDialogTitle>
@@ -76,7 +79,9 @@ export const ChooseFileDialog = ({ open, onClose, onChooseFile, allowedMimetypes
             </StyledDialogTitle>
             <MemoryRouter>
                 <DamTable
-                    renderDamLabel={(row, { matches }) => renderDamLabel(row, onChooseFile, { matches })}
+                    renderDamLabel={(row, { matches }) =>
+                        renderDamLabel(row, onChooseFile, { matches, showLicenseWarnings: damConfig.enableLicenseFeature })
+                    }
                     TableContainer={DialogContent}
                     allowedMimetypes={allowedMimetypes}
                     damLocationStorageKey="choose-file-dam-location"


### PR DESCRIPTION
Hides the DAM license form fields and warnings per default. The `enableLicenseFeature` option in the DamConfig has to be true to enable adding asset license information.

### Before:
<img width="951" alt="Bildschirm­foto 2023-07-06 um 10 58 57" src="https://github.com/vivid-planet/comet/assets/13380047/0d0fb2f3-7394-4e6c-a4d9-4a760819af45">
<img width="1609" alt="Bildschirm­foto 2023-07-06 um 10 59 12" src="https://github.com/vivid-planet/comet/assets/13380047/8979800e-b457-4214-852e-eea61f6fd6c3">


### Now:
<img width="764" alt="Bildschirm­foto 2023-07-06 um 10 59 52" src="https://github.com/vivid-planet/comet/assets/13380047/734015c9-225d-471d-96ee-31b69945f991">
<img width="1607" alt="Bildschirm­foto 2023-07-06 um 11 00 03" src="https://github.com/vivid-planet/comet/assets/13380047/60dee80a-f766-48dc-b7a5-34871c988885">


