### PR TITLE
Fix Storybook build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "build:cms:site": "pnpm recursive --filter '@comet/cms-site' run build",
         "build:cms:site:skippable": "test -f packages/site/cms-site/lib/index.d.ts && echo 'Skipping CMS Site build' || $npm_execpath build:cms:site",
         "build:cms:skippable": "test -f packages/admin/cms-admin/lib/index.d.ts && echo 'Skipping CMS build' || $npm_execpath build:cms",
-        "build:storybook": "pnpm recursive --filter '@comet/admin*' run build && pnpm --filter comet-admin-stories run build-storybook",
+        "build:storybook": "pnpm recursive --filter '@comet/admin*' --filter '@comet/eslint-plugin' run build && pnpm --filter comet-admin-stories run build-storybook",
         "build:lib": "pnpm recursive --filter '@comet/*' run build",
         "clean": "pnpm recursive run clean",
         "copy-schema-files": "node copy-schema-files.js",


### PR DESCRIPTION
The `@comet/eslint-plugin` package needs to be built before building the `@comet/admin*` packages.