### PR TITLE
Readd imports to blocks module definition

### DIFF
--- a/packages/api/cms-api/src/blocks/blocks.module.ts
+++ b/packages/api/cms-api/src/blocks/blocks.module.ts
@@ -36,7 +36,7 @@ export class BlocksModule {
 
         return {
             module: BlocksModule,
-            imports: [],
+            imports: options.imports ?? [],
             providers: [
                 optionsProvider,
                 transformerDependenciesProvider,


### PR DESCRIPTION
The imports from the passed options were incorrectly removed in 784d40226c064eaecfbd4ad8e141f6dc9448c09c. This prevents users from defining additional transformer dependencies in application code that come from another module, for instance, an entity repository.