### PR TITLE
Fix useSubRoutePrefix if used inside a Route

### DIFF
--- a/.changeset/sharp-gifts-kneel.md
+++ b/.changeset/sharp-gifts-kneel.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix useSubRoutePrefix if used inside a Route

--- a/packages/admin/admin-stories/src/admin/form/RouterTabsInFormWithSubroutes.tsx
+++ b/packages/admin/admin-stories/src/admin/form/RouterTabsInFormWithSubroutes.tsx
@@ -1,0 +1,62 @@
+import { Field, FinalForm, FinalFormInput, RouterTab, RouterTabs, Stack, StackLink, StackPage, StackSwitch } from "@comet/admin";
+import { Button } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { useLocation } from "react-router";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+function Path() {
+    const location = useLocation();
+    const [, rerender] = React.useState(0);
+    React.useEffect(() => {
+        const timer = setTimeout(() => {
+            rerender(new Date().getTime());
+        }, 1000);
+        return () => clearTimeout(timer);
+    }, []);
+    return <div>{location.pathname}</div>;
+}
+
+function Story() {
+    return (
+        <>
+            <Path />
+            <FinalForm
+                mode="edit"
+                onSubmit={(values: any) => {
+                    alert(JSON.stringify(values));
+                }}
+                initialValues={{
+                    foo: "foo",
+                    bar: "bar",
+                }}
+            >
+                {() => (
+                    <RouterTabs>
+                        <RouterTab label="Form 1" path="" forceRender={true}>
+                            <Field label="Foo" name="foo" component={FinalFormInput} />
+                        </RouterTab>
+                        <RouterTab label="Form 2" path="/form2" forceRender={true}>
+                            <Field label="Bar" name="bar" component={FinalFormInput} />
+                            <Stack topLevelTitle="">
+                                <StackSwitch initialPage="page1">
+                                    <StackPage name="page1">
+                                        Form 2 Subpage 1
+                                        <StackLink pageName="page2" payload="test">
+                                            <Button>To subpage 2</Button>
+                                        </StackLink>
+                                    </StackPage>
+                                    <StackPage name="page2">Form 2 Subpage 2</StackPage>
+                                </StackSwitch>
+                            </Stack>
+                        </RouterTab>
+                    </RouterTabs>
+                )}
+            </FinalForm>
+        </>
+    );
+}
+storiesOf("@comet/admin/form", module)
+    .addDecorator(storyRouterDecorator())
+    .add("RouterTabsInFormWithSubroutes", () => <Story />);

--- a/packages/admin/admin/src/router/SubRoute.test.tsx
+++ b/packages/admin/admin/src/router/SubRoute.test.tsx
@@ -184,3 +184,43 @@ test("Subrote other route hidden", async () => {
     });
     expect(rendered.queryByText("Cmp2 Sub")).not.toBeInTheDocument();
 });
+
+test("Route below Subroute", async () => {
+    function Cmp2() {
+        const urlPrefix = useSubRoutePrefix();
+        return <div>urlPrefix={urlPrefix}</div>;
+    }
+    function Cmp1() {
+        const urlPrefix = useSubRoutePrefix();
+        return (
+            <>
+                <Link to={`${urlPrefix}/sub`}>Sub</Link>
+                <Route path={`${urlPrefix}/sub`}>
+                    <Cmp2 />
+                </Route>
+            </>
+        );
+    }
+    function Story() {
+        return (
+            <>
+                <SubRoute path="/foo">
+                    <Cmp1 />
+                </SubRoute>
+            </>
+        );
+    }
+
+    const history = createMemoryHistory();
+
+    const rendered = render(
+        <MuiThemeProvider theme={createTheme()}>
+            <Router history={history}>
+                <Story />
+            </Router>
+        </MuiThemeProvider>,
+    );
+
+    fireEvent.click(rendered.getByText("Sub"));
+    expect(rendered.getByText("urlPrefix=/foo/sub")).toBeInTheDocument();
+});

--- a/packages/admin/admin/src/router/SubRoute.tsx
+++ b/packages/admin/admin/src/router/SubRoute.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { matchPath, Route, useLocation, useRouteMatch } from "react-router";
+import { __RouterContext, matchPath, Route, useLocation, useRouteMatch } from "react-router";
 
 interface SubRoutesContext {
     path: string;
@@ -23,9 +23,17 @@ export function SubRoute({ children, path }: { children: React.ReactNode; path: 
 }
 
 export function useSubRoutePrefix() {
-    const match = useRouteMatch();
+    const routerContext = React.useContext(__RouterContext);
     const subRoutesContext = React.useContext(SubRoutesContext);
-    let ret = subRoutesContext?.path || match.url;
+    let ret;
+    if (subRoutesContext?.path) {
+        ret = subRoutesContext.path;
+        if (routerContext?.match?.url && routerContext.match.url.startsWith(subRoutesContext.path)) {
+            ret = routerContext.match.url;
+        }
+    } else {
+        ret = routerContext?.match.url || "";
+    }
     ret = ret.replace(/\/$/, ""); //remove trailing slash
     return ret;
 }

--- a/packages/admin/admin/src/stack/Stack.tsx
+++ b/packages/admin/admin/src/stack/Stack.tsx
@@ -104,6 +104,9 @@ export class Stack extends React.Component<StackProps, IState> {
                     {(routerProps: RouteComponentProps<any>) => {
                         const { topLevelTitle, children } = this.props;
                         this.history = routerProps.history;
+                        if (!routerProps.match) {
+                            return children;
+                        }
                         return (
                             <>
                                 <StackBreadcrumb title={topLevelTitle} url={routerProps.match.url} ignoreParentId={true}>


### PR DESCRIPTION
## 1. In the following situation useSubRoutePrefix was buggy:

```
<Route path="/foo">
  <SubRoute path="/foo/sub">
    <Route path="/foo/sub/bar">
        useSubRoutePrefix()
    </Route>
  </SubRoute>
<Route>
```
(pseudo code)

BEFORE: /foo/sub
NOW: /foo/sub/bar


```
<Route path="/foo">
  <SubRoute path="/foo/sub">
    <Route path="/foo/sub/bar">
        useSubRoutePrefix()
    </Route>
  </SubRoute>
<Route>
```
(pseudo code)


## 2. useRouteMatch -> React.useContext(__RouterContext).match;

useRouteMatch throws an error if there is no match, can (now) happen in the following situation:

```
  <SubRoute path="/foo/sub">
        useSubRoutePrefix()
  </SubRoute>
```