### PR TITLE
Fix ManyImagesTestPageGenerator

### DIFF
--- a/demo/api/src/db/fixtures/generators/many-images-test-page.generator.ts
+++ b/demo/api/src/db/fixtures/generators/many-images-test-page.generator.ts
@@ -6,6 +6,7 @@ import { PageTreeNodeCategory } from "@src/page-tree/page-tree-node-category";
 import { PageContentBlock } from "@src/pages/blocks/PageContentBlock";
 import { PageInput } from "@src/pages/dto/page.input";
 import { Page } from "@src/pages/entities/page.entity";
+import { UserGroup } from "@src/user-groups/user-group";
 import faker from "faker";
 
 import { generateImageBlock } from "./blocks/image.generator";
@@ -71,6 +72,7 @@ export class ManyImagesTestPageGenerator {
                 visible: true,
                 type: "image",
                 props: c,
+                userGroup: UserGroup.All,
             })),
         });
 


### PR DESCRIPTION
Previously:

Saving or copying the "Test many images" page created by the fixtures failed with a validation error. The reason was that each block is expected to have a userGroup which wasn't set in the fixtures.

https://github.com/vivid-planet/comet/assets/13380047/28327902-5880-4f99-9e42-75a090f55b12

<img width="654" alt="Bildschirm­foto 2023-07-13 um 12 43 31" src="https://github.com/vivid-planet/comet/assets/13380047/29258922-13ed-45ca-ab3e-0e25593ae7ae">

Now:

The userGroup is set in the fixtures. Saving and copying the page works as expected