### PR TITLE
Add build:docs script to root package.json

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,44 +1,40 @@
 name: Build Docs
 
 on:
-  pull_request:
-    paths:
-      - docs/**
-    branches:
-      - main
-      - next
-  push:
-    paths:
-      - docs/**
-    branches:
-      - main
-      - next
+    pull_request:
+        paths:
+            - docs/**
+        branches:
+            - main
+            - next
+    push:
+        paths:
+            - docs/**
+        branches:
+            - main
+            - next
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "${{ github.actor }}"
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+        steps:
+            - run: echo "${{ github.actor }}"
 
-      - uses: actions/checkout@v3
+            - uses: actions/checkout@v3
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+            - uses: pnpm/action-setup@v2
+              with:
+                  version: 8
 
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+            - name: Use Node.js 18.x
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18
+                  registry-url: "https://registry.npmjs.org"
+                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
 
-      - run: pnpm install --frozen-lockfile
+            - run: pnpm install --frozen-lockfile
 
-      - name: Build admin libs
-        run: pnpm recursive --filter "./packages/admin/admin*" run build
-
-      - name: Build docusaurus
-        run: |
-          pnpm --filter ./docs run build
+            - name: Build docs
+              run: pnpm run build:docs

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "build:cms:skippable": "test -f packages/admin/cms-admin/lib/index.d.ts && echo 'Skipping CMS build' || $npm_execpath build:cms",
         "build:storybook": "pnpm recursive --filter '@comet/admin*' run build && pnpm --filter comet-admin-stories run build-storybook",
         "build:lib": "pnpm recursive --filter '@comet/*' run build",
+        "build:docs": "pnpm recursive --filter '@comet/admin*' --filter 'comet-docs' run build",
         "clean": "pnpm recursive run clean",
         "copy-schema-files": "node copy-schema-files.js",
         "dev:admin": "pnpm recursive --filter '@comet/admin*' run clean && dotenv -c -- dev-pm start @comet-admin",


### PR DESCRIPTION
The docs build is needed for GitHub actions and Netlify deployments. We add this script to have a singe source of truth on how to build docs.