### PR TITLE
Fix ChooseFileDialog SubRoute

### DIFF
--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -1,4 +1,4 @@
-import { StackLink } from "@comet/admin";
+import { StackLink, SubRoute } from "@comet/admin";
 import { Close } from "@comet/admin-icons";
 import { Button, Dialog, DialogTitle, IconButton, Link } from "@mui/material";
 import { styled } from "@mui/material/styles";
@@ -98,16 +98,18 @@ export const ChooseFileDialog = ({ open, onClose, onChooseFile, allowedMimetypes
             </StyledDialogTitle>
             <DamScopeProvider>
                 <MemoryRouter>
-                    <RedirectToPersistedDamLocation stateKey={stateKey} />
-                    <DamTable
-                        renderDamLabel={(row, { matches, filterApi }: RenderDamLabelOptions) =>
-                            renderDamLabel(row, onChooseFile, { matches, filterApi, showLicenseWarnings: damConfig.enableLicenseFeature })
-                        }
-                        allowedMimetypes={allowedMimetypes}
-                        hideContextMenu={true}
-                        hideMultiselect={true}
-                        hideArchiveFilter={true}
-                    />
+                    <SubRoute path="">
+                        <RedirectToPersistedDamLocation stateKey={stateKey} />
+                        <DamTable
+                            renderDamLabel={(row, { matches, filterApi }: RenderDamLabelOptions) =>
+                                renderDamLabel(row, onChooseFile, { matches, filterApi, showLicenseWarnings: damConfig.enableLicenseFeature })
+                            }
+                            allowedMimetypes={allowedMimetypes}
+                            hideContextMenu={true}
+                            hideMultiselect={true}
+                            hideArchiveFilter={true}
+                        />
+                    </SubRoute>
                 </MemoryRouter>
             </DamScopeProvider>
         </FixedHeightDialog>


### PR DESCRIPTION
## Previously

When navigating into a folder in the `ChooseFileDialog` in a CompositeBlock, the tab started to hang.

### Reason

In MR https://github.com/vivid-planet/comet/pull/1049, the `SubRoute` was added to Comet. The `SubRoute` is automatically added when creating a composite block:
https://github.com/vivid-planet/comet/blob/265cb2810ff095353c8e494152277bc8b634e994/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx#L196
In the `StackSwitch` component, the `subRoutePrefix` is always added to the URL used for navigating within the Stack:
https://github.com/vivid-planet/comet/blob/265cb2810ff095353c8e494152277bc8b634e994/packages/admin/admin/src/stack/Switch.tsx#L108-L117

In the `ChooseFileDialog`, the `DamTable` is wrapped with a `MemoryRouter` to isolate the virtual DAM url (from the actual browser URL). Since the `subRoutePrefix` is now automatically added to the URL, the URL provided by the `StackLink` wasn't correct. This lead to the described bug. 

## Fix

The `ChooseFileDialog` wraps the `DamTable` in a `SubRoute` with an empty path. This means the `subRoutePrefix` is empty and the URL in the `StackLink` is correct.