### PR TITLE
Fix build:docs script in next

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "build:cms:skippable": "test -f packages/admin/cms-admin/lib/index.d.ts && echo 'Skipping CMS build' || $npm_execpath build:cms",
         "build:storybook": "pnpm recursive --filter '@comet/admin*' --filter '@comet/eslint-plugin' run build && pnpm --filter comet-admin-stories run build-storybook",
         "build:lib": "pnpm recursive --filter '@comet/*' run build",
-        "build:docs": "pnpm recursive --filter '@comet/admin*' --filter 'comet-docs' run build",
+        "build:docs": "pnpm recursive --filter '@comet/eslint-plugin' --filter '@comet/admin*' --filter 'comet-docs' run build",
         "clean": "pnpm recursive run clean",
         "copy-schema-files": "node copy-schema-files.js",
         "dev:admin": "pnpm recursive --filter '@comet/admin*' run clean && dotenv -c -- dev-pm start @comet-admin",


### PR DESCRIPTION
The `@comet/eslint-plugin` package needs to be built before building the docs.