### PR TITLE
Fix MikroORM dependency issue

### DIFF
--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -69,7 +69,6 @@
         "nestjs-console": "^8.0.0",
         "node-fetch": "^2.0.0",
         "passport": "^0.4.0",
-        "pg": "^8.0.0",
         "pg-error-constants": "^1.0.0",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.0",

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -82,7 +82,6 @@
         "@mikro-orm/migrations": "^5.7.1",
         "@mikro-orm/nestjs": "^5.1.8",
         "@mikro-orm/postgresql": "^5.7.1",
-        "@mikro-orm/sqlite": "^5.7.1",
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/graphql": "^10.0.0",
@@ -111,7 +110,6 @@
         "jest-junit": "^15.0.0",
         "nestjs-console": "^8.0.0",
         "npm-run-all": "^4.0.0",
-        "pg": "^8.0.0",
         "pg-error-constants": "^1.0.0",
         "prettier": "^2.0.0",
         "rxjs": "^7.8.0",
@@ -135,7 +133,6 @@
         "express": "^4.0.0",
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
         "nestjs-console": "^8.0.0",
-        "pg": "^8.0.0",
         "pg-error-constants": "^1.0.0",
         "rxjs": "^7.0.0"
     },

--- a/packages/api/cms-api/src/generator/generate-crud-input-json.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input-json.spec.ts
@@ -56,7 +56,7 @@ describe("GenerateCrudInputJson", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityWithJsonLiteralArray],
             });
@@ -95,7 +95,7 @@ describe("GenerateCrudInputJson", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityWithJsonObject],
             });
@@ -132,7 +132,7 @@ describe("GenerateCrudInputJson", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityWithEmbedded, TestEmbedded],
             });

--- a/packages/api/cms-api/src/generator/generate-crud-input-relations.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input-relations.spec.ts
@@ -27,7 +27,7 @@ describe("GenerateCrudInputRelations", () => {
     it("n:1 input dto should contain relation id", async () => {
         LazyMetadataStorage.load();
         const orm = await MikroORM.init({
-            type: "sqlite",
+            type: "postgresql",
             dbName: "test-db",
             entities: [Product, ProductCategory],
         });
@@ -59,7 +59,7 @@ describe("GenerateCrudInputRelations", () => {
     it("1:n input dto should contain relation id", async () => {
         LazyMetadataStorage.load();
         const orm = await MikroORM.init({
-            type: "sqlite",
+            type: "postgresql",
             dbName: "test-db",
             entities: [Product, ProductCategory],
         });

--- a/packages/api/cms-api/src/generator/generate-crud-input.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.spec.ts
@@ -54,7 +54,7 @@ describe("GenerateCrudInput", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityWithString],
             });
@@ -88,7 +88,7 @@ describe("GenerateCrudInput", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityWithDate],
             });
@@ -122,7 +122,7 @@ describe("GenerateCrudInput", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityWithBoolean],
             });
@@ -157,7 +157,7 @@ describe("GenerateCrudInput", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityWithEnum],
             });

--- a/packages/api/cms-api/src/generator/generate-crud-relations-nested.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-nested.spec.ts
@@ -35,7 +35,7 @@ describe("GenerateCrudRelations", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityProduct, TestEntityVariant],
             });

--- a/packages/api/cms-api/src/generator/generate-crud-relations.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations.spec.ts
@@ -51,7 +51,7 @@ describe("GenerateCrudRelations", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityProduct, TestEntityCategory],
             });
@@ -79,7 +79,7 @@ describe("GenerateCrudRelations", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityProduct, TestEntityCategory],
             });

--- a/packages/api/cms-api/src/generator/generate-crud.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.spec.ts
@@ -19,7 +19,7 @@ describe("GenerateCrud", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
-                type: "sqlite",
+                type: "postgresql",
                 dbName: "test-db",
                 entities: [TestEntityWithString],
             });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,13 +426,13 @@ importers:
         version: 0.18.1
       '@mikro-orm/cli':
         specifier: ^5.7.1
-        version: 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)(pg@8.8.0)
+        version: 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)
       '@mikro-orm/core':
         specifier: ^5.7.1
-        version: 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)
+        version: 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)
       '@mikro-orm/migrations':
         specifier: ^5.7.1
-        version: 5.7.1(@mikro-orm/core@5.7.1)(pg@8.8.0)
+        version: 5.7.1(@mikro-orm/core@5.7.1)
       '@mikro-orm/nestjs':
         specifier: ^5.1.8
         version: 5.1.8(@mikro-orm/core@5.7.1)(@nestjs/common@9.2.1)(@nestjs/core@9.2.1)
@@ -541,9 +541,6 @@ importers:
       passport:
         specifier: ^0.4.0
         version: 0.4.1
-      pg:
-        specifier: ^8.0.0
-        version: 8.8.0
       pg-error-constants:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2384,22 +2381,19 @@ importers:
         version: 0.18.1
       '@mikro-orm/cli':
         specifier: ^5.7.1
-        version: 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)(pg@8.8.0)
+        version: 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)
       '@mikro-orm/core':
         specifier: ^5.7.1
-        version: 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)
+        version: 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)
       '@mikro-orm/migrations':
         specifier: ^5.7.1
-        version: 5.7.1(@mikro-orm/core@5.7.1)(pg@8.8.0)
+        version: 5.7.1(@mikro-orm/core@5.7.1)
       '@mikro-orm/nestjs':
         specifier: ^5.1.8
         version: 5.1.8(@mikro-orm/core@5.7.1)(@nestjs/common@9.2.1)(@nestjs/core@9.2.1)
       '@mikro-orm/postgresql':
         specifier: ^5.7.1
         version: 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)
-      '@mikro-orm/sqlite':
-        specifier: ^5.7.1
-        version: 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.8.0)
       '@nestjs/common':
         specifier: ^9.0.0
         version: 9.2.1(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
@@ -2484,9 +2478,6 @@ importers:
       npm-run-all:
         specifier: ^4.0.0
         version: 4.1.5
-      pg:
-        specifier: ^8.0.0
-        version: 8.8.0
       pg-error-constants:
         specifier: ^1.0.0
         version: 1.0.0
@@ -6941,6 +6932,7 @@ packages:
 
   /@gar/promisify@1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+    dev: false
 
   /@gitbeaker/core@25.6.0:
     resolution: {integrity: sha512-+CohJNsbZiPl7jPgw7PHt5t0JIIV9NngObOskY1Ww8jef7SqaKpz0NsbSDawuWFBdmXApMpK81AEfASKtVI+cw==}
@@ -8362,23 +8354,6 @@ packages:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  /@mapbox/node-pre-gyp@1.0.10:
-    resolution: {integrity: sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==}
-    hasBin: true
-    dependencies:
-      detect-libc: 2.0.1
-      https-proxy-agent: 5.0.1
-      make-dir: 3.1.0
-      node-fetch: 2.6.8
-      nopt: 5.0.0
-      npmlog: 5.0.1
-      rimraf: 3.0.2
-      semver: 7.3.8
-      tar: 6.1.13
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   /@mdx-js/mdx@1.6.22:
     resolution: {integrity: sha512-AMxuLxPz2j5/6TpF/XSdKpQP1NlG0z11dFOlq+2IP/lSgl11GY8ji6S/rgsViN/L0BDvHvUMruRb7ub+24LUYA==}
     dependencies:
@@ -8421,7 +8396,7 @@ packages:
     resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
     dev: true
 
-  /@mikro-orm/cli@5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)(pg@8.8.0):
+  /@mikro-orm/cli@5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1):
     resolution: {integrity: sha512-wh6xjXlLjfaDshcGtPhfh/iH55fl07/rRq0GckglVMGod7vOlOTOxJe9mQB6iwgr8nZ7jKsXuk1eHS44jZB3pw==}
     engines: {node: '>= 14.0.0'}
     hasBin: true
@@ -8459,11 +8434,10 @@ packages:
         optional: true
     dependencies:
       '@jercle/yargonaut': 1.1.5
-      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)
-      '@mikro-orm/knex': 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.8.0)(sqlite3@5.1.6)
-      '@mikro-orm/migrations': 5.7.1(@mikro-orm/core@5.7.1)(pg@8.8.0)
+      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)
+      '@mikro-orm/knex': 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.10.0)
+      '@mikro-orm/migrations': 5.7.1(@mikro-orm/core@5.7.1)
       '@mikro-orm/postgresql': 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)
-      '@mikro-orm/sqlite': 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.8.0)
       fs-extra: 11.1.1
       tsconfig-paths: 4.2.0
       yargs: 17.7.1
@@ -8478,7 +8452,7 @@ packages:
       - supports-color
       - tedious
 
-  /@mikro-orm/core@5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1):
+  /@mikro-orm/core@5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1):
     resolution: {integrity: sha512-r6l+2rcqLsg16g2J4pZKbx8EqTrP3SG5FBR/wlIENU94gBJoHJ5KFcWx6J2+QBrVoykQd3hT3u3y82jS+RCp+Q==}
     engines: {node: '>= 14.0.0'}
     peerDependencies:
@@ -8514,9 +8488,8 @@ packages:
       '@mikro-orm/sqlite':
         optional: true
     dependencies:
-      '@mikro-orm/migrations': 5.7.1(@mikro-orm/core@5.7.1)(pg@8.8.0)
+      '@mikro-orm/migrations': 5.7.1(@mikro-orm/core@5.7.1)
       '@mikro-orm/postgresql': 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)
-      '@mikro-orm/sqlite': 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.8.0)
       acorn-loose: 8.3.0
       acorn-walk: 8.2.0
       dotenv: 16.0.3
@@ -8556,8 +8529,8 @@ packages:
       sqlite3:
         optional: true
     dependencies:
-      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)
-      '@mikro-orm/migrations': 5.7.1(@mikro-orm/core@5.7.1)(pg@8.8.0)
+      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)
+      '@mikro-orm/migrations': 5.7.1(@mikro-orm/core@5.7.1)
       fs-extra: 11.1.1
       knex: 2.4.2(pg@8.10.0)
       pg: 8.10.0
@@ -8567,59 +8540,16 @@ packages:
       - supports-color
       - tedious
 
-  /@mikro-orm/knex@5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.8.0)(sqlite3@5.1.6):
-    resolution: {integrity: sha512-lKQLlH024RrC8MbcY6JEqEIBRqHptPjRibSs+l5O32tOjZY4YQbbRcDwMLT+2RMpqn6yCt8brJYOE/IlNKh/Jw==}
-    engines: {node: '>= 14.0.0'}
-    peerDependencies:
-      '@mikro-orm/core': ^5.0.0
-      '@mikro-orm/entity-generator': ^5.0.0
-      '@mikro-orm/migrations': ^5.0.0
-      better-sqlite3: ^8.0.0
-      mssql: ^7.0.0
-      mysql: ^2.18.1
-      mysql2: ^2.1.0
-      pg: ^8.0.3
-      sqlite3: ^5.0.0
-    peerDependenciesMeta:
-      '@mikro-orm/entity-generator':
-        optional: true
-      '@mikro-orm/migrations':
-        optional: true
-      better-sqlite3:
-        optional: true
-      mssql:
-        optional: true
-      mysql:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      sqlite3:
-        optional: true
-    dependencies:
-      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)
-      '@mikro-orm/migrations': 5.7.1(@mikro-orm/core@5.7.1)(pg@8.8.0)
-      fs-extra: 11.1.1
-      knex: 2.4.2(pg@8.8.0)(sqlite3@5.1.6)
-      pg: 8.8.0
-      sqlite3: 5.1.6
-      sqlstring: 2.3.3
-    transitivePeerDependencies:
-      - pg-native
-      - supports-color
-      - tedious
-
-  /@mikro-orm/migrations@5.7.1(@mikro-orm/core@5.7.1)(pg@8.8.0):
+  /@mikro-orm/migrations@5.7.1(@mikro-orm/core@5.7.1):
     resolution: {integrity: sha512-hCAMPjNDoxr4z9ZRq182bcbxiHy+TfzsNnd82VTDneUkRgyGZAcWT69TQtLrvlqMXaQERSfsPLAx7qM5gKcyIw==}
     engines: {node: '>= 14.0.0'}
     peerDependencies:
       '@mikro-orm/core': ^5.0.0
     dependencies:
-      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)
-      '@mikro-orm/knex': 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.8.0)(sqlite3@5.1.6)
+      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)
+      '@mikro-orm/knex': 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.10.0)
       fs-extra: 11.1.1
-      knex: 2.4.2(pg@8.8.0)(sqlite3@5.1.6)
+      knex: 2.4.2(pg@8.10.0)
       umzug: 3.2.1
     transitivePeerDependencies:
       - '@mikro-orm/entity-generator'
@@ -8641,7 +8571,7 @@ packages:
       '@nestjs/common': ^8.0.0 || ^9.0.0
       '@nestjs/core': ^8.0.0 || ^9.0.0
     dependencies:
-      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)
+      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)
       '@nestjs/common': 9.2.1(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 9.2.1(@nestjs/common@9.2.1)(@nestjs/platform-express@9.2.1)(reflect-metadata@0.1.13)(rxjs@7.8.0)
 
@@ -8661,9 +8591,9 @@ packages:
       '@mikro-orm/seeder':
         optional: true
     dependencies:
-      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)
+      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)
       '@mikro-orm/knex': 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.10.0)
-      '@mikro-orm/migrations': 5.7.1(@mikro-orm/core@5.7.1)(pg@8.8.0)
+      '@mikro-orm/migrations': 5.7.1(@mikro-orm/core@5.7.1)
       pg: 8.10.0
     transitivePeerDependencies:
       - better-sqlite3
@@ -8672,40 +8602,6 @@ packages:
       - mysql2
       - pg-native
       - sqlite3
-      - supports-color
-      - tedious
-
-  /@mikro-orm/sqlite@5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.8.0):
-    resolution: {integrity: sha512-/DAvoYg6qpXRFG1PaT57csaoynC1QeboVJtduUpFtiC1v+PyES1RgHbn+9sdXIEvv0EeUihGJhYM/J1lnly97w==}
-    engines: {node: '>= 14.0.0'}
-    peerDependencies:
-      '@mikro-orm/core': ^5.0.0
-      '@mikro-orm/entity-generator': ^5.0.0
-      '@mikro-orm/migrations': ^5.0.0
-      '@mikro-orm/seeder': ^5.0.0
-    peerDependenciesMeta:
-      '@mikro-orm/entity-generator':
-        optional: true
-      '@mikro-orm/migrations':
-        optional: true
-      '@mikro-orm/seeder':
-        optional: true
-    dependencies:
-      '@mikro-orm/core': 5.7.1(@mikro-orm/migrations@5.7.1)(@mikro-orm/postgresql@5.7.1)(@mikro-orm/sqlite@5.7.1)
-      '@mikro-orm/knex': 5.7.1(@mikro-orm/core@5.7.1)(@mikro-orm/migrations@5.7.1)(pg@8.8.0)(sqlite3@5.1.6)
-      '@mikro-orm/migrations': 5.7.1(@mikro-orm/core@5.7.1)(pg@8.8.0)
-      fs-extra: 11.1.1
-      sqlite3: 5.1.6
-      sqlstring-sqlite: 0.1.1
-    transitivePeerDependencies:
-      - better-sqlite3
-      - bluebird
-      - encoding
-      - mssql
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
       - supports-color
       - tedious
 
@@ -9474,6 +9370,7 @@ packages:
     dependencies:
       '@gar/promisify': 1.1.3
       semver: 7.3.8
+    dev: false
 
   /@npmcli/move-file@1.1.2:
     resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
@@ -9482,6 +9379,7 @@ packages:
     dependencies:
       mkdirp: 1.0.4
       rimraf: 3.0.2
+    dev: false
 
   /@nuxtjs/opencollective@0.3.2:
     resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
@@ -11983,11 +11881,6 @@ packages:
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
     dev: false
 
-  /@tootallnate/once@1.1.2:
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
-    optional: true
-
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -13542,9 +13435,6 @@ packages:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     dev: true
 
-  /abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
-
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -13636,6 +13526,7 @@ packages:
       debug: 4.3.4(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /agentkeepalive@4.2.1:
     resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==}
@@ -13646,6 +13537,7 @@ packages:
       humanize-ms: 1.2.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -14021,6 +13913,7 @@ packages:
 
   /aproba@2.0.0:
     resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
+    dev: false
 
   /archiver-utils@2.1.0:
     resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
@@ -14057,14 +13950,7 @@ packages:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.0
-
-  /are-we-there-yet@3.0.1:
-    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.0
-    optional: true
+    dev: false
 
   /arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -14826,6 +14712,7 @@ packages:
 
   /bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+    dev: false
 
   /bn.js@4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
@@ -15190,6 +15077,7 @@ packages:
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
+    dev: false
 
   /cache-base@1.0.1:
     resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
@@ -15757,6 +15645,7 @@ packages:
   /color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
+    dev: false
 
   /colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -15912,6 +15801,7 @@ packages:
 
   /console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
+    dev: false
 
   /console-log-level@1.4.1:
     resolution: {integrity: sha512-VZzbIORbP+PPcN/gg3DXClTLPLg5Slwd5fL2MIc+o1qZ4BXBvWyc6QxPk6T/Mkr6IVjRpoAGf32XxP3ZWMVRcQ==}
@@ -16831,6 +16721,7 @@ packages:
 
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+    dev: false
 
   /depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -16868,10 +16759,6 @@ packages:
 
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
-
-  /detect-libc@2.0.1:
-    resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
 
   /detect-newline@3.1.0:
@@ -17397,13 +17284,6 @@ packages:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
 
-  /encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-    requiresBuild: true
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
-
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
@@ -17449,11 +17329,6 @@ packages:
     resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
     engines: {node: '>=0.12'}
 
-  /env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
-    optional: true
-
   /envinfo@7.8.1:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
@@ -17464,10 +17339,6 @@ packages:
     dependencies:
       jkroso-type: 1.1.1
     dev: false
-
-  /err-code@2.0.3:
-    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
-    optional: true
 
   /errno@0.1.8:
     resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
@@ -19131,20 +19002,7 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
-
-  /gauge@4.0.4:
-    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      aproba: 2.0.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
-    optional: true
+    dev: false
 
   /generic-pool@3.9.0:
     resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
@@ -19753,6 +19611,7 @@ packages:
 
   /has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+    dev: false
 
   /has-value@0.3.1:
     resolution: {integrity: sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==}
@@ -20092,17 +19951,6 @@ packages:
   /http-parser-js@0.5.8:
     resolution: {integrity: sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==}
 
-  /http-proxy-agent@4.0.1:
-    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
-    engines: {node: '>= 6'}
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.3.1)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   /http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -20169,6 +20017,7 @@ packages:
       debug: 4.3.4(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
@@ -20186,6 +20035,7 @@ packages:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
     dependencies:
       ms: 2.1.3
+    dev: false
 
   /husky@7.0.4:
     resolution: {integrity: sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==}
@@ -20207,6 +20057,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+    dev: true
 
   /icss-utils@4.1.1:
     resolution: {integrity: sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==}
@@ -20317,6 +20168,7 @@ packages:
 
   /infer-owner@1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+    dev: false
 
   /infima@0.2.0-alpha.42:
     resolution: {integrity: sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww==}
@@ -20456,6 +20308,7 @@ packages:
 
   /ip@2.0.0:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
+    dev: false
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -20719,10 +20572,6 @@ packages:
   /is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
-
-  /is-lambda@1.0.1:
-    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
-    optional: true
 
   /is-lower-case@2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
@@ -22061,53 +21910,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /knex@2.4.2(pg@8.8.0)(sqlite3@5.1.6):
-    resolution: {integrity: sha512-tMI1M7a+xwHhPxjbl/H9K1kHX+VncEYcvCx5K00M16bWvpYPKAZd6QrCu68PtHAdIZNQPWZn0GVhqVBEthGWCg==}
-    engines: {node: '>=12'}
-    hasBin: true
-    peerDependencies:
-      better-sqlite3: '*'
-      mysql: '*'
-      mysql2: '*'
-      pg: '*'
-      pg-native: '*'
-      sqlite3: '*'
-      tedious: '*'
-    peerDependenciesMeta:
-      better-sqlite3:
-        optional: true
-      mysql:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      pg-native:
-        optional: true
-      sqlite3:
-        optional: true
-      tedious:
-        optional: true
-    dependencies:
-      colorette: 2.0.19
-      commander: 9.5.0
-      debug: 4.3.4(supports-color@9.3.1)
-      escalade: 3.1.1
-      esm: 3.2.25
-      get-package-type: 0.1.0
-      getopts: 2.3.0
-      interpret: 2.2.0
-      lodash: 4.17.21
-      pg: 8.8.0
-      pg-connection-string: 2.5.0
-      rechoir: 0.8.0
-      resolve-from: 5.0.0
-      sqlite3: 5.1.6
-      tarn: 3.0.2
-      tildify: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   /language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
     dev: false
@@ -22643,31 +22445,6 @@ packages:
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
-  /make-fetch-happen@9.1.0:
-    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
-    engines: {node: '>= 10'}
-    dependencies:
-      agentkeepalive: 4.2.1
-      cacache: 15.3.0
-      http-cache-semantics: 4.1.0
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
-      is-lambda: 1.0.1
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 1.4.1
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.3
-      promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1
-      ssri: 8.0.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    optional: true
-
   /makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
     dependencies:
@@ -23064,36 +22841,21 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       minipass: 3.3.6
-
-  /minipass-fetch@1.4.1:
-    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
-    engines: {node: '>=8'}
-    dependencies:
-      minipass: 3.3.6
-      minipass-sized: 1.0.3
-      minizlib: 2.1.2
-    optionalDependencies:
-      encoding: 0.1.13
-    optional: true
+    dev: false
 
   /minipass-flush@1.0.5:
     resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
     engines: {node: '>= 8'}
     dependencies:
       minipass: 3.3.6
+    dev: false
 
   /minipass-pipeline@1.2.4:
     resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
     engines: {node: '>=8'}
     dependencies:
       minipass: 3.3.6
-
-  /minipass-sized@1.0.3:
-    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
-    engines: {node: '>=8'}
-    dependencies:
-      minipass: 3.3.6
-    optional: true
+    dev: false
 
   /minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
@@ -23428,9 +23190,6 @@ packages:
   /node-abort-controller@3.0.1:
     resolution: {integrity: sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==}
 
-  /node-addon-api@4.3.0:
-    resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
-
   /node-bitmap@0.0.1:
     resolution: {integrity: sha512-Jx5lPaaLdIaOsj2mVLWMWulXF6GQVdyLvNSxmiYCvZ8Ma2hfKX0POoR2kgKOqz+oFsRreq0yYZjQ2wjE9VNzCA==}
     engines: {node: '>=v0.6.5'}
@@ -23484,27 +23243,6 @@ packages:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
 
-  /node-gyp@8.4.1:
-    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
-    engines: {node: '>= 10.12.0'}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      env-paths: 2.2.1
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      make-fetch-happen: 9.1.0
-      nopt: 5.0.0
-      npmlog: 6.0.2
-      rimraf: 3.0.2
-      semver: 7.3.8
-      tar: 6.1.13
-      which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    optional: true
-
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -23546,13 +23284,6 @@ packages:
 
   /node-releases@2.0.8:
     resolution: {integrity: sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==}
-
-  /nopt@5.0.0:
-    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dependencies:
-      abbrev: 1.1.1
 
   /normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -23622,16 +23353,7 @@ packages:
       console-control-strings: 1.1.0
       gauge: 3.0.2
       set-blocking: 2.0.0
-
-  /npmlog@6.0.2:
-    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      are-we-there-yet: 3.0.1
-      console-control-strings: 1.1.0
-      gauge: 4.0.4
-      set-blocking: 2.0.0
-    optional: true
+    dev: false
 
   /nprogress@0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
@@ -24357,13 +24079,6 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
-  /pg-pool@3.5.2(pg@8.8.0):
-    resolution: {integrity: sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==}
-    peerDependencies:
-      pg: '>=8.0'
-    dependencies:
-      pg: 8.8.0
-
   /pg-pool@3.6.0(pg@8.10.0):
     resolution: {integrity: sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ==}
     peerDependencies:
@@ -24401,23 +24116,6 @@ packages:
       pg-connection-string: 2.5.0
       pg-pool: 3.6.0(pg@8.10.0)
       pg-protocol: 1.6.0
-      pg-types: 2.2.0
-      pgpass: 1.0.5
-
-  /pg@8.8.0:
-    resolution: {integrity: sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==}
-    engines: {node: '>= 8.0.0'}
-    peerDependencies:
-      pg-native: '>=3.0.1'
-    peerDependenciesMeta:
-      pg-native:
-        optional: true
-    dependencies:
-      buffer-writer: 2.0.0
-      packet-reader: 1.0.0
-      pg-connection-string: 2.5.0
-      pg-pool: 3.5.2(pg@8.8.0)
-      pg-protocol: 1.5.0
       pg-types: 2.2.0
       pgpass: 1.0.5
 
@@ -25199,14 +24897,7 @@ packages:
         optional: true
     dependencies:
       bluebird: 3.7.2
-
-  /promise-retry@2.0.1:
-    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
-    engines: {node: '>=10'}
-    dependencies:
-      err-code: 2.0.3
-      retry: 0.12.0
-    optional: true
+    dev: false
 
   /promise.allsettled@1.0.6:
     resolution: {integrity: sha512-22wJUOD3zswWFqgwjNHa1965LvqTX87WPu/lreY2KSd7SVcERfuZ4GfUaOnJNnvtoIv2yXT/W00YIGMetXtFXg==}
@@ -26599,11 +26290,6 @@ packages:
     engines: {node: '>=0.12'}
     dev: false
 
-  /retry@0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
-    optional: true
-
   /retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -27139,11 +26825,6 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: false
 
-  /smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-    optional: true
-
   /smartwrap@2.0.2:
     resolution: {integrity: sha512-vCsKNQxb7PnCNd2wY1WClWifAc2lwqsG8OaswpJkVJsvMGcnEntdTCDajZCkk93Ay1U3t/9puJmb525Rg5MZBA==}
     engines: {node: '>=6'}
@@ -27201,25 +26882,6 @@ packages:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
-
-  /socks-proxy-agent@6.2.1:
-    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
-    engines: {node: '>= 10'}
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.3.1)
-      socks: 2.7.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  /socks@2.7.1:
-    resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
-    engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
-    dependencies:
-      ip: 2.0.0
-      smart-buffer: 4.2.0
-    optional: true
 
   /sonic-boom@1.4.1:
     resolution: {integrity: sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==}
@@ -27394,27 +27056,6 @@ packages:
     resolution: {integrity: sha512-IpCr2tpnNkP3Jera4ncexsZUp0enJBLr+pHCyTweMUBrbJsTgQeLWx1FXLhoBj/MvcnUQpkgOn2EY8FKOkUzww==}
     dev: false
 
-  /sqlite3@5.1.6:
-    resolution: {integrity: sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==}
-    requiresBuild: true
-    peerDependenciesMeta:
-      node-gyp:
-        optional: true
-    dependencies:
-      '@mapbox/node-pre-gyp': 1.0.10
-      node-addon-api: 4.3.0
-      tar: 6.1.13
-    optionalDependencies:
-      node-gyp: 8.4.1
-    transitivePeerDependencies:
-      - bluebird
-      - encoding
-      - supports-color
-
-  /sqlstring-sqlite@0.1.1:
-    resolution: {integrity: sha512-9CAYUJ0lEUPYJrswqiqdINNSfq3jqWo/bFJ7tufdoNeSK0Fy+d1kFTxjqO9PIqza0Kri+ZtYMfPVf1aZaFOvrQ==}
-    engines: {node: '>= 0.6'}
-
   /sqlstring@2.3.1:
     resolution: {integrity: sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==}
     engines: {node: '>= 0.6'}
@@ -27454,6 +27095,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       minipass: 3.3.6
+    dev: false
 
   /stable@0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
@@ -28861,11 +28503,13 @@ packages:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
     dependencies:
       unique-slug: 2.0.2
+    dev: false
 
   /unique-slug@2.0.2:
     resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
     dependencies:
       imurmurhash: 0.1.4
+    dev: false
 
   /unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
@@ -29827,6 +29471,7 @@ packages:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
       string-width: 4.2.3
+    dev: false
 
   /widest-line@3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}


### PR DESCRIPTION
Installing both the `@mikro-orm/postgresql` and `@mikro-orm/sqlite` adapter in `@comet/cms-api` led to multiple copies of `@mikro-orm/knex`, which could not be easily resolved. As were not really using the sqlite adapter anyway (expect the tests in `@comet/cms-api`, which only use MikroORM's metadata storage), I have decided to remove the adapter completely. Furthermore, I've removed direct the dependency on the database driver `pg` as recommended by the [MikroORM docs](https://mikro-orm.io/docs/installation).