### PR TITLE
Fix main-into-next-pr workflow status

### DIFF
--- a/.github/workflows/main-into-next-pr.yml
+++ b/.github/workflows/main-into-next-pr.yml
@@ -19,6 +19,8 @@ jobs:
                   git config user.email github-actions@github.com
 
             - name: Try automatic merge of main into next
+              id: automatic-merge-attempt
+              continue-on-error: true
               run: |
                   git checkout next
                   git merge main
@@ -26,7 +28,7 @@ jobs:
                   echo 'PR_BODY=This is an automated pull request to merge changes from `main` into `next`.' >> $GITHUB_ENV
 
             - name: Merge with conflicts if automatic merge failed
-              if: failure()
+              if: steps.automatic-merge-attempt.outcome == 'failure' && steps.automatic-merge-attempt.conclusion == 'success' # https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
               run: |
                   git add .
                   git commit -m "Merge main into next"
@@ -34,7 +36,6 @@ jobs:
                   echo 'PR_BODY=This is an automated pull request to merge changes from `main` into `next`. It has merge conflicts. To resolve conflicts, check out the branch `merge-main-into-next` locally, make any necessary changes to conflicting files, and commit and publish your changes.' >> $GITHUB_ENV
 
             - name: Create pull request
-              if: success() || failure()
               uses: peter-evans/create-pull-request@v5
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The workflow was marked as failed if the automatic merge failed, resulting in the commit being marked as failed. To fix this, we use the `continue-on-error` flag in combination with the `steps` context: We allow the "Try automatic merge of main into next" step to fail and use the step's `outcome` and `conclusion` context information to only run the "Merge with conflicts if automatic merge failed" step if the automatic merge failed.