### PR TITLE
Fix build name in publisher table for empty string labels

### DIFF
--- a/packages/admin/cms-admin/src/builds/PublisherPage.tsx
+++ b/packages/admin/cms-admin/src/builds/PublisherPage.tsx
@@ -83,7 +83,7 @@ export function PublisherPage(): React.ReactElement {
                             headerName: intl.formatMessage({ id: "comet.pages.publisher.name", defaultMessage: "Name" }),
                             flex: 2,
                             renderCell: ({ row }) => {
-                                return row.label ?? row.name;
+                                return row.label && row.label.length > 0 ? row.label : row.name;
                             },
                         },
                         {


### PR DESCRIPTION
In one of our customer projects, build labels can be an empty string, resulting in nothing being displayed at the moment.