### PR TITLE
Optimize UX for download option in more actions dropdown

### DIFF
--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
@@ -17,10 +17,15 @@ interface DamMoreActionsProps {
 
 export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMoreActionsProps): React.ReactElement => {
     const damSelectionActionsApi = useDamSelectionApi();
+    const { selectionMap, archiveSelected, deleteSelected, downloadSelected, restoreSelected, moveSelected } = damSelectionActionsApi;
     const snackbarApi = useSnackbarApi();
     const intl = useIntl();
 
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+    const selectionMapValues = Array.from(selectionMap.values());
+    const lengthOfSelectedFiles = selectionMapValues.filter((value) => value === "file").length;
+    const onlyFoldersSelected = selectionMapValues.every((value) => value === "folder");
 
     const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
         setAnchorEl(event.currentTarget);
@@ -30,46 +35,42 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMor
         setAnchorEl(null);
     };
 
-    const selectionMapValues = Array.from(damSelectionActionsApi.selectionMap.values());
-    const lengthOfSelectedFiles = selectionMapValues.filter((value) => value === "file").length;
-    const isFolderInSelection = selectionMapValues.some((value) => value === "folder");
-    const onlyFoldersSelected = selectionMapValues.every((value) => value === "folder");
+    const handleDownloadClick = () => {
+        const isFolderInSelection = selectionMapValues.some((value) => value === "folder");
+        const snackbarElement = (
+            <Snackbar
+                anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+                autoHideDuration={5000}
+                TransitionComponent={(props: SlideProps) => <Slide {...props} direction="right" />}
+                message={intl.formatMessage({
+                    id: "comet.dam.moreActions.folderNotDownloaded",
+                    defaultMessage: "Download of files started successfully. Folder downloads are not supported yet.",
+                })}
+            />
+        );
 
-    const snackbarComponent = (
-        <Snackbar
-            anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-            autoHideDuration={5000}
-            TransitionComponent={(props: SlideProps) => <Slide {...props} direction="right" />}
-            message={intl.formatMessage({
-                id: "comet.dam.moreActions.folderNotDownloaded",
-                defaultMessage: "Download of files started successfully. Folder downloads are not supported yet.",
-            })}
-        />
-    );
-
-    const onDownloadClick = () => {
-        damSelectionActionsApi.downloadSelected();
+        downloadSelected();
         handleClose();
-        isFolderInSelection && snackbarApi.showSnackbar(snackbarComponent);
+        isFolderInSelection && snackbarApi.showSnackbar(snackbarElement);
     };
 
-    const onMoveClick = () => {
-        damSelectionActionsApi.moveSelected();
+    const handleMoveClick = () => {
+        moveSelected();
         handleClose();
     };
 
-    const onArchiveClick = () => {
-        damSelectionActionsApi.archiveSelected();
+    const handleArchiveClick = () => {
+        archiveSelected();
         handleClose();
     };
 
-    const onRestoreClick = () => {
-        damSelectionActionsApi.restoreSelected();
+    const handleRestoreClick = () => {
+        restoreSelected();
         handleClose();
     };
 
-    const onDeleteClick = () => {
-        damSelectionActionsApi.deleteSelected();
+    const handleDeleteClick = () => {
+        deleteSelected();
         handleClose();
     };
 
@@ -87,7 +88,7 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMor
                 <MenuList>
                     {!onlyFoldersSelected && (
                         <>
-                            <MenuItem onClick={onDownloadClick}>
+                            <MenuItem onClick={handleDownloadClick}>
                                 <ListItemIcon>
                                     <Download />
                                 </ListItemIcon>
@@ -99,33 +100,33 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMor
                             <StyledDivider />
                         </>
                     )}
-                    <MenuItem onClick={onMoveClick}>
+                    <MenuItem onClick={handleMoveClick}>
                         <ListItemIcon>
                             <Move />
                         </ListItemIcon>
                         <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.moveItems" defaultMessage="Move items" />} />
-                        <NumberSelectedChip>{damSelectionActionsApi.selectionMap.size}</NumberSelectedChip>
+                        <NumberSelectedChip>{selectionMap.size}</NumberSelectedChip>
                     </MenuItem>
-                    <MenuItem onClick={onArchiveClick}>
+                    <MenuItem onClick={handleArchiveClick}>
                         <ListItemIcon>
                             <Archive />
                         </ListItemIcon>
                         <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.archiveItems" defaultMessage="Archive items" />} />
-                        <NumberSelectedChip>{damSelectionActionsApi.selectionMap.size}</NumberSelectedChip>
+                        <NumberSelectedChip>{selectionMap.size}</NumberSelectedChip>
                     </MenuItem>
-                    <MenuItem onClick={onRestoreClick}>
+                    <MenuItem onClick={handleRestoreClick}>
                         <ListItemIcon>
                             <Restore />
                         </ListItemIcon>
                         <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.restoreItems" defaultMessage="Restore items" />} />
-                        <NumberSelectedChip>{damSelectionActionsApi.selectionMap.size}</NumberSelectedChip>
+                        <NumberSelectedChip>{selectionMap.size}</NumberSelectedChip>
                     </MenuItem>
-                    <MenuItem onClick={onDeleteClick}>
+                    <MenuItem onClick={handleDeleteClick}>
                         <ListItemIcon>
                             <Delete />
                         </ListItemIcon>
                         <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.deleteItems" defaultMessage="Delete items" />} />
-                        <NumberSelectedChip>{damSelectionActionsApi.selectionMap.size}</NumberSelectedChip>
+                        <NumberSelectedChip>{selectionMap.size}</NumberSelectedChip>
                     </MenuItem>
                 </MenuList>
             </Menu>

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
@@ -1,9 +1,11 @@
+import { useSnackbarApi } from "@comet/admin";
 import { Archive, Delete, Download, Move, Restore } from "@comet/admin-icons";
-import { Divider, ListItemIcon, ListItemText, Menu, MenuItem, MenuList } from "@mui/material";
+import { Divider, ListItemIcon, ListItemText, Menu, MenuItem, MenuList, Slide, Snackbar } from "@mui/material";
 import { PopoverOrigin } from "@mui/material/Popover/Popover";
+import { SlideProps } from "@mui/material/Slide/Slide";
 import { styled } from "@mui/material/styles";
 import * as React from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { useDamSelectionApi } from "./DamSelectionContext";
 
@@ -15,6 +17,8 @@ interface DamMoreActionsProps {
 
 export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMoreActionsProps): React.ReactElement => {
     const damSelectionActionsApi = useDamSelectionApi();
+    const snackbarApi = useSnackbarApi();
+    const intl = useIntl();
 
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
@@ -24,6 +28,49 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMor
 
     const handleClose = () => {
         setAnchorEl(null);
+    };
+
+    const selectionMapValues = Array.from(damSelectionActionsApi.selectionMap.values());
+    const lengthOfSelectedFiles = selectionMapValues.filter((value) => value === "file").length;
+    const isFolderInSelection = selectionMapValues.some((value) => value === "folder");
+    const onlyFoldersSelected = selectionMapValues.every((value) => value === "folder");
+
+    const snackbarComponent = (
+        <Snackbar
+            anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+            autoHideDuration={5000}
+            TransitionComponent={(props: SlideProps) => <Slide {...props} direction="right" />}
+            message={intl.formatMessage({
+                id: "comet.dam.moreActions.folderNotDownloaded",
+                defaultMessage: "Download of files started successfully. Folder downloads are not supported yet.",
+            })}
+        />
+    );
+
+    const onDownloadClick = () => {
+        damSelectionActionsApi.downloadSelected();
+        handleClose();
+        isFolderInSelection && snackbarApi.showSnackbar(snackbarComponent);
+    };
+
+    const onMoveClick = () => {
+        damSelectionActionsApi.moveSelected();
+        handleClose();
+    };
+
+    const onArchiveClick = () => {
+        damSelectionActionsApi.archiveSelected();
+        handleClose();
+    };
+
+    const onRestoreClick = () => {
+        damSelectionActionsApi.restoreSelected();
+        handleClose();
+    };
+
+    const onDeleteClick = () => {
+        damSelectionActionsApi.deleteSelected();
+        handleClose();
     };
 
     return (
@@ -38,61 +85,42 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMor
                 anchorOrigin={anchorOrigin}
             >
                 <MenuList>
-                    <MenuItem
-                        onClick={() => {
-                            damSelectionActionsApi.downloadSelected();
-                            handleClose();
-                        }}
-                    >
-                        <ListItemIcon>
-                            <Download />
-                        </ListItemIcon>
-                        <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.downloadSelected" defaultMessage="Download selected" />} />
-                        <NumberSelectedChip>{damSelectionActionsApi.selectionMap.size}</NumberSelectedChip>
-                    </MenuItem>
-                    <StyledDivider />
-                    <MenuItem
-                        onClick={() => {
-                            damSelectionActionsApi.moveSelected();
-                            handleClose();
-                        }}
-                    >
+                    {!onlyFoldersSelected && (
+                        <>
+                            <MenuItem onClick={onDownloadClick}>
+                                <ListItemIcon>
+                                    <Download />
+                                </ListItemIcon>
+                                <ListItemText
+                                    primary={<FormattedMessage id="comet.dam.moreActions.downloadSelected" defaultMessage="Download selected" />}
+                                />
+                                <NumberSelectedChip>{lengthOfSelectedFiles}</NumberSelectedChip>
+                            </MenuItem>
+                            <StyledDivider />
+                        </>
+                    )}
+                    <MenuItem onClick={onMoveClick}>
                         <ListItemIcon>
                             <Move />
                         </ListItemIcon>
                         <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.moveItems" defaultMessage="Move items" />} />
                         <NumberSelectedChip>{damSelectionActionsApi.selectionMap.size}</NumberSelectedChip>
                     </MenuItem>
-                    <MenuItem
-                        onClick={() => {
-                            damSelectionActionsApi.archiveSelected();
-                            handleClose();
-                        }}
-                    >
+                    <MenuItem onClick={onArchiveClick}>
                         <ListItemIcon>
                             <Archive />
                         </ListItemIcon>
                         <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.archiveItems" defaultMessage="Archive items" />} />
                         <NumberSelectedChip>{damSelectionActionsApi.selectionMap.size}</NumberSelectedChip>
                     </MenuItem>
-                    <MenuItem
-                        onClick={() => {
-                            damSelectionActionsApi.restoreSelected();
-                            handleClose();
-                        }}
-                    >
+                    <MenuItem onClick={onRestoreClick}>
                         <ListItemIcon>
                             <Restore />
                         </ListItemIcon>
                         <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.restoreItems" defaultMessage="Restore items" />} />
                         <NumberSelectedChip>{damSelectionActionsApi.selectionMap.size}</NumberSelectedChip>
                     </MenuItem>
-                    <MenuItem
-                        onClick={() => {
-                            damSelectionActionsApi.deleteSelected();
-                            handleClose();
-                        }}
-                    >
+                    <MenuItem onClick={onDeleteClick}>
                         <ListItemIcon>
                             <Delete />
                         </ListItemIcon>


### PR DESCRIPTION
- hide download button if only folders selected
- only show amount of files and not folders
- add snackbar with message if folder was in selection

<details>
<summary>Screenshots</summary>

<img width="853" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/225a2740-7fc0-4c7c-ab01-e1418aa50f40">
<img width="848" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/fca2cc6f-0d05-46dd-893d-47b6054bf6df">
<img width="835" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/fbed3f1d-ed22-4a39-a03d-c9e2aa9d61fa">
<h3>If download items is clicked with a folder selected the following snackbar appears</h3>
<img width="832" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/d3c286fe-25ce-4977-b0b7-db9dd513950b">
</details>