### PR TITLE
Add loop Toggle to Youtube Video Block

### DIFF
--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -1766,6 +1766,11 @@
                 "name": "showControls",
                 "kind": "Boolean",
                 "nullable": true
+            },
+            {
+                "name": "loop",
+                "kind": "Boolean",
+                "nullable": true
             }
         ],
         "inputFields": [
@@ -1790,6 +1795,11 @@
             },
             {
                 "name": "showControls",
+                "kind": "Boolean",
+                "nullable": true
+            },
+            {
+                "name": "loop",
                 "kind": "Boolean",
                 "nullable": true
             }

--- a/demo/site/src/blocks/YouTubeVideoBlock.tsx
+++ b/demo/site/src/blocks/YouTubeVideoBlock.tsx
@@ -14,7 +14,7 @@ const getHeightInPercentForAspectRatio = (aspectRatio: YouTubeVideoBlockData["as
 };
 
 const YouTubeVideoBlock: React.FunctionComponent<PropsWithData<YouTubeVideoBlockData>> = ({
-    data: { youtubeIdentifier, autoplay, showControls, aspectRatio },
+    data: { youtubeIdentifier, autoplay, loop, showControls, aspectRatio },
 }) => {
     try {
         const url = new URL(youtubeIdentifier);
@@ -29,10 +29,11 @@ const YouTubeVideoBlock: React.FunctionComponent<PropsWithData<YouTubeVideoBlock
 
     return (
         <sc.VideoContainer heightInPercent={getHeightInPercentForAspectRatio(aspectRatio)}>
+            {/* the playlist parameter is needed so that the video loops. See https://developers.google.com/youtube/player_parameters#loop */}
             <iframe
-                src={`https://www.youtube-nocookie.com/embed/${youtubeIdentifier}?&modestbranding=1&autoplay=${Number(autoplay)}&controls=${Number(
-                    showControls,
-                )}`}
+                src={`https://www.youtube-nocookie.com/embed/${youtubeIdentifier}?&modestbranding=1&autoplay=${Number(autoplay)}${
+                    autoplay ? `&mute=1` : ""
+                }&controls=${Number(showControls)}&loop=${Number(loop)}${loop ? `&playlist=${youtubeIdentifier}` : ""}`}
                 frameBorder="0"
             />
         </sc.VideoContainer>

--- a/packages/admin/blocks-admin/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/YouTubeVideoBlock.tsx
@@ -18,7 +18,7 @@ export const YouTubeVideoBlock: BlockInterface<YouTubeVideoBlockData, State, You
 
     displayName: <FormattedMessage id="comet.blocks.youTubeVideo" defaultMessage="Video (YouTube)" />,
 
-    defaultValues: () => ({ youtubeIdentifier: "", autoplay: false, showControls: false, aspectRatio: "16X9" }),
+    defaultValues: () => ({ youtubeIdentifier: "", autoplay: false, showControls: false, loop: false, aspectRatio: "16X9" }),
 
     category: BlockCategory.Media,
 
@@ -73,6 +73,12 @@ export const YouTubeVideoBlock: BlockInterface<YouTubeVideoBlockData, State, You
                     <Field
                         label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.showControls", defaultMessage: "Show controls" })}
                         name="showControls"
+                        type="checkbox"
+                        component={FinalFormSwitch}
+                    />
+                    <Field
+                        label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.loop", defaultMessage: "Loop" })}
+                        name="loop"
                         type="checkbox"
                         component={FinalFormSwitch}
                     />

--- a/packages/api/blocks-api/block-meta.json
+++ b/packages/api/blocks-api/block-meta.json
@@ -69,6 +69,11 @@
                 "name": "showControls",
                 "kind": "Boolean",
                 "nullable": true
+            },
+            {
+                "name": "loop",
+                "kind": "Boolean",
+                "nullable": true
             }
         ],
         "inputFields": [
@@ -93,6 +98,11 @@
             },
             {
                 "name": "showControls",
+                "kind": "Boolean",
+                "nullable": true
+            },
+            {
+                "name": "loop",
                 "kind": "Boolean",
                 "nullable": true
             }

--- a/packages/api/blocks-api/src/blocks/youtube-video.block.ts
+++ b/packages/api/blocks-api/src/blocks/youtube-video.block.ts
@@ -20,6 +20,9 @@ class YouTubeVideoBlockData extends BlockData {
 
     @BlockField({ nullable: true })
     showControls?: boolean;
+
+    @BlockField({ nullable: true })
+    loop?: boolean;
 }
 
 class YouTubeVideoBlockInput extends BlockInput {
@@ -41,6 +44,11 @@ class YouTubeVideoBlockInput extends BlockInput {
     @IsOptional()
     @BlockField({ nullable: true })
     showControls?: boolean;
+
+    @IsBoolean()
+    @IsOptional()
+    @BlockField({ nullable: true })
+    loop?: boolean;
 
     transformToBlockData(): BlockDataInterface {
         return inputToData(YouTubeVideoBlockData, this);

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -971,6 +971,11 @@
                 "name": "showControls",
                 "kind": "Boolean",
                 "nullable": true
+            },
+            {
+                "name": "loop",
+                "kind": "Boolean",
+                "nullable": true
             }
         ],
         "inputFields": [
@@ -995,6 +1000,11 @@
             },
             {
                 "name": "showControls",
+                "kind": "Boolean",
+                "nullable": true
+            },
+            {
+                "name": "loop",
                 "kind": "Boolean",
                 "nullable": true
             }


### PR DESCRIPTION
This PR adds a loop toggle button to the Youtube Video Block in the Comet Admin. Refer to the Youtube Docs for a list of embed url params: https://developers.google.com/youtube/player_parameters

## Screenshot
<img width="395" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/33073d49-a3e8-42fc-aa7d-fe1f81b5bf16">
