### PR TITLE
Restructure Asset Browser Toolbar Actions

### DIFF
--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -16,14 +16,14 @@ import {
     useStoredState,
     useTableQueryFilter,
 } from "@comet/admin";
-import { AddFolder as AddFolderIcon, ChevronDown } from "@comet/admin-icons";
+import { MoreVertical } from "@comet/admin-icons";
 import { Button } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { ManualDuplicatedFilenamesHandlerContextProvider } from "./DataGrid/duplicatedFilenames/ManualDuplicatedFilenamesHandler";
 import { FileUploadContextProvider } from "./DataGrid/fileUpload/FileUploadContext";
-import { UploadSplitButton } from "./DataGrid/fileUpload/UploadSplitButton";
+import { UploadFilesButton } from "./DataGrid/fileUpload/UploadFilesButton";
 import { DamTableFilter } from "./DataGrid/filter/DamTableFilter";
 import FolderDataGrid, {
     damFolderQuery,
@@ -34,7 +34,7 @@ import FolderDataGrid, {
 } from "./DataGrid/FolderDataGrid";
 import { RenderDamLabelOptions } from "./DataGrid/label/DamItemLabelColumn";
 import { DamMoreActions } from "./DataGrid/selection/DamMoreActions";
-import { DamSelectionProvider, useDamSelectionApi } from "./DataGrid/selection/DamSelectionContext";
+import { DamSelectionProvider } from "./DataGrid/selection/DamSelectionContext";
 import EditFile from "./FileForm/EditFile";
 
 interface FolderProps extends DamConfig {
@@ -53,7 +53,6 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
     const intl = useIntl();
     const stackApi = useStackApi();
     const [, , editDialogApi, selectionApi] = useEditDialog();
-    const damSelectionActionsApi = useDamSelectionApi();
 
     // The selectedFolderId is only used to determine the name of a folder for the "folder" stack page
     // If you want to use the id of the current folder in the "table" stack page, use the id prop
@@ -66,6 +65,10 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
         skip: selectedFolderId === undefined,
     });
 
+    const uploadFilters = {
+        allowedMimetypes: props.allowedMimetypes,
+    };
+
     return (
         <StackSwitch initialPage="table">
             <StackPage name="table">
@@ -76,15 +79,10 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
                             <DamTableFilter hideArchiveFilter={props.hideArchiveFilter} filterApi={filterApi} />
                         </ToolbarItem>
                         <ToolbarFillSpace />
-                        <ToolbarItem>
+                        <ToolbarActions>
                             <DamMoreActions
                                 button={
-                                    <Button
-                                        variant="text"
-                                        color="inherit"
-                                        endIcon={<ChevronDown />}
-                                        disabled={damSelectionActionsApi.selectionMap.size === 0}
-                                    >
+                                    <Button variant="text" color="inherit" endIcon={<MoreVertical />} sx={{ mx: 2 }}>
                                         <FormattedMessage id="comet.pages.dam.moreActions" defaultMessage="More actions" />
                                     </Button>
                                 }
@@ -96,25 +94,11 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
                                     vertical: "top",
                                     horizontal: "left",
                                 }}
-                            />
-                        </ToolbarItem>
-                        <ToolbarActions>
-                            <Button
-                                variant="text"
-                                color="inherit"
-                                startIcon={<AddFolderIcon />}
-                                onClick={() => {
-                                    editDialogApi.openAddDialog(id);
-                                }}
-                            >
-                                <FormattedMessage id="comet.pages.dam.addFolder" defaultMessage="Add Folder" />
-                            </Button>
-                            <UploadSplitButton
                                 folderId={id}
-                                filter={{
-                                    allowedMimetypes: props.allowedMimetypes,
-                                }}
+                                filter={uploadFilters}
                             />
+
+                            <UploadFilesButton folderId={id} filter={uploadFilters} />
                         </ToolbarActions>
                     </Toolbar>
                     <FolderDataGrid id={id} breadcrumbs={stackApi?.breadCrumbs} selectionApi={selectionApi} filterApi={filterApi} {...props} />

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/UploadFilesButton.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/UploadFilesButton.tsx
@@ -1,5 +1,4 @@
 import { useApolloClient } from "@apollo/client";
-import { SplitButton } from "@comet/admin";
 import { Upload } from "@comet/admin-icons";
 import { Button } from "@mui/material";
 import * as React from "react";
@@ -17,12 +16,11 @@ interface UploadSplitButtonProps {
     };
 }
 
-export const UploadSplitButton = ({ folderId, filter }: UploadSplitButtonProps): React.ReactElement => {
+export const UploadFilesButton = ({ folderId, filter }: UploadSplitButtonProps): React.ReactElement => {
     const client = useApolloClient();
     const { allAcceptedMimeTypes } = useDamAcceptedMimeTypes();
 
     const fileInputRef = React.useRef<HTMLInputElement>(null);
-    const folderInputRef = React.useRef<HTMLInputElement>(null);
 
     const {
         uploadFiles,
@@ -45,33 +43,18 @@ export const UploadSplitButton = ({ folderId, filter }: UploadSplitButtonProps):
 
     return (
         <>
-            <SplitButton localStorageKey="damUpload">
-                <Button
-                    variant="contained"
-                    color="primary"
-                    startIcon={<Upload />}
-                    onClick={() => {
-                        // Add explicit onClick to make it work in SplitButton
-                        fileInputRef.current?.click();
-                    }}
-                >
-                    <FormattedMessage id="comet.pages.dam.uploadFiles" defaultMessage="Upload files" />
-                </Button>
-                <Button
-                    variant="contained"
-                    color="primary"
-                    startIcon={<Upload />}
-                    onClick={() => {
-                        // Add explicit onClick to make it work in SplitButton
-                        folderInputRef.current?.click();
-                    }}
-                >
-                    <FormattedMessage id="comet.pages.dam.uploadFolder" defaultMessage="Upload folder" />
-                </Button>
-            </SplitButton>
+            <Button
+                variant="contained"
+                color="primary"
+                startIcon={<Upload />}
+                onClick={() => {
+                    // Trigger file input with button click
+                    fileInputRef.current?.click();
+                }}
+            >
+                <FormattedMessage id="comet.pages.dam.uploadFiles" defaultMessage="Upload files" />
+            </Button>
             <input type="file" hidden {...getInputProps()} ref={fileInputRef} />
-            {/* eslint-disable-next-line react/no-unknown-property */}
-            <input type="file" hidden {...getInputProps()} webkitdirectory="webkitdirectory" directory="directory" ref={folderInputRef} />
             {fileUploadDialogs}
         </>
     );

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
@@ -1,28 +1,44 @@
-import { useSnackbarApi } from "@comet/admin";
-import { Archive, Delete, Download, Move, Restore } from "@comet/admin-icons";
-import { Divider, ListItemIcon, ListItemText, Menu, MenuItem, MenuList, Slide, Snackbar } from "@mui/material";
+import { useApolloClient } from "@apollo/client";
+import { useEditDialog, useSnackbarApi } from "@comet/admin";
+import { AddFolder as AddFolderIcon, Archive, Delete, Download, Move, Restore, Upload } from "@comet/admin-icons";
+import { Box, Divider, ListItemIcon, ListItemText, Menu, MenuItem, MenuList, Slide, Snackbar, Typography } from "@mui/material";
 import { PopoverOrigin } from "@mui/material/Popover/Popover";
 import { SlideProps } from "@mui/material/Slide/Slide";
 import { styled } from "@mui/material/styles";
 import * as React from "react";
+import { FileRejection, useDropzone } from "react-dropzone";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { useDamAcceptedMimeTypes } from "../../config/useDamAcceptedMimeTypes";
+import { clearDamItemCache } from "../../helpers/clearDamItemCache";
+import { useFileUpload } from "../fileUpload/useFileUpload";
 import { useDamSelectionApi } from "./DamSelectionContext";
 
 interface DamMoreActionsProps {
     transformOrigin?: PopoverOrigin;
     anchorOrigin?: PopoverOrigin;
     button: React.ReactElement;
+    folderId?: string;
+    filter?: {
+        allowedMimetypes?: string[];
+    };
 }
 
-export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMoreActionsProps): React.ReactElement => {
+export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId, filter }: DamMoreActionsProps): React.ReactElement => {
     const damSelectionActionsApi = useDamSelectionApi();
     const { selectionMap, archiveSelected, deleteSelected, downloadSelected, restoreSelected, moveSelected } = damSelectionActionsApi;
     const snackbarApi = useSnackbarApi();
+    const [, , editDialogApi] = useEditDialog();
     const intl = useIntl();
+    const client = useApolloClient();
+    const { allAcceptedMimeTypes } = useDamAcceptedMimeTypes();
+
+    const folderInputRef = React.useRef<HTMLInputElement>(null);
 
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
+    const selectionSize = selectionMap.size;
+    const itemsSelected = !!selectionSize;
     const selectionMapValues = Array.from(selectionMap.values());
     const lengthOfSelectedFiles = selectionMapValues.filter((value) => value === "file").length;
     const onlyFoldersSelected = selectionMapValues.every((value) => value === "folder");
@@ -54,6 +70,16 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMor
         isFolderInSelection && snackbarApi.showSnackbar(snackbarElement);
     };
 
+    const handleUploadFolderClick = () => {
+        folderInputRef.current?.click();
+        handleClose();
+    };
+
+    const handleAddFolderClick = () => {
+        editDialogApi.openAddDialog(folderId);
+        handleClose();
+    };
+
     const handleMoveClick = () => {
         moveSelected();
         handleClose();
@@ -74,6 +100,25 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMor
         handleClose();
     };
 
+    const {
+        uploadFiles,
+        dialogs: fileUploadDialogs,
+        dropzoneConfig,
+    } = useFileUpload({
+        acceptedMimetypes: filter?.allowedMimetypes ?? allAcceptedMimeTypes,
+        onAfterUpload: () => {
+            client.reFetchObservableQueries();
+            clearDamItemCache(client.cache);
+        },
+    });
+
+    const { getInputProps } = useDropzone({
+        ...dropzoneConfig,
+        onDrop: async (acceptedFiles: File[], fileRejections: FileRejection[]) => {
+            await uploadFiles({ acceptedFiles, fileRejections }, folderId);
+        },
+    });
+
     return (
         <>
             {React.cloneElement(button, { onClick: handleClick })}
@@ -85,61 +130,83 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin }: DamMor
                 transformOrigin={transformOrigin}
                 anchorOrigin={anchorOrigin}
             >
-                <MenuList>
-                    {!onlyFoldersSelected && (
-                        <>
-                            <MenuItem onClick={handleDownloadClick}>
-                                <ListItemIcon>
-                                    <Download />
-                                </ListItemIcon>
-                                <ListItemText
-                                    primary={<FormattedMessage id="comet.dam.moreActions.downloadSelected" defaultMessage="Download selected" />}
-                                />
-                                <NumberSelectedChip>{lengthOfSelectedFiles}</NumberSelectedChip>
-                            </MenuItem>
-                            <StyledDivider />
-                        </>
-                    )}
-                    <MenuItem onClick={handleMoveClick}>
-                        <ListItemIcon>
-                            <Move />
-                        </ListItemIcon>
-                        <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.moveItems" defaultMessage="Move items" />} />
-                        <NumberSelectedChip>{selectionMap.size}</NumberSelectedChip>
-                    </MenuItem>
-                    <MenuItem onClick={handleArchiveClick}>
-                        <ListItemIcon>
-                            <Archive />
-                        </ListItemIcon>
-                        <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.archiveItems" defaultMessage="Archive items" />} />
-                        <NumberSelectedChip>{selectionMap.size}</NumberSelectedChip>
-                    </MenuItem>
-                    <MenuItem onClick={handleRestoreClick}>
-                        <ListItemIcon>
-                            <Restore />
-                        </ListItemIcon>
-                        <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.restoreItems" defaultMessage="Restore items" />} />
-                        <NumberSelectedChip>{selectionMap.size}</NumberSelectedChip>
-                    </MenuItem>
-                    <MenuItem onClick={handleDeleteClick}>
-                        <ListItemIcon>
-                            <Delete />
-                        </ListItemIcon>
-                        <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.deleteItems" defaultMessage="Delete items" />} />
-                        <NumberSelectedChip>{selectionMap.size}</NumberSelectedChip>
-                    </MenuItem>
-                </MenuList>
+                <Box px={3}>
+                    <Typography variant="subtitle2" color={(theme) => theme.palette.grey[500]} fontWeight="bold" mt={5}>
+                        <FormattedMessage id="comet.dam.moreActions.overallActions" defaultMessage="Overall actions" />
+                    </Typography>
+                    <MenuList>
+                        <MenuItem disabled={itemsSelected} onClick={handleUploadFolderClick}>
+                            <ListItemIcon>
+                                <Upload />
+                            </ListItemIcon>
+                            <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.uploadFolder" defaultMessage="Upload folder" />} />
+                        </MenuItem>
+
+                        <MenuItem disabled={itemsSelected} onClick={handleAddFolderClick}>
+                            <ListItemIcon>
+                                <AddFolderIcon />
+                            </ListItemIcon>
+                            <FormattedMessage id="comet.pages.dam.addFolder" defaultMessage="Add Folder" />
+                        </MenuItem>
+                    </MenuList>
+                    <Divider sx={{ my: 1, borderColor: (theme) => theme.palette.grey[50] }} />
+                    <Typography variant="subtitle2" color={(theme) => theme.palette.grey[500]} fontWeight="bold" mt={5}>
+                        <FormattedMessage id="comet.dam.moreActions.selectiveActions" defaultMessage="Selective actions" />
+                    </Typography>
+                    <MenuList>
+                        {!onlyFoldersSelected && (
+                            <>
+                                <MenuItem onClick={handleDownloadClick}>
+                                    <ListItemIcon>
+                                        <Download />
+                                    </ListItemIcon>
+                                    <ListItemText
+                                        primary={<FormattedMessage id="comet.dam.moreActions.downloadSelected" defaultMessage="Download" />}
+                                    />
+                                    <NumberSelectedChip>{lengthOfSelectedFiles}</NumberSelectedChip>
+                                </MenuItem>
+                                <Divider sx={{ my: 1, borderColor: (theme) => theme.palette.grey[50] }} />
+                            </>
+                        )}
+                        <MenuItem disabled={!itemsSelected} onClick={handleMoveClick}>
+                            <ListItemIcon>
+                                <Move />
+                            </ListItemIcon>
+                            <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.moveItems" defaultMessage="Move" />} />
+                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
+                        </MenuItem>
+                        <MenuItem disabled={!itemsSelected} onClick={handleArchiveClick}>
+                            <ListItemIcon>
+                                <Archive />
+                            </ListItemIcon>
+                            <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.archiveItems" defaultMessage="Archive" />} />
+                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
+                        </MenuItem>
+                        <MenuItem disabled={!itemsSelected} onClick={handleRestoreClick}>
+                            <ListItemIcon>
+                                <Restore />
+                            </ListItemIcon>
+                            <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.restoreItems" defaultMessage="Restore" />} />
+                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
+                        </MenuItem>
+                        <MenuItem disabled={!itemsSelected} onClick={handleDeleteClick}>
+                            <ListItemIcon>
+                                <Delete />
+                            </ListItemIcon>
+                            <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.deleteItems" defaultMessage="Delete" />} />
+                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
+                        </MenuItem>
+                    </MenuList>
+                </Box>
             </Menu>
+
+            {/* the directory property is needed for the folder upload to work but not known to eslint */}
+            {/* eslint-disable-next-line react/no-unknown-property */}
+            <input type="file" hidden {...getInputProps()} webkitdirectory="webkitdirectory" directory="directory" ref={folderInputRef} />
+            {fileUploadDialogs}
         </>
     );
 };
-
-const StyledDivider = styled(Divider)`
-    &.MuiDivider-root {
-        border-color: ${({ theme }) => theme.palette.grey["50"]};
-        margin: 8px 10px;
-    }
-`;
 
 const NumberSelectedChip = styled("div")`
     display: flex;


### PR DESCRIPTION
depends on #1196 

This PR restructures the toolbar actions in the assets browser and implements a few design changes.

<details>
<summary><b>Screenshots</b></summary>
<h3>Implementation</h3>
<img width="358" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/0d4e43bd-6d26-4abd-9285-5686744d3078">

<img width="347" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/a9ea55c1-e38b-4526-ad6e-98256f32aede">


<h3>Design</h3>

![image](https://github.com/vivid-planet/comet/assets/56400587/7ede23ac-5b3c-4974-9384-d8bf2009d7d8)

</details>


