### PR TITLE
Fix build names in start builds dialog

### DIFF
--- a/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
+++ b/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
@@ -68,7 +68,7 @@ export function StartBuildsDialog(props: StartBuildsDialogProps) {
                             }),
                             flex: 1,
                             renderCell: ({ row }) => {
-                                return row.label ?? row.name;
+                                return row.label && row.label.length > 0 ? row.label : row.name;
                             },
                         },
                     ]}


### PR DESCRIPTION
Build label kann be an empty string, therefore nothing got displayed in the StartBuildsDialog