### PR TITLE
DAM: Fix move files

### DIFF
--- a/packages/api/cms-api/src/dam/files/dto/file.args.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.args.ts
@@ -1,10 +1,11 @@
 import { Type } from "@nestjs/common";
 import { ArgsType, Field, ID, InputType, IntersectionType } from "@nestjs/graphql";
 import { Type as TransformerType } from "class-transformer";
-import { IsBoolean, IsOptional, IsString, IsUUID, ValidateNested } from "class-validator";
+import { IsArray, IsBoolean, IsOptional, IsString, IsUUID, ValidateNested } from "class-validator";
 
 import { OffsetBasedPaginationArgs } from "../../../common/pagination/offset-based.args";
 import { SortArgs } from "../../../common/sorting/sort.args";
+import { IsNullable } from "../../../common/validators/is-nullable";
 import { DamScopeInterface } from "../../types";
 import { EmptyDamScope } from "./empty-dam-scope";
 
@@ -61,4 +62,17 @@ export interface DamFileListPositionArgs extends SortArgs {
     folderId?: string;
     includeArchived?: boolean;
     filter?: FileFilterInput;
+}
+
+@ArgsType()
+export class MoveDamFilesArgs {
+    @Field(() => [ID])
+    @IsArray()
+    @IsUUID(4, { each: true })
+    fileIds: string[];
+
+    @Field(() => ID, { nullable: true })
+    @IsNullable()
+    @IsUUID()
+    targetFolderId: string | null;
 }

--- a/packages/api/cms-api/src/dam/files/dto/file.input.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.input.ts
@@ -126,7 +126,7 @@ export class UpdateFileInput {
     @Field(() => ID, { nullable: true })
     @IsUUID()
     @IsOptional()
-    folderId?: string;
+    folderId: string | null | undefined;
 
     @Field({ nullable: true })
     @Type(() => LicenseInput)

--- a/packages/api/cms-api/src/dam/files/dto/file.input.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.input.ts
@@ -3,6 +3,8 @@ import { Type } from "class-transformer";
 import { IsDate, IsEnum, IsHash, IsInt, IsMimeType, IsNotEmpty, IsObject, IsOptional, IsString, IsUUID, ValidateNested } from "class-validator";
 import { DamScopeInterface } from "src/dam/types";
 
+import { IsNullable } from "../../../common/validators/is-nullable";
+import { IsUndefinable } from "../../../common/validators/is-undefinable";
 import { ImageCropAreaInput } from "../../images/dto/image-crop-area.input";
 import { LicenseType } from "../entities/license.embeddable";
 
@@ -125,7 +127,8 @@ export class UpdateFileInput {
 
     @Field(() => ID, { nullable: true })
     @IsUUID()
-    @IsOptional()
+    @IsNullable()
+    @IsUndefinable()
     folderId: string | null | undefined;
 
     @Field({ nullable: true })

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -80,10 +80,10 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
         @SkipBuild()
         async moveDamFiles(
             @Args("fileIds", { type: () => [ID] }) fileIds: string[],
-            @Args("targetFolderId", { type: () => ID, nullable: true }) targetFolderId: string | null | undefined,
+            @Args("targetFolderId", { type: () => ID, nullable: true }) targetFolderId: string | null,
             @GetCurrentUser() user: CurrentUserInterface,
         ): Promise<FileInterface[]> {
-            let targetFolder;
+            let targetFolder = null;
 
             if (targetFolderId != null) {
                 targetFolder = await this.foldersRepository.findOneOrFail(targetFolderId);

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -15,7 +15,7 @@ import { DependenciesService } from "../../dependencies/dependencies.service";
 import { Dependency } from "../../dependencies/dependency";
 import { DamScopeInterface } from "../types";
 import { EmptyDamScope } from "./dto/empty-dam-scope";
-import { createFileArgs, FileArgsInterface } from "./dto/file.args";
+import { createFileArgs, FileArgsInterface, MoveDamFilesArgs } from "./dto/file.args";
 import { UpdateFileInput } from "./dto/file.input";
 import { FilenameInput, FilenameResponse } from "./dto/filename.args";
 import { FileInterface } from "./entities/file.entity";
@@ -79,14 +79,9 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
         @Mutation(() => [File])
         @SkipBuild()
         async moveDamFiles(
-            @Args("fileIds", { type: () => [ID] }) fileIds: string[],
-            @Args("targetFolderId", { type: () => ID, nullable: true }) targetFolderId: string | null | undefined,
+            @Args({ type: () => MoveDamFilesArgs }) { fileIds, targetFolderId }: MoveDamFilesArgs,
             @GetCurrentUser() user: CurrentUserInterface,
         ): Promise<FileInterface[]> {
-            if (targetFolderId === undefined) {
-                throw new Error("targetFolderId must be null or a string");
-            }
-
             let targetFolder = null;
             if (targetFolderId !== null) {
                 targetFolder = await this.foldersRepository.findOneOrFail(targetFolderId);

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -80,12 +80,15 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
         @SkipBuild()
         async moveDamFiles(
             @Args("fileIds", { type: () => [ID] }) fileIds: string[],
-            @Args("targetFolderId", { type: () => ID, nullable: true }) targetFolderId: string | null,
+            @Args("targetFolderId", { type: () => ID, nullable: true }) targetFolderId: string | null | undefined,
             @GetCurrentUser() user: CurrentUserInterface,
         ): Promise<FileInterface[]> {
-            let targetFolder = null;
+            if (targetFolderId === undefined) {
+                throw new Error("targetFolderId must be null or a string");
+            }
 
-            if (targetFolderId != null) {
+            let targetFolder = null;
+            if (targetFolderId !== null) {
                 targetFolder = await this.foldersRepository.findOneOrFail(targetFolderId);
 
                 if (targetFolder.scope !== undefined && !this.contentScopeService.canAccessScope(targetFolder.scope, user)) {

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -233,7 +233,7 @@ export class FilesService {
         return this.save(file);
     }
 
-    async moveBatch(files: FileInterface[], targetFolder?: FolderInterface): Promise<FileInterface[]> {
+    async moveBatch(files: FileInterface[], targetFolder: FolderInterface | null): Promise<FileInterface[]> {
         const updatedFiles = [];
 
         for (const file of files) {
@@ -242,7 +242,7 @@ export class FilesService {
                 throw new Error("Target folder scope doesn't match file scope");
             }
 
-            updatedFiles.push(await this.updateByEntity(file, { folderId: targetFolder?.id }));
+            updatedFiles.push(await this.updateByEntity(file, { folderId: targetFolder?.id ?? null }));
         }
 
         return updatedFiles;


### PR DESCRIPTION
## Previously: 

Moving files to the root folder wasn't possible

https://github.com/vivid-planet/comet/assets/13380047/05f4a5cf-c012-424a-ad8c-1888b7100dc0

## Problem:

When the `moveDamFiles()` was defined initially, the `targetFolderId` was typed incorrectly. The GraphQL type was defined as `ID` and `nullable = true`. This means, the typescript types `string`, `undefined` and `null` are allowed. However, the typescript type was set to only `string`.

https://github.com/vivid-planet/comet/blob/ffbc37419ead6b0edf4ce3226719228e034c0427/packages/api/cms-api/src/dam/files/folders.resolver.ts#L57

When moving files to the root folder, the targetFolderId was set to null. This value was looped through all service methods, leading to the correct behaviour, although the typing was wrong.

Later, the typing was fixed. However, the `null` type was now not passed to the `filesService.moveBatch()` anymore (instead `undefined` was passed).

https://github.com/vivid-planet/comet/blob/e4c88ff6726196443c4f7b2537b17234dfc81c52/packages/api/cms-api/src/dam/files/files.resolver.ts#L80-L91

So now the typing in the resolver was correct, but the behavior was incorrect.

## Solution:

Now, the resolver either passes `null` or a `string` to `filesService.moveBatch()`. `moveBatch()` passes it on correctly.

https://github.com/vivid-planet/comet/assets/13380047/295f66c3-fcc1-472f-80c1-e60b5a1b911a