### PR TITLE
Add little helper muiGridPagingToGql to simplify data grid handling

### DIFF
--- a/.changeset/tasty-tomatoes-jog.md
+++ b/.changeset/tasty-tomatoes-jog.md
@@ -1,0 +1,18 @@
+---
+"@comet/cms-admin": minor
+"@comet/admin": minor
+---
+
+Add little helper for mui grid pagination (muiGridPagingToGql)
+
+Sample usage:
+
+```
+const { data, loading, error } = useQuery<GQLProductsListQuery, GQLProductsListQueryVariables>(productsQuery, {
+    variables: {
+        ...muiGridFilterToGql(columns, dataGridProps.filterModel),
+        ...muiGridPagingToGql({ page: dataGridProps.page, pageSize: dataGridProps.pageSize }),
+        sort: muiGridSortToGql(sortModel),
+    },
+});
+```

--- a/demo/admin/src/products/ProductsTable.tsx
+++ b/demo/admin/src/products/ProductsTable.tsx
@@ -3,6 +3,7 @@ import {
     CrudContextMenu,
     GridFilterButton,
     muiGridFilterToGql,
+    muiGridPagingToGql,
     muiGridSortToGql,
     StackLink,
     Toolbar,
@@ -118,8 +119,7 @@ function ProductsTable() {
     const { data, loading, error } = useQuery<GQLProductsListQuery, GQLProductsListQueryVariables>(productsQuery, {
         variables: {
             ...muiGridFilterToGql(columns, dataGridProps.filterModel),
-            offset: dataGridProps.page * dataGridProps.pageSize,
-            limit: dataGridProps.pageSize,
+            ...muiGridPagingToGql({ page: dataGridProps.page, pageSize: dataGridProps.pageSize }),
             sort: muiGridSortToGql(sortModel),
         },
     });

--- a/packages/admin/admin-stories/src/docs/components/DataGrid/DataGrid.stories.mdx
+++ b/packages/admin/admin-stories/src/docs/components/DataGrid/DataGrid.stories.mdx
@@ -91,10 +91,11 @@ Component that can be rendered as ContextMenu in a row that has some basic CRUD 
 
 ## DataGrid to Comet Graphl API Converter
 
-Comet Admin comes with two helper that convert MUI DataGrid state to standard Comet GraphQL API variables.
+Comet Admin comes with three helpers that convert MUI DataGrid state to standard Comet GraphQL API variables.
 
 -   `muiGridFilterToGql`
 -   `muiGridSortToGql`
+-   `muiGridPagingToGql`
 
 Typical Usage Example:
 
@@ -104,8 +105,7 @@ const sortModel = dataGridProps.sortModel;
 const { data, loading, error } = useQuery<GQLProductsListQuery, GQLProductsListQueryVariables>(productsQuery, {
     variables: {
         ...muiGridFilterToGql(columns, dataGridProps.filterModel),
-        offset: dataGridProps.page * dataGridProps.pageSize,
-        limit: dataGridProps.pageSize,
+        ...muiGridPagingToGql({ page: dataGridProps.page, pageSize: dataGridProps.pageSize }),
         sort: muiGridSortToGql(sortModel),
     },
 });

--- a/packages/admin/admin/src/dataGrid/muiGridPagingToGql.ts
+++ b/packages/admin/admin/src/dataGrid/muiGridPagingToGql.ts
@@ -1,0 +1,5 @@
+export const muiGridPagingToGql = (options: { page: number; pageSize: number }) => {
+    const { page, pageSize } = options;
+
+    return { offset: page * pageSize, limit: pageSize };
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -44,6 +44,7 @@ export { Tooltip, TooltipClassKey, TooltipProps } from "./common/Tooltip";
 export { CrudContextMenu } from "./dataGrid/CrudContextMenu";
 export { GridFilterButton } from "./dataGrid/GridFilterButton";
 export { muiGridFilterToGql } from "./dataGrid/muiGridFilterToGql";
+export { muiGridPagingToGql } from "./dataGrid/muiGridPagingToGql";
 export { muiGridSortToGql } from "./dataGrid/muiGridSortToGql";
 export { useBufferedRowCount } from "./dataGrid/useBufferedRowCount";
 export { useDataGridRemote } from "./dataGrid/useDataGridRemote";

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
@@ -3,6 +3,7 @@ import {
     GridFilterButton,
     LocalErrorScopeApolloContext,
     muiGridFilterToGql,
+    muiGridPagingToGql,
     muiGridSortToGql,
     StackLink,
     StackSwitchApiContext,
@@ -175,8 +176,7 @@ export function RedirectsTable({ linkBlock, scope }: Props): JSX.Element {
         variables: {
             scope,
             ...muiGridFilterToGql(columns, dataGridProps.filterModel),
-            limit: dataGridProps.pageSize,
-            offset: dataGridProps.page * dataGridProps.pageSize,
+            ...muiGridPagingToGql({ page: dataGridProps.page, pageSize: dataGridProps.pageSize }),
             sort: muiGridSortToGql(sortModel),
         },
         context: LocalErrorScopeApolloContext,


### PR DESCRIPTION
Motivation:
- avoids duplication
- nicer to read
- less error-prone