### PR TITLE
Implement Visible/Invisible Action for BlockListHeaderActions

### DIFF
--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
@@ -291,6 +291,19 @@ export function createBlocksBlock({
                 [handleUndoClick, snackbarApi, updateState],
             );
 
+            const handleToggleVisibilityOfAllSelectedBlocks = (visible = false) => {
+                const blocksToShow = state.blocks.map((c) => {
+                    if (c.selected) {
+                        c.visible = visible;
+                    }
+                    return c;
+                });
+
+                updateState((prevState) => {
+                    return { ...prevState, blocks: blocksToShow };
+                });
+            };
+
             const handleDeleteAllSelectedBlocks = () => {
                 const blocksToDelete = state.blocks.filter((c) => {
                     return c.selected;
@@ -476,16 +489,39 @@ export function createBlocksBlock({
                                                             <div />
                                                         )}
                                                         <BlockListHeaderActionContainer>
-                                                            {selectedCount > 0 && (
-                                                                <>
-                                                                    <IconButton onClick={handleDeleteAllSelectedBlocks} size="large">
-                                                                        <Delete />
-                                                                    </IconButton>
-                                                                    <IconButton onClick={handleCopySelectedBlocks} size="large">
-                                                                        <Copy />
-                                                                    </IconButton>
-                                                                </>
-                                                            )}
+                                                            <IconButton
+                                                                onClick={() => {
+                                                                    handleToggleVisibilityOfAllSelectedBlocks(true);
+                                                                }}
+                                                                size="large"
+                                                                disabled={selectedCount === 0}
+                                                            >
+                                                                <Visible />
+                                                            </IconButton>
+                                                            <IconButton
+                                                                onClick={() => {
+                                                                    handleToggleVisibilityOfAllSelectedBlocks();
+                                                                }}
+                                                                size="large"
+                                                                disabled={selectedCount === 0}
+                                                            >
+                                                                <Invisible />
+                                                            </IconButton>
+                                                            <Separator />
+                                                            <IconButton
+                                                                onClick={handleDeleteAllSelectedBlocks}
+                                                                size="large"
+                                                                disabled={selectedCount === 0}
+                                                            >
+                                                                <Delete />
+                                                            </IconButton>
+                                                            <IconButton
+                                                                onClick={handleCopySelectedBlocks}
+                                                                size="large"
+                                                                disabled={selectedCount === 0}
+                                                            >
+                                                                <Copy />
+                                                            </IconButton>
                                                             <IconButton onClick={() => pasteBlock(0)} size="large">
                                                                 <Paste />
                                                             </IconButton>
@@ -685,6 +721,8 @@ const BlockListHeader = styled("div")`
 `;
 
 const BlockListHeaderActionContainer = styled("div")`
+    display: flex;
+    align-items: center;
     padding: 12px 0;
 `;
 
@@ -702,4 +740,10 @@ const LargeAddButtonContent = styled("span")`
 const LargeAddButtonIcon = styled(Add)`
     font-size: 24px;
     margin-bottom: 8px;
+`;
+
+const Separator = styled("div")`
+    background-color: ${(props) => props.theme.palette.grey["100"]};
+    height: 22px;
+    width: 1px;
 `;


### PR DESCRIPTION
**Changes:**
- New Visible & Invisible Actions for BlockListHeaderActions
- Behavior changes of the Toolbar Action Icons

**Details:**
In this commit, the code for handling block actions in the Block List has been refactored. The new `handleToggleVisibilityOfAllSelectedBlocks` function allows toggling the visibility of selected blocks, with "Visible" and "Invisible" icons added for this purpose. 

The "Delete," "Copy," and "Paste" icons remain unchanged in their functionality but have been updated to align with the design specified in the Figma files.  The icons are now always shown regardless of the amount of selected blocks, but they will be disabled when no blocks are selected. 

**Screencaptures:**
**Before:**
<img width="558" alt="Screenshot 2023-08-03 at 08 53 06" src="https://github.com/vivid-planet/comet/assets/67897480/76510dca-001a-4ca4-b3f7-2bb8482534c4">
<img width="552" alt="Screenshot 2023-08-03 at 08 53 13" src="https://github.com/vivid-planet/comet/assets/67897480/243d1445-14b0-4728-a390-508453163f11">
**After:**
<img width="558" alt="Screenshot 2023-08-03 at 08 51 55" src="https://github.com/vivid-planet/comet/assets/67897480/6c3e6242-f763-4be6-8cdb-9e472cc3a829">
<img width="555" alt="Screenshot 2023-08-03 at 08 52 04" src="https://github.com/vivid-planet/comet/assets/67897480/680a047f-43c9-4789-a4b4-75d20851a9c6">
<img width="557" alt="Screenshot 2023-08-03 at 08 52 14" src="https://github.com/vivid-planet/comet/assets/67897480/72f556d1-ff13-4f4b-bb59-ee4ebbaf14b0">
