### PR TITLE
Restrict Next router and image imports

### DIFF
--- a/packages/eslint-config/nextjs.js
+++ b/packages/eslint-config/nextjs.js
@@ -5,6 +5,28 @@ module.exports = {
         "react/prop-types": "off",
         "react/self-closing-comp": "error",
         "import/no-extraneous-dependencies": "error",
-        "@comet/no-private-sibling-import": ["error", ["gql", "sc", "gql.generated"]]
+        "@comet/no-private-sibling-import": ["error", ["gql", "sc", "gql.generated"]],
+        "no-restricted-imports": [
+            "error",
+            {
+                paths: [
+                    {
+                        name: "next/link",
+                        importNames: ["default"],
+                        message: "Please use Link from @comet/cms-site instead",
+                    },
+                    {
+                        name: "next/router",
+                        importNames: ["useRouter"],
+                        message: "Please use useRouter from @comet/cms-site instead",
+                    },
+                    {
+                        name: "next/image",
+                        importNames: ["default"],
+                        message: "Please use Image from @comet/cms-site instead",
+                    },
+                ],
+            },
+        ],
     },
 };

--- a/packages/site/cms-site/src/blocks/PixelImageBlock.tsx
+++ b/packages/site/cms-site/src/blocks/PixelImageBlock.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import NextImage, { ImageProps } from "next/image";
 import * as React from "react";
 

--- a/packages/site/cms-site/src/image/Image.tsx
+++ b/packages/site/cms-site/src/image/Image.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import NextImage, { ImageLoaderProps, ImageProps as NextImageProps } from "next/image";
 import * as React from "react";
 

--- a/packages/site/cms-site/src/link/Link.tsx
+++ b/packages/site/cms-site/src/link/Link.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import NextLink, { LinkProps as NextLinkProps } from "next/link";
 import * as React from "react";
 

--- a/packages/site/cms-site/src/router/useRouter.tsx
+++ b/packages/site/cms-site/src/router/useRouter.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { NextRouter, useRouter as useNextRouter } from "next/router";
 
 import { usePreview } from "../preview/usePreview";

--- a/packages/site/cms-site/src/sitePreview/SitePreviewProvider.tsx
+++ b/packages/site/cms-site/src/sitePreview/SitePreviewProvider.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { useRouter } from "next/router";
 import * as React from "react";
 


### PR DESCRIPTION
We provide wrappers for Next's router and image components to make them work with our preview and image scaling service. We restrict importing them from Next to ensure that our developers use the wrappers.

<img width="1003" alt="lint example" src="https://github.com/vivid-planet/comet/assets/48853629/73c96400-2078-4a37-897a-f3bbe001ad99">
