### PR TITLE
Add `fullHeight` & `disablePadding` props to MainContent

### DIFF
--- a/.changeset/fair-cobras-tell.md
+++ b/.changeset/fair-cobras-tell.md
@@ -1,0 +1,10 @@
+---
+"@comet/admin": minor
+---
+
+Add `fullHeight` & `disablePadding` props to MainContent
+
+`fullHeight` makes MainContent take up the remaining space below to fill the entire page.
+This is helpful for virtualized components that need a fixed height, such as DataGrid or the PageTree.
+
+`disablePadding` is helpful if a component requires the `fullHeight` behaviour but should fill the entire page without the surrounding space.

--- a/demo/admin/src/products/ProductsTable.tsx
+++ b/demo/admin/src/products/ProductsTable.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@apollo/client";
 import {
     CrudContextMenu,
     GridFilterButton,
+    MainContent,
     muiGridFilterToGql,
     muiGridSortToGql,
     StackLink,
@@ -15,7 +16,7 @@ import {
     usePersistentColumnState,
 } from "@comet/admin";
 import { Add as AddIcon, Edit, Info } from "@comet/admin-icons";
-import { Box, Button, IconButton, Typography } from "@mui/material";
+import { Button, IconButton, Typography } from "@mui/material";
 import { DataGridPro, GridColDef, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import {
     GQLCreateProductMutation,
@@ -127,7 +128,7 @@ function ProductsTable() {
     const rowCount = useBufferedRowCount(data?.products.totalCount);
 
     return (
-        <Box sx={{ height: `calc(100vh - var(--comet-admin-master-layout-content-top-spacing))` }}>
+        <MainContent fullHeight disablePadding>
             <DataGridPro
                 {...dataGridProps}
                 disableSelectionOnClick
@@ -140,7 +141,7 @@ function ProductsTable() {
                     Toolbar: ProductsTableToolbar,
                 }}
             />
-        </Box>
+        </MainContent>
     );
 }
 

--- a/packages/admin/admin/src/mui/MainContent.tsx
+++ b/packages/admin/admin/src/mui/MainContent.tsx
@@ -2,12 +2,14 @@ import { ComponentsOverrides, Theme } from "@mui/material";
 import { createStyles, WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 
-export type MainContentClassKey = "root" | "disablePaddingTop" | "disablePaddingBottom";
+export type MainContentClassKey = "root" | "disablePaddingTop" | "disablePaddingBottom" | "disablePadding" | "fullHeight";
 
 export interface MainContentProps {
     children?: React.ReactNode;
     disablePaddingTop?: boolean;
     disablePaddingBottom?: boolean;
+    disablePadding?: boolean;
+    fullHeight?: boolean;
 }
 
 const styles = ({ spacing }: Theme) => {
@@ -17,20 +19,47 @@ const styles = ({ spacing }: Theme) => {
             zIndex: 5,
             padding: spacing(4),
         },
+        fullHeight: {
+            height: "calc(100vh - var(--comet-admin-main-content-top-position))",
+        },
         disablePaddingTop: {
             paddingTop: 0,
         },
         disablePaddingBottom: {
             paddingBottom: 0,
         },
+        disablePadding: {
+            padding: 0,
+        },
     });
 };
 
-function Main({ children, disablePaddingTop, disablePaddingBottom, classes }: MainContentProps & WithStyles<typeof styles>) {
+function Main({
+    children,
+    fullHeight,
+    disablePaddingTop,
+    disablePaddingBottom,
+    disablePadding,
+    classes,
+}: MainContentProps & WithStyles<typeof styles>) {
+    const mainRef = React.useRef<HTMLElement>(null);
+    const topPosition = fullHeight ? mainRef.current?.offsetTop : 0;
+
     const rootClasses: string[] = [classes.root];
     if (disablePaddingTop) rootClasses.push(classes.disablePaddingTop);
     if (disablePaddingBottom) rootClasses.push(classes.disablePaddingBottom);
-    return <main className={rootClasses.join(" ")}>{children}</main>;
+    if (disablePadding) rootClasses.push(classes.disablePadding);
+    if (fullHeight) rootClasses.push(classes.fullHeight);
+
+    return (
+        <main
+            ref={mainRef}
+            className={rootClasses.join(" ")}
+            style={{ "--comet-admin-main-content-top-position": `${topPosition}px` } as React.CSSProperties}
+        >
+            {children}
+        </main>
+    );
 }
 
 export const MainContent = withStyles(styles, { name: "CometAdminMainContent" })(Main);

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -155,7 +155,7 @@ export function PagesPage({
                         </ToolbarActions>
                     </Toolbar>
                     <PageTreeContext.Provider value={{ allCategories, documentTypes, tree, query: pagesQuery }}>
-                        <FullHeightMainContent>
+                        <PageTreeContent fullHeight>
                             <ActionToolbarBox>
                                 <PagesPageActionToolbar
                                     selectedState={selectState}
@@ -190,7 +190,7 @@ export function PagesPage({
                                     siteUrl={siteConfig.url}
                                 />
                             </FullHeightPaper>
-                        </FullHeightMainContent>
+                        </PageTreeContent>
                     </PageTreeContext.Provider>
 
                     <EditDialog>
@@ -230,9 +230,8 @@ export function PagesPage({
     );
 }
 
-const FullHeightMainContent = withStyles({
+const PageTreeContent = withStyles({
     root: {
-        height: "calc(100vh - 140px)",
         display: "flex",
         flexDirection: "column",
     },


### PR DESCRIPTION
`fullHeight` makes MainContent take up the remaining space below to fill the entire page. This is helpful for virtualized components that need a fixed height, such as DataGrid or the PageTree.

`disablePadding` is helpful if a component requires the `fullHeight` behaviour but should fill the entire page without the surrounding space.

---

Alternative for #1105