### PR TITLE
Correctly position loading indicators with new `Loading` component

### DIFF
--- a/.changeset/happy-jobs-wink.md
+++ b/.changeset/happy-jobs-wink.md
@@ -1,0 +1,6 @@
+---
+"@comet/cms-admin": patch
+"@comet/admin": patch
+---
+
+Correctly position loading indicators by centring them using the new `Loading` component

--- a/.changeset/odd-dolphins-beam.md
+++ b/.changeset/odd-dolphins-beam.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": minor
+---
+
+Add a generic Loading component for use in Admin
+
+`Loading` handles the positioning of the loading indicator automatically, depending on the set `behaviour` prop.

--- a/demo/admin/src/common/ContentScopeProvider.tsx
+++ b/demo/admin/src/common/ContentScopeProvider.tsx
@@ -1,4 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
+import { Loading } from "@comet/admin";
 import { Domain as DomainIcon } from "@comet/admin-icons";
 import {
     ContentScopeConfigProps,
@@ -12,7 +13,6 @@ import {
     useContentScopeConfig as useContentScopeConfigLibrary,
     useSitesConfig,
 } from "@comet/cms-admin";
-import { CircularProgress } from "@mui/material";
 import { GQLCurrentUserScopeQuery } from "@src/graphql.generated";
 import React from "react";
 
@@ -64,7 +64,7 @@ const ContentScopeProvider: React.FC<Pick<ContentScopeProviderProps, "children">
     const sitesConfig = useSitesConfig();
     const { loading, data } = useQuery<GQLCurrentUserScopeQuery>(currentUserQuery);
 
-    if (loading || !data) return <CircularProgress />;
+    if (loading || !data) return <Loading behavior="fillPageHeight" />;
 
     const allowedUserDomains = data.currentUser.domains;
 

--- a/demo/admin/src/links/EditLink.tsx
+++ b/demo/admin/src/links/EditLink.tsx
@@ -1,9 +1,20 @@
 import { gql } from "@apollo/client";
-import { MainContent, messages, RouterPrompt, RouterTab, RouterTabs, Toolbar, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
+import {
+    Loading,
+    MainContent,
+    messages,
+    RouterPrompt,
+    RouterTab,
+    RouterTabs,
+    Toolbar,
+    ToolbarFillSpace,
+    ToolbarItem,
+    useStackApi,
+} from "@comet/admin";
 import { ArrowLeft } from "@comet/admin-icons";
 import { AdminComponentRoot } from "@comet/blocks-admin";
 import { createUsePage, EditPageLayout, PageName } from "@comet/cms-admin";
-import { CircularProgress, IconButton } from "@mui/material";
+import { IconButton } from "@mui/material";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
 import { GQLEditLinkQuery, GQLEditLinkQueryVariables, GQLUpdateLinkMutation, GQLUpdateLinkMutationVariables } from "@src/graphql.generated";
 import * as React from "react";
@@ -76,7 +87,7 @@ export const EditLink: React.FC<Props> = ({ id }) => {
     };
 
     if (loading) {
-        return <CircularProgress />;
+        return <Loading behavior="fillPageHeight" />;
     }
 
     if (!linkState) return <></>;

--- a/demo/admin/src/pages/EditPage.tsx
+++ b/demo/admin/src/pages/EditPage.tsx
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { MainContent, messages, RouterPrompt, Toolbar, ToolbarActions, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
+import { Loading, MainContent, messages, RouterPrompt, Toolbar, ToolbarActions, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
 import { ArrowLeft, Preview } from "@comet/admin-icons";
 import { AdminComponentRoot, AdminTabLabel } from "@comet/blocks-admin";
 import {
@@ -12,7 +12,7 @@ import {
     useCmsBlockContext,
     useSiteConfig,
 } from "@comet/cms-admin";
-import { Button, CircularProgress, IconButton } from "@mui/material";
+import { Button, IconButton } from "@mui/material";
 import { SeoBlock } from "@src/common/blocks/SeoBlock";
 import { useContentScope } from "@src/common/ContentScopeProvider";
 import {
@@ -112,7 +112,7 @@ export const EditPage: React.FC<Props> = ({ id, category }) => {
     if (!pageState) return <></>;
 
     if (loading) {
-        return <CircularProgress />;
+        return <Loading behavior="fillPageHeight" />;
     }
 
     return (

--- a/demo/admin/src/pages/mainMenu/MainMenu.tsx
+++ b/demo/admin/src/pages/mainMenu/MainMenu.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
-import { Selected, Stack, StackPage, StackSwitch } from "@comet/admin";
-import { LinearProgress } from "@mui/material";
+import { Loading, Selected, Stack, StackPage, StackSwitch } from "@comet/admin";
 import { GQLEditMainMenuItemFragment } from "@src/graphql.generated";
 import * as React from "react";
 import { useIntl } from "react-intl";
@@ -35,7 +34,7 @@ const MainMenu: React.FunctionComponent = () => {
                             query={MAIN_MENU_ITEM_QUERY}
                             dataAccessor="mainMenuItem"
                         >
-                            {(item) => (item === undefined ? <LinearProgress /> : <EditMainMenuItem item={item} />)}
+                            {(item) => (item === undefined ? <Loading behavior="fillPageHeight" /> : <EditMainMenuItem item={item} />)}
                         </Selected>
                     )}
                 </StackPage>

--- a/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
+++ b/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
@@ -3,6 +3,7 @@ import {
     Field,
     FinalForm,
     FinalFormSelect,
+    Loading,
     MainContent,
     messages,
     SaveButton,
@@ -14,7 +15,7 @@ import {
 } from "@comet/admin";
 import { ArrowLeft } from "@comet/admin-icons";
 import { EditPageLayout, PageName } from "@comet/cms-admin";
-import { CircularProgress, IconButton, MenuItem } from "@mui/material";
+import { IconButton, MenuItem } from "@mui/material";
 import {
     GQLPredefinedPageQuery,
     GQLPredefinedPageQueryVariables,
@@ -72,7 +73,7 @@ export const EditPredefinedPage: React.FC<Props> = ({ id }) => {
     });
 
     if (loading) {
-        return <CircularProgress />;
+        return <Loading behavior="fillPageHeight" />;
     }
 
     return (

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -5,6 +5,7 @@ import {
     FinalFormCheckbox,
     FinalFormInput,
     FinalFormSelect,
+    Loading,
     MainContent,
     messages,
     SaveButton,
@@ -18,7 +19,7 @@ import {
 } from "@comet/admin";
 import { ArrowLeft } from "@comet/admin-icons";
 import { EditPageLayout } from "@comet/cms-admin";
-import { CircularProgress, FormControlLabel, IconButton, MenuItem } from "@mui/material";
+import { FormControlLabel, IconButton, MenuItem } from "@mui/material";
 import {
     GQLProductFormCreateProductMutation,
     GQLProductFormCreateProductMutationVariables,
@@ -79,7 +80,7 @@ function ProductForm({ id }: FormProps): React.ReactElement {
     }
 
     if (loading) {
-        return <CircularProgress />;
+        return <Loading behavior="fillPageHeight" />;
     }
 
     return (

--- a/packages/admin/admin-stories/src/admin/stack/StackTableFormQueryAtStack.tsx
+++ b/packages/admin/admin-stories/src/admin/stack/StackTableFormQueryAtStack.tsx
@@ -4,6 +4,7 @@ import {
     FinalForm,
     FinalFormInput,
     IFilterApi,
+    Loading,
     MainContent,
     Stack,
     StackPage,
@@ -19,7 +20,7 @@ import {
     useTableQueryFilter,
 } from "@comet/admin";
 import { Edit as EditIcon } from "@mui/icons-material";
-import { CircularProgress, Grid, IconButton, Typography } from "@mui/material";
+import { Grid, IconButton, Typography } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
@@ -133,9 +134,6 @@ function ExampleForm(props: IExampleFormProps) {
 
     const { loading, data, error } = useQuery(detailQuery, { variables: { id: props.id } });
 
-    if (loading || !data) {
-        return <CircularProgress />;
-    }
     if (error) return <p>Error :( {error.toString()}</p>;
 
     return (
@@ -146,16 +144,20 @@ function ExampleForm(props: IExampleFormProps) {
                     <Typography variant="h3">Stack Table Form Query At Stack - Detail</Typography>
                 </ToolbarItem>
             </Toolbar>
-            <MainContent>
-                <FinalForm
-                    mode="edit"
-                    onSubmit={(values) => {
-                        // submit here
-                    }}
-                    initialValues={data.user}
-                >
-                    <Field label="Name" name="name" defaultOptions required component={FinalFormInput} />
-                </FinalForm>
+            <MainContent fullHeight>
+                {loading || !data ? (
+                    <Loading behavior="fillParent" />
+                ) : (
+                    <FinalForm
+                        mode="edit"
+                        onSubmit={(values) => {
+                            // submit here
+                        }}
+                        initialValues={data.user}
+                    >
+                        <Field label="Name" name="name" defaultOptions required component={FinalFormInput} />
+                    </FinalForm>
+                )}
             </MainContent>
         </>
     );

--- a/packages/admin/admin-stories/src/admin/stack/StackTableFormQueryInTable.tsx
+++ b/packages/admin/admin-stories/src/admin/stack/StackTableFormQueryInTable.tsx
@@ -3,6 +3,7 @@ import {
     Field,
     FinalForm,
     FinalFormInput,
+    Loading,
     MainContent,
     Stack,
     StackPage,
@@ -19,7 +20,7 @@ import {
     useTableQueryFilter,
 } from "@comet/admin";
 import { Edit as EditIcon } from "@mui/icons-material";
-import { Card, CardContent, CircularProgress, Grid, IconButton, Typography } from "@mui/material";
+import { Card, CardContent, Grid, IconButton, Typography } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
@@ -138,9 +139,6 @@ function ExampleForm(props: IExampleFormProps) {
 
     const { loading, data, error } = useQuery(detailQuery, { variables: { id: props.id } });
 
-    if (loading || !data) {
-        return <CircularProgress />;
-    }
     if (error) return <p>Error :( {error.toString()}</p>;
 
     return (
@@ -151,20 +149,24 @@ function ExampleForm(props: IExampleFormProps) {
                     <Typography variant="h3">Stack Table Form Query In Table - Detail</Typography>
                 </ToolbarItem>
             </Toolbar>
-            <MainContent>
-                <Card variant="outlined">
-                    <CardContent>
-                        <FinalForm
-                            mode="edit"
-                            onSubmit={(values) => {
-                                // submit here
-                            }}
-                            initialValues={data.user}
-                        >
-                            <Field label="Name" name="name" defaultOptions required component={FinalFormInput} />
-                        </FinalForm>
-                    </CardContent>
-                </Card>
+            <MainContent fullHeight>
+                {loading || !data ? (
+                    <Loading behavior="fillParent" />
+                ) : (
+                    <Card variant="outlined">
+                        <CardContent>
+                            <FinalForm
+                                mode="edit"
+                                onSubmit={(values) => {
+                                    // submit here
+                                }}
+                                initialValues={data.user}
+                            >
+                                <Field label="Name" name="name" defaultOptions required component={FinalFormInput} />
+                            </FinalForm>
+                        </CardContent>
+                    </Card>
+                )}
             </MainContent>
         </>
     );

--- a/packages/admin/admin/src/FinalForm.tsx
+++ b/packages/admin/admin/src/FinalForm.tsx
@@ -1,10 +1,10 @@
 import { useApolloClient } from "@apollo/client";
-import { CircularProgress } from "@mui/material";
 import { FORM_ERROR, FormApi, Mutator, SubmissionErrors, ValidationErrors } from "final-form";
 import setFieldData from "final-form-set-field-data";
 import * as React from "react";
 import { AnyObject, Form, FormProps, FormRenderProps } from "react-final-form";
 
+import { Loading } from "./common/Loading";
 import { DirtyHandlerApiContext } from "./DirtyHandlerApiContext";
 import { EditDialogApiContext } from "./EditDialogApiContext";
 import { useEditDialogFormApi } from "./EditDialogFormApiContext";
@@ -171,7 +171,7 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                     {(formRenderProps.submitError || formRenderProps.error) && (
                         <div className="error">{formRenderProps.submitError || formRenderProps.error}</div>
                     )}
-                    {!editDialog && <>{formRenderProps.submitting && <CircularProgress />}</>}
+                    {!editDialog && <>{formRenderProps.submitting && <Loading behavior="fillParent" />}</>}
                 </form>
             </FinalFormContextProvider>
         );

--- a/packages/admin/admin/src/Selected.tsx
+++ b/packages/admin/admin/src/Selected.tsx
@@ -1,8 +1,10 @@
 import { ApolloError, useQuery } from "@apollo/client";
-import { Box, Card, CircularProgress, Typography } from "@mui/material";
+import { Box, Card, Typography } from "@mui/material";
 import { DocumentNode } from "graphql";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
+
+import { Loading } from "./common/Loading";
 
 interface IProps<Data extends { id: string | number } = { id: string | number }> {
     selectionMode?: "edit" | "add";
@@ -40,11 +42,7 @@ const SelectEdit = <Data extends { id: string | number }>(props: IProps<Data>) =
         );
     }
     if (queryResult.loading || !queryResult.data) {
-        return (
-            <Box display="flex" justifyContent="center">
-                <CircularProgress />
-            </Box>
-        );
+        return <Loading behavior="fillPageHeight" />;
     }
     if (!props.dataAccessor) {
         throw new Error("dataChild prop is required");

--- a/packages/admin/admin/src/common/Loading.tsx
+++ b/packages/admin/admin/src/common/Loading.tsx
@@ -1,0 +1,60 @@
+import { CircularProgress, CircularProgressProps } from "@mui/material";
+import { css, styled } from "@mui/material/styles";
+import React from "react";
+
+export interface LoadingProps extends CircularProgressProps {
+    behavior?: "auto" | "fillParent" | "fillParentAbsolute" | "fillPageHeight";
+}
+
+export const Loading = ({ behavior = "auto", ...circularProgressProps }: LoadingProps) => {
+    const rootRef = React.useRef<HTMLDivElement>(null);
+    const offsetTop = rootRef.current?.offsetTop || 0;
+
+    return (
+        <Root ref={rootRef} style={{ "--comet-admin-loading-offset-top": `${offsetTop}px` } as React.CSSProperties} behavior={behavior}>
+            <LoadingContainer behavior={behavior}>
+                <CircularProgress {...circularProgressProps} />
+            </LoadingContainer>
+        </Root>
+    );
+};
+
+const Root = styled("div")<Required<Pick<LoadingProps, "behavior">>>`
+    position: relative;
+
+    ${({ behavior }) => {
+        if (behavior === "fillParent") {
+            return css`
+                height: 100%;
+                flex-grow: 1;
+            `;
+        }
+
+        if (behavior === "fillParentAbsolute") {
+            return css`
+                position: absolute;
+                inset: 0;
+            `;
+        }
+
+        if (behavior === "fillPageHeight") {
+            return css`
+                height: calc(100vh - var(--comet-admin-loading-offset-top));
+            `;
+        }
+    }}
+`;
+
+const LoadingContainer = styled("div")<Required<Pick<LoadingProps, "behavior">>>`
+    text-align: center;
+
+    ${({ behavior }) =>
+        behavior !== "auto" &&
+        css`
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        `}
+`;

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -27,6 +27,7 @@ export { useSplitButtonContext } from "./common/buttons/split/useSplitButtonCont
 export { ClearInputAdornment, ClearInputAdornmentProps } from "./common/ClearInputAdornment";
 export { CometLogo } from "./common/CometLogo";
 export { HoverActions, HoverActionsClassKey, HoverActionsProps } from "./common/HoverActions";
+export { Loading, LoadingProps } from "./common/Loading";
 export { ToolbarActions, ToolbarActionsClassKey } from "./common/toolbar/actions/ToolbarActions";
 export {
     ToolbarAutomaticTitleItem,

--- a/packages/admin/admin/src/table/LocalChangesToolbar.tsx
+++ b/packages/admin/admin/src/table/LocalChangesToolbar.tsx
@@ -1,37 +1,37 @@
-import { CircularProgress, Toolbar } from "@mui/material";
+import { Toolbar } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { SaveButton } from "../common/buttons/save/SaveButton";
+import { Loading } from "../common/Loading";
 import { ITableLocalChangesApi } from "./TableLocalChanges";
 
-interface IProps {
+interface Props {
     tableLocalChangesApi: ITableLocalChangesApi;
     localChangesCount: number;
     updateMutation: any;
     loading: boolean;
 }
 
-export class TableLocalChangesToolbar extends React.Component<IProps> {
-    public render() {
-        return (
-            <>
-                {this.props.loading && <CircularProgress />}
-                {!this.props.loading && (
-                    <Toolbar>
-                        <SaveButton onClick={this.handleSaveClick} />
-                        <FormattedMessage
-                            values={{ count: this.props.localChangesCount }}
-                            id="comet.table.localChangesToolbar.unsavedItems"
-                            defaultMessage="{count, plural, =0 {No unsaved changes} one {# unsaved change} other {# unsaved changes}}"
-                        />
-                    </Toolbar>
-                )}
-            </>
-        );
-    }
-
-    private handleSaveClick = () => {
-        this.props.tableLocalChangesApi.submitLocalDataChanges();
+export const TableLocalChangesToolbar = ({ tableLocalChangesApi, localChangesCount, updateMutation, loading }: Props) => {
+    const handleSaveClick = () => {
+        tableLocalChangesApi.submitLocalDataChanges();
     };
-}
+
+    return (
+        <Toolbar>
+            {loading ? (
+                <Loading behavior="fillParent" />
+            ) : (
+                <>
+                    <SaveButton onClick={handleSaveClick} />
+                    <FormattedMessage
+                        values={{ count: localChangesCount }}
+                        id="comet.table.localChangesToolbar.unsavedItems"
+                        defaultMessage="{count, plural, =0 {No unsaved changes} one {# unsaved change} other {# unsaved changes}}"
+                    />
+                </>
+            )}
+        </Toolbar>
+    );
+};

--- a/packages/admin/admin/src/table/TableQuery.tsx
+++ b/packages/admin/admin/src/table/TableQuery.tsx
@@ -1,9 +1,10 @@
 import { ApolloError } from "@apollo/client";
-import { CircularProgress, ComponentsOverrides, Paper, Theme } from "@mui/material";
+import { ComponentsOverrides, Paper, Theme } from "@mui/material";
 import { WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { Loading } from "../common/Loading";
 import { styles, TableQueryClassKey } from "./TableQuery.styles";
 import { ITableQueryApi, TableQueryContext } from "./TableQueryContext";
 
@@ -34,7 +35,7 @@ export function Query({ classes, ...otherProps }: IProps & WithStyles<typeof sty
                 <div className={classes.loadingContainer}>
                     {otherProps.loading && (
                         <Paper classes={{ root: classes.loadingPaper }}>
-                            <CircularProgress />
+                            <Loading behavior="fillParent" />
                         </Paper>
                     )}
                 </div>

--- a/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
+++ b/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
@@ -88,6 +88,7 @@ export function StartBuildsDialog(props: StartBuildsDialogProps) {
                     variant="contained"
                     color="primary"
                     disabled={loading || selectionModel.length < 1}
+                    startIcon={loading ? <CircularProgress size={20} /> : undefined}
                     onClick={async () => {
                         await startBuilds({
                             variables: { input: { names: rows.filter((row) => selectionModel.includes(row.id)).map((row) => row.name) } },
@@ -96,7 +97,6 @@ export function StartBuildsDialog(props: StartBuildsDialogProps) {
                     }}
                 >
                     <FormattedMessage id="comet.pages.publisher.startBuildsDialog.button" defaultMessage="Start builds" />
-                    {loading && <CircularProgress size={16} />}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
+++ b/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
@@ -1,6 +1,6 @@
-import { AppHeaderDropdown } from "@comet/admin";
+import { AppHeaderDropdown, Loading } from "@comet/admin";
 import { Account, Info, Logout } from "@comet/admin-icons";
-import { Box, Button as MUIButton, CircularProgress } from "@mui/material";
+import { Box, Button as MUIButton } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import React from "react";
 import { FormattedMessage } from "react-intl";
@@ -22,6 +22,12 @@ const Separator = styled(Box)`
     width: 100%;
     margin-top: 20px;
     margin-bottom: 20px;
+`;
+
+const LoadingWrapper = styled("div")`
+    width: 60px;
+    height: 100%;
+    border-left: 1px solid rgba(255, 255, 255, 0.2);
 `;
 
 import { gql, useMutation, useQuery } from "@apollo/client";
@@ -51,7 +57,12 @@ export function UserHeaderItem(props: UserHeaderItemProps): React.ReactElement {
     const { loading, data } = useQuery<GQLCurrentUserQuery>(currentUserQuery);
     const [signOut, { loading: isSigningOut }] = useMutation<GQLSignOutMutation>(signOutMutation);
 
-    if (loading || !data) return <CircularProgress />;
+    if (loading || !data)
+        return (
+            <LoadingWrapper>
+                <Loading behavior="fillParent" size={20} color="inherit" />
+            </LoadingWrapper>
+        );
 
     return (
         <AppHeaderDropdown buttonChildren={data.currentUser.name} startIcon={<Account />}>
@@ -67,8 +78,9 @@ export function UserHeaderItem(props: UserHeaderItemProps): React.ReactElement {
                     <FormattedMessage id="comet.about" defaultMessage="About" />
                 </Button>
                 <Separator />
-                {isSigningOut && <CircularProgress />}
-                {!isSigningOut && (
+                {isSigningOut ? (
+                    <Loading />
+                ) : (
                     <Button
                         fullWidth
                         variant="contained"

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from "@apollo/client";
 import {
     FinalForm,
+    Loading,
     LocalErrorScopeApolloContext,
     MainContent,
     messages,
@@ -16,7 +17,7 @@ import {
     ToolbarTitleItem,
     useStackApi,
 } from "@comet/admin";
-import { Card, CardContent, CircularProgress, Link, Typography } from "@mui/material";
+import { Card, CardContent, Link, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { FORM_ERROR } from "final-form";
 import isEqual from "lodash.isequal";
@@ -85,7 +86,7 @@ const EditFile = ({ id }: EditFormProps): React.ReactElement => {
     const file = initialValues.data?.damFile;
 
     if (initialValues.loading) {
-        return <CircularProgress />;
+        return <Loading behavior="fillPageHeight" />;
     } else if (initialValues.error || file === undefined) {
         // otherwise, the user always gets redirected to the broken file and is stuck there
         persistedDamLocationApi?.reset();

--- a/packages/admin/cms-admin/src/dam/FolderForm/EditFolder.tsx
+++ b/packages/admin/cms-admin/src/dam/FolderForm/EditFolder.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery } from "@apollo/client";
-import { FinalForm, ISelectionApi } from "@comet/admin";
-import { CircularProgress } from "@mui/material";
+import { FinalForm, ISelectionApi, Loading } from "@comet/admin";
 import React from "react";
 
 import {
@@ -27,7 +26,7 @@ const EditFolder = ({ id, selectionApi }: EditFolderProps): React.ReactElement =
     const [updateDamFolder] = useMutation<GQLUpdateDamFolderMutation, GQLUpdateDamFolderMutationVariables>(updateDamFolderMutation);
 
     if (loading || !data?.damFolder) {
-        return <CircularProgress />;
+        return <Loading />;
     }
 
     return (

--- a/packages/admin/cms-admin/src/dam/Table/InnerTableWrapper.tsx
+++ b/packages/admin/cms-admin/src/dam/Table/InnerTableWrapper.tsx
@@ -1,31 +1,12 @@
 import { ApolloError } from "@apollo/client/errors";
-import { CircularProgress, Paper } from "@mui/material";
+import { Loading } from "@comet/admin";
 import { styled } from "@mui/material/styles";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 const OuterWrapper = styled("div")`
     position: relative;
-`;
-
-const LoadingContainer = styled("div")`
-    position: sticky;
-    top: 0;
-    width: 100%;
-    z-index: ${({ theme }) => theme.zIndex.modal};
-    transform: translate(50%, 200px);
-`;
-
-const LoadingPaper = styled(Paper)`
-    display: flex;
-    position: absolute;
-    transform: translate(-50%, -50%);
-    justify-content: center;
-    align-items: center;
-    margin-left: auto;
-    margin-right: auto;
-    height: 100px;
-    width: 100px;
+    flex-grow: 1;
 `;
 
 interface InnerTableWrapperProps {
@@ -36,26 +17,25 @@ interface InnerTableWrapperProps {
 export const InnerTableWrapper: React.FunctionComponent<InnerTableWrapperProps> = ({ error, loading, children }) => {
     return (
         <OuterWrapper>
-            <LoadingContainer>
-                {loading && (
-                    <LoadingPaper>
-                        <CircularProgress />
-                    </LoadingPaper>
-                )}
-            </LoadingContainer>
-            {error && (
-                <p>
-                    <FormattedMessage
-                        id="comet.table.tableQuery.error"
-                        defaultMessage="Error :( {error}"
-                        description="Display apollo error message"
-                        values={{
-                            error: error.toString(),
-                        }}
-                    />
-                </p>
+            {loading ? (
+                <Loading behavior="fillParentAbsolute" />
+            ) : (
+                <>
+                    {error && (
+                        <p>
+                            <FormattedMessage
+                                id="comet.table.tableQuery.error"
+                                defaultMessage="Error :( {error}"
+                                description="Display apollo error message"
+                                values={{
+                                    error: error.toString(),
+                                }}
+                            />
+                        </p>
+                    )}
+                    {children}
+                </>
             )}
-            {children}
         </OuterWrapper>
     );
 };

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -1,6 +1,6 @@
 import { gql, useApolloClient, useQuery } from "@apollo/client";
-import { ErrorScope, Field, FieldContainer, FinalForm, FinalFormCheckbox, FinalFormInput, FinalFormSelect } from "@comet/admin";
-import { CircularProgress, FormControlLabel, MenuItem, Typography } from "@mui/material";
+import { ErrorScope, Field, FieldContainer, FinalForm, FinalFormCheckbox, FinalFormInput, FinalFormSelect, Loading } from "@comet/admin";
+import { FormControlLabel, MenuItem, Typography } from "@mui/material";
 import { Mutator } from "final-form";
 import setFieldTouched from "final-form-set-field-touched";
 import { DocumentNode } from "graphql";
@@ -189,7 +189,7 @@ export function createEditPageNode({
         const debouncedValidateSlug = debounce(validateSlug, 200);
 
         if (mode === "edit" && (loading || !data?.page)) {
-            return <CircularProgress />;
+            return <Loading />;
         }
         return (
             <div>

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@apollo/client";
 import {
+    Loading,
     LocalErrorScopeApolloContext,
     MainContent,
     messages,
@@ -13,7 +14,7 @@ import {
     useStoredState,
 } from "@comet/admin";
 import { Add } from "@comet/admin-icons";
-import { Box, Button, CircularProgress, FormControlLabel, Paper, Switch } from "@mui/material";
+import { Box, Button, FormControlLabel, Paper, Switch } from "@mui/material";
 import withStyles from "@mui/styles/withStyles";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -178,17 +179,19 @@ export function PagesPage({
                                 />
                             </ActionToolbarBox>
                             <FullHeightPaper variant="outlined">
-                                {loading && <CircularProgress />}
-
-                                <PageTree
-                                    ref={refPageTree}
-                                    pages={pagesToRenderWithMatches}
-                                    editDialogApi={editDialogApi}
-                                    toggleExpand={toggleExpand}
-                                    onSelectChanged={onSelectChanged}
-                                    category={category}
-                                    siteUrl={siteConfig.url}
-                                />
+                                {loading ? (
+                                    <Loading behavior="fillParent" />
+                                ) : (
+                                    <PageTree
+                                        ref={refPageTree}
+                                        pages={pagesToRenderWithMatches}
+                                        editDialogApi={editDialogApi}
+                                        toggleExpand={toggleExpand}
+                                        onSelectChanged={onSelectChanged}
+                                        category={category}
+                                        siteUrl={siteConfig.url}
+                                    />
+                                )}
                             </FullHeightPaper>
                         </PageTreeContent>
                     </PageTreeContext.Provider>

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -4,6 +4,7 @@ import {
     FinalForm,
     FinalFormInput,
     FinalFormSelect,
+    Loading,
     MainContent,
     messages,
     SaveButton,
@@ -17,7 +18,7 @@ import {
 } from "@comet/admin";
 import { useStackSwitchApi } from "@comet/admin/lib/stack/Switch";
 import { BlockInterface, BlockState, createFinalFormBlock, isValidUrl } from "@comet/blocks-admin";
-import { Card, CardContent, CircularProgress, Grid, MenuItem } from "@mui/material";
+import { Card, CardContent, Grid, MenuItem } from "@mui/material";
 import { FORM_ERROR } from "final-form";
 import isEqual from "lodash.isequal";
 import * as React from "react";
@@ -103,7 +104,7 @@ export const RedirectForm = ({ mode, id, linkBlock, scope }: Props): JSX.Element
     const newlyCreatedRedirectId = React.useRef<string>();
 
     if (mode === "edit" && initialValues === undefined) {
-        return <CircularProgress />;
+        return <Loading behavior="fillPageHeight" />;
     }
 
     const validateSource = async (value: string, allValues: GQLRedirectDetailFragment) => {


### PR DESCRIPTION
Add a generic Loading component for use in Admin.
`Loading` handles the positioning of the loading indicator automatically, depending on the set `behaviour` prop.

Correctly position loading indicators by centring them using the new Loading component.