### PR TITLE
allow colon(:) and questionmark as redirect source path character

### DIFF
--- a/demo/site/preBuild/src/createRedirects.ts
+++ b/demo/site/preBuild/src/createRedirects.ts
@@ -49,7 +49,7 @@ const createApiRedirects = async (): Promise<Redirect[]> => {
         let destination: string | undefined;
 
         if (redirect.sourceType === "path") {
-            source = redirect.source;
+            source = redirect.source.replaceAll(":", "\\:"); // escape colon, otherwise it is used for next.js regex path matching  (https://nextjs.org/docs/pages/api-reference/next-config-js/redirects#regex-path-matching)
         }
 
         const target = redirect.target as RedirectsLinkBlockData;

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -114,7 +114,7 @@ export const RedirectForm = ({ mode, id, linkBlock, scope }: Props): JSX.Element
                 return <FormattedMessage id="comet.pages.redirects.validate.path.error" defaultMessage="Needs to start with /" />;
             } else if (value.includes("?")) {
                 return <FormattedMessage id="comet.pages.redirects.validate.path.queryStringError" defaultMessage="Must not contain ?" />;
-            } else if (!/^\/([a-zA-Z0-9-._~/]|%[0-9a-fA-F]{2})+$/.test(value)) {
+            } else if (!/^\/([a-zA-Z0-9-._~/:]|%[0-9a-fA-F]{2})+$/.test(value)) {
                 return <FormattedMessage id="comet.pages.redirects.validate.path.invalidPathError" defaultMessage="Invalid path" />;
             }
 

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -112,9 +112,7 @@ export const RedirectForm = ({ mode, id, linkBlock, scope }: Props): JSX.Element
         if (allValues.sourceType === "path") {
             if (!value.startsWith("/")) {
                 return <FormattedMessage id="comet.pages.redirects.validate.path.error" defaultMessage="Needs to start with /" />;
-            } else if (value.includes("?")) {
-                return <FormattedMessage id="comet.pages.redirects.validate.path.queryStringError" defaultMessage="Must not contain ?" />;
-            } else if (!/^\/([a-zA-Z0-9-._~/:]|%[0-9a-fA-F]{2})+$/.test(value)) {
+            } else if (!/^\/([a-zA-Z0-9-._~/:?=&]|%[0-9a-fA-F]{2})+$/.test(value)) {
                 return <FormattedMessage id="comet.pages.redirects.validate.path.invalidPathError" defaultMessage="Invalid path" />;
             }
 

--- a/packages/api/cms-api/src/redirects/validators/isValidRedirectSource.ts
+++ b/packages/api/cms-api/src/redirects/validators/isValidRedirectSource.ts
@@ -23,7 +23,7 @@ export class IsValidRedirectSourceConstraint implements ValidatorConstraintInter
         const sourceType = validationArguments.object.sourceType;
 
         if (sourceType === RedirectSourceTypeValues.path) {
-            return /^\/([a-zA-Z0-9-._~/]|%[0-9a-fA-F]{2})+$/.test(value);
+            return /^\/([a-zA-Z0-9-._~/:]|%[0-9a-fA-F]{2})+$/.test(value);
         } else {
             return isURL(value);
         }

--- a/packages/api/cms-api/src/redirects/validators/isValidRedirectSource.ts
+++ b/packages/api/cms-api/src/redirects/validators/isValidRedirectSource.ts
@@ -23,7 +23,7 @@ export class IsValidRedirectSourceConstraint implements ValidatorConstraintInter
         const sourceType = validationArguments.object.sourceType;
 
         if (sourceType === RedirectSourceTypeValues.path) {
-            return /^\/([a-zA-Z0-9-._~/:]|%[0-9a-fA-F]{2})+$/.test(value);
+            return /^\/([a-zA-Z0-9-._~/:?=&]|%[0-9a-fA-F]{2})+$/.test(value);
         } else {
             return isURL(value);
         }


### PR DESCRIPTION
Nextjs uses some characters like ":" for regex path matching.
However, there are redirects that need to be created that can contain a ":". 

https://nextjs.org/docs/pages/api-reference/next-config-js/redirects#regex-path-matching