### PR TITLE
Fix api-generator path detection for RichText blocks as they don't use createBlock

### DIFF
--- a/packages/api/blocks-api/src/blocks/helpers/lookupPath.ts
+++ b/packages/api/blocks-api/src/blocks/helpers/lookupPath.ts
@@ -39,8 +39,7 @@ export function lookupPath(): string | undefined {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const stack = new Error().stack!.split("\n");
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    let line = stack.findIndex((line) => line.includes("createBlock"))!;
+    let line = stack.findIndex((line) => line.includes("createBlock") || line.includes("createRichTextBlock"));
 
     if (line === -1) {
         return undefined;


### PR DESCRIPTION
This is re-implemented using a completely different technique in next (ts-morph)