### PR TITLE
Allow forcing a Block Index Update via GraphQL Query

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -149,7 +149,7 @@ type Page implements DocumentInterface {
   seo: SeoBlockData!
   createdAt: DateTime!
   pageTreeNode: PageTreeNode
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
 }
 
 """PageContent root block data"""
@@ -188,7 +188,7 @@ type PageTreeNode {
   path: String!
   parentNodes: [PageTreeNode!]!
   document: PageContentUnion
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, force: Boolean = false): PaginatedDependencies!
 }
 
 enum PageTreeNodeVisibility {
@@ -272,7 +272,7 @@ type DamFile {
   fileUrl: String!
   duplicates: [DamFile!]!
   damPath: String!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, force: Boolean = false): PaginatedDependencies!
 }
 
 type FooterContentScope {
@@ -286,7 +286,7 @@ type Footer implements DocumentInterface {
   content: FooterContentBlockData!
   scope: FooterContentScope!
   createdAt: DateTime!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
 }
 
 """FooterContent root block data"""
@@ -298,7 +298,7 @@ type MainMenuItem {
   content: RichTextBlockData
   createdAt: DateTime!
   updatedAt: DateTime!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
 }
 
 """RichText root block data"""
@@ -333,8 +333,8 @@ type News implements DocumentInterface {
   content: NewsContentBlockData!
   createdAt: DateTime!
   comments: [NewsComment!]!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter): PaginatedDependencies!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, force: Boolean = false): PaginatedDependencies!
 }
 
 enum NewsCategory {
@@ -466,7 +466,7 @@ type Redirect implements DocumentInterface {
   generationType: RedirectGenerationType!
   createdAt: DateTime!
   scope: RedirectScope!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
 }
 
 enum RedirectSourceTypeValues {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -149,7 +149,7 @@ type Page implements DocumentInterface {
   seo: SeoBlockData!
   createdAt: DateTime!
   pageTreeNode: PageTreeNode
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 """PageContent root block data"""
@@ -188,7 +188,7 @@ type PageTreeNode {
   path: String!
   parentNodes: [PageTreeNode!]!
   document: PageContentUnion
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 enum PageTreeNodeVisibility {
@@ -272,7 +272,7 @@ type DamFile {
   fileUrl: String!
   duplicates: [DamFile!]!
   damPath: String!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 type FooterContentScope {
@@ -286,7 +286,7 @@ type Footer implements DocumentInterface {
   content: FooterContentBlockData!
   scope: FooterContentScope!
   createdAt: DateTime!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 """FooterContent root block data"""
@@ -298,7 +298,7 @@ type MainMenuItem {
   content: RichTextBlockData
   createdAt: DateTime!
   updatedAt: DateTime!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 """RichText root block data"""
@@ -333,8 +333,8 @@ type News implements DocumentInterface {
   content: NewsContentBlockData!
   createdAt: DateTime!
   comments: [NewsComment!]!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 enum NewsCategory {
@@ -466,7 +466,7 @@ type Redirect implements DocumentInterface {
   generationType: RedirectGenerationType!
   createdAt: DateTime!
   scope: RedirectScope!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 enum RedirectSourceTypeValues {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -149,7 +149,7 @@ type Page implements DocumentInterface {
   seo: SeoBlockData!
   createdAt: DateTime!
   pageTreeNode: PageTreeNode
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
 }
 
 """PageContent root block data"""
@@ -188,7 +188,7 @@ type PageTreeNode {
   path: String!
   parentNodes: [PageTreeNode!]!
   document: PageContentUnion
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, force: Boolean = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean = false): PaginatedDependencies!
 }
 
 enum PageTreeNodeVisibility {
@@ -272,7 +272,7 @@ type DamFile {
   fileUrl: String!
   duplicates: [DamFile!]!
   damPath: String!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, force: Boolean = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean = false): PaginatedDependencies!
 }
 
 type FooterContentScope {
@@ -286,7 +286,7 @@ type Footer implements DocumentInterface {
   content: FooterContentBlockData!
   scope: FooterContentScope!
   createdAt: DateTime!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
 }
 
 """FooterContent root block data"""
@@ -298,7 +298,7 @@ type MainMenuItem {
   content: RichTextBlockData
   createdAt: DateTime!
   updatedAt: DateTime!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
 }
 
 """RichText root block data"""
@@ -333,8 +333,8 @@ type News implements DocumentInterface {
   content: NewsContentBlockData!
   createdAt: DateTime!
   comments: [NewsComment!]!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, force: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean = false): PaginatedDependencies!
 }
 
 enum NewsCategory {
@@ -466,7 +466,7 @@ type Redirect implements DocumentInterface {
   generationType: RedirectGenerationType!
   createdAt: DateTime!
   scope: RedirectScope!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
 }
 
 enum RedirectSourceTypeValues {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -140,7 +140,7 @@ type PageTreeNode {
   path: String!
   parentNodes: [PageTreeNode!]!
   document: PageContentUnion
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 enum PageTreeNodeVisibility {
@@ -190,7 +190,7 @@ type Redirect implements DocumentInterface {
   active: Boolean!
   generationType: RedirectGenerationType!
   createdAt: DateTime!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 enum RedirectSourceTypeValues {
@@ -248,7 +248,7 @@ type DamFile {
   fileUrl: String!
   duplicates: [DamFile!]!
   damPath: String!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 type PaginatedDamItems {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -140,7 +140,7 @@ type PageTreeNode {
   path: String!
   parentNodes: [PageTreeNode!]!
   document: PageContentUnion
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, force: Boolean = false): PaginatedDependencies!
 }
 
 enum PageTreeNodeVisibility {
@@ -190,7 +190,7 @@ type Redirect implements DocumentInterface {
   active: Boolean!
   generationType: RedirectGenerationType!
   createdAt: DateTime!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
 }
 
 enum RedirectSourceTypeValues {
@@ -248,7 +248,7 @@ type DamFile {
   fileUrl: String!
   duplicates: [DamFile!]!
   damPath: String!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, force: Boolean = false): PaginatedDependencies!
 }
 
 type PaginatedDamItems {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -140,7 +140,7 @@ type PageTreeNode {
   path: String!
   parentNodes: [PageTreeNode!]!
   document: PageContentUnion
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, force: Boolean = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean = false): PaginatedDependencies!
 }
 
 enum PageTreeNodeVisibility {
@@ -190,7 +190,7 @@ type Redirect implements DocumentInterface {
   active: Boolean!
   generationType: RedirectGenerationType!
   createdAt: DateTime!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, force: Boolean = false): PaginatedDependencies!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean = false): PaginatedDependencies!
 }
 
 enum RedirectSourceTypeValues {
@@ -248,7 +248,7 @@ type DamFile {
   fileUrl: String!
   duplicates: [DamFile!]!
   damPath: String!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, force: Boolean = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean = false): PaginatedDependencies!
 }
 
 type PaginatedDamItems {

--- a/packages/api/cms-api/src/dependencies/dependencies.resolver.factory.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.resolver.factory.ts
@@ -15,9 +15,9 @@ export class DependenciesResolverFactory {
             @ResolveField(() => PaginatedDependencies)
             async dependencies(
                 @Parent() node: AnyEntity<{ id: string }>,
-                @Args() { filter, offset, limit, force }: DependenciesArgs,
+                @Args() { filter, offset, limit, forceRefresh }: DependenciesArgs,
             ): Promise<PaginatedDependencies> {
-                return this.dependenciesService.getDependencies(node, filter, { offset, limit }, { force });
+                return this.dependenciesService.getDependencies(node, filter, { offset, limit }, { force: forceRefresh });
             }
         }
 

--- a/packages/api/cms-api/src/dependencies/dependencies.resolver.factory.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.resolver.factory.ts
@@ -17,7 +17,7 @@ export class DependenciesResolverFactory {
                 @Parent() node: AnyEntity<{ id: string }>,
                 @Args() { filter, offset, limit, forceRefresh }: DependenciesArgs,
             ): Promise<PaginatedDependencies> {
-                return this.dependenciesService.getDependencies(node, filter, { offset, limit }, { force: forceRefresh });
+                return this.dependenciesService.getDependencies(node, filter, { offset, limit }, { forceRefresh });
             }
         }
 

--- a/packages/api/cms-api/src/dependencies/dependencies.resolver.factory.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.resolver.factory.ts
@@ -15,9 +15,9 @@ export class DependenciesResolverFactory {
             @ResolveField(() => PaginatedDependencies)
             async dependencies(
                 @Parent() node: AnyEntity<{ id: string }>,
-                @Args() { filter, offset, limit }: DependenciesArgs,
+                @Args() { filter, offset, limit, force }: DependenciesArgs,
             ): Promise<PaginatedDependencies> {
-                return this.dependenciesService.getDependencies(node, filter, { offset, limit });
+                return this.dependenciesService.getDependencies(node, filter, { offset, limit }, { force });
             }
         }
 

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -173,9 +173,9 @@ export class DependenciesService {
             rootEntityName?: string;
         },
         paginationArgs?: { offset: number; limit: number },
-        options?: { force: boolean },
+        options?: { forceRefresh: boolean },
     ): Promise<PaginatedDependencies> {
-        await this.refreshViews({ force: options?.force });
+        await this.refreshViews({ force: options?.forceRefresh });
 
         const entityName = "entityName" in target ? target.entityName : target.constructor.name;
 
@@ -202,9 +202,9 @@ export class DependenciesService {
             targetEntityName?: string;
         },
         paginationArgs?: { offset: number; limit: number },
-        options?: { force: boolean },
+        options?: { forceRefresh: boolean },
     ): Promise<PaginatedDependencies> {
-        await this.refreshViews({ force: options?.force });
+        await this.refreshViews({ force: options?.forceRefresh });
 
         const entityName = "entityName" in root ? root.entityName : root.constructor.name;
 

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -4,6 +4,7 @@ import { EntityManager, EntityRepository, Knex } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
 import * as console from "console";
 import { subMinutes } from "date-fns";
+import { v4 } from "uuid";
 
 import { Dependency } from "./dependency";
 import { DiscoverService } from "./discover.service";
@@ -91,14 +92,15 @@ export class DependenciesService {
 
     async refreshViews(options?: { force?: boolean; awaitRefresh?: boolean }): Promise<void> {
         const refresh = async (options?: { concurrently: boolean }) => {
-            console.time("refresh materialized block dependency");
+            const uuid = v4();
+            console.time(`refresh materialized block dependency ${uuid}`);
             const blockIndexRefresh = this.refreshRepository.create({ startedAt: new Date() });
             await this.refreshRepository.getEntityManager().persistAndFlush(blockIndexRefresh);
 
             await this.connection.execute(`REFRESH MATERIALIZED VIEW ${options?.concurrently ? "CONCURRENTLY" : ""} block_index_dependencies`);
 
             await this.refreshRepository.getEntityManager().persistAndFlush(Object.assign(blockIndexRefresh, { finishedAt: new Date() }));
-            console.timeEnd("refresh materialized block dependency");
+            console.timeEnd(`refresh materialized block dependency ${uuid}`);
         };
 
         const abortActiveRefreshes = async (activeRefreshes: PGStatActivity[]) => {
@@ -171,8 +173,9 @@ export class DependenciesService {
             rootEntityName?: string;
         },
         paginationArgs?: { offset: number; limit: number },
+        options?: { force: boolean },
     ): Promise<PaginatedDependencies> {
-        await this.refreshViews();
+        await this.refreshViews({ force: options?.force });
 
         const entityName = "entityName" in target ? target.entityName : target.constructor.name;
 
@@ -199,8 +202,9 @@ export class DependenciesService {
             targetEntityName?: string;
         },
         paginationArgs?: { offset: number; limit: number },
+        options?: { force: boolean },
     ): Promise<PaginatedDependencies> {
-        await this.refreshViews();
+        await this.refreshViews({ force: options?.force });
 
         const entityName = "entityName" in root ? root.entityName : root.constructor.name;
 

--- a/packages/api/cms-api/src/dependencies/dependents.resolver.factory.ts
+++ b/packages/api/cms-api/src/dependencies/dependents.resolver.factory.ts
@@ -15,9 +15,9 @@ export class DependentsResolverFactory {
             @ResolveField(() => PaginatedDependencies)
             async dependents(
                 @Parent() node: AnyEntity<{ id: string }>,
-                @Args() { filter, offset, limit }: DependentsArgs,
+                @Args() { filter, offset, limit, force }: DependentsArgs,
             ): Promise<PaginatedDependencies> {
-                return this.dependenciesService.getDependents(node, filter, { offset, limit });
+                return this.dependenciesService.getDependents(node, filter, { offset, limit }, { force });
             }
         }
 

--- a/packages/api/cms-api/src/dependencies/dependents.resolver.factory.ts
+++ b/packages/api/cms-api/src/dependencies/dependents.resolver.factory.ts
@@ -15,9 +15,9 @@ export class DependentsResolverFactory {
             @ResolveField(() => PaginatedDependencies)
             async dependents(
                 @Parent() node: AnyEntity<{ id: string }>,
-                @Args() { filter, offset, limit, force }: DependentsArgs,
+                @Args() { filter, offset, limit, forceRefresh }: DependentsArgs,
             ): Promise<PaginatedDependencies> {
-                return this.dependenciesService.getDependents(node, filter, { offset, limit }, { force });
+                return this.dependenciesService.getDependents(node, filter, { offset, limit }, { force: forceRefresh });
             }
         }
 

--- a/packages/api/cms-api/src/dependencies/dependents.resolver.factory.ts
+++ b/packages/api/cms-api/src/dependencies/dependents.resolver.factory.ts
@@ -17,7 +17,7 @@ export class DependentsResolverFactory {
                 @Parent() node: AnyEntity<{ id: string }>,
                 @Args() { filter, offset, limit, forceRefresh }: DependentsArgs,
             ): Promise<PaginatedDependencies> {
-                return this.dependenciesService.getDependents(node, filter, { offset, limit }, { force: forceRefresh });
+                return this.dependenciesService.getDependents(node, filter, { offset, limit }, { forceRefresh });
             }
         }
 

--- a/packages/api/cms-api/src/dependencies/dto/dependencies.args.ts
+++ b/packages/api/cms-api/src/dependencies/dto/dependencies.args.ts
@@ -16,7 +16,7 @@ export class DependenciesArgs extends OffsetBasedPaginationArgs {
 
     @Field(() => Boolean, { nullable: true, defaultValue: false })
     @IsUndefinable()
-    force: boolean;
+    forceRefresh: boolean;
 }
 
 @ArgsType()
@@ -29,5 +29,5 @@ export class DependentsArgs extends OffsetBasedPaginationArgs {
 
     @Field(() => Boolean, { nullable: true, defaultValue: false })
     @IsUndefinable()
-    force: boolean;
+    forceRefresh: boolean;
 }

--- a/packages/api/cms-api/src/dependencies/dto/dependencies.args.ts
+++ b/packages/api/cms-api/src/dependencies/dto/dependencies.args.ts
@@ -15,7 +15,6 @@ export class DependenciesArgs extends OffsetBasedPaginationArgs {
     filter?: DependencyFilter;
 
     @Field(() => Boolean, { defaultValue: false })
-    @IsUndefinable()
     forceRefresh: boolean;
 }
 
@@ -28,6 +27,5 @@ export class DependentsArgs extends OffsetBasedPaginationArgs {
     filter?: DependentFilter;
 
     @Field(() => Boolean, { defaultValue: false })
-    @IsUndefinable()
     forceRefresh: boolean;
 }

--- a/packages/api/cms-api/src/dependencies/dto/dependencies.args.ts
+++ b/packages/api/cms-api/src/dependencies/dto/dependencies.args.ts
@@ -14,7 +14,7 @@ export class DependenciesArgs extends OffsetBasedPaginationArgs {
     @IsUndefinable()
     filter?: DependencyFilter;
 
-    @Field(() => Boolean, { nullable: true, defaultValue: false })
+    @Field(() => Boolean, { defaultValue: false })
     @IsUndefinable()
     forceRefresh: boolean;
 }
@@ -27,7 +27,7 @@ export class DependentsArgs extends OffsetBasedPaginationArgs {
     @IsUndefinable()
     filter?: DependentFilter;
 
-    @Field(() => Boolean, { nullable: true, defaultValue: false })
+    @Field(() => Boolean, { defaultValue: false })
     @IsUndefinable()
     forceRefresh: boolean;
 }

--- a/packages/api/cms-api/src/dependencies/dto/dependencies.args.ts
+++ b/packages/api/cms-api/src/dependencies/dto/dependencies.args.ts
@@ -1,8 +1,9 @@
 import { ArgsType, Field } from "@nestjs/graphql";
 import { Type } from "class-transformer";
-import { IsOptional, ValidateNested } from "class-validator";
+import { ValidateNested } from "class-validator";
 
 import { OffsetBasedPaginationArgs } from "../../common/pagination/offset-based.args";
+import { IsUndefinable } from "../../common/validators/is-undefinable";
 import { DependencyFilter, DependentFilter } from "./dependencies.filter";
 
 @ArgsType()
@@ -10,8 +11,12 @@ export class DependenciesArgs extends OffsetBasedPaginationArgs {
     @Field(() => DependencyFilter, { nullable: true })
     @ValidateNested()
     @Type(() => DependencyFilter)
-    @IsOptional()
+    @IsUndefinable()
     filter?: DependencyFilter;
+
+    @Field(() => Boolean, { nullable: true, defaultValue: false })
+    @IsUndefinable()
+    force: boolean;
 }
 
 @ArgsType()
@@ -19,6 +24,10 @@ export class DependentsArgs extends OffsetBasedPaginationArgs {
     @Field(() => DependentFilter, { nullable: true })
     @ValidateNested()
     @Type(() => DependentFilter)
-    @IsOptional()
+    @IsUndefinable()
     filter?: DependentFilter;
+
+    @Field(() => Boolean, { nullable: true, defaultValue: false })
+    @IsUndefinable()
+    force: boolean;
 }


### PR DESCRIPTION
depends on https://github.com/vivid-planet/comet/pull/1222

- add a `forceRefresh` arg to `dependencies()` and `dependents()` field resolver