### PR TITLE
Migration fix: alter table PageTreeNode only if exists

### DIFF
--- a/packages/api/cms-api/src/mikro-orm/migrations/Migration20230302145445.ts
+++ b/packages/api/cms-api/src/mikro-orm/migrations/Migration20230302145445.ts
@@ -2,12 +2,20 @@ import { Migration } from "@mikro-orm/migrations";
 
 export class Migration20230302145445 extends Migration {
     async up(): Promise<void> {
-        this.addSql('alter table "PageTreeNode" add column "updatedAt" timestamp with time zone;');
-        this.addSql('update "PageTreeNode" SET "updatedAt"=CURRENT_DATE');
-        this.addSql('alter table "PageTreeNode" alter column "updatedAt" set not null');
+        this.addSql('alter table if exists "PageTreeNode" add column if not exists "updatedAt" timestamp with time zone;');
+        this.addSql(
+            `do $$
+            begin
+                if exists (select 1 from pg_class where relname='PageTreeNode')
+                then update "PageTreeNode" SET "updatedAt"=CURRENT_DATE;
+                end if;
+            end
+            $$;`,
+        );
+        this.addSql('alter table if exists "PageTreeNode" alter column "updatedAt" set not null');
     }
 
     async down(): Promise<void> {
-        this.addSql('alter table "PageTreeNode" drop column "updatedAt";');
+        this.addSql('alter table if exists "PageTreeNode" drop column "updatedAt";');
     }
 }


### PR DESCRIPTION
the change is needed because i'm getting the following error in one of my projects:

```Processing 'Migration20230302145445'
MigrationError: Migration Migration20230302145445 (up) failed: Original error: alter table "PageTreeNode" add column "updatedAt" timestamp with time zone; - relation "PageTreeNode" does not exist
at /opt/app-root/src/node_modules/umzug/lib/umzug.js:151:27
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async Umzug.runCommand (/opt/app-root/src/node_modules/umzug/lib/umzug.js:107:20)
at async Migrator.runInTransaction (/opt/app-root/src/node_modules/@mikro-orm/migrations/Migrator.js:290:21)
at async MigrateConsole.migrate (/opt/app-root/src/dist/db/migrate.console.js:52:13) {
cause: TableNotFoundException: alter table "PageTreeNode" add column "updatedAt" timestamp with time zone; - relation "PageTreeNode" does not exist```