### PR TITLE
Fix improper validation of dynamic DTOs

### DIFF
--- a/.changeset/early-pots-thank.md
+++ b/.changeset/early-pots-thank.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix improper validation of input when creating/updating page tree nodes or redirects

--- a/packages/api/cms-api/src/common/validation/dynamic-dto-validation.pipe.ts
+++ b/packages/api/cms-api/src/common/validation/dynamic-dto-validation.pipe.ts
@@ -1,0 +1,16 @@
+import { Type, ValidationPipe } from "@nestjs/common";
+
+import { ValidationExceptionFactory } from "../errors/validation.exception-factory";
+
+export class DynamicDtoValidationPipe extends ValidationPipe {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(expectedType: Type<any>) {
+        super({
+            exceptionFactory: ValidationExceptionFactory,
+            transform: true,
+            forbidNonWhitelisted: true,
+            whitelist: true,
+            expectedType,
+        });
+    }
+}

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -3,6 +3,7 @@ import { Args, createUnionType, ID, Info, Mutation, Parent, Query, ResolveField,
 import { GraphQLError, GraphQLResolveInfo } from "graphql";
 
 import { SubjectEntity } from "../common/decorators/subject-entity.decorator";
+import { DynamicDtoValidationPipe } from "../common/validation/dynamic-dto-validation.pipe";
 import { DocumentInterface } from "../document/dto/document-interface";
 import { AttachedDocumentLoaderService } from "./attached-document-loader.service";
 import { EmptyPageTreeNodeScope } from "./dto/empty-page-tree-node-scope";
@@ -193,7 +194,8 @@ export function createPageTreeResolver({
         @SubjectEntity(PageTreeNode)
         async updatePageTreeNode(
             @Args("id", { type: () => ID }) id: string,
-            @Args("input", { type: () => PageTreeNodeUpdateInput }) input: PageTreeNodeUpdateInputInterface,
+            @Args("input", { type: () => PageTreeNodeUpdateInput }, new DynamicDtoValidationPipe(PageTreeNodeUpdateInput))
+            input: PageTreeNodeUpdateInputInterface,
         ): Promise<PageTreeNodeInterface> {
             // Archived pages cannot be updated
             const pageTreeReadApi = this.pageTreeService.createReadApi({
@@ -348,8 +350,9 @@ export function createPageTreeResolver({
 
         @Mutation(() => PageTreeNode)
         async createPageTreeNode(
-            @Args("input", { type: () => PageTreeNodeCreateInput }) input: PageTreeNodeCreateInputInterface,
-            @Args("scope", { type: () => Scope }) scope: ScopeInterface,
+            @Args("input", { type: () => PageTreeNodeCreateInput }, new DynamicDtoValidationPipe(PageTreeNodeCreateInput))
+            input: PageTreeNodeCreateInputInterface,
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: ScopeInterface,
             @Args("category", { type: () => String }) category: PageTreeNodeCategory,
         ): Promise<PageTreeNodeInterface> {
             // Can not add a subpage under an archived page


### PR DESCRIPTION
The global validation pipeline can't validate dynamic DTOs (for instance, `PageTreeNodeUpdateInput`) as it can't transform the provided input to the respective classes. This is due to missing TypeScript metadata for interfaces (see hint in [NestJS docs on validation](https://docs.nestjs.com/techniques/validation#auto-validation)). To fix this, we add a new `DynamicDtoValidationPipe` that transforms the provided input to the class using the `expectedType` option of `ValidationPipe`. This pipe needs to be used for all args that use dynamic DTOs.