### PR TITLE
Expose pixelImage fileUrl only in admin

### DIFF
--- a/.changeset/lemon-bees-drop.md
+++ b/.changeset/lemon-bees-drop.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Prevent the fileUrl from being exposed in the Site via the PixelImageBlock

--- a/packages/api/cms-api/src/blocks/PixelImageBlock.ts
+++ b/packages/api/cms-api/src/blocks/PixelImageBlock.ts
@@ -28,7 +28,7 @@ class PixelImageBlockData extends BlockData {
 
     async transformToPlain(
         { filesService, imagesService }: { filesService: FilesService; imagesService: ImagesService },
-        { previewDamUrls }: BlockContext,
+        { previewDamUrls, includeInvisibleContent }: BlockContext,
     ): Promise<TraversableTransformResponse> {
         if (!this.damFileId) {
             return {};
@@ -43,6 +43,8 @@ class PixelImageBlockData extends BlockData {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { createdAt, updatedAt, folder, license, ...data } = file;
 
+        const fileUrl = includeInvisibleContent ? await filesService.createFileUrl(file, previewDamUrls) : undefined;
+
         return {
             damFile: {
                 ...data,
@@ -54,7 +56,7 @@ class PixelImageBlockData extends BlockData {
                           dominantColor: file.image.dominantColor,
                       }
                     : undefined,
-                fileUrl: await filesService.createFileUrl(file, previewDamUrls),
+                fileUrl,
             },
             cropArea: this.cropArea ? { ...this.cropArea } : undefined,
             urlTemplate: imagesService.createUrlTemplate({ file, cropArea: this.cropArea }, previewDamUrls),


### PR DESCRIPTION
Use the already existing context parameter includeInvisibleContent that is set in admin.

This avoids getting the fileUrl into site JSON which might be found by crawlers. We don't want the original file to be cralwed.