### PR TITLE
[v3] Fix improper validation of dynamic DTOs

### DIFF
--- a/.changeset/early-pots-thank.md
+++ b/.changeset/early-pots-thank.md
@@ -1,5 +1,0 @@
----
-"@comet/cms-api": patch
----
-
-Fix improper validation of input when creating/updating page tree nodes or redirects

--- a/.changeset/early-pots-thank.md
+++ b/.changeset/early-pots-thank.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix improper validation of input when creating/updating page tree nodes or redirects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.2.7
+
+_TBD_
+
+### @comet/cms-api
+
+#### Changes
+
+-   Fix improper validation of input when creating/updating page tree nodes or redirects
+
 ## 3.2.6
 
 _Sep 4, 2023_

--- a/packages/api/cms-api/src/common/validation/dynamic-dto-validation.pipe.ts
+++ b/packages/api/cms-api/src/common/validation/dynamic-dto-validation.pipe.ts
@@ -1,0 +1,16 @@
+import { Type, ValidationPipe } from "@nestjs/common";
+
+import { ValidationExceptionFactory } from "../errors/validation.exception-factory";
+
+export class DynamicDtoValidationPipe extends ValidationPipe {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(expectedType: Type<any>) {
+        super({
+            exceptionFactory: ValidationExceptionFactory,
+            transform: true,
+            forbidNonWhitelisted: true,
+            whitelist: true,
+            expectedType,
+        });
+    }
+}

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -6,6 +6,7 @@ import { GraphQLError } from "graphql";
 
 import { getRequestContextHeadersFromRequest } from "../common/decorators/request-context.decorator";
 import { SubjectEntity } from "../common/decorators/subject-entity.decorator";
+import { DynamicDtoValidationPipe } from "../common/validation/dynamic-dto-validation.pipe";
 import { DocumentInterface } from "../document/dto/document-interface";
 import { EmptyPageTreeNodeScope } from "./dto/empty-page-tree-node-scope";
 import {
@@ -165,7 +166,8 @@ export function createPageTreeResolver({
         @SubjectEntity(PageTreeNode)
         async updatePageTreeNode(
             @Args("id", { type: () => ID }) id: string,
-            @Args("input", { type: () => PageTreeNodeUpdateInput }) input: PageTreeNodeUpdateInputInterface,
+            @Args("input", { type: () => PageTreeNodeUpdateInput }, new DynamicDtoValidationPipe(PageTreeNodeUpdateInput))
+            input: PageTreeNodeUpdateInputInterface,
         ): Promise<PageTreeNodeInterface> {
             // Archived pages cannot be updated
             const pageTreeReadApi = this.pageTreeService.createReadApi({
@@ -324,8 +326,9 @@ export function createPageTreeResolver({
 
         @Mutation(() => PageTreeNode)
         async createPageTreeNode(
-            @Args("input", { type: () => PageTreeNodeCreateInput }) input: PageTreeNodeCreateInputInterface,
-            @Args("scope", { type: () => Scope }) scope: ScopeInterface,
+            @Args("input", { type: () => PageTreeNodeCreateInput }, new DynamicDtoValidationPipe(PageTreeNodeCreateInput))
+            input: PageTreeNodeCreateInputInterface,
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: ScopeInterface,
             @Args("category", { type: () => String }) category: PageTreeNodeCategory,
         ): Promise<PageTreeNodeInterface> {
             // Can not add a subpage under an archived page

--- a/packages/api/cms-api/src/redirects/redirects.resolver.ts
+++ b/packages/api/cms-api/src/redirects/redirects.resolver.ts
@@ -3,14 +3,13 @@ import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
 import { forwardRef, Inject, Type } from "@nestjs/common";
 import { Args, ArgsType, CONTEXT, ID, Mutation, ObjectType, Query, Resolver } from "@nestjs/graphql";
-import { plainToInstance } from "class-transformer";
-import { validate } from "class-validator";
 import { Request } from "express";
 
 import { getRequestContextHeadersFromRequest } from "../common/decorators/request-context.decorator";
 import { SubjectEntity } from "../common/decorators/subject-entity.decorator";
 import { CometValidationException } from "../common/errors/validation.exception";
 import { PaginatedResponseFactory } from "../common/pagination/paginated-response.factory";
+import { DynamicDtoValidationPipe } from "../common/validation/dynamic-dto-validation.pipe";
 import { ScopeGuardActive } from "../content-scope/decorators/scope-guard-active.decorator";
 import { validateNotModified } from "../document/validateNotModified";
 import { PageTreeReadApi, PageTreeService } from "../page-tree/page-tree.service";
@@ -126,25 +125,18 @@ export function createRedirectsResolver({
 
         @Mutation(() => Redirect)
         async createRedirect(
-            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
-            @Args("input", { type: () => RedirectInput }) input: RedirectInputInterface,
+            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }, new DynamicDtoValidationPipe(Scope))
+            scope: typeof Scope,
+            @Args("input", { type: () => RedirectInput }, new DynamicDtoValidationPipe(RedirectInput)) input: RedirectInputInterface,
         ): Promise<RedirectInterface> {
             if (!(await this.redirectService.isRedirectSourceAvailable(input.source, nonEmptyScopeOrNothing(scope)))) {
                 throw new CometValidationException("Validation failed");
             }
 
-            const tranformedInput = plainToInstance(RedirectInput, input);
-
-            const errors = await validate(tranformedInput, { whitelist: true, forbidNonWhitelisted: true });
-
-            if (errors.length > 0) {
-                throw new CometValidationException("Validation failed", errors);
-            }
-
             const entity = this.repository.create({
                 scope: nonEmptyScopeOrNothing(scope),
-                ...tranformedInput,
-                target: tranformedInput.target.transformToBlockData(),
+                ...input,
+                target: input.target.transformToBlockData(),
             });
             await this.repository.persistAndFlush(entity);
             return this.repository.findOneOrFail(entity.id);
@@ -154,17 +146,9 @@ export function createRedirectsResolver({
         @SubjectEntity(Redirect)
         async updateRedirect(
             @Args("id", { type: () => ID }) id: string,
-            @Args("input", { type: () => RedirectInput }) input: RedirectInputInterface,
+            @Args("input", { type: () => RedirectInput }, new DynamicDtoValidationPipe(RedirectInput)) input: RedirectInputInterface,
             @Args("lastUpdatedAt", { type: () => Date, nullable: true }) lastUpdatedAt?: Date,
         ): Promise<RedirectInterface> {
-            const tranformedInput = plainToInstance(RedirectInput, input);
-
-            const errors = await validate(tranformedInput, { whitelist: true, forbidNonWhitelisted: true });
-
-            if (errors.length > 0) {
-                throw new CometValidationException("Validation failed", errors);
-            }
-
             const redirect = await this.repository.findOneOrFail(id);
             if (redirect != null && lastUpdatedAt) {
                 validateNotModified(redirect, lastUpdatedAt);
@@ -174,7 +158,7 @@ export function createRedirectsResolver({
                 throw new CometValidationException("Validation failed");
             }
 
-            wrap(redirect).assign({ ...tranformedInput, target: tranformedInput.target.transformToBlockData() });
+            wrap(redirect).assign({ ...input, target: input.target.transformToBlockData() });
             await this.repository.persistAndFlush(redirect);
             return this.repository.findOneOrFail(id);
         }


### PR DESCRIPTION
Backport https://github.com/vivid-planet/comet/pull/1266 to v3

---

The global validation pipeline can't validate dynamic DTOs (for instance, `PageTreeNodeUpdateInput`) as it can't transform the provided input to the respective classes. This is due to missing TypeScript metadata for interfaces (see hint in [NestJS docs on validation](https://docs.nestjs.com/techniques/validation#auto-validation)). To fix this, we add a new `DynamicDtoValidationPipe` that transforms the provided input to the class using the `expectedType` option of `ValidationPipe`. This pipe needs to be used for all args that use dynamic DTOs.