### PR TITLE
Ignore empty labels for publisher

### DIFF
--- a/.changeset/lovely-socks-watch.md
+++ b/.changeset/lovely-socks-watch.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Ignore empty labels for publisher

--- a/packages/admin/cms-admin/src/builds/PublisherPage.tsx
+++ b/packages/admin/cms-admin/src/builds/PublisherPage.tsx
@@ -83,7 +83,7 @@ export function PublisherPage(): React.ReactElement {
                             headerName: intl.formatMessage({ id: "comet.pages.publisher.name", defaultMessage: "Name" }),
                             flex: 2,
                             renderCell: ({ row }) => {
-                                return row.label ?? row.name;
+                                return row.label && row.label.length > 0 ? row.label : row.name;
                             },
                         },
                         {

--- a/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
+++ b/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
@@ -68,7 +68,7 @@ export function StartBuildsDialog(props: StartBuildsDialogProps) {
                             }),
                             flex: 1,
                             renderCell: ({ row }) => {
-                                return row.label ?? row.name;
+                                return row.label && row.label.length > 0 ? row.label : row.name;
                             },
                         },
                     ]}


### PR DESCRIPTION
We introduced the ability to set human readable labels for jobs in #1134. In some cases the label would be an empty string, resulting in nothing being display in the name column. This was fixed in #1189 and #1203, but only for `next`. This change backports the fix to `main`.