### PR TITLE
Rename dam entitiy class to match commonly used alias

### DIFF
--- a/.changeset/cyan-cycles-care.md
+++ b/.changeset/cyan-cycles-care.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": major
+---
+
+Rename dam entitiy class to match commonly used alias (File -> DamFile, Folder -> DamFolder)

--- a/packages/api/blocks-api/src/blocks/transformToSaveIndex/test/blocks/ImageBlock.ts
+++ b/packages/api/blocks-api/src/blocks/transformToSaveIndex/test/blocks/ImageBlock.ts
@@ -15,7 +15,7 @@ class ImageBlockData extends BlockData {
         return {
             dependencies: [
                 {
-                    targetEntityName: "File",
+                    targetEntityName: "DamFile",
                     id: this.damFileId,
                 },
             ],

--- a/packages/api/blocks-api/src/blocks/transformToSaveIndex/transformToSaveIndex.spec.ts
+++ b/packages/api/blocks-api/src/blocks/transformToSaveIndex/transformToSaveIndex.spec.ts
@@ -233,7 +233,7 @@ describe("transform to save index", () => {
                 visible: true,
                 dependencies: [
                     {
-                        targetEntityName: "File",
+                        targetEntityName: "DamFile",
                         id: "abc",
                     },
                 ],

--- a/packages/api/cms-api/src/dam/dam.module.ts
+++ b/packages/api/cms-api/src/dam/dam.module.ts
@@ -9,7 +9,7 @@ import { DAM_CONFIG, IMGPROXY_CONFIG } from "./dam.constants";
 import { createDamItemsResolver } from "./files/dam-items.resolver";
 import { DamItemsService } from "./files/dam-items.service";
 import { createFileEntity, FILE_ENTITY, FileInterface } from "./files/entities/file.entity";
-import { FileImage } from "./files/entities/file-image.entity";
+import { DamFileImage } from "./files/entities/file-image.entity";
 import { createFolderEntity, FolderInterface } from "./files/entities/folder.entity";
 import { FileImagesResolver } from "./files/file-image.resolver";
 import { FileLicensesResolver } from "./files/file-licenses.resolver";
@@ -86,7 +86,7 @@ export class DamModule {
 
         return {
             module: DamModule,
-            imports: [MikroOrmModule.forFeature([File, Folder, FileImage, ImageCropArea]), BlobStorageModule],
+            imports: [MikroOrmModule.forFeature([File, Folder, DamFileImage, ImageCropArea]), BlobStorageModule],
             providers: [
                 damConfigProvider,
                 DamItemsResolver,

--- a/packages/api/cms-api/src/dam/files/entities/file-image.entity.ts
+++ b/packages/api/cms-api/src/dam/files/entities/file-image.entity.ts
@@ -8,7 +8,7 @@ import { FileInterface } from "./file.entity";
 
 @Entity({ tableName: "DamFileImage" })
 @ObjectType("DamFileImage")
-export class FileImage extends BaseEntity<FileImage, "id"> {
+export class DamFileImage extends BaseEntity<DamFileImage, "id"> {
     @PrimaryKey({ columnType: "uuid" })
     @Field(() => ID)
     id: string = uuid();
@@ -33,6 +33,6 @@ export class FileImage extends BaseEntity<FileImage, "id"> {
     @Field(() => ImageCropArea)
     cropArea: ImageCropArea;
 
-    @OneToOne({ entity: "File", mappedBy: (file: FileInterface) => file.image, onDelete: "CASCADE" })
+    @OneToOne({ entity: "DamFile", mappedBy: (file: FileInterface) => file.image, onDelete: "CASCADE" })
     file: FileInterface;
 }

--- a/packages/api/cms-api/src/dam/files/entities/file.entity.ts
+++ b/packages/api/cms-api/src/dam/files/entities/file.entity.ts
@@ -4,7 +4,7 @@ import { Field, ID, Int, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
 
 import { DamScopeInterface } from "../../types";
-import { FileImage } from "./file-image.entity";
+import { DamFileImage } from "./file-image.entity";
 import { FolderInterface } from "./folder.entity";
 import { License } from "./license.embeddable";
 
@@ -19,7 +19,7 @@ export interface FileInterface extends BaseEntity<FileInterface, "id"> {
     title?: string;
     altText?: string;
     archived: boolean;
-    image?: FileImage;
+    image?: DamFileImage;
     license?: License;
     createdAt: Date;
     updatedAt: Date;
@@ -81,16 +81,16 @@ export function createFileEntity({ Scope, Folder }: { Scope?: Type<DamScopeInter
         })
         archived: boolean;
 
-        @Field(() => FileImage, { nullable: true })
+        @Field(() => DamFileImage, { nullable: true })
         @OneToOne({
-            entity: () => FileImage,
+            entity: () => DamFileImage,
             inversedBy: (image) => image.file,
             joinColumn: "imageId",
             nullable: true,
             cascade: [Cascade.ALL],
             eager: true,
         })
-        image?: FileImage;
+        image?: DamFileImage;
 
         @Field(() => License, { nullable: true })
         @Embedded(() => License, { nullable: true })
@@ -115,20 +115,20 @@ export function createFileEntity({ Scope, Folder }: { Scope?: Type<DamScopeInter
     if (Scope) {
         @Entity({ tableName: FILE_TABLE_NAME })
         @ObjectType("DamFile")
-        class File extends FileBase {
+        class DamFile extends FileBase {
             @Embedded(() => Scope)
             @Field(() => Scope)
             scope: typeof Scope;
         }
-        return File;
+        return DamFile;
     } else {
         @Entity({ tableName: FILE_TABLE_NAME })
         @ObjectType("DamFile")
-        class File extends FileBase {}
-        return File;
+        class DamFile extends FileBase {}
+        return DamFile;
     }
 }
 
-export const FILE_ENTITY = "File";
+export const FILE_ENTITY = "DamFile";
 
 export const FILE_TABLE_NAME = "DamFile";

--- a/packages/api/cms-api/src/dam/files/entities/folder.entity.ts
+++ b/packages/api/cms-api/src/dam/files/entities/folder.entity.ts
@@ -37,7 +37,7 @@ export function createFolderEntity({ Scope }: { Scope?: Type<DamScopeInterface> 
         name: string;
 
         @ManyToOne({
-            entity: "Folder",
+            entity: "DamFolder",
             inversedBy: (folder: FolderInterface) => folder.children,
             joinColumn: "parentId",
             nullable: true,
@@ -45,7 +45,7 @@ export function createFolderEntity({ Scope }: { Scope?: Type<DamScopeInterface> 
         })
         parent: FolderInterface | null;
 
-        @OneToMany("Folder", (folder: FolderInterface) => folder.parent)
+        @OneToMany("DamFolder", (folder: FolderInterface) => folder.parent)
         children: FolderInterface[];
 
         @Property({ persist: false })
@@ -65,7 +65,7 @@ export function createFolderEntity({ Scope }: { Scope?: Type<DamScopeInterface> 
         @Field()
         archived: boolean;
 
-        @OneToMany("File", (file: FileInterface) => file.folder)
+        @OneToMany("DamFile", (file: FileInterface) => file.folder)
         files: FileInterface[];
 
         @Property({ columnType: "timestamp with time zone" })
@@ -83,23 +83,23 @@ export function createFolderEntity({ Scope }: { Scope?: Type<DamScopeInterface> 
     if (Scope) {
         @Entity({ tableName: FOLDER_TABLE_NAME })
         @ObjectType("DamFolder")
-        class Folder extends FolderBase {
+        class DamFolder extends FolderBase {
             @Embedded(() => Scope)
             @Field(() => Scope)
             scope: typeof Scope;
 
-            @Field(() => Folder, { nullable: true })
-            parent: Folder | null;
+            @Field(() => DamFolder, { nullable: true })
+            parent: DamFolder | null;
         }
-        return Folder;
+        return DamFolder;
     } else {
         @Entity({ tableName: FOLDER_TABLE_NAME })
         @ObjectType("DamFolder")
-        class Folder extends FolderBase {
-            @Field(() => Folder, { nullable: true })
-            parent: Folder | null;
+        class DamFolder extends FolderBase {
+            @Field(() => DamFolder, { nullable: true })
+            parent: DamFolder | null;
         }
-        return Folder;
+        return DamFolder;
     }
 }
 

--- a/packages/api/cms-api/src/dam/files/file-image.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/file-image.resolver.ts
@@ -1,10 +1,10 @@
 import { Args, Int, Parent, ResolveField, Resolver } from "@nestjs/graphql";
 
 import { ImagesService } from "../images/images.service";
-import { FileImage } from "./entities/file-image.entity";
+import { DamFileImage } from "./entities/file-image.entity";
 import { FilesService } from "./files.service";
 
-@Resolver(() => FileImage)
+@Resolver(() => DamFileImage)
 export class FileImagesResolver {
     constructor(private readonly imagesService: ImagesService, private readonly filesService: FilesService) {}
 
@@ -12,7 +12,7 @@ export class FileImagesResolver {
     async url(
         @Args("width", { type: () => Int }) width: number,
         @Args("height", { type: () => Int }) height: number,
-        @Parent() fileImage: FileImage,
+        @Parent() fileImage: DamFileImage,
     ): Promise<string | undefined> {
         const file = await this.filesService.findOneByImageId(fileImage.id);
         if (file) {

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -43,8 +43,8 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
     class FilesResolver {
         constructor(
             private readonly filesService: FilesService,
-            @InjectRepository("File") private readonly filesRepository: EntityRepository<FileInterface>,
-            @InjectRepository("Folder") private readonly foldersRepository: EntityRepository<FolderInterface>,
+            @InjectRepository("DamFile") private readonly filesRepository: EntityRepository<FileInterface>,
+            @InjectRepository("DamFolder") private readonly foldersRepository: EntityRepository<FolderInterface>,
             private readonly contentScopeService: ContentScopeService,
         ) {}
 

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -28,7 +28,7 @@ import { CreateFileInput, UpdateFileInput } from "./dto/file.input";
 import { FileParams } from "./dto/file.params";
 import { FileUploadInterface } from "./dto/file-upload.interface";
 import { FILE_TABLE_NAME, FileInterface } from "./entities/file.entity";
-import { FileImage } from "./entities/file-image.entity";
+import { DamFileImage } from "./entities/file-image.entity";
 import { FolderInterface } from "./entities/folder.entity";
 import { createHashedPath, slugifyFilename } from "./files.utils";
 import { FoldersService } from "./folders.service";
@@ -96,8 +96,8 @@ export class FilesService {
     static readonly UPLOAD_FIELD = "file";
 
     constructor(
-        @InjectRepository("File") private readonly filesRepository: EntityRepository<FileInterface>,
-        @InjectRepository(FileImage) private readonly fileImagesRepository: EntityRepository<FileImage>,
+        @InjectRepository("DamFile") private readonly filesRepository: EntityRepository<FileInterface>,
+        @InjectRepository(DamFileImage) private readonly fileImagesRepository: EntityRepository<DamFileImage>,
         @Inject(forwardRef(() => BlobStorageBackendService)) private readonly blobStorageBackendService: BlobStorageBackendService,
         private readonly foldersService: FoldersService,
         @Inject(IMGPROXY_CONFIG) private readonly imgproxyConfig: ImgproxyConfig,
@@ -333,7 +333,7 @@ export class FilesService {
                 // See https://mikro-orm.io/docs/faq#you-cannot-call-emflush-from-inside-lifecycle-hook-handlers and
                 // https://mikro-orm.io/docs/unit-of-work for more information.
                 const entityManager = this.orm.em.fork();
-                const image = await entityManager.findOneOrFail(FileImage, result.image.id);
+                const image = await entityManager.findOneOrFail(DamFileImage, result.image.id);
 
                 this.calculateDominantColor(contentHash).then((dominantColor) => {
                     image.dominantColor = dominantColor;

--- a/packages/api/cms-api/src/dam/files/folders.service.ts
+++ b/packages/api/cms-api/src/dam/files/folders.service.ts
@@ -73,7 +73,7 @@ export class FoldersService {
     protected readonly logger = new Logger(FoldersService.name);
 
     constructor(
-        @InjectRepository("Folder") private readonly foldersRepository: EntityRepository<FolderInterface>,
+        @InjectRepository("DamFolder") private readonly foldersRepository: EntityRepository<FolderInterface>,
         @Inject(forwardRef(() => FilesService)) private readonly filesService: FilesService,
         private readonly orm: MikroORM,
     ) {}

--- a/packages/api/cms-api/src/dam/images/calculateDominantImageColor.console.ts
+++ b/packages/api/cms-api/src/dam/images/calculateDominantImageColor.console.ts
@@ -4,15 +4,15 @@ import { Injectable } from "@nestjs/common";
 import { Command, Console } from "nestjs-console";
 
 import { FileInterface } from "../files/entities/file.entity";
-import { FileImage } from "../files/entities/file-image.entity";
+import { DamFileImage } from "../files/entities/file-image.entity";
 import { FilesService } from "../files/files.service";
 
 @Injectable()
 @Console()
 export class CalculateDominantImageColor {
     constructor(
-        @InjectRepository("File") private readonly filesRepository: EntityRepository<FileInterface>,
-        @InjectRepository(FileImage) private readonly fileImagesRepository: EntityRepository<FileImage>,
+        @InjectRepository("DamFile") private readonly filesRepository: EntityRepository<FileInterface>,
+        @InjectRepository(DamFileImage) private readonly fileImagesRepository: EntityRepository<DamFileImage>,
         private readonly fileService: FilesService,
     ) {}
 

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -84,7 +84,7 @@ export { CreateFileInput, ImageFileInput, UpdateFileInput } from "./dam/files/dt
 export { FileUploadInterface } from "./dam/files/dto/file-upload.interface";
 export { CreateFolderInput, UpdateFolderInput } from "./dam/files/dto/folder.input";
 export { createFileEntity, FileInterface } from "./dam/files/entities/file.entity";
-export { FileImage } from "./dam/files/entities/file-image.entity";
+export { DamFileImage } from "./dam/files/entities/file-image.entity";
 export { createFolderEntity, FolderInterface } from "./dam/files/entities/folder.entity";
 export { FileImagesResolver } from "./dam/files/file-image.resolver";
 export { FilesService } from "./dam/files/files.service";


### PR DESCRIPTION
api-generator always uses the class name (from mikro-orm metadata) and not the application specific alias. Usually we use DamFile as alias in the application, align the class name in library with that.

Also now matches the graphql object type.