### PR TITLE
Fix Menu

### DIFF
--- a/packages/admin/admin/src/mui/menu/Menu.tsx
+++ b/packages/admin/admin/src/mui/menu/Menu.tsx
@@ -36,9 +36,10 @@ const MenuDrawer: React.FC<WithStyles<typeof styles> & MenuProps> = ({
     React.useEffect(() => {
         if (variant === "temporary" && open) {
             toggleOpen();
-            // workaround for issue: https://github.com/mui/material-ui/issues/35793
-            initialRender.current = false;
         }
+        // workaround for issue: https://github.com/mui/material-ui/issues/35793
+        initialRender.current = false;
+
         // useEffect dependencies need to stay empty, because the function should only be called on first render.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);


### PR DESCRIPTION
Before this change, the menu wouldn't open if you loaded the page on desktop and then made the window smaller.

Before:

https://github.com/vivid-planet/comet/assets/13380047/d722c849-871b-41ab-9413-565a86c8e93f


Now:

https://github.com/vivid-planet/comet/assets/13380047/017f83c0-3131-460a-8951-728c7285578e

