### PR TITLE
api generator: In relation input support different target types instead of assuming uuid

### DIFF
--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -145,7 +145,7 @@ export async function generateCrudInput(
                 decorators.push("@IsString()");
             } else if (refType == "integer") {
                 type = "number";
-                decorators.push("@IsInt()");
+                decorators.push("@Transform(({ value }) => parseInt(value))");
             } else {
                 console.warn(`${prop.name}: Unsupported referenced type`);
             }
@@ -186,7 +186,7 @@ export async function generateCrudInput(
                     decorators.push("@IsString({ each: true })");
                 } else if (refType == "integer") {
                     type = "number[]";
-                    decorators.push("@IsInt({ each: true })");
+                    decorators.push("@Transform(({ value }) => value.map(id) => parseInt(id))");
                 } else {
                     console.warn(`${prop.name}: Unsupported referenced type`);
                 }
@@ -209,7 +209,7 @@ export async function generateCrudInput(
                 decorators.push("@IsString({ each: true })");
             } else if (refType == "integer") {
                 type = "number[]";
-                decorators.push("@IsInt({ each: true })");
+                decorators.push("@Transform(({ value }) => value.map(id) => parseInt(id))");
             } else {
                 console.warn(`${prop.name}: Unsupported referenced type`);
             }

--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -146,6 +146,7 @@ export async function generateCrudInput(
             } else if (refType == "integer") {
                 type = "number";
                 decorators.push("@Transform(({ value }) => parseInt(value))");
+                decorators.push("@IsInt()");
             } else {
                 console.warn(`${prop.name}: Unsupported referenced type`);
             }
@@ -187,6 +188,7 @@ export async function generateCrudInput(
                 } else if (refType == "integer") {
                     type = "number[]";
                     decorators.push("@Transform(({ value }) => value.map(id) => parseInt(id))");
+                    decorators.push("@IsInt({ each: true })");
                 } else {
                     console.warn(`${prop.name}: Unsupported referenced type`);
                 }

--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -24,6 +24,23 @@ function tsCodeRecordToString(object: Record<string, string | undefined>) {
     return `{${filteredEntries.map(([key, value]) => `${key}: ${value},`).join("\n")}}`;
 }
 
+function findReferenceTargetType(
+    targetMeta: EntityMetadata<unknown> | undefined,
+    referencedColumnName: string,
+): "uuid" | "string" | "integer" | null {
+    const referencedColumnProp = targetMeta?.props.find((p) => p.name == referencedColumnName);
+    if (!referencedColumnProp) throw new Error("referencedColumnProp not found");
+    if (referencedColumnProp.type == "uuid") {
+        return "uuid";
+    } else if (referencedColumnProp.type == "string") {
+        return "string";
+    } else if (referencedColumnProp.type == "integer") {
+        return "integer";
+    } else {
+        return null;
+    }
+}
+
 export async function generateCrudInput(
     generatorOptions: { targetDirectory: string },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -114,8 +131,24 @@ export async function generateCrudInput(
                 defaultValue: defaultValueNull ? "null" : undefined,
             });
             decorators.push(`@Field(() => ID, ${fieldOptions})`);
-            decorators.push("@IsUUID()");
-            type = "string";
+
+            if (prop.referencedColumnNames.length > 1) {
+                console.warn(`${prop.name}: Composite keys are not supported`);
+                continue;
+            }
+            const refType = findReferenceTargetType(prop.targetMeta, prop.referencedColumnNames[0]);
+            if (refType == "uuid") {
+                type = "string";
+                decorators.push("@IsUUID()");
+            } else if (refType == "string") {
+                type = "string";
+                decorators.push("@IsString()");
+            } else if (refType == "integer") {
+                type = "number";
+                decorators.push("@IsInt()");
+            } else {
+                console.warn(`${prop.name}: Unsupported referenced type`);
+            }
         } else if (prop.reference == "1:m") {
             if (prop.orphanRemoval) {
                 //if orphanRemoval is enabled, we need to generate a nested input type
@@ -139,15 +172,47 @@ export async function generateCrudInput(
                 decorators.length = 0;
                 decorators.push(`@Field(() => [ID], {${prop.nullable ? "nullable: true" : "defaultValue: []"}})`);
                 decorators.push(`@IsArray()`);
-                decorators.push(`@IsUUID(undefined, { each: true })`);
-                type = "string[]";
+
+                if (prop.referencedColumnNames.length > 1) {
+                    console.warn(`${prop.name}: Composite keys are not supported`);
+                    continue;
+                }
+                const refType = findReferenceTargetType(prop.targetMeta, prop.referencedColumnNames[0]);
+                if (refType == "uuid") {
+                    type = "string[]";
+                    decorators.push("@IsUUID(undefined, { each: true })");
+                } else if (refType == "string") {
+                    type = "string[]";
+                    decorators.push("@IsString({ each: true })");
+                } else if (refType == "integer") {
+                    type = "number[]";
+                    decorators.push("@IsInt({ each: true })");
+                } else {
+                    console.warn(`${prop.name}: Unsupported referenced type`);
+                }
             }
         } else if (prop.reference == "m:n") {
             decorators.length = 0;
             decorators.push(`@Field(() => [ID], {${prop.nullable ? "nullable" : "defaultValue: []"}})`);
             decorators.push(`@IsArray()`);
-            decorators.push(`@IsUUID(undefined, { each: true })`);
-            type = "string[]";
+
+            if (prop.referencedColumnNames.length > 1) {
+                console.warn(`${prop.name}: Composite keys are not supported`);
+                continue;
+            }
+            const refType = findReferenceTargetType(prop.targetMeta, prop.referencedColumnNames[0]);
+            if (refType == "uuid") {
+                type = "string[]";
+                decorators.push("@IsUUID(undefined, { each: true })");
+            } else if (refType == "string") {
+                type = "string[]";
+                decorators.push("@IsString({ each: true })");
+            } else if (refType == "integer") {
+                type = "number[]";
+                decorators.push("@IsInt({ each: true })");
+            } else {
+                console.warn(`${prop.name}: Unsupported referenced type`);
+            }
         } else if (prop.reference == "1:1") {
             {
                 if (!prop.targetMeta) throw new Error("No targetMeta");
@@ -218,7 +283,7 @@ export async function generateCrudInput(
     }
     const inputOut = `import { Field, InputType, ID } from "@nestjs/graphql";
 import { Transform, Type } from "class-transformer";
-import { IsString, IsNotEmpty, ValidateNested, IsNumber, IsBoolean, IsDate, IsOptional, IsEnum, IsUUID, IsArray } from "class-validator";
+import { IsString, IsNotEmpty, ValidateNested, IsNumber, IsBoolean, IsDate, IsOptional, IsEnum, IsUUID, IsArray, IsInt } from "class-validator";
 import { IsSlug, RootBlockInputScalar, IsNullable, PartialType} from "@comet/cms-api";
 import { GraphQLJSONObject } from "graphql-type-json";
 import { BlockInputInterface, isBlockInputInterface } from "@comet/blocks-api";

--- a/packages/api/cms-api/src/generator/generate-crud-relations-id-integer.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-id-integer.spec.ts
@@ -1,0 +1,57 @@
+import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Ref } from "@mikro-orm/core";
+import { MikroORM } from "@mikro-orm/postgresql";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { v4 as uuid } from "uuid";
+
+import { generateCrud } from "./generate-crud";
+import { lintGeneratedFiles, parseSource } from "./utils/test-helper";
+
+@Entity()
+class TestEntityCategoryWithIntegerId extends BaseEntity<TestEntityCategoryWithIntegerId, "id"> {
+    @PrimaryKey({ columnType: "int", type: "integer" })
+    id: number;
+
+    @OneToMany(() => TestEntityProduct, (products) => products.category)
+    products = new Collection<TestEntityProduct>(this);
+}
+
+@Entity()
+class TestEntityProduct extends BaseEntity<TestEntityProduct, "id"> {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @ManyToOne(() => TestEntityCategoryWithIntegerId, { nullable: true, ref: true })
+    category?: Ref<TestEntityCategoryWithIntegerId>;
+}
+
+describe("GenerateCrudRelationsIdString", () => {
+    describe("resolver class", () => {
+        it("should be a valid generated ts file", async () => {
+            LazyMetadataStorage.load();
+            const orm = await MikroORM.init({
+                type: "postgresql",
+                dbName: "test-db",
+                entities: [TestEntityProduct, TestEntityCategoryWithIntegerId],
+            });
+
+            const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProduct"));
+            const lintedOut = await lintGeneratedFiles(out);
+            const file = lintedOut.find((file) => file.name === "dto/test-entity-product.input.ts");
+            if (!file) throw new Error("File not found");
+
+            const source = parseSource(file.content);
+            const classes = source.getClasses();
+            expect(classes.length).toBe(2);
+
+            const cls = classes[0];
+            const structure = cls.getStructure();
+            expect(structure.properties?.length).toBe(1);
+            expect(structure.properties?.[0].name).toBe("category");
+            expect(structure.properties?.[0].type).toBe("number");
+            expect(structure.properties?.[0].decorators?.length).toBe(3);
+            expect(structure.properties?.[0].decorators?.[2].name).toBe("IsInteger");
+
+            orm.close();
+        });
+    });
+});

--- a/packages/api/cms-api/src/generator/generate-crud-relations-id-integer.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-id-integer.spec.ts
@@ -50,7 +50,7 @@ describe("GenerateCrudRelationsIdString", () => {
             expect(structure.properties?.[0].type).toBe("number");
             expect(structure.properties?.[0].decorators?.length).toBe(3);
             const decorators = structure.properties?.[0].decorators?.map((dec) => dec.name);
-            expect(decorators).toContain("IsInt");
+            expect(decorators).toContain("Transform");
             expect(decorators).not.toContain("IsUUID");
             expect(decorators).not.toContain("IsString");
             orm.close();

--- a/packages/api/cms-api/src/generator/generate-crud-relations-id-integer.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-id-integer.spec.ts
@@ -48,9 +48,10 @@ describe("GenerateCrudRelationsIdString", () => {
             expect(structure.properties?.length).toBe(1);
             expect(structure.properties?.[0].name).toBe("category");
             expect(structure.properties?.[0].type).toBe("number");
-            expect(structure.properties?.[0].decorators?.length).toBe(3);
+            expect(structure.properties?.[0].decorators?.length).toBe(4);
             const decorators = structure.properties?.[0].decorators?.map((dec) => dec.name);
             expect(decorators).toContain("Transform");
+            expect(decorators).toContain("IsInt");
             expect(decorators).not.toContain("IsUUID");
             expect(decorators).not.toContain("IsString");
             orm.close();

--- a/packages/api/cms-api/src/generator/generate-crud-relations-id-integer.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-id-integer.spec.ts
@@ -26,7 +26,7 @@ class TestEntityProduct extends BaseEntity<TestEntityProduct, "id"> {
 
 describe("GenerateCrudRelationsIdString", () => {
     describe("resolver class", () => {
-        it("should be a valid generated ts file", async () => {
+        it("input type to category relation should be number with integer validator", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
                 type: "postgresql",
@@ -49,8 +49,10 @@ describe("GenerateCrudRelationsIdString", () => {
             expect(structure.properties?.[0].name).toBe("category");
             expect(structure.properties?.[0].type).toBe("number");
             expect(structure.properties?.[0].decorators?.length).toBe(3);
-            expect(structure.properties?.[0].decorators?.[2].name).toBe("IsInteger");
-
+            const decorators = structure.properties?.[0].decorators?.map((dec) => dec.name);
+            expect(decorators).toContain("IsInt");
+            expect(decorators).not.toContain("IsUUID");
+            expect(decorators).not.toContain("IsString");
             orm.close();
         });
     });

--- a/packages/api/cms-api/src/generator/generate-crud-relations-id-string.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-id-string.spec.ts
@@ -1,0 +1,57 @@
+import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Ref } from "@mikro-orm/core";
+import { MikroORM } from "@mikro-orm/postgresql";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { v4 as uuid } from "uuid";
+
+import { generateCrud } from "./generate-crud";
+import { lintGeneratedFiles, parseSource } from "./utils/test-helper";
+
+@Entity()
+class TestEntityCategoryWithStringId extends BaseEntity<TestEntityCategoryWithStringId, "id"> {
+    @PrimaryKey({ columnType: "text", type: "string" })
+    id: string;
+
+    @OneToMany(() => TestEntityProduct, (products) => products.category)
+    products = new Collection<TestEntityProduct>(this);
+}
+
+@Entity()
+class TestEntityProduct extends BaseEntity<TestEntityProduct, "id"> {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @ManyToOne(() => TestEntityCategoryWithStringId, { nullable: true, ref: true })
+    category?: Ref<TestEntityCategoryWithStringId>;
+}
+
+describe("GenerateCrudRelationsIdString", () => {
+    describe("resolver class", () => {
+        it("should be a valid generated ts file", async () => {
+            LazyMetadataStorage.load();
+            const orm = await MikroORM.init({
+                type: "postgresql",
+                dbName: "test-db",
+                entities: [TestEntityProduct, TestEntityCategoryWithStringId],
+            });
+
+            const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProduct"));
+            const lintedOut = await lintGeneratedFiles(out);
+            const file = lintedOut.find((file) => file.name === "dto/test-entity-product.input.ts");
+            if (!file) throw new Error("File not found");
+
+            const source = parseSource(file.content);
+            const classes = source.getClasses();
+            expect(classes.length).toBe(2);
+
+            const cls = classes[0];
+            const structure = cls.getStructure();
+            expect(structure.properties?.length).toBe(1);
+            expect(structure.properties?.[0].name).toBe("category");
+            expect(structure.properties?.[0].type).toBe("string");
+            expect(structure.properties?.[0].decorators?.length).toBe(3);
+            expect(structure.properties?.[0].decorators?.[2].name).toBe("IsString");
+
+            orm.close();
+        });
+    });
+});

--- a/packages/api/cms-api/src/generator/generate-crud-relations-id-string.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-id-string.spec.ts
@@ -26,7 +26,7 @@ class TestEntityProduct extends BaseEntity<TestEntityProduct, "id"> {
 
 describe("GenerateCrudRelationsIdString", () => {
     describe("resolver class", () => {
-        it("should be a valid generated ts file", async () => {
+        it("input type to category relation should be string with isString and not IsUuid validator", async () => {
             LazyMetadataStorage.load();
             const orm = await MikroORM.init({
                 type: "postgresql",
@@ -49,7 +49,9 @@ describe("GenerateCrudRelationsIdString", () => {
             expect(structure.properties?.[0].name).toBe("category");
             expect(structure.properties?.[0].type).toBe("string");
             expect(structure.properties?.[0].decorators?.length).toBe(3);
-            expect(structure.properties?.[0].decorators?.[2].name).toBe("IsString");
+            const decorators = structure.properties?.[0].decorators?.map((dec) => dec.name);
+            expect(decorators).toContain("IsString");
+            expect(decorators).not.toContain("IsUUID");
 
             orm.close();
         });


### PR DESCRIPTION
fixes test from #1285

Open question:

currently for Integer target types also graphl `ID` type is used.
- is this wanted
- is it even working (and converted by class-validator from string to number?)