### PR TITLE
api generator: fix generated update code for ManyToOne relations

### DIFF
--- a/demo/api/src/products/generated/product.resolver.ts
+++ b/demo/api/src/products/generated/product.resolver.ts
@@ -148,8 +148,6 @@ export class ProductResolver {
         } = input;
         product.assign({
             ...assignInput,
-
-            category: categoryInput ? Reference.create(await this.productCategoryRepository.findOneOrFail(categoryInput)) : undefined,
         });
         if (variantsInput) {
             product.variants.set(
@@ -176,6 +174,9 @@ export class ProductResolver {
             this.productStatisticsRepository.assign(statistic, {
                 ...statisticsInput,
             });
+        }
+        if (categoryInput !== undefined) {
+            product.category = categoryInput ? Reference.create(await this.productCategoryRepository.findOneOrFail(categoryInput)) : undefined;
         }
 
         if (imageInput) {


### PR DESCRIPTION
For update the input can be undefinable (do not change) or null (set to null). Now this case is supported

fixes issue from #1298, but doesn't integrate the test as it assets in a way I don't think it should be done. Too fragile when working with strings imho.