### PR TITLE
Admin Generator: Set fetchPolicy for grid query to cache-and-network

### DIFF
--- a/demo/admin/src/news/generated/NewsGrid.tsx
+++ b/demo/admin/src/news/generated/NewsGrid.tsx
@@ -216,6 +216,7 @@ export function NewsGrid(): React.ReactElement {
             limit: dataGridProps.pageSize,
             sort: muiGridSortToGql(dataGridProps.sortModel),
         },
+        fetchPolicy: "cache-and-network",
     });
     const rowCount = useBufferedRowCount(data?.newsList.totalCount);
     if (error) throw error;

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -195,6 +195,7 @@ function ProductsGrid() {
             limit: dataGridProps.pageSize,
             sort: muiGridSortToGql(sortModel),
         },
+        fetchPolicy: "cache-and-network",
     });
     const rows = data?.products.nodes ?? [];
     const rowCount = useBufferedRowCount(data?.products.totalCount);

--- a/demo/admin/src/products/categories/ProductCategoriesTable.tsx
+++ b/demo/admin/src/products/categories/ProductCategoriesTable.tsx
@@ -104,6 +104,7 @@ function ProductCategoriesTable() {
             ...muiGridPagingToGql({ page: dataGridProps.page, pageSize: dataGridProps.pageSize }),
             sort: muiGridSortToGql(sortModel),
         },
+        fetchPolicy: "cache-and-network",
     });
     const rows = data?.productCategories.nodes ?? [];
     const rowCount = useBufferedRowCount(data?.productCategories.totalCount);

--- a/demo/admin/src/products/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/generated/ProductsGrid.tsx
@@ -202,6 +202,7 @@ export function ProductsGrid(): React.ReactElement {
             limit: dataGridProps.pageSize,
             sort: muiGridSortToGql(dataGridProps.sortModel),
         },
+        fetchPolicy: "cache-and-network",
     });
     const rowCount = useBufferedRowCount(data?.products.totalCount);
     if (error) throw error;

--- a/demo/admin/src/products/tags/ProductTagTable.tsx
+++ b/demo/admin/src/products/tags/ProductTagTable.tsx
@@ -103,6 +103,7 @@ function ProductTagsTable() {
             limit: dataGridProps.pageSize,
             sort: muiGridSortToGql(sortModel),
         },
+        fetchPolicy: "cache-and-network",
     });
     const rows = data?.productTags.nodes ?? [];
     const rowCount = useBufferedRowCount(data?.productTags.totalCount);

--- a/packages/admin/cms-admin/src/generator/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/generateGrid.ts
@@ -417,6 +417,7 @@ export async function writeCrudGrid(
                 limit: dataGridProps.pageSize,
                 sort: muiGridSortToGql(dataGridProps.sortModel),
             },
+            fetchPolicy: "cache-and-network",
         });
         const rowCount = useBufferedRowCount(data?.${gridQuery}.totalCount);
         if (error) throw error;


### PR DESCRIPTION
- Fixes bug when creating a new entry to show up in the grid
- enabled reload after changing main menu

I consider this best practice for all grids. I want to avoid having the form a dependency on grid by triggering a reload after create.