### PR TITLE
api generator: Add test for optional enum

### DIFF
--- a/packages/api/cms-api/src/generator/generate-crud-enum-optional.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-enum-optional.spec.ts
@@ -1,0 +1,61 @@
+import { BaseEntity, Entity, Enum, PrimaryKey } from "@mikro-orm/core";
+import { MikroORM } from "@mikro-orm/postgresql";
+import { Field, registerEnumType } from "@nestjs/graphql";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { v4 as uuid } from "uuid";
+
+import { generateCrud } from "./generate-crud";
+import { lintGeneratedFiles, parseSource } from "./utils/test-helper";
+
+export enum TestEnum {
+    AND = "AND",
+    OR = "OR",
+}
+registerEnumType(TestEnum, {
+    name: "TestEnumOperator",
+});
+
+@Entity()
+class TestEntity extends BaseEntity<TestEntity, "id"> {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @Field(() => TestEnum, { nullable: true })
+    @Enum({ items: () => TestEnum, nullable: true })
+    foo?: TestEnum;
+}
+
+describe("GenerateCrudEnumOptional", () => {
+    it("should correctly determine enum import path", async () => {
+        LazyMetadataStorage.load();
+        const orm = await MikroORM.init({
+            type: "postgresql",
+            dbName: "test-db",
+            entities: [TestEntity],
+        });
+
+        const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntity"));
+        const lintedOut = await lintGeneratedFiles(out);
+        const file = lintedOut.find((file) => file.name === "dto/test-entity.input.ts");
+        if (!file) throw new Error("File not found");
+        const source = parseSource(file.content);
+
+        const classes = source.getClasses();
+        expect(classes.length).toBe(2);
+
+        const cls = classes[0];
+        const structure = cls.getStructure();
+        expect(structure.properties?.length).toBe(1);
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const prop = structure.properties![0];
+        expect(prop.name).toBe("foo");
+        expect(prop.type).toBe("TestEnum");
+        const decorators = prop.decorators?.map((i) => i.name);
+        expect(decorators).toContain("Field");
+        expect(decorators).toContain("IsEnum");
+        expect(decorators).toContain("IsNullable");
+
+        orm.close();
+    });
+});

--- a/packages/api/cms-api/src/generator/utils/ts-morph-helper.ts
+++ b/packages/api/cms-api/src/generator/utils/ts-morph-helper.ts
@@ -61,7 +61,10 @@ function findImportPath(importName: string, generatorOptions: { targetDirectory:
 
 export function findEnumName(propertyName: string, metadata: EntityMetadata<any>): string {
     const tsProp = morphTsProperty(propertyName, metadata);
-    return tsProp.getType().getText(tsProp);
+    return tsProp
+        .getType()
+        .getText(tsProp)
+        .replace(/ ?\| ?undefined$/, "");
 }
 
 export function findEnumImportPath(enumName: string, generatorOptions: { targetDirectory: string }, metadata: EntityMetadata<any>): string {


### PR DESCRIPTION
Optional enums currently cause an exception when generating the code. The reason for this is, that `findEnumName()` in ts-morph-helper.ts tries to get the class name via the type attribute which in this case results in `EnumName | undefined` (not a valid class name).

`TestEnum | undefined import not found in ./src/generator/generate-crud-enum-optional.spec.ts

      57 |         }
      58 |     }
      59 |     throw new Error(`${importName} import not found in ${metadata.path}`);
           |           ^
      60 | }
      61 |
      62 | export function findEnumName(propertyName: string, metadata: EntityMetadata<any>): string {

      at findImportPath (generator/utils/ts-morph-helper.ts:59:11)
      at findEnumImportPath (generator/utils/ts-morph-helper.ts:77:32)
      at generator/generate-crud-input.ts:81:50
      at generator/generate-crud-input.ts:8:71
      at Object.<anonymous>.__awaiter (generator/generate-crud-input.ts:4:12)
      at generateCrudInput (generator/generate-crud-input.ts:53:12)
      at generator/generate-crud.ts:957:40
      at generator/generate-crud.ts:31:71
      at Object.<anonymous>.__awaiter (generator/generate-crud.ts:27:12)
      at generateCrud (generator/generate-crud.ts:786:12)
      at generator/generate-crud-enum-optional.spec.ts:37:39
      at fulfilled (generator/generate-crud-enum-optional.spec.ts:14:58)`