### PR TITLE
api generator: Generate correctly typed id argument for integer ids

### DIFF
--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -2,6 +2,7 @@ import { EntityMetadata } from "@mikro-orm/core";
 
 import { hasFieldFeature } from "./crud-generator.decorator";
 import { buildNameVariants } from "./utils/build-name-variants";
+import { integerTypes } from "./utils/constants";
 import { generateImportsCode, Imports } from "./utils/generate-imports-code";
 import {
     findBlockImportPath,
@@ -99,7 +100,6 @@ export async function generateCrudInput(
             const initializer = morphTsProperty(prop.name, metadata).getInitializer()?.getText();
             const defaultValue = prop.nullable && (initializer == "undefined" || initializer == "null") ? "null" : initializer;
             const fieldOptions = tsCodeRecordToString({ nullable: prop.nullable ? "true" : undefined, defaultValue });
-            const integerTypes = ["int", "integer", "tinyint", "smallint", "mediumint", "bigint", "int2", "int4", "int8", "serial"];
             if (integerTypes.includes(prop.columnTypes[0])) {
                 decorators.push("@IsInt()");
             } else {

--- a/packages/api/cms-api/src/generator/generate-crud-resolve-id-integer.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-resolve-id-integer.spec.ts
@@ -1,0 +1,54 @@
+import { BaseEntity, Entity, PrimaryKey } from "@mikro-orm/core";
+import { MikroORM } from "@mikro-orm/postgresql";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+
+import { generateCrud } from "./generate-crud";
+import { lintGeneratedFiles, parseSource } from "./utils/test-helper";
+
+@Entity()
+class TestEntityWithIntegerId extends BaseEntity<TestEntityWithIntegerId, "id"> {
+    @PrimaryKey({ columnType: "int", type: "integer" })
+    id: number;
+}
+
+describe("GenerateCrudResolveIdInteger", () => {
+    it("should generate item resolver with correctly typed id parameter", async () => {
+        LazyMetadataStorage.load();
+        const orm = await MikroORM.init({
+            type: "postgresql",
+            dbName: "test-db",
+            entities: [TestEntityWithIntegerId],
+        });
+
+        const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithIntegerId"));
+        const lintedOut = await lintGeneratedFiles(out);
+        const file = lintedOut.find((file) => file.name === "test-entity-with-integer-id.resolver.ts");
+        if (!file) throw new Error("File not found");
+        const source = parseSource(file.content);
+
+        const classes = source.getClasses();
+        expect(classes.length).toBe(1);
+        const cls = classes[0];
+        const structure = cls.getStructure();
+
+        const singleItemMethod = structure.methods?.find((method) => method.name === "testEntityWithIntegerId");
+        expect(!!singleItemMethod).toBe(true);
+        expect(singleItemMethod?.parameters?.length).toBe(1);
+        expect(singleItemMethod?.parameters?.[0].name).toBe("id");
+        expect(singleItemMethod?.parameters?.[0].type).toBe("number");
+
+        const updateMethod = structure.methods?.find((method) => method.name === "updateTestEntityWithIntegerId");
+        expect(!!updateMethod).toBe(true);
+        expect(updateMethod?.parameters?.length).toBe(2);
+        expect(updateMethod?.parameters?.[0].name).toBe("id");
+        expect(updateMethod?.parameters?.[0].type).toBe("number");
+
+        const deleteMethod = structure.methods?.find((method) => method.name === "deleteTestEntityWithIntegerId");
+        expect(!!deleteMethod).toBe(true);
+        expect(deleteMethod?.parameters?.length).toBe(1);
+        expect(deleteMethod?.parameters?.[0].name).toBe("id");
+        expect(deleteMethod?.parameters?.[0].type).toBe("number");
+
+        orm.close();
+    });
+});

--- a/packages/api/cms-api/src/generator/utils/constants.ts
+++ b/packages/api/cms-api/src/generator/utils/constants.ts
@@ -1,0 +1,1 @@
+export const integerTypes = ["int", "integer", "tinyint", "smallint", "mediumint", "bigint", "int2", "int4", "int8", "serial"];


### PR DESCRIPTION
Previously, the `id` parameter for retrieving a single item was assumed to be of type `string`. However, the id of an entity can also be of an `integer` type, which requires the `id` parameter of the generated method to be of type `number`.