### PR TITLE
api generator: Do not parse null values as int

### DIFF
--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -151,7 +151,7 @@ export async function generateCrudInput(
                 decorators.push("@IsString()");
             } else if (refType == "integer") {
                 type = "number";
-                decorators.push("@Transform(({ value }) => parseInt(value))");
+                decorators.push("@Transform(({ value }) => (value ? parseInt(value) : null))");
                 decorators.push("@IsInt()");
             } else {
                 console.warn(`${prop.name}: Unsupported referenced type`);
@@ -194,7 +194,7 @@ export async function generateCrudInput(
                     decorators.push("@IsString({ each: true })");
                 } else if (refType == "integer") {
                     type = "number[]";
-                    decorators.push("@Transform(({ value }) => value.map(id) => parseInt(id))");
+                    decorators.push("@Transform(({ value }) => value.map((id: string) => parseInt(id)))");
                     decorators.push("@IsInt({ each: true })");
                 } else {
                     console.warn(`${prop.name}: Unsupported referenced type`);
@@ -218,7 +218,7 @@ export async function generateCrudInput(
                 decorators.push("@IsString({ each: true })");
             } else if (refType == "integer") {
                 type = "number[]";
-                decorators.push("@Transform(({ value }) => value.map(id) => parseInt(id))");
+                decorators.push("@Transform(({ value }) => value.map((id: string) => parseInt(id)))");
             } else {
                 console.warn(`${prop.name}: Unsupported referenced type`);
             }


### PR DESCRIPTION
Currently an exception is thrown if `null` is sent in order to remove a relation with an integer id.

This fixes the exception and if undefined is sent (or rather, if the field is not sent at all) , this works as well and the relation remains untouched.