### PR TITLE
Replace Loading Icon

### DIFF
--- a/.changeset/smart-kangaroos-marry.md
+++ b/.changeset/smart-kangaroos-marry.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": major
+---
+
+Change the icon used in the `Loading` component from Mui's `CircularProgress` to our `BallTriangle`

--- a/.changeset/smart-kangaroos-marry.md
+++ b/.changeset/smart-kangaroos-marry.md
@@ -2,4 +2,4 @@
 "@comet/admin": major
 ---
 
-Change the icon used in the `Loading` component from Mui's `CircularProgress` to our `BallTriangle`
+Change the icon used in the `Loading` component from MUI's `CircularProgress` to our `BallTriangle`

--- a/packages/admin/admin/src/common/Loading.tsx
+++ b/packages/admin/admin/src/common/Loading.tsx
@@ -5,16 +5,17 @@ import React from "react";
 
 export interface LoadingProps extends SvgIconProps {
     behavior?: "auto" | "fillParent" | "fillParentAbsolute" | "fillPageHeight";
+    size?: number;
 }
 
-export const Loading = ({ behavior = "auto", ...svgIconsProps }: LoadingProps) => {
+export const Loading = ({ behavior = "auto", size = 40, ...svgIconsProps }: LoadingProps) => {
     const rootRef = React.useRef<HTMLDivElement>(null);
     const offsetTop = rootRef.current?.offsetTop || 0;
 
     return (
         <Root ref={rootRef} style={{ "--comet-admin-loading-offset-top": `${offsetTop}px` } as React.CSSProperties} behavior={behavior}>
             <LoadingContainer behavior={behavior}>
-                <StyledBallTriangle {...svgIconsProps} />
+                <StyledBallTriangle {...svgIconsProps} size={size} />
             </LoadingContainer>
         </Root>
     );
@@ -60,7 +61,9 @@ const LoadingContainer = styled("div")<Required<Pick<LoadingProps, "behavior">>>
         `}
 `;
 
-const StyledBallTriangle = styled(BallTriangle)`
-    width: 40px;
-    height: 40px;
+const StyledBallTriangle = styled(BallTriangle, {
+    shouldForwardProp: (propName) => propName !== "size",
+})<{ size: number }>`
+    width: ${({ size }) => `${size}px`};
+    height: ${({ size }) => `${size}px`};
 `;

--- a/packages/admin/admin/src/common/Loading.tsx
+++ b/packages/admin/admin/src/common/Loading.tsx
@@ -1,19 +1,20 @@
-import { CircularProgress, CircularProgressProps } from "@mui/material";
+import { BallTriangle } from "@comet/admin-icons";
+import { SvgIconProps } from "@mui/material";
 import { css, styled } from "@mui/material/styles";
 import React from "react";
 
-export interface LoadingProps extends CircularProgressProps {
+export interface LoadingProps extends SvgIconProps {
     behavior?: "auto" | "fillParent" | "fillParentAbsolute" | "fillPageHeight";
 }
 
-export const Loading = ({ behavior = "auto", ...circularProgressProps }: LoadingProps) => {
+export const Loading = ({ behavior = "auto", ...svgIconsProps }: LoadingProps) => {
     const rootRef = React.useRef<HTMLDivElement>(null);
     const offsetTop = rootRef.current?.offsetTop || 0;
 
     return (
         <Root ref={rootRef} style={{ "--comet-admin-loading-offset-top": `${offsetTop}px` } as React.CSSProperties} behavior={behavior}>
             <LoadingContainer behavior={behavior}>
-                <CircularProgress {...circularProgressProps} />
+                <StyledBallTriangle {...svgIconsProps} />
             </LoadingContainer>
         </Root>
     );
@@ -57,4 +58,9 @@ const LoadingContainer = styled("div")<Required<Pick<LoadingProps, "behavior">>>
             align-items: center;
             justify-content: center;
         `}
+`;
+
+const StyledBallTriangle = styled(BallTriangle)`
+    width: 40px;
+    height: 40px;
 `;

--- a/packages/admin/admin/src/common/Loading.tsx
+++ b/packages/admin/admin/src/common/Loading.tsx
@@ -5,17 +5,16 @@ import React from "react";
 
 export interface LoadingProps extends SvgIconProps {
     behavior?: "auto" | "fillParent" | "fillParentAbsolute" | "fillPageHeight";
-    size?: number;
 }
 
-export const Loading = ({ behavior = "auto", size = 40, ...svgIconsProps }: LoadingProps) => {
+export const Loading = ({ behavior = "auto", fontSize, sx, ...svgIconsProps }: LoadingProps) => {
     const rootRef = React.useRef<HTMLDivElement>(null);
     const offsetTop = rootRef.current?.offsetTop || 0;
 
     return (
         <Root ref={rootRef} style={{ "--comet-admin-loading-offset-top": `${offsetTop}px` } as React.CSSProperties} behavior={behavior}>
             <LoadingContainer behavior={behavior}>
-                <StyledBallTriangle {...svgIconsProps} size={size} />
+                <BallTriangle sx={{ fontSize: fontSize ?? 40, ...sx }} {...svgIconsProps} />
             </LoadingContainer>
         </Root>
     );
@@ -59,11 +58,4 @@ const LoadingContainer = styled("div")<Required<Pick<LoadingProps, "behavior">>>
             align-items: center;
             justify-content: center;
         `}
-`;
-
-const StyledBallTriangle = styled(BallTriangle, {
-    shouldForwardProp: (propName) => propName !== "size",
-})<{ size: number }>`
-    width: ${({ size }) => `${size}px`};
-    height: ${({ size }) => `${size}px`};
 `;

--- a/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
+++ b/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
@@ -60,7 +60,7 @@ export function UserHeaderItem(props: UserHeaderItemProps): React.ReactElement {
     if (loading || !data)
         return (
             <LoadingWrapper>
-                <Loading behavior="fillParent" size={20} color="inherit" />
+                <Loading behavior="fillParent" color="inherit" />
             </LoadingWrapper>
         );
 

--- a/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
+++ b/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
@@ -60,7 +60,7 @@ export function UserHeaderItem(props: UserHeaderItemProps): React.ReactElement {
     if (loading || !data)
         return (
             <LoadingWrapper>
-                <Loading behavior="fillParent" size={20} color="inherit" />
+                <Loading behavior="fillParent" sx={{ fontSize: 20 }} color="inherit" />
             </LoadingWrapper>
         );
 

--- a/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
+++ b/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
@@ -60,7 +60,7 @@ export function UserHeaderItem(props: UserHeaderItemProps): React.ReactElement {
     if (loading || !data)
         return (
             <LoadingWrapper>
-                <Loading behavior="fillParent" color="inherit" />
+                <Loading behavior="fillParent" size={20} color="inherit" />
             </LoadingWrapper>
         );
 


### PR DESCRIPTION
Replaces `CircularProgress` with our `BallTriangle` icon in the `Loading` component

Unfortunately, that's a breaking change because the `CircularProgressProps` was passed through. I replaced that with the `SvgIconProps`, although it's debatable if passing the props through is needed at all.