### PR TITLE
Fix DAM folder migration

### DIFF
--- a/packages/api/cms-api/src/dam/files/entities/folder.entity.ts
+++ b/packages/api/cms-api/src/dam/files/entities/folder.entity.ts
@@ -82,7 +82,7 @@ export function createFolderEntity({ Scope }: { Scope?: Type<DamScopeInterface> 
         @Field()
         archived: boolean;
 
-        @Property({ columnType: "boolean" })
+        @Property({ columnType: "boolean", default: false })
         @Field()
         isInboxFromOtherScope: boolean = false;
 

--- a/packages/api/cms-api/src/mikro-orm/migrations/Migration20230821090303.ts
+++ b/packages/api/cms-api/src/mikro-orm/migrations/Migration20230821090303.ts
@@ -5,7 +5,7 @@ export class Migration20230821090303 extends Migration {
   async up(): Promise<void> {
     this.addSql('alter table "DamFile" add column "copyOfId" uuid null;');
     this.addSql('alter table "DamFile" add constraint "DamFile_copyOfId_foreign" foreign key ("copyOfId") references "DamFile" ("id") on update cascade on delete set null;');
-    this.addSql('alter table "DamFolder" add column "isInboxFromOtherScope" boolean not null;');
+    this.addSql('alter table "DamFolder" add column "isInboxFromOtherScope" boolean not null default false;');
   }
 
   async down(): Promise<void> {


### PR DESCRIPTION
The new non-nullable `isInboxFromOtherScope` column introduced in #1192 caused the migration to fail. Adding a default value resolves the issue.