### PR TITLE
Add `@SkipBuild()` decorator to mutations without content changes

### DIFF
--- a/.changeset/perfect-vans-rhyme.md
+++ b/.changeset/perfect-vans-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Add `@SkipBuild()` decorator to mutations without content changes

--- a/packages/api/cms-api/src/auth/resolver/auth.resolver.ts
+++ b/packages/api/cms-api/src/auth/resolver/auth.resolver.ts
@@ -2,6 +2,7 @@ import { Type } from "@nestjs/common";
 import { Context, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { IncomingMessage } from "http";
 
+import { SkipBuild } from "../../builds/skip-build.decorator";
 import { CurrentUserInterface } from "../current-user/current-user";
 import { GetCurrentUser } from "../decorators/get-current-user.decorator";
 
@@ -20,6 +21,7 @@ export function createAuthResolver(config: AuthResolverConfig): Type<unknown> {
         }
 
         @Mutation(() => String)
+        @SkipBuild()
         async currentUserSignOut(@Context("req") req: IncomingMessage): Promise<string | null> {
             let signOutUrl = config.postLogoutRedirectUri || "/";
 

--- a/packages/api/cms-api/src/builds/changes-checker.interceptor.ts
+++ b/packages/api/cms-api/src/builds/changes-checker.interceptor.ts
@@ -1,8 +1,10 @@
 import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { GqlExecutionContext } from "@nestjs/graphql";
+import { GraphQLResolveInfo } from "graphql";
 import { Observable } from "rxjs";
 
+import { ContentScope } from "../common/decorators/content-scope.interface";
 import { ContentScopeService } from "../content-scope/content-scope.service";
 import { BuildsService } from "./builds.service";
 import { SKIP_BUILD_METADATA_KEY } from "./skip-build.decorator";
@@ -19,7 +21,9 @@ export class ChangesCheckerInterceptor implements NestInterceptor {
     async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
         if (context.getType().toString() === "graphql") {
             const gqlContext = GqlExecutionContext.create(context);
-            if (gqlContext.getInfo().operation.operation === "mutation") {
+            const operation = gqlContext.getInfo<GraphQLResolveInfo>().operation;
+
+            if (operation.operation === "mutation") {
                 const skipBuild =
                     this.reflector.get<string[]>(SKIP_BUILD_METADATA_KEY, context.getHandler()) ||
                     this.reflector.get<string[]>(SKIP_BUILD_METADATA_KEY, context.getClass());
@@ -27,11 +31,23 @@ export class ChangesCheckerInterceptor implements NestInterceptor {
                 if (!skipBuild) {
                     const scope = await this.contentScopeService.inferScopeFromExecutionContext(context);
 
+                    if (process.env.NODE_ENV === "development" && this.changeAffectsAllScopes(scope)) {
+                        if (operation.name) {
+                            console.warn(`Mutation "${operation.name.value}" affects all scopes. Are you sure this is correct?`);
+                        } else {
+                            console.warn(`Unknown mutation affects all scopes. Are you sure this is correct?`);
+                        }
+                    }
+
                     await this.buildsService.setChangesSinceLastBuild(scope);
                 }
             }
         }
 
         return next.handle();
+    }
+
+    private changeAffectsAllScopes(scope: ContentScope | undefined): boolean {
+        return !scope || Object.keys(scope).length === 0; // Caused by features with optional scoping, e.g. redirects
     }
 }

--- a/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from "@mikro-orm/nestjs";
 import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { GraphQLJSONObject } from "graphql-type-json";
 
+import { SkipBuild } from "../builds/skip-build.decorator";
 import { UserContentScopesInput } from "./dto/user-content-scopes.input";
 import { UserContentScopes } from "./entities/user-content-scopes.entity";
 import { ContentScope } from "./interfaces/content-scope.interface";
@@ -16,6 +17,7 @@ export class UserContentScopesResolver {
     ) {}
 
     @Mutation(() => [GraphQLJSONObject])
+    @SkipBuild()
     async userPermissionsUpdateContentScopes(
         @Args("userId", { type: () => String }) userId: string,
         @Args("input", { type: () => UserContentScopesInput }) { contentScopes }: UserContentScopesInput,

--- a/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from "@mikro-orm/nestjs";
 import { Args, ArgsType, Field, ID, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { IsString } from "class-validator";
 
+import { SkipBuild } from "../builds/skip-build.decorator";
 import { UserPermissionInput } from "./dto/user-permission.input";
 import { UserPermission } from "./entities/user-permission.entity";
 import { UserPermissionsService } from "./user-permissions.service";
@@ -35,6 +36,7 @@ export class UserPermissionResolver {
     }
 
     @Mutation(() => UserPermission)
+    @SkipBuild()
     async userPermissionsCreatePermission(
         @Args("userId", { type: () => String }) userId: string,
         @Args("input", { type: () => UserPermissionInput }) input: UserPermissionInput,
@@ -53,6 +55,7 @@ export class UserPermissionResolver {
     }
 
     @Mutation(() => UserPermission)
+    @SkipBuild()
     async userPermissionsUpdatePermission(
         @Args("id", { type: () => String }) id: string,
         @Args("input", { type: () => UserPermissionInput }) input: UserPermissionInput,
@@ -64,6 +67,7 @@ export class UserPermissionResolver {
     }
 
     @Mutation(() => Boolean)
+    @SkipBuild()
     async userPermissionsDeletePermission(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
         this.permissionRepository.removeAndFlush(await this.getPermission(id));
         return true;


### PR DESCRIPTION
The decorator was missing for some mutations that don't cause content changes, for instance `currentUserSignOut`. This change also adds a warning during development when a change affects all scopes.