### PR TITLE
Sort migrations by timestamp

### DIFF
--- a/packages/api/cms-api/src/mikro-orm/mikro-orm.module.ts
+++ b/packages/api/cms-api/src/mikro-orm/mikro-orm.module.ts
@@ -64,7 +64,7 @@ export function createOrmConfig({ migrations, ...defaults }: MikroOrmNestjsOptio
                 { name: "Migration20220905145606", class: Migration20220905145606 },
                 { name: "Migration20230613150332", class: Migration20230613150332 },
                 ...(migrations?.migrationsList || []),
-            ],
+            ].sort((migrationA, migrationB) => migrationA.name.localeCompare(migrationB.name)),
         },
     };
 }

--- a/packages/api/cms-api/src/mikro-orm/mikro-orm.module.ts
+++ b/packages/api/cms-api/src/mikro-orm/mikro-orm.module.ts
@@ -64,7 +64,15 @@ export function createOrmConfig({ migrations, ...defaults }: MikroOrmNestjsOptio
                 { name: "Migration20220905145606", class: Migration20220905145606 },
                 { name: "Migration20230613150332", class: Migration20230613150332 },
                 ...(migrations?.migrationsList || []),
-            ].sort((migrationA, migrationB) => migrationA.name.localeCompare(migrationB.name)),
+            ].sort((migrationA, migrationB) => {
+                if (migrationA.name < migrationB.name) {
+                    return -1;
+                } else if (migrationA.name > migrationB.name) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            }),
         },
     };
 }


### PR DESCRIPTION
The migrations from both the library and the application were not sorted by timestamp. This prevented certain workarounds, for instance, adding an "earlier" migration to fix schema issues discovered at a later point.