### PR TITLE
COM-32: Fix padding of DamVideoBlock and YouTubeVideoBlock

### DIFF
--- a/demo/admin/src/pages/PageContentBlock.tsx
+++ b/demo/admin/src/pages/PageContentBlock.tsx
@@ -11,6 +11,7 @@ import { ColumnsBlock } from "./blocks/ColumnsBlock";
 import { FullWidthImageBlock } from "./blocks/FullWidthImageBlock";
 import { HeadlineBlock } from "./blocks/HeadlineBlock";
 import { TextImageBlock } from "./blocks/TextImageBlock";
+import { VideoBlock } from "./blocks/VideoBlock";
 
 export const PageContentBlock = createBlocksBlock({
     name: "PageContent",
@@ -22,6 +23,7 @@ export const PageContentBlock = createBlocksBlock({
         textImage: TextImageBlock,
         damVideo: DamVideoBlock,
         youTubeVideo: YouTubeVideoBlock,
+        video: VideoBlock,
         linkList: LinkListBlock,
         fullWidthImage: FullWidthImageBlock,
         columns: ColumnsBlock,

--- a/demo/admin/src/pages/blocks/VideoBlock.tsx
+++ b/demo/admin/src/pages/blocks/VideoBlock.tsx
@@ -1,0 +1,12 @@
+import { BlockCategory, createOneOfBlock, YouTubeVideoBlock } from "@comet/blocks-admin";
+import { DamVideoBlock } from "@comet/cms-admin";
+import * as React from "react";
+import { FormattedMessage } from "react-intl";
+
+export const VideoBlock = createOneOfBlock({
+    name: "Video",
+    displayName: <FormattedMessage id="pages.blocks.video" defaultMessage="Video" />,
+    category: BlockCategory.Media,
+    supportedBlocks: { youtubeVideo: YouTubeVideoBlock, damVideo: DamVideoBlock },
+    allowEmpty: true,
+});

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -927,6 +927,7 @@
                                 "TextImage",
                                 "DamVideo",
                                 "YouTubeVideo",
+                                "Video",
                                 "LinkList",
                                 "FullWidthImage",
                                 "Columns",
@@ -1584,6 +1585,69 @@
                 "name": "imageAspectRatio",
                 "kind": "String",
                 "nullable": false
+            }
+        ]
+    },
+    {
+        "name": "Video",
+        "fields": [
+            {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": [
+                                "DamVideo",
+                                "YouTubeVideo"
+                            ],
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
+            {
+                "name": "activeType",
+                "kind": "String",
+                "nullable": true
+            },
+            {
+                "name": "block",
+                "kind": "NestedObject",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": [
+                                "DamVideo",
+                                "YouTubeVideo"
+                            ],
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": true
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "activeType",
+                "kind": "String",
+                "nullable": true
             }
         ]
     },

--- a/demo/api/src/pages/blocks/PageContentBlock.ts
+++ b/demo/api/src/pages/blocks/PageContentBlock.ts
@@ -9,6 +9,7 @@ import { ColumnsBlock } from "./columns.block";
 import { FullWidthImageBlock } from "./full-width-image.block";
 import { HeadlineBlock } from "./headline.block";
 import { TextImageBlock } from "./TextImageBlock";
+import { VideoBlock } from "./video.block";
 
 const supportedBlocks = {
     space: SpaceBlock,
@@ -18,6 +19,7 @@ const supportedBlocks = {
     textImage: TextImageBlock,
     damVideo: DamVideoBlock,
     youTubeVideo: YouTubeVideoBlock,
+    video: VideoBlock,
     linkList: LinkListBlock,
     fullWidthImage: FullWidthImageBlock,
     columns: ColumnsBlock,

--- a/demo/api/src/pages/blocks/video.block.ts
+++ b/demo/api/src/pages/blocks/video.block.ts
@@ -1,0 +1,16 @@
+import { createOneOfBlock } from "@comet/blocks-api/lib/blocks/factories/createOneOfBlock";
+import { YouTubeVideoBlock } from "@comet/blocks-api/lib/blocks/youtube-video.block";
+import { DamVideoBlock } from "@comet/cms-api";
+
+export const VideoBlock = createOneOfBlock(
+    {
+        supportedBlocks: {
+            damVideo: DamVideoBlock,
+            youtubeVideo: YouTubeVideoBlock,
+        },
+        allowEmpty: true,
+    },
+    {
+        name: "Video",
+    },
+);

--- a/packages/admin/blocks-admin/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/YouTubeVideoBlock.tsx
@@ -1,11 +1,12 @@
 import { Field, FieldContainer, FinalFormInput, FinalFormRadio, FinalFormSwitch } from "@comet/admin";
-import { FormControlLabel } from "@mui/material";
+import { Box, FormControlLabel } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { YouTubeVideoBlockData, YouTubeVideoBlockInput } from "../blocks.generated";
 import { BlocksFinalForm } from "../form/BlocksFinalForm";
 import { SelectPreviewComponent } from "../iframebridge/SelectPreviewComponent";
+import { useAdminComponentPaper } from "./common/AdminComponentPaper";
 import { createBlockSkeleton } from "./helpers/createBlockSkeleton";
 import { BlockCategory, BlockInterface } from "./types";
 
@@ -26,64 +27,69 @@ export const YouTubeVideoBlock: BlockInterface<YouTubeVideoBlockData, State, You
         return { ...state, autoplay: false, adminMeta: { route: previewCtx.parentUrl } };
     },
 
+    definesOwnPadding: true,
+
     AdminComponent: ({ state, updateState }) => {
         const intl = useIntl();
+        const isInPaper = useAdminComponentPaper();
 
         return (
-            <SelectPreviewComponent>
-                <BlocksFinalForm
-                    onSubmit={(newState) => {
-                        updateState({ ...state, ...newState });
-                    }}
-                    initialValues={state}
-                >
-                    <Field
-                        label={intl.formatMessage({
-                            id: "comet.blocks.youTubeVideo.youtubeIdentifier",
-                            defaultMessage: "YouTube URL or YouTube Video ID",
-                        })}
-                        name="youtubeIdentifier"
-                        component={FinalFormInput}
-                        fullWidth
-                    />
-                    <FieldContainer label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.aspectRatio", defaultMessage: "Aspect Ratio" })}>
-                        <Field name="aspectRatio" type="radio" value="16X9">
-                            {(props) => (
-                                <FormControlLabel
-                                    label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.aspectRatio.16X9", defaultMessage: "16:9" })}
-                                    control={<FinalFormRadio {...props} />}
-                                />
-                            )}
-                        </Field>
-                        <Field name="aspectRatio" type="radio" value="4X3">
-                            {(props) => (
-                                <FormControlLabel
-                                    label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.aspectRatio.4X3", defaultMessage: "4:3" })}
-                                    control={<FinalFormRadio {...props} />}
-                                />
-                            )}
-                        </Field>
-                    </FieldContainer>
-                    <Field
-                        label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.autoplay", defaultMessage: "Autoplay" })}
-                        name="autoplay"
-                        type="checkbox"
-                        component={FinalFormSwitch}
-                    />
-                    <Field
-                        label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.showControls", defaultMessage: "Show controls" })}
-                        name="showControls"
-                        type="checkbox"
-                        component={FinalFormSwitch}
-                    />
-                    <Field
-                        label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.loop", defaultMessage: "Loop" })}
-                        name="loop"
-                        type="checkbox"
-                        component={FinalFormSwitch}
-                    />
-                </BlocksFinalForm>
-            </SelectPreviewComponent>
+            <Box padding={isInPaper ? 3 : 0} pb={0}>
+                <SelectPreviewComponent>
+                    <BlocksFinalForm
+                        onSubmit={(newState) => {
+                            updateState({ ...state, ...newState });
+                        }}
+                        initialValues={state}
+                    >
+                        <Field
+                            label={intl.formatMessage({
+                                id: "comet.blocks.youTubeVideo.youtubeIdentifier",
+                                defaultMessage: "YouTube URL or YouTube Video ID",
+                            })}
+                            name="youtubeIdentifier"
+                            component={FinalFormInput}
+                            fullWidth
+                        />
+                        <FieldContainer label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.aspectRatio", defaultMessage: "Aspect Ratio" })}>
+                            <Field name="aspectRatio" type="radio" value="16X9">
+                                {(props) => (
+                                    <FormControlLabel
+                                        label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.aspectRatio.16X9", defaultMessage: "16:9" })}
+                                        control={<FinalFormRadio {...props} />}
+                                    />
+                                )}
+                            </Field>
+                            <Field name="aspectRatio" type="radio" value="4X3">
+                                {(props) => (
+                                    <FormControlLabel
+                                        label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.aspectRatio.4X3", defaultMessage: "4:3" })}
+                                        control={<FinalFormRadio {...props} />}
+                                    />
+                                )}
+                            </Field>
+                        </FieldContainer>
+                        <Field
+                            label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.autoplay", defaultMessage: "Autoplay" })}
+                            name="autoplay"
+                            type="checkbox"
+                            component={FinalFormSwitch}
+                        />
+                        <Field
+                            label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.showControls", defaultMessage: "Show controls" })}
+                            name="showControls"
+                            type="checkbox"
+                            component={FinalFormSwitch}
+                        />
+                        <Field
+                            label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.loop", defaultMessage: "Loop" })}
+                            name="loop"
+                            type="checkbox"
+                            component={FinalFormSwitch}
+                        />
+                    </BlocksFinalForm>
+                </SelectPreviewComponent>
+            </Box>
         );
     },
 

--- a/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
@@ -1,7 +1,15 @@
 import { gql } from "@apollo/client";
 import { Field, FieldContainer, FinalFormSwitch, messages } from "@comet/admin";
 import { Delete, Video } from "@comet/admin-icons";
-import { AdminComponentButton, AdminComponentPaper, BlockCategory, BlockInterface, BlocksFinalForm, createBlockSkeleton } from "@comet/blocks-admin";
+import {
+    AdminComponentButton,
+    AdminComponentPaper,
+    BlockCategory,
+    BlockInterface,
+    BlocksFinalForm,
+    createBlockSkeleton,
+    useAdminComponentPaper,
+} from "@comet/blocks-admin";
 import { Box, Divider, Grid, Typography } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
@@ -75,73 +83,77 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
     definesOwnPadding: true,
 
     AdminComponent: ({ state, updateState }) => {
+        const isInPaper = useAdminComponentPaper();
+
         return (
-            <BlocksFinalForm
-                onSubmit={(values) => {
-                    updateState((prevState) => {
-                        // case: autoplay = false and showControls = false is not allowed
-                        if (!values.autoplay && prevState.autoplay) {
-                            return { ...prevState, ...values, showControls: true };
-                        }
-                        if (!values.showControls && prevState.showControls) {
-                            return { ...prevState, ...values, autoplay: true };
-                        }
-                        return { ...prevState, ...values };
-                    });
-                }}
-                initialValues={state}
-            >
-                {state.damFile ? (
-                    <FieldContainer label={<FormattedMessage {...messages.file} />} fullWidth>
-                        <AdminComponentPaper disablePadding>
-                            <Box padding={3}>
-                                <Grid container alignItems="center" spacing={3}>
-                                    <Grid item>
-                                        {/* TODO show thumbnail of video */}
-                                        <Video fontSize="large" color="primary" />
+            <Box padding={isInPaper ? 3 : 0} pb={0}>
+                <BlocksFinalForm
+                    onSubmit={(values) => {
+                        updateState((prevState) => {
+                            // case: autoplay = false and showControls = false is not allowed
+                            if (!values.autoplay && prevState.autoplay) {
+                                return { ...prevState, ...values, showControls: true };
+                            }
+                            if (!values.showControls && prevState.showControls) {
+                                return { ...prevState, ...values, autoplay: true };
+                            }
+                            return { ...prevState, ...values };
+                        });
+                    }}
+                    initialValues={state}
+                >
+                    {state.damFile ? (
+                        <FieldContainer label={<FormattedMessage {...messages.file} />} fullWidth>
+                            <AdminComponentPaper disablePadding>
+                                <Box padding={3}>
+                                    <Grid container alignItems="center" spacing={3}>
+                                        <Grid item>
+                                            {/* TODO show thumbnail of video */}
+                                            <Video fontSize="large" color="primary" />
+                                        </Grid>
+                                        <Grid item xs>
+                                            <Typography variant="subtitle1">{state.damFile.name}</Typography>
+                                            <Typography variant="body1" color="textSecondary">
+                                                <DamPathLazy fileId={state.damFile.id} />
+                                            </Typography>
+                                        </Grid>
                                     </Grid>
-                                    <Grid item xs>
-                                        <Typography variant="subtitle1">{state.damFile.name}</Typography>
-                                        <Typography variant="body1" color="textSecondary">
-                                            <DamPathLazy fileId={state.damFile.id} />
-                                        </Typography>
-                                    </Grid>
-                                </Grid>
-                            </Box>
-                            <Divider />
-                            <AdminComponentButton startIcon={<Delete />} onClick={() => updateState({ damFile: undefined })}>
-                                <FormattedMessage id="comet.blocks.image.empty" defaultMessage="Empty" />
-                            </AdminComponentButton>
-                        </AdminComponentPaper>
-                    </FieldContainer>
-                ) : (
+                                </Box>
+                                <Divider />
+                                <AdminComponentButton startIcon={<Delete />} onClick={() => updateState({ damFile: undefined })}>
+                                    <FormattedMessage id="comet.blocks.image.empty" defaultMessage="Empty" />
+                                </AdminComponentButton>
+                            </AdminComponentPaper>
+                        </FieldContainer>
+                    ) : (
+                        <Field
+                            name="damFile"
+                            label={<FormattedMessage {...messages.file} />}
+                            component={FileField}
+                            fullWidth
+                            allowedMimetypes={["video/mp4"]}
+                        />
+                    )}
                     <Field
-                        name="damFile"
-                        label={<FormattedMessage {...messages.file} />}
-                        component={FileField}
-                        fullWidth
-                        allowedMimetypes={["video/mp4"]}
+                        type="checkbox"
+                        name="autoplay"
+                        label={<FormattedMessage id="comet.blocks.video.autoplay" defaultMessage="Autoplay" />}
+                        component={FinalFormSwitch}
                     />
-                )}
-                <Field
-                    type="checkbox"
-                    name="autoplay"
-                    label={<FormattedMessage id="comet.blocks.video.autoplay" defaultMessage="Autoplay" />}
-                    component={FinalFormSwitch}
-                />
-                <Field
-                    type="checkbox"
-                    name="loop"
-                    label={<FormattedMessage id="comet.blocks.video.loop" defaultMessage="Loop" />}
-                    component={FinalFormSwitch}
-                />
-                <Field
-                    type="checkbox"
-                    name="showControls"
-                    label={<FormattedMessage id="comet.blocks.video.showControls" defaultMessage="Show controls" />}
-                    component={FinalFormSwitch}
-                />
-            </BlocksFinalForm>
+                    <Field
+                        type="checkbox"
+                        name="loop"
+                        label={<FormattedMessage id="comet.blocks.video.loop" defaultMessage="Loop" />}
+                        component={FinalFormSwitch}
+                    />
+                    <Field
+                        type="checkbox"
+                        name="showControls"
+                        label={<FormattedMessage id="comet.blocks.video.showControls" defaultMessage="Show controls" />}
+                        component={FinalFormSwitch}
+                    />
+                </BlocksFinalForm>
+            </Box>
         );
     },
 


### PR DESCRIPTION
This PR fixes the padding behaviour of DamVideoBlock and YouTubeVideoBlock in Paper components. It also adds a generic VideoBlock, where a user can decide whether to use a Dam- or YouTube video.

<details>
<summary><h2>Screenshots Fix</h2></summary>

### Before 

<img width="380" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/981e74ab-9a8a-4dd4-b7bb-1a6a9bd878f4">
<br>
<img width="383" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/637cba36-8d12-4362-abe3-61d28964283a">

### After
<img width="386" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/acc3b64e-93aa-4b85-b379-9e6169a1ab5c">
<br>
<img width="383" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/94258cfc-81da-4e20-9019-9ec645079be8">
</details>

<details>
<summary><h2>Screenshots Video Block</h2></summary>
<img width="380" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/a36cb1e1-c69b-4641-b814-d881552c2565">
<br>
<img width="379" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/ef80d128-c012-4e1b-859e-4254bd488754">
<br>
<img width="381" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/d41f7247-0a77-4224-85ee-1ca8fe65ac05">
</details>