### PR TITLE
Ignore field resolvers in changes checker interceptor

### DIFF
--- a/.changeset/shiny-bears-relax.md
+++ b/.changeset/shiny-bears-relax.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Ignore field resolvers in `ChangesCheckerInterceptor`

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -21,7 +21,7 @@ import {
 } from "@comet/cms-api";
 import { ApolloDriver } from "@nestjs/apollo";
 import { DynamicModule, Module } from "@nestjs/common";
-import { GraphQLModule } from "@nestjs/graphql";
+import { Enhancer, GraphQLModule } from "@nestjs/graphql";
 import { Config } from "@src/config/config";
 import { ConfigModule } from "@src/config/config.module";
 import { DbModule } from "@src/db/db.module";
@@ -71,6 +71,8 @@ export class AppModule {
                         buildSchemaOptions: {
                             fieldMiddleware: [BlocksTransformerMiddlewareFactory.create(dependencies)],
                         },
+                        // See https://docs.nestjs.com/graphql/other-features#execute-enhancers-at-the-field-resolver-level
+                        fieldResolverEnhancers: ["guards", "interceptors", "filters"] as Enhancer[],
                     }),
                     inject: [BLOCKS_MODULE_TRANSFORMER_DEPENDENCIES],
                 }),

--- a/packages/api/cms-api/src/builds/changes-checker.interceptor.ts
+++ b/packages/api/cms-api/src/builds/changes-checker.interceptor.ts
@@ -21,9 +21,9 @@ export class ChangesCheckerInterceptor implements NestInterceptor {
     async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
         if (context.getType().toString() === "graphql") {
             const gqlContext = GqlExecutionContext.create(context);
-            const operation = gqlContext.getInfo<GraphQLResolveInfo>().operation;
+            const { operation, parentType } = gqlContext.getInfo<GraphQLResolveInfo>();
 
-            if (operation.operation === "mutation") {
+            if (parentType.name === "Mutation") {
                 const skipBuild =
                     this.reflector.get<string[]>(SKIP_BUILD_METADATA_KEY, context.getHandler()) ||
                     this.reflector.get<string[]>(SKIP_BUILD_METADATA_KEY, context.getClass());


### PR DESCRIPTION
Scoped mutations would cause a change for all scopes when querying a field resolver with `fieldResolverEnhancers: ["interceptors"]` enabled in the `GraphQLModule` config. This is due to using `operator.operator` to check whether an operation is a mutation. To fix this, we now use `parentType.name`, as recommended in the [Nest docs](https://docs.nestjs.com/graphql/other-features#execute-enhancers-at-the-field-resolver-level).