### PR TITLE
Enrich blocks-meta by adding the key (type) for OneOfBlocks

### DIFF
--- a/.changeset/happy-weeks-switch.md
+++ b/.changeset/happy-weeks-switch.md
@@ -1,0 +1,7 @@
+---
+"@comet/blocks-api": major
+---
+
+Change blocks-meta.json format: the key (type) for OneOfBlocks is now included
+
+projets that still have a copy of generate-block-types should swtich to @comet/cli

--- a/.changeset/happy-weeks-switch.md
+++ b/.changeset/happy-weeks-switch.md
@@ -4,4 +4,4 @@
 
 Change blocks-meta.json format: the key (type) for OneOfBlocks is now included
 
-projets that still have a copy of generate-block-types should swtich to @comet/cli
+Projects that still have a copy of generate-block-types should switch to @comet/cli

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -109,12 +109,12 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "Space",
-                                "RichText",
-                                "Headline",
-                                "DamImage"
-                            ],
+                            "blocks": {
+                                "space": "Space",
+                                "richtext": "RichText",
+                                "headline": "Headline",
+                                "image": "DamImage"
+                            },
                             "nullable": false
                         }
                     ]
@@ -140,10 +140,10 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "PixelImage",
-                                "SvgImage"
-                            ],
+                            "blocks": {
+                                "pixelImage": "PixelImage",
+                                "svgImage": "SvgImage"
+                            },
                             "nullable": false
                         }
                     ]
@@ -168,10 +168,10 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "PixelImage",
-                                "SvgImage"
-                            ],
+                            "blocks": {
+                                "pixelImage": "PixelImage",
+                                "svgImage": "SvgImage"
+                            },
                             "nullable": false
                         }
                     ]
@@ -651,11 +651,11 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "InternalLink",
-                                "ExternalLink",
-                                "NewsLink"
-                            ],
+                            "blocks": {
+                                "internal": "InternalLink",
+                                "external": "ExternalLink",
+                                "news": "NewsLink"
+                            },
                             "nullable": false
                         }
                     ]
@@ -680,11 +680,11 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "InternalLink",
-                                "ExternalLink",
-                                "NewsLink"
-                            ],
+                            "blocks": {
+                                "internal": "InternalLink",
+                                "external": "ExternalLink",
+                                "news": "NewsLink"
+                            },
                             "nullable": false
                         }
                     ]
@@ -793,10 +793,10 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "DamImage",
-                                "DamVideo"
-                            ],
+                            "blocks": {
+                                "image": "DamImage",
+                                "video": "DamVideo"
+                            },
                             "nullable": false
                         }
                     ]
@@ -821,10 +821,10 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "DamImage",
-                                "DamVideo"
-                            ],
+                            "blocks": {
+                                "image": "DamImage",
+                                "video": "DamVideo"
+                            },
                             "nullable": false
                         }
                     ]
@@ -866,12 +866,12 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "Headline",
-                                "RichText",
-                                "DamImage",
-                                "TextImage"
-                            ],
+                            "blocks": {
+                                "heading": "Headline",
+                                "richtext": "RichText",
+                                "image": "DamImage",
+                                "textImage": "TextImage"
+                            },
                             "nullable": false
                         }
                     ]
@@ -982,21 +982,21 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "Space",
-                                "RichText",
-                                "Headline",
-                                "DamImage",
-                                "TextImage",
-                                "DamVideo",
-                                "YouTubeVideo",
-                                "LinkList",
-                                "FullWidthImage",
-                                "Columns",
-                                "Anchor",
-                                "TwoLists",
-                                "Media"
-                            ],
+                            "blocks": {
+                                "space": "Space",
+                                "richtext": "RichText",
+                                "headline": "Headline",
+                                "image": "DamImage",
+                                "textImage": "TextImage",
+                                "damVideo": "DamVideo",
+                                "youTubeVideo": "YouTubeVideo",
+                                "linkList": "LinkList",
+                                "fullWidthImage": "FullWidthImage",
+                                "columns": "Columns",
+                                "anchor": "Anchor",
+                                "twoLists": "TwoLists",
+                                "media": "Media"
+                            },
                             "nullable": false
                         },
                         {
@@ -1253,11 +1253,11 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "InternalLink",
-                                "ExternalLink",
-                                "NewsLink"
-                            ],
+                            "blocks": {
+                                "internal": "InternalLink",
+                                "external": "ExternalLink",
+                                "news": "NewsLink"
+                            },
                             "nullable": false
                         }
                     ]
@@ -1282,11 +1282,11 @@
                         {
                             "name": "props",
                             "kind": "OneOfBlocks",
-                            "blocks": [
-                                "InternalLink",
-                                "ExternalLink",
-                                "NewsLink"
-                            ],
+                            "blocks": {
+                                "internal": "InternalLink",
+                                "external": "ExternalLink",
+                                "news": "NewsLink"
+                            },
                             "nullable": false
                         }
                     ]

--- a/packages/api/blocks-api/src/blocks-meta.ts
+++ b/packages/api/blocks-api/src/blocks-meta.ts
@@ -22,7 +22,7 @@ type BlockMetaField =
           name: string;
           kind: "OneOfBlocks";
           nullable: boolean;
-          blocks: string[];
+          blocks: Record<string, string>;
       }
     | {
           name: string;
@@ -82,7 +82,7 @@ function extractFromBlockMeta(blockMeta: BlockMetaInterface): BlockMetaField[] {
             return {
                 name: field.name,
                 kind: field.kind,
-                blocks: field.blocks.map((i) => i.name),
+                blocks: Object.fromEntries(Object.entries(field.blocks).map(([key, block]) => [key, block.name])),
                 nullable: field.nullable,
             };
         } else {

--- a/packages/api/blocks-api/src/blocks/block.ts
+++ b/packages/api/blocks-api/src/blocks/block.ts
@@ -200,7 +200,7 @@ export type BlockMetaField =
     | { name: string; kind: BlockMetaFieldKind.Block; block: Block; nullable: boolean }
     | { name: string; kind: BlockMetaFieldKind.NestedObject; object: BlockMetaInterface; nullable: boolean }
     | { name: string; kind: BlockMetaFieldKind.NestedObjectList; object: BlockMetaInterface; nullable: boolean }
-    | { name: string; kind: BlockMetaFieldKind.OneOfBlocks; blocks: Block[]; nullable: boolean };
+    | { name: string; kind: BlockMetaFieldKind.OneOfBlocks; blocks: Record<string, Block>; nullable: boolean };
 
 export interface BlockMetaInterface {
     fields: BlockMetaField[];

--- a/packages/api/blocks-api/src/blocks/factories/createBlocksBlock.ts
+++ b/packages/api/blocks-api/src/blocks/factories/createBlocksBlock.ts
@@ -54,7 +54,7 @@ export function BaseBlocksBlockItemData<BlockMap extends BaseBlockMap>(supported
             },
             { toClassOnly: true },
         )
-        @BlockField(Object.values(supportedBlocks))
+        @BlockField({ kind: "oneOfBlocks", blocks: supportedBlocks })
         props: BlockDataInterface;
 
         async transformToPlain(deps: TransformDependencies, { includeInvisibleContent }: BlockContext): Promise<TraversableTransformResponse> {

--- a/packages/api/blocks-api/src/blocks/factories/createOneOfBlock.ts
+++ b/packages/api/blocks-api/src/blocks/factories/createOneOfBlock.ts
@@ -80,7 +80,7 @@ export function createOneOfBlock<BlockMap extends BaseBlockMap>(
             },
             { toClassOnly: true },
         )
-        @BlockField(Object.values(supportedBlocks))
+        @BlockField({ kind: "oneOfBlocks", blocks: supportedBlocks })
         props: BlockData;
 
         async transformToPlain(): Promise<TraversableTransformResponse> {
@@ -210,7 +210,7 @@ export function createOneOfBlock<BlockMap extends BaseBlockMap>(
                         {
                             name: "props",
                             kind: BlockMetaFieldKind.OneOfBlocks,
-                            blocks: Object.values(supportedBlocks),
+                            blocks: supportedBlocks,
                             nullable: false,
                         },
                     ],

--- a/packages/cli/src/commands/generate-block-types.ts
+++ b/packages/cli/src/commands/generate-block-types.ts
@@ -24,7 +24,7 @@ type BlockMetaField =
           name: string;
           kind: "OneOfBlocks";
           nullable: boolean;
-          blocks: string[];
+          blocks: Record<string, string>;
       }
     | {
           name: string;
@@ -59,10 +59,10 @@ function writeFieldType(field: BlockMetaField, blockNamePostfix: string) {
     } else if (field.kind === "Block") {
         content += `${field.block}${blockNamePostfix}`;
     } else if (field.kind === "OneOfBlocks") {
-        if (field.blocks.length < 1) {
+        if (Object.values(field.blocks).length < 1) {
             content += "{}";
         } else {
-            content += field.blocks
+            content += Object.values(field.blocks)
                 .map((i) => {
                     return `${i}${blockNamePostfix}`;
                 })


### PR DESCRIPTION
Single Commit from #1314

with that we could change the generated interfaces from
```
    blocks: Array<{
        key: string;
        visible: boolean;
        type: string;
        props: SpaceBlockData | RichTextBlockData | HeadlineBlockData | DamImageBlockData;
    }>;
```
to
```
    blocks: Array<{
        key: string;
        visible: boolean;
        type: "space";
        props: SpaceBlockData
    } | {
        key: string;
        visible: boolean;
        type: "richText";
        props: RichTextBlockData
    } | {
        key: string;
        visible: boolean;
        type: "headline";
        props: HeadlineBlockData
    } | {
        key: string;
        visible: boolean;
        type: "damImage";
        props: DamImageBlockData;
    }>;
```

but that is out of scope for this PR