### PR TITLE
Fix drag and drop reordering in collection blocks

### DIFF
--- a/.changeset/plenty-buckets-compete.md
+++ b/.changeset/plenty-buckets-compete.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Fix drag and drop reordering in collection blocks

--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
@@ -548,12 +548,13 @@ export function createBlocksBlock({
                                                                     onDeleteClick={() => {
                                                                         deleteBlocks([data.key]);
                                                                     }}
-                                                                    moveBlock={(dragIndex: number, hoverIndex: number) => {
-                                                                        const blocks = [...state.blocks];
-                                                                        const dragItem = state.blocks[dragIndex];
-                                                                        blocks[dragIndex] = state.blocks[hoverIndex];
-                                                                        blocks[hoverIndex] = dragItem;
-                                                                        updateState((prevState) => ({ ...prevState, blocks }));
+                                                                    moveBlock={(from, to) => {
+                                                                        updateState((prevState) => {
+                                                                            const blocks = [...prevState.blocks];
+                                                                            const blockToMove = blocks.splice(from, 1)[0];
+                                                                            blocks.splice(to, 0, blockToMove);
+                                                                            return { ...prevState, blocks };
+                                                                        });
                                                                     }}
                                                                     visibilityButton={
                                                                         <IconButton onClick={() => toggleVisible(data.key)} size="small">

--- a/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
@@ -310,12 +310,13 @@ export function createColumnsBlock<T extends BlockInterface>({
                                                                             onDeleteClick={() => {
                                                                                 deleteBlocks([column.key]);
                                                                             }}
-                                                                            moveBlock={(dragIndex: number, hoverIndex: number) => {
-                                                                                const columns = [...state.columns];
-                                                                                const dragItem = state.columns[dragIndex];
-                                                                                columns[dragIndex] = state.columns[hoverIndex];
-                                                                                columns[hoverIndex] = dragItem;
-                                                                                updateState((prevState) => ({ ...prevState, columns }));
+                                                                            moveBlock={(from, to) => {
+                                                                                updateState((prevState) => {
+                                                                                    const columns = [...prevState.columns];
+                                                                                    const columnToMove = columns.splice(from, 1)[0];
+                                                                                    columns.splice(to, 0, columnToMove);
+                                                                                    return { ...prevState, columns };
+                                                                                });
                                                                             }}
                                                                             visibilityButton={
                                                                                 <IconButton onClick={() => toggleVisible(column.key)} size="small">

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -265,12 +265,13 @@ export function createListBlock<T extends BlockInterface>({
                                                                         onDeleteClick={() => {
                                                                             deleteBlocks([data.key]);
                                                                         }}
-                                                                        moveBlock={(dragIndex: number, hoverIndex: number) => {
-                                                                            const blocks = [...state.blocks];
-                                                                            const dragItem = state.blocks[dragIndex];
-                                                                            blocks[dragIndex] = state.blocks[hoverIndex];
-                                                                            blocks[hoverIndex] = dragItem;
-                                                                            updateState((prevState) => ({ ...prevState, blocks }));
+                                                                        moveBlock={(from, to) => {
+                                                                            updateState((prevState) => {
+                                                                                const blocks = [...prevState.blocks];
+                                                                                const blockToMove = blocks.splice(from, 1)[0];
+                                                                                blocks.splice(to, 0, blockToMove);
+                                                                                return { ...prevState, blocks };
+                                                                            });
                                                                         }}
                                                                         visibilityButton={
                                                                             canChangeVisibility ? (


### PR DESCRIPTION
The implementation of `moveBlock` was flawed. Moving blocks by swapping only works if the move happens between directly adjacent blocks. However, there are scenarios where the move should be performed between non-adjacent blocks, for instance when a block is dragged outside the block list (see screencasts). To fix this, we change the implementation to move by removing the block at the `from` index and inserting it at the `to` index.

### Bug

Block "9" swaps place with block "1"

https://github.com/vivid-planet/comet/assets/48853629/d252ba02-b767-4fe6-b79f-444add93ccbe

### Fix

Block "9" is inserted before block "1"

https://github.com/vivid-planet/comet/assets/48853629/0ff4f2ea-8431-45d3-95c1-1aba528d34de