### PR TITLE
COM-120: add final form save button

### DIFF
--- a/.changeset/tough-islands-share.md
+++ b/.changeset/tough-islands-share.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Add a FinalFormSaveButton component

--- a/packages/admin/admin-stories/src/docs/components/Toolbar/stories/FinalFormSaveButton.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/components/Toolbar/stories/FinalFormSaveButton.stories.tsx
@@ -1,0 +1,83 @@
+import {
+    Field,
+    FinalForm,
+    FinalFormInput,
+    MainContent,
+    Toolbar,
+    ToolbarActions,
+    ToolbarBackButton,
+    ToolbarFillSpace,
+    ToolbarTitleItem,
+    useStackApi,
+    useStackSwitchApi,
+} from "@comet/admin";
+import { FinalFormSaveButton } from "@comet/admin/lib/FinalFormSaveButton";
+import { Button, Typography } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { apolloSwapiStoryDecorator } from "../../../../apollo-story.decorator";
+import { storyRouterDecorator } from "../../../../story-router.decorator";
+import { toolbarDecorator } from "../toolbar.decorator";
+
+storiesOf("stories/components/Toolbar/Final Form Save Button", module)
+    .addDecorator(apolloSwapiStoryDecorator())
+    .addDecorator(toolbarDecorator())
+    .addDecorator(storyRouterDecorator())
+    .add("Final Form Save Button", () => {
+        function delay(ms: number) {
+            return new Promise((resolve) => setTimeout(resolve, ms));
+        }
+        return (
+            <FinalForm
+                mode="edit"
+                onSubmit={async () => {
+                    // add your form-submit function here
+                    console.log("saving async...");
+
+                    await delay(500); // simulate asynchronous submitting
+
+                    console.log("saving successful");
+                }}
+                onAfterSubmit={(values, form) => {
+                    form.reset(values);
+                }}
+            >
+                {() => {
+                    const stackSwitchApi = useStackSwitchApi();
+                    const stackApi = useStackApi();
+                    const canGoBack = stackApi && stackApi.breadCrumbs.length > 1;
+
+                    return (
+                        <>
+                            <Toolbar>
+                                <ToolbarBackButton />
+                                <ToolbarTitleItem>Final Form Save Button</ToolbarTitleItem>
+                                <ToolbarFillSpace />
+                                <ToolbarActions>
+                                    {canGoBack ? (
+                                        <FinalFormSaveButton />
+                                    ) : (
+                                        <Button
+                                            variant="contained"
+                                            color="primary"
+                                            onClick={() => {
+                                                stackSwitchApi?.activatePage("automaticTitleDetail", "details");
+                                            }}
+                                        >
+                                            <Typography>Go To Details</Typography>
+                                        </Button>
+                                    )}
+                                </ToolbarActions>
+                            </Toolbar>
+                            {canGoBack && (
+                                <MainContent>
+                                    <Field label="Title" placeholder="Title" name="title" component={FinalFormInput} />
+                                </MainContent>
+                            )}
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    });

--- a/packages/admin/admin/src/FinalFormSaveButton.tsx
+++ b/packages/admin/admin/src/FinalFormSaveButton.tsx
@@ -13,15 +13,17 @@ export const FinalFormSaveButton = ({ message = <FormattedMessage {...messages.s
     const form = useForm();
     const { pristine, hasValidationErrors, submitting, hasSubmitErrors } = useFormState();
 
+    const isDisabled = pristine || hasValidationErrors || submitting;
+
     return (
         <SaveButton
-            disabled={pristine || hasValidationErrors || submitting}
+            disabled={isDisabled}
             color="primary"
             variant="contained"
             saving={submitting}
             hasErrors={hasSubmitErrors}
             onClick={() => {
-                !pristine && !hasValidationErrors && !submitting && form.submit();
+                if (!isDisabled) form.submit();
             }}
         >
             {message}

--- a/packages/admin/admin/src/FinalFormSaveButton.tsx
+++ b/packages/admin/admin/src/FinalFormSaveButton.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { useForm, useFormState } from "react-final-form";
+import { FormattedMessage } from "react-intl";
+
+import { SaveButton } from "./common/buttons/save/SaveButton";
+import { messages } from "./messages";
+
+interface FinalFormSaveButtonProps {
+    message?: React.ReactNode;
+}
+
+export const FinalFormSaveButton = ({ message = <FormattedMessage {...messages.save} /> }: FinalFormSaveButtonProps) => {
+    const form = useForm();
+    const { pristine, hasValidationErrors, submitting, hasSubmitErrors } = useFormState();
+
+    return (
+        <SaveButton
+            disabled={pristine || hasValidationErrors || submitting}
+            color="primary"
+            variant="contained"
+            saving={submitting}
+            hasErrors={hasSubmitErrors}
+            onClick={() => {
+                !pristine && !hasValidationErrors && !submitting && form.submit();
+            }}
+        >
+            {message}
+        </SaveButton>
+    );
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -65,6 +65,7 @@ export { useErrorDialog, UseErrorDialogReturn } from "./error/errordialog/useErr
 export { createFetch, FetchContext, FetchProvider, useFetch } from "./fetchProvider/fetch";
 export { FileIcon } from "./fileIcons/FileIcon";
 export { FinalForm, useFormApiRef } from "./FinalForm";
+export { FinalFormSaveButton } from "./FinalFormSaveButton";
 export {
     FinalFormSaveCancelButtonsLegacy,
     FinalFormSaveCancelButtonsLegacyClassKey,


### PR DESCRIPTION
This PR adds a final form save button, which should be used in the future instead of the FinalFormSaveSplitButton.

## Screen recording
https://github.com/vivid-planet/comet/assets/56400587/01af6bec-0e37-4fbe-b759-c2a9b433f00a

