### PR TITLE
COM-118: fix StackLink not supporting forward ref

### DIFF
--- a/packages/admin/admin/src/stack/StackLink.tsx
+++ b/packages/admin/admin/src/stack/StackLink.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { Link as RouterLink, LinkProps as RouterLinkProps } from "react-router-dom";
 
 import { IStackSwitchApi, useStackSwitchApi } from "./Switch";
@@ -10,21 +10,16 @@ interface StackLinkProps extends Omit<RouterLinkProps, "to"> {
     switchApi?: IStackSwitchApi;
 }
 
-export const StackLink = ({
-    pageName,
-    payload,
-    subUrl,
-    switchApi: externalSwitchApi,
-    children,
-    ...props
-}: PropsWithChildren<StackLinkProps>): React.ReactElement => {
-    const internalSwitchApi = useStackSwitchApi();
-    // external switchApi allows the creation of StackLinks outside of the stack with the useStackSwitch() hook
-    const _switchApi = externalSwitchApi !== undefined ? externalSwitchApi : internalSwitchApi;
+export const StackLink = React.forwardRef<HTMLAnchorElement, StackLinkProps>(
+    ({ switchApi: externalSwitchApi, payload, pageName, subUrl, children, ...props }, ref) => {
+        const internalSwitchApi = useStackSwitchApi();
+        // external switchApi allows the creation of StackLinks outside of the stack with the useStackSwitch() hook
+        const _switchApi = externalSwitchApi !== undefined ? externalSwitchApi : internalSwitchApi;
 
-    return (
-        <RouterLink to={() => _switchApi.getTargetUrl(pageName, payload, subUrl)} {...props}>
-            {children}
-        </RouterLink>
-    );
-};
+        return (
+            <RouterLink ref={ref} to={() => _switchApi.getTargetUrl(pageName, payload, subUrl)} {...props}>
+                {children}
+            </RouterLink>
+        );
+    },
+);


### PR DESCRIPTION
This PR fixes a bug where the StackLink component didn't support forward refs.

## Screenshots
### Before
![image](https://github.com/vivid-planet/comet/assets/56400587/2026a46f-d456-45ab-83df-2fd7dda1baaf)

### After
![image](https://github.com/vivid-planet/comet/assets/56400587/5b44dc6c-d4da-43a2-a680-da7a7b242a78)
