### PR TITLE
Add error message to generate-icons.ts

### DIFF
--- a/packages/admin/admin-icons/generate-icons.ts
+++ b/packages/admin/admin-icons/generate-icons.ts
@@ -3,10 +3,13 @@ import { ESLint } from "eslint";
 import { XMLParser } from "fast-xml-parser";
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { pascalCase, pascalCaseTransformMerge } from "pascal-case";
+import * as path from "path";
 const eslint = new ESLint({ fix: true });
 
 const main = async () => {
-    const files = readdirSync("icons");
+    const files = readdirSync("icons").filter((file) => {
+        return path.extname(file).toLowerCase() === ".svg";
+    });
 
     const bar = new SingleBar(
         {
@@ -44,7 +47,7 @@ const getPathData = (fileName: string) => {
     const parsedXml = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "" }).parse(fileContents.toString());
 
     if (parsedXml?.svg?.path?.d === undefined) {
-        throw new Error(`The file ${fileName} must contain a path element with a d attribute`);
+        throw new Error(`The file ${fileName} must contain a <path> element with a d attribute`);
     }
 
     return parsedXml.svg.path.d;

--- a/packages/admin/admin-icons/generate-icons.ts
+++ b/packages/admin/admin-icons/generate-icons.ts
@@ -43,6 +43,10 @@ const getPathData = (fileName: string) => {
     const fileContents = readFileSync(`icons/${fileName}`);
     const parsedXml = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "" }).parse(fileContents.toString());
 
+    if (parsedXml?.svg?.path?.d === undefined) {
+        throw new Error(`The file ${fileName} doesn't contain a valid SVG`);
+    }
+
     return parsedXml.svg.path.d;
 };
 

--- a/packages/admin/admin-icons/generate-icons.ts
+++ b/packages/admin/admin-icons/generate-icons.ts
@@ -44,7 +44,7 @@ const getPathData = (fileName: string) => {
     const parsedXml = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "" }).parse(fileContents.toString());
 
     if (parsedXml?.svg?.path?.d === undefined) {
-        throw new Error(`The file ${fileName} doesn't contain a valid SVG`);
+        throw new Error(`The file ${fileName} must contain a path element with a d attribute`);
     }
 
     return parsedXml.svg.path.d;


### PR DESCRIPTION
Show an error message if a file in the /icons directory doesn't contain valid SVG code

### Motivation:
I added new icons to the /icons directory. In this process, MacOS generated a .DS_Store file. Then the generate-icons script failed with an unspecific error because .DS_Store doesn't contain a valid SVG.
The problem was hard to figure out because the .DS_Store is also not displayed in the IDE. 