### PR TITLE
Backport fix Page Properties Dialog (#1414) to v4

### DIFF
--- a/.changeset/fifty-apricots-count.md
+++ b/.changeset/fifty-apricots-count.md
@@ -2,5 +2,9 @@
 "@comet/admin": patch
 ---
 
-Fix a bug in `FinalForm` where the submit mutation wasn't correctly awaited if a `FinalForm` inside an `EditDialog` used an asynchronous validation. 
-Instead, the EditDialog closed before the submission was completed. All changes were omitted. The result of the submission (fail or success) was never shown.
+
+Fix `submit` implementation for `DirtyHandler` in `FinalForm`
+
+The submit mutation wasn't correctly awaited if a `FinalForm` using an asynchronous validation was saved via the `saveAction` provided in the `RouterPrompt`.
+
+In practice, this affected `FinalForm`s within an `EditDialog`. The `EditDialog` closed before the submission was completed. All changes were omitted. The result of the submission (fail or success) was never shown.

--- a/.changeset/fifty-apricots-count.md
+++ b/.changeset/fifty-apricots-count.md
@@ -1,0 +1,6 @@
+---
+"@comet/admin": patch
+---
+
+Fix a bug in `FinalForm` where the submit mutation wasn't correctly awaited if a `FinalForm` inside an `EditDialog` used an asynchronous validation. 
+Instead, the EditDialog closed before the submission was completed. All changes were omitted. The result of the submission (fail or success) was never shown.

--- a/.changeset/tough-gorillas-travel.md
+++ b/.changeset/tough-gorillas-travel.md
@@ -2,7 +2,7 @@
 "@comet/cms-admin": patch
 ---
 
-Improved the EditPageNode dialog ("Page Properties" dialog):
+Improved the `EditPageNode` dialog ("Page Properties" dialog):
 
 - Execute the asynchronous slug validation less often (increased the debounce wait time from 200ms to 500ms)
 - Cache the slug validation results. Evict the cache on the initial render of the dialog

--- a/.changeset/tough-gorillas-travel.md
+++ b/.changeset/tough-gorillas-travel.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-admin": patch
+---
+
+Improved the EditPageNode dialog ("Page Properties" dialog):
+
+- Execute the asynchronous slug validation less often (increased the debounce wait time from 200ms to 500ms)
+- Cache the slug validation results. Evict the cache on the initial render of the dialog

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -136,6 +136,12 @@ export function createEditPageNode({
             label: documentTypes[type].displayName,
         }));
 
+        React.useEffect(() => {
+            apollo.cache.evict({ fieldName: "pageTreeNodeSlugAvailable" });
+            // should only be executed on initial render
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []);
+
         const isPathAvailable = React.useCallback(
             async (newSlug: string): Promise<GQLSlugAvailability> => {
                 if (slug === newSlug) {

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -149,7 +149,7 @@ export function createEditPageNode({
                         slug: newSlug,
                         scope,
                     },
-                    fetchPolicy: "network-only",
+                    fetchPolicy: "cache-first",
                 });
 
                 return data.availability;
@@ -186,7 +186,7 @@ export function createEditPageNode({
         // Use `p-debounce` instead of `use-debounce`
         // because Final Form expects all validate calls to be resolved.
         // `p-debounce` resolves all calls, `use-debounce` doesn't
-        const debouncedValidateSlug = debounce(validateSlug, 200);
+        const debouncedValidateSlug = debounce(validateSlug, 500);
 
         if (mode === "edit" && (loading || !data?.page)) {
             return <Loading />;
@@ -246,6 +246,9 @@ export function createEditPageNode({
                                 refetchQueries: [namedOperations.Query.Pages],
                             });
                         }
+                    }}
+                    onAfterSubmit={() => {
+                        // noop
                     }}
                     initialValues={data?.page ?? { documentType: Object.keys(documentTypes)[0] }}
                     render={({ form }) => {

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -138,9 +138,7 @@ export function createEditPageNode({
 
         React.useEffect(() => {
             apollo.cache.evict({ fieldName: "pageTreeNodeSlugAvailable" });
-            // should only be executed on initial render
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, []);
+        }, [apollo.cache]);
 
         const isPathAvailable = React.useCallback(
             async (newSlug: string): Promise<GQLSlugAvailability> => {
@@ -201,6 +199,9 @@ export function createEditPageNode({
             <div>
                 <FinalForm<FormValues>
                     mode={mode}
+                    onAfterSubmit={() => {
+                        // noop
+                    }}
                     mutators={{
                         setFieldTouched: setFieldTouched as Mutator<FormValues>,
                     }}
@@ -252,9 +253,6 @@ export function createEditPageNode({
                                 refetchQueries: [namedOperations.Query.Pages],
                             });
                         }
-                    }}
-                    onAfterSubmit={() => {
-                        // noop
                     }}
                     initialValues={data?.page ?? { documentType: Object.keys(documentTypes)[0] }}
                     render={({ form }) => {

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -28,6 +28,8 @@ import {
     ScopeInterface,
 } from "./types";
 
+const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));
+
 export function createPageTreeResolver({
     PageTreeNode,
     PageTreeNodeCreateInput = DefaultPageTreeNodeCreateInput,
@@ -94,6 +96,8 @@ export function createPageTreeResolver({
             @Args("parentId", { type: () => ID, nullable: true }) parentId: string,
             @Args("slug") slug: string,
         ): Promise<SlugAvailability> {
+            await sleep(3000);
+
             const requestedPath = await this.pageTreeService.pathForParentAndSlug(parentId || null, slug);
 
             if (this.config.reservedPaths.includes(requestedPath)) {

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -28,8 +28,6 @@ import {
     ScopeInterface,
 } from "./types";
 
-const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));
-
 export function createPageTreeResolver({
     PageTreeNode,
     PageTreeNodeCreateInput = DefaultPageTreeNodeCreateInput,
@@ -96,8 +94,6 @@ export function createPageTreeResolver({
             @Args("parentId", { type: () => ID, nullable: true }) parentId: string,
             @Args("slug") slug: string,
         ): Promise<SlugAvailability> {
-            await sleep(3000);
-
             const requestedPath = await this.pageTreeService.pathForParentAndSlug(parentId || null, slug);
 
             if (this.config.reservedPaths.includes(requestedPath)) {


### PR DESCRIPTION
de facto duplicate of https://github.com/vivid-planet/comet/pull/1414

## Previously:

The page properties dialog contains a slug field. This field has an async validation to check in the API if the resulting path is still available.

This led to a problem when saving the form in an `EditDialog`. In the save action, the form was saved using `formRenderProps.form.submit()`. However, this function doesn't wait for the validation to be finished.

On main, this led to the dialog closing and the changes being omitted if the save was triggered while the validation request was still pending.

https://github.com/vivid-planet/comet/assets/13380047/58891028-fc79-460d-b9bf-e48c52587ef9

## Now:

Now the submission is handled correctly. The save action waits for the validation and submission to finish successfully before closing the dialog.

https://github.com/vivid-planet/comet/assets/13380047/2fa7d2e6-830c-44a3-b2d4-0a540c04bf33
