### PR TITLE
Make admin-icons a dependency of admin-rte

### DIFF
--- a/packages/admin/admin-rte/package.json
+++ b/packages/admin/admin-rte/package.json
@@ -25,6 +25,7 @@
         "start:types": "tsc --project ./tsconfig.json --emitDeclarationOnly --watch --preserveWatchOutput"
     },
     "dependencies": {
+        "@comet/admin-icons": "workspace:^4.5.0",
         "detect-browser": "^5.2.1",
         "draftjs-conductor": "^3.0.0",
         "immutable": "~3.7.4"
@@ -33,7 +34,6 @@
         "@babel/cli": "^7.17.6",
         "@babel/core": "^7.20.12",
         "@comet/admin-babel-preset": "workspace:^4.5.0",
-        "@comet/admin-icons": "workspace:^4.5.0",
         "@comet/eslint-config": "workspace:^4.5.0",
         "@mui/icons-material": "^5.0.0",
         "@mui/material": "^5.0.0",
@@ -55,7 +55,6 @@
         "typescript": "^4.0.0"
     },
     "peerDependencies": {
-        "@comet/admin-icons": "workspace:^4.5.0",
         "@mui/icons-material": "^5.0.0",
         "@mui/material": "^5.0.0",
         "@mui/styles": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1450,6 +1450,9 @@ importers:
 
   packages/admin/admin-rte:
     dependencies:
+      '@comet/admin-icons':
+        specifier: workspace:^4.5.0
+        version: link:../admin-icons
       detect-browser:
         specifier: ^5.2.1
         version: 5.3.0
@@ -1469,9 +1472,6 @@ importers:
       '@comet/admin-babel-preset':
         specifier: workspace:^4.5.0
         version: link:../admin-babel-preset
-      '@comet/admin-icons':
-        specifier: workspace:^4.5.0
-        version: link:../admin-icons
       '@comet/eslint-config':
         specifier: workspace:^4.5.0
         version: link:../../eslint-config


### PR DESCRIPTION
It was previously added as a peer dependency, leading to a breaking change