### PR TITLE
Fix Hover Thumbnail in Asset Picker

### DIFF
--- a/.changeset/fast-bats-knock.md
+++ b/.changeset/fast-bats-knock.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Show a bigger version of an image when hovering over a image thumbnail in the DAM and asset picker dialog

--- a/.changeset/fast-bats-knock.md
+++ b/.changeset/fast-bats-knock.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": minor
 ---
 
-Show a bigger version of an image when hovering over a image thumbnail in the DAM and asset picker dialog
+Show a bigger version of an image when hovering over an image thumbnail in the DAM and asset picker dialog

--- a/packages/admin/cms-admin/src/dam/DataGrid/thumbnail/DamThumbnail.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/thumbnail/DamThumbnail.tsx
@@ -64,7 +64,15 @@ export const DamThumbnail = ({ asset }: DamThumbnailProps): React.ReactElement =
             thumbnail = (
                 <>
                     <ImageThumbnail onMouseOver={handleMouseOver} onMouseLeave={handleMouseLeave} src={asset.image.thumbnailUrl} />
-                    <Popper open={open} anchorEl={anchorEl} placement="auto-end" onResize={undefined} onResizeCapture={undefined} transition>
+                    <Popper
+                        sx={{ zIndex: 1301 }}
+                        open={open}
+                        anchorEl={anchorEl}
+                        placement="auto-end"
+                        onResize={undefined}
+                        onResizeCapture={undefined}
+                        transition
+                    >
                         {({ TransitionProps }) => (
                             <Fade {...TransitionProps} timeout={350}>
                                 <ImagePreview src={asset.fileUrl || undefined} />


### PR DESCRIPTION
## Previously:

The hover thumbnail was shown behind the asset picker dialog.
<img width="660" alt="Bildschirmfoto 2023-11-02 um 11 56 46" src="https://github.com/vivid-planet/comet/assets/13380047/d159ca6e-a1bf-4190-9676-1dea498454e4">


## Now:

The thumbnail is shown on top of the asset picker dialog
<img width="1318" alt="Bildschirmfoto 2023-11-02 um 11 56 11" src="https://github.com/vivid-planet/comet/assets/13380047/e2e25870-96c3-4033-beb4-725d4a2fa85a">


I further added a changeset because https://github.com/vivid-planet/comet/pull/1198 has none.

- [x] Add changeset (if necessary)