### PR TITLE
COM-156: Prevent overlapping of clear-button with select-arrow

### DIFF
--- a/.changeset/slow-queens-unite.md
+++ b/.changeset/slow-queens-unite.md
@@ -1,0 +1,6 @@
+---
+"@comet/admin-theme": patch
+"@comet/admin": patch
+---
+
+Prevent the clear-button and the select-arrow from overlapping when using `FinalFormSelect` with the `clearble` prop.

--- a/.changeset/slow-queens-unite.md
+++ b/.changeset/slow-queens-unite.md
@@ -3,4 +3,4 @@
 "@comet/admin": patch
 ---
 
-Prevent the clear-button and the select-arrow from overlapping when using `FinalFormSelect` with the `clearble` prop.
+Prevent the clear-button and the select-arrow from overlapping when using `FinalFormSelect` with the `clearable` prop.

--- a/packages/admin/admin-stories/src/admin/form/Select.tsx
+++ b/packages/admin/admin-stories/src/admin/form/Select.tsx
@@ -1,5 +1,6 @@
 import { Field, FinalFormSelect } from "@comet/admin";
-import { Card, CardContent, MenuItem } from "@mui/material";
+import { Account } from "@comet/admin-icons";
+import { Card, CardContent, InputAdornment, MenuItem } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 import { Form } from "react-final-form";
@@ -60,6 +61,18 @@ function Story() {
                                         )}
                                     </Field>
 
+                                    <Field name="flavorClearable" label="Clearble Flavor" fullWidth>
+                                        {(props) => (
+                                            <FinalFormSelect {...props} fullWidth clearable>
+                                                {options.map((option: Option) => (
+                                                    <MenuItem value={option.value} key={option.value}>
+                                                        {option.label}
+                                                    </MenuItem>
+                                                ))}
+                                            </FinalFormSelect>
+                                        )}
+                                    </Field>
+
                                     <Field name="flavorRequired" label="Required Flavor" fullWidth>
                                         {(props) => (
                                             <FinalFormSelect {...props} fullWidth required>
@@ -76,6 +89,31 @@ function Story() {
                                         {(props) => (
                                             <FinalFormSelect {...props} fullWidth disabled>
                                                 {options.map((option) => (
+                                                    <MenuItem value={option.value} key={option.value}>
+                                                        {option.label}
+                                                    </MenuItem>
+                                                ))}
+                                            </FinalFormSelect>
+                                        )}
+                                    </Field>
+
+                                    <Field name="flavorMultipleAdornments" label="Flavor with adornments" fullWidth>
+                                        {(props) => (
+                                            <FinalFormSelect
+                                                {...props}
+                                                fullWidth
+                                                startAdornment={
+                                                    <InputAdornment position="start">
+                                                        <Account />
+                                                    </InputAdornment>
+                                                }
+                                                endAdornment={
+                                                    <InputAdornment position="end" disablePointerEvents sx={{ width: 24 }}>
+                                                        <Account />
+                                                    </InputAdornment>
+                                                }
+                                            >
+                                                {options.map((option: Option) => (
                                                     <MenuItem value={option.value} key={option.value}>
                                                         {option.label}
                                                     </MenuItem>

--- a/packages/admin/admin-stories/src/admin/form/Select.tsx
+++ b/packages/admin/admin-stories/src/admin/form/Select.tsx
@@ -61,7 +61,7 @@ function Story() {
                                         )}
                                     </Field>
 
-                                    <Field name="flavorClearable" label="Clearble Flavor" fullWidth>
+                                    <Field name="flavorClearable" label="Clearable Flavor" fullWidth>
                                         {(props) => (
                                             <FinalFormSelect {...props} fullWidth clearable>
                                                 {options.map((option: Option) => (

--- a/packages/admin/admin-theme/src/componentsTheme/getCommonSelectTheme.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/getCommonSelectTheme.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from "@comet/admin-icons";
-import { Palette } from "@mui/material";
+import { inputAdornmentClasses, inputBaseClasses, Palette } from "@mui/material";
 
 export const commonSelectDefaultProps = {
     IconComponent: ChevronDown,
@@ -11,6 +11,17 @@ export const commonSelectStyleOverrides = {
 
     "&:focus": {
         backgroundColor: "transparent",
+    },
+
+    [`&.${inputBaseClasses.inputAdornedEnd}`]: {
+        paddingRight: 42,
+    },
+
+    [`& ~ .${inputAdornmentClasses.positionEnd}`]: {
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        right: 26,
     },
 };
 

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -35,10 +35,7 @@ export const FinalFormSelect = <T,>({
     ...rest
 }: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input">) => {
     const selectEndAdornment = clearable ? (
-        <>
-            <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange(undefined)} />
-            {endAdornment}
-        </>
+        <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange(undefined)} />
     ) : (
         endAdornment
     );


### PR DESCRIPTION
Since the end-adornment for the clear-button needs absolute positioning, it is no longer possible to use the `clearable` prop in combination with an  `endAdornment`. However, this is not a common use-case, and an `endAdornment` on a select is generally not supported by MUI, see: https://github.com/mui/material-ui/issues/17799.

An alternative would have been to position the select-arrow relative. Unfortunately, this would cause the clickable element that opens the select to shrink and prevent opening the select by clicking the select-arrow. Since this would confuse users, the `endAdornment` is now also positioned absolutely.

| Previously | Now |
| ---------- | --- |
| <img width="400" alt="Previously" src="https://github.com/vivid-planet/comet/assets/6264317/886ac1f4-c1c5-49c2-b8ac-0ab74bfa6bf3"> | <img width="400" alt="Now" src="https://github.com/vivid-planet/comet/assets/6264317/c89be77b-3dea-4c72-a84a-2f6ce6890c88"> | 