### PR TITLE
COM-159: Fix findOneByNameAndParentId in FoldersService

### DIFF
--- a/packages/api/cms-api/src/dam/files/folders.service.ts
+++ b/packages/api/cms-api/src/dam/files/folders.service.ts
@@ -144,7 +144,10 @@ export class FoldersService {
         { name, parentId }: { name: string; parentId?: string },
         scope?: DamScopeInterface,
     ): Promise<FolderInterface | null> {
-        const qb = this.selectQueryBuilder().andWhere({ name, scope });
+        const qb = this.selectQueryBuilder().andWhere({ name });
+        if (scope) {
+            qb.andWhere({ scope });
+        }
         if (parentId) {
             qb.andWhere({ parent: { id: parentId } });
         } else {


### PR DESCRIPTION
## Previously:

`findOneByNameAndParentId` didn't work with an empty scope. Instead, the API would throw following error:

<img width="621" alt="Bildschirmfoto 2023-11-03 um 14 42 09" src="https://github.com/vivid-planet/comet/assets/13380047/e948f8b4-68cd-4d2e-903c-e9881183f77b">


Thus, it wasn't possible to upload a folder to the DAM.


## Now:

`findOneByNameAndParentId` also works with an empty scope