### PR TITLE
Only require partial props for theme `defaultProps`

### DIFF
--- a/.changeset/proud-cheetahs-sleep.md
+++ b/.changeset/proud-cheetahs-sleep.md
@@ -1,0 +1,9 @@
+---
+"@comet/admin-color-picker": patch
+"@comet/admin-react-select": patch
+"@comet/admin-date-time": patch
+"@comet/admin-rte": patch
+"@comet/admin": patch
+---
+
+Allow partial props in the theme's `defaultProps` instead of requiring all props when setting the `defaultProps` of a component

--- a/packages/admin/admin-color-picker/src/ColorPicker.tsx
+++ b/packages/admin/admin-color-picker/src/ColorPicker.tsx
@@ -222,7 +222,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminColorPicker: ColorPickerProps;
+        CometAdminColorPicker: Partial<ColorPickerProps>;
     }
 
     interface Components {

--- a/packages/admin/admin-date-time/src/DatePicker.tsx
+++ b/packages/admin/admin-date-time/src/DatePicker.tsx
@@ -108,7 +108,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminDatePicker: DatePickerProps;
+        CometAdminDatePicker: Partial<DatePickerProps>;
     }
 
     interface Components {

--- a/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
+++ b/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
@@ -154,7 +154,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminDatePickerNavigation: DatePickerNavigationProps;
+        CometAdminDatePickerNavigation: Partial<DatePickerNavigationProps>;
     }
 
     interface Components {

--- a/packages/admin/admin-date-time/src/DateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/DateRangePicker.tsx
@@ -167,7 +167,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminDateRangePicker: DateRangePickerProps;
+        CometAdminDateRangePicker: Partial<DateRangePickerProps>;
     }
 
     interface Components {

--- a/packages/admin/admin-date-time/src/DateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/DateTimePicker.tsx
@@ -118,7 +118,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminDateTimePicker: DateTimePickerProps;
+        CometAdminDateTimePicker: Partial<DateTimePickerProps>;
     }
 
     interface Components {

--- a/packages/admin/admin-date-time/src/TimePicker.tsx
+++ b/packages/admin/admin-date-time/src/TimePicker.tsx
@@ -116,7 +116,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminTimePicker: TimePickerProps;
+        CometAdminTimePicker: Partial<TimePickerProps>;
     }
 
     interface Components {

--- a/packages/admin/admin-date-time/src/TimeRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/TimeRangePicker.tsx
@@ -154,7 +154,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminTimeRangePicker: TimeRangePickerProps;
+        CometAdminTimeRangePicker: Partial<TimeRangePickerProps>;
     }
 
     interface Components {

--- a/packages/admin/admin-react-select/src/ReactSelect.tsx
+++ b/packages/admin/admin-react-select/src/ReactSelect.tsx
@@ -222,7 +222,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminSelect: SelectProps<any>;
+        CometAdminSelect: Partial<SelectProps<any>>;
     }
 
     interface Components {

--- a/packages/admin/admin-rte/src/core/BlockElement.tsx
+++ b/packages/admin/admin-rte/src/core/BlockElement.tsx
@@ -94,7 +94,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminRteBlockElement: RteBlockElementProps;
+        CometAdminRteBlockElement: Partial<RteBlockElementProps>;
     }
 
     interface Components {

--- a/packages/admin/admin-rte/src/core/Rte.tsx
+++ b/packages/admin/admin-rte/src/core/Rte.tsx
@@ -349,7 +349,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminRte: RteProps;
+        CometAdminRte: Partial<RteProps>;
     }
 
     interface Components {

--- a/packages/admin/admin-stories/src/docs/development/CreateAComponentWithThemeSupport.stories.mdx
+++ b/packages/admin/admin-stories/src/docs/development/CreateAComponentWithThemeSupport.stories.mdx
@@ -98,7 +98,7 @@ export { MyComponentWithStyles as MyComponent };
  */
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminMyComponent: MyComponentProps;
+        CometAdminMyComponent: Partial<MyComponentProps>;
     }
 
     interface ComponentNameToClassKey {
@@ -107,8 +107,8 @@ declare module "@mui/material/styles" {
 
     interface Components {
         CometAdminMyComponent?: {
-            defaultProps?: ComponentsPropsList["CometAdminMyComponent"];
-            styleOverrides?: ComponentNameToClassKey["CometAdminMyComponent"];
+            defaultProps?: Partial<ComponentsPropsList["CometAdminMyComponent"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminMyComponent"];
         };
     }
 }

--- a/packages/admin/admin/src/FinalFormSaveCancelButtonsLegacy.tsx
+++ b/packages/admin/admin/src/FinalFormSaveCancelButtonsLegacy.tsx
@@ -65,7 +65,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminFinalFormSaveCancelButtonsLegacy: FinalFormSaveCancelButtonsLegacyProps;
+        CometAdminFinalFormSaveCancelButtonsLegacy: Partial<FinalFormSaveCancelButtonsLegacyProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/appHeader/AppHeader.tsx
+++ b/packages/admin/admin/src/appHeader/AppHeader.tsx
@@ -49,7 +49,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminAppHeader: AppHeaderProps;
+        CometAdminAppHeader: Partial<AppHeaderProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
+++ b/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
@@ -53,7 +53,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminAppHeaderButton: AppHeaderButtonProps;
+        CometAdminAppHeaderButton: Partial<AppHeaderButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
+++ b/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
@@ -97,7 +97,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminAppHeaderDropdown: AppHeaderDropdownProps;
+        CometAdminAppHeaderDropdown: Partial<AppHeaderDropdownProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/ClearInputAdornment.tsx
+++ b/packages/admin/admin/src/common/ClearInputAdornment.tsx
@@ -80,7 +80,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminClearInputAdornment: ClearInputAdornmentProps;
+        CometAdminClearInputAdornment: Partial<ClearInputAdornmentProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/HoverActions.tsx
+++ b/packages/admin/admin/src/common/HoverActions.tsx
@@ -63,7 +63,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminHoverActions: HoverActionsProps;
+        CometAdminHoverActions: Partial<HoverActionsProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { ClickAwayListener, Theme, Tooltip as MuiTooltip, tooltipClasses, TooltipProps as MuiTooltipProps } from "@mui/material";
+import { ClickAwayListener, ComponentsOverrides, Theme, Tooltip as MuiTooltip, tooltipClasses, TooltipProps as MuiTooltipProps } from "@mui/material";
 import { createStyles, WithStyles, withStyles } from "@mui/styles";
 import React, { cloneElement } from "react";
 
@@ -96,7 +96,7 @@ export { TooltipWithStyles as Tooltip };
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminTooltip: TooltipProps;
+        CometAdminTooltip: Partial<TooltipProps>;
     }
 
     interface ComponentNameToClassKey {
@@ -106,7 +106,7 @@ declare module "@mui/material/styles" {
     interface Components {
         CometAdminTooltip?: {
             defaultProps?: ComponentsPropsList["CometAdminTooltip"];
-            styleOverrides?: ComponentNameToClassKey["CometAdminTooltip"];
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTooltip"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/CopyToClipboardButton.tsx
+++ b/packages/admin/admin/src/common/buttons/CopyToClipboardButton.tsx
@@ -137,7 +137,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminCopyToClipboardButton: CopyToClipboardButtonProps;
+        CometAdminCopyToClipboardButton: Partial<CopyToClipboardButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/buttons/cancel/CancelButton.tsx
+++ b/packages/admin/admin/src/common/buttons/cancel/CancelButton.tsx
@@ -84,7 +84,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminCancelButton: CancelButtonProps;
+        CometAdminCancelButton: Partial<CancelButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
+++ b/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
@@ -49,7 +49,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminClearInputButton: ClearInputButtonProps;
+        CometAdminClearInputButton: Partial<ClearInputButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/buttons/delete/DeleteButton.tsx
+++ b/packages/admin/admin/src/common/buttons/delete/DeleteButton.tsx
@@ -88,7 +88,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminDeleteButton: DeleteButtonProps;
+        CometAdminDeleteButton: Partial<DeleteButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
+++ b/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
@@ -83,7 +83,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminOkayButton: OkayButtonProps;
+        CometAdminOkayButton: Partial<OkayButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/buttons/save/SaveButton.tsx
+++ b/packages/admin/admin/src/common/buttons/save/SaveButton.tsx
@@ -147,7 +147,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminSaveButton: SaveButtonProps;
+        CometAdminSaveButton: Partial<SaveButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/buttons/split/SplitButton.tsx
+++ b/packages/admin/admin/src/common/buttons/split/SplitButton.tsx
@@ -121,7 +121,7 @@ export const SplitButton = withStyles({}, { name: "CometAdminSplitButton" })(Spl
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminSplitButton: SplitButtonProps;
+        CometAdminSplitButton: Partial<SplitButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -58,7 +58,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbar: ToolbarProps;
+        CometAdminToolbar: Partial<ToolbarProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/toolbar/automatictitleitem/ToolbarAutomaticTitleItem.tsx
+++ b/packages/admin/admin/src/common/toolbar/automatictitleitem/ToolbarAutomaticTitleItem.tsx
@@ -41,7 +41,7 @@ declare module "@mui/material/styles" {
         CometAdminToolbarAutomaticTitleItem: ToolbarAutomaticTitleItemClassKey;
     }
     interface ComponentsPropsList {
-        CometAdminToolbarAutomaticTitleItem: ToolbarAutomaticTitleItemProps;
+        CometAdminToolbarAutomaticTitleItem: Partial<ToolbarAutomaticTitleItemProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/toolbar/backbutton/ToolbarBackButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/backbutton/ToolbarBackButton.tsx
@@ -53,7 +53,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbarBackButton: ToolbarBackButtonProps;
+        CometAdminToolbarBackButton: Partial<ToolbarBackButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/toolbar/breadcrumb/ToolbarBreadcrumbs.tsx
+++ b/packages/admin/admin/src/common/toolbar/breadcrumb/ToolbarBreadcrumbs.tsx
@@ -57,7 +57,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbarBreadcrumbs: ToolbarBreadcrumbsProps;
+        CometAdminToolbarBreadcrumbs: Partial<ToolbarBreadcrumbsProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/toolbar/fillspace/ToolbarFillSpace.tsx
+++ b/packages/admin/admin/src/common/toolbar/fillspace/ToolbarFillSpace.tsx
@@ -28,7 +28,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbarFillSpace: ToolbarFillSpaceProps;
+        CometAdminToolbarFillSpace: Partial<ToolbarFillSpaceProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/toolbar/item/ToolbarItem.tsx
+++ b/packages/admin/admin/src/common/toolbar/item/ToolbarItem.tsx
@@ -34,7 +34,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbarItem: ToolbarItemProps;
+        CometAdminToolbarItem: Partial<ToolbarItemProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/common/toolbar/titleitem/ToolbarTitleItem.tsx
+++ b/packages/admin/admin/src/common/toolbar/titleitem/ToolbarTitleItem.tsx
@@ -39,7 +39,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbarTitleItem: ToolbarTitleItemProps;
+        CometAdminToolbarTitleItem: Partial<ToolbarTitleItemProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/error/errorboundary/ErrorBoundary.tsx
+++ b/packages/admin/admin/src/error/errorboundary/ErrorBoundary.tsx
@@ -135,7 +135,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminErrorBoundary: ErrorBoundaryProps;
+        CometAdminErrorBoundary: Partial<ErrorBoundaryProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -170,7 +170,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminFormFieldContainer: FieldContainerProps;
+        CometAdminFormFieldContainer: Partial<FieldContainerProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
+++ b/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
@@ -52,7 +52,7 @@ export const FinalFormSearchTextField = withStyles({}, { name: "CometAdminFinalF
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminFinalFormSearchTextField: FinalFormSearchTextFieldProps;
+        CometAdminFinalFormSearchTextField: Partial<FinalFormSearchTextFieldProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/form/FormSection.tsx
+++ b/packages/admin/admin/src/form/FormSection.tsx
@@ -55,7 +55,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminFormSection: FormSectionProps;
+        CometAdminFormSection: Partial<FormSectionProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/mui/MainContent.tsx
+++ b/packages/admin/admin/src/mui/MainContent.tsx
@@ -70,7 +70,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminMainContent: MainContentProps;
+        CometAdminMainContent: Partial<MainContentProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/mui/MasterLayout.tsx
+++ b/packages/admin/admin/src/mui/MasterLayout.tsx
@@ -68,7 +68,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminMasterLayout: MasterLayoutProps;
+        CometAdminMasterLayout: Partial<MasterLayoutProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/mui/menu/CollapsibleItem.tsx
+++ b/packages/admin/admin/src/mui/menu/CollapsibleItem.tsx
@@ -101,7 +101,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminMenuCollapsibleItem: MenuCollapsibleItemProps;
+        CometAdminMenuCollapsibleItem: Partial<MenuCollapsibleItemProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/mui/menu/Menu.tsx
+++ b/packages/admin/admin/src/mui/menu/Menu.tsx
@@ -108,7 +108,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminMenu: MenuProps;
+        CometAdminMenu: Partial<MenuProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/stack/backbutton/StackBackButton.tsx
+++ b/packages/admin/admin/src/stack/backbutton/StackBackButton.tsx
@@ -37,7 +37,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminStackBackButton: StackBackButtonProps;
+        CometAdminStackBackButton: Partial<StackBackButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
@@ -67,7 +67,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminStackBreadcrumbs: StackBreadcrumbsProps;
+        CometAdminStackBreadcrumbs: Partial<StackBreadcrumbsProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/table/TableBodyRow.tsx
+++ b/packages/admin/admin/src/table/TableBodyRow.tsx
@@ -42,7 +42,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminTableBodyRow: TableBodyRowProps;
+        CometAdminTableBodyRow: Partial<TableBodyRowProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/table/TableDndOrder.tsx
+++ b/packages/admin/admin/src/table/TableDndOrder.tsx
@@ -1,4 +1,5 @@
 import { DragHandle } from "@comet/admin-icons";
+import { ComponentsOverrides, Theme } from "@mui/material";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
 import { ClassKeyOfStyles, ClassNameMap, createStyles, WithStyles, withStyles } from "@mui/styles";
@@ -184,7 +185,7 @@ export { TableDndOrderWithStyles as TableDndOrder };
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminTableDndOrder: TableDndOrderProps<IRow>;
+        CometAdminTableDndOrder: Partial<TableDndOrderProps<IRow>>;
     }
 
     interface ComponentNameToClassKey {
@@ -193,8 +194,8 @@ declare module "@mui/material/styles" {
 
     interface Components {
         CometAdminTableDndOrder?: {
-            defaultProps?: ComponentsPropsList["CometAdminTableDndOrder"];
-            styleOverrides?: ComponentNameToClassKey["CometAdminTableDndOrder"];
+            defaultProps?: Partial<ComponentsPropsList["CometAdminTableDndOrder"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTableDndOrder"];
         };
     }
 }

--- a/packages/admin/admin/src/table/filterbar/FilterBar.tsx
+++ b/packages/admin/admin/src/table/filterbar/FilterBar.tsx
@@ -47,7 +47,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminFilterBar: FilterBarProps;
+        CometAdminFilterBar: Partial<FilterBarProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/table/filterbar/filterBarActiveFilterBadge/FilterBarActiveFilterBadge.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarActiveFilterBadge/FilterBarActiveFilterBadge.tsx
@@ -36,7 +36,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminFilterBarActiveFilterBadge: FilterBarActiveFilterBadgeProps;
+        CometAdminFilterBarActiveFilterBadge: Partial<FilterBarActiveFilterBadgeProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/table/filterbar/filterBarButton/FilterBarButton.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarButton/FilterBarButton.tsx
@@ -62,7 +62,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminFilterBarButton: FilterBarButtonProps;
+        CometAdminFilterBarButton: Partial<FilterBarButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/table/filterbar/filterBarMoreFilters/FilterBarMoreFilters.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarMoreFilters/FilterBarMoreFilters.tsx
@@ -45,7 +45,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminFilterBarMoreFilters: FilterBarMoreFiltersProps;
+        CometAdminFilterBarMoreFilters: Partial<FilterBarMoreFiltersProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/table/filterbar/filterBarPopoverFilter/FilterBarPopoverFilter.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarPopoverFilter/FilterBarPopoverFilter.tsx
@@ -138,7 +138,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminFilterBarPopoverFilter: FilterBarPopoverFilterProps;
+        CometAdminFilterBarPopoverFilter: Partial<FilterBarPopoverFilterProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/tabs/TabScrollButton.tsx
+++ b/packages/admin/admin/src/tabs/TabScrollButton.tsx
@@ -49,7 +49,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminTabScrollButton: TabScrollButtonProps;
+        CometAdminTabScrollButton: Partial<TabScrollButtonProps>;
     }
 
     interface Components {

--- a/packages/admin/admin/src/tabs/Tabs.tsx
+++ b/packages/admin/admin/src/tabs/Tabs.tsx
@@ -104,7 +104,7 @@ declare module "@mui/material/styles" {
     }
 
     interface ComponentsPropsList {
-        CometAdminTabs: TabsProps;
+        CometAdminTabs: Partial<TabsProps>;
     }
 
     interface Components {


### PR DESCRIPTION
Instead of requiring all props when setting the `defaultProps` of a component.