### PR TITLE
Ignore leading and trailing spaces in searchToMikroOrmQuery

### DIFF
--- a/packages/api/cms-api/src/common/filter/mikro-orm.spec.ts
+++ b/packages/api/cms-api/src/common/filter/mikro-orm.spec.ts
@@ -30,6 +30,11 @@ describe("searchToMikroOrmQuery", () => {
             ],
         });
     });
+    it("should ignore leading and trailing spaces", async () => {
+        expect(searchToMikroOrmQuery(" a ", ["title"])).toStrictEqual({
+            $or: [{ title: { $ilike: "%a%" } }],
+        });
+    });
 });
 
 describe("filterToMikroOrmQuery", () => {

--- a/packages/api/cms-api/src/common/filter/mikro-orm.ts
+++ b/packages/api/cms-api/src/common/filter/mikro-orm.ts
@@ -152,7 +152,11 @@ export function filtersToMikroOrmQuery(
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function searchToMikroOrmQuery(search: string, fields: string[]): ObjectQuery<any> {
-    const quotedSearchParts = search.split(/ /).map((searchString) => `%${searchString.replace(/([%_\\])/g, "\\$1")}%`);
+    const quotedSearchParts = search
+        .trim()
+        .split(/ /)
+        .map((searchString) => `%${searchString.replace(/([%_\\])/g, "\\$1")}%`);
+
     const ors = [];
     for (const field of fields) {
         for (const quotedSearch of quotedSearchParts) {


### PR DESCRIPTION
## Previously:

Leading and trailing spaces weren't ignored. The input " a " led to the search parts: `[ '%%', '%a%',  '%%']`. This means, everything was matched.

## Now:

The search input is trimmed before processing. Leading and trailing spaces are ignored.

Fixes COM-170