### PR TITLE
Theme LinearProgress for use in DataGrid

### DIFF
--- a/.changeset/brave-rockets-invent.md
+++ b/.changeset/brave-rockets-invent.md
@@ -2,7 +2,7 @@
 "@comet/admin-theme": minor
 ---
 
-Add custom theme for LinearProgress
+Add custom default styling for LinearProgress
 
 The LinearProgress is intended to be used as a LoadingOverlay in the DataGrid. This styling change adjusts it for this purpose.
 

--- a/.changeset/brave-rockets-invent.md
+++ b/.changeset/brave-rockets-invent.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin-theme": minor
+---
+
+Add custom theme for LinearProgress
+
+The LinearProgress is intended to be used as a LoadingOverlay in the DataGrid. This styling change adjusts it for this purpose.
+

--- a/packages/admin/admin-theme/src/componentsTheme/MuiLinearProgress.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiLinearProgress.ts
@@ -1,12 +1,15 @@
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
 export const getMuiLinearProgress: GetMuiComponentTheme<"MuiLinearProgress"> = (component) => ({
     ...component,
     defaultProps: {
         color: "primary",
-        sx: {
+    },
+    styleOverrides: mergeOverrideStyles<"MuiLinearProgress">(component?.styleOverrides, {
+        root: {
             height: "2px",
             zIndex: 1, // for use in LoadingOverlay of DataGrid, otherwise the LinearProgress is behind the border
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiLinearProgress.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiLinearProgress.ts
@@ -1,0 +1,12 @@
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiLinearProgress: GetMuiComponentTheme<"MuiLinearProgress"> = (component) => ({
+    ...component,
+    defaultProps: {
+        color: "primary",
+        sx: {
+            height: "2px",
+            zIndex: 1, // for use in LoadingOverlay of DataGrid, otherwise the LinearProgress is behind the border
+        },
+    },
+});

--- a/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
@@ -26,6 +26,7 @@ import { getMuiIconButton } from "./MuiIconButton";
 import { getMuiInput } from "./MuiInput";
 import { getMuiInputAdornment } from "./MuiInputAdornment";
 import { getMuiInputBase } from "./MuiInputBase";
+import { getMuiLinearProgress } from "./MuiLinearProgress";
 import { getMuiLink } from "./MuiLink";
 import { getMuiListItem } from "./MuiListItem";
 import { getMuiNativeSelect } from "./MuiNativeSelect";
@@ -80,6 +81,7 @@ export const getComponentsTheme = (components: Components, themeData: ThemeData)
     MuiInputAdornment: getMuiInputAdornment(components.MuiInputAdornment, themeData),
     MuiInputBase: getMuiInputBase(components.MuiInputBase, themeData),
     MuiInput: getMuiInput(components.MuiInput, themeData),
+    MuiLinearProgress: getMuiLinearProgress(components.MuiLinearProgress, themeData),
     MuiLink: getMuiLink(components.MuiLink, themeData),
     MuiListItem: getMuiListItem(components.MuiListItem, themeData),
     MuiPaper: getMuiPaper(components.MuiPaper, themeData),


### PR DESCRIPTION
Add custom theme for LinearProgress

The LinearProgress is intended to be used as a LoadingOverlay in the DataGrid. This styling change adjusts it for this purpose.

## Screencast:

https://github.com/vivid-planet/comet/assets/13380047/db730e32-b10e-4794-96a7-e147d6bf6654

