### PR TITLE
COM-152: Change button variant to standardize button styling in dialogues

### DIFF
--- a/demo/admin/src/userGroups/UserGroupContextMenuItem.tsx
+++ b/demo/admin/src/userGroups/UserGroupContextMenuItem.tsx
@@ -84,7 +84,7 @@ function UserGroupContextMenuItem({ item, onChange, onMenuClose }: Props): JSX.E
                                 >
                                     <FormattedMessage {...messages.cancel} />
                                 </Button>
-                                <Button type="submit">
+                                <Button type="submit" variant="contained">
                                     <FormattedMessage {...messages.ok} />
                                 </Button>
                             </DialogActions>


### PR DESCRIPTION
Before:
<img width="1637" alt="Pasted Graphic 4" src="https://github.com/vivid-planet/comet/assets/148231586/cf3cd6a9-48bd-4f4a-a287-2c379faac58c">

Now:
<img width="609" alt="image" src="https://github.com/vivid-planet/comet/assets/148231586/cb159391-c67f-4333-a616-6d1b8e9e62a5">
