### PR TITLE
Select: Fix default getOptionValue implementation for values not beeing an object

### DIFF
--- a/.changeset/new-vans-report.md
+++ b/.changeset/new-vans-report.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Select: Fix default getOptionValue implementation for values not beeing an object

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -228,9 +228,6 @@ function ProductForm({ id }: FormProps): React.ReactElement {
                             component={FinalFormSelect}
                             {...categorySelectAsyncProps}
                             getOptionLabel={(option: GQLProductCategorySelectFragment) => option.title}
-                            getOptionSelected={(option: GQLProductCategorySelectFragment, value: GQLProductCategorySelectFragment) => {
-                                return option.id === value.id;
-                            }}
                         />
                         <Field
                             fullWidth
@@ -240,9 +237,6 @@ function ProductForm({ id }: FormProps): React.ReactElement {
                             multiple
                             {...tagsSelectAsyncProps}
                             getOptionLabel={(option: GQLProductTagsSelectFragment) => option.title}
-                            getOptionSelected={(option: GQLProductTagsSelectFragment, value: GQLProductTagsSelectFragment) => {
-                                return option.id === value.id;
-                            }}
                         />
                         <Field
                             fullWidth

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -27,9 +27,13 @@ export const FinalFormSelect = <T,>({
         return "";
     },
     getOptionValue = (option: T) => {
-        if ((option as any).id) return String((option as any).id);
-        if ((option as any).value) return String((option as any).value);
-        return JSON.stringify(option);
+        if (typeof option === "object") {
+            if ((option as any).id) return String((option as any).id);
+            if ((option as any).value) return String((option as any).value);
+            return JSON.stringify(option);
+        } else {
+            return String(option);
+        }
     },
     children,
     endAdornment,


### PR DESCRIPTION
Also don't use the old getOptionSelected that got removed in #1099 in Demo Products Form.

This fixes buggy Products Form