### PR TITLE
Fix copying non-image files

### DIFF
--- a/packages/api/cms-api/src/dam/files/dto/find-copies-of-file-in-scope.args.ts
+++ b/packages/api/cms-api/src/dam/files/dto/find-copies-of-file-in-scope.args.ts
@@ -1,0 +1,33 @@
+import { Type } from "@nestjs/common";
+import { ArgsType, Field, ID } from "@nestjs/graphql";
+import { IsString, ValidateNested } from "class-validator";
+
+import { IsUndefinable } from "../../../common/validators/is-undefinable";
+import { ImageCropAreaInput } from "../../images/dto/image-crop-area.input";
+import { DamScopeInterface } from "../../types";
+
+export interface FindCopiesOfFileInScopeArgsInterface {
+    id: string;
+    scope: DamScopeInterface;
+    imageCropArea?: ImageCropAreaInput;
+}
+
+export function createFindCopiesOfFileInScopeArgs({ Scope, hasNonEmptyScope }: { Scope: Type<DamScopeInterface>; hasNonEmptyScope: boolean }): Type {
+    @ArgsType()
+    class FindCopiesOfFileInScopeArgs {
+        @Field(() => ID)
+        @IsString()
+        id: string;
+
+        @Field(() => Scope, { defaultValue: hasNonEmptyScope ? undefined : {} })
+        @ValidateNested()
+        scope: typeof Scope;
+
+        @Field(() => ImageCropAreaInput, { nullable: true })
+        @ValidateNested()
+        @IsUndefinable()
+        imageCropArea?: ImageCropAreaInput;
+    }
+
+    return FindCopiesOfFileInScopeArgs;
+}

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -13,13 +13,13 @@ import { PaginatedResponseFactory } from "../../common/pagination/paginated-resp
 import { ContentScopeService } from "../../content-scope/content-scope.service";
 import { ScopeGuardActive } from "../../content-scope/decorators/scope-guard-active.decorator";
 import { DAM_FILE_VALIDATION_SERVICE } from "../dam.constants";
-import { ImageCropAreaInput } from "../images/dto/image-crop-area.input";
 import { DamScopeInterface } from "../types";
 import { CopyFilesResponseInterface, createCopyFilesResponseType } from "./dto/copyFiles.types";
 import { EmptyDamScope } from "./dto/empty-dam-scope";
 import { createFileArgs, FileArgsInterface, MoveDamFilesArgs } from "./dto/file.args";
 import { UpdateFileInput } from "./dto/file.input";
 import { FilenameInput, FilenameResponse } from "./dto/filename.args";
+import { createFindCopiesOfFileInScopeArgs, FindCopiesOfFileInScopeArgsInterface } from "./dto/find-copies-of-file-in-scope.args";
 import { FileInterface } from "./entities/file.entity";
 import { FolderInterface } from "./entities/folder.entity";
 import { FileValidationService } from "./file-validation.service";
@@ -40,6 +40,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
 
     const FileArgs = createFileArgs({ Scope });
     const CopyFilesResponse = createCopyFilesResponseType({ File });
+    const FindCopiesOfFileInScopeArgs = createFindCopiesOfFileInScopeArgs({ Scope, hasNonEmptyScope });
 
     @ObjectType()
     class PaginatedDamFiles extends PaginatedResponseFactory.create(File) {}
@@ -74,9 +75,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
         @Query(() => [File])
         //@ SubjectEntity is not required here
         async findCopiesOfFileInScope(
-            @Args("id", { type: () => ID }) id: string,
-            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
-            @Args("imageCropArea", { type: () => ImageCropAreaInput, nullable: true }) imageCropArea?: ImageCropAreaInput,
+            @Args({ type: () => FindCopiesOfFileInScopeArgs }) { id, scope, imageCropArea }: FindCopiesOfFileInScopeArgsInterface,
         ): Promise<FileInterface[]> {
             return this.filesService.findCopiesOfFileInScope(id, imageCropArea, scope);
         }


### PR DESCRIPTION
## Previously: 

Copying pages that used a non-image file failed. The reason was that the `findCopiesOfFileInScope` query is used to check for copies of a file. This query has a nullable imageCropArea argument. Still, the validation failed when imageCropArea wasn't provided.

<img width="640" alt="Bildschirmfoto 2023-11-13 um 14 01 31" src="https://github.com/vivid-planet/comet/assets/13380047/a2439923-4b7f-4563-80a4-cb7116e662a5">


## Now:
The args of findCopiesOfFileInScope were extracted to a @ArgsType(). Now the validation works as expected.
