### PR TITLE
COM-181: Change loading indicator in page tree

### DIFF
--- a/.changeset/fuzzy-years-switch.md
+++ b/.changeset/fuzzy-years-switch.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Show LinearProgress instead of CircularProgress when polling after initially loading the page tree

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
@@ -1,6 +1,5 @@
 import { ObservableQuery, useApolloClient } from "@apollo/client";
 import { IEditDialogApi, UndoSnackbar, useSnackbarApi } from "@comet/admin";
-import { Divider } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import gql from "graphql-tag";
 import isEqual from "lodash.isequal";
@@ -320,7 +319,6 @@ const PageTree: React.ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = 
         <>
             <PageTreeDragLayer numberSelectedPages={selectedPages.length} />
             <Root>
-                <Divider />
                 <Table>
                     <AutoSizer>
                         {({ height, width }) => {

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -185,7 +185,7 @@ export function PagesPage({
                                     <>
                                         <Divider />
                                         {loading && !isInitialLoad.current ? (
-                                            <LinearProgress sx={{ height: 2 }} />
+                                            <LinearProgress />
                                         ) : (
                                             /* Placeholder to avoid content jumping when the loading bar appears */
                                             <Box sx={{ backgroundColor: "white", width: "100%", height: 2 }} />

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -14,7 +14,7 @@ import {
     useStoredState,
 } from "@comet/admin";
 import { Add } from "@comet/admin-icons";
-import { Box, Button, FormControlLabel, Paper, Switch } from "@mui/material";
+import { Box, Button, Divider, FormControlLabel, LinearProgress, Paper, Switch } from "@mui/material";
 import withStyles from "@mui/styles/withStyles";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -179,18 +179,27 @@ export function PagesPage({
                                 />
                             </ActionToolbarBox>
                             <FullHeightPaper variant="outlined">
-                                {loading ? (
+                                {loading && isInitialLoad.current ? (
                                     <Loading behavior="fillParent" />
                                 ) : (
-                                    <PageTree
-                                        ref={refPageTree}
-                                        pages={pagesToRenderWithMatches}
-                                        editDialogApi={editDialogApi}
-                                        toggleExpand={toggleExpand}
-                                        onSelectChanged={onSelectChanged}
-                                        category={category}
-                                        siteUrl={siteConfig.url}
-                                    />
+                                    <>
+                                        <Divider />
+                                        {loading && !isInitialLoad.current ? (
+                                            <LinearProgress sx={{ height: 2 }} />
+                                        ) : (
+                                            /* Placeholder to avoid content jumping when the loading bar appears */
+                                            <Box sx={{ backgroundColor: "white", width: "100%", height: 2 }} />
+                                        )}
+                                        <PageTree
+                                            ref={refPageTree}
+                                            pages={pagesToRenderWithMatches}
+                                            editDialogApi={editDialogApi}
+                                            toggleExpand={toggleExpand}
+                                            onSelectChanged={onSelectChanged}
+                                            category={category}
+                                            siteUrl={siteConfig.url}
+                                        />
+                                    </>
                                 )}
                             </FullHeightPaper>
                         </PageTreeContent>


### PR DESCRIPTION
This pull request changes the page tree loading behavior. Instead of displaying a CircularProgress continuously during focus polling, it now shows a LinearProgress after the initial loading of the page tree.

### Acceptance Criteria
- [x] Add changeset

### Screen recording
https://github.com/vivid-planet/comet/assets/56400587/2863fbdf-54e3-4916-9e99-51664d0eb96a






