### PR TITLE
Add missing changesets for v5

### DIFF
--- a/.changeset/chatty-peaches-refuse.md
+++ b/.changeset/chatty-peaches-refuse.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+API Generator: Prevent duplicate imports in generated files

--- a/.changeset/empty-mails-approve.md
+++ b/.changeset/empty-mails-approve.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-admin": minor
+"@comet/cms-api": minor
+---
+
+It's now possible to opt-out of creating a redirect when changing the slug of a page
+
+Previously, a redirect was always created.

--- a/.changeset/gorgeous-boats-argue.md
+++ b/.changeset/gorgeous-boats-argue.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+API Generator: Support IDs of type string and integer (previously only UUID was supported"

--- a/.changeset/hungry-dots-end.md
+++ b/.changeset/hungry-dots-end.md
@@ -1,0 +1,6 @@
+---
+"@comet/cms-admin": patch
+"@comet/cms-api": patch
+---
+
+Allow `:`, `?`, `=` and `&` in redirect source paths

--- a/.changeset/purple-impalas-remain.md
+++ b/.changeset/purple-impalas-remain.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Add `calculateHashForFile()` method to `FilesService`

--- a/.changeset/rich-shrimps-drive.md
+++ b/.changeset/rich-shrimps-drive.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+API Generator: Enums don't need to be exported from the entity file

--- a/.changeset/sharp-dodos-guess.md
+++ b/.changeset/sharp-dodos-guess.md
@@ -1,0 +1,17 @@
+---
+"@comet/cms-admin": major
+"@comet/blocks-admin": major
+"@comet/cms-api": minor
+---
+
+Support automatically importing DAM files into another scope when copying documents from one scope to another
+
+The copy process was reworked:
+
+- The `DocumentInterface` now requires a `dependencies()` and a `replaceDependenciesInOutput()` method
+- The `BlockInterface` now has an optional `dependencies()` and a required `replaceDependenciesInOutput()` method 
+- `rewriteInternalLinks()` was removed from `@comet/cms-admin`. Its functionality is replaced by `replaceDependenciesInOutput()`.
+
+`dependencies()` returns information about dependencies of a document or block (e.g. a used `DamFile` or linked `PageTreeNode`). `replaceDependenciesInOutput()` replaces the IDs of all dependencies of a document or block with new IDs (necessary for copying documents or blocks to another scope).
+
+You can use the new `createDocumentRootBlocksMethods()` to generate the methods for documents.

--- a/.changeset/sharp-numbers-fix.md
+++ b/.changeset/sharp-numbers-fix.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Extend configuration options for `createAuthProxyJwtStrategy()`
+
+It's now possible to override the strategy and strategy options.

--- a/.changeset/stupid-fans-call.md
+++ b/.changeset/stupid-fans-call.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+API Generator: Support OneToOne relations

--- a/.changeset/sweet-dancers-boil.md
+++ b/.changeset/sweet-dancers-boil.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add a hover preview for images to the DAM

--- a/.changeset/tasty-scissors-suffer.md
+++ b/.changeset/tasty-scissors-suffer.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+The `updatePageTreeNode` query no longer requires an `attachedDocument` argument

--- a/.changeset/tender-donkeys-watch.md
+++ b/.changeset/tender-donkeys-watch.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": major
+---
+
+Don't remember the last folder or file the user opened in the DAM. The `ChooseFileDialog` still remembers the last folder opened.

--- a/.changeset/wise-rocks-wait.md
+++ b/.changeset/wise-rocks-wait.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+`searchToMikroOrmQuery()` now ignores leading and trailing spaces. This fixes a bug where all rows were matched if there was a space before or after the search string.


### PR DESCRIPTION
Many PRs in next had no changesets. I went over all merged PRs and added them retrospectively (and I hope I didn't miss anything)

Please don't squash (so that the commit IDs added by changesets are correct)