### PR TITLE
Make replaceDependenciesInOutput() required in the DocumentInterface

### DIFF
--- a/packages/admin/cms-admin/src/documents/types.ts
+++ b/packages/admin/cms-admin/src/documents/types.ts
@@ -46,5 +46,5 @@ export interface DocumentInterface<
     InfoTag?: React.ComponentType<{ page: PageTreePage }>;
     anchors: (input: DocumentInput) => string[];
     dependencies: (input: DocumentInput) => BlockDependency[];
-    replaceDependenciesInOutput?: (output: DocumentOutput, replacements: ReplaceDependencyObject[]) => DocumentOutput;
+    replaceDependenciesInOutput: (output: DocumentOutput, replacements: ReplaceDependencyObject[]) => DocumentOutput;
 }


### PR DESCRIPTION
Make `replaceDependenciesInOutput()` required in the `DocumentInterface`

In practice, this will be added by https://github.com/vivid-planet/comet/blob/next/packages/admin/cms-admin/src/documents/createDocumentRootBlocksMethods.ts anyway

Changeset in https://github.com/vivid-planet/comet/pull/1401