### PR TITLE
COM-184: Display Complete Path label for the home site

### DIFF
--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -313,22 +313,6 @@ export function createEditPageNode({
                                             return null;
                                         }
 
-                                        if (values.slug === "home") {
-                                            return (
-                                                <>
-                                                    <FieldContainer
-                                                        label={intl.formatMessage({
-                                                            id: "comet.pages.pages.page.path",
-                                                            defaultMessage: "Complete Path",
-                                                        })}
-                                                        variant="horizontal"
-                                                    >
-                                                        <Typography>/</Typography>
-                                                    </FieldContainer>
-                                                </>
-                                            );
-                                        }
-
                                         const numberOfDescendants = data?.page?.numberOfDescendants ?? 0;
 
                                         return (
@@ -341,7 +325,11 @@ export function createEditPageNode({
                                                     variant="horizontal"
                                                 >
                                                     <Typography>
-                                                        {parentPath}/{values.slug}
+                                                        {values.slug === "home"
+                                                            ? "/"
+                                                            : parentPath === null
+                                                            ? `/${values.slug}`
+                                                            : `${parentPath}/${values.slug}`}
                                                     </Typography>
                                                 </FieldContainer>
                                                 {mode === "edit" && dirtyFields.slug && (

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -192,6 +192,7 @@ export function createEditPageNode({
         if (mode === "edit" && (loading || !data?.page)) {
             return <Loading />;
         }
+
         return (
             <div>
                 <FinalForm<FormValues>
@@ -313,7 +314,19 @@ export function createEditPageNode({
                                         }
 
                                         if (values.slug === "home") {
-                                            return <Typography>/</Typography>;
+                                            return (
+                                                <>
+                                                    <FieldContainer
+                                                        label={intl.formatMessage({
+                                                            id: "comet.pages.pages.page.path",
+                                                            defaultMessage: "Complete Path",
+                                                        })}
+                                                        variant="horizontal"
+                                                    >
+                                                        <Typography>/</Typography>
+                                                    </FieldContainer>
+                                                </>
+                                            );
                                         }
 
                                         const numberOfDescendants = data?.page?.numberOfDescendants ?? 0;


### PR DESCRIPTION
<details>
 <summary>Screenshot</summary>
 
<img width="3007" alt="Screenshot 2023-11-20 at 13 22 59" src="https://github.com/vivid-planet/comet/assets/148231586/234384d7-d28d-4fd1-82ab-77fd7d2cda42">

</details>

I'm not sure how 'ugly' the code repetition for the FieldContainer is here.