### PR TITLE
PixelImageBlock: Valid preview URL if file has no file extension

### DIFF
--- a/.changeset/fuzzy-forks-relate.md
+++ b/.changeset/fuzzy-forks-relate.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix issue in PixelImageBlock that caused the preview URLs for files without a file extension in their filename to be invalid

--- a/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
@@ -37,7 +37,9 @@ export function createPreviewUrl({ damFile, cropArea }: ImageBlockState, apiUrl:
         imageCropArea.focalPoint === "SMART"
             ? [imageCropArea.focalPoint]
             : [imageCropArea.width, imageCropArea.height, imageCropArea.focalPoint, imageCropArea.x, imageCropArea.y];
-    const filename = damFile.name.substr(0, damFile.name.lastIndexOf("."));
+
+    const filenameContainsExtension = damFile.name.lastIndexOf(".") >= 0;
+    const filename = filenameContainsExtension ? damFile.name.substr(0, damFile.name.lastIndexOf(".")) : damFile.name;
 
     let urlTemplate = apiUrl + urlTemplateRoute;
     if (resize) {


### PR DESCRIPTION
## Previously:

URL: http://localhost:4000/dam/images/preview/df7399ea-7b9a-4257-9139-eeff0cc64cd3/crop:SMART/resize:320:320/

URL is invalid because the filename is missing -> 404

<img width="1920" alt="Bildschirmfoto 2023-11-20 um 15 38 40" src="https://github.com/vivid-planet/comet/assets/13380047/ddaace3e-beb8-4e20-a642-da985b2141ec">


## Now: 

URL: http://localhost:4000/dam/images/preview/df7399ea-7b9a-4257-9139-eeff0cc64cd3/crop:SMART/resize:320:320/1254x2030

<img width="1920" alt="Bildschirmfoto 2023-11-20 um 15 41 22" src="https://github.com/vivid-planet/comet/assets/13380047/a58d7c59-e48f-40bd-aa47-032dcc824ce1">

---

Fixes COM-188