### PR TITLE
COM-129: Fix Page Properties Dialog 

### DIFF
--- a/.changeset/fifty-apricots-count.md
+++ b/.changeset/fifty-apricots-count.md
@@ -2,5 +2,7 @@
 "@comet/admin": patch
 ---
 
-Fix a bug in `FinalForm` where the submit mutation wasn't correctly awaited if a `FinalForm` inside an `EditDialog` used an asynchronous validation. 
-Instead, the EditDialog closed before the submission was completed. All changes were omitted. The result of the submission (fail or success) was never shown.
+Fix a bug in `FinalForm` where the submit mutation wasn't correctly awaited if a `FinalForm` using an asynchronous validation was saved via the `saveAction` provided by the `RouterContext`. 
+
+In practice, this affected `FinalForm`s within an `EditDialog`. 
+The `EditDialog` closed before the submission was completed. All changes were omitted. The result of the submission (fail or success) was never shown.

--- a/.changeset/fifty-apricots-count.md
+++ b/.changeset/fifty-apricots-count.md
@@ -1,0 +1,6 @@
+---
+"@comet/admin": patch
+---
+
+Fix a bug in `FinalForm` where the submit mutation wasn't correctly awaited if a `FinalForm` inside an `EditDialog` used an asynchronous validation. 
+Instead, the EditDialog closed before the submission was completed. All changes were omitted. The result of the submission (fail or success) was never shown.

--- a/.changeset/fifty-apricots-count.md
+++ b/.changeset/fifty-apricots-count.md
@@ -2,7 +2,8 @@
 "@comet/admin": patch
 ---
 
-Fix a bug in `FinalForm` where the submit mutation wasn't correctly awaited if a `FinalForm` using an asynchronous validation was saved via the `saveAction` provided by the `RouterContext`. 
+Fix `saveAction` in `RouterPrompt` of `FinalForm`
 
-In practice, this affected `FinalForm`s within an `EditDialog`. 
-The `EditDialog` closed before the submission was completed. All changes were omitted. The result of the submission (fail or success) was never shown.
+The submit mutation wasn't correctly awaited if a `FinalForm` using an asynchronous validation was saved via the `saveAction` provided in the `RouterPrompt`. 
+
+In practice, this affected `FinalForm`s within an `EditDialog`. The `EditDialog` closed before the submission was completed. All changes were omitted. The result of the submission (fail or success) was never shown.

--- a/.changeset/tough-gorillas-travel.md
+++ b/.changeset/tough-gorillas-travel.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-admin": patch
+---
+
+Improved the EditPageNode dialog ("Page Properties" dialog):
+
+- Execute the asynchronous slug validation less often (increased the debounce wait time from 200ms to 500ms)
+- Cache the slug validation results. Evict the cache on the initial render of the dialog

--- a/packages/admin/admin/src/FinalForm.tsx
+++ b/packages/admin/admin/src/FinalForm.tsx
@@ -260,10 +260,15 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
 }
 
 const waitForFormValidationToBeFinished = (form: FormApi<any>): Promise<boolean> => {
+    if (!form.getState().validating) {
+        return Promise.resolve(false);
+    }
+
     return new Promise((resolve) => {
-        form.subscribe(
+        const unsubscribe = form.subscribe(
             (state) => {
                 if (!state.validating) {
+                    unsubscribe();
                     resolve(state.hasValidationErrors);
                 }
             },

--- a/packages/admin/admin/src/FinalForm.tsx
+++ b/packages/admin/admin/src/FinalForm.tsx
@@ -210,12 +210,12 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
     }
 
     async function handleSubmit(values: FormValues, form: FormApi<FormValues>) {
-        editDialogFormApi?.onFormStatusChange("saving");
-
         const submitEvent = (form.mutators.getSubmitEvent ? form.mutators.getSubmitEvent() : undefined) || new FinalFormSubmitEvent("submit");
         const ret = props.onSubmit(values, form, submitEvent);
 
         if (ret === undefined) return ret;
+
+        editDialogFormApi?.onFormStatusChange("saving");
 
         return Promise.resolve(ret)
             .then((data) => {

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -137,6 +137,12 @@ export function createEditPageNode({
             label: documentTypes[type].displayName,
         }));
 
+        React.useEffect(() => {
+            apollo.cache.evict({ fieldName: "pageTreeNodeSlugAvailable" });
+            // should only be executed on initial render
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []);
+
         const isPathAvailable = React.useCallback(
             async (newSlug: string): Promise<GQLSlugAvailability> => {
                 if (slug === newSlug) {

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -150,7 +150,7 @@ export function createEditPageNode({
                         slug: newSlug,
                         scope,
                     },
-                    fetchPolicy: "network-only",
+                    fetchPolicy: "cache-first",
                 });
 
                 return data.availability;
@@ -187,7 +187,7 @@ export function createEditPageNode({
         // Use `p-debounce` instead of `use-debounce`
         // because Final Form expects all validate calls to be resolved.
         // `p-debounce` resolves all calls, `use-debounce` doesn't
-        const debouncedValidateSlug = debounce(validateSlug, 200);
+        const debouncedValidateSlug = debounce(validateSlug, 500);
 
         if (mode === "edit" && (loading || !data?.page)) {
             return <Loading />;
@@ -196,6 +196,9 @@ export function createEditPageNode({
             <div>
                 <FinalForm<FormValues>
                     mode={mode}
+                    onAfterSubmit={() => {
+                        // noop
+                    }}
                     mutators={{
                         setFieldTouched: setFieldTouched as Mutator<FormValues>,
                     }}

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -139,9 +139,7 @@ export function createEditPageNode({
 
         React.useEffect(() => {
             apollo.cache.evict({ fieldName: "pageTreeNodeSlugAvailable" });
-            // should only be executed on initial render
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, []);
+        }, [apollo.cache]);
 
         const isPathAvailable = React.useCallback(
             async (newSlug: string): Promise<GQLSlugAvailability> => {

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -30,6 +30,8 @@ import {
     ScopeInterface,
 } from "./types";
 
+const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));
+
 export function createPageTreeResolver({
     PageTreeNode,
     PageTreeNodeCreateInput = DefaultPageTreeNodeCreateInput,
@@ -112,6 +114,8 @@ export function createPageTreeResolver({
             @Args("parentId", { type: () => ID, nullable: true }) parentId: string,
             @Args("slug") slug: string,
         ): Promise<SlugAvailability> {
+            await sleep(3000);
+
             const requestedPath = await this.pageTreeService.pathForParentAndSlug(parentId || null, slug);
 
             if (this.config.reservedPaths.includes(requestedPath)) {

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -30,8 +30,6 @@ import {
     ScopeInterface,
 } from "./types";
 
-const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));
-
 export function createPageTreeResolver({
     PageTreeNode,
     PageTreeNodeCreateInput = DefaultPageTreeNodeCreateInput,
@@ -114,8 +112,6 @@ export function createPageTreeResolver({
             @Args("parentId", { type: () => ID, nullable: true }) parentId: string,
             @Args("slug") slug: string,
         ): Promise<SlugAvailability> {
-            await sleep(3000);
-
             const requestedPath = await this.pageTreeService.pathForParentAndSlug(parentId || null, slug);
 
             if (this.config.reservedPaths.includes(requestedPath)) {


### PR DESCRIPTION
Copy of https://github.com/vivid-planet/comet/pull/1353 adjusted for v5

## Previously:

The page properties dialog contains a slug field. This field has an async validation to check in the API if the resulting path is still available.

This led to a problem when saving the form in an `EditDialog`. In the save action, the form was saved using `formRenderProps.form.submit()`. However, this function doesn't wait for the validation and the internal submit to be finished.

### In v4:

On main, this led to the dialog closing and the changes being omitted if the save was triggered while the validation request was still pending.

https://github.com/vivid-planet/comet/assets/13380047/58891028-fc79-460d-b9bf-e48c52587ef9

### In v5:

On next, this led to a "Discard unsaved changes" dialog showing after clicking save.

https://github.com/vivid-planet/comet/assets/13380047/4ff77bec-746c-46d3-b6ae-9e226ce8a324

## Now:

Now the submission is handled correctly. The save action waits for the validation and submission to finish successfully before closing the dialog.

https://github.com/vivid-planet/comet/assets/13380047/2fa7d2e6-830c-44a3-b2d4-0a540c04bf33
