### PR TITLE
Remove guards from fieldResolverEnhancers

### DIFF
--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -70,7 +70,7 @@ export class AppModule {
                             fieldMiddleware: [BlocksTransformerMiddlewareFactory.create(dependencies)],
                         },
                         // See https://docs.nestjs.com/graphql/other-features#execute-enhancers-at-the-field-resolver-level
-                        fieldResolverEnhancers: ["guards", "interceptors", "filters"] as Enhancer[],
+                        fieldResolverEnhancers: ["interceptors", "filters"] as Enhancer[],
                     }),
                     inject: [BLOCKS_MODULE_TRANSFORMER_DEPENDENCIES],
                 }),


### PR DESCRIPTION
Guards work on a per-request basis and should not be invoked for field resolvers

Introduced with: https://github.com/vivid-planet/comet/commit/c1502d1471b160e4147194001aaa656a28bc7b2b