### PR TITLE
Add RequiredPermission-decorator and enforce it by guard

### DIFF
--- a/.changeset/sixty-cobras-brake.md
+++ b/.changeset/sixty-cobras-brake.md
@@ -7,7 +7,7 @@ Replace ContentScopeModule with UserPermissionsModule
 Breaking changes:
 
 -   ContentScope-Module has been removed
--   canAccessScope has been moved to AccessControlService
+-   canAccessScope has been moved to AccessControlService and renamed to isAllowedContentScope
 -   role- and rights-fields has been removed from CurrentUser-Object
 -   AllowForRole-decorator has been removed
 -   Rename decorator SubjectEntity to AffectedEntity

--- a/.changeset/sixty-cobras-brake.md
+++ b/.changeset/sixty-cobras-brake.md
@@ -11,5 +11,6 @@ Breaking changes:
 -   role- and rights-fields has been removed from CurrentUser-Object
 -   AllowForRole-decorator has been removed
 -   Rename decorator SubjectEntity to AffectedEntity
+-   Add RequiredPermission-decorator and make it mandatory when using UserPermissionsModule
 
 Upgrade-Guide: tbd

--- a/packages/api/cms-api/src/builds/build-templates.service.ts
+++ b/packages/api/cms-api/src/builds/build-templates.service.ts
@@ -1,19 +1,23 @@
 import { V1CronJob } from "@kubernetes/client-node";
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 
 import { CurrentUserInterface } from "../auth/current-user/current-user";
 import { INSTANCE_LABEL } from "../kubernetes/kubernetes.constants";
 import { KubernetesService } from "../kubernetes/kubernetes.service";
-import { ContentScopeService } from "../user-permissions/content-scope.service";
+import { ACCESS_CONTROL_SERVICE } from "../user-permissions/user-permissions.constants";
+import { AccessControlServiceInterface } from "../user-permissions/user-permissions.types";
 import { BUILDER_LABEL } from "./builds.constants";
 
 @Injectable()
 export class BuildTemplatesService {
-    constructor(private readonly kubernetesService: KubernetesService, private readonly contentScopeService: ContentScopeService) {}
+    constructor(
+        private readonly kubernetesService: KubernetesService,
+        @Inject(ACCESS_CONTROL_SERVICE) private accessControlService: AccessControlServiceInterface,
+    ) {}
 
     async getAllowedBuilderCronJobs(user: CurrentUserInterface): Promise<V1CronJob[]> {
         return (await this.getAllBuilderCronJobs()).filter((cronJob) => {
-            return this.contentScopeService.canAccessScope(this.kubernetesService.getContentScope(cronJob), user);
+            return this.accessControlService.isAllowedContentScope(user, this.kubernetesService.getContentScope(cronJob));
         });
     }
 

--- a/packages/api/cms-api/src/builds/builds.resolver.ts
+++ b/packages/api/cms-api/src/builds/builds.resolver.ts
@@ -1,11 +1,13 @@
 import { V1CronJob } from "@kubernetes/client-node";
+import { Inject } from "@nestjs/common";
 import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
 
 import { CurrentUserInterface } from "../auth/current-user/current-user";
 import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
 import { INSTANCE_LABEL } from "../kubernetes/kubernetes.constants";
 import { KubernetesService } from "../kubernetes/kubernetes.service";
-import { ContentScopeService } from "../user-permissions/content-scope.service";
+import { ACCESS_CONTROL_SERVICE } from "../user-permissions/user-permissions.constants";
+import { AccessControlServiceInterface } from "../user-permissions/user-permissions.types";
 import { BuildsService } from "./builds.service";
 import { AutoBuildStatus } from "./dto/auto-build-status.object";
 import { Build } from "./dto/build.object";
@@ -17,7 +19,7 @@ export class BuildsResolver {
     constructor(
         private readonly kubernetesService: KubernetesService,
         private readonly buildsService: BuildsService,
-        private readonly contentScopeService: ContentScopeService,
+        @Inject(ACCESS_CONTROL_SERVICE) private accessControlService: AccessControlServiceInterface,
     ) {}
 
     @Mutation(() => Boolean)
@@ -33,7 +35,7 @@ export class BuildsResolver {
                 throw new Error("Triggering build from different instance is not allowed");
             }
 
-            if (!this.contentScopeService.canAccessScope(this.kubernetesService.getContentScope(cronJob), user)) {
+            if (!this.accessControlService.isAllowedContentScope(user, this.kubernetesService.getContentScope(cronJob))) {
                 throw new Error("Triggering build not allowed");
             }
 

--- a/packages/api/cms-api/src/builds/builds.service.ts
+++ b/packages/api/cms-api/src/builds/builds.service.ts
@@ -1,7 +1,7 @@
 import { V1CronJob, V1Job } from "@kubernetes/client-node";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import parser from "cron-parser";
 import { format } from "date-fns";
 
@@ -9,8 +9,9 @@ import { CurrentUserInterface } from "../auth/current-user/current-user";
 import { JobStatus } from "../kubernetes/job-status.enum";
 import { INSTANCE_LABEL, PARENT_CRON_JOB_LABEL } from "../kubernetes/kubernetes.constants";
 import { KubernetesService } from "../kubernetes/kubernetes.service";
-import { ContentScopeService } from "../user-permissions/content-scope.service";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
+import { ACCESS_CONTROL_SERVICE } from "../user-permissions/user-permissions.constants";
+import { AccessControlServiceInterface } from "../user-permissions/user-permissions.types";
 import { BuildTemplatesService } from "./build-templates.service";
 import { BUILDER_LABEL, LABEL_ANNOTATION, TRIGGER_ANNOTATION } from "./builds.constants";
 import { AutoBuildStatus } from "./dto/auto-build-status.object";
@@ -25,13 +26,13 @@ export class BuildsService {
         @InjectRepository(ChangesSinceLastBuild) private readonly changesRepository: EntityRepository<ChangesSinceLastBuild>,
         private readonly buildTemplatesService: BuildTemplatesService,
         private readonly kubernetesService: KubernetesService,
-        private readonly contentScopeService: ContentScopeService,
+        @Inject(ACCESS_CONTROL_SERVICE) private accessControlService: AccessControlServiceInterface,
     ) {}
 
     private async getAllowedBuildJobs(user: CurrentUserInterface): Promise<V1Job[]> {
         const allJobs = await this.kubernetesService.getAllJobs(`${BUILDER_LABEL} = true, ${INSTANCE_LABEL} = ${this.kubernetesService.helmRelease}`);
         return allJobs.filter((job) => {
-            return this.contentScopeService.canAccessScope(this.kubernetesService.getContentScope(job), user);
+            return this.accessControlService.isAllowedContentScope(user, this.kubernetesService.getContentScope(job));
         });
     }
 

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -7,7 +7,6 @@ import exifr from "exifr";
 import { createReadStream } from "fs";
 import getColors from "get-image-colors";
 import * as hasha from "hasha";
-import isEqual from "lodash.isequal";
 import fetch from "node-fetch";
 import { basename, extname, parse } from "path";
 import probe from "probe-image-size";
@@ -18,6 +17,8 @@ import { BlobStorageBackendService } from "../../blob-storage/backends/blob-stor
 import { CometEntityNotFoundException } from "../../common/errors/entity-not-found.exception";
 import { SortDirection } from "../../common/sorting/sort-direction.enum";
 import { ContentScopeService } from "../../user-permissions/content-scope.service";
+import { ACCESS_CONTROL_SERVICE } from "../../user-permissions/user-permissions.constants";
+import { AccessControlServiceInterface } from "../../user-permissions/user-permissions.types";
 import { FocalPoint } from "../common/enums/focal-point.enum";
 import { CometImageResolutionException } from "../common/errors/image-resolution.exception";
 import { DamConfig } from "../dam.config";
@@ -115,6 +116,7 @@ export class FilesService {
         private readonly imgproxyService: ImgproxyService,
         private readonly orm: MikroORM,
         private readonly contentScopeService: ContentScopeService,
+        @Inject(ACCESS_CONTROL_SERVICE) private accessControlService: AccessControlServiceInterface,
     ) {}
 
     private selectQueryBuilder(): QueryBuilder<FileInterface> {
@@ -259,7 +261,7 @@ export class FilesService {
 
         for (const file of files) {
             // Convert to JS object because deep-comparing classes and objects doesn't work
-            if (targetFolder?.scope !== undefined && !isEqual({ ...file.scope }, { ...targetFolder.scope })) {
+            if (targetFolder?.scope !== undefined && !this.contentScopeService.scopesAreEqual(file.scope, targetFolder.scope)) {
                 throw new Error("Target folder scope doesn't match file scope");
             }
 
@@ -452,7 +454,7 @@ export class FilesService {
         if (!inboxFolder) {
             throw new Error("Specified inbox folder doesn't exist.");
         }
-        if (inboxFolder.scope && !this.contentScopeService.canAccessScope(inboxFolder.scope, user)) {
+        if (inboxFolder.scope && !this.accessControlService.isAllowedContentScope(user, inboxFolder.scope)) {
             throw new Error("User can't access the target scope");
         }
 
@@ -478,7 +480,7 @@ export class FilesService {
 
         const fileScopes = getUniqueFileScopes(files);
         const canAccessFileScopes = fileScopes.every((scope) => {
-            return this.contentScopeService.canAccessScope(scope, user);
+            return this.accessControlService.isAllowedContentScope(user, scope);
         });
         if (!canAccessFileScopes) {
             throw new Error(`User can't access the scope of one or more files`);

--- a/packages/api/cms-api/src/dam/images/images.controller.ts
+++ b/packages/api/cms-api/src/dam/images/images.controller.ts
@@ -10,7 +10,8 @@ import { CurrentUserInterface } from "../../auth/current-user/current-user";
 import { GetCurrentUser } from "../../auth/decorators/get-current-user.decorator";
 import { DisableGlobalGuard } from "../../auth/decorators/global-guard-disable.decorator";
 import { BlobStorageBackendService } from "../../blob-storage/backends/blob-storage-backend.service";
-import { ContentScopeService } from "../../user-permissions/content-scope.service";
+import { ACCESS_CONTROL_SERVICE } from "../../user-permissions/user-permissions.constants";
+import { AccessControlServiceInterface } from "../../user-permissions/user-permissions.types";
 import { ScaledImagesCacheService } from "../cache/scaled-images-cache.service";
 import { FocalPoint } from "../common/enums/focal-point.enum";
 import { CDN_ORIGIN_CHECK_HEADER, DamConfig } from "../dam.config";
@@ -48,7 +49,7 @@ export class ImagesController {
         private readonly imagesService: ImagesService,
         private readonly cacheService: ScaledImagesCacheService,
         @Inject(forwardRef(() => BlobStorageBackendService)) private readonly blobStorageBackendService: BlobStorageBackendService,
-        private readonly contentScopeService: ContentScopeService,
+        @Inject(ACCESS_CONTROL_SERVICE) private accessControlService: AccessControlServiceInterface,
     ) {}
 
     @Get(`/preview/${smartImageUrl}`)
@@ -68,7 +69,7 @@ export class ImagesController {
             throw new NotFoundException();
         }
 
-        if (file.scope !== undefined && !this.contentScopeService.canAccessScope(file.scope, user)) {
+        if (file.scope !== undefined && !this.accessControlService.isAllowedContentScope(user, file.scope)) {
             throw new ForbiddenException();
         }
 
@@ -94,7 +95,7 @@ export class ImagesController {
             throw new NotFoundException();
         }
 
-        if (file.scope !== undefined && !this.contentScopeService.canAccessScope(file.scope, user)) {
+        if (file.scope !== undefined && !this.accessControlService.isAllowedContentScope(user, file.scope)) {
             throw new ForbiddenException();
         }
 

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -141,6 +141,7 @@ export { RedirectsService } from "./redirects/redirects.service";
 export { IsValidRedirectSource, IsValidRedirectSourceConstraint } from "./redirects/validators/isValidRedirectSource";
 export { AbstractAccessControlService } from "./user-permissions/access-control.service";
 export { AffectedEntity, AffectedEntityMeta, AffectedEntityOptions } from "./user-permissions/decorators/affected-entity.decorator";
+export { RequiredPermission } from "./user-permissions/decorators/required-permission.decorator";
 export { ScopedEntity, ScopedEntityMeta } from "./user-permissions/decorators/scoped-entity.decorator";
 export { CurrentUser } from "./user-permissions/dto/current-user";
 export { FindUsersArgs } from "./user-permissions/dto/paginated-user-list";

--- a/packages/api/cms-api/src/user-permissions/access-control.service.ts
+++ b/packages/api/cms-api/src/user-permissions/access-control.service.ts
@@ -7,12 +7,12 @@ import { AccessControlServiceInterface } from "./user-permissions.types";
 
 @Injectable()
 export abstract class AbstractAccessControlService implements AccessControlServiceInterface {
-    canAccessScope(requestScope: ContentScope, user: CurrentUserInterface): boolean {
+    isAllowedContentScope(user: CurrentUserInterface, contentScope: ContentScope): boolean {
         if (!user.contentScopes) return false;
-        return user.contentScopes.some((cs) => Object.entries(requestScope).every(([scope, value]) => cs[scope] === value));
+        return user.contentScopes.some((cs) => Object.entries(contentScope).every(([scope, value]) => cs[scope] === value));
     }
 
-    isAllowed(user: CurrentUserInterface, permission: keyof Permission): boolean {
+    isAllowedPermission(user: CurrentUserInterface, permission: keyof Permission): boolean {
         if (!user.permissions) return false;
         return user.permissions.some((p) => p.permission === permission);
     }

--- a/packages/api/cms-api/src/user-permissions/access-control.service.ts
+++ b/packages/api/cms-api/src/user-permissions/access-control.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 
 import { CurrentUserInterface } from "../auth/current-user/current-user";
 import { ContentScope } from "./interfaces/content-scope.interface";
+import { Permission } from "./interfaces/user-permission.interface";
 import { AccessControlServiceInterface } from "./user-permissions.types";
 
 @Injectable()
@@ -9,5 +10,10 @@ export abstract class AbstractAccessControlService implements AccessControlServi
     canAccessScope(requestScope: ContentScope, user: CurrentUserInterface): boolean {
         if (!user.contentScopes) return false;
         return user.contentScopes.some((cs) => Object.entries(requestScope).every(([scope, value]) => cs[scope] === value));
+    }
+
+    isAllowed(user: CurrentUserInterface, permission: keyof Permission): boolean {
+        if (!user.permissions) return false;
+        return user.permissions.some((p) => p.permission === permission);
     }
 }

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
@@ -36,20 +36,20 @@ export class UserPermissionsGuard implements CanActivate {
         }
 
         if (!this.isResolvingGraphQLField(context) && !requiredPermission.options?.skipScopeCheck) {
-            const requestScope = await this.contentScopeService.inferScopeFromExecutionContext(context);
-            if (!requestScope) {
+            const contentScope = await this.contentScopeService.inferScopeFromExecutionContext(context);
+            if (!contentScope) {
                 throw new Error(
                     `Could not get ContentScope. Either pass a scope-argument or add @AffectedEntity()-decorator or enable skipScopeCheck in @RequiredPermission() (${
                         context.getClass().name
                     }::${context.getHandler().name}())`,
                 );
             }
-            if (!this.accessControlService.canAccessScope(requestScope, user)) {
+            if (!this.accessControlService.isAllowedContentScope(user, contentScope)) {
                 return false;
             }
         }
 
-        return requiredPermission.requiredPermission.some((permission) => this.accessControlService.isAllowed(user, permission));
+        return requiredPermission.requiredPermission.some((permission) => this.accessControlService.isAllowedPermission(user, permission));
     }
 
     // See https://docs.nestjs.com/graphql/other-features#execute-enhancers-at-the-field-resolver-level

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
@@ -1,14 +1,20 @@
-import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import { CanActivate, ExecutionContext, Inject, Injectable } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { GqlExecutionContext } from "@nestjs/graphql";
 
 import { CurrentUserInterface } from "../../auth/current-user/current-user";
 import { ContentScopeService } from "../content-scope.service";
-import { SCOPE_GUARD_ACTIVE_METADATA_KEY, ScopeGuardActiveMetadataValue } from "../decorators/scope-guard-active.decorator";
+import { RequiredPermission } from "../decorators/required-permission.decorator";
+import { ACCESS_CONTROL_SERVICE } from "../user-permissions.constants";
+import { AccessControlServiceInterface } from "../user-permissions.types";
 
 @Injectable()
 export class UserPermissionsGuard implements CanActivate {
-    constructor(protected reflector: Reflector, private readonly contentScopeService: ContentScopeService) {}
+    constructor(
+        protected reflector: Reflector,
+        private readonly contentScopeService: ContentScopeService,
+        @Inject(ACCESS_CONTROL_SERVICE) private readonly accessControlService: AccessControlServiceInterface,
+    ) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const isPublicApi = this.reflector.getAllAndOverride("publicApi", [context.getHandler(), context.getClass()]);
@@ -16,27 +22,33 @@ export class UserPermissionsGuard implements CanActivate {
             return true;
         }
 
-        const scopeGuardActive = this.reflector.getAllAndOverride<ScopeGuardActiveMetadataValue | undefined>(SCOPE_GUARD_ACTIVE_METADATA_KEY, [
-            context.getHandler(),
-            context.getClass(),
-        ]);
-
-        if (scopeGuardActive === false) {
-            return true;
-        }
-
         const request =
             context.getType().toString() === "graphql" ? GqlExecutionContext.create(context).getContext().req : context.switchToHttp().getRequest();
         const user = request.user as CurrentUserInterface | undefined;
-        if (!user) return true;
+        if (!user) return false;
 
-        const requestScope = await this.contentScopeService.inferScopeFromExecutionContext(context);
-        if (requestScope) {
-            return this.contentScopeService.canAccessScope(requestScope, user);
-        } else {
-            //not a scoped request, open to anyone
+        const requiredPermission = this.reflector.getAllAndOverride<RequiredPermission>("requiredPermission", [
+            context.getHandler(),
+            context.getClass(),
+        ]);
+        if (!requiredPermission) {
+            throw new Error(`RequiredPermission decorator is missing in ${context.getClass().name}::${context.getHandler().name}()`);
         }
 
-        return true;
+        if (!requiredPermission.options?.skipScopeCheck) {
+            const requestScope = await this.contentScopeService.inferScopeFromExecutionContext(context);
+            if (!requestScope) {
+                throw new Error(
+                    `Could not get ContentScope. Either pass a scope-argument or add @AffectedEntity()-decorator or enable skipScopeCheck in @RequiredPermission() (${
+                        context.getClass().name
+                    }::${context.getHandler().name}())`,
+                );
+            }
+            if (!this.accessControlService.canAccessScope(requestScope, user)) {
+                return false;
+            }
+        }
+
+        return requiredPermission.requiredPermission.some((permission) => this.accessControlService.isAllowed(user, permission));
     }
 }

--- a/packages/api/cms-api/src/user-permissions/decorators/required-permission.decorator.ts
+++ b/packages/api/cms-api/src/user-permissions/decorators/required-permission.decorator.ts
@@ -1,0 +1,29 @@
+import { EntityClass, EntityManager } from "@mikro-orm/core";
+import { CustomDecorator, SetMetadata } from "@nestjs/common";
+import { Request } from "express";
+
+import { CurrentUser } from "../dto/current-user";
+import { ContentScope } from "../interfaces/content-scope.interface";
+import { Permission } from "../interfaces/user-permission.interface";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RequiredPermissionArgs<ArgsType = any> = {
+    args: ArgsType;
+    getScopeFromEntity: (entityClass: EntityClass<object>, id: string) => Promise<ContentScope>;
+    user: CurrentUser;
+    entityManager: EntityManager;
+    request: Request;
+};
+
+type RequiredPermissionOptions = {
+    skipScopeCheck?: boolean;
+};
+
+export type RequiredPermission = {
+    requiredPermission: (keyof Permission)[];
+    options: RequiredPermissionOptions | undefined;
+};
+
+export const RequiredPermission = (requiredPermission: (keyof Permission)[], options?: RequiredPermissionOptions): CustomDecorator<string> => {
+    return SetMetadata<string, RequiredPermission>("requiredPermission", { requiredPermission, options });
+};

--- a/packages/api/cms-api/src/user-permissions/user-permissions.module.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.module.ts
@@ -38,7 +38,7 @@ import {
             useClass: UserPermissionsGuard,
         },
     ],
-    exports: [CURRENT_USER_LOADER, ContentScopeService],
+    exports: [CURRENT_USER_LOADER, ContentScopeService, ACCESS_CONTROL_SERVICE],
 })
 export class UserPermissionsModule {
     static forRoot(options: UserPermissionsModuleSyncOptions): DynamicModule {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -21,8 +21,8 @@ export type PermissionsForUser =
 export type ContentScopesForUser = ContentScope[] | UserPermissions.allContentScopes;
 
 export interface AccessControlServiceInterface {
-    isAllowed(user: CurrentUserInterface, permission: keyof Permission): boolean;
-    canAccessScope(requestScope: ContentScope, user: CurrentUserInterface): boolean;
+    isAllowedPermission(user: CurrentUserInterface, permission: keyof Permission): boolean;
+    isAllowedContentScope(user: CurrentUserInterface, contentScope: ContentScope): boolean;
     getPermissionsForUser?: (user: User) => Promise<PermissionsForUser> | PermissionsForUser;
     getContentScopesForUser?: (user: User) => Promise<ContentScopesForUser> | ContentScopesForUser;
 }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -21,6 +21,7 @@ export type PermissionsForUser =
 export type ContentScopesForUser = ContentScope[] | UserPermissions.allContentScopes;
 
 export interface AccessControlServiceInterface {
+    isAllowed(user: CurrentUserInterface, permission: keyof Permission): boolean;
     canAccessScope(requestScope: ContentScope, user: CurrentUserInterface): boolean;
     getPermissionsForUser?: (user: User) => Promise<PermissionsForUser> | PermissionsForUser;
     getContentScopesForUser?: (user: User) => Promise<ContentScopesForUser> | ContentScopesForUser;


### PR DESCRIPTION
Annotations are missing, so this pr makes the demo not working. Annotations will follow once this PR is merged.

- Enforces RequiredPermission-decorator
- Enforces scope-check unless skipScopeCheck is set in RequiredPermission-decorator
- CurrentUser must have at least one of the permissions set in RequiredPermission-decorator
- Permission are checked also for Field-Resolvers, scope only per request