### PR TITLE
API Generator: Use correct type for `where` when `getFindCondition` service method is not used

### DIFF
--- a/.changeset/fair-clouds-poke.md
+++ b/.changeset/fair-clouds-poke.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+api generator: use correct type for where when findCondition is not used

--- a/.changeset/fair-clouds-poke.md
+++ b/.changeset/fair-clouds-poke.md
@@ -2,4 +2,4 @@
 "@comet/cms-api": patch
 ---
 
-api generator: use correct type for where when findCondition is not used
+API Generator: Use correct type for `where` when `getFindCondition` service method is not used

--- a/packages/api/cms-api/src/generator/generate-crud-without-find.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-without-find.spec.ts
@@ -1,0 +1,49 @@
+import { BaseEntity, Embeddable, Embedded, Entity, PrimaryKey, Property } from "@mikro-orm/core";
+import { MikroORM } from "@mikro-orm/postgresql";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { v4 as uuid } from "uuid";
+
+import { generateCrud } from "./generate-crud";
+import { lintGeneratedFiles, parseSource } from "./utils/test-helper";
+
+@Embeddable()
+export class TestEntityScope {
+    @Property({ columnType: "text" })
+    language: string;
+}
+
+@Entity()
+export class TestEntity extends BaseEntity<TestEntity, "id"> {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @Embedded(() => TestEntityScope)
+    scope: TestEntityScope;
+}
+
+describe("GenerateCrud without find condition", () => {
+    it("where should be typed as ObjectQuery as it is when findCondition is used", async () => {
+        LazyMetadataStorage.load();
+        const orm = await MikroORM.init({
+            type: "postgresql",
+            dbName: "test-db",
+            entities: [TestEntity, TestEntityScope],
+        });
+
+        const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntity"));
+        const lintedOut = await lintGeneratedFiles(out);
+
+        {
+            const file = lintedOut.find((file) => file.name === "test-entity.resolver.ts");
+            if (!file) throw new Error("File not found");
+            const source = parseSource(file.content);
+
+            const cls = source.getClassOrThrow("TestEntityResolver");
+            const testEntitiesQuery = cls.getInstanceMethodOrThrow("testEntities");
+            const bodyText = testEntitiesQuery.getBodyText();
+            expect(bodyText).toContain("const where: ObjectQuery<TestEntity> = {};");
+        }
+
+        orm.close();
+    });
+});

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -755,10 +755,10 @@ function generateResolver({ generatorOptions, metadata }: { generatorOptions: Cr
         hasSortArg ? `sort, ` : ""
     }offset, limit }: ${argsClassName}${hasOutputRelations ? `, @Info() info: GraphQLResolveInfo` : ""}
         ): Promise<Paginated${classNamePlural}> {
-            const where = ${
+            const where${
                 hasSearchArg || hasFilterArg
-                    ? `this.${instanceNamePlural}Service.getFindCondition({ ${hasSearchArg ? `search, ` : ""}${hasFilterArg ? `filter, ` : ""} });`
-                    : "{}"
+                    ? ` = this.${instanceNamePlural}Service.getFindCondition({ ${hasSearchArg ? `search, ` : ""}${hasFilterArg ? `filter, ` : ""} });`
+                    : `: ObjectQuery<${metadata.className}> = {}`
             }
             ${scopeProp ? `where.scope = scope;` : ""}
 


### PR DESCRIPTION
This caused problems if scope is used which is not possible to assign to {}.

Before:
`const where = {};`

Now:
`const where: ObjectQuery<TestEntity> = {};`

If find/search is used:
`const where = this.xxService.getFindCondition(...);`
which also returns an ObjectQuery
