### PR TITLE
Limit code-width in docs to prevent horizontal scrolling

### DIFF
--- a/docs/.prettierrc.json
+++ b/docs/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "printWidth": 150,
+    "tabWidth": 4,
+    "trailingComma": "all",
+    "semi": true
+}

--- a/docs/docs/.prettierrc.json
+++ b/docs/docs/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "printWidth": 100,
+    "tabWidth": 4,
+    "trailingComma": "all",
+    "semi": true
+}


### PR DESCRIPTION
The prettier-config in `docs/` is required for the prettier-config in `docs/docs/` to work.