### PR TITLE
FinalForm: Don't handle sync submit differently than async submit

### DIFF
--- a/.changeset/six-wolves-help.md
+++ b/.changeset/six-wolves-help.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": major
+---
+
+FinalForm: Don't handle sync submit differently than async submit

--- a/packages/admin/admin/src/FinalForm.tsx
+++ b/packages/admin/admin/src/FinalForm.tsx
@@ -208,8 +208,6 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
         const submitEvent = (form.mutators.getSubmitEvent ? form.mutators.getSubmitEvent() : undefined) || new FinalFormSubmitEvent("submit");
         const ret = props.onSubmit(values, form, submitEvent);
 
-        if (ret === undefined) return ret;
-
         editDialogFormApi?.onFormStatusChange("saving");
         return Promise.resolve(ret)
             .then((data) => {


### PR DESCRIPTION
before, the formStatusChange, onAfterSubmit, reset another stuff was not executed