### PR TITLE
Enable no other module relative import for v6

### DIFF
--- a/.changeset/unlucky-files-compare.md
+++ b/.changeset/unlucky-files-compare.md
@@ -1,0 +1,5 @@
+---
+"@comet/eslint-config": major
+---
+
+Enable no-other-module-relative-import rule by default

--- a/packages/eslint-config/core-without-import.js
+++ b/packages/eslint-config/core-without-import.js
@@ -9,7 +9,8 @@ module.exports = {
         "unused-imports/no-unused-imports": "error",
         "no-console": ["error", { allow: ["warn", "error"] }],
         "no-return-await": "error",
-        "json-files/sort-package-json": "error"
+        "json-files/sort-package-json": "error",
+        "@comet/no-other-module-relative-import": ["warn"]
     },
     overrides: [
         {


### PR DESCRIPTION
rule was added in v5 but not enabled by default