### PR TITLE
Feature-Request: add string array tags to news entity

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -365,6 +365,7 @@ type News implements DocumentInterface {
   image: DamImageBlockData!
   content: NewsContentBlockData!
   createdAt: DateTime!
+  tags: [String!]!
   comments: [NewsComment!]!
   dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
   dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -1,6 +1,18 @@
 import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
 import { CrudField, CrudGenerator, DamImageBlock, DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
-import { BaseEntity, Collection, Embeddable, Embedded, Entity, Enum, OneToMany, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
+import {
+    ArrayType,
+    BaseEntity,
+    Collection,
+    Embeddable,
+    Embedded,
+    Entity,
+    Enum,
+    OneToMany,
+    OptionalProps,
+    PrimaryKey,
+    Property,
+} from "@mikro-orm/core";
 import { Field, ID, InputType, ObjectType, registerEnumType } from "@nestjs/graphql";
 import { IsString } from "class-validator";
 import { v4 as uuid } from "uuid";
@@ -94,4 +106,8 @@ export class News extends BaseEntity<News, "id"> implements DocumentInterface {
     @Property({ onUpdate: () => new Date(), columnType: "timestamp with time zone" })
     @Field()
     updatedAt: Date = new Date();
+
+    @Property({ type: ArrayType })
+    @Field(() => [String])
+    tags: string[];
 }


### PR DESCRIPTION
description:
added a string array to news

When creating files with the API generator, a line is written in the console:
`tags: unsupported type ArrayType`

Feature-Request:
 - add support for postgres string array