### PR TITLE
Fix AccessLogInterceptor

### DIFF
--- a/packages/api/cms-api/src/access-log/access-log.interceptor.ts
+++ b/packages/api/cms-api/src/access-log/access-log.interceptor.ts
@@ -36,7 +36,7 @@ export class AccessLogInterceptor implements NestInterceptor {
             requestData.push(`ip: ${graphqlContext.req.ip}`);
             this.pushUserToRequestData(graphqlContext.req.user, requestData);
 
-            const gqlArgs = graphqlExecutionContext.getArgs();
+            const gqlArgs = { ...graphqlExecutionContext.getArgs() };
             const gqlInfo = graphqlExecutionContext.getInfo();
 
             if (gqlInfo.operation.operation === "mutation") {


### PR DESCRIPTION
# Previously:

All mutations containing an input or data argument failed because the arguments were deleted

For example: 


https://github.com/vivid-planet/comet/assets/13380047/d295b506-70b0-4e5f-80c6-86bb71788f52

# Now:

gqlArgs object is copied before deletion -> mutations work again
