### PR TITLE
Remove default SQL value for news visibility

### DIFF
--- a/demo/api/src/db/migrations/Migration20231204114637.ts
+++ b/demo/api/src/db/migrations/Migration20231204114637.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231204114637 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "News" alter column "visible" drop default;');
+  }
+
+  async down(): Promise<void> {
+    throw new Error('No revert');
+  }
+
+}

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -65,7 +65,7 @@ export class News extends BaseEntity<News, "id"> implements DocumentInterface {
     @Field(() => NewsCategory)
     category: NewsCategory = NewsCategory.Awards; // TODO remove default value once CRUD generator supports enums
 
-    @Property({ default: false })
+    @Property()
     @Field()
     visible: boolean;
 


### PR DESCRIPTION
Changed to adhere to our best practices; no further changes needed, because crud generator handles visible on its own