### PR TITLE
Demo: Remove SQL defaults from page tree node

### DIFF
--- a/demo/api/src/db/migrations/Migration20231204124414.ts
+++ b/demo/api/src/db/migrations/Migration20231204124414.ts
@@ -1,0 +1,14 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231204124414 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "PageTreeNode" alter column "category" drop default;');
+    this.addSql('alter table "PageTreeNode" alter column "userGroup" drop default;');
+  }
+
+  async down(): Promise<void> {
+    throw new Error('No revert');
+  }
+
+}

--- a/demo/api/src/page-tree/entities/page-tree-node.entity.ts
+++ b/demo/api/src/page-tree/entities/page-tree-node.entity.ts
@@ -19,11 +19,11 @@ export class PageTreeNode extends PageTreeNodeBase {
     @Index()
     parent?: PageTreeNode;
 
-    @Enum({ items: () => PageTreeNodeCategory, default: PageTreeNodeCategory.MainNavigation })
+    @Enum({ items: () => PageTreeNodeCategory })
     @Field(() => PageTreeNodeCategory)
     category: PageTreeNodeCategory;
 
-    @Enum({ items: () => UserGroup, default: UserGroup.All })
+    @Enum({ items: () => UserGroup })
     @Field(() => UserGroup, { defaultValue: UserGroup.All })
     userGroup: UserGroup;
 }


### PR DESCRIPTION
Reason: stick to best practices

- category is a required arg
- userGroup has GQL default value
