### PR TITLE
CRUD Generator: Correctly support `type: "text"` fields in filter and sort

### DIFF
--- a/.changeset/lovely-rats-rest.md
+++ b/.changeset/lovely-rats-rest.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+CRUD Generator: correctly support type="text" fields in filter and sort

--- a/.changeset/lovely-rats-rest.md
+++ b/.changeset/lovely-rats-rest.md
@@ -2,4 +2,4 @@
 "@comet/cms-api": patch
 ---
 
-CRUD Generator: correctly support type="text" fields in filter and sort
+CRUD Generator: Correctly support `type: "text"` fields in filter and sort

--- a/packages/api/cms-api/src/generator/generate-crud.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.spec.ts
@@ -23,7 +23,33 @@ export class TestEntityWithNumber extends BaseEntity<TestEntityWithNumber, "id">
     foo: number;
 }
 
+@Entity()
+export class TestEntityWithTextRuntimeType extends BaseEntity<TestEntityWithTextRuntimeType, "id"> {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @Property({ type: "text" })
+    title: string;
+}
+
 describe("GenerateCrud", () => {
+    describe("metadata validation", () => {
+        it("should throw an error for runtime type 'text'", async () => {
+            LazyMetadataStorage.load();
+            const orm = await MikroORM.init({
+                type: "postgresql",
+                dbName: "test-db",
+                entities: [TestEntityWithTextRuntimeType],
+            });
+
+            expect(async () => {
+                await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithTextRuntimeType"));
+            }).rejects.toThrow("Runtime type 'text' of property 'title' is not supported. Maybe you wanted to use 'columnType' instead?");
+
+            orm.close();
+        });
+    });
+
     describe("resolver class", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -18,7 +18,7 @@ function buildOptions(metadata: EntityMetadata<any>) {
     const crudSearchPropNames = metadata.props
         .filter((prop) => hasFieldFeature(metadata.class, prop.name, "search") && !prop.name.startsWith("scope_"))
         .reduce((acc, prop) => {
-            if (prop.type === "string") {
+            if (prop.type === "string" || prop.type === "text") {
                 acc.push(prop.name);
             } else if (prop.reference == "m:1") {
                 if (!prop.targetMeta) {
@@ -28,7 +28,7 @@ function buildOptions(metadata: EntityMetadata<any>) {
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     .filter((innerProp) => hasFieldFeature(prop.targetMeta!.class, innerProp.name, "search") && !innerProp.name.startsWith("scope_"))
                     .forEach((innerProp) => {
-                        if (innerProp.type === "string") {
+                        if (innerProp.type === "string" || innerProp.type === "text") {
                             acc.push(`${prop.name}.${innerProp.name}`);
                         }
                     });
@@ -43,6 +43,7 @@ function buildOptions(metadata: EntityMetadata<any>) {
             !prop.name.startsWith("scope_") &&
             (prop.enum ||
                 prop.type === "string" ||
+                prop.type === "text" ||
                 prop.type === "DecimalType" ||
                 prop.type === "number" ||
                 integerTypes.includes(prop.type) ||
@@ -58,6 +59,7 @@ function buildOptions(metadata: EntityMetadata<any>) {
             hasFieldFeature(metadata.class, prop.name, "sort") &&
             !prop.name.startsWith("scope_") &&
             (prop.type === "string" ||
+                prop.type === "text" ||
                 prop.type === "DecimalType" ||
                 prop.type === "number" ||
                 integerTypes.includes(prop.type) ||
@@ -140,7 +142,7 @@ function generateFilterDto({ generatorOptions, metadata }: { generatorOptions: C
                     @Type(() => ${enumName}EnumFilter)
                     ${prop.name}?: ${enumName}EnumFilter;
                     `;
-                } else if (prop.type === "string") {
+                } else if (prop.type === "string" || prop.type === "text") {
                     return `@Field(() => StringFilter, { nullable: true })
                     @ValidateNested()
                     @IsOptional()


### PR DESCRIPTION
fixes test added in https://github.com/vivid-planet/comet/pull/1491 (althouth differently)