### PR TITLE
CRUD Generator: Correctly support `type: "text"` fields in input

### DIFF
--- a/.changeset/four-cherries-chew.md
+++ b/.changeset/four-cherries-chew.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+CRUD Generator: Correctly support `type: "text"` fields in input

--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -96,6 +96,7 @@ export async function generateCrudInput(
                 decorators.push("@IsSlug()");
             }
             decorators.push(`@Field(${fieldOptions})`);
+            type = "string";
         } else if (prop.type === "DecimalType" || prop.type == "BigIntType" || prop.type === "number") {
             const initializer = morphTsProperty(prop.name, metadata).getInitializer()?.getText();
             const defaultValue = prop.nullable && (initializer == "undefined" || initializer == "null") ? "null" : initializer;


### PR DESCRIPTION




- [x] Add changeset (if necessary)