### PR TITLE
[POC] Custom block categories

### DIFF
--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -4,6 +4,7 @@ import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "material-design-icons/iconfont/material-icons.css";
 import "typeface-open-sans";
+import "./common/blocks/customBlockCategories";
 
 import { ApolloProvider } from "@apollo/client";
 import { ErrorDialogHandler, MasterLayout, MuiThemeProvider, RouterBrowserRouter, RouteWithErrorBoundary, SnackbarProvider } from "@comet/admin";

--- a/demo/admin/src/common/blocks/customBlockCategories.tsx
+++ b/demo/admin/src/common/blocks/customBlockCategories.tsx
@@ -1,0 +1,13 @@
+import { BlockCategory, blockCategoryLabels } from "@comet/blocks-admin";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+declare module "@comet/blocks-admin" {
+    interface AllBlockCategories {
+        Custom: "Custom";
+    }
+}
+
+BlockCategory["Custom"] = "Custom";
+
+blockCategoryLabels.Custom = <FormattedMessage id="blocks.category.custom" defaultMessage="Custom category" />;

--- a/demo/admin/src/pages/blocks/FullWidthImageBlock.tsx
+++ b/demo/admin/src/pages/blocks/FullWidthImageBlock.tsx
@@ -12,7 +12,7 @@ const FullWidthImageContentBlock = createOptionalBlock(RichTextBlock, {
 export const FullWidthImageBlock = createCompositeBlock({
     name: "FullWidthImage",
     displayName: <FormattedMessage id="blocks.fullWidthImage" defaultMessage="Full Width Image" />,
-    category: BlockCategory.Media,
+    category: BlockCategory.Custom,
     blocks: {
         image: {
             block: DamImageBlock,

--- a/packages/admin/blocks-admin/src/blocks/types.tsx
+++ b/packages/admin/blocks-admin/src/blocks/types.tsx
@@ -139,16 +139,29 @@ export type BlockState<B extends BlockMethods> = ExtractGenericTypesFromBlockInt
 export type BlockInputApi<B extends BlockMethods> = ExtractGenericTypesFromBlockInterface<B, 0>; // InputApi is the 1. generic
 export type BlockOutputApi<B extends BlockMethods> = ExtractGenericTypesFromBlockInterface<B, 2>; // OutputApi is the 3. generic
 
-export enum BlockCategory {
-    TextAndContent = "TextAndContent",
-    Media = "Media",
-    Navigation = "Navigation",
-    Teaser = "Teaser",
-    StructuredContent = "StructuredContent",
-    Layout = "Layout",
-    Form = "Form",
-    Other = "Other",
+export interface AllBlockCategories {
+    TextAndContent: "TextAndContent";
+    Media: "Media";
+    Navigation: "Navigation";
+    Teaser: "Teaser";
+    StructuredContent: "StructuredContent";
+    Layout: "Layout";
+    Form: "Form";
+    Other: "Other";
 }
+
+export type BlockCategory = keyof AllBlockCategories;
+
+export const BlockCategory: Record<BlockCategory, BlockCategory> = {
+    TextAndContent: "TextAndContent",
+    Media: "Media",
+    Navigation: "Navigation",
+    Teaser: "Teaser",
+    StructuredContent: "StructuredContent",
+    Layout: "Layout",
+    Form: "Form",
+    Other: "Other",
+};
 
 export const blockCategoryLabels = {
     [BlockCategory.TextAndContent]: <FormattedMessage id="comet.blocks.category.textAndContent" defaultMessage="Text & Content" />,

--- a/packages/admin/blocks-admin/src/index.ts
+++ b/packages/admin/blocks-admin/src/index.ts
@@ -32,6 +32,7 @@ export { withAdditionalBlockAttributes } from "./blocks/helpers/withAdditionalBl
 export { SpaceBlock } from "./blocks/SpaceBlock";
 export type {
     AdminComponentPart,
+    AllBlockCategories,
     BindBlockAdminComponent,
     BlockAdminComponent,
     BlockDependency,


### PR DESCRIPTION
Enables custom block categories in the application using an object instead of an enum and TypeScript module augmentation.






- [ ] Add changeset (if necessary)