### PR TITLE
Fix `shouldScrollTo()`, `shouldShowError()` and `shouldShowWarning()` in `Field`

### DIFF
--- a/.changeset/tender-swans-fry.md
+++ b/.changeset/tender-swans-fry.md
@@ -2,16 +2,6 @@
 "@comet/admin": patch
 ---
 
-Fix typing of `Field`'s `shouldScrollTo()`, `shouldShowError()` and `shouldShowWarning()` props.
+Fix `shouldScrollTo()`, `shouldShowError()` and `shouldShowWarning()` in `Field`
 
-Previously, all methods were incorrectly typed as 
-
-```ts
-(meta: FieldMetaState<FieldValue>) => boolean;
-```
-
-when in fact an object containing the `FieldMetaState` is passed. The typing is now correct:
-
-```ts
-({ fieldMeta }: { fieldMeta: FieldMetaState<FieldValue> }) => boolean;
-```
+Previously, the `meta` argument was passed to these methods incorrectly. Now, the argument is passed as defined by the typing.

--- a/.changeset/tender-swans-fry.md
+++ b/.changeset/tender-swans-fry.md
@@ -1,0 +1,17 @@
+---
+"@comet/admin": patch
+---
+
+Fix typing of `Field`'s `shouldScrollTo()`, `shouldShowError()` and `shouldShowWarning()` props.
+
+Previously, all methods were incorrectly typed as 
+
+```ts
+(meta: FieldMetaState<FieldValue>) => boolean;
+```
+
+when in fact an object containing the `FieldMetaState` is passed. The typing is now correct:
+
+```ts
+({ fieldMeta }: { fieldMeta: FieldMetaState<FieldValue> }) => boolean;
+```

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -23,9 +23,9 @@ export interface FieldProps<FieldValue = any, T extends HTMLElement = HTMLElemen
     validate?: FieldValidator<FieldValue>;
     validateWarning?: FieldValidator<FieldValue>;
     variant?: FieldContainerProps["variant"];
-    shouldScrollTo?: (meta: FieldMetaState<FieldValue>) => boolean;
-    shouldShowError?: (meta: FieldMetaState<FieldValue>) => boolean;
-    shouldShowWarning?: (meta: FieldMetaState<FieldValue>) => boolean;
+    shouldScrollTo?: ({ fieldMeta }: { fieldMeta: FieldMetaState<FieldValue> }) => boolean;
+    shouldShowError?: ({ fieldMeta }: { fieldMeta: FieldMetaState<FieldValue> }) => boolean;
+    shouldShowWarning?: ({ fieldMeta }: { fieldMeta: FieldMetaState<FieldValue> }) => boolean;
     [otherProp: string]: any;
 }
 

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -23,9 +23,9 @@ export interface FieldProps<FieldValue = any, T extends HTMLElement = HTMLElemen
     validate?: FieldValidator<FieldValue>;
     validateWarning?: FieldValidator<FieldValue>;
     variant?: FieldContainerProps["variant"];
-    shouldScrollTo?: ({ fieldMeta }: { fieldMeta: FieldMetaState<FieldValue> }) => boolean;
-    shouldShowError?: ({ fieldMeta }: { fieldMeta: FieldMetaState<FieldValue> }) => boolean;
-    shouldShowWarning?: ({ fieldMeta }: { fieldMeta: FieldMetaState<FieldValue> }) => boolean;
+    shouldScrollTo?: (meta: FieldMetaState<FieldValue>) => boolean;
+    shouldShowError?: (meta: FieldMetaState<FieldValue>) => boolean;
+    shouldShowWarning?: (meta: FieldMetaState<FieldValue>) => boolean;
     [otherProp: string]: any;
 }
 
@@ -51,9 +51,12 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
     const validateError = required ? (validate ? composeValidators(requiredValidator, validate) : requiredValidator) : validate;
 
     const finalFormContext = useFinalFormContext();
-    const shouldShowError = passedShouldShowError || finalFormContext.shouldShowFieldError;
-    const shouldShowWarning = passedShouldShowWarning || finalFormContext.shouldShowFieldWarning;
-    const shouldScrollToField = passedShouldScrollTo || finalFormContext.shouldScrollToField;
+    const shouldShowError =
+        passedShouldShowError ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldShowFieldError({ fieldMeta }));
+    const shouldShowWarning =
+        passedShouldShowWarning ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldShowFieldWarning({ fieldMeta }));
+    const shouldScrollToField =
+        passedShouldScrollTo ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldScrollToField({ fieldMeta }));
 
     function renderField({ input, meta, fieldContainerProps, ...rest }: FieldRenderProps<FieldValue, FieldElement> & { warning?: string }) {
         function render() {
@@ -71,11 +74,11 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
                 label={label}
                 required={required}
                 disabled={disabled}
-                error={shouldShowError({ fieldMeta: meta }) && (meta.error || meta.submitError)}
-                warning={shouldShowWarning({ fieldMeta: meta }) && meta.data?.warning}
+                error={shouldShowError(meta) && (meta.error || meta.submitError)}
+                warning={shouldShowWarning(meta) && meta.data?.warning}
                 variant={variant}
                 fullWidth={fullWidth}
-                scrollTo={shouldScrollToField({ fieldMeta: meta })}
+                scrollTo={shouldScrollToField(meta)}
                 {...fieldContainerProps}
             >
                 {render()}


### PR DESCRIPTION
Fix typing of `Field`'s `shouldScrollTo()`, `shouldShowError()` and `shouldShowWarning()` props.

---

Previously, all methods were incorrectly typed as 

```ts
(meta: FieldMetaState<FieldValue>) => boolean;
```

when in fact an object containing the `FieldMetaState` is passed:

https://github.com/vivid-planet/comet/blob/079d20b6ad99f06d99c4b47bde69b8929713e37a/packages/admin/admin/src/form/Field.tsx#L74-L78

The typing is now correct:

```ts
({ fieldMeta }: { fieldMeta: FieldMetaState<FieldValue> }) => boolean;
```