### PR TITLE
ESLint: Enable `import/newline-after-import`

### DIFF
--- a/.changeset/sharp-readers-tie.md
+++ b/.changeset/sharp-readers-tie.md
@@ -1,0 +1,5 @@
+---
+"@comet/eslint-config": major
+---
+
+Enable `import/newline-after-import`

--- a/demo/admin/src/common/EditPageNode.tsx
+++ b/demo/admin/src/common/EditPageNode.tsx
@@ -4,6 +4,7 @@ import { createEditPageNode } from "@comet/cms-admin";
 import { Box, Divider, MenuItem } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
+
 export type { GQLPageTreeNodeAdditionalFieldsFragment } from "./EditPageNode.generated"; //re-export
 
 const userGroupOptions = [

--- a/demo/admin/src/pages/mainMenu/components/EditMainMenuItem.tsx
+++ b/demo/admin/src/pages/mainMenu/components/EditMainMenuItem.tsx
@@ -24,6 +24,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { useRouteMatch } from "react-router-dom";
 
 import { GQLEditMainMenuItemFragment, GQLUpdateMainMenuItemMutation, GQLUpdateMainMenuItemMutationVariables } from "./EditMainMenuItem.generated";
+
 export type { GQLEditMainMenuItemFragment } from "./EditMainMenuItem.generated"; // re-export
 
 export const editMainMenuItemFragment = gql`

--- a/demo/api/src/links/links.module.ts
+++ b/demo/api/src/links/links.module.ts
@@ -5,6 +5,7 @@ import { PagesModule } from "@src/pages/pages.module";
 
 import { Link } from "./entities/link.entity";
 import { LinksResolver } from "./links.resolver";
+
 @Module({
     imports: [PagesModule, BlocksModule, MikroOrmModule.forFeature([Link])],
     providers: [LinksResolver],

--- a/packages/admin/admin-color-picker/src/ColorPicker.tsx
+++ b/packages/admin/admin-color-picker/src/ColorPicker.tsx
@@ -11,6 +11,7 @@ import tinycolor from "tinycolor2";
 import { useDebouncedCallback } from "use-debounce";
 
 import { ColorPickerClassKey, styles } from "./ColorPicker.styles";
+
 export interface ColorPickerPropsComponents extends InputWithPopperComponents {
     ColorPickerColorPreview?: React.ElementType<ColorPickerColorPreviewProps>;
     ColorPickerInvalidPreview?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;

--- a/packages/admin/admin-rte/src/core/extension/LinksRemove/ToolbarButton.tsx
+++ b/packages/admin/admin-rte/src/core/extension/LinksRemove/ToolbarButton.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 
 import ControlButton from "../../Controls/ControlButton";
 import { IControlProps } from "../../types";
+
 export default function ToolbarButton(props: IControlProps) {
     const selection = props.editorState.getSelection();
     const globallyDisabled = !!props.disabled;

--- a/packages/admin/admin-rte/src/core/makeRteApi.ts
+++ b/packages/admin/admin-rte/src/core/makeRteApi.ts
@@ -5,6 +5,7 @@ import useDebounce from "../useDebounce";
 import usePrevious from "../usePrevious";
 import LinkDecorator from "./extension/Link/Decorator";
 import NonBreakingSpaceDecorator from "./extension/NonBreakingSpace/Decorator";
+
 export interface IMakeRteApiProps<T = any> {
     decorators?: DraftDecorator[];
     parse?: (v: T) => ContentState;

--- a/packages/admin/admin-stories/src/admin/router/Prompt.tsx
+++ b/packages/admin/admin-stories/src/admin/router/Prompt.tsx
@@ -5,6 +5,7 @@ import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
+
 function Story() {
     return (
         <Switch>

--- a/packages/admin/admin/src/error/errordialog/useErrorDialog.ts
+++ b/packages/admin/admin/src/error/errordialog/useErrorDialog.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { ErrorDialogOptions } from "./ErrorDialog";
 import { errorDialogVar } from "./errorDialogVar";
+
 export interface UseErrorDialogReturn {
     showError: (options: ErrorDialogOptions) => void;
 }

--- a/packages/admin/admin/src/stack/breadcrumbs/utils.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/utils.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbItem } from "../Stack";
 import { BreadcrumbsEntry } from "./BreadcrumbsEntry";
 import { BreadcrumbsOverflow } from "./BreadcrumbsOverflow";
 import { styles } from "./StackBreadcrumbs.styles";
+
 export const getElementOuterWidth = (element: Element): number =>
     element.clientWidth + parseFloat(getComputedStyle(element).marginLeft) + parseFloat(getComputedStyle(element).marginRight);
 

--- a/packages/admin/blocks-admin/src/blocks/SpaceBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/SpaceBlock.tsx
@@ -7,6 +7,7 @@ import { BlocksFinalForm } from "../form/BlocksFinalForm";
 import { SelectPreviewComponent } from "../iframebridge/SelectPreviewComponent";
 import { createBlockSkeleton } from "./helpers/createBlockSkeleton";
 import { BlockCategory, BlockInterface } from "./types";
+
 type State = SpaceBlockData;
 
 const isHeightValid = (h: number) => h <= 1000;

--- a/packages/admin/blocks-admin/src/blocks/common/AdminTabLabel.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminTabLabel.tsx
@@ -3,6 +3,7 @@ import { styled } from "@mui/material/styles";
 import * as React from "react";
 
 import { usePromise } from "../../common/usePromise";
+
 export interface AdminTabLabelProps {
     children: React.ReactNode;
     isValid?: () => Promise<boolean> | boolean;

--- a/packages/admin/blocks-admin/src/blocks/common/blockRow/InsertInBetweenAction.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/blockRow/InsertInBetweenAction.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import * as sc from "./InsertInBetweenAction.sc";
+
 interface Props {
     top?: React.ReactNode;
     bottom?: React.ReactNode;

--- a/packages/admin/blocks-admin/src/common/Collapsible.tsx
+++ b/packages/admin/blocks-admin/src/common/Collapsible.tsx
@@ -1,5 +1,6 @@
 import { Button, Collapse } from "@mui/material";
 import React, { FunctionComponent } from "react";
+
 interface CollapsibleProps {
     open: boolean;
     header: React.ReactNode;

--- a/packages/admin/blocks-admin/src/iframebridge/HoverPreviewComponent.tsx
+++ b/packages/admin/blocks-admin/src/iframebridge/HoverPreviewComponent.tsx
@@ -4,6 +4,7 @@ import scrollIntoView from "scroll-into-view-if-needed";
 
 import * as sc from "./HoverPreviewComponent.sc";
 import { useIFrameBridge } from "./useIFrameBridge";
+
 interface IHoverPreviewComponentProps {
     componentSlug: string;
 }

--- a/packages/admin/cms-admin/src/blocks/CmsBlockContextProvider.tsx
+++ b/packages/admin/cms-admin/src/blocks/CmsBlockContextProvider.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 
 import { DocumentInterface, DocumentType } from "../documents/types";
 import { AllCategories } from "../pages/pageTree/PageTreeContext";
+
 export interface CmsBlockContext {
     apolloClient: ApolloClient<NormalizedCacheObject>;
     damConfig: {

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -45,6 +45,7 @@ import { DamUploadFooter } from "./footer/UploadFooter";
 import { DamItemLabelColumn } from "./label/DamItemLabelColumn";
 import { useDamSelectionApi } from "./selection/DamSelectionContext";
 import { useDamSearchHighlighting } from "./useDamSearchHighlighting";
+
 export { damFolderQuery } from "./FolderDataGrid.gql";
 export { moveDamFilesMutation, moveDamFoldersMutation } from "./FolderDataGrid.gql";
 export {

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderHead.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderHead.tsx
@@ -8,6 +8,7 @@ import { useOptimisticQuery } from "../../common/useOptimisticQuery";
 import FolderBreadcrumbs from "./breadcrumbs/FolderBreadcrumbs";
 import { damFolderMPathFragment, damFolderMPathQuery } from "./FolderHead.gql";
 import { GQLDamFolderMPathFragment, GQLDamFolderMPathQuery, GQLDamFolderMPathQueryVariables } from "./FolderHead.gql.generated";
+
 export { GQLDamFolderMPathFragment, GQLDamFolderMPathQuery, GQLDamFolderMPathQueryVariables } from "./FolderHead.gql.generated";
 
 interface TableHeadProps {

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useFileUpload.gql.ts
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useFileUpload.gql.ts
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+
 export {
     GQLDamFolderByNameAndParentIdQuery,
     GQLDamFolderByNameAndParentIdQueryVariables,

--- a/packages/admin/cms-admin/src/dam/DataGrid/tags/LicenseValidityTags.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/tags/LicenseValidityTags.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { Tag } from "./Tag";
+
 export const LicenseNotValidYetTag: React.VoidFunctionComponent = () => {
     return (
         <Tag type="error">

--- a/packages/admin/cms-admin/src/dam/DataGrid/thumbnail/DamThumbnail.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/thumbnail/DamThumbnail.tsx
@@ -7,6 +7,7 @@ import { GQLDamFile, GQLDamFolder } from "../../../graphql.generated";
 import { AudioThumbnail } from "./AudioThumbnail";
 import { GQLDamFileThumbnailFragment } from "./DamThumbnail.gql.generated";
 import { VideoThumbnail } from "./VideoThumbnail";
+
 export { damFileThumbnailFragment } from "./DamThumbnail.gql";
 
 export const inboxFolderColor = "#952F80";

--- a/packages/admin/cms-admin/src/dam/FileForm/previews/PdfPreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/previews/PdfPreview.tsx
@@ -2,6 +2,7 @@ import { styled } from "@mui/material/styles";
 import React from "react";
 
 import { DamFileDetails } from "../EditFile";
+
 const PdfPreviewWrapper = styled("div")`
     width: 100%;
     height: calc(100vh - 300px);

--- a/packages/admin/cms-admin/src/dam/MoveDamItemDialog/ChooseFolder.tsx
+++ b/packages/admin/cms-admin/src/dam/MoveDamItemDialog/ChooseFolder.tsx
@@ -9,6 +9,7 @@ import { FixedSizeList as List } from "react-window";
 import { MarkedMatches } from "../../common/MarkedMatches";
 import { FolderTreeMap } from "./useFolderTree";
 import { FolderWithMatches } from "./useFolderTreeSearch";
+
 export { allFoldersQuery } from "./ChooseFolder.gql";
 export { GQLAllFoldersWithoutFiltersQuery, GQLAllFoldersWithoutFiltersQueryVariables } from "./ChooseFolder.gql.generated";
 

--- a/packages/admin/cms-admin/src/form/file/FileField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileField.tsx
@@ -8,6 +8,7 @@ import { FormattedMessage } from "react-intl";
 import { ChooseFileDialog } from "./chooseFile/ChooseFileDialog";
 import { damFileFieldFileQuery } from "./FileField.gql";
 import { GQLDamFileFieldFileFragment, GQLDamFileFieldFileQuery, GQLDamFileFieldFileQueryVariables } from "./FileField.gql.generated";
+
 export { GQLDamFileFieldFileFragment } from "./FileField.gql.generated";
 
 interface FileFieldProps extends FieldRenderProps<GQLDamFileFieldFileFragment, HTMLInputElement> {

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -97,4 +97,5 @@ import csstype from "csstype";
 // import can not be used here as this file is outside of rootDir
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const version: string = require("../package.json").version;
+
 export { version };

--- a/packages/admin/cms-admin/src/pages/pageTree/Page.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/Page.ts
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+
 export { GQLDeletePageTreeNodeMutation, GQLDeletePageTreeNodeMutationVariables } from "./Page.generated";
 
 export const deletePageMutation = gql`

--- a/packages/admin/cms-admin/src/pages/pageTree/PageVisibility.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageVisibility.tsx
@@ -10,6 +10,7 @@ import { PageVisibilityIcon } from "./PageVisibilityIcon";
 import { subTreeFromNode, treeMapToArray } from "./treemap/TreeMapUtils";
 import { GQLPageTreePageFragment, PageTreePage } from "./usePageTree";
 import { usePageTreeContext } from "./usePageTreeContext";
+
 export { GQLUpdatePageVisibilityMutation, GQLUpdatePageVisibilityMutationVariables } from "./PageVisibility.generated";
 
 export const updatePageVisibilityMutation = gql`

--- a/packages/admin/cms-admin/src/pages/pageTree/usePageTree.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/usePageTree.ts
@@ -5,6 +5,7 @@ import * as React from "react";
 import { PageSearchMatch } from "../pageSearch/usePageSearch";
 import { arrayToTreeMap, subTreeFromNodes, TreeMap } from "./treemap/TreeMapUtils";
 import { GQLPageTreePageFragment } from "./usePageTree.generated";
+
 export { GQLPageTreePageFragment } from "./usePageTree.generated";
 
 export const pageTreePageFragment = gql`

--- a/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
@@ -23,6 +23,7 @@ import { PageVisibilityIcon } from "../pageTree/PageVisibilityIcon";
 import { PageTreePage, usePageTree } from "../pageTree/usePageTree";
 import { GQLSelectedPageFragment } from "./PageTreeSelectDialog.generated";
 import * as sc from "./PageTreeSelectDialog.sc";
+
 export { GQLSelectedPageFragment } from "./PageTreeSelectDialog.generated";
 
 export const selectedPageFragment = gql`

--- a/packages/admin/cms-admin/src/pages/pagesPage/createPagesQuery.ts
+++ b/packages/admin/cms-admin/src/pages/pagesPage/createPagesQuery.ts
@@ -3,6 +3,7 @@ import { DocumentNode } from "graphql";
 
 import { pageSearchFragment } from "../pageSearch/usePageSearch";
 import { pageTreePageFragment } from "../pageTree/usePageTree";
+
 export { GQLPageTreePageFragment } from "../pageTree/usePageTree";
 export { GQLPagesQuery, GQLPagesQueryVariables } from "./createPagesQuery.generated";
 

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -34,6 +34,7 @@ import {
     GQLRedirectDetailQueryVariables,
 } from "./RedirectForm.gql.generated";
 import { useSubmitMutation } from "./submitMutation";
+
 export { GQLRedirectSourceAvailableQuery, GQLRedirectSourceAvailableQueryVariables } from "./RedirectForm.generated";
 export { createRedirectMutation, updateRedirectMutation } from "./RedirectForm.gql";
 export { GQLCreateRedirectMutation, GQLUpdateRedirectMutation } from "./RedirectForm.gql.generated";

--- a/packages/api/cms-api/src/blocks/blocks-meta.service.ts
+++ b/packages/api/cms-api/src/blocks/blocks-meta.service.ts
@@ -1,6 +1,7 @@
 import { getBlocksMeta } from "@comet/blocks-api";
 import { OnModuleInit } from "@nestjs/common";
 import { promises as fs } from "fs";
+
 export class BlocksMetaService implements OnModuleInit {
     async onModuleInit(): Promise<void> {
         const metaJson = getBlocksMeta();

--- a/packages/api/cms-api/src/page-tree/dto/attached-document.input.ts
+++ b/packages/api/cms-api/src/page-tree/dto/attached-document.input.ts
@@ -1,5 +1,6 @@
 import { Field, InputType } from "@nestjs/graphql";
 import { IsOptional, IsString } from "class-validator";
+
 @InputType()
 export class AttachedDocumentInput {
     @Field()

--- a/packages/api/cms-api/src/page-tree/page-tree.service.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.ts
@@ -18,6 +18,7 @@ import {
     PageTreeNodeVisibility as Visibility,
     ScopeInterface,
 } from "./types";
+
 export { PageTreeReadApi } from "./page-tree-read-api";
 
 @Injectable()

--- a/packages/eslint-config/core.js
+++ b/packages/eslint-config/core.js
@@ -5,6 +5,7 @@ module.exports = {
     plugins: [...core.plugins, "import"],
     rules: {
         "import/no-extraneous-dependencies": "error",
-        "import/no-duplicates": "error"
+        "import/no-duplicates": "error",
+        "import/newline-after-import": "error"
     },
 };

--- a/packages/eslint-config/nextjs.js
+++ b/packages/eslint-config/nextjs.js
@@ -5,6 +5,7 @@ module.exports = {
         "react/prop-types": "off",
         "react/self-closing-comp": "error",
         "import/no-extraneous-dependencies": "error",
+        "import/newline-after-import": "error",
         "@comet/no-private-sibling-import": ["error", ["gql", "sc", "gql.generated"]],
         "no-restricted-imports": [
             "error",


### PR DESCRIPTION
I think it is more visual appealing if it is separated (also found this in projects). 



- [x] Add changeset (if necessary)