### PR TITLE
Fix position calculation with mimetype filters

### DIFF
--- a/.changeset/tricky-berries-trade.md
+++ b/.changeset/tricky-berries-trade.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Consider filtered mimetypes when calculating the position of a DAM item in `DamItemsService`'s `getDamItemPosition()`
+
+Previously, the mimetypes were ignored, sometimes resulting in an incorrect position.

--- a/packages/api/cms-api/src/dam/files/dam-items.service.ts
+++ b/packages/api/cms-api/src/dam/files/dam-items.service.ts
@@ -88,7 +88,7 @@ export class DamItemsService {
             {
                 folderId: args.folderId,
                 includeArchived: args.includeArchived,
-                filter: { searchText: args.filter?.searchText },
+                filter: args.filter,
                 sortDirection: args.sortDirection,
                 sortColumnName: args.sortColumnName,
             },


### PR DESCRIPTION
Consider filtered mimetypes when calculating the position of a DAM item in `DamItemsService`'s `getDamItemPosition()`

Previously, the mimetypes were ignored, sometimes resulting in an incorrect position.