### PR TITLE
Add MRE to show different admin route behaviors in `createCompositeBlock`

### DIFF
--- a/demo/admin/src/pages/PageContentBlock.tsx
+++ b/demo/admin/src/pages/PageContentBlock.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { ColumnsBlock } from "./blocks/ColumnsBlock";
 import { FullWidthImageBlock } from "./blocks/FullWidthImageBlock";
 import { MediaBlock } from "./blocks/MediaBlock";
+import { TeaserBlock } from "./blocks/TeaserBlock";
 import { TwoListsBlock } from "./blocks/TwoListsBlock";
 import { VideoBlock } from "./blocks/VideoBlock";
 
@@ -32,6 +33,7 @@ export const PageContentBlock = createBlocksBlock({
         anchor: AnchorBlock,
         twoLists: TwoListsBlock,
         media: MediaBlock,
+        teaser: TeaserBlock,
     },
     additionalItemFields: {
         ...userGroupAdditionalItemFields,

--- a/demo/admin/src/pages/blocks/TeaserBlock.tsx
+++ b/demo/admin/src/pages/blocks/TeaserBlock.tsx
@@ -1,0 +1,43 @@
+import { BlockCategory, createCompositeBlock } from "@comet/blocks-admin";
+import { DamImageBlock } from "@comet/cms-admin";
+import { HeadlineBlock } from "@src/common/blocks/HeadlineBlock";
+import { LinkListBlock } from "@src/common/blocks/LinkListBlock";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+const TeaserBlock = createCompositeBlock(
+    {
+        name: "Teaser",
+        displayName: <FormattedMessage id="blocks.teaser" defaultMessage="Teaser" />,
+        blocks: {
+            // Normal
+            headline: {
+                block: HeadlineBlock,
+                title: <FormattedMessage id="blocks.teaser.headline" defaultMessage="Headline" />,
+            },
+            // Nested
+            image: {
+                block: DamImageBlock,
+                title: <FormattedMessage id="blocks.teaser.image" defaultMessage="Image" />,
+                nested: true,
+            },
+            // Subroutes
+            links: {
+                block: LinkListBlock,
+                title: <FormattedMessage id="blocks.teaser.links" defaultMessage="Links" />,
+            },
+            // Nested inner subroutes
+            buttons: {
+                block: LinkListBlock,
+                title: <FormattedMessage id="blocks.teaser.buttons" defaultMessage="Buttons" />,
+                nested: true,
+            },
+        },
+    },
+    (block) => {
+        block.category = BlockCategory.Teaser;
+        return block;
+    },
+);
+
+export { TeaserBlock };

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -1073,7 +1073,8 @@
                                 "columns": "Columns",
                                 "anchor": "Anchor",
                                 "twoLists": "TwoLists",
-                                "media": "Media"
+                                "media": "Media",
+                                "teaser": "Teaser"
                             },
                             "nullable": false
                         },
@@ -1130,7 +1131,8 @@
                                 "columns": "Columns",
                                 "anchor": "Anchor",
                                 "twoLists": "TwoLists",
-                                "media": "Media"
+                                "media": "Media",
+                                "teaser": "Teaser"
                             },
                             "nullable": false
                         },
@@ -1734,6 +1736,61 @@
                 "name": "damFileId",
                 "kind": "String",
                 "nullable": true
+            }
+        ]
+    },
+    {
+        "name": "Teaser",
+        "fields": [
+            {
+                "name": "headline",
+                "kind": "Block",
+                "block": "Headline",
+                "nullable": false
+            },
+            {
+                "name": "image",
+                "kind": "Block",
+                "block": "DamImage",
+                "nullable": false
+            },
+            {
+                "name": "links",
+                "kind": "Block",
+                "block": "LinkList",
+                "nullable": false
+            },
+            {
+                "name": "buttons",
+                "kind": "Block",
+                "block": "LinkList",
+                "nullable": false
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "headline",
+                "kind": "Block",
+                "block": "Headline",
+                "nullable": false
+            },
+            {
+                "name": "image",
+                "kind": "Block",
+                "block": "DamImage",
+                "nullable": false
+            },
+            {
+                "name": "links",
+                "kind": "Block",
+                "block": "LinkList",
+                "nullable": false
+            },
+            {
+                "name": "buttons",
+                "kind": "Block",
+                "block": "LinkList",
+                "nullable": false
             }
         ]
     },

--- a/demo/api/src/pages/blocks/PageContentBlock.ts
+++ b/demo/api/src/pages/blocks/PageContentBlock.ts
@@ -9,6 +9,7 @@ import { ColumnsBlock } from "./columns.block";
 import { FullWidthImageBlock } from "./full-width-image.block";
 import { HeadlineBlock } from "./headline.block";
 import { MediaBlock } from "./media.block";
+import { TeaserBlock } from "./teaser.block";
 import { TextImageBlock } from "./TextImageBlock";
 import { TwoListsBlock } from "./two-lists.block";
 import { VideoBlock } from "./video.block";
@@ -28,6 +29,7 @@ const supportedBlocks = {
     anchor: AnchorBlock,
     twoLists: TwoListsBlock,
     media: MediaBlock,
+    teaser: TeaserBlock,
 };
 
 class BlocksBlockItemData extends BaseBlocksBlockItemData(supportedBlocks) {

--- a/demo/api/src/pages/blocks/teaser.block.ts
+++ b/demo/api/src/pages/blocks/teaser.block.ts
@@ -1,0 +1,51 @@
+import {
+    BlockData,
+    BlockDataInterface,
+    BlockInput,
+    ChildBlock,
+    ChildBlockInput,
+    createBlock,
+    ExtractBlockData,
+    ExtractBlockInput,
+    inputToData,
+} from "@comet/blocks-api";
+import { DamImageBlock } from "@comet/cms-api";
+import { LinkListBlock } from "@src/common/blocks/link-list.block";
+
+import { HeadlineBlock } from "./headline.block";
+
+class TeaserBlockData extends BlockData {
+    @ChildBlock(HeadlineBlock)
+    headline: ExtractBlockData<typeof HeadlineBlock>;
+
+    @ChildBlock(DamImageBlock)
+    image: ExtractBlockData<typeof DamImageBlock>;
+
+    @ChildBlock(LinkListBlock)
+    links: ExtractBlockData<typeof LinkListBlock>;
+
+    @ChildBlock(LinkListBlock)
+    buttons: ExtractBlockData<typeof LinkListBlock>;
+}
+
+class TeaserBlockInput extends BlockInput {
+    @ChildBlockInput(HeadlineBlock)
+    headline: ExtractBlockInput<typeof HeadlineBlock>;
+
+    @ChildBlockInput(DamImageBlock)
+    image: ExtractBlockInput<typeof DamImageBlock>;
+
+    @ChildBlockInput(LinkListBlock)
+    links: ExtractBlockInput<typeof LinkListBlock>;
+
+    @ChildBlockInput(LinkListBlock)
+    buttons: ExtractBlockInput<typeof LinkListBlock>;
+
+    transformToBlockData(): BlockDataInterface {
+        return inputToData(TeaserBlockData, this);
+    }
+}
+
+const TeaserBlock = createBlock(TeaserBlockData, TeaserBlockInput, "Teaser");
+
+export { TeaserBlock };

--- a/demo/site/src/blocks/PageContentBlock.tsx
+++ b/demo/site/src/blocks/PageContentBlock.tsx
@@ -1,5 +1,6 @@
 import { BlocksBlock, PropsWithData, SupportedBlocks, YouTubeVideoBlock } from "@comet/cms-site";
 import { PageContentBlockData } from "@src/blocks.generated";
+import { TeaserBlock } from "@src/documents/pages/blocks/TeaserBlock";
 import * as React from "react";
 
 import { AnchorBlock } from "./AnchorBlock";
@@ -29,6 +30,7 @@ const supportedBlocks: SupportedBlocks = {
     anchor: (props) => <AnchorBlock data={props} />,
     media: (props) => <MediaBlock data={props} />,
     twoLists: (props) => <TwoListsBlock data={props} />,
+    teaser: (props) => <TeaserBlock data={props} />,
 };
 
 export const PageContentBlock: React.FC<PropsWithData<PageContentBlockData>> = ({ data }) => {

--- a/demo/site/src/documents/pages/blocks/TeaserBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/TeaserBlock.tsx
@@ -1,0 +1,29 @@
+import { PropsWithData, withPreview } from "@comet/cms-site";
+import { TeaserBlockData } from "@src/blocks.generated";
+import { DamImageBlock } from "@src/blocks/DamImageBlock";
+import { HeadlineBlock } from "@src/blocks/HeadlineBlock";
+import { LinkListBlock } from "@src/blocks/LinkListBlock";
+import styled from "styled-components";
+
+const TeaserBlock = withPreview(
+    ({ data: { headline, image, links, buttons } }: PropsWithData<TeaserBlockData>) => {
+        return (
+            <Root>
+                <HeadlineBlock data={headline} />
+                <DamImageBlock data={image} />
+                <LinkListBlock data={links} />
+                <LinkListBlock data={buttons} />
+            </Root>
+        );
+    },
+    { label: "Teaser" },
+);
+
+const Root = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+`;
+
+export { TeaserBlock };

--- a/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/composeBlocks.tsx
+++ b/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/composeBlocks.tsx
@@ -127,16 +127,20 @@ export function composeBlocks<C extends CompositeBlocksConfig>(compositeBlocks: 
                     { flatten: true },
                 ),
 
-            createPreviewState: (s, previewCtx) =>
-                applyToCompositeBlocks(
-                    compositeBlocks,
-                    ([block, options], attr) => {
-                        const extractedState = extractData([block, options], attr, s);
-                        return block.createPreviewState(extractedState, previewCtx);
-                    },
-                    { flatten: true },
-                ),
-
+            createPreviewState: (s, previewCtx) => {
+                return {
+                    adminRoute: previewCtx.parentUrl,
+                    adminMeta: { route: previewCtx.parentUrl },
+                    ...applyToCompositeBlocks(
+                        compositeBlocks,
+                        ([block, options], attr) => {
+                            const extractedState = extractData([block, options], attr, s);
+                            return block.createPreviewState(extractedState, previewCtx);
+                        },
+                        { flatten: true },
+                    ),
+                };
+            },
             isValid: async (state) => {
                 const isValidPromises: Promise<boolean>[] = Object.values(
                     applyToCompositeBlocks(compositeBlocks, ([block, options], attr) => {


### PR DESCRIPTION
Four different scenarios, creating different subroutes

1. Normal: Should be at root of `createCompositeBlock` `/`
2. Nested: Should be at `/<child-block-key>`
3. Inner stack: Should be at `/<child-block-key>/<child-block-key>`
4. Inner stack + nested: Should be at `/<child-block-key>/<child-block-key>/<child-block-key>` ?!

### Demo

https://github.com/vivid-planet/comet/assets/48853629/6b65262c-2500-4883-8f5f-d5aa1ec7a7a2


