### PR TITLE
Make `PageTreeReadApiService` optional in `BlocksTransformerService`

### DIFF
--- a/packages/api/cms-api/src/blocks/blocks-transformer.service.ts
+++ b/packages/api/cms-api/src/blocks/blocks-transformer.service.ts
@@ -1,5 +1,5 @@
 import { BlockContext, BlockDataInterface } from "@comet/blocks-api";
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Optional } from "@nestjs/common";
 import { CONTEXT } from "@nestjs/graphql";
 
 import { getRequestContextHeadersFromRequest } from "../common/decorators/request-context.decorator";
@@ -13,9 +13,9 @@ export class BlocksTransformerService {
     private dependencies: Record<string, unknown>;
     constructor(
         @Inject(BLOCKS_MODULE_TRANSFORMER_DEPENDENCIES) dependencies: Record<string, unknown>,
-        pageTreeReadApi: PageTreeReadApiService,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         @Inject(CONTEXT) context: any,
+        @Optional() pageTreeReadApi?: PageTreeReadApiService,
     ) {
         let includeInvisibleBlocks: boolean | undefined = false;
         let previewDamUrls = false;


### PR DESCRIPTION
Removes tight coupling between `PageTreeModule` and `BlocksModule`. Allows projects that use blocks but have no page tree.