### PR TITLE
Deprecate `nullable: true` for child blocks

### DIFF
--- a/.changeset/rare-pants-hope.md
+++ b/.changeset/rare-pants-hope.md
@@ -1,0 +1,8 @@
+---
+"@comet/blocks-api": minor
+---
+
+Deprecate `nullable: true` for child blocks
+
+Nullable child blocks are not correctly supported in the Admin, for instance, in `createCompositeBlock`.
+Save a block's default values instead.

--- a/packages/api/blocks-api/src/blocks/decorators/child-block-input.ts
+++ b/packages/api/blocks-api/src/blocks/decorators/child-block-input.ts
@@ -5,6 +5,11 @@ import { Block, isBlockInputInterface } from "../block";
 import { BlockField } from "./field";
 
 interface ChildBlockInputOptions {
+    /**
+     * @deprecated Nullable child blocks are not correctly supported in
+     * the Admin, for instance, in `createCompositeBlock`. Save a
+     * block's default values instead.
+     */
     nullable?: boolean;
     disableValidateNested?: boolean; // Useful when a custom validation strategy is needed
 }

--- a/packages/api/blocks-api/src/blocks/decorators/child-block.ts
+++ b/packages/api/blocks-api/src/blocks/decorators/child-block.ts
@@ -4,6 +4,11 @@ import { Block, isBlockDataInterface } from "../block";
 import { BlockField } from "./field";
 
 interface ChildBlockOptions {
+    /**
+     * @deprecated Nullable child blocks are not correctly supported in
+     * the Admin, for instance, in `createCompositeBlock`. Save a
+     * block's default values instead.
+     */
     nullable?: boolean;
 }
 export function ChildBlock(block: Block, options?: ChildBlockOptions): PropertyDecorator {


### PR DESCRIPTION
Nullable child blocks are not correctly supported in the Admin, for instance, in `createCompositeBlock`. Save a block's default values instead.