### PR TITLE
Fix fixtures

### DIFF
--- a/demo/api/src/db/fixtures/fixtures.console.ts
+++ b/demo/api/src/db/fixtures/fixtures.console.ts
@@ -19,6 +19,7 @@ import { PageTreeNodeCategory } from "@src/page-tree/page-tree-node-category";
 import { PageContentBlock } from "@src/pages/blocks/PageContentBlock";
 import { PageInput } from "@src/pages/dto/page.input";
 import { Page } from "@src/pages/entities/page.entity";
+import { UserGroup } from "@src/user-groups/user-group";
 import faker from "faker";
 import { Command, Console } from "nestjs-console";
 import slugify from "slugify";
@@ -102,6 +103,9 @@ export class FixturesConsole {
                     id: attachedDocumentIds[0],
                     type: "Page",
                 },
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
             scope,
@@ -111,7 +115,15 @@ export class FixturesConsole {
         await this.pageTreeService.updateNodeVisibility(node.id, PageTreeNodeVisibility.Published);
 
         node = await this.pageTreeService.createNode(
-            { name: "Sub", slug: "sub", parentId: node.id, attachedDocument: { id: attachedDocumentIds[1], type: "Page" } },
+            {
+                name: "Sub",
+                slug: "sub",
+                parentId: node.id,
+                attachedDocument: { id: attachedDocumentIds[1], type: "Page" },
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                userGroup: UserGroup.All,
+            },
             PageTreeNodeCategory.MainNavigation,
             scope,
         );
@@ -127,6 +139,9 @@ export class FixturesConsole {
                     id: attachedDocumentIds[2],
                     type: "Page",
                 },
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
             scope,
@@ -142,6 +157,9 @@ export class FixturesConsole {
                 attachedDocument: {
                     type: "Page",
                 },
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
             scope,
@@ -158,6 +176,9 @@ export class FixturesConsole {
                     id: attachedDocumentIds[3],
                     type: "Link",
                 },
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
             scope,
@@ -174,6 +195,9 @@ export class FixturesConsole {
                     id: attachedDocumentIds[4],
                     type: "Page",
                 },
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
             scope,
@@ -224,6 +248,9 @@ export class FixturesConsole {
                             slug: slugify(name),
                             parentId: level > 0 ? faker.random.arrayElement(pages[level - 1]).id : undefined,
                             attachedDocument: { type: "Page" },
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                            // @ts-ignore
+                            userGroup: UserGroup.All,
                         },
                         PageTreeNodeCategory.MainNavigation,
                         {

--- a/demo/api/src/db/fixtures/fixtures.console.ts
+++ b/demo/api/src/db/fixtures/fixtures.console.ts
@@ -103,8 +103,7 @@ export class FixturesConsole {
                     id: attachedDocumentIds[0],
                     type: "Page",
                 },
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
+                // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                 userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
@@ -120,8 +119,7 @@ export class FixturesConsole {
                 slug: "sub",
                 parentId: node.id,
                 attachedDocument: { id: attachedDocumentIds[1], type: "Page" },
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
+                // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                 userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
@@ -139,8 +137,7 @@ export class FixturesConsole {
                     id: attachedDocumentIds[2],
                     type: "Page",
                 },
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
+                // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                 userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
@@ -157,8 +154,7 @@ export class FixturesConsole {
                 attachedDocument: {
                     type: "Page",
                 },
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
+                // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                 userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
@@ -176,8 +172,7 @@ export class FixturesConsole {
                     id: attachedDocumentIds[3],
                     type: "Link",
                 },
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
+                // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                 userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
@@ -195,8 +190,7 @@ export class FixturesConsole {
                     id: attachedDocumentIds[4],
                     type: "Page",
                 },
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
+                // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                 userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
@@ -248,8 +242,7 @@ export class FixturesConsole {
                             slug: slugify(name),
                             parentId: level > 0 ? faker.random.arrayElement(pages[level - 1]).id : undefined,
                             attachedDocument: { type: "Page" },
-                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                            // @ts-ignore
+                            // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                             userGroup: UserGroup.All,
                         },
                         PageTreeNodeCategory.MainNavigation,

--- a/demo/api/src/db/fixtures/generators/many-images-test-page.generator.ts
+++ b/demo/api/src/db/fixtures/generators/many-images-test-page.generator.ts
@@ -49,8 +49,7 @@ export class ManyImagesTestPageGenerator {
                     id: uuidDocument,
                     type: "Page",
                 },
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
+                // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                 userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,

--- a/demo/api/src/db/fixtures/generators/many-images-test-page.generator.ts
+++ b/demo/api/src/db/fixtures/generators/many-images-test-page.generator.ts
@@ -49,6 +49,9 @@ export class ManyImagesTestPageGenerator {
                     id: uuidDocument,
                     type: "Page",
                 },
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                userGroup: UserGroup.All,
             },
             PageTreeNodeCategory.MainNavigation,
             scope,


### PR DESCRIPTION
## Problem:

Our fixtures are currently broken. You always get this error when executing them:

<img width="573" alt="Bildschirmfoto 2023-12-14 um 17 02 52" src="https://github.com/vivid-planet/comet/assets/13380047/ce7eed3c-5834-4618-8ced-ec93875c71ca">


The problem is that a required `userGroup` field is added to `PageTreeNode` in Demo:

https://github.com/vivid-planet/comet/blob/99e0c57cc8ef542befd74d5b8ad9cf71058570e1/demo/api/src/page-tree/entities/page-tree-node.entity.ts#L26-L28

https://github.com/vivid-planet/comet/blob/1c098e4d0f23946c0fd543856c8f0aa897b83b82/demo/api/src/page-tree/dto/page-tree-node.input.ts#L7-L12

We don't provide a userGroup in the fixtures and it didn't strike because the typing of `PageTreeService.createNode()` is wrong. The input is typed with `PageTreeNodeBaseCreateInput`

https://github.com/vivid-planet/comet/blob/b73eb4c34c70c694fc8b267ce330af5959c50e7b/packages/api/cms-api/src/page-tree/page-tree.service.ts#L33

but the actual input type can be defined in the application and is passed to the resolver via a factory:

https://github.com/vivid-planet/comet/blob/46bced34cbb9ec02de6dd462bd9111a6be7898b7/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts#L35

### -> So actually the typing in the `PageTreeService` is wrong and we need to fix that

I now circumvented this by using ts-ignore. 
But I think we need a solution to get the typing right. I'm however not sure what the best way to do this is.