### PR TITLE
Fix: Enable copying documents from one `PageTree` category to another

### DIFF
--- a/.changeset/grumpy-glasses-hear.md
+++ b/.changeset/grumpy-glasses-hear.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Enable copying documents from one `PageTree` category to another (e.g. from "Main navigation" to "Top menu" in Demo)

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTreeContext.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTreeContext.ts
@@ -9,6 +9,7 @@ export type AllCategories = Array<{ category: string; label: React.ReactNode }>;
 
 export interface PageTreeContext {
     allCategories: AllCategories;
+    activeCategory: string;
     documentTypes: Record<DocumentType, DocumentInterface>;
     tree: TreeMap<GQLPageTreePageFragment>;
     query: DocumentNode;

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTreeContext.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTreeContext.ts
@@ -9,7 +9,7 @@ export type AllCategories = Array<{ category: string; label: React.ReactNode }>;
 
 export interface PageTreeContext {
     allCategories: AllCategories;
-    activeCategory: string;
+    currentCategory: string;
     documentTypes: Record<DocumentType, DocumentInterface>;
     tree: TreeMap<GQLPageTreePageFragment>;
     query: DocumentNode;

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages.tsx
@@ -64,7 +64,7 @@ interface UseCopyPastePagesApi {
  * This hooks provides some helper functions to copy / paste Pages and PageTreeNodes
  */
 function useCopyPastePages(): UseCopyPastePagesApi {
-    const { documentTypes, activeCategory } = usePageTreeContext();
+    const { documentTypes, currentCategory } = usePageTreeContext();
     const client = useApolloClient();
     const { scope } = useContentScope();
     const damScope = useDamScope();
@@ -170,7 +170,7 @@ function useCopyPastePages(): UseCopyPastePagesApi {
     const sendPagesCb = React.useCallback(
         async (parentId: string | null, pages: PagesClipboard, options: SendPagesOptions) => {
             try {
-                await sendPages(parentId, pages, options, { client, scope, documentTypes, blockContext, damScope, activeCategory }, updateProgress);
+                await sendPages(parentId, pages, options, { client, scope, documentTypes, blockContext, damScope, currentCategory }, updateProgress);
             } catch (e) {
                 errorDialog?.showError({
                     title: <FormattedMessage {...messages.error} />,
@@ -183,7 +183,7 @@ function useCopyPastePages(): UseCopyPastePagesApi {
                 updateProgress(undefined); //hides progress dialog
             }
         },
-        [client, scope, documentTypes, blockContext, damScope, activeCategory, updateProgress, errorDialog],
+        [client, scope, documentTypes, blockContext, damScope, currentCategory, updateProgress, errorDialog],
     );
 
     return {

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages.tsx
@@ -64,7 +64,7 @@ interface UseCopyPastePagesApi {
  * This hooks provides some helper functions to copy / paste Pages and PageTreeNodes
  */
 function useCopyPastePages(): UseCopyPastePagesApi {
-    const { documentTypes } = usePageTreeContext();
+    const { documentTypes, activeCategory } = usePageTreeContext();
     const client = useApolloClient();
     const { scope } = useContentScope();
     const damScope = useDamScope();
@@ -170,7 +170,7 @@ function useCopyPastePages(): UseCopyPastePagesApi {
     const sendPagesCb = React.useCallback(
         async (parentId: string | null, pages: PagesClipboard, options: SendPagesOptions) => {
             try {
-                await sendPages(parentId, pages, options, { client, scope, documentTypes, blockContext, damScope }, updateProgress);
+                await sendPages(parentId, pages, options, { client, scope, documentTypes, blockContext, damScope, activeCategory }, updateProgress);
             } catch (e) {
                 errorDialog?.showError({
                     title: <FormattedMessage {...messages.error} />,
@@ -183,7 +183,7 @@ function useCopyPastePages(): UseCopyPastePagesApi {
                 updateProgress(undefined); //hides progress dialog
             }
         },
-        [client, scope, documentTypes, blockContext, damScope, updateProgress, errorDialog],
+        [client, scope, documentTypes, blockContext, damScope, activeCategory, updateProgress, errorDialog],
     );
 
     return {

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
@@ -72,7 +72,7 @@ interface SendPagesDependencies {
     documentTypes: PageTreeContext["documentTypes"];
     blockContext: CmsBlockContext;
     damScope: Record<string, unknown>;
-    activeCategory: string;
+    currentCategory: string;
 }
 
 /**
@@ -93,7 +93,7 @@ export async function sendPages(
     parentId: string | null,
     { pages }: PagesClipboard,
     options: SendPagesOptions,
-    { client, scope, documentTypes, blockContext, damScope, activeCategory }: SendPagesDependencies,
+    { client, scope, documentTypes, blockContext, damScope, currentCategory }: SendPagesDependencies,
     updateProgress: (progress: number, message: React.ReactNode) => void,
 ): Promise<void> {
     const dependencyReplacements = createPageTreeNodeIdReplacements(pages);
@@ -218,7 +218,7 @@ export async function sendPages(
                     pos: options.targetPos ? options.targetPos + posOffset : undefined,
                 },
                 contentScope: scope,
-                category: activeCategory,
+                category: currentCategory,
             },
             context: LocalErrorScopeApolloContext,
         });

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
@@ -72,6 +72,7 @@ interface SendPagesDependencies {
     documentTypes: PageTreeContext["documentTypes"];
     blockContext: CmsBlockContext;
     damScope: Record<string, unknown>;
+    activeCategory: string;
 }
 
 /**
@@ -92,7 +93,7 @@ export async function sendPages(
     parentId: string | null,
     { pages }: PagesClipboard,
     options: SendPagesOptions,
-    { client, scope, documentTypes, blockContext, damScope }: SendPagesDependencies,
+    { client, scope, documentTypes, blockContext, damScope, activeCategory }: SendPagesDependencies,
     updateProgress: (progress: number, message: React.ReactNode) => void,
 ): Promise<void> {
     const dependencyReplacements = createPageTreeNodeIdReplacements(pages);
@@ -217,7 +218,7 @@ export async function sendPages(
                     pos: options.targetPos ? options.targetPos + posOffset : undefined,
                 },
                 contentScope: scope,
-                category: node.category,
+                category: activeCategory,
             },
             context: LocalErrorScopeApolloContext,
         });

--- a/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
@@ -224,7 +224,7 @@ export default function PageTreeSelectDialog({ value, onChange, open, onClose, d
                 <PageTreeContext.Provider
                     value={{
                         allCategories: pageTreeCategories,
-                        activeCategory: category,
+                        currentCategory: category,
                         documentTypes: pageTreeDocumentTypes,
                         tree,
                         query: pagesQuery,

--- a/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
@@ -222,7 +222,13 @@ export default function PageTreeSelectDialog({ value, onChange, open, onClose, d
             </Toolbar>
             <DialogContent ref={refDialogContent}>
                 <PageTreeContext.Provider
-                    value={{ allCategories: pageTreeCategories, documentTypes: pageTreeDocumentTypes, tree, query: pagesQuery }}
+                    value={{
+                        allCategories: pageTreeCategories,
+                        activeCategory: category,
+                        documentTypes: pageTreeDocumentTypes,
+                        tree,
+                        query: pagesQuery,
+                    }}
                 >
                     <List
                         ref={refList}

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -156,7 +156,7 @@ export function PagesPage({
                                 </Button>
                             </ToolbarActions>
                         </Toolbar>
-                        <PageTreeContext.Provider value={{ allCategories, activeCategory: category, documentTypes, tree, query: pagesQuery }}>
+                        <PageTreeContext.Provider value={{ allCategories, currentCategory: category, documentTypes, tree, query: pagesQuery }}>
                             <PageTreeContent fullHeight>
                                 <ActionToolbarBox>
                                     <PagesPageActionToolbar

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -156,7 +156,7 @@ export function PagesPage({
                                 </Button>
                             </ToolbarActions>
                         </Toolbar>
-                        <PageTreeContext.Provider value={{ allCategories, documentTypes, tree, query: pagesQuery }}>
+                        <PageTreeContext.Provider value={{ allCategories, activeCategory: category, documentTypes, tree, query: pagesQuery }}>
                             <PageTreeContent fullHeight>
                                 <ActionToolbarBox>
                                     <PagesPageActionToolbar


### PR DESCRIPTION
## Previously:

It wasn't possible to copy a document from one category to another (e.g. from "Main navigation" to "Top menu"). Instead, the document was always pasted to its original category because we always used the category of the copied node in `sendPages()`.
 
https://github.com/vivid-planet/comet/assets/13380047/8112d742-f73c-47cb-a664-516ee4e3286b

## Now:

The active category is passed via the `PageTreeContext`. So the node is always pasted to the active category.

https://github.com/vivid-planet/comet/assets/13380047/b947feb8-c9f5-4b94-816b-3f89641f31ce