### PR TITLE
Make DAM license fields optional for ROYALTY_FREE

### DIFF
--- a/.changeset/tricky-adults-laugh.md
+++ b/.changeset/tricky-adults-laugh.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Make all DAM license fields optional if `LicenseType` is `ROYALTY_FREE` even if `requireLicense` is true in `DamConfig`

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -195,7 +195,6 @@ const EditFileInner = ({ file, id }: EditFileInnerProps) => {
                 // override default onAfterSubmit because default is stackApi.goBack()
                 // https://github.com/vivid-planet/comet/blob/master/packages/admin/src/FinalForm.tsx#L53
             }}
-            validateOnBlur
         >
             {({ pristine, hasValidationErrors, submitting, handleSubmit }) => (
                 <>

--- a/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
@@ -59,6 +59,18 @@ export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): Re
         [apollo, folderId, scope],
     );
 
+    const requiredValidator = React.useCallback(
+        (value: unknown, allValues: object) => {
+            const type = (allValues as EditFileFormValues).license?.type;
+            const isRequired = type === "ROYALTY_FREE" ? false : damConfig.requireLicense;
+
+            if (isRequired && !value) {
+                return <FormattedMessage id="comet.form.required" defaultMessage="Required" />;
+            }
+        },
+        [damConfig.requireLicense],
+    );
+
     return (
         <div>
             <FormSection title="General">
@@ -122,10 +134,9 @@ export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): Re
                             }
                         }}
                         shouldShowError={() => true}
-                        validateFields={["license.durationTo"]}
                     />
                     <Field name="license.type">
-                        {({ input: { value } }) => {
+                        {({ input: { value: licenseType } }) => {
                             return (
                                 <>
                                     <Field
@@ -135,8 +146,8 @@ export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): Re
                                         multiline
                                         minRows={3}
                                         fullWidth
-                                        disabled={value === "NO_LICENSE"}
-                                        required={damConfig.requireLicense}
+                                        disabled={licenseType === "NO_LICENSE"}
+                                        validate={requiredValidator}
                                         shouldShowError={() => true}
                                     />
                                     <Field
@@ -144,15 +155,14 @@ export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): Re
                                         name="license.author"
                                         component={FinalFormInput}
                                         fullWidth
-                                        disabled={value === "NO_LICENSE"}
-                                        required={damConfig.requireLicense}
+                                        disabled={licenseType === "NO_LICENSE"}
+                                        validate={requiredValidator}
                                         shouldShowError={() => true}
                                     />
                                     <FieldContainer
                                         label={<FormattedMessage id="comet.dam.file.licenseDuration" defaultMessage="License duration" />}
                                         fullWidth
-                                        disabled={value === "NO_LICENSE"}
-                                        required={damConfig.requireLicense}
+                                        disabled={licenseType === "NO_LICENSE"}
                                     >
                                         <DurationFieldWrapper>
                                             <Field
@@ -166,8 +176,9 @@ export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): Re
                                                         <Calendar />
                                                     </InputAdornment>
                                                 }
-                                                disabled={value === "NO_LICENSE"}
-                                                required={damConfig.requireLicense}
+                                                validateFields={["license.durationTo"]}
+                                                disabled={licenseType === "NO_LICENSE"}
+                                                validate={requiredValidator}
                                                 shouldShowError={() => true}
                                             />
                                             <Field
@@ -182,7 +193,13 @@ export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): Re
                                                     </InputAdornment>
                                                 }
                                                 validate={(value: Date | undefined, allValues) => {
-                                                    if (value && allValues && value < (allValues as EditFileFormValues).license?.durationFrom) {
+                                                    const requiredError = requiredValidator(value, allValues);
+                                                    if (requiredError) {
+                                                        return requiredError;
+                                                    }
+
+                                                    const durationFrom = (allValues as EditFileFormValues).license?.durationFrom;
+                                                    if (value && durationFrom && value < durationFrom) {
                                                         return (
                                                             <FormattedMessage
                                                                 id="comet.dam.file.error.durationTo"
@@ -191,8 +208,7 @@ export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): Re
                                                         );
                                                     }
                                                 }}
-                                                disabled={value === "NO_LICENSE"}
-                                                required={value === "ROYALTY_FREE" ? false : damConfig.requireLicense}
+                                                disabled={licenseType === "NO_LICENSE"}
                                                 shouldShowError={() => true}
                                             />
                                         </DurationFieldWrapper>


### PR DESCRIPTION
Make all DAM license fields optional if `LicenseType` is `ROYALTY_FREE` even if `requireLicense` is true in `DamConfig`

-- 

Screencast:


https://github.com/vivid-planet/comet/assets/13380047/d34bd253-5edd-4716-902e-503bf2a5913d

--

Closes COM-250