### PR TITLE
COM-251: remove license types micro and subscription from admin

### DIFF
--- a/.changeset/popular-mirrors-obey.md
+++ b/.changeset/popular-mirrors-obey.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Remove license types `MICRO` and `SUBSCRIPTION` as options from selection in `FileSettingsFields`.

--- a/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
@@ -27,14 +27,12 @@ const damIsFilenameOccupiedQuery = gql`
 
 export type LicenseType = GQLLicenseType | "NO_LICENSE";
 
-const licenseTypeArray: readonly LicenseType[] = ["NO_LICENSE", "ROYALTY_FREE", "RIGHTS_MANAGED", "SUBSCRIPTION", "MICRO"];
+const licenseTypeArray: readonly LicenseType[] = ["NO_LICENSE", "ROYALTY_FREE", "RIGHTS_MANAGED"];
 
-const licenseTypeLabels: { [key in LicenseType]: React.ReactNode } = {
+const licenseTypeLabels: { [key in LicenseType]?: React.ReactNode } = {
     NO_LICENSE: "-",
     ROYALTY_FREE: <FormattedMessage id="comet.dam.file.licenseType.royaltyFree" defaultMessage="Royalty free" />,
     RIGHTS_MANAGED: <FormattedMessage id="comet.dam.file.licenseType.rightsManaged" defaultMessage="Rights managed" />,
-    SUBSCRIPTION: <FormattedMessage id="comet.dam.file.licenseType.subscription" defaultMessage="Subscription" />,
-    MICRO: <FormattedMessage id="comet.dam.file.licenseType.micro" defaultMessage="Micro" />,
 };
 
 export const FileSettingsFields = ({ isImage, folderId }: SettingsFormProps): React.ReactElement => {


### PR DESCRIPTION
This PR removes the license types `micro` and `subscription` from the comet admin.

### Acceptance Criteria
- [x] Add changeset