### PR TITLE
Fix encoding of special characters in filename

### DIFF
--- a/.changeset/kind-fans-watch.md
+++ b/.changeset/kind-fans-watch.md
@@ -1,0 +1,15 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix encoding of special characters in names of uploaded files
+
+For example:
+
+Previously: 
+- `€.jpg` -> `a.jpg`
+- `ä.jpg` -> `ai.jpg`
+
+Now: 
+- `€.jpg` -> `euro.jpg`
+- `ä.jpg` -> `ae.jpg`

--- a/packages/api/cms-api/src/dam/files/dam-upload-file.interceptor.ts
+++ b/packages/api/cms-api/src/dam/files/dam-upload-file.interceptor.ts
@@ -33,6 +33,8 @@ export function DamUploadFileInterceptor(fieldName: string): Type<NestIntercepto
                         });
                     },
                     filename: function (req, file, cb) {
+                        // otherwise special characters aren't decoded properly (https://github.com/expressjs/multer/issues/836#issuecomment-1264338996)
+                        file.originalname = Buffer.from(file.originalname, "latin1").toString("utf8");
                         cb(null, `${uuid()}-${file.originalname}`);
                     },
                 }),

--- a/packages/api/cms-api/src/public-upload/public-upload-file.interceptor.ts
+++ b/packages/api/cms-api/src/public-upload/public-upload-file.interceptor.ts
@@ -33,6 +33,8 @@ export function PublicUploadFileInterceptor(fieldName: string): Type<NestInterce
                         });
                     },
                     filename: function (req, file, cb) {
+                        // otherwise special characters aren't decoded properly (https://github.com/expressjs/multer/issues/836#issuecomment-1264338996)
+                        file.originalname = Buffer.from(file.originalname, "latin1").toString("utf8");
                         cb(null, `${uuid()}-${file.originalname}`);
                     },
                 }),


### PR DESCRIPTION
Special characters in names of uploaded files weren't properly decoded. This led to a wrong result during slugification. For example:

--

### Previously:

`€.jpg`:
<img width="309" alt="Bildschirmfoto 2023-12-22 um 14 38 05" src="https://github.com/vivid-planet/comet/assets/13380047/62d124e7-35a8-4c08-bd42-6a66729dd016">

`ä.jpg`:
<img width="329" alt="Bildschirmfoto 2023-12-22 um 14 37 58" src="https://github.com/vivid-planet/comet/assets/13380047/6627901f-0308-4573-a603-661a2634f2ad">

<img width="890" alt="Bildschirmfoto 2023-12-22 um 14 39 00" src="https://github.com/vivid-planet/comet/assets/13380047/c3d329e8-128d-4cae-9477-4ab58cdaa3cc">

### Now:

`€.jpg`:
<img width="290" alt="Bildschirmfoto 2023-12-22 um 14 36 35" src="https://github.com/vivid-planet/comet/assets/13380047/866b5648-c985-403b-b4cb-c1b5009f359d">

`ä.jpg`:
<img width="290" alt="Bildschirmfoto 2023-12-22 um 14 36 46" src="https://github.com/vivid-planet/comet/assets/13380047/9c590bbf-b07a-4f42-b73e-fd6cecc7db07">

<img width="891" alt="Bildschirmfoto 2023-12-22 um 14 37 36" src="https://github.com/vivid-planet/comet/assets/13380047/6cc4e552-a06b-4db7-824d-d6fe57784fcd">