### PR TITLE
Change `DataGrid`'s `noRowsLabel` from "No rows" to "No results found."

### DIFF
--- a/.changeset/five-tigers-run.md
+++ b/.changeset/five-tigers-run.md
@@ -1,0 +1,6 @@
+---
+"@comet/admin-theme": minor
+---
+
+Change `DataGrid`'s `noRowsLabel` from "No rows" to "No results found"
+

--- a/.changeset/five-tigers-run.md
+++ b/.changeset/five-tigers-run.md
@@ -2,5 +2,5 @@
 "@comet/admin-theme": minor
 ---
 
-Change `DataGrid`'s `noRowsLabel` from "No rows" to "No results found"
+Change `DataGrid`'s `noRowsLabel` from "No rows" to "No results found."
 

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -34,6 +34,9 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             ColumnMenuIcon: (props: SvgIconProps) => <MoreVertical {...props} fontSize="medium" />,
             ...component?.defaultProps?.components,
         },
+        localeText: {
+            noRowsLabel: "No results found",
+        },
         ...component?.defaultProps,
     },
     styleOverrides: mergeOverrideStyles<"MuiDataGrid">(component?.styleOverrides, {

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -12,7 +12,7 @@ import {
     TextField,
     TextFieldProps,
 } from "@mui/material";
-import { getDataGridUtilityClass } from "@mui/x-data-grid";
+import { getDataGridUtilityClass, GRID_DEFAULT_LOCALE_TEXT } from "@mui/x-data-grid";
 import type {} from "@mui/x-data-grid/themeAugmentation";
 import React from "react";
 
@@ -35,7 +35,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             ...component?.defaultProps?.components,
         },
         localeText: {
-            noRowsLabel: "No results found",
+            noRowsLabel: GRID_DEFAULT_LOCALE_TEXT.noResultsOverlayLabel,
         },
         ...component?.defaultProps,
     },


### PR DESCRIPTION
Before:

<img width="1920" alt="Bildschirmfoto 2023-12-28 um 14 46 39" src="https://github.com/vivid-planet/comet/assets/13380047/62ca9910-affb-46bd-b432-32a6fb921374">


Now:

<img width="1920" alt="Bildschirmfoto 2024-01-18 um 10 00 00" src="https://github.com/vivid-planet/comet/assets/13380047/8f33ac38-8a50-416c-9f1f-08f3977e566a">

---

Closes COM-168