### PR TITLE
Fix `createDependencyMethods`

### DIFF
--- a/demo/admin/src/news/dependencies/NewsDependency.tsx
+++ b/demo/admin/src/news/dependencies/NewsDependency.tsx
@@ -16,6 +16,7 @@ export const NewsDependency: DependencyInterface = {
                 node: news(id: $id) {
                     id
                     content
+                    image
                 }
             }
         `,


### PR DESCRIPTION
The field was incorrectly assumed to always be `content`. Use `data.node[rootColumnName]` instead. Also, make function generic to infer keys of root blocks and require them in GraphQL query.