### PR TITLE
Add support for a custom block name and migrations to `createRichTextBlock`

### DIFF
--- a/.changeset/hungry-wombats-behave.md
+++ b/.changeset/hungry-wombats-behave.md
@@ -2,4 +2,4 @@
 "@comet/blocks-api": minor
 ---
 
-Add property `migrationOptions` to `createRichTextBlock()` factory to enable adding migrations to the RichTextBlock
+Add support for a custom block name and migrations to `createRichTextBlock`

--- a/.changeset/hungry-wombats-behave.md
+++ b/.changeset/hungry-wombats-behave.md
@@ -2,4 +2,4 @@
 "@comet/blocks-api": minor
 ---
 
-Add property migrationOptions to createRichTextBlock factory in order to be able to add migrations to the RichTextBlock
+Add property `migrationOptions` to `createRichTextBlock()` factory to enable adding migrations to the RichTextBlock

--- a/.changeset/hungry-wombats-behave.md
+++ b/.changeset/hungry-wombats-behave.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-api": minor
+---
+
+Add property migrationOptions to createRichTextBlock factory in order to be able to add migrations to the RichTextBlock

--- a/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
+++ b/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
@@ -23,6 +23,7 @@ import { strictBlockInputFactoryDecorator } from "./helpers/strictBlockInputFact
 interface CreateRichTextBlockOptions {
     link: Block;
     indexSearchText?: boolean;
+    migrateOptions?: MigrateOptions;
 }
 
 // Replaces draft-js' RawDraftContentBlock
@@ -70,12 +71,10 @@ export interface RichTextBlockInputInterface<LinkBlockInput extends BlockInputIn
 export function createRichTextBlock<LinkBlock extends Block>({
     link: LinkBlock,
     indexSearchText = true,
+    migrateOptions = { migrations: [], version: 0 },
 }: CreateRichTextBlockOptions): Block<RichTextBlockDataInterface, RichTextBlockInputInterface<ExtractBlockInput<LinkBlock>>> {
     const BLOCK_NAME = "RichText";
-    const MIGRATE: MigrateOptions = {
-        migrations: [],
-        version: 0,
-    }; // Placeholder for future migrations
+    const MIGRATE = migrateOptions;
 
     @BlockDataMigrationVersion(MIGRATE.version)
     class RichTextBlockData extends BlockData {

--- a/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
+++ b/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
@@ -71,10 +71,10 @@ export function createRichTextBlock<LinkBlock extends Block>(
     { link: LinkBlock, indexSearchText = true }: CreateRichTextBlockOptions,
     nameOrOptions: NameOrOptions = "RichText",
 ): Block<RichTextBlockDataInterface, RichTextBlockInputInterface<ExtractBlockInput<LinkBlock>>> {
-    const BLOCK_NAME = typeof nameOrOptions === "string" ? nameOrOptions : nameOrOptions.name;
-    const MIGRATE = typeof nameOrOptions !== "string" && nameOrOptions.migrate ? nameOrOptions.migrate : { migrations: [], version: 0 };
+    const blockName = typeof nameOrOptions === "string" ? nameOrOptions : nameOrOptions.name;
+    const migrate = typeof nameOrOptions !== "string" && nameOrOptions.migrate ? nameOrOptions.migrate : { migrations: [], version: 0 };
 
-    @BlockDataMigrationVersion(MIGRATE.version)
+    @BlockDataMigrationVersion(migrate.version)
     class RichTextBlockData extends BlockData {
         @BlockField({ type: "json" })
         draftContent: RawDraftContentState;
@@ -171,8 +171,8 @@ export function createRichTextBlock<LinkBlock extends Block>(
 
     // Decorate BlockDataFactory
     let decorateBlockDataFactory = blockDataFactory;
-    if (MIGRATE.migrations) {
-        const blockDataFactoryDecorator1 = createAppliedMigrationsBlockDataFactoryDecorator(MIGRATE.migrations, BLOCK_NAME);
+    if (migrate.migrations) {
+        const blockDataFactoryDecorator1 = createAppliedMigrationsBlockDataFactoryDecorator(migrate.migrations, blockName);
         decorateBlockDataFactory = blockDataFactoryDecorator1(decorateBlockDataFactory);
     }
     decorateBlockDataFactory = strictBlockDataFactoryDecorator(decorateBlockDataFactory);
@@ -181,7 +181,7 @@ export function createRichTextBlock<LinkBlock extends Block>(
     const decorateBlockInputFactory = strictBlockInputFactoryDecorator(blockInputFactory);
 
     const RichTextBlock: Block<RichTextBlockData, RichTextBlockInputInterface<ExtractBlockInput<LinkBlock>>> = {
-        name: BLOCK_NAME,
+        name: blockName,
         blockDataFactory: decorateBlockDataFactory,
         blockInputFactory: decorateBlockInputFactory,
         blockMeta: new AnnotationBlockMeta(RichTextBlockData),

--- a/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
+++ b/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
@@ -13,17 +13,16 @@ import {
     BlockInputFactory,
     BlockInputInterface,
     ExtractBlockInput,
-    MigrateOptions,
     registerBlock,
 } from "./block";
 import { AnnotationBlockMeta, BlockField } from "./decorators/field";
+import { NameOrOptions } from "./factories/types";
 import { strictBlockDataFactoryDecorator } from "./helpers/strictBlockDataFactoryDecorator";
 import { strictBlockInputFactoryDecorator } from "./helpers/strictBlockInputFactoryDecorator";
 
 interface CreateRichTextBlockOptions {
     link: Block;
     indexSearchText?: boolean;
-    migrateOptions?: MigrateOptions;
 }
 
 // Replaces draft-js' RawDraftContentBlock
@@ -68,13 +67,12 @@ export interface RichTextBlockInputInterface<LinkBlockInput extends BlockInputIn
     draftContent: DraftJsInput<LinkBlockInput>;
 }
 
-export function createRichTextBlock<LinkBlock extends Block>({
-    link: LinkBlock,
-    indexSearchText = true,
-    migrateOptions = { migrations: [], version: 0 },
-}: CreateRichTextBlockOptions): Block<RichTextBlockDataInterface, RichTextBlockInputInterface<ExtractBlockInput<LinkBlock>>> {
-    const BLOCK_NAME = "RichText";
-    const MIGRATE = migrateOptions;
+export function createRichTextBlock<LinkBlock extends Block>(
+    { link: LinkBlock, indexSearchText = true }: CreateRichTextBlockOptions,
+    nameOrOptions: NameOrOptions = "RichText",
+): Block<RichTextBlockDataInterface, RichTextBlockInputInterface<ExtractBlockInput<LinkBlock>>> {
+    const BLOCK_NAME = typeof nameOrOptions === "string" ? nameOrOptions : nameOrOptions.name;
+    const MIGRATE = typeof nameOrOptions !== "string" && nameOrOptions.migrate ? nameOrOptions.migrate : { migrations: [], version: 0 };
 
     @BlockDataMigrationVersion(MIGRATE.version)
     class RichTextBlockData extends BlockData {


### PR DESCRIPTION
Allows adding migrations to a `RichTextBlock` in application code.