### PR TITLE
Improve API for copying DAM files

### DIFF
--- a/.changeset/afraid-pumpkins-leave.md
+++ b/.changeset/afraid-pumpkins-leave.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-api": patch
+---
+
+Deprecate
+
+- `FilesService.copyFilesToScope()`
+- `FilesResolver.copyFilesToScope()`
+- `inboxFolder` param of `FilesService.createCopyOfFile()`

--- a/.changeset/afraid-pumpkins-leave.md
+++ b/.changeset/afraid-pumpkins-leave.md
@@ -1,5 +1,5 @@
 ---
-"@comet/cms-api": patch
+"@comet/cms-api": minor
 ---
 
 Deprecate

--- a/.changeset/eleven-rice-brush.md
+++ b/.changeset/eleven-rice-brush.md
@@ -2,6 +2,6 @@
 "@comet/cms-api": minor
 ---
 
-Add `copyFiles()` mutation to `FilesResolver`
+Add `copyDamFiles()` mutation to `FilesResolver`
 
-`copyFiles()` replaces the deprecated `copyFilesToScope()` mutation. It also supports copying to the DAM root folder.
+`copyDamFiles()` replaces the deprecated `copyFilesToScope()` mutation. It also supports copying to the DAM root folder.

--- a/.changeset/eleven-rice-brush.md
+++ b/.changeset/eleven-rice-brush.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Add `copyFiles()` mutation to `FilesResolver`
+
+`copyFiles()` replaces the deprecated `copyFilesToScope()` mutation. It also supports copying to the DAM root folder.

--- a/.changeset/fair-impalas-melt.md
+++ b/.changeset/fair-impalas-melt.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Support copying to root folder in `createCopyOfFile()`
+
+Add new params `targetFolder` and `targetScope`. To copy to root folder, set `targetFolder` to `null` and `targetScope` to the respective scope.

--- a/.changeset/fair-impalas-melt.md
+++ b/.changeset/fair-impalas-melt.md
@@ -2,6 +2,6 @@
 "@comet/cms-api": minor
 ---
 
-Support copying to root folder in `createCopyOfFile()`
+Support copying to root folder in `FilesService.createCopyOfFile()`
 
 Add new params `targetFolder` and `targetScope`. To copy to root folder, set `targetFolder` to `null` and `targetScope` to the respective scope.

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -847,7 +847,7 @@ type Mutation {
     fileIds: [ID!]!
     targetFolderId: ID
 
-    """Doesn't need to be set if targetFolderId is set"""
+    """Not needed when using targetFolderId"""
     targetScope: DamScopeInput
   ): CopyDamFilesResponse!
   archiveDamFile(id: ID!): DamFile!

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -492,7 +492,7 @@ type PaginatedDamItems {
 
 union DamItem = DamFile | DamFolder
 
-type CopyFilesResponse {
+type CopyDamFilesResponse {
   mappedFiles: [MappedFile!]!
 }
 
@@ -842,14 +842,14 @@ type Mutation {
   updateDamFile(id: ID!, input: UpdateDamFileInput!): DamFile!
   importDamFileByDownload(url: String!, scope: DamScopeInput!, input: UpdateDamFileInput!): DamFile!
   moveDamFiles(fileIds: [ID!]!, targetFolderId: ID): [DamFile!]!
-  copyFilesToScope(fileIds: [ID!]!, inboxFolderId: ID!): CopyFilesResponse! @deprecated(reason: "Use copyFiles instead")
-  copyFiles(
+  copyFilesToScope(fileIds: [ID!]!, inboxFolderId: ID!): CopyDamFilesResponse! @deprecated(reason: "Use copyDamFiles instead")
+  copyDamFiles(
     fileIds: [ID!]!
     targetFolderId: ID
 
     """Doesn't need to be set if targetFolderId is set"""
     targetScope: DamScopeInput
-  ): CopyFilesResponse!
+  ): CopyDamFilesResponse!
   archiveDamFile(id: ID!): DamFile!
   archiveDamFiles(ids: [ID!]!): [DamFile!]!
   restoreDamFile(id: ID!): DamFile!

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -842,7 +842,14 @@ type Mutation {
   updateDamFile(id: ID!, input: UpdateDamFileInput!): DamFile!
   importDamFileByDownload(url: String!, scope: DamScopeInput!, input: UpdateDamFileInput!): DamFile!
   moveDamFiles(fileIds: [ID!]!, targetFolderId: ID): [DamFile!]!
-  copyFilesToScope(fileIds: [ID!]!, inboxFolderId: ID!): CopyFilesResponse!
+  copyFilesToScope(fileIds: [ID!]!, inboxFolderId: ID!): CopyFilesResponse! @deprecated(reason: "Use copyFiles instead")
+  copyFiles(
+    fileIds: [ID!]!
+    targetFolderId: ID
+
+    """Doesn't need to be set if targetFolderId is set"""
+    targetScope: DamScopeInput
+  ): CopyFilesResponse!
   archiveDamFile(id: ID!): DamFile!
   archiveDamFiles(ids: [ID!]!): [DamFile!]!
   restoreDamFile(id: ID!): DamFile!

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
@@ -15,8 +15,8 @@ import { arrayToTreeMap } from "../treemap/TreeMapUtils";
 import { PageClipboard, PagesClipboard } from "../useCopyPastePages";
 import { createInboxFolder } from "./createInboxFolder";
 import {
-    GQLCopyFilesMutation,
-    GQLCopyFilesMutationVariables,
+    GQLCopyDamFilesMutation,
+    GQLCopyDamFilesMutationVariables,
     GQLCreatePageNodeMutation,
     GQLCreatePageNodeMutationVariables,
     GQLDownloadDamFileMutation,
@@ -41,9 +41,9 @@ const createPageNodeMutation = gql`
     }
 `;
 
-const copyFilesMutation = gql`
-    mutation CopyFiles($fileIds: [ID!]!, $inboxFolderId: ID!) {
-        copyFiles(fileIds: $fileIds, targetFolderId: $inboxFolderId) {
+const copyDamFilesMutation = gql`
+    mutation CopyDamFiles($fileIds: [ID!]!, $inboxFolderId: ID!) {
+        copyDamFiles(fileIds: $fileIds, targetFolderId: $inboxFolderId) {
             mappedFiles {
                 rootFile {
                     id
@@ -335,8 +335,8 @@ export async function sendPages(
 
                 if (fileIdsToCopyDirectly.length > 0) {
                     if (!inboxFolderIdForCopiedFiles) throw new Error("inbox folder must be created in step 0 when files need to be copied");
-                    const { data: copiedFiles } = await client.mutate<GQLCopyFilesMutation, GQLCopyFilesMutationVariables>({
-                        mutation: copyFilesMutation,
+                    const { data: copiedFiles } = await client.mutate<GQLCopyDamFilesMutation, GQLCopyDamFilesMutationVariables>({
+                        mutation: copyDamFilesMutation,
                         variables: { fileIds: fileIdsToCopyDirectly, inboxFolderId: inboxFolderIdForCopiedFiles },
                         update: (cache, result) => {
                             cache.evict({ fieldName: "damItemsList" });
@@ -344,7 +344,7 @@ export async function sendPages(
                     });
 
                     if (copiedFiles) {
-                        for (const item of copiedFiles.copyFiles.mappedFiles) {
+                        for (const item of copiedFiles.copyDamFiles.mappedFiles) {
                             dependencyReplacements.push({ type: "DamFile", originalId: item.rootFile.id, replaceWithId: item.copy.id });
                         }
                     }

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
@@ -15,8 +15,8 @@ import { arrayToTreeMap } from "../treemap/TreeMapUtils";
 import { PageClipboard, PagesClipboard } from "../useCopyPastePages";
 import { createInboxFolder } from "./createInboxFolder";
 import {
-    GQLCopyFilesToScopeMutation,
-    GQLCopyFilesToScopeMutationVariables,
+    GQLCopyFilesMutation,
+    GQLCopyFilesMutationVariables,
     GQLCreatePageNodeMutation,
     GQLCreatePageNodeMutationVariables,
     GQLDownloadDamFileMutation,
@@ -41,9 +41,9 @@ const createPageNodeMutation = gql`
     }
 `;
 
-const copyFilesToScopeMutation = gql`
-    mutation CopyFilesToScope($fileIds: [ID!]!, $inboxFolderId: ID!) {
-        copyFilesToScope(fileIds: $fileIds, inboxFolderId: $inboxFolderId) {
+const copyFilesMutation = gql`
+    mutation CopyFiles($fileIds: [ID!]!, $inboxFolderId: ID!) {
+        copyFiles(fileIds: $fileIds, targetFolderId: $inboxFolderId) {
             mappedFiles {
                 rootFile {
                     id
@@ -335,8 +335,8 @@ export async function sendPages(
 
                 if (fileIdsToCopyDirectly.length > 0) {
                     if (!inboxFolderIdForCopiedFiles) throw new Error("inbox folder must be created in step 0 when files need to be copied");
-                    const { data: copiedFiles } = await client.mutate<GQLCopyFilesToScopeMutation, GQLCopyFilesToScopeMutationVariables>({
-                        mutation: copyFilesToScopeMutation,
+                    const { data: copiedFiles } = await client.mutate<GQLCopyFilesMutation, GQLCopyFilesMutationVariables>({
+                        mutation: copyFilesMutation,
                         variables: { fileIds: fileIdsToCopyDirectly, inboxFolderId: inboxFolderIdForCopiedFiles },
                         update: (cache, result) => {
                             cache.evict({ fieldName: "damItemsList" });
@@ -344,7 +344,7 @@ export async function sendPages(
                     });
 
                     if (copiedFiles) {
-                        for (const item of copiedFiles.copyFilesToScope.mappedFiles) {
+                        for (const item of copiedFiles.copyFiles.mappedFiles) {
                             dependencyReplacements.push({ type: "DamFile", originalId: item.rootFile.id, replaceWithId: item.copy.id });
                         }
                     }

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -427,7 +427,7 @@ type Mutation {
     fileIds: [ID!]!
     targetFolderId: ID
 
-    """Doesn't need to be set if targetFolderId is set"""
+    """Not needed when using targetFolderId"""
     targetScope: DamScopeInput = {}
   ): CopyDamFilesResponse!
   archiveDamFile(id: ID!): DamFile!

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -259,7 +259,7 @@ type PaginatedDamItems {
 
 union DamItem = DamFile | DamFolder
 
-type CopyFilesResponse {
+type CopyDamFilesResponse {
   mappedFiles: [MappedFile!]!
 }
 
@@ -422,14 +422,14 @@ type Mutation {
   updateDamFile(id: ID!, input: UpdateDamFileInput!): DamFile!
   importDamFileByDownload(url: String!, scope: DamScopeInput! = {}, input: UpdateDamFileInput!): DamFile!
   moveDamFiles(fileIds: [ID!]!, targetFolderId: ID): [DamFile!]!
-  copyFilesToScope(fileIds: [ID!]!, inboxFolderId: ID!): CopyFilesResponse! @deprecated(reason: "Use copyFiles instead")
-  copyFiles(
+  copyFilesToScope(fileIds: [ID!]!, inboxFolderId: ID!): CopyDamFilesResponse! @deprecated(reason: "Use copyDamFiles instead")
+  copyDamFiles(
     fileIds: [ID!]!
     targetFolderId: ID
 
     """Doesn't need to be set if targetFolderId is set"""
     targetScope: DamScopeInput = {}
-  ): CopyFilesResponse!
+  ): CopyDamFilesResponse!
   archiveDamFile(id: ID!): DamFile!
   archiveDamFiles(ids: [ID!]!): [DamFile!]!
   restoreDamFile(id: ID!): DamFile!

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -422,7 +422,14 @@ type Mutation {
   updateDamFile(id: ID!, input: UpdateDamFileInput!): DamFile!
   importDamFileByDownload(url: String!, scope: DamScopeInput! = {}, input: UpdateDamFileInput!): DamFile!
   moveDamFiles(fileIds: [ID!]!, targetFolderId: ID): [DamFile!]!
-  copyFilesToScope(fileIds: [ID!]!, inboxFolderId: ID!): CopyFilesResponse!
+  copyFilesToScope(fileIds: [ID!]!, inboxFolderId: ID!): CopyFilesResponse! @deprecated(reason: "Use copyFiles instead")
+  copyFiles(
+    fileIds: [ID!]!
+    targetFolderId: ID
+
+    """Doesn't need to be set if targetFolderId is set"""
+    targetScope: DamScopeInput = {}
+  ): CopyFilesResponse!
   archiveDamFile(id: ID!): DamFile!
   archiveDamFiles(ids: [ID!]!): [DamFile!]!
   restoreDamFile(id: ID!): DamFile!

--- a/packages/api/cms-api/src/dam/files/dto/copyFiles.types.ts
+++ b/packages/api/cms-api/src/dam/files/dto/copyFiles.types.ts
@@ -3,7 +3,7 @@ import { Field, ObjectType } from "@nestjs/graphql";
 
 import { FileInterface } from "../entities/file.entity";
 
-export interface CopyFilesResponseInterface {
+export interface CopyDamFilesResponseInterface {
     mappedFiles: Array<MappedFileInterface>;
 }
 
@@ -12,9 +12,9 @@ export interface MappedFileInterface {
     copy: FileInterface;
 }
 
-export function createCopyFilesResponseType({ File }: { File: Type<FileInterface> }) {
+export function createCopyDamFilesResponseType({ File }: { File: Type<FileInterface> }) {
     @ObjectType()
-    class CopyFilesResponse implements CopyFilesResponseInterface {
+    class CopyDamFilesResponse implements CopyDamFilesResponseInterface {
         @Field(() => [MappedFile])
         mappedFiles: Array<MappedFile>;
     }
@@ -28,5 +28,5 @@ export function createCopyFilesResponseType({ File }: { File: Type<FileInterface
         copy: FileInterface;
     }
 
-    return CopyFilesResponse;
+    return CopyDamFilesResponse;
 }

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -173,7 +173,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
                 type: () => Scope,
                 nullable: true,
                 defaultValue: hasNonEmptyScope ? undefined : {},
-                description: "Doesn't need to be set if targetFolderId is set",
+                description: "Not needed when using targetFolderId",
             })
             targetScope?: typeof Scope | null,
         ): Promise<CopyDamFilesResponseInterface> {

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -14,7 +14,7 @@ import { ContentScopeService } from "../../content-scope/content-scope.service";
 import { ScopeGuardActive } from "../../content-scope/decorators/scope-guard-active.decorator";
 import { DAM_FILE_VALIDATION_SERVICE } from "../dam.constants";
 import { DamScopeInterface } from "../types";
-import { CopyFilesResponseInterface, createCopyFilesResponseType } from "./dto/copyFiles.types";
+import { CopyDamFilesResponseInterface, createCopyDamFilesResponseType } from "./dto/copyFiles.types";
 import { EmptyDamScope } from "./dto/empty-dam-scope";
 import { createFileArgs, FileArgsInterface, MoveDamFilesArgs } from "./dto/file.args";
 import { UpdateFileInput } from "./dto/file.input";
@@ -40,7 +40,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
     }
 
     const FileArgs = createFileArgs({ Scope });
-    const CopyFilesResponse = createCopyFilesResponseType({ File });
+    const CopyDamFilesResponse = createCopyDamFilesResponseType({ File });
     const FindCopiesOfFileInScopeArgs = createFindCopiesOfFileInScopeArgs({ Scope, hasNonEmptyScope });
 
     @ObjectType()
@@ -144,9 +144,9 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
         }
 
         /**
-         *  @deprecated Use copyFiles() instead
+         *  @deprecated Use copyDamFiles() instead
          */
-        @Mutation(() => CopyFilesResponse, { deprecationReason: "Use copyFiles instead" })
+        @Mutation(() => CopyDamFilesResponse, { deprecationReason: "Use copyDamFiles instead" })
         @SkipBuild()
         async copyFilesToScope(
             @GetCurrentUser() user: CurrentUserInterface,
@@ -155,13 +155,13 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
                 type: () => ID,
             })
             inboxFolderId: string,
-        ): Promise<CopyFilesResponseInterface> {
-            return this.copyFiles(user, fileIds, inboxFolderId);
+        ): Promise<CopyDamFilesResponseInterface> {
+            return this.copyDamFiles(user, fileIds, inboxFolderId);
         }
 
-        @Mutation(() => CopyFilesResponse)
+        @Mutation(() => CopyDamFilesResponse)
         @SkipBuild()
-        async copyFiles(
+        async copyDamFiles(
             @GetCurrentUser() user: CurrentUserInterface,
             @Args("fileIds", { type: () => [ID] }) fileIds: string[],
             @Args("targetFolderId", {
@@ -176,7 +176,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
                 description: "Doesn't need to be set if targetFolderId is set",
             })
             targetScope?: typeof Scope | null,
-        ): Promise<CopyFilesResponseInterface> {
+        ): Promise<CopyDamFilesResponseInterface> {
             const targetFolder = targetFolderId ? await this.foldersService.findOneById(targetFolderId) : null;
             if (targetFolderId && !targetFolder) {
                 throw new Error("Specified target folder doesn't exist.");

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -168,14 +168,14 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
                 type: () => ID,
                 nullable: true,
             })
-            targetFolderId: string | undefined,
+            targetFolderId?: string | null,
             @Args("targetScope", {
                 type: () => Scope,
                 nullable: true,
                 defaultValue: hasNonEmptyScope ? undefined : {},
                 description: "Doesn't need to be set if targetFolderId is set",
             })
-            targetScope?: typeof Scope,
+            targetScope?: typeof Scope | null,
         ): Promise<CopyFilesResponseInterface> {
             const targetFolder = targetFolderId ? await this.foldersService.findOneById(targetFolderId) : null;
             if (targetFolderId && !targetFolder) {

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -25,6 +25,7 @@ import { FolderInterface } from "./entities/folder.entity";
 import { FileValidationService } from "./file-validation.service";
 import { FilesService } from "./files.service";
 import { download, slugifyFilename } from "./files.utils";
+import { FoldersService } from "./folders.service";
 
 export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<FileInterface>; Scope?: Type<DamScopeInterface> }): Type<unknown> {
     const Scope = PassedScope ?? EmptyDamScope;
@@ -50,6 +51,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
     class FilesResolver {
         constructor(
             private readonly filesService: FilesService,
+            private readonly foldersService: FoldersService,
             @InjectRepository("DamFile") private readonly filesRepository: EntityRepository<FileInterface>,
             @InjectRepository("DamFolder") private readonly foldersRepository: EntityRepository<FolderInterface>,
             private readonly contentScopeService: ContentScopeService,
@@ -141,7 +143,10 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
             return this.filesService.moveBatch(files, targetFolder);
         }
 
-        @Mutation(() => CopyFilesResponse)
+        /**
+         *  @deprecated Use copyFiles() instead
+         */
+        @Mutation(() => CopyFilesResponse, { deprecationReason: "Use copyFiles instead" })
         @SkipBuild()
         async copyFilesToScope(
             @GetCurrentUser() user: CurrentUserInterface,
@@ -151,7 +156,78 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
             })
             inboxFolderId: string,
         ): Promise<CopyFilesResponseInterface> {
-            return this.filesService.copyFilesToScope({ fileIds, inboxFolderId, user });
+            return this.copyFiles(user, fileIds, inboxFolderId);
+        }
+
+        @Mutation(() => CopyFilesResponse)
+        @SkipBuild()
+        async copyFiles(
+            @GetCurrentUser() user: CurrentUserInterface,
+            @Args("fileIds", { type: () => [ID] }) fileIds: string[],
+            @Args("targetFolderId", {
+                type: () => ID,
+                nullable: true,
+            })
+            targetFolderId: string | undefined,
+            @Args("targetScope", {
+                type: () => Scope,
+                nullable: true,
+                defaultValue: hasNonEmptyScope ? undefined : {},
+                description: "Doesn't need to be set if targetFolderId is set",
+            })
+            targetScope?: typeof Scope,
+        ): Promise<CopyFilesResponseInterface> {
+            const targetFolder = targetFolderId ? await this.foldersService.findOneById(targetFolderId) : null;
+            if (targetFolderId && !targetFolder) {
+                throw new Error("Specified target folder doesn't exist.");
+            }
+            if (targetScope && targetFolder?.scope && !this.contentScopeService.scopesAreEqual(targetScope, targetFolder.scope)) {
+                throw new Error("targetScope and targetFolder.scope don't match");
+            }
+
+            const scope = targetScope ?? targetFolder?.scope;
+            if (scope && !this.contentScopeService.canAccessScope(scope, user)) {
+                throw new Error("User can't access the target scope");
+            }
+
+            const files = await this.filesService.findMultipleByIds(fileIds);
+            if (files.length === 0) {
+                throw new Error("No valid file ids provided");
+            }
+
+            const getUniqueFileScopes = (files: FileInterface[]): DamScopeInterface[] => {
+                const fileScopes: DamScopeInterface[] = [];
+                for (const file of files) {
+                    if (file.scope === undefined) {
+                        continue;
+                    }
+
+                    const isDuplicateScope = Boolean(fileScopes.find((scope) => this.contentScopeService.scopesAreEqual(scope, file.scope)));
+                    if (!isDuplicateScope) {
+                        fileScopes.push(file.scope);
+                    }
+                }
+                return fileScopes;
+            };
+
+            const fileScopes = getUniqueFileScopes(files);
+            const canAccessFileScopes = fileScopes.every((scope) => {
+                return this.contentScopeService.canAccessScope(scope, user);
+            });
+            if (!canAccessFileScopes) {
+                throw new Error(`User can't access the scope of one or more files`);
+            }
+
+            const mappedFiles: Array<{ rootFile: FileInterface; copy: FileInterface }> = [];
+            for (const file of files) {
+                const copiedFile = await this.filesService.createCopyOfFile(file, {
+                    inboxFolder: targetFolder,
+                    scope: scope,
+                });
+                mappedFiles.push({ rootFile: file, copy: copiedFile });
+            }
+
+            return { mappedFiles };
         }
 
         @Mutation(() => File)

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -221,8 +221,8 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
             const mappedFiles: Array<{ rootFile: FileInterface; copy: FileInterface }> = [];
             for (const file of files) {
                 const copiedFile = await this.filesService.createCopyOfFile(file, {
-                    inboxFolder: targetFolder,
-                    scope: scope,
+                    targetFolder,
+                    targetScope: scope,
                 });
                 mappedFiles.push({ rootFile: file, copy: copiedFile });
             }

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -422,16 +422,25 @@ export class FilesService {
         file: FileInterface,
         {
             inboxFolder,
-            scope: inputScope,
+            targetFolder: inputTargetFolder,
+            targetScope: inputTargetScope,
         }: {
-            inboxFolder: FolderInterface | null;
-            scope?: DamScopeInterface;
+            /**
+             * @deprecated Use targetFolder instead
+             */
+            inboxFolder?: FolderInterface;
+            targetFolder?: FolderInterface | null;
+            targetScope?: DamScopeInterface;
         },
     ) {
-        if (inputScope && inboxFolder?.scope && !this.contentScopeService.scopesAreEqual(inputScope, inboxFolder.scope)) {
-            throw new Error("Passed scope and scope of inbox folder don't match");
+        const targetFolder = inputTargetFolder !== undefined ? inputTargetFolder : inboxFolder;
+        if (targetFolder === undefined) {
+            throw new Error("targetFolder cannot be undefined");
         }
-        const scope = inputScope ?? inboxFolder?.scope;
+        if (inputTargetScope && targetFolder?.scope && !this.contentScopeService.scopesAreEqual(inputTargetScope, targetFolder.scope)) {
+            throw new Error("Passed scope and scope of target folder don't match");
+        }
+        const targetScope = inputTargetScope ?? targetFolder?.scope;
 
         let fileImageInput: ImageFileInput | undefined;
         if (file.image) {
@@ -453,9 +462,9 @@ export class FilesService {
         const fileInput: CreateFileInput & { copyOf: FileInterface } = {
             ...Utils.copy(fileProps),
             image: fileImageInput,
-            folderId: inboxFolder?.id,
+            folderId: targetFolder?.id,
             copyOf: file,
-            scope: scope,
+            scope: targetScope,
         };
 
         return this.create(fileInput);

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -461,6 +461,9 @@ export class FilesService {
         return this.create(fileInput);
     }
 
+    /**
+     *  @deprecated Loop over FilesService.createCopyOfFile() instead
+     */
     async copyFilesToScope({ user, fileIds, inboxFolderId }: { user: CurrentUserInterface; fileIds: string[]; inboxFolderId: string }) {
         const inboxFolder = await this.foldersService.findOneById(inboxFolderId);
         if (!inboxFolder) {

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -418,7 +418,21 @@ export class FilesService {
         return Number(result.rows[0].row_number) - 1;
     }
 
-    async createCopyOfFile(file: FileInterface, { inboxFolder }: { inboxFolder: FolderInterface }) {
+    async createCopyOfFile(
+        file: FileInterface,
+        {
+            inboxFolder,
+            scope: inputScope,
+        }: {
+            inboxFolder: FolderInterface | null;
+            scope?: DamScopeInterface;
+        },
+    ) {
+        if (inputScope && inboxFolder?.scope && !this.contentScopeService.scopesAreEqual(inputScope, inboxFolder.scope)) {
+            throw new Error("Passed scope and scope of inbox folder don't match");
+        }
+        const scope = inputScope ?? inboxFolder?.scope;
+
         let fileImageInput: ImageFileInput | undefined;
         if (file.image) {
             const { id: ignoreId, file: ignoreFile, ...imageProps } = file.image;
@@ -439,9 +453,9 @@ export class FilesService {
         const fileInput: CreateFileInput & { copyOf: FileInterface } = {
             ...Utils.copy(fileProps),
             image: fileImageInput,
-            folderId: inboxFolder.id,
+            folderId: inboxFolder?.id,
             copyOf: file,
-            scope: inboxFolder.scope,
+            scope: scope,
         };
 
         return this.create(fileInput);


### PR DESCRIPTION
Deprecates

- `FilesService.copyFilesToScope()`
- `FilesResolver.copyFilesToScope()`
- `inboxFolder` param of `FilesService.createCopyOfFile()`

Adds `copyFiles()` mutation to `FilesResolver` as a more flexible replacement of `copyFilesToScope()`

Extend `createCopyOfFile()` to support copying to the root folder

---

Part of COM-55
