### PR TITLE
Copy DAM Files

### DIFF
--- a/.changeset/four-gorillas-obey.md
+++ b/.changeset/four-gorillas-obey.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Prevent duplicate filenames when copying files in `FilesService.createCopyOfFile()`

--- a/.changeset/serious-trees-change.md
+++ b/.changeset/serious-trees-change.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `useCopyPasteDamItems()` hook for manually copying DAM files
+
+Enable copying one or multiple files in the DAM and pasting them in a folder. This also works across scopes.

--- a/packages/admin/admin-stories/.storybook/preview.tsx
+++ b/packages/admin/admin-stories/.storybook/preview.tsx
@@ -9,13 +9,13 @@ import { createCometTheme } from "@comet/admin-theme";
 import { createTheme as createMuiTheme, GlobalStyles } from "@mui/material";
 import { select, withKnobs } from "@storybook/addon-knobs";
 import { addDecorator, addParameters } from "@storybook/react";
+import { Locale as DateFnsLocale } from "date-fns";
+import { de as deLocale, enUS as enLocale } from "date-fns/locale";
 import * as React from "react";
 import { IntlProvider } from "react-intl";
-import { de as deLocale, enUS as enLocale } from "date-fns/locale";
-import { Locale as DateFnsLocale } from "date-fns";
 
-import { previewGlobalStyles } from "./preview.styles";
 import { worker } from "./mocks/browser";
+import { previewGlobalStyles } from "./preview.styles";
 
 type LocaleKey = "de" | "en";
 
@@ -160,4 +160,4 @@ addParameters({
     },
 });
 
-worker.start()
+worker.start();

--- a/packages/admin/admin/src/messages.ts
+++ b/packages/admin/admin/src/messages.ts
@@ -50,4 +50,12 @@ export const messages = defineMessages({
     filter: { id: "comet.generic.filter", defaultMessage: "Filter" },
     copyUrl: { id: "comet.generic.copyUrl", defaultMessage: "Copy URL" },
     deleteItem: { id: "comet.generic.deleteItem", defaultMessage: "Delete Item" },
+    failedToReadClipboard: {
+        id: "comet.generic.failedToReadClipboard",
+        defaultMessage: "Can't read clipboard content. Please make sure that clipboard access is given",
+    },
+    emptyClipboard: {
+        id: "comet.generic.emptyClipboard",
+        defaultMessage: "Clipboard is empty",
+    },
 });

--- a/packages/admin/cms-admin/src/dam/DataGrid/DamContextMenu.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/DamContextMenu.tsx
@@ -28,10 +28,11 @@ interface FolderInnerMenuProps {
 }
 
 const FolderInnerMenu = ({ folder, openMoveDialog }: FolderInnerMenuProps): React.ReactElement => {
+    const errorDialogApi = useErrorDialog();
     const editDialogApi = useEditDialogApi();
     const errorDialog = useErrorDialog();
     const apolloClient = useApolloClient();
-    const { createCopies, getFromClipboard } = useCopyPasteDamItems();
+    const { pasteFromClipboard } = useCopyPasteDamItems();
 
     const [deleteDialogOpen, setDeleteDialogOpen] = React.useState<boolean>(false);
 
@@ -81,9 +82,9 @@ const FolderInnerMenu = ({ folder, openMoveDialog }: FolderInnerMenuProps): Reac
                     <RowActionsItem
                         icon={<Paste />}
                         onClick={async () => {
-                            const clipboard = await getFromClipboard();
-                            if (clipboard.canPaste) {
-                                await createCopies({ clipboard: clipboard.content, targetFolderId: folder.id });
+                            const { error } = await pasteFromClipboard({ targetFolderId: folder.id });
+                            if (error) {
+                                errorDialogApi?.showError({ error: "Cannot paste", userMessage: error });
                             }
                         }}
                     >
@@ -122,7 +123,7 @@ interface FileInnerMenuProps {
 const FileInnerMenu = ({ file, openMoveDialog }: FileInnerMenuProps): React.ReactElement => {
     const client = useApolloClient();
     const stackApi = useStackSwitchApi();
-    const { prepareForClipboard, writeToClipboard } = useCopyPasteDamItems();
+    const { writeToClipboard } = useCopyPasteDamItems();
 
     const [deleteDialogOpen, setDeleteDialogOpen] = React.useState<boolean>(false);
 
@@ -149,7 +150,7 @@ const FileInnerMenu = ({ file, openMoveDialog }: FileInnerMenuProps): React.Reac
                     <RowActionsItem
                         icon={<Copy />}
                         onClick={async () => {
-                            await writeToClipboard(prepareForClipboard([{ type: "file", id: file.id }]));
+                            await writeToClipboard([{ type: "file", id: file.id }]);
                         }}
                     >
                         <FormattedMessage {...messages.copy} />

--- a/packages/admin/cms-admin/src/dam/DataGrid/copyPaste/useCopyPasteDamItems.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/copyPaste/useCopyPasteDamItems.tsx
@@ -37,7 +37,7 @@ const copyFilesMutation = gql`
 `;
 
 export const useCopyPasteDamItems = () => {
-    const currScope = useDamScope();
+    const scope = useDamScope();
     const apolloClient = useApolloClient();
 
     const prepareForClipboard = React.useCallback((damItems: Array<{ id: string; type: "file" | "folder" }>): DamItemsClipboard => {
@@ -91,13 +91,13 @@ export const useCopyPasteDamItems = () => {
 
             await apolloClient.mutate<GQLCopyPasteFilesMutation, GQLCopyPasteFilesMutationVariables>({
                 mutation: copyFilesMutation,
-                variables: { fileIds, targetFolderId, targetScope: currScope },
+                variables: { fileIds, targetFolderId, targetScope: scope },
                 update: (cache) => {
                     cache.evict({ fieldName: "damItemsList" });
                 },
             });
         },
-        [apolloClient, currScope],
+        [apolloClient, scope],
     );
 
     return { prepareForClipboard, writeToClipboard, getFromClipboard, createCopies };

--- a/packages/admin/cms-admin/src/dam/DataGrid/copyPaste/useCopyPasteDamItems.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/copyPaste/useCopyPasteDamItems.tsx
@@ -1,0 +1,114 @@
+import { gql, useApolloClient } from "@apollo/client";
+import { messages, readClipboardText, writeClipboardText } from "@comet/admin";
+import * as React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { useDamScope } from "../../config/useDamScope";
+import { GQLCopyPasteFilesMutation, GQLCopyPasteFilesMutationVariables } from "./useCopyPasteDamItems.generated";
+
+interface DamItem {
+    id: string;
+    type: "file" | "folder";
+}
+
+interface DamItemsClipboard {
+    damItems: DamItem[];
+    scope: Record<string, unknown>;
+}
+
+type GetFromClipboardResponse = { canPaste: true; content: DamItemsClipboard } | { canPaste: false; error: React.ReactNode };
+
+function isDamItemsClipboard(damItemsClipboard: unknown): damItemsClipboard is DamItemsClipboard {
+    return (damItemsClipboard as DamItemsClipboard).damItems !== undefined;
+}
+
+const copyFilesMutation = gql`
+    mutation CopyPasteFiles($fileIds: [ID!]!, $targetFolderId: ID, $targetScope: DamScopeInput) {
+        copyFiles(fileIds: $fileIds, targetFolderId: $targetFolderId, targetScope: $targetScope) {
+            mappedFiles {
+                rootFile {
+                    id
+                }
+                copy {
+                    id
+                }
+            }
+        }
+    }
+`;
+
+export const useCopyPasteDamItems = () => {
+    const currScope = useDamScope();
+    const apolloClient = useApolloClient();
+
+    const prepareForClipboard = React.useCallback(
+        async (damItems: Array<{ id: string; type: "file" | "folder" }>): Promise<DamItemsClipboard> => {
+            return { scope: currScope, damItems };
+        },
+        [currScope],
+    );
+
+    const writeToClipboard = React.useCallback(async (items: DamItemsClipboard) => {
+        return writeClipboardText(JSON.stringify(items));
+    }, []);
+
+    const getFromClipboard = React.useCallback(async (): Promise<GetFromClipboardResponse> => {
+        const text = await readClipboardText();
+
+        if (text === undefined) {
+            return {
+                canPaste: false,
+                error: <FormattedMessage {...messages.failedToReadClipboard} />,
+            };
+        }
+
+        if (text.trim() === "") {
+            return {
+                canPaste: false,
+                error: <FormattedMessage {...messages.emptyClipboard} />,
+            };
+        }
+
+        try {
+            const parsedText = JSON.parse(text);
+            if (isDamItemsClipboard(parsedText)) {
+                return { canPaste: true, content: parsedText };
+            } else {
+                throw new Error("Invalid clipboard content");
+            }
+        } catch {
+            return {
+                canPaste: false,
+                error: (
+                    <FormattedMessage
+                        id="comet.dam.cannotPasteFiles.messageFailedToParseClipboard"
+                        defaultMessage="Content from clipboard aren't valid DAM items"
+                    />
+                ),
+            };
+        }
+    }, []);
+
+    const doCopy = React.useCallback(
+        async ({
+            clipboard: { scope: rootScope, damItems },
+            targetFolderId,
+        }: {
+            clipboard: DamItemsClipboard;
+            targetFolderId: string | undefined;
+        }) => {
+            const fileIds = damItems.filter(({ type }) => type === "file").map((file) => file.id);
+
+            await apolloClient.mutate<GQLCopyPasteFilesMutation, GQLCopyPasteFilesMutationVariables>({
+                mutation: copyFilesMutation,
+                variables: { fileIds, targetFolderId, targetScope: currScope },
+                update: (cache) => {
+                    cache.evict({ fieldName: "damItemsList" });
+                },
+            });
+        },
+        [apolloClient, currScope],
+    );
+
+    return { prepareForClipboard, writeToClipboard, getFromClipboard, doCopy };
+};

--- a/packages/admin/cms-admin/src/dam/DataGrid/copyPaste/useCopyPasteDamItems.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/copyPaste/useCopyPasteDamItems.tsx
@@ -23,7 +23,7 @@ function isDamItemsClipboard(damItemsClipboard: unknown): damItemsClipboard is D
 
 const copyFilesMutation = gql`
     mutation CopyPasteFiles($fileIds: [ID!]!, $targetFolderId: ID, $targetScope: DamScopeInput) {
-        copyFiles(fileIds: $fileIds, targetFolderId: $targetFolderId, targetScope: $targetScope) {
+        copyDamFiles(fileIds: $fileIds, targetFolderId: $targetFolderId, targetScope: $targetScope) {
             mappedFiles {
                 rootFile {
                     id

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
@@ -33,7 +33,7 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
     const intl = useIntl();
     const client = useApolloClient();
     const { allAcceptedMimeTypes } = useDamAcceptedMimeTypes();
-    const { doCopy, getFromClipboard } = useCopyPasteDamItems();
+    const { createCopies, getFromClipboard } = useCopyPasteDamItems();
 
     const folderInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -85,7 +85,7 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
     const handlePasteClick = async () => {
         const clipboard = await getFromClipboard();
         if (clipboard.canPaste) {
-            await doCopy({ clipboard: clipboard.content, targetFolderId: folderId });
+            await createCopies({ clipboard: clipboard.content, targetFolderId: folderId });
         }
         handleClose();
     };
@@ -164,7 +164,7 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
                             <FormattedMessage id="comet.pages.dam.addFolder" defaultMessage="Add Folder" />
                         </MenuItem>
 
-                        <MenuItem disabled={itemsSelected} onClick={handlePasteClick}>
+                        <MenuItem onClick={handlePasteClick}>
                             <ListItemIcon>
                                 <Paste />
                             </ListItemIcon>
@@ -197,6 +197,13 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
                             <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.moveItems" defaultMessage="Move" />} />
                             {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
                         </MenuItem>
+                        <MenuItem disabled={!itemsSelected} onClick={handleCopyClick}>
+                            <ListItemIcon>
+                                <Copy />
+                            </ListItemIcon>
+                            <ListItemText primary={<FormattedMessage {...messages.copy} />} />
+                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
+                        </MenuItem>
                         <MenuItem disabled={!itemsSelected} onClick={handleArchiveClick}>
                             <ListItemIcon>
                                 <Archive />
@@ -216,13 +223,6 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
                                 <Delete />
                             </ListItemIcon>
                             <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.deleteItems" defaultMessage="Delete" />} />
-                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
-                        </MenuItem>
-                        <MenuItem disabled={!itemsSelected} onClick={handleCopyClick}>
-                            <ListItemIcon>
-                                <Copy />
-                            </ListItemIcon>
-                            <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.copyItems" defaultMessage="Copy" />} />
                             {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
                         </MenuItem>
                     </MenuList>

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
@@ -110,8 +110,8 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
         handleClose();
     };
 
-    const handleCopyClick = () => {
-        copySelected();
+    const handleCopyClick = async () => {
+        await copySelected();
         handleClose();
     };
 
@@ -156,14 +156,12 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
                             </ListItemIcon>
                             <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.uploadFolder" defaultMessage="Upload folder" />} />
                         </MenuItem>
-
                         <MenuItem disabled={itemsSelected} onClick={handleAddFolderClick}>
                             <ListItemIcon>
                                 <AddFolderIcon />
                             </ListItemIcon>
                             <FormattedMessage id="comet.pages.dam.addFolder" defaultMessage="Add Folder" />
                         </MenuItem>
-
                         <MenuItem onClick={handlePasteClick}>
                             <ListItemIcon>
                                 <Paste />

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
@@ -1,6 +1,6 @@
 import { useApolloClient } from "@apollo/client";
-import { useEditDialog, useSnackbarApi } from "@comet/admin";
-import { AddFolder as AddFolderIcon, Archive, Delete, Download, Move, Restore, Upload } from "@comet/admin-icons";
+import { messages, useEditDialog, useSnackbarApi } from "@comet/admin";
+import { AddFolder as AddFolderIcon, Archive, Copy, Delete, Download, Move, Paste, Restore, Upload } from "@comet/admin-icons";
 import { Box, Divider, ListItemIcon, ListItemText, Menu, MenuItem, MenuList, Slide, Snackbar, Typography } from "@mui/material";
 import { PopoverOrigin } from "@mui/material/Popover/Popover";
 import { SlideProps } from "@mui/material/Slide/Slide";
@@ -11,6 +11,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { useDamAcceptedMimeTypes } from "../../config/useDamAcceptedMimeTypes";
 import { clearDamItemCache } from "../../helpers/clearDamItemCache";
+import { useCopyPasteDamItems } from "../copyPaste/useCopyPasteDamItems";
 import { useFileUpload } from "../fileUpload/useFileUpload";
 import { useDamSelectionApi } from "./DamSelectionContext";
 
@@ -26,12 +27,13 @@ interface DamMoreActionsProps {
 
 export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId, filter }: DamMoreActionsProps): React.ReactElement => {
     const damSelectionActionsApi = useDamSelectionApi();
-    const { selectionMap, archiveSelected, deleteSelected, downloadSelected, restoreSelected, moveSelected } = damSelectionActionsApi;
+    const { selectionMap, archiveSelected, deleteSelected, downloadSelected, restoreSelected, moveSelected, copySelected } = damSelectionActionsApi;
     const snackbarApi = useSnackbarApi();
     const [, , editDialogApi] = useEditDialog();
     const intl = useIntl();
     const client = useApolloClient();
     const { allAcceptedMimeTypes } = useDamAcceptedMimeTypes();
+    const { doCopy, getFromClipboard } = useCopyPasteDamItems();
 
     const folderInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -80,6 +82,14 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
         handleClose();
     };
 
+    const handlePasteClick = async () => {
+        const clipboard = await getFromClipboard();
+        if (clipboard.canPaste) {
+            await doCopy({ clipboard: clipboard.content, targetFolderId: folderId });
+        }
+        handleClose();
+    };
+
     const handleMoveClick = () => {
         moveSelected();
         handleClose();
@@ -97,6 +107,11 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
 
     const handleDeleteClick = () => {
         deleteSelected();
+        handleClose();
+    };
+
+    const handleCopyClick = () => {
+        copySelected();
         handleClose();
     };
 
@@ -148,6 +163,13 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
                             </ListItemIcon>
                             <FormattedMessage id="comet.pages.dam.addFolder" defaultMessage="Add Folder" />
                         </MenuItem>
+
+                        <MenuItem disabled={itemsSelected} onClick={handlePasteClick}>
+                            <ListItemIcon>
+                                <Paste />
+                            </ListItemIcon>
+                            <FormattedMessage {...messages.paste} />
+                        </MenuItem>
                     </MenuList>
                     <Divider sx={{ my: 1, borderColor: (theme) => theme.palette.grey[50] }} />
                     <Typography variant="subtitle2" color={(theme) => theme.palette.grey[500]} fontWeight="bold" mt={5}>
@@ -194,6 +216,13 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
                                 <Delete />
                             </ListItemIcon>
                             <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.deleteItems" defaultMessage="Delete" />} />
+                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
+                        </MenuItem>
+                        <MenuItem disabled={!itemsSelected} onClick={handleCopyClick}>
+                            <ListItemIcon>
+                                <Copy />
+                            </ListItemIcon>
+                            <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.copyItems" defaultMessage="Copy" />} />
                             {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
                         </MenuItem>
                     </MenuList>

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
@@ -1,5 +1,5 @@
 import { useApolloClient } from "@apollo/client";
-import { messages, useEditDialog, useSnackbarApi } from "@comet/admin";
+import { messages, useEditDialog, useErrorDialog, useSnackbarApi } from "@comet/admin";
 import { AddFolder as AddFolderIcon, Archive, Copy, Delete, Download, Move, Paste, Restore, Upload } from "@comet/admin-icons";
 import { Box, Divider, ListItemIcon, ListItemText, Menu, MenuItem, MenuList, Slide, Snackbar, Typography } from "@mui/material";
 import { PopoverOrigin } from "@mui/material/Popover/Popover";
@@ -27,13 +27,14 @@ interface DamMoreActionsProps {
 
 export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId, filter }: DamMoreActionsProps): React.ReactElement => {
     const damSelectionActionsApi = useDamSelectionApi();
+    const errorDialogApi = useErrorDialog();
     const { selectionMap, archiveSelected, deleteSelected, downloadSelected, restoreSelected, moveSelected, copySelected } = damSelectionActionsApi;
     const snackbarApi = useSnackbarApi();
     const [, , editDialogApi] = useEditDialog();
     const intl = useIntl();
     const client = useApolloClient();
     const { allAcceptedMimeTypes } = useDamAcceptedMimeTypes();
-    const { createCopies, getFromClipboard } = useCopyPasteDamItems();
+    const { pasteFromClipboard } = useCopyPasteDamItems();
 
     const folderInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -83,10 +84,11 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
     };
 
     const handlePasteClick = async () => {
-        const clipboard = await getFromClipboard();
-        if (clipboard.canPaste) {
-            await createCopies({ clipboard: clipboard.content, targetFolderId: folderId });
+        const { error } = await pasteFromClipboard({ targetFolderId: folderId });
+        if (error) {
+            errorDialogApi?.showError({ error: "Cannot paste", userMessage: error });
         }
+
         handleClose();
     };
 

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
@@ -300,7 +300,7 @@ export const DamSelectionProvider: React.FunctionComponent = ({ children }) => {
         });
 
         try {
-            await writeToClipboard(await prepareForClipboard(selectedItems));
+            await writeToClipboard(prepareForClipboard(selectedItems));
         } catch (e) {
             showError(setHasCopyErrors);
         }

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
@@ -113,7 +113,7 @@ export const useDamSelectionApi = () => {
 export const DamSelectionProvider: React.FunctionComponent = ({ children }) => {
     const apolloClient = useApolloClient();
     const [selectionMap, setSelectionMap] = React.useState<DamItemSelectionMap>(new Map());
-    const { prepareForClipboard, writeToClipboard } = useCopyPasteDamItems();
+    const { writeToClipboard } = useCopyPasteDamItems();
 
     const showError = (setError: React.Dispatch<React.SetStateAction<boolean>>) => {
         setError(true);
@@ -300,7 +300,7 @@ export const DamSelectionProvider: React.FunctionComponent = ({ children }) => {
         });
 
         try {
-            await writeToClipboard(prepareForClipboard(selectedItems));
+            await writeToClipboard(selectedItems);
         } catch (e) {
             showError(setHasCopyErrors);
         }

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
@@ -58,7 +58,7 @@ interface DamSelectionApi {
     hasDownloadErrors: boolean;
 
     // copying
-    copySelected: () => void;
+    copySelected: () => Promise<void>;
     copying: boolean;
     hasCopyErrors: boolean;
 }

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { ConfirmDeleteDialog } from "../../FileActions/ConfirmDeleteDialog";
 import { clearDamItemCache } from "../../helpers/clearDamItemCache";
 import { MoveDamItemDialog } from "../../MoveDamItemDialog/MoveDamItemDialog";
+import { useCopyPasteDamItems } from "../copyPaste/useCopyPasteDamItems";
 import { DamItemSelectionMap } from "../FolderDataGrid";
 import {
     GQLArchiveFilesMutation,
@@ -55,6 +56,11 @@ interface DamSelectionApi {
     downloadSelected: () => void;
     downloading: boolean;
     hasDownloadErrors: boolean;
+
+    // copying
+    copySelected: () => void;
+    copying: boolean;
+    hasCopyErrors: boolean;
 }
 
 export const DamSelectionContext = React.createContext<DamSelectionApi>({
@@ -92,6 +98,12 @@ export const DamSelectionContext = React.createContext<DamSelectionApi>({
     },
     downloading: false,
     hasDownloadErrors: false,
+
+    copySelected: () => {
+        throw new Error("Missing DamSelectionContext. Please add a <DamSelectionProvider /> somewhere up in the tree.");
+    },
+    copying: false,
+    hasCopyErrors: false,
 });
 
 export const useDamSelectionApi = () => {
@@ -101,6 +113,7 @@ export const useDamSelectionApi = () => {
 export const DamSelectionProvider: React.FunctionComponent = ({ children }) => {
     const apolloClient = useApolloClient();
     const [selectionMap, setSelectionMap] = React.useState<DamItemSelectionMap>(new Map());
+    const { prepareForClipboard, writeToClipboard } = useCopyPasteDamItems();
 
     const showError = (setError: React.Dispatch<React.SetStateAction<boolean>>) => {
         setError(true);
@@ -275,6 +288,26 @@ export const DamSelectionProvider: React.FunctionComponent = ({ children }) => {
         setDownloading(false);
     };
 
+    // copy
+    const [copying, setCopying] = React.useState(false);
+    const [hasCopyErrors, setHasCopyErrors] = React.useState(false);
+
+    const copySelected = async () => {
+        setCopying(true);
+
+        const selectedItems = Array.from(selectionMap.entries()).map((item) => {
+            return { id: item[0], type: item[1] };
+        });
+
+        try {
+            await writeToClipboard(await prepareForClipboard(selectedItems));
+        } catch (e) {
+            showError(setHasCopyErrors);
+        }
+
+        setCopying(false);
+    };
+
     return (
         <DamSelectionContext.Provider
             value={{
@@ -300,6 +333,10 @@ export const DamSelectionProvider: React.FunctionComponent = ({ children }) => {
                 downloadSelected,
                 downloading,
                 hasDownloadErrors,
+
+                copySelected,
+                copying,
+                hasCopyErrors,
             }}
         >
             {children}

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages.tsx
@@ -122,19 +122,14 @@ function useCopyPastePages(): UseCopyPastePagesApi {
         if (text === undefined) {
             return {
                 canPaste: false,
-                error: (
-                    <FormattedMessage
-                        id="comet.pages.cannotPastePage.messageFailedToReadClipboard"
-                        defaultMessage="Can't read clipboard content. Please make sure that clipboard access is given"
-                    />
-                ),
+                error: <FormattedMessage {...messages.failedToReadClipboard} />,
             };
         }
 
         if (text.trim() === "") {
             return {
                 canPaste: false,
-                error: <FormattedMessage id="comet.pages.cannotPastePage.messageEmptyClipboard" defaultMessage="Clipboard is empty" />,
+                error: <FormattedMessage {...messages.emptyClipboard} />,
             };
         }
 

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -465,6 +465,7 @@ export class FilesService {
             folderId: targetFolder?.id,
             copyOf: file,
             scope: targetScope,
+            name: await this.findNextAvailableFilename({ filePath: fileProps.name, folderId: targetFolder?.id, scope: targetScope }),
         };
 
         return this.create(fileInput);


### PR DESCRIPTION
depends on https://github.com/vivid-planet/comet/pull/1546

Add `useCopyPasteDamItems()` hook for manually copying DAM files

Enable copying one or multiple files in the DAM and pasting them in a folder. This also works across scopes.

Note: Copying folders is not part of this PR and will be done in a follow-up PR

--- 

Copy to current folder:

https://github.com/vivid-planet/comet/assets/13380047/972c9208-f017-4a8f-b20f-3e57b3797bbd

Copy to specific folder:

https://github.com/vivid-planet/comet/assets/13380047/ea151e6c-3ad2-459b-8470-def4a5db25aa

Copy to folder in other scope:

https://github.com/vivid-planet/comet/assets/13380047/923751db-500d-4a17-a210-e609732a1274

---

Part of COM-55