### PR TITLE
Clip crop values when cropping an image

### DIFF
--- a/.changeset/silent-clocks-compete.md
+++ b/.changeset/silent-clocks-compete.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Clip crop values when cropping an image in the DAM or `PixelImageBlock`
+
+Previously, negative values could occur, causing the image proxy to fail on delivery.

--- a/packages/admin/cms-admin/src/common/image/ImageCrop.tsx
+++ b/packages/admin/cms-admin/src/common/image/ImageCrop.tsx
@@ -11,6 +11,10 @@ const focalPoints: GQLFocalPoint[] = ["CENTER", "NORTHEAST", "NORTHWEST", "SOUTH
 
 type ImageCropProps = Pick<ReactCropProps, "src" | "imageStyle" | "disabled">;
 
+const clipValue = (value?: number) => {
+    return value === undefined ? undefined : Math.max(0, Math.min(100, value));
+};
+
 export const ImageCrop = (props: ImageCropProps): React.ReactElement => {
     const form = useForm<EditImageFormValues>();
     const {
@@ -39,10 +43,10 @@ export const ImageCrop = (props: ImageCropProps): React.ReactElement => {
                             }
 
                             onChange({
-                                x: percentCrop.x,
-                                y: percentCrop.y,
-                                width: percentCrop.width,
-                                height: percentCrop.height,
+                                x: clipValue(percentCrop.x),
+                                y: clipValue(percentCrop.y),
+                                width: clipValue(percentCrop.width),
+                                height: clipValue(percentCrop.height),
                             });
                         }}
                         renderSelectionAddon={() => {


### PR DESCRIPTION
Clip crop values when cropping an image in the DAM or `PixelImageBlock`

Previously, negative values could occur, causing the image proxy to fail on delivery.

---

Screencast of the problem:

https://github.com/vivid-planet/comet/assets/13380047/e2f3141c-0faf-4f75-bc15-341b129d6864

Causes following error in image proxy:

```
{
    "statusCode": 400,
    "message": "Validation failed",
    "error": "CometValidationException",
    "validationErrors": [
        {
            "target": {
                "hash": "3d95adbcdc631982f5feb9c8ed8b79b1c1f3f5c3",
                "fileId": "87a55278-d87f-4fe7-a8f8-02f1af9c40be",
                "cropWidth": 100,
                "cropHeight": 100,
                "focalPoint": "CENTER",
                "cropX": 0,
                "cropY": -4.5582452972092663e-14,
                "resizeWidth": 320,
                "resizeHeight": 320,
                "filename": "1254x2030"
            },
            "value": -4.5582452972092663e-14,
            "property": "cropY",
            "children": [],
            "constraints": {
                "min": "cropY must not be less than 0"
            }
        }
    ]
}
```

---

Closes COM-349