### PR TITLE
Add `helperText` prop to `Field` and `FieldContainer`

### DIFF
--- a/.changeset/eleven-impalas-attack.md
+++ b/.changeset/eleven-impalas-attack.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+`Field` now supports a `helperText` prop to provide information.

--- a/.changeset/eleven-impalas-attack.md
+++ b/.changeset/eleven-impalas-attack.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-`Field` now supports a `helperText` prop to provide information
+Add `helperText` prop to `Field` and `FieldContainer` to provide additional information

--- a/.changeset/eleven-impalas-attack.md
+++ b/.changeset/eleven-impalas-attack.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-`Field` now supports a `helperText` prop to provide information.
+`Field` now supports a `helperText` prop to provide information

--- a/packages/admin/admin-stories/src/docs/form/components/stories/FieldContainer.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/form/components/stories/FieldContainer.stories.tsx
@@ -28,6 +28,9 @@ storiesOf("stories/Form/Components", module).add("FieldContainer", () => {
             <FieldContainer label="Warning" warning="This is a warning">
                 <InputBase onChange={handleChange} value={value} placeholder="Placeholder" />
             </FieldContainer>
+            <FieldContainer label="Helper" helperText="This is a helper">
+                <InputBase onChange={handleChange} value={value} placeholder="Placeholder" />
+            </FieldContainer>
         </form>
     );
 });

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -26,6 +26,7 @@ export interface FieldProps<FieldValue = any, T extends HTMLElement = HTMLElemen
     shouldScrollTo?: (meta: FieldMetaState<FieldValue>) => boolean;
     shouldShowError?: (meta: FieldMetaState<FieldValue>) => boolean;
     shouldShowWarning?: (meta: FieldMetaState<FieldValue>) => boolean;
+    shouldShowHelperText?: (meta: FieldMetaState<FieldValue>) => boolean;
     [otherProp: string]: any;
 }
 
@@ -39,6 +40,7 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
     validateWarning,
     shouldShowError: passedShouldShowError,
     shouldShowWarning: passedShouldShowWarning,
+    shouldShowHelperText: passedShouldShowHelperText,
     shouldScrollTo: passedShouldScrollTo,
     ...otherProps
 }: FieldProps<FieldValue, FieldElement>): React.ReactElement {
@@ -55,6 +57,8 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
         passedShouldShowError ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldShowFieldError({ fieldMeta }));
     const shouldShowWarning =
         passedShouldShowWarning ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldShowFieldWarning({ fieldMeta }));
+    const shouldShowHelperText =
+        passedShouldShowHelperText ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldShowFieldHelperText({ fieldMeta }));
     const shouldScrollToField =
         passedShouldScrollTo ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldScrollToField({ fieldMeta }));
 
@@ -76,6 +80,7 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
                 disabled={disabled}
                 error={shouldShowError(meta) && (meta.error || meta.submitError)}
                 warning={shouldShowWarning(meta) && meta.data?.warning}
+                helperText={shouldShowHelperText(meta) && meta.data?.helperText}
                 variant={variant}
                 fullWidth={fullWidth}
                 scrollTo={shouldScrollToField(meta)}

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -42,7 +42,6 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
     shouldShowError: passedShouldShowError,
     shouldShowWarning: passedShouldShowWarning,
     shouldScrollTo: passedShouldScrollTo,
-
     ...otherProps
 }: FieldProps<FieldValue, FieldElement>): React.ReactElement {
     const { disabled, variant, fullWidth } = otherProps;

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -16,6 +16,7 @@ const composeValidators =
 export interface FieldProps<FieldValue = any, T extends HTMLElement = HTMLElement> {
     name: string;
     label?: React.ReactNode;
+    helperText?: React.ReactNode;
     component?: React.ComponentType<any> | string;
     children?: (props: FieldRenderProps<FieldValue, T>) => React.ReactNode;
     required?: boolean;
@@ -34,12 +35,14 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
     component,
     name,
     label,
+    helperText,
     required,
     validate,
     validateWarning,
     shouldShowError: passedShouldShowError,
     shouldShowWarning: passedShouldShowWarning,
     shouldScrollTo: passedShouldScrollTo,
+
     ...otherProps
 }: FieldProps<FieldValue, FieldElement>): React.ReactElement {
     const { disabled, variant, fullWidth } = otherProps;
@@ -76,7 +79,7 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
                 disabled={disabled}
                 error={shouldShowError(meta) && (meta.error || meta.submitError)}
                 warning={shouldShowWarning(meta) && meta.data?.warning}
-                helperText={meta.data?.helperText}
+                helperText={helperText}
                 variant={variant}
                 fullWidth={fullWidth}
                 scrollTo={shouldScrollToField(meta)}

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -26,7 +26,6 @@ export interface FieldProps<FieldValue = any, T extends HTMLElement = HTMLElemen
     shouldScrollTo?: (meta: FieldMetaState<FieldValue>) => boolean;
     shouldShowError?: (meta: FieldMetaState<FieldValue>) => boolean;
     shouldShowWarning?: (meta: FieldMetaState<FieldValue>) => boolean;
-    shouldShowHelperText?: (meta: FieldMetaState<FieldValue>) => boolean;
     [otherProp: string]: any;
 }
 
@@ -40,7 +39,6 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
     validateWarning,
     shouldShowError: passedShouldShowError,
     shouldShowWarning: passedShouldShowWarning,
-    shouldShowHelperText: passedShouldShowHelperText,
     shouldScrollTo: passedShouldScrollTo,
     ...otherProps
 }: FieldProps<FieldValue, FieldElement>): React.ReactElement {
@@ -57,8 +55,6 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
         passedShouldShowError ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldShowFieldError({ fieldMeta }));
     const shouldShowWarning =
         passedShouldShowWarning ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldShowFieldWarning({ fieldMeta }));
-    const shouldShowHelperText =
-        passedShouldShowHelperText ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldShowFieldHelperText({ fieldMeta }));
     const shouldScrollToField =
         passedShouldScrollTo ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldScrollToField({ fieldMeta }));
 
@@ -80,7 +76,7 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
                 disabled={disabled}
                 error={shouldShowError(meta) && (meta.error || meta.submitError)}
                 warning={shouldShowWarning(meta) && meta.data?.warning}
-                helperText={shouldShowHelperText(meta) && meta.data?.helperText}
+                helperText={meta.data?.helperText}
                 variant={variant}
                 fullWidth={fullWidth}
                 scrollTo={shouldScrollToField(meta)}

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -13,7 +13,7 @@ export interface FieldContainerProps {
     warning?: string;
     scrollTo?: boolean;
     fieldMargin?: "always" | "never" | "onlyIfNotLast";
-    helperText?: string;
+    helperText?: React.ReactNode;
 }
 
 export type FieldContainerClassKey =
@@ -32,7 +32,6 @@ export type FieldContainerClassKey =
     | "error"
     | "hasWarning"
     | "warning"
-    | "hasHelperText"
     | "helperText";
 
 const styles = (theme: Theme) => {
@@ -102,11 +101,7 @@ const styles = (theme: Theme) => {
         warning: {
             color: theme.palette.warning.main,
         },
-        hasHelperText: {},
         helperText: {
-            "& $label:not([class*='Mui-focused'])": {
-                color: theme.palette.grey["300"],
-            },
             color: theme.palette.grey["300"],
         },
     });
@@ -129,7 +124,6 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles> & Field
 }) => {
     const hasError = !!error;
     const hasWarning = !!warning;
-    const hasHelperText = !!helperText;
 
     const formControlClasses: string[] = [classes.root];
     if (variant === "vertical") formControlClasses.push(classes.vertical);
@@ -137,7 +131,7 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles> & Field
     if (fullWidth) formControlClasses.push(classes.fullWidth);
     if (hasError) formControlClasses.push(classes.hasError);
     if (hasWarning && !hasError) formControlClasses.push(classes.hasWarning);
-    if (hasHelperText) formControlClasses.push(classes.hasHelperText);
+    if (helperText) formControlClasses.push(classes.helperText);
     if (disabled) formControlClasses.push(classes.disabled);
     if (required) formControlClasses.push(classes.required);
     if (fieldMargin === "always") formControlClasses.push(classes.fieldMarginAlways);
@@ -169,9 +163,7 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles> & Field
                         </FormHelperText>
                     )}
                     {hasWarning && !hasError && <FormHelperText classes={{ root: classes.warning }}>{warning}</FormHelperText>}
-                    {hasHelperText && !hasError && !hasWarning && (
-                        <FormHelperText classes={{ root: classes.helperText }}>{helperText}</FormHelperText>
-                    )}
+                    {helperText && !hasError && !hasWarning && <FormHelperText classes={{ root: classes.helperText }}>{helperText}</FormHelperText>}
                 </div>
             </>
         </FormControl>

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -131,7 +131,6 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles> & Field
     if (fullWidth) formControlClasses.push(classes.fullWidth);
     if (hasError) formControlClasses.push(classes.hasError);
     if (hasWarning && !hasError) formControlClasses.push(classes.hasWarning);
-    if (helperText) formControlClasses.push(classes.helperText);
     if (disabled) formControlClasses.push(classes.disabled);
     if (required) formControlClasses.push(classes.required);
     if (fieldMargin === "always") formControlClasses.push(classes.fieldMarginAlways);

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -13,6 +13,7 @@ export interface FieldContainerProps {
     warning?: string;
     scrollTo?: boolean;
     fieldMargin?: "always" | "never" | "onlyIfNotLast";
+    helperText?: string;
 }
 
 export type FieldContainerClassKey =
@@ -30,7 +31,9 @@ export type FieldContainerClassKey =
     | "hasError"
     | "error"
     | "hasWarning"
-    | "warning";
+    | "warning"
+    | "hasHelperText"
+    | "helperText";
 
 const styles = (theme: Theme) => {
     return createStyles<FieldContainerClassKey, FieldContainerProps>({
@@ -99,6 +102,14 @@ const styles = (theme: Theme) => {
         warning: {
             color: theme.palette.warning.main,
         },
+        hasHelperText: {
+            "& $label:not([class*='Mui-focused'])": {
+                color: theme.palette.grey["300"],
+            },
+        },
+        helperText: {
+            color: theme.palette.grey["300"],
+        },
     });
 };
 
@@ -115,9 +126,11 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles> & Field
     warning,
     scrollTo = false,
     fieldMargin = "onlyIfNotLast",
+    helperText,
 }) => {
     const hasError = !!error;
     const hasWarning = !!warning;
+    const hasHelperText = !!helperText;
 
     const formControlClasses: string[] = [classes.root];
     if (variant === "vertical") formControlClasses.push(classes.vertical);
@@ -125,6 +138,7 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles> & Field
     if (fullWidth) formControlClasses.push(classes.fullWidth);
     if (hasError) formControlClasses.push(classes.hasError);
     if (hasWarning && !hasError) formControlClasses.push(classes.hasWarning);
+    if (hasHelperText) formControlClasses.push(classes.helperText);
     if (disabled) formControlClasses.push(classes.disabled);
     if (required) formControlClasses.push(classes.required);
     if (fieldMargin === "always") formControlClasses.push(classes.fieldMarginAlways);
@@ -156,6 +170,9 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles> & Field
                         </FormHelperText>
                     )}
                     {hasWarning && !hasError && <FormHelperText classes={{ root: classes.warning }}>{warning}</FormHelperText>}
+                    {hasHelperText && !hasError && !hasWarning && (
+                        <FormHelperText classes={{ root: classes.helperText }}>{helperText}</FormHelperText>
+                    )}
                 </div>
             </>
         </FormControl>

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -102,12 +102,11 @@ const styles = (theme: Theme) => {
         warning: {
             color: theme.palette.warning.main,
         },
-        hasHelperText: {
+        hasHelperText: {},
+        helperText: {
             "& $label:not([class*='Mui-focused'])": {
                 color: theme.palette.grey["300"],
             },
-        },
-        helperText: {
             color: theme.palette.grey["300"],
         },
     });
@@ -138,7 +137,7 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles> & Field
     if (fullWidth) formControlClasses.push(classes.fullWidth);
     if (hasError) formControlClasses.push(classes.hasError);
     if (hasWarning && !hasError) formControlClasses.push(classes.hasWarning);
-    if (hasHelperText) formControlClasses.push(classes.helperText);
+    if (hasHelperText) formControlClasses.push(classes.hasHelperText);
     if (disabled) formControlClasses.push(classes.disabled);
     if (required) formControlClasses.push(classes.required);
     if (fieldMargin === "always") formControlClasses.push(classes.fieldMarginAlways);

--- a/packages/admin/admin/src/form/FinalFormContextProvider.tsx
+++ b/packages/admin/admin/src/form/FinalFormContextProvider.tsx
@@ -5,12 +5,14 @@ export interface FinalFormContext {
     shouldScrollToField: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
     shouldShowFieldError: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
     shouldShowFieldWarning: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
+    shouldShowFieldHelperText: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
 }
 
 const defaultFinalFormContext: FinalFormContext = {
     shouldScrollToField: () => false,
     shouldShowFieldError: ({ fieldMeta }) => !!fieldMeta?.touched,
     shouldShowFieldWarning: ({ fieldMeta }) => !!fieldMeta?.touched,
+    shouldShowFieldHelperText: ({ fieldMeta }) => !!fieldMeta?.touched,
 };
 
 const FinalFormContext = React.createContext<FinalFormContext>(defaultFinalFormContext);

--- a/packages/admin/admin/src/form/FinalFormContextProvider.tsx
+++ b/packages/admin/admin/src/form/FinalFormContextProvider.tsx
@@ -5,14 +5,12 @@ export interface FinalFormContext {
     shouldScrollToField: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
     shouldShowFieldError: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
     shouldShowFieldWarning: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
-    shouldShowFieldHelperText: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
 }
 
 const defaultFinalFormContext: FinalFormContext = {
     shouldScrollToField: () => false,
     shouldShowFieldError: ({ fieldMeta }) => !!fieldMeta?.touched,
     shouldShowFieldWarning: ({ fieldMeta }) => !!fieldMeta?.touched,
-    shouldShowFieldHelperText: ({ fieldMeta }) => !!fieldMeta?.touched,
 };
 
 const FinalFormContext = React.createContext<FinalFormContext>(defaultFinalFormContext);


### PR DESCRIPTION
Alongside `error` and `warning` messages for `Field` there is now a a `helperText` prop.
Errors and warnings override the helper message.

<details><summary>Screenshot of Field</summary>
<p>

<img width="625" alt="Screenshot 2024-01-11 at 13 28 04" src="https://github.com/vivid-planet/comet/assets/122883866/e8ae78c4-fe71-4b38-b014-2ff9943490b0">

</p>
</details> 

- [x] Add changeset (if necessary)