### PR TITLE
Refactor theming of `ClearInputButton`

### DIFF
--- a/.changeset/twelve-spoons-play.md
+++ b/.changeset/twelve-spoons-play.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": major
+---
+
+Remove the `disabled` class key in `ClearInputButtonClassKey`
+
+Use the `:disabled` selector on `root` instead when styling the disabled state. 

--- a/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
+++ b/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
@@ -1,5 +1,5 @@
 import { Clear } from "@comet/admin-icons";
-import { ButtonBase, ButtonBaseProps, ComponentsOverrides } from "@mui/material";
+import { ButtonBase, ButtonBaseProps, ComponentsOverrides, inputAdornmentClasses } from "@mui/material";
 import { css, styled, Theme, useThemeProps } from "@mui/material/styles";
 import * as React from "react";
 
@@ -17,11 +17,11 @@ const Root = styled(ButtonBase, {
         width: 40px;
         color: ${theme.palette.action.active};
 
-        &:last-child {
+        ${`.${inputAdornmentClasses.positionEnd}`}:last-child & {
             margin-right: ${theme.spacing(-2)};
         }
 
-        &:first-child {
+        ${`.${inputAdornmentClasses.positionStart}`}:first-child & {
             margin-left: ${theme.spacing(-2)};
         }
 

--- a/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
+++ b/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
@@ -1,47 +1,55 @@
 import { Clear } from "@comet/admin-icons";
-import { ButtonBase, ButtonBaseClassKey, ButtonBaseProps, ComponentsOverrides, inputAdornmentClasses, Theme } from "@mui/material";
-import { createStyles, WithStyles, withStyles } from "@mui/styles";
+import { ButtonBase, ButtonBaseProps, ComponentsOverrides } from "@mui/material";
+import { css, styled, Theme, useThemeProps } from "@mui/material/styles";
 import * as React from "react";
 
-export type ClearInputButtonClassKey = ButtonBaseClassKey;
+export type ClearInputButtonClassKey = "root" | "focusVisible";
+
+const Root = styled(ButtonBase, {
+    name: "CometAdminClearInputButton",
+    slot: "root",
+    overridesResolver(_, styles) {
+        return [styles.root];
+    },
+})(
+    ({ theme }) => css`
+        height: 100%;
+        width: 40px;
+        color: ${theme.palette.action.active};
+
+        &:last-child {
+            margin-right: ${theme.spacing(-2)};
+        }
+
+        &:first-child {
+            margin-left: ${theme.spacing(-2)};
+        }
+
+        &:disabled {
+            color: ${theme.palette.action.disabled};
+        }
+    `,
+);
+
 export interface ClearInputButtonProps extends ButtonBaseProps {
     icon?: React.ReactNode;
 }
 
-const styles = ({ palette, spacing }: Theme) => {
-    return createStyles<ClearInputButtonClassKey, ClearInputButtonProps>({
-        root: {
-            height: "100%",
-            width: 40,
-            color: palette.action.active,
-
-            [`.${inputAdornmentClasses.positionEnd}:last-child &`]: {
-                marginRight: spacing(-2),
-            },
-
-            [`.${inputAdornmentClasses.positionStart}:first-child &`]: {
-                marginLeft: spacing(-2),
-            },
-        },
-        disabled: {
-            color: palette.action.disabled,
-        },
-        focusVisible: {},
+export function ClearInputButton(inProps: ClearInputButtonProps) {
+    const { icon = <Clear />, ...restProps } = useThemeProps({
+        props: inProps,
+        name: "CometAdminClearInputButton",
     });
-};
-
-const ClearInputBtn: React.FC<WithStyles<typeof styles> & ClearInputButtonProps> = ({ icon = <Clear />, ...restProps }) => {
     return (
-        <ButtonBase tabIndex={-1} {...restProps}>
+        <Root tabIndex={-1} {...restProps}>
             {icon}
-        </ButtonBase>
+        </Root>
     );
-};
+}
 
 /**
  * @deprecated Use `ClearInputAdornment` directly as the InputAdornment instead
  */
-export const ClearInputButton = withStyles(styles, { name: "CometAdminClearInputButton" })(ClearInputBtn);
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {


### PR DESCRIPTION
<img width="769" alt="Screenshot 2024-01-11 at 13 53 34" src="https://github.com/vivid-planet/comet/assets/72875628/d879c8ee-f444-471c-8943-bdb6414e86a1">

I couldn't find how to use focusVisible and [`.${inputAdornmentClasses.positionEnd}:last-child &`], please comment 