### PR TITLE
Change the signatures of `shouldScrollToField`, `shouldShowFieldError` and `shouldShowFieldWarning` in `FinalFormContext` to match the corresponding methods in `Field`

### DIFF
--- a/.changeset/stale-wombats-reply.md
+++ b/.changeset/stale-wombats-reply.md
@@ -1,0 +1,30 @@
+---
+"@comet/admin": major
+---
+
+Change the signatures of `shouldScrollToField`, `shouldShowFieldError` and `shouldShowFieldWarning` in `FinalFormContext` to match the corresponding methods in `Field`
+
+The API in `FinalFormContext` was changed from 
+
+```tsx
+// ❌
+export interface FinalFormContext {
+    shouldScrollToField: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
+    shouldShowFieldError: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
+    shouldShowFieldWarning: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
+}
+```
+
+to
+
+```tsx
+// ✅
+export interface FinalFormContext {
+    shouldScrollToField: (fieldMeta: FieldMetaState<any>) => boolean;
+    shouldShowFieldError: (fieldMeta: FieldMetaState<any>) => boolean;
+    shouldShowFieldWarning: (fieldMeta: FieldMetaState<any>) => boolean;
+}
+```
+
+Now the corresponding methods in `Field` and `FinalFormContext` have the same signature.
+

--- a/packages/admin/admin-stories/src/admin/form/ScrollToErrorField.tsx
+++ b/packages/admin/admin-stories/src/admin/form/ScrollToErrorField.tsx
@@ -43,7 +43,7 @@ function Story() {
                         }}
                         initialValues={initialValues}
                         validate={validate}
-                        formContext={{ shouldScrollToField: ({ fieldMeta: { touched } }) => !touched, shouldShowFieldError: () => true }}
+                        formContext={{ shouldScrollToField: ({ touched }) => !touched, shouldShowFieldError: () => true }}
                     >
                         <Field label="Foo" name="foo" component={FinalFormInput} fullWidth />
                         <div style={{ height: "2000px", borderLeft: "1px solid black" }} />

--- a/packages/admin/admin-stories/src/admin/form/ShowErrorStrategies.tsx
+++ b/packages/admin/admin-stories/src/admin/form/ShowErrorStrategies.tsx
@@ -25,9 +25,9 @@ function validate({ foo, bar }: FormValues) {
 type ShowStrategy = "always" | "while-typing" | "on-blur" | "when-submitted";
 const strategies: Record<ShowStrategy, FinalFormContext["shouldShowFieldError"]> = {
     always: () => true,
-    "on-blur": ({ fieldMeta: { touched } }) => !!touched,
-    "while-typing": ({ fieldMeta: { touched, active } }) => !!(touched || active),
-    "when-submitted": ({ fieldMeta: { submitFailed } }) => !!submitFailed,
+    "on-blur": ({ touched }) => !!touched,
+    "while-typing": ({ touched, active }) => !!(touched || active),
+    "when-submitted": ({ submitFailed }) => !!submitFailed,
 };
 
 function Story() {

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -51,12 +51,9 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
     const validateError = required ? (validate ? composeValidators(requiredValidator, validate) : requiredValidator) : validate;
 
     const finalFormContext = useFinalFormContext();
-    const shouldShowError =
-        passedShouldShowError ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldShowFieldError({ fieldMeta }));
-    const shouldShowWarning =
-        passedShouldShowWarning ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldShowFieldWarning({ fieldMeta }));
-    const shouldScrollToField =
-        passedShouldScrollTo ?? ((fieldMeta: FieldMetaState<FieldValue>) => finalFormContext.shouldScrollToField({ fieldMeta }));
+    const shouldShowError = passedShouldShowError ?? finalFormContext.shouldShowFieldError;
+    const shouldShowWarning = passedShouldShowWarning ?? finalFormContext.shouldShowFieldWarning;
+    const shouldScrollToField = passedShouldScrollTo ?? finalFormContext.shouldScrollToField;
 
     function renderField({ input, meta, fieldContainerProps, ...rest }: FieldRenderProps<FieldValue, FieldElement> & { warning?: string }) {
         function render() {

--- a/packages/admin/admin/src/form/FinalFormContextProvider.tsx
+++ b/packages/admin/admin/src/form/FinalFormContextProvider.tsx
@@ -2,15 +2,15 @@ import * as React from "react";
 import { FieldMetaState } from "react-final-form";
 
 export interface FinalFormContext {
-    shouldScrollToField: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
-    shouldShowFieldError: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
-    shouldShowFieldWarning: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
+    shouldScrollToField: (fieldMeta: FieldMetaState<any>) => boolean;
+    shouldShowFieldError: (fieldMeta: FieldMetaState<any>) => boolean;
+    shouldShowFieldWarning: (fieldMeta: FieldMetaState<any>) => boolean;
 }
 
 const defaultFinalFormContext: FinalFormContext = {
     shouldScrollToField: () => false,
-    shouldShowFieldError: ({ fieldMeta }) => !!fieldMeta?.touched,
-    shouldShowFieldWarning: ({ fieldMeta }) => !!fieldMeta?.touched,
+    shouldShowFieldError: (fieldMeta) => !!fieldMeta?.touched,
+    shouldShowFieldWarning: (fieldMeta) => !!fieldMeta?.touched,
 };
 
 const FinalFormContext = React.createContext<FinalFormContext>(defaultFinalFormContext);

--- a/packages/admin/blocks-admin/src/form/BlocksFinalForm.tsx
+++ b/packages/admin/blocks-admin/src/form/BlocksFinalForm.tsx
@@ -27,9 +27,9 @@ const noop = () => {
 };
 
 const finalFormContextValues: Omit<FinalFormContextProviderProps, "children"> = {
-    shouldShowFieldError: ({ fieldMeta }) => fieldMeta.error || fieldMeta.submitError, // Doesnt matter if touched or not
-    shouldShowFieldWarning: ({ fieldMeta }) => fieldMeta.data?.warning,
-    shouldScrollToField: ({ fieldMeta }) => fieldMeta.error && !fieldMeta.touched, // If a field is not touched yet and has an error we scroll to it
+    shouldShowFieldError: (fieldMeta) => fieldMeta.error || fieldMeta.submitError, // Doesnt matter if touched or not
+    shouldShowFieldWarning: (fieldMeta) => fieldMeta.data?.warning,
+    shouldScrollToField: (fieldMeta) => fieldMeta.error && !fieldMeta.touched, // If a field is not touched yet and has an error we scroll to it
 };
 
 export function BlocksFinalForm<FormValues = AnyObject>({ onSubmit, children, ...rest }: FormProps<FormValues>): JSX.Element {


### PR DESCRIPTION
We could also wait until v7 for this

---

The API in `FinalFormContext` was changed from 

```tsx
// ❌
export interface FinalFormContext {
    shouldScrollToField: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
    shouldShowFieldError: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
    shouldShowFieldWarning: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
}
```

to

```tsx
// ✅
export interface FinalFormContext {
    shouldScrollToField: (fieldMeta: FieldMetaState<any>) => boolean;
    shouldShowFieldError: (fieldMeta: FieldMetaState<any>) => boolean;
    shouldShowFieldWarning: (fieldMeta: FieldMetaState<any>) => boolean;
}
```