### PR TITLE
Clean generated files before build

### DIFF
--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -19,7 +19,7 @@
         "build": "$npm_execpath run clean && run-p generate-graphql-types generate-block-types && run-p build:babel build:types",
         "build:babel": "npx babel ./src -x \".ts,.tsx\" -d lib",
         "build:types": "tsc --project ./tsconfig.build.json --emitDeclarationOnly",
-        "clean": "rimraf lib",
+        "clean": "rimraf lib 'src/**/*.generated.ts'",
         "generate-block-types": "comet generate-block-types --inputs",
         "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",
         "generate-graphql-types": "graphql-codegen",

--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -14,7 +14,7 @@
     ],
     "scripts": {
         "build": "$npm_execpath run clean && npm run generate-block-types && tsc --project tsconfig.build.json",
-        "clean": "rimraf lib",
+        "clean": "rimraf lib 'src/**/*.generated.ts'",
         "dev": "$npm_execpath generate-block-types && tsc --watch --preserveWatchOutput --project tsconfig.build.json",
         "generate-block-types": "comet generate-block-types",
         "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",


### PR DESCRIPTION
Previously, generated GraphQL and block types were not removed before the build. This caused when a GraphQL feature was removed in the API (for instance, user permissions). To fix it, we now remove the generated files in the clean script.