### PR TITLE
Change NPM tag for v4 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
               uses: dotansimha/changesets-action@cbc5ff3569ae9861100a48b290f4e9c1b94e45b5
               with:
                   version: pnpm run version
-                  publish: pnpm run publish --tag=v4.x.x
+                  publish: pnpm run publish --tag=stable-v4
                   title: "Version Packages (v4)"
                   createGithubReleases: aggregate
                   githubReleaseName: "${{ env.PUBLISHED_VERSION }}"


### PR DESCRIPTION
`v4.x.x` isn't acceptable because it's a valid SemVer range. Change it to `stable-v4` instead.