### PR TITLE
Make sites config generic

### DIFF
--- a/.changeset/rich-crews-smell.md
+++ b/.changeset/rich-crews-smell.md
@@ -1,0 +1,43 @@
+---
+"@comet/cms-admin": major
+---
+
+Make sites config generic
+
+The sites config was previously assumed to be `Record<string, SiteConfg`.
+However, as the sites config is solely used in application code, it could be of any shape.
+Therefore, the `SitesConfigProvider` and `useSitesConfig` are made generic.
+The following changes have to be made in the application:
+
+1.  Define the type of your sites config
+
+    Preferably this should be done in `config.ts`:
+
+    ```diff
+    export function createConfig() {
+        // ...
+
+        return {
+            ...cometConfig,
+            apiUrl: environmentVariables.API_URL,
+            adminUrl: environmentVariables.ADMIN_URL,
+    +       sitesConfig: JSON.parse(environmentVariables.SITES_CONFIG) as SitesConfig,
+        };
+    }
+
+    + export type SitesConfig = Record<string, SiteConfig>;
+    ```
+
+2.  Use the type when using `useSitesConfig`
+
+    ```diff
+    - const sitesConfig = useSitesConfig();
+    + const sitesConfig = useSitesConfig<SitesConfig>();
+    ```
+
+3.  Optional: Remove type annotation from `ContentScopeProvider#resolveSiteConfigForScope` (as it's now inferred)
+
+    ```diff
+    - resolveSiteConfigForScope: (configs: Record<string, SiteConfig>, scope: ContentScope) => configs[scope.domain],
+    + resolveSiteConfigForScope: (configs, scope: ContentScope) => configs[scope.domain],
+    ```

--- a/.changeset/rich-crews-smell.md
+++ b/.changeset/rich-crews-smell.md
@@ -4,7 +4,7 @@
 
 Make sites config generic
 
-The sites config was previously assumed to be `Record<string, SiteConfg`.
+The sites config was previously assumed to be `Record<string, SiteConfg>`.
 However, as the sites config is solely used in application code, it could be of any shape.
 Therefore, the `SitesConfigProvider` and `useSitesConfig` are made generic.
 The following changes have to be made in the application:

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -14,7 +14,6 @@ import {
     DamConfigProvider,
     LocaleProvider,
     MasterMenuRoutes,
-    SiteConfig,
     SitePreview,
     SitesConfigProvider,
 } from "@comet/cms-admin";
@@ -63,7 +62,7 @@ class App extends React.Component {
                     <SitesConfigProvider
                         value={{
                             configs: config.sitesConfig,
-                            resolveSiteConfigForScope: (configs: Record<string, SiteConfig>, scope: ContentScope) => configs[scope.domain],
+                            resolveSiteConfigForScope: (configs, scope: ContentScope) => configs[scope.domain],
                         }}
                     >
                         <DamConfigProvider value={{ scopeParts: ["domain"], additionalToolbarItems: <ImportFromUnsplash /> }}>

--- a/demo/admin/src/common/ContentScopeProvider.tsx
+++ b/demo/admin/src/common/ContentScopeProvider.tsx
@@ -12,6 +12,7 @@ import {
     useCurrentUser,
     useSitesConfig,
 } from "@comet/cms-admin";
+import { SitesConfig } from "@src/config";
 import React from "react";
 
 type Domain = "main" | "secondary" | string;
@@ -50,7 +51,7 @@ export function useContentScopeConfig(p: ContentScopeConfigProps): void {
 }
 
 const ContentScopeProvider: React.FC<Pick<ContentScopeProviderProps, "children">> = ({ children }) => {
-    const sitesConfig = useSitesConfig();
+    const sitesConfig = useSitesConfig<SitesConfig>();
     const user = useCurrentUser();
 
     const allowedUserDomains = user.contentScopes.map((scope) => scope.domain);

--- a/demo/admin/src/config.ts
+++ b/demo/admin/src/config.ts
@@ -1,3 +1,5 @@
+import { SiteConfig } from "@comet/cms-admin";
+
 import cometConfig from "./comet-config.json";
 import environment from "./environment";
 
@@ -18,8 +20,10 @@ export function createConfig() {
         ...cometConfig,
         apiUrl: environmentVariables.API_URL,
         adminUrl: environmentVariables.ADMIN_URL,
-        sitesConfig: JSON.parse(environmentVariables.SITES_CONFIG),
+        sitesConfig: JSON.parse(environmentVariables.SITES_CONFIG) as SitesConfig,
     };
 }
+
+export type SitesConfig = Record<string, SiteConfig>;
 
 export type Config = ReturnType<typeof createConfig>;

--- a/packages/admin/cms-admin/src/sitesConfig/SitesConfigContext.tsx
+++ b/packages/admin/cms-admin/src/sitesConfig/SitesConfigContext.tsx
@@ -8,9 +8,9 @@ export interface SiteConfig {
     preloginEnabled: boolean;
 }
 
-export interface SiteConfigApi {
-    configs: Record<string, SiteConfig>;
-    resolveSiteConfigForScope: (configs: Record<string, SiteConfig>, scope: ContentScopeInterface) => SiteConfig;
+export interface SiteConfigApi<Configs = unknown> {
+    configs: Configs;
+    resolveSiteConfigForScope: (configs: Configs, scope: ContentScopeInterface) => SiteConfig;
 }
 
 export const SiteConfigContext = React.createContext<SiteConfigApi | undefined>(undefined);

--- a/packages/admin/cms-admin/src/sitesConfig/SitesConfigProvider.tsx
+++ b/packages/admin/cms-admin/src/sitesConfig/SitesConfigProvider.tsx
@@ -8,6 +8,5 @@ interface Props<Config> {
 }
 
 export function SitesConfigProvider<Config = unknown>({ children, value }: Props<Config>) {
-    //@ts-expect-error SiteConfigContext can't be generic
-    return <SiteConfigContext.Provider value={value}>{children}</SiteConfigContext.Provider>;
+    return <SiteConfigContext.Provider value={value as SiteConfigApi<unknown>}>{children}</SiteConfigContext.Provider>;
 }

--- a/packages/admin/cms-admin/src/sitesConfig/SitesConfigProvider.tsx
+++ b/packages/admin/cms-admin/src/sitesConfig/SitesConfigProvider.tsx
@@ -2,11 +2,12 @@ import * as React from "react";
 
 import { SiteConfigApi, SiteConfigContext } from "./SitesConfigContext";
 
-interface Props {
+interface Props<Config> {
     children: React.ReactNode;
-    value: SiteConfigApi;
+    value: SiteConfigApi<Config>;
 }
 
-export const SitesConfigProvider = ({ children, value }: Props): React.ReactElement => {
+export function SitesConfigProvider<Config = unknown>({ children, value }: Props<Config>) {
+    //@ts-expect-error SiteConfigContext can't be generic
     return <SiteConfigContext.Provider value={value}>{children}</SiteConfigContext.Provider>;
-};
+}

--- a/packages/admin/cms-admin/src/sitesConfig/useSitesConfig.ts
+++ b/packages/admin/cms-admin/src/sitesConfig/useSitesConfig.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { SiteConfigApi, SiteConfigContext } from "./SitesConfigContext";
 
-export function useSitesConfig(): SiteConfigApi {
+export function useSitesConfig<Configs = unknown>(): SiteConfigApi<Configs> {
     const context = React.useContext(SiteConfigContext);
 
     if (!context) {
@@ -11,5 +11,6 @@ export function useSitesConfig(): SiteConfigApi {
         );
     }
 
+    //@ts-expect-error SiteConfigContext can't be generic
     return context;
 }

--- a/packages/admin/cms-admin/src/sitesConfig/useSitesConfig.ts
+++ b/packages/admin/cms-admin/src/sitesConfig/useSitesConfig.ts
@@ -11,6 +11,5 @@ export function useSitesConfig<Configs = unknown>(): SiteConfigApi<Configs> {
         );
     }
 
-    //@ts-expect-error SiteConfigContext can't be generic
-    return context;
+    return context as SiteConfigApi<Configs>;
 }


### PR DESCRIPTION
The sites config was previously assumed to be `Record<string, SiteConfg`. However, as the sites config is solely used in application code, it could be of any shape. Therefore, the `SitesConfigProvider` and `useSitesConfig` are made generic.