### PR TITLE
COM-291: Refactor theming of `AppHeaderButton`

### DIFF
--- a/.changeset/tough-zoos-refuse.md
+++ b/.changeset/tough-zoos-refuse.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin": minor
+"@comet/admin": major
 ---
 
 Remove the `disabled` and `focusVisible` class key in `AppHeaderDropdownClassKey`

--- a/.changeset/tough-zoos-refuse.md
+++ b/.changeset/tough-zoos-refuse.md
@@ -6,4 +6,4 @@ Remove the `disabled` and `focusVisible` class key and rename `inner` class key 
 
 Use the `:disabled` selector on `root` instead when styling the disabled state.
 Use the `:focus` selector on `root` instead when styling the focus state.
-Use the `content` prop instead of `inner` to override styles.
+Use the `content` class key instead of `inner` to override styles.

--- a/.changeset/tough-zoos-refuse.md
+++ b/.changeset/tough-zoos-refuse.md
@@ -2,7 +2,8 @@
 "@comet/admin": major
 ---
 
-Remove the `disabled` and `focusVisible` class key in `AppHeaderDropdownClassKey`
+Remove the `disabled` and `focusVisible` class key and rename `inner` class key to `content` in `AppHeaderButtonClassKey`
 
 Use the `:disabled` selector on `root` instead when styling the disabled state.
 Use the `:focus` selector on `root` instead when styling the focus state.
+Use the `content` prop instead of `inner` to override styles.

--- a/.changeset/tough-zoos-refuse.md
+++ b/.changeset/tough-zoos-refuse.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": minor
+---
+
+Remove the `disabled` and `focusVisible` class key in `AppHeaderDropdownClassKey`
+
+Use the `:disabled` selector on `root` instead when styling the disabled state.
+Use the `:focus` selector on `root` instead when styling the focus state.

--- a/packages/admin/admin/src/appHeader/button/AppHeaderButton.styles.tsx
+++ b/packages/admin/admin/src/appHeader/button/AppHeaderButton.styles.tsx
@@ -1,43 +1,78 @@
-import { ButtonBaseClassKey } from "@mui/material";
-import { Theme } from "@mui/material/styles";
-import { createStyles } from "@mui/styles";
+import { ButtonBase, Typography } from "@mui/material";
+import { css, styled } from "@mui/material/styles";
 
-import { AppHeaderButtonProps } from "./AppHeaderButton";
+export type AppHeaderButtonClassKey = "root" | "inner" | "startIcon" | "endIcon" | "typography";
 
-export type AppHeaderButtonClassKey = ButtonBaseClassKey | "inner" | "startIcon" | "endIcon" | "typography";
+export const Root = styled(ButtonBase, {
+    name: "CometAdminAppHeaderButton",
+    slot: "root",
+    overridesResolver(_, styles) {
+        return [styles.root];
+    },
+})(
+    css`
+        height: 100%;
+        border-left: 1px solid rgba(255, 255, 255, 0.2);
+    `,
+);
 
-export const styles = ({ spacing }: Theme) => {
-    return createStyles<AppHeaderButtonClassKey, AppHeaderButtonProps>({
-        root: {
-            height: "100%",
-            borderLeft: "1px solid rgba(255, 255, 255, 0.2)",
-        },
-        inner: {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            height: "100%",
-            minWidth: "var(--header-height)",
-            boxSizing: "border-box",
-            paddingLeft: spacing(4),
-            paddingRight: spacing(4),
-        },
-        disabled: {},
-        focusVisible: {},
-        startIcon: {
-            display: "flex",
-            alignItems: "center",
-            "&:not(:last-child)": {
-                marginRight: spacing(2),
-            },
-        },
-        endIcon: {
-            display: "flex",
-            alignItems: "center",
-            "&:not(:first-child)": {
-                marginLeft: spacing(2),
-            },
-        },
-        typography: {},
-    });
-};
+export const Inner = styled("div", {
+    name: "CometAdminAppHeaderButton",
+    slot: "inner",
+    overridesResolver(_, styles) {
+        return [styles.inner];
+    },
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        min-width: var(--header-height);
+        box-sizing: border-box;
+        padding-left: ${theme.spacing(4)};
+        padding-right: ${theme.spacing(4)};
+    `,
+);
+
+export const StartIcon = styled("div", {
+    name: "CometAdminAppHeaderButton",
+    slot: "startIcon",
+    overridesResolver(_, styles) {
+        return [styles.startIcon];
+    },
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+
+        &:not(:last-child) {
+            margin-right: ${theme.spacing(2)};
+        }
+    `,
+);
+
+export const EndIcon = styled("div", {
+    name: "CometAdminAppHeaderButton",
+    slot: "endIcon",
+    overridesResolver(_, styles) {
+        return [styles.endIcon];
+    },
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+
+        &:not(:first-child) {
+            margin-left: ${theme.spacing(2)};
+        }
+    `,
+);
+
+export const Text = styled(Typography, {
+    name: "CometAdminAppHeaderButton",
+    slot: "typography",
+    overridesResolver(_, styles) {
+        return [styles.typography];
+    },
+})();

--- a/packages/admin/admin/src/appHeader/button/AppHeaderButton.styles.tsx
+++ b/packages/admin/admin/src/appHeader/button/AppHeaderButton.styles.tsx
@@ -1,7 +1,7 @@
 import { ButtonBase, Typography } from "@mui/material";
 import { css, styled } from "@mui/material/styles";
 
-export type AppHeaderButtonClassKey = "root" | "inner" | "startIcon" | "endIcon" | "typography";
+export type AppHeaderButtonClassKey = "root" | "content" | "startIcon" | "endIcon" | "typography";
 
 export const Root = styled(ButtonBase, {
     name: "CometAdminAppHeaderButton",
@@ -16,11 +16,11 @@ export const Root = styled(ButtonBase, {
     `,
 );
 
-export const Inner = styled("div", {
+export const Content = styled("div", {
     name: "CometAdminAppHeaderButton",
-    slot: "inner",
+    slot: "content",
     overridesResolver(_, styles) {
-        return [styles.inner];
+        return [styles.content];
     },
 })(
     ({ theme }) => css`

--- a/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
+++ b/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
@@ -10,7 +10,7 @@ export interface AppHeaderButtonProps
         ThemedComponentBaseProps<{
             root: typeof ButtonBase;
             inner: "div";
-            text: typeof Typography;
+            typography: typeof Typography;
             startIcon: "div";
             endIcon: "div";
         }> {
@@ -34,7 +34,7 @@ export function AppHeaderButton(inProps: AppHeaderButtonProps) {
                         { children }
                     ) : (
                         // @ts-expect-error TODO
-                        <Text component="div" {...slotProps?.text}>
+                        <Text component="div" {...slotProps?.typography}>
                             {children}
                         </Text>
                     ))}

--- a/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
+++ b/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
@@ -3,13 +3,13 @@ import { useThemeProps } from "@mui/material/styles";
 import * as React from "react";
 
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
-import { AppHeaderButtonClassKey, EndIcon, Inner, Root, StartIcon, Text } from "./AppHeaderButton.styles";
+import { AppHeaderButtonClassKey, Content, EndIcon, Root, StartIcon, Text } from "./AppHeaderButton.styles";
 
 export interface AppHeaderButtonProps
     extends ButtonBaseProps,
         ThemedComponentBaseProps<{
             root: typeof ButtonBase;
-            inner: "div";
+            content: "div";
             typography: typeof Typography;
             startIcon: "div";
             endIcon: "div";
@@ -27,7 +27,7 @@ export function AppHeaderButton(inProps: AppHeaderButtonProps) {
 
     return (
         <Root {...restProps} {...slotProps?.root} onClick={onClick}>
-            <Inner {...slotProps?.inner}>
+            <Content {...slotProps?.content}>
                 {startIcon && <StartIcon {...slotProps?.startIcon}>{startIcon}</StartIcon>}
                 {children &&
                     (disableTypography ? (
@@ -40,7 +40,7 @@ export function AppHeaderButton(inProps: AppHeaderButtonProps) {
                     ))}
 
                 {endIcon && <EndIcon {...slotProps?.endIcon}>{endIcon}</EndIcon>}
-            </Inner>
+            </Content>
         </Root>
     );
 }

--- a/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
+++ b/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
@@ -31,7 +31,7 @@ export function AppHeaderButton(inProps: AppHeaderButtonProps) {
                 {startIcon && <StartIcon {...slotProps?.startIcon}>{startIcon}</StartIcon>}
                 {children &&
                     (disableTypography ? (
-                        { children }
+                        children
                     ) : (
                         // @ts-expect-error TODO
                         <Text component="div" {...slotProps?.typography}>

--- a/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
+++ b/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
@@ -1,64 +1,62 @@
 import { ButtonBase, ButtonBaseProps, ComponentsOverrides, Theme, Typography } from "@mui/material";
-import { WithStyles, withStyles } from "@mui/styles";
+import { useThemeProps } from "@mui/material/styles";
 import * as React from "react";
 
-import { AppHeaderButtonClassKey, styles } from "./AppHeaderButton.styles";
+import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
+import { AppHeaderButtonClassKey, EndIcon, Inner, Root, StartIcon, Text } from "./AppHeaderButton.styles";
 
-export interface AppHeaderButtonProps extends ButtonBaseProps {
+export interface AppHeaderButtonProps
+    extends ButtonBaseProps,
+        ThemedComponentBaseProps<{
+            root: typeof ButtonBase;
+            inner: "div";
+            text: typeof Typography;
+            startIcon: "div";
+            endIcon: "div";
+        }> {
     startIcon?: React.ReactNode;
     endIcon?: React.ReactNode;
     disableTypography?: boolean;
 }
 
-function Button({
-    classes,
-    children,
-    startIcon,
-    endIcon,
-    disableTypography,
-    onClick,
-    ...restProps
-}: AppHeaderButtonProps & WithStyles<typeof styles>): React.ReactElement {
-    const {
-        startIcon: startIconClassName,
-        endIcon: endIconClassName,
-        typography: typographyClassName,
-        inner: innerClassName,
-        ...buttonBaseClasses
-    } = classes;
+export function AppHeaderButton(inProps: AppHeaderButtonProps) {
+    const { children, disableTypography, slotProps, onClick, startIcon, endIcon, ...restProps } = useThemeProps({
+        props: inProps,
+        name: "CometAdminAppHeaderButton",
+    });
 
     return (
-        <ButtonBase classes={buttonBaseClasses} {...restProps} onClick={onClick}>
-            <div className={innerClassName}>
-                {startIcon && <div className={startIconClassName}>{startIcon}</div>}
+        <Root {...restProps} {...slotProps?.root} onClick={onClick}>
+            <Inner {...slotProps?.inner}>
+                {startIcon && <StartIcon {...slotProps?.startIcon}>{startIcon}</StartIcon>}
                 {children &&
                     (disableTypography ? (
-                        children
+                        { children }
                     ) : (
-                        <Typography component="div" classes={{ root: typographyClassName }}>
+                        // @ts-expect-error TODO
+                        <Text component="div" {...slotProps?.text}>
                             {children}
-                        </Typography>
+                        </Text>
                     ))}
-                {endIcon && <div className={endIconClassName}>{endIcon}</div>}
-            </div>
-        </ButtonBase>
+
+                {endIcon && <EndIcon {...slotProps?.endIcon}>{endIcon}</EndIcon>}
+            </Inner>
+        </Root>
     );
 }
 
-export const AppHeaderButton = withStyles(styles, { name: "CometAdminAppHeaderButton" })(Button);
-
 declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminAppHeaderButton: AppHeaderButtonProps;
+    }
+
     interface ComponentNameToClassKey {
         CometAdminAppHeaderButton: AppHeaderButtonClassKey;
     }
 
-    interface ComponentsPropsList {
-        CometAdminAppHeaderButton: Partial<AppHeaderButtonProps>;
-    }
-
     interface Components {
         CometAdminAppHeaderButton?: {
-            defaultProps?: ComponentsPropsList["CometAdminAppHeaderButton"];
+            defaultProps?: Partial<ComponentsPropsList["CometAdminAppHeaderButton"]>;
             styleOverrides?: ComponentsOverrides<Theme>["CometAdminAppHeaderButton"];
         };
     }


### PR DESCRIPTION
COM-291

Styling of `AppHeaderButton` is refactored.

Screenshot of Storybook:
<img width="1169" alt="Screenshot 2024-01-18 at 14 51 26" src="https://github.com/vivid-planet/comet/assets/122883866/04a89099-f712-4f92-a330-d0f43017592d">