### PR TITLE
Rewrite fileUrl to use AuthProxy URL

### DIFF
--- a/.changeset/strange-lobsters-explode.md
+++ b/.changeset/strange-lobsters-explode.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix bug in the `PixelImageBlock` that caused images not to be displayed in the `EditImageDialog`
+
+Since v5.3.0 we use preview file URLs everywhere in the admin app. The preview file URLs are behind the global guard. Meaning, the request must be routed via the auth proxy. This requires replacing the public API url with the auth proxy URL in the admin block.

--- a/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
@@ -52,6 +52,15 @@ export function createPreviewUrl({ damFile, cropArea }: ImageBlockState, apiUrl:
     return url.toString();
 }
 
+function rewriteUrlHost(url: string, newHost: string) {
+    const oldUrl = new URL(url);
+    const newHostUrl = new URL(newHost);
+
+    const newUrl = new URL(oldUrl);
+    newUrl.host = newHostUrl.host;
+    return newUrl.toString();
+}
+
 export const PixelImageBlock: BlockInterface<PixelImageBlockData, ImageBlockState, PixelImageBlockInput> = {
     ...createBlockSkeleton(),
 
@@ -224,7 +233,7 @@ export const PixelImageBlock: BlockInterface<PixelImageBlockData, ImageBlockStat
                             <EditImageDialog
                                 image={{
                                     name: state.damFile.name,
-                                    url: state.damFile.fileUrl,
+                                    url: rewriteUrlHost(state.damFile.fileUrl, context.damConfig.apiUrl), // replace public api domain with auth proxy domain
                                     width: state.damFile.image.width,
                                     height: state.damFile.image.height,
                                     size: state.damFile.size,


### PR DESCRIPTION
### Problem

At the moment, images in the `PixelImageBlock` are not displayed in the EditImageDialog if no CDN is used

### Reason 

Since v5.3.0 we use preview file URLs everywhere in the admin app (see https://github.com/vivid-planet/comet/pull/1503). 
The preview file URLs are behind the global guard. Meaning, the request must be routed via the auth proxy. This requires replacing the public API url with the auth proxy URL in the admin block.

### Solution

I rewrite the URL and replace the host with the auth proxy domain