### PR TITLE
COM-292: Refactor theming of `AppHeaderDropdown` 

### DIFF
--- a/.changeset/violet-wombats-try.md
+++ b/.changeset/violet-wombats-try.md
@@ -2,6 +2,7 @@
 "@comet/admin": major
 ---
 
-Remove the `popoverPaper` class key from `AppHeaderDropdownClassKey`
+Remove the `popoverPaper` class key, rename `popoverRoot` to `popover` in `AppHeaderDropdownClassKey`
 
 Instead of using `styleOverrides` for `popoverPaper` in the theme, use the `slotProps` and `sx` props. 
+Use the `popover` prop instead of `popoverRoot` to override styles.

--- a/.changeset/violet-wombats-try.md
+++ b/.changeset/violet-wombats-try.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": major
+---
+
+Remove the `popoverPaper` class key from `AppHeaderDropdownClassKey`
+
+Styling overrides of `popoverPaper` need to be done via `sx` and `slotProps`.

--- a/.changeset/violet-wombats-try.md
+++ b/.changeset/violet-wombats-try.md
@@ -4,4 +4,4 @@
 
 Remove the `popoverPaper` class key from `AppHeaderDropdownClassKey`
 
-Styling overrides of `popoverPaper` need to be done via `sx` and `slotProps`.
+Instead of using `styleOverrides` for `popoverPaper` in the theme, use the `slotProps` and `sx` props. 

--- a/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
+++ b/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
@@ -60,7 +60,6 @@ export function AppHeaderDropdown(inProps: AppHeaderDropdownProps) {
         popoverProps,
         open,
         onOpenChange,
-        classes,
         slotProps,
         ...restProps
     } = useThemeProps({ props: inProps, name: "CometAdminAppHeaderDropdown" });

--- a/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
+++ b/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
@@ -38,7 +38,7 @@ const PopoverRoot = styled(Popover, {
     name: "CometAdminAppHeaderDropdown",
     slot: "popoverRoot",
     overridesResolver(_, styles) {
-        return [styles.root];
+        return [styles.popoverRoot];
     },
 })();
 

--- a/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
+++ b/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
@@ -1,18 +1,18 @@
 import { ChevronDown, ChevronUp } from "@comet/admin-icons";
-import { ComponentsOverrides, Popover, PopoverProps, Theme, useTheme } from "@mui/material";
+import { ComponentsOverrides, Popover as MuiPopover, PopoverProps, Theme, useTheme } from "@mui/material";
 import { css, styled, useThemeProps } from "@mui/material/styles";
 import * as React from "react";
 
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { AppHeaderButton, AppHeaderButtonProps } from "../button/AppHeaderButton";
 
-export type AppHeaderDropdownClassKey = "root" | "popoverRoot";
+export type AppHeaderDropdownClassKey = "root" | "popover";
 
 export interface AppHeaderDropdownProps
     extends Omit<AppHeaderButtonProps, "children">,
         ThemedComponentBaseProps<{
             root: "div";
-            popoverRoot: typeof Popover;
+            popover: typeof Popover;
         }> {
     children?: ((closeDropdown: () => void) => React.ReactNode) | React.ReactNode;
     buttonChildren?: React.ReactNode;
@@ -34,11 +34,11 @@ const Root = styled("div", {
     `,
 );
 
-const PopoverRoot = styled(Popover, {
+const Popover = styled(MuiPopover, {
     name: "CometAdminAppHeaderDropdown",
-    slot: "popoverRoot",
+    slot: "popover",
     overridesResolver(_, styles) {
-        return [styles.popoverRoot];
+        return [styles.popover];
     },
 })();
 
@@ -89,8 +89,8 @@ export function AppHeaderDropdown(inProps: AppHeaderDropdownProps) {
             <AppHeaderButton endIcon={dropdownArrow !== null ? dropdownArrow(_open) : undefined} {...restProps} onClick={() => _onOpenChange(true)}>
                 {buttonChildren}
             </AppHeaderButton>
-            <PopoverRoot
-                {...slotProps?.popoverRoot}
+            <Popover
+                {...slotProps?.popover}
                 open={_open}
                 anchorEl={rootRef.current}
                 anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
@@ -105,7 +105,7 @@ export function AppHeaderDropdown(inProps: AppHeaderDropdownProps) {
                 {...popoverProps}
             >
                 {typeof children === "function" ? children(() => _onOpenChange(false)) : children}
-            </PopoverRoot>
+            </Popover>
         </Root>
     );
 }

--- a/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
+++ b/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
@@ -112,7 +112,7 @@ export function AppHeaderDropdown(inProps: AppHeaderDropdownProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminAppHeaderDropdown: Partial<AppHeaderDropdownProps>;
+        CometAdminAppHeaderDropdown: AppHeaderDropdownProps;
     }
 
     interface ComponentNameToClassKey {


### PR DESCRIPTION
COM-292

Styling is refactored for `AppHeaderDropdown`.

<details><summary>Demo Video of `AppHeaderDropdown`</summary>
<p>

https://github.com/vivid-planet/comet/assets/122883866/b5e2b3d4-1374-459c-813e-8c960490a1f9

</p>
</details> 

- [x] Add changeset (if necessary)