### PR TITLE
Return newly uploaded items from `useDamFileUpload#uploadFiles`

### DIFF
--- a/.changeset/olive-weeks-yawn.md
+++ b/.changeset/olive-weeks-yawn.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Return newly uploaded items from `useDamFileUpload#uploadFiles`

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/FileUploadContext.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/FileUploadContext.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 
+import { FileWithFolderPath } from "./useDamFileUpload";
+
 export interface NewlyUploadedItem {
     id: string;
     parentId?: string;
     type: "file" | "folder";
+    file?: FileWithFolderPath;
 }
 
 interface FileUploadContextApi {

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
@@ -34,7 +34,7 @@ interface FileWithPath extends File {
     path?: string;
 }
 
-interface FileWithFolderPath extends FileWithPath {
+export interface FileWithFolderPath extends FileWithPath {
     folderPath?: string;
 }
 
@@ -55,7 +55,10 @@ interface UploadFilesOptions {
 }
 
 export interface FileUploadApi {
-    uploadFiles: ({ acceptedFiles, fileRejections }: Files, { folderId, importSource }: UploadFilesOptions) => Promise<void>;
+    uploadFiles: (
+        { acceptedFiles, fileRejections }: Files,
+        { folderId, importSource }: UploadFilesOptions,
+    ) => Promise<{ hasError: boolean; rejectedFiles: RejectedFile[]; uploadedItems: NewlyUploadedItem[] }>;
     validationErrors?: FileUploadValidationError[];
     maxFileSizeInBytes: number;
     dialogs: React.ReactNode;
@@ -70,6 +73,10 @@ export interface FileUploadApi {
 export interface FileUploadValidationError {
     file: Pick<FileWithFolderPath, "name" | "path">;
     message: React.ReactNode;
+}
+
+interface RejectedFile {
+    file: FileWithFolderPath;
 }
 
 const addFolderPathToFiles = async (acceptedFiles: FileWithPath[]): Promise<FileWithFolderPath[]> => {
@@ -358,17 +365,22 @@ export const useDamFileUpload = (options: UploadDamFileOptions): FileUploadApi =
         [manualDuplicatedFilenamesHandler],
     );
 
-    const uploadFiles = async ({ acceptedFiles, fileRejections }: Files, { folderId, importSource }: UploadFilesOptions): Promise<void> => {
+    const uploadFiles = async (
+        { acceptedFiles, fileRejections }: Files,
+        { folderId, importSource }: UploadFilesOptions,
+    ): Promise<{ hasError: boolean; rejectedFiles: RejectedFile[]; uploadedItems: NewlyUploadedItem[] }> => {
         setProgressDialogOpen(true);
         setValidationErrors(undefined);
 
         const uploadedFolders: Array<NewlyUploadedItem & { type: "folder" }> = [];
         const uploadedFiles: Array<NewlyUploadedItem & { type: "file" }> = [];
+        const rejectedFiles: Array<RejectedFile> = [];
 
         let errorOccurred = false;
         if (fileRejections.length > 0) {
             errorOccurred = true;
             generateValidationErrorsForRejectedFiles(fileRejections);
+            rejectedFiles.push(...fileRejections);
         }
 
         if (acceptedFiles.length > 0) {
@@ -415,7 +427,7 @@ export const useDamFileUpload = (options: UploadDamFileOptions): FileUploadApi =
                         },
                     );
 
-                    uploadedFiles.push({ id: response.data.id, parentId: targetFolderId, type: "file" });
+                    uploadedFiles.push({ id: response.data.id, parentId: targetFolderId, type: "file", file });
                 } catch (err) {
                     errorOccurred = true;
                     const typedErr = err as AxiosError<{ error: string; message: string; statusCode: number }>;
@@ -442,6 +454,8 @@ export const useDamFileUpload = (options: UploadDamFileOptions): FileUploadApi =
                     } else {
                         addValidationError(file, <UnknownError />);
                     }
+
+                    rejectedFiles.push({ file });
                 }
             }
 
@@ -457,6 +471,8 @@ export const useDamFileUpload = (options: UploadDamFileOptions): FileUploadApi =
         setUploadedSizes({});
 
         addNewlyUploadedItems([...uploadedFolders, ...uploadedFiles]);
+
+        return { hasError: errorOccurred, rejectedFiles: rejectedFiles, uploadedItems: [...uploadedFolders, ...uploadedFiles] };
     };
 
     return {

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
@@ -76,7 +76,7 @@ export interface FileUploadValidationError {
 }
 
 interface RejectedFile {
-    file: FileWithFolderPath;
+    file: File;
 }
 
 const addFolderPathToFiles = async (acceptedFiles: FileWithPath[]): Promise<FileWithFolderPath[]> => {
@@ -380,7 +380,7 @@ export const useDamFileUpload = (options: UploadDamFileOptions): FileUploadApi =
         if (fileRejections.length > 0) {
             errorOccurred = true;
             generateValidationErrorsForRejectedFiles(fileRejections);
-            rejectedFiles.push(...fileRejections);
+            rejectedFiles.push(...fileRejections.map(({ errors, ...rejection }) => rejection));
         }
 
         if (acceptedFiles.length > 0) {


### PR DESCRIPTION
I'm not sure why we didn't return this in the first place, but I think it was just because it wasn't needed at the moment. But for some use cases it can be convenient to have the items returned directly.


https://github.com/vivid-planet/comet/assets/13380047/75419547-10a0-4173-8717-a4f7d1335958


