### PR TITLE
COM-291: Fix the type of the `component` prop on `styled(Typography)`

### DIFF
--- a/packages/admin/admin/src/appHeader/button/AppHeaderButton.styles.tsx
+++ b/packages/admin/admin/src/appHeader/button/AppHeaderButton.styles.tsx
@@ -75,4 +75,4 @@ export const Text = styled(Typography, {
     overridesResolver(_, styles) {
         return [styles.typography];
     },
-})();
+})() as typeof Typography;

--- a/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
+++ b/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
@@ -10,7 +10,7 @@ export interface AppHeaderButtonProps
         ThemedComponentBaseProps<{
             root: typeof ButtonBase;
             content: "div";
-            typography: typeof Typography;
+            typography: typeof Typography<"div">;
             startIcon: "div";
             endIcon: "div";
         }> {
@@ -33,7 +33,6 @@ export function AppHeaderButton(inProps: AppHeaderButtonProps) {
                     (disableTypography ? (
                         children
                     ) : (
-                        // @ts-expect-error TODO
                         <Text component="div" {...slotProps?.typography}>
                             {children}
                         </Text>


### PR DESCRIPTION
See: https://mui.com/material-ui/guides/typescript/#complications-with-the-component-prop