### PR TITLE
Remove supported blocks and inline styles from blacklist

### DIFF
--- a/.changeset/plenty-dots-exist.md
+++ b/.changeset/plenty-dots-exist.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-rte": patch
+---
+
+Retain headings 4 - 6, blockquote and strikethrough formatting when copying from one RTE to another

--- a/packages/admin/admin-rte/src/core/filterEditor/removeUnsupportedBlockTypes.ts
+++ b/packages/admin/admin-rte/src/core/filterEditor/removeUnsupportedBlockTypes.ts
@@ -5,7 +5,7 @@ import changeBlockType from "./utils/changeBlockType";
 
 const removeUnsupportedBlockTypes: FilterEditorStateBeforeUpdateFn = (newState, { supports, standardBlockType }) => {
     // unstyle all core-blocks which are not supported
-    const blackListBlocks: DraftBlockType[] = ["paragraph", "header-four", "header-five", "header-six", "blockquote", "code-block", "atomic"]; // these are not supported at all by our rte
+    const blackListBlocks: DraftBlockType[] = ["paragraph", "code-block", "atomic"]; // these are not supported at all by our rte
 
     const supportsToBlockMap: Partial<Record<SupportedThings, DraftBlockType>> = {
         "header-one": "header-one",

--- a/packages/admin/admin-rte/src/core/filterEditor/removeUnsupportedInlineStyles.ts
+++ b/packages/admin/admin-rte/src/core/filterEditor/removeUnsupportedInlineStyles.ts
@@ -4,7 +4,7 @@ import removeInlineStyles from "./utils/removeInlineStyles";
 
 const removeUnsupportedInlineStyles: FilterEditorStateBeforeUpdateFn = (newState, { supports }) => {
     // unstyle all core-blocks which are not supported
-    const blackListInlineStyles: InlineStyleType[] = ["STRIKETHROUGH", "CODE"]; // these are not supported at all by our rte
+    const blackListInlineStyles: InlineStyleType[] = ["CODE"]; // these are not supported at all by our rte
 
     const supportsToInlineStyleMap: Partial<Record<SupportedThings, InlineStyleType>> = {
         bold: "BOLD",


### PR DESCRIPTION
## Problem 

Headings 4 - 6, blockquote and strikethrough formatting was lost when copying from one RTE to another.


https://github.com/vivid-planet/comet/assets/13380047/c9195363-0081-4bf1-ab56-7f93281c97c7



### Reason

These blocks / inline styles where added to the blacklist when they weren't supported yet (https://github.com/vivid-planet/comet/pull/200). Later when they were added, they weren't removed from the blacklist (https://github.com/vivid-planet/comet/pull/212). I suppose it was simply forgotten.

## Now


https://github.com/vivid-planet/comet/assets/13380047/555a2a55-61d0-43c6-89dd-484edb7ec0d4

---

Closes COM-361