### PR TITLE
Add eslint rule to enforce PascalCase for enums

### DIFF
--- a/.changeset/nice-years-wash.md
+++ b/.changeset/nice-years-wash.md
@@ -1,0 +1,5 @@
+---
+"@comet/eslint-plugin": minor
+---
+
+Add new eslint rule `pascal-case-enums` that enforces using PascalCase for enums

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -12,6 +12,9 @@
         "test": "jest",
         "test:watch": "jest --watch"
     },
+    "dependencies": {
+        "change-case": "^4.1.2"
+    },
     "devDependencies": {
         "@types/eslint": "^8.37.0",
         "@types/jest": "^27.0.2",

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,10 +1,12 @@
 import noOtherModuleRelativeImport from "./rules/no-other-module-relative-import";
 import noPrivateSiblingImport from "./rules/no-private-sibling-import";
+import pascalCaseEnums from "./rules/pascal-case-enums";
 
 const plugin = {
     rules: {
         "no-private-sibling-import": noPrivateSiblingImport,
         "no-other-module-relative-import": noOtherModuleRelativeImport,
+        "pascal-case-enums": pascalCaseEnums,
     },
 };
 export type Plugin = typeof plugin;

--- a/packages/eslint-plugin/src/rules/pascal-case-enums.test.ts
+++ b/packages/eslint-plugin/src/rules/pascal-case-enums.test.ts
@@ -1,0 +1,103 @@
+import { RuleTester } from "eslint";
+
+import pascalCaseEnums from "./pascal-case-enums";
+
+const ruleTester = new RuleTester({
+    parser: require.resolve("@typescript-eslint/parser"),
+});
+
+const validCode = 'enum ProductVariant {  LightBlue = "LightBlue",}';
+
+ruleTester.run("pascal-case-enums", pascalCaseEnums, {
+    valid: [
+        {
+            code: validCode,
+        },
+    ],
+    invalid: [
+        // TSEnumDeclaration > Identifier
+        {
+            code: 'enum productVariant {  LightBlue = "LightBlue",}',
+            output: validCode,
+            errors: [
+                {
+                    message: "Enum name should be PascalCase, is: productVariant, expected: ProductVariant",
+                },
+            ],
+        },
+        {
+            code: 'enum PRODUCT_VARIANT {  LightBlue = "LightBlue",}',
+            output: validCode,
+            errors: [
+                {
+                    message: "Enum name should be PascalCase, is: PRODUCT_VARIANT, expected: ProductVariant",
+                },
+            ],
+        },
+        {
+            code: 'enum product_variant {  LightBlue = "LightBlue",}',
+            output: validCode,
+            errors: [
+                {
+                    message: "Enum name should be PascalCase, is: product_variant, expected: ProductVariant",
+                },
+            ],
+        },
+        // TSEnumMember > Identifier
+        {
+            code: 'enum ProductVariant {  lightBlue = "LightBlue",}',
+            output: validCode,
+            errors: [
+                {
+                    message: "Enum member name should be PascalCase, is: lightBlue, expected: LightBlue",
+                },
+            ],
+        },
+        {
+            code: 'enum ProductVariant {  LIGHT_BLUE = "LightBlue",}',
+            output: validCode,
+            errors: [
+                {
+                    message: "Enum member name should be PascalCase, is: LIGHT_BLUE, expected: LightBlue",
+                },
+            ],
+        },
+        {
+            code: 'enum ProductVariant {  light_blue = "LightBlue",}',
+            output: validCode,
+            errors: [
+                {
+                    message: "Enum member name should be PascalCase, is: light_blue, expected: LightBlue",
+                },
+            ],
+        },
+        // TSEnumMember > Literal
+        {
+            code: 'enum ProductVariant {  LightBlue = "lightBlue",}',
+            output: validCode,
+            errors: [
+                {
+                    message: "Enum member literal should be PascalCase, is: lightBlue, expected: LightBlue",
+                },
+            ],
+        },
+        {
+            code: 'enum ProductVariant {  LightBlue = "LIGHT_BLUE",}',
+            output: validCode,
+            errors: [
+                {
+                    message: "Enum member literal should be PascalCase, is: LIGHT_BLUE, expected: LightBlue",
+                },
+            ],
+        },
+        {
+            code: 'enum ProductVariant {  LightBlue = "light_blue",}',
+            output: validCode,
+            errors: [
+                {
+                    message: "Enum member literal should be PascalCase, is: light_blue, expected: LightBlue",
+                },
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin/src/rules/pascal-case-enums.ts
+++ b/packages/eslint-plugin/src/rules/pascal-case-enums.ts
@@ -1,0 +1,75 @@
+import { pascalCase } from "change-case";
+import { Rule } from "eslint";
+
+export default {
+    meta: {
+        type: "layout",
+        docs: {
+            description: "Enforce PascalCase for enum names",
+        },
+        fixable: "code",
+        messages: {
+            pascalCaseEnumDeclarationMessage: "Enum name should be PascalCase, is: {{name}}, expected: {{pascalCaseName}}",
+            pascalCaseEnumMemberMessage: "Enum member name should be PascalCase, is: {{name}}, expected: {{pascalCaseName}}",
+            pascalCaseEnumMemberLiteralMessage: "Enum member literal should be PascalCase, is: {{name}}, expected: {{pascalCaseName}}",
+        },
+    },
+    create(context) {
+        return {
+            "TSEnumDeclaration > Identifier": (identifier) => {
+                const name = identifier.name;
+                const pascalCaseName = pascalCase(name);
+
+                if (name !== pascalCaseName) {
+                    context.report({
+                        node: identifier,
+                        messageId: "pascalCaseEnumDeclarationMessage",
+                        data: {
+                            name,
+                            pascalCaseName,
+                        },
+                        fix: function (fixer) {
+                            return fixer.replaceText(identifier, pascalCaseName);
+                        },
+                    });
+                }
+            },
+            "TSEnumMember > Identifier": (identifier) => {
+                const name = identifier.name;
+                const pascalCaseName = pascalCase(name);
+
+                if (name !== pascalCaseName) {
+                    context.report({
+                        node: identifier,
+                        messageId: "pascalCaseEnumMemberMessage",
+                        data: {
+                            name,
+                            pascalCaseName,
+                        },
+                        fix: function (fixer) {
+                            return fixer.replaceText(identifier, pascalCaseName);
+                        },
+                    });
+                }
+            },
+            "TSEnumMember > Literal": (literal) => {
+                const value = literal.value;
+                const pascalCaseValue = pascalCase(value);
+
+                if (value !== pascalCaseValue) {
+                    context.report({
+                        node: literal,
+                        messageId: "pascalCaseEnumMemberLiteralMessage",
+                        data: {
+                            name: value,
+                            pascalCaseName: pascalCaseValue,
+                        },
+                        fix: function (fixer) {
+                            return fixer.replaceText(literal, literal.raw.replace(value, pascalCaseValue));
+                        },
+                    });
+                }
+            },
+        };
+    },
+} as Rule.RuleModule;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2721,6 +2721,10 @@ importers:
         version: 4.9.4
 
   packages/eslint-plugin:
+    dependencies:
+      change-case:
+        specifier: ^4.1.2
+        version: 4.1.2
     devDependencies:
       '@types/eslint':
         specifier: ^8.37.0
@@ -17043,7 +17047,6 @@ packages:
       no-case: 3.0.4
       tslib: 2.4.1
       upper-case-first: 2.0.2
-    dev: true
 
   /capture-exit@2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -17138,7 +17141,6 @@ packages:
       sentence-case: 3.0.4
       snake-case: 3.0.4
       tslib: 2.4.1
-    dev: true
 
   /change-case@5.2.0:
     resolution: {integrity: sha512-L6VzznESnMIKKdKhVzCG+KPz4+x1FWbjOs1AdhoHStV3qo8aySMRGPUoqC0aL1ThKaQNGhAu6ZfHL/QAyQRuiw==}
@@ -17670,7 +17672,6 @@ packages:
       no-case: 3.0.4
       tslib: 2.4.1
       upper-case: 2.0.2
-    dev: true
 
   /constants-browserify@1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
@@ -21645,7 +21646,6 @@ packages:
     dependencies:
       capital-case: 1.0.4
       tslib: 2.4.1
-    dev: true
 
   /headers-utils@3.0.2:
     resolution: {integrity: sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==}
@@ -25881,7 +25881,6 @@ packages:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.4.1
-    dev: true
 
   /path-dirname@1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
@@ -28588,7 +28587,6 @@ packages:
       no-case: 3.0.4
       tslib: 2.4.1
       upper-case-first: 2.0.2
-    dev: true
 
   /serialize-javascript@4.0.0:
     resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
@@ -28875,7 +28873,6 @@ packages:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.4.1
-    dev: true
 
   /snapdragon-node@2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -30836,13 +30833,11 @@ packages:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
       tslib: 2.4.1
-    dev: true
 
   /upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
       tslib: 2.4.1
-    dev: true
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}


### PR DESCRIPTION
Add new eslint rule `pascal-case-enums` that enforces using PascalCase for enums

---

Closes COM-378