### PR TITLE
Remove 'Edit content' from PageTree context menu

### DIFF
--- a/packages/admin/cms-admin/src/pages/pageTree/PageActions.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageActions.tsx
@@ -86,15 +86,6 @@ export default function PageActions({ page, editDialog, children, siteUrl }: Pro
                 <RowActionsMenu>
                     {page.visibility !== "Archived" && [
                         <RowActionsItem
-                            key="edit"
-                            icon={<Edit />}
-                            onClick={() => {
-                                stackSwitchApi.activatePage("edit", String(page.id));
-                            }}
-                        >
-                            <FormattedMessage id="comet.pages.pages.page.editContent" defaultMessage="Edit content" />
-                        </RowActionsItem>,
-                        <RowActionsItem
                             key="pageProperties"
                             icon={<Settings />}
                             onClick={() => {


### PR DESCRIPTION
'Edit content' existed twice:

- outside the context menu as an icon
   
<img width="137" alt="Bildschirmfoto 2024-01-29 um 16 17 10" src="https://github.com/vivid-planet/comet/assets/13380047/6bff6fd2-4779-4e69-81ce-990dcc9fabd9">

- inside the context menu

I removed the option from the context menu, since it's unnecessary

---

Before:

<img width="237" alt="Bildschirmfoto 2024-01-29 um 16 15 17" src="https://github.com/vivid-planet/comet/assets/13380047/9ad7e181-41bb-4407-b203-c0fd71647903">


After:

<img width="233" alt="Bildschirmfoto 2024-01-29 um 16 15 01" src="https://github.com/vivid-planet/comet/assets/13380047/26bc965d-fb87-4cd0-b524-e730f76aef13">

---

Closes COM-373