### PR TITLE
Remove 'Duplicate' from PageTree context menu

### DIFF
--- a/packages/admin/cms-admin/src/pages/pageTree/CopyPasteMenuItem.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/CopyPasteMenuItem.tsx
@@ -41,17 +41,6 @@ export const CopyPasteMenuItem = ({ page }: Props): React.ReactElement => {
             >
                 <FormattedMessage id="comet.pages.pages.page.paste" defaultMessage="Paste" />
             </RowActionsItem>
-            <RowActionsItem
-                icon={<Copy />}
-                onClick={async () => {
-                    const subTree = subTreeFromNode(page, tree);
-                    const pagesAsArray = treeMapToArray(subTree, "root");
-                    const pages = await prepareForClipboard(pagesAsArray);
-                    await sendPages(page.parentId, pages, { targetPos: page.pos + 1 });
-                }}
-            >
-                <FormattedMessage id="comet.pageTree.duplicate" defaultMessage="Duplicate" />
-            </RowActionsItem>
         </>
     );
 };


### PR DESCRIPTION
We decided to retire the duplicate pattern because

- it adds additional complexity
- the same thing can be achieved via copy/paste with little additional effort

so I removed the duplicate option from the PageTree

Duplicate only existed in the context menu. It was apparently never possible to duplicate the selected items.

---

Before:

<img width="240" alt="Bildschirmfoto 2024-01-29 um 16 24 53" src="https://github.com/vivid-planet/comet/assets/13380047/774fdb11-a39f-4a3f-aa19-afd84ed79cf6">


After:

<img width="220" alt="Bildschirmfoto 2024-01-29 um 16 24 36" src="https://github.com/vivid-planet/comet/assets/13380047/90d738a8-9790-4df3-a591-b107a8988392">


---

Closes COM-367