### PR TITLE
PascalCase for enums with @typescript-eslint

### DIFF
--- a/.changeset/beige-chefs-confess.md
+++ b/.changeset/beige-chefs-confess.md
@@ -1,0 +1,40 @@
+---
+"@comet/eslint-config": major
+---
+
+Enforce PascalCase for enums
+
+Changing the casing of an existing enum can be problematic, e.g. if the enum values are persisted in the database. 
+In such cases, the rule can be disabled like so
+
+```diff
++ /* eslint-disable @typescript-eslint/naming-convention */
+  export enum ExampleEnum {
+      attr1 = "attr1",
+  }
++ /* eslint-enable @typescript-eslint/naming-convention */
+```
+
+You can also "disable" the rule in your whole project by overriding it and allowing multiple casings:
+
+```json 
+// .eslintrc.json
+"overrides": [
+    {
+        "files": ["*.ts", "*.tsx"],
+        "rules": {
+            "@typescript-eslint/naming-convention": [
+                "error",
+                {
+                    "selector": "enum",
+                    "format": ["PascalCase", "camelCase", "UPPER_CASE"]
+                },
+                {
+                    "selector": "enumMember",
+                    "format": ["PascalCase", "camelCase", "UPPER_CASE"]
+                }
+            ]
+        }
+    }
+]
+```

--- a/.changeset/beige-chefs-confess.md
+++ b/.changeset/beige-chefs-confess.md
@@ -4,7 +4,7 @@
 
 Enforce PascalCase for enums
 
-Changing the casing of an existing enum can be problematic, e.g. if the enum values are persisted in the database. 
+Changing the casing of an existing enum can be problematic, e.g., if the enum values are persisted in the database. 
 In such cases, the rule can be disabled like so
 
 ```diff
@@ -13,28 +13,4 @@ In such cases, the rule can be disabled like so
       attr1 = "attr1",
   }
 + /* eslint-enable @typescript-eslint/naming-convention */
-```
-
-You can also "disable" the rule in your whole project by overriding it and allowing multiple casings:
-
-```json 
-// .eslintrc.json
-"overrides": [
-    {
-        "files": ["*.ts", "*.tsx"],
-        "rules": {
-            "@typescript-eslint/naming-convention": [
-                "error",
-                {
-                    "selector": "enum",
-                    "format": ["PascalCase", "camelCase", "UPPER_CASE"]
-                },
-                {
-                    "selector": "enumMember",
-                    "format": ["PascalCase", "camelCase", "UPPER_CASE"]
-                }
-            ]
-        }
-    }
-]
 ```

--- a/.changeset/chilled-walls-shop.md
+++ b/.changeset/chilled-walls-shop.md
@@ -1,0 +1,21 @@
+---
+"@comet/eslint-config": major
+---
+
+Add the rule `@typescript-eslint/prefer-enum-initializers` to require enum initializers
+
+```ts
+// ✅
+enum ExampleEnum {
+    One = "One",
+    Two = "Two"
+}
+```
+
+```ts
+// ❌
+enum ExampleEnum {
+    One,
+    Two
+}
+```

--- a/demo/api/src/news/generated/dto/news.sort.ts
+++ b/demo/api/src/news/generated/dto/news.sort.ts
@@ -4,6 +4,8 @@ import { SortDirection } from "@comet/cms-api";
 import { Field, InputType, registerEnumType } from "@nestjs/graphql";
 import { IsEnum } from "class-validator";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum NewsSortField {
     slug = "slug",
     title = "title",
@@ -13,6 +15,7 @@ export enum NewsSortField {
     createdAt = "createdAt",
     updatedAt = "updatedAt",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(NewsSortField, {
     name: "NewsSortField",
 });

--- a/demo/api/src/products/generated/dto/manufacturer.sort.ts
+++ b/demo/api/src/products/generated/dto/manufacturer.sort.ts
@@ -4,6 +4,8 @@ import { SortDirection } from "@comet/cms-api";
 import { Field, InputType, registerEnumType } from "@nestjs/graphql";
 import { IsEnum } from "class-validator";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum ManufacturerSortField {
     addressAsEmbeddable_street = "addressAsEmbeddable_street",
     addressAsEmbeddable_streetNumber = "addressAsEmbeddable_streetNumber",
@@ -15,6 +17,7 @@ export enum ManufacturerSortField {
     addressAsEmbeddable_alternativeAddress_country = "addressAsEmbeddable_alternativeAddress_country",
     updatedAt = "updatedAt",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(ManufacturerSortField, {
     name: "ManufacturerSortField",
 });

--- a/demo/api/src/products/generated/dto/product-category.sort.ts
+++ b/demo/api/src/products/generated/dto/product-category.sort.ts
@@ -4,12 +4,15 @@ import { SortDirection } from "@comet/cms-api";
 import { Field, InputType, registerEnumType } from "@nestjs/graphql";
 import { IsEnum } from "class-validator";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum ProductCategorySortField {
     title = "title",
     slug = "slug",
     createdAt = "createdAt",
     updatedAt = "updatedAt",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(ProductCategorySortField, {
     name: "ProductCategorySortField",
 });

--- a/demo/api/src/products/generated/dto/product-tag.sort.ts
+++ b/demo/api/src/products/generated/dto/product-tag.sort.ts
@@ -4,11 +4,14 @@ import { SortDirection } from "@comet/cms-api";
 import { Field, InputType, registerEnumType } from "@nestjs/graphql";
 import { IsEnum } from "class-validator";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum ProductTagSortField {
     title = "title",
     createdAt = "createdAt",
     updatedAt = "updatedAt",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(ProductTagSortField, {
     name: "ProductTagSortField",
 });

--- a/demo/api/src/products/generated/dto/product-variant.sort.ts
+++ b/demo/api/src/products/generated/dto/product-variant.sort.ts
@@ -4,12 +4,15 @@ import { SortDirection } from "@comet/cms-api";
 import { Field, InputType, registerEnumType } from "@nestjs/graphql";
 import { IsEnum } from "class-validator";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum ProductVariantSortField {
     name = "name",
     product = "product",
     createdAt = "createdAt",
     updatedAt = "updatedAt",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(ProductVariantSortField, {
     name: "ProductVariantSortField",
 });

--- a/demo/api/src/products/generated/dto/product.sort.ts
+++ b/demo/api/src/products/generated/dto/product.sort.ts
@@ -4,6 +4,8 @@ import { SortDirection } from "@comet/cms-api";
 import { Field, InputType, registerEnumType } from "@nestjs/graphql";
 import { IsEnum } from "class-validator";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum ProductSortField {
     title = "title",
     status = "status",
@@ -19,6 +21,7 @@ export enum ProductSortField {
     updatedAt = "updatedAt",
     manufacturer = "manufacturer",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(ProductSortField, {
     name: "ProductSortField",
 });

--- a/packages/admin/admin/src/router/ConfirmationDialog.tsx
+++ b/packages/admin/admin/src/router/ConfirmationDialog.tsx
@@ -85,9 +85,9 @@ const DiscardButton = createComponentSlot(Button)<RouterConfirmationDialogClassK
 );
 
 export enum PromptAction {
-    Cancel,
-    Discard,
-    Save,
+    Cancel = "Cancel",
+    Discard = "Discard",
+    Save = "Save",
 }
 
 export interface RouterConfirmationDialogProps

--- a/packages/admin/cms-admin/src/preview/common/Device.ts
+++ b/packages/admin/cms-admin/src/preview/common/Device.ts
@@ -1,8 +1,10 @@
+/* eslint-disable @typescript-eslint/prefer-enum-initializers */
 enum Device {
     Responsive,
     Mobile,
     Tablet,
     Desktop,
 }
+/* eslint-enable @typescript-eslint/prefer-enum-initializers */
 
 export { Device };

--- a/packages/api/blocks-api/src/blocks/youtube-video.block.ts
+++ b/packages/api/blocks-api/src/blocks/youtube-video.block.ts
@@ -3,10 +3,13 @@ import { IsBoolean, IsEnum, IsOptional, IsString } from "class-validator";
 import { BlockData, BlockDataInterface, BlockInput, createBlock, inputToData } from "./block";
 import { BlockField } from "./decorators/field";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 enum AspectRatio {
     "16X9" = "16X9",
     "4X3" = "4X3",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 
 class YouTubeVideoBlockData extends BlockData {
     @BlockField()

--- a/packages/api/cms-api/src/blocks/createSeoBlock.ts
+++ b/packages/api/cms-api/src/blocks/createSeoBlock.ts
@@ -23,6 +23,8 @@ import { IsBoolean, IsEnum, IsJSON, IsOptional, IsString, IsUrl, ValidateNested 
 
 import { PixelImageBlock } from "./PixelImageBlock";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum SitemapPagePriority {
     _0_0 = "0_0",
     _0_1 = "0_1",
@@ -36,7 +38,10 @@ export enum SitemapPagePriority {
     _0_9 = "0_9",
     _1_0 = "1_0",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum SitemapPageChangeFrequency {
     "always" = "always",
     "hourly" = "hourly",
@@ -46,6 +51,7 @@ export enum SitemapPageChangeFrequency {
     "yearly" = "yearly",
     "never" = "never",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 
 interface CreateSeoBlockOptions<ImageBlock extends Block> {
     image?: ImageBlock;

--- a/packages/api/cms-api/src/dam/files/entities/license.embeddable.ts
+++ b/packages/api/cms-api/src/dam/files/entities/license.embeddable.ts
@@ -1,10 +1,13 @@
 import { Embeddable, Enum, Property } from "@mikro-orm/core";
 import { Field, ObjectType, registerEnumType } from "@nestjs/graphql";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum LicenseType {
     ROYALTY_FREE = "ROYALTY_FREE",
     RIGHTS_MANAGED = "RIGHTS_MANAGED",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(LicenseType, { name: "LicenseType" });
 
 @ObjectType("DamFileLicense")

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -255,6 +255,8 @@ function generateSortDto({ generatorOptions, metadata }: { generatorOptions: Cru
     import { Type } from "class-transformer";
     import { IsEnum } from "class-validator";
 
+    /* eslint-disable @typescript-eslint/naming-convention */
+    // TODO: Replace with PascalCase
     export enum ${classNameSingular}SortField {
         ${crudSortProps
             .map((prop) => {
@@ -262,6 +264,7 @@ function generateSortDto({ generatorOptions, metadata }: { generatorOptions: Cru
             })
             .join("\n")}
     }
+    /* eslint-enable @typescript-eslint/naming-convention */
     registerEnumType(${classNameSingular}SortField, {
         name: "${classNameSingular}SortField",
     });

--- a/packages/api/cms-api/src/kubernetes/job-status.enum.ts
+++ b/packages/api/cms-api/src/kubernetes/job-status.enum.ts
@@ -1,10 +1,12 @@
 import { registerEnumType } from "@nestjs/graphql";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum KubernetesJobStatus {
     "pending" = "pending",
     "active" = "active",
     "succeeded" = "succeeded",
     "failed" = "failed",
 }
-
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(KubernetesJobStatus, { name: "KubernetesJobStatus" });

--- a/packages/api/cms-api/src/page-tree/dto/page-tree-node.sort.ts
+++ b/packages/api/cms-api/src/page-tree/dto/page-tree-node.sort.ts
@@ -3,10 +3,13 @@ import { IsEnum } from "class-validator";
 
 import { SortDirection } from "../../common/sorting/sort-direction.enum";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum PageTreeNodeSortField {
     updatedAt = "updatedAt",
     pos = "pos",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(PageTreeNodeSortField, {
     name: "PageTreeNodeSortField",
 });

--- a/packages/api/cms-api/src/redirects/dto/redirect.sort.ts
+++ b/packages/api/cms-api/src/redirects/dto/redirect.sort.ts
@@ -3,11 +3,14 @@ import { IsEnum } from "class-validator";
 
 import { SortDirection } from "../../common/sorting/sort-direction.enum";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum RedirectSortField {
     source = "source",
     createdAt = "createdAt",
     updatedAt = "updatedAt",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(RedirectSortField, {
     name: "RedirectSortField",
 });

--- a/packages/api/cms-api/src/redirects/redirects.enum.ts
+++ b/packages/api/cms-api/src/redirects/redirects.enum.ts
@@ -1,13 +1,18 @@
 import { registerEnumType } from "@nestjs/graphql";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum RedirectSourceTypeValues {
     "path" = "path",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(RedirectSourceTypeValues, { name: "RedirectSourceTypeValues" });
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum RedirectGenerationType {
     "manual" = "manual",
     "automatic" = "automatic",
 }
-
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(RedirectGenerationType, { name: "RedirectGenerationType" });

--- a/packages/api/cms-api/src/user-permissions/dto/paginated-user-list.ts
+++ b/packages/api/cms-api/src/user-permissions/dto/paginated-user-list.ts
@@ -39,12 +39,15 @@ class UserFilter {
     or?: UserFilter[];
 }
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 enum UserSortField {
     name = "name",
     email = "email",
     status = "status",
     locale = "locale",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(UserSortField, {
     name: "UserSortField",
 });

--- a/packages/api/cms-api/src/user-permissions/entities/user-permission.entity.ts
+++ b/packages/api/cms-api/src/user-permissions/entities/user-permission.entity.ts
@@ -5,10 +5,13 @@ import { v4 } from "uuid";
 
 import { ContentScope } from "../interfaces/content-scope.interface";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum UserPermissionSource {
     MANUAL = "MANUAL",
     BY_RULE = "BY_RULE",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 registerEnumType(UserPermissionSource, {
     name: "UserPermissionSource",
 });

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -6,10 +6,13 @@ import { User } from "./dto/user";
 import { UserPermission } from "./entities/user-permission.entity";
 import { ContentScope } from "./interfaces/content-scope.interface";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+// TODO: Replace with PascalCase
 export enum UserPermissions {
     allContentScopes = "all-content-scopes",
     allPermissions = "all-permissions",
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export type Users = [User[], number];
 

--- a/packages/eslint-config/core.js
+++ b/packages/eslint-config/core.js
@@ -15,6 +15,9 @@ module.exports = {
         "import/no-duplicates": "error",
         "import/newline-after-import": "error",
     },
+    parserOptions: {
+        project: true,
+    },
     overrides: [
         {
             files: ["*.ts", "*.tsx"],
@@ -24,6 +27,18 @@ module.exports = {
             rules: {
                 "@typescript-eslint/no-unused-vars": ["error", { args: "none", ignoreRestSiblings: true }],
                 "@typescript-eslint/no-inferrable-types": ["error", { ignoreProperties: true }],
+                "@typescript-eslint/naming-convention": [
+                    "error",
+                    {
+                        selector: "enum",
+                        format: ["PascalCase"]
+                    },
+                    {
+                        selector: "enumMember",
+                        format: ["PascalCase"]
+                    }
+                ],
+                "@typescript-eslint/prefer-enum-initializers": "error"
             },
         },
     ],

--- a/packages/eslint-config/nestjs.js
+++ b/packages/eslint-config/nestjs.js
@@ -21,6 +21,8 @@ module.exports = {
                         format: ["PascalCase"],
                         custom: { regex: "^I[A-Z]", match: false },
                     },
+                    { selector: "enum", format: ["PascalCase"] },
+                    { selector: "enumMember", format: ["PascalCase"] }
                 ],
             },
         },


### PR DESCRIPTION
- Enforce PascalCase for enums using `@typescript-eslint/naming-convention`
- Add the rule `@typescript-eslint/prefer-enum-initializers` to require enum initializers

---

Changing the casing of an existing enum can be problematic, e.g. if the enum values are persisted in the database. 
In such cases, the rule can be disabled like so

```diff
+ /* eslint-disable @typescript-eslint/naming-convention */
  export enum ExampleEnum {
      attr1 = "attr1",
  }
+ /* eslint-enable @typescript-eslint/naming-convention */
```

You can also "disable" the rule in your whole project by overriding it and allowing multiple casings:

```json 
// .eslintrc.json
"overrides": [
    {
        "files": ["*.ts", "*.tsx"],
        "rules": {
            "@typescript-eslint/naming-convention": [
                "error",
                {
                    "selector": "enum",
                    "format": ["PascalCase", "camelCase", "UPPER_CASE"]
                },
                {
                    "selector": "enumMember",
                    "format": ["PascalCase", "camelCase", "UPPER_CASE"]
                }
            ]
        }
    }
]
```

---

COM-378