### PR TITLE
Don't run lint workflow on PR `closed` event

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,6 @@ on:
             - opened
             - synchronize
             - reopened
-            - closed
     push:
         branches:
             - main


### PR DESCRIPTION
Results in runs for closed PRs (actual close, no merge) and duplicate runs for merged PRs (closed + push on main).