### PR TITLE
COM-294: Refactor theming of `AppHeaderMenuButton`

### DIFF
--- a/packages/admin/admin/src/appHeader/menuButton/AppHeaderMenuButton.tsx
+++ b/packages/admin/admin/src/appHeader/menuButton/AppHeaderMenuButton.tsx
@@ -1,6 +1,5 @@
 import { HamburgerClose, HamburgerOpen } from "@comet/admin-icons";
-import { ComponentsOverrides, IconButton, IconButtonClassKey, IconButtonProps, Theme } from "@mui/material";
-import { createStyles, WithStyles, withStyles } from "@mui/styles";
+import { ComponentsOverrides, css, IconButton, IconButtonClassKey, IconButtonProps, styled, Theme, useThemeProps } from "@mui/material";
 import * as React from "react";
 
 import { MenuContext } from "../../mui/menu/Context";
@@ -9,44 +8,32 @@ export type AppHeaderMenuButtonProps = IconButtonProps;
 
 export type AppHeaderMenuButtonClassKey = IconButtonClassKey;
 
-const styles = ({ spacing }: Theme) => {
-    return createStyles<AppHeaderMenuButtonClassKey, AppHeaderMenuButtonProps>({
-        root: {
-            color: "#fff",
-            marginLeft: spacing(2),
-            marginRight: spacing(2),
-        },
-        edgeStart: {},
-        edgeEnd: {},
-        colorInherit: {},
-        colorPrimary: {},
-        colorSecondary: {},
-        disabled: {},
-        sizeSmall: {},
-        sizeMedium: {},
-        sizeLarge: {},
-        colorError: {},
-        colorInfo: {},
-        colorSuccess: {},
-        colorWarning: {},
-    });
-};
-
-function MenuButton({ children, classes, ...restProps }: AppHeaderMenuButtonProps & WithStyles<typeof styles>): React.ReactElement {
+export const AppHeaderMenuButton = (inProps: AppHeaderMenuButtonProps) => {
+    const { children: propChildren, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminAppHeaderMenuButton" });
     const { toggleOpen, open } = React.useContext(MenuContext);
-    if (!children) {
-        children = open ? <HamburgerClose fontSize="large" /> : <HamburgerOpen fontSize="large" />;
-    }
+
+    const children = !propChildren ? open ? <HamburgerClose fontSize="large" /> : <HamburgerOpen fontSize="large" /> : propChildren;
 
     return (
-        <IconButton classes={classes} onClick={toggleOpen} {...restProps} size="large">
+        <Root onClick={toggleOpen} {...restProps} size="large">
             {children}
-        </IconButton>
+        </Root>
     );
-}
+};
 
-export const AppHeaderMenuButton = withStyles(styles, { name: "CometAdminAppHeaderMenuButton" })(MenuButton);
-
+const Root = styled(IconButton, {
+    name: "CometAdminAppHeaderMenuButton",
+    slot: "root",
+    overridesResolver(_, styles) {
+        return [styles.root];
+    },
+})(
+    ({ theme }) => css`
+        color: #fff;
+        margin-left: ${theme.spacing(2)};
+        margin-right: ${theme.spacing(2)};
+    `,
+);
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
         CometAdminAppHeaderMenuButton: AppHeaderMenuButtonClassKey;

--- a/packages/admin/admin/src/appHeader/menuButton/AppHeaderMenuButton.tsx
+++ b/packages/admin/admin/src/appHeader/menuButton/AppHeaderMenuButton.tsx
@@ -15,7 +15,7 @@ export const AppHeaderMenuButton = (inProps: AppHeaderMenuButtonProps) => {
     const children = !propChildren ? open ? <HamburgerClose fontSize="large" /> : <HamburgerOpen fontSize="large" /> : propChildren;
 
     return (
-        <Root onClick={toggleOpen} {...restProps} size="large">
+        <Root onClick={toggleOpen} size="large" {...restProps}>
             {children}
         </Root>
     );


### PR DESCRIPTION
<details><summary>AppHeaderMenuButton</summary>

![comet-appHeaderMenuButton](https://github.com/vivid-planet/comet/assets/71731085/713ac5eb-a176-4622-86aa-b80b2a71d6e4)

https://github.com/vivid-planet/comet/assets/71731085/efb8ab61-8bd2-4e2c-8aaa-b34687b36681

</details> 

<details><summary>AppHeaderMenuButton themed</summary>

![comet-appHeaderMenuButton-themed](https://github.com/vivid-planet/comet/assets/71731085/31edde8a-758a-41bc-912e-1a01d7fb43c1)

https://github.com/vivid-planet/comet/assets/71731085/05f8639b-1186-4f75-9d8c-44548939b9e1

</details> 