### PR TITLE
Site loader: add caching mechanismn to block loader

### DIFF
--- a/demo/site/src/news/blocks/NewsDetailBlock.tsx
+++ b/demo/site/src/news/blocks/NewsDetailBlock.tsx
@@ -11,8 +11,8 @@ interface LoadedData {
 
 function NewsDetailBlock({
     data: { id, loaded },
-}: React.PropsWithChildren<PropsWithData<NewsLinkBlockData & { loaded: LoadedData }>>): JSX.Element | null {
-    if (id === undefined) {
+}: React.PropsWithChildren<PropsWithData<NewsLinkBlockData & { loaded: LoadedData | null }>>): JSX.Element | null {
+    if (!loaded) {
         return null;
     }
 
@@ -26,9 +26,12 @@ function NewsDetailBlock({
 
 export { NewsDetailBlock };
 
-registerBlock<NewsLinkBlockData>("NewsDetail", {
-    async loader({ blockData, client }): Promise<LoadedData | null> {
-        if (!blockData.id) return null;
+registerBlock("NewsDetail", {
+    loaderPayload(blockData: NewsLinkBlockData) {
+        return blockData.id;
+    },
+    async loader(payload, client): Promise<LoadedData | null> {
+        if (!payload) return null;
         const data = await client.request<GQLNewsBlockDetailQuery, GQLNewsBlockDetailQueryVariables>(
             gql`
                 query NewsBlockDetail($id: ID!) {
@@ -37,7 +40,7 @@ registerBlock<NewsLinkBlockData>("NewsDetail", {
                     }
                 }
             `,
-            { id: blockData.id },
+            { id: payload },
         );
         return data.news;
     },

--- a/demo/site/src/pages/preview/admin/page.tsx
+++ b/demo/site/src/pages/preview/admin/page.tsx
@@ -25,6 +25,8 @@ const PreviewPage: React.FunctionComponent = () => {
             includeInvisiblePages: true,
         }),
     );
+    const loaderCache = React.useRef({});
+
     const [blockData, setBlockData] = React.useState<PageContentBlockData>();
     React.useEffect(() => {
         async function load() {
@@ -32,7 +34,12 @@ const PreviewPage: React.FunctionComponent = () => {
                 setBlockData(undefined);
                 return;
             }
-            const newData = await recursivelyLoadBlockData({ blockType: "PageContent", blockData: iFrameBridge.block, client: clientRef.current });
+            const newData = await recursivelyLoadBlockData({
+                blockType: "PageContent",
+                blockData: iFrameBridge.block,
+                client: clientRef.current,
+                cache: loaderCache.current,
+            });
             setBlockData(newData);
         }
         load();

--- a/demo/site/src/recursivelyLoadBlockData.ts
+++ b/demo/site/src/recursivelyLoadBlockData.ts
@@ -2,7 +2,12 @@ import { recursivelyLoadBlockData as cometRecursivelyLoadBlockData } from "@come
 import { GraphQLClient } from "graphql-request";
 
 //small wrapper for @comet/cms-site recursivelyLoadBlockData that injects blockMeta from block-meta.json
-export async function recursivelyLoadBlockData(options: { blockType: string; blockData: unknown; client: GraphQLClient }) {
+export async function recursivelyLoadBlockData(options: {
+    blockType: string;
+    blockData: unknown;
+    client: GraphQLClient;
+    cache?: Record<string, Record<string, unknown>>;
+}) {
     const blocksMeta = await import("../block-meta.json"); //dynamic import to avoid this json in client bundle
     return cometRecursivelyLoadBlockData({ ...options, blocksMeta: blocksMeta.default });
 }

--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -45,7 +45,6 @@
         "chokidar-cli": "^2.0.0",
         "eslint": "^8.0.0",
         "graphql": "^15.0.0",
-        "graphql-request": "^3.0.0",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "jest-junit": "^15.0.0",

--- a/packages/site/cms-site/src/blockRegistry/blockRegistry.ts
+++ b/packages/site/cms-site/src/blockRegistry/blockRegistry.ts
@@ -1,4 +1,4 @@
-import type { GraphQLClient } from "graphql-request";
+import type { DocumentNode } from "graphql";
 
 type BlockMetaField = {
     name: string;
@@ -60,10 +60,15 @@ interface BetterBlockMetaNestedObject {
     fields: BetterBlockMetaField[];
 }
 
+//generic graphql client, compatible with eg. graphql-request
+type GenericGraphQLClient = {
+    request: <T, V>(query: string | DocumentNode, variables: V) => Promise<T>;
+};
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface RegisterBlockOptions<BlockData, LoaderPayload> {
     loaderPayload: (blockData: BlockData) => LoaderPayload;
-    loader: (payload: LoaderPayload, client: GraphQLClient) => Promise<any> | any;
+    loader: (payload: LoaderPayload, client: GenericGraphQLClient) => Promise<any> | any;
 }
 const blocks: Record<string, RegisterBlockOptions<any, any>> = {};
 export function registerBlock<BlockData, LoaderPayload>(blockName: string, options: RegisterBlockOptions<BlockData, LoaderPayload>) {
@@ -79,7 +84,7 @@ export async function recursivelyLoadBlockData({
 }: {
     blockType: string;
     blockData: unknown;
-    client: GraphQLClient;
+    client: GenericGraphQLClient;
     blocksMeta: BlockMeta[];
     cache?: Record<string, Record<string, unknown>>;
 }) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,25 +826,25 @@ importers:
         version: 3.7.4(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
       '@comet/admin':
         specifier: '*'
-        version: link:../packages/admin/admin
+        version: 6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-color-picker':
         specifier: '*'
-        version: link:../packages/admin/admin-color-picker
+        version: 6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-date-time':
         specifier: '*'
-        version: link:../packages/admin/admin-date-time
+        version: 6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-icons':
         specifier: '*'
-        version: link:../packages/admin/admin-icons
+        version: 6.3.0(@mui/material@5.11.6)(react-dom@17.0.2)(react@17.0.2)
       '@comet/admin-react-select':
         specifier: '*'
-        version: link:../packages/admin/admin-react-select
+        version: 6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-rte':
         specifier: '*'
-        version: link:../packages/admin/admin-rte
+        version: 6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-theme':
         specifier: '*'
-        version: link:../packages/admin/admin-theme
+        version: 6.3.0(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/system@5.11.5)(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/core':
         specifier: 2.4.1
         version: 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.4)
@@ -2398,7 +2398,7 @@ importers:
     devDependencies:
       '@comet/eslint-config':
         specifier: ^6.0.0
-        version: link:../eslint-config
+        version: 6.3.0(eslint@8.32.0)(prettier@2.8.3)(typescript@4.9.4)
       '@types/node':
         specifier: ^18.0.0
         version: 18.15.3
@@ -2557,9 +2557,6 @@ importers:
       graphql:
         specifier: ^15.0.0
         version: 15.8.0
-      graphql-request:
-        specifier: ^3.0.0
-        version: 3.7.0(graphql@15.8.0)
       jest:
         specifier: ^29.5.0
         version: 29.5.0(@types/node@18.15.3)(ts-node@10.9.1)
@@ -6869,7 +6866,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       requireindex: 1.1.0
-    dev: false
 
   /@changesets/apply-release-plan@6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
@@ -7053,6 +7049,259 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@comet/admin-color-picker@6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
+    resolution: {integrity: sha512-dLVk5pjrnZnhXalwty6RjRf1WUlwOolqA9sy0K8Yib/woZd5YY9QFsNo0Kdh6kRKEk7iR244OnEtmtAMjLmybA==}
+    peerDependencies:
+      '@mui/icons-material': ^5.0.0
+      '@mui/material': ^5.0.0
+      '@mui/styles': ^5.0.0
+      react: ^17.0
+      react-dom: ^17.0
+      react-final-form: ^6.3.1
+      react-intl: ^5.24.6
+    dependencies:
+      '@comet/admin': 6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@comet/admin-icons': 6.3.0(@mui/material@5.11.6)(react-dom@17.0.2)(react@17.0.2)
+      '@mui/icons-material': 5.11.0(@mui/material@5.11.6)(@types/react@17.0.53)(react@17.0.2)
+      '@mui/material': 5.11.6(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@types/react@17.0.53)(react-dom@17.0.2)(react@17.0.2)
+      '@mui/styles': 5.11.2(@types/react@17.0.53)(react@17.0.2)
+      clsx: 1.2.1
+      react: 17.0.2
+      react-colorful: 5.6.1(react-dom@17.0.2)(react@17.0.2)
+      react-dom: 17.0.2(react@17.0.2)
+      react-final-form: 6.5.9(final-form@4.20.9)(react@17.0.2)
+      react-intl: 5.25.1(react@17.0.2)(typescript@4.9.4)
+      tinycolor2: 1.5.2
+      use-debounce: 6.0.1(react@17.0.2)
+    transitivePeerDependencies:
+      - '@apollo/client'
+      - '@emotion/react'
+      - '@emotion/styled'
+      - '@mui/x-data-grid'
+      - '@mui/x-data-grid-premium'
+      - '@mui/x-data-grid-pro'
+      - '@types/react'
+      - final-form
+      - graphql
+      - history
+      - react-dnd
+      - react-router
+      - react-router-dom
+    dev: false
+
+  /@comet/admin-date-time@6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
+    resolution: {integrity: sha512-6MdUrONPHDD17wHiauoLo0qNi79soIPrbuLyPtj0zJp1NdOavP7gNZn0LMZmV95sh+Rz9wSNJIE68vDGgoADRQ==}
+    peerDependencies:
+      '@mui/material': ^5.0.0
+      '@mui/styles': ^5.0.0
+      react: ^17.0
+      react-dom: ^17.0
+      react-final-form: ^6.5.7
+      react-intl: ^5.24.6
+    dependencies:
+      '@comet/admin': 6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@comet/admin-icons': 6.3.0(@mui/material@5.11.6)(react-dom@17.0.2)(react@17.0.2)
+      '@mui/material': 5.11.6(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@types/react@17.0.53)(react-dom@17.0.2)(react@17.0.2)
+      '@mui/styles': 5.11.2(@types/react@17.0.53)(react@17.0.2)
+      '@mui/utils': 5.11.2(react@17.0.2)
+      clsx: 1.2.1
+      date-fns: 2.29.3
+      react: 17.0.2
+      react-date-range: 1.4.0(date-fns@2.29.3)(react@17.0.2)
+      react-dom: 17.0.2(react@17.0.2)
+      react-final-form: 6.5.9(final-form@4.20.9)(react@17.0.2)
+      react-intl: 5.25.1(react@17.0.2)(typescript@4.9.4)
+    transitivePeerDependencies:
+      - '@apollo/client'
+      - '@emotion/react'
+      - '@emotion/styled'
+      - '@mui/icons-material'
+      - '@mui/x-data-grid'
+      - '@mui/x-data-grid-premium'
+      - '@mui/x-data-grid-pro'
+      - '@types/react'
+      - final-form
+      - graphql
+      - history
+      - react-dnd
+      - react-router
+      - react-router-dom
+    dev: false
+
+  /@comet/admin-icons@6.3.0(@mui/material@5.11.6)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-l77LwQG9S0Th+7RBlT72VOTOlromvpgT+kT+Y2vOX9MJLJBGnRQMRNvTawjAF1iONsuvAgAurXtEt82vr79rvg==}
+    peerDependencies:
+      '@mui/material': ^5.0.0
+      react: ^17.0
+      react-dom: ^17.0
+    dependencies:
+      '@mui/material': 5.11.6(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@types/react@17.0.53)(react-dom@17.0.2)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@comet/admin-react-select@6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
+    resolution: {integrity: sha512-zOS4Ka7t2QtQxdC4H6yZy8hrRR4jmVCKvrGszG5M1wh8/YAgLMe5h3Y/20zvIN8P3exJGbIFZXI8fqZ8UAEPpQ==}
+    peerDependencies:
+      '@mui/icons-material': ^5.0.0
+      '@mui/material': ^5.0.0
+      '@mui/styles': ^5.0.0
+      final-form: ^4.16.1
+      react: ^17.0
+      react-dom: ^17.0
+      react-final-form: ^6.3.1
+      react-select: ^3.0.4
+    dependencies:
+      '@comet/admin': 6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@mui/icons-material': 5.11.0(@mui/material@5.11.6)(@types/react@17.0.53)(react@17.0.2)
+      '@mui/material': 5.11.6(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@types/react@17.0.53)(react-dom@17.0.2)(react@17.0.2)
+      '@mui/styles': 5.11.2(@types/react@17.0.53)(react@17.0.2)
+      classnames: 2.3.2
+      final-form: 4.20.9
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      react-final-form: 6.5.9(final-form@4.20.9)(react@17.0.2)
+    transitivePeerDependencies:
+      - '@apollo/client'
+      - '@emotion/react'
+      - '@emotion/styled'
+      - '@mui/x-data-grid'
+      - '@mui/x-data-grid-premium'
+      - '@mui/x-data-grid-pro'
+      - '@types/react'
+      - graphql
+      - history
+      - react-dnd
+      - react-intl
+      - react-router
+      - react-router-dom
+    dev: false
+
+  /@comet/admin-rte@6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
+    resolution: {integrity: sha512-WOTG7aUcM92dlw+Pd8ZQ2i7Qpeu3m0j7bD3HwyUL5sNpcEVqxCsrY4OY83FfOz76Ha9xjEQcPKyH2FGx/FfwGg==}
+    peerDependencies:
+      '@mui/icons-material': ^5.0.0
+      '@mui/material': ^5.0.0
+      '@mui/styles': ^5.0.0
+      draft-js: ^0.11.4
+      final-form: ^4.16.1
+      react: ^17.0
+      react-dom: ^17.0
+      react-final-form: ^6.3.1
+      react-intl: ^5.10.0
+    dependencies:
+      '@comet/admin': 6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@comet/admin-icons': 6.3.0(@mui/material@5.11.6)(react-dom@17.0.2)(react@17.0.2)
+      '@mui/icons-material': 5.11.0(@mui/material@5.11.6)(@types/react@17.0.53)(react@17.0.2)
+      '@mui/material': 5.11.6(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@types/react@17.0.53)(react-dom@17.0.2)(react@17.0.2)
+      '@mui/styles': 5.11.2(@types/react@17.0.53)(react@17.0.2)
+      detect-browser: 5.3.0
+      draft-js-export-html: 1.4.1(draft-js@0.11.7)(immutable@3.7.6)
+      draft-js-import-html: 1.4.1(immutable@3.7.6)
+      draftjs-conductor: 3.0.0(draft-js@0.11.7)
+      final-form: 4.20.9
+      immutable: 3.7.6
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      react-final-form: 6.5.9(final-form@4.20.9)(react@17.0.2)
+      react-intl: 5.25.1(react@17.0.2)(typescript@4.9.4)
+    transitivePeerDependencies:
+      - '@apollo/client'
+      - '@emotion/react'
+      - '@emotion/styled'
+      - '@mui/x-data-grid'
+      - '@mui/x-data-grid-premium'
+      - '@mui/x-data-grid-pro'
+      - '@types/react'
+      - graphql
+      - history
+      - react-dnd
+      - react-router
+      - react-router-dom
+    dev: false
+
+  /@comet/admin-theme@6.3.0(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/system@5.11.5)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-+O0MTcvHoerkuXpypbMR+Q9ZnDEmbW62edcCaC4WXTph6YY1aE7La6zT9T/jFldEfEfVd0i7k7rVD95zpJe22Q==}
+    peerDependencies:
+      '@mui/material': ^5.0.0
+      '@mui/styles': ^5.0.0
+      '@mui/system': ^5.0.0
+      react: ^17.0
+    dependencies:
+      '@comet/admin-icons': 6.3.0(@mui/material@5.11.6)(react-dom@17.0.2)(react@17.0.2)
+      '@mui/material': 5.11.6(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@types/react@17.0.53)(react-dom@17.0.2)(react@17.0.2)
+      '@mui/styles': 5.11.2(@types/react@17.0.53)(react@17.0.2)
+      '@mui/system': 5.11.5(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@types/react@17.0.53)(react@17.0.2)
+      '@mui/utils': 5.11.2(react@17.0.2)
+      react: 17.0.2
+    transitivePeerDependencies:
+      - react-dom
+    dev: false
+
+  /@comet/admin@6.3.0(@apollo/client@3.7.4)(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/icons-material@5.11.0)(@mui/material@5.11.6)(@mui/styles@5.11.2)(@mui/x-data-grid@5.17.20)(@types/react@17.0.53)(final-form@4.20.9)(graphql@15.8.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
+    resolution: {integrity: sha512-+ElTk2ZaKJb4+5suMyHYNspuG/5sLfK5l54uobvK8gmWhxnEDCUsw3SDpyOesvfxF6exp1xyqp5EJd35n+Y2AA==}
+    peerDependencies:
+      '@apollo/client': ^3.7.0
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@mui/icons-material': ^5.0.0
+      '@mui/material': ^5.0.0
+      '@mui/styles': ^5.0.0
+      '@mui/x-data-grid': ^5.0.0
+      '@mui/x-data-grid-premium': ^5.0.0
+      '@mui/x-data-grid-pro': ^5.0.0
+      final-form: ^4.16.1
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      history: ^4.10.1
+      react: ^17.0
+      react-dnd: ^16.0.0
+      react-dom: ^17.0
+      react-final-form: ^6.3.1
+      react-intl: ^5.10.0
+      react-router: ^5.1.2
+      react-router-dom: ^5.1.2
+    peerDependenciesMeta:
+      '@mui/x-data-grid-premium':
+        optional: true
+      '@mui/x-data-grid-pro':
+        optional: true
+      react-dnd:
+        optional: true
+    dependencies:
+      '@apollo/client': 3.7.4(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
+      '@comet/admin-icons': 6.3.0(@mui/material@5.11.6)(react-dom@17.0.2)(react@17.0.2)
+      '@emotion/react': 11.9.3(@babel/core@7.22.11)(@types/react@17.0.53)(react@17.0.2)
+      '@emotion/styled': 11.10.5(@babel/core@7.22.11)(@emotion/react@11.9.3)(@types/react@17.0.53)(react@17.0.2)
+      '@mui/icons-material': 5.11.0(@mui/material@5.11.6)(@types/react@17.0.53)(react@17.0.2)
+      '@mui/material': 5.11.6(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@types/react@17.0.53)(react-dom@17.0.2)(react@17.0.2)
+      '@mui/private-theming': 5.11.2(@types/react@17.0.53)(react@17.0.2)
+      '@mui/styles': 5.11.2(@types/react@17.0.53)(react@17.0.2)
+      '@mui/x-data-grid': 5.17.20(@mui/material@5.11.6)(@mui/system@5.11.5)(react-dom@17.0.2)(react@17.0.2)
+      clsx: 1.2.1
+      exceljs: 3.10.0
+      file-saver: 2.0.5
+      final-form: 4.20.9
+      final-form-set-field-data: 1.0.2(final-form@4.20.9)
+      graphql: 15.8.0
+      history: 4.10.1
+      http-status-codes: 2.3.0
+      is-mobile: 4.0.0
+      lodash.debounce: 4.0.8
+      lodash.isequal: 4.5.0
+      query-string: 6.14.1
+      react: 17.0.2
+      react-dnd: 16.0.1(@types/node@18.15.3)(@types/react@17.0.53)(react@17.0.2)
+      react-dom: 17.0.2(react@17.0.2)
+      react-final-form: 6.5.9(final-form@4.20.9)(react@17.0.2)
+      react-intl: 5.25.1(react@17.0.2)(typescript@4.9.4)
+      react-router: 5.3.4(react@17.0.2)
+      react-router-dom: 5.3.4(react@17.0.2)
+      use-constant: 1.1.1(react@17.0.2)
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
   /@comet/dev-process-manager@2.3.2:
     resolution: {integrity: sha512-SOP1H8rZBpNhgRzFMofiZPtXYzU16s/uD4ME3J7IXPtqsHNkSjm+WD1LzpK1czVqWAGgowZsXbjL46cYPt41oA==}
     engines: {node: '>=14'}
@@ -7070,6 +7319,49 @@ packages:
       wait-on: 6.0.1
     transitivePeerDependencies:
       - debug
+    dev: true
+
+  /@comet/eslint-config@6.3.0(eslint@8.32.0)(prettier@2.8.3)(typescript@4.9.4):
+    resolution: {integrity: sha512-Gi5BABuLV5+/hNZX4ebDdAEZDc4SvxpSV4kgeRwRg4qY/swhqwnMHRdYqFgWc6eL1PZSdBp1yEs8ueH6YaJ4XQ==}
+    peerDependencies:
+      eslint: '>= 8'
+      next: '*'
+      prettier: '>= 2'
+    peerDependenciesMeta:
+      next:
+        optional: true
+    dependencies:
+      '@calm/eslint-plugin-react-intl': 1.4.1
+      '@comet/eslint-plugin': 6.3.0(eslint@8.32.0)
+      '@next/eslint-plugin-next': 12.3.4
+      '@typescript-eslint/eslint-plugin': 5.49.0(@typescript-eslint/parser@5.49.0)(eslint@8.32.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.49.0(eslint@8.32.0)(typescript@4.9.4)
+      eslint: 8.32.0
+      eslint-config-next: 13.1.5(eslint@8.32.0)(typescript@4.9.4)
+      eslint-config-prettier: 8.6.0(eslint@8.32.0)
+      eslint-plugin-formatjs: 4.3.9(eslint@8.32.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.49.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.32.0)
+      eslint-plugin-json-files: 2.2.0(eslint@8.32.0)
+      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.6.0)(eslint@8.32.0)(prettier@2.8.3)
+      eslint-plugin-react: 7.32.1(eslint@8.32.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.32.0)
+      eslint-plugin-simple-import-sort: 9.0.0(eslint@8.32.0)
+      eslint-plugin-unused-imports: 2.0.0(@typescript-eslint/eslint-plugin@5.49.0)(eslint@8.32.0)
+      prettier: 2.8.3
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+      - ts-jest
+      - typescript
+    dev: true
+
+  /@comet/eslint-plugin@6.3.0(eslint@8.32.0):
+    resolution: {integrity: sha512-PT3O50+gOVcbS3Z+Y0DajXM/mFe6NaqAQX7o5X5Y5JFeK5lcq+UYdgs290SiiPC32J3Qd8Ba45VGIY2Y2zrc7w==}
+    peerDependencies:
+      eslint: '8'
+    dependencies:
+      eslint: 8.32.0
     dev: true
 
   /@cspotcode/source-map-support@0.8.1:
@@ -8312,7 +8604,6 @@ packages:
     dependencies:
       '@formatjs/intl-localematcher': 0.2.32
       tslib: 2.4.1
-    dev: false
 
   /@formatjs/ecma402-abstract@1.5.0:
     resolution: {integrity: sha512-wXv36yo+mfWllweN0Fq7sUs7PUiNopn7I0JpLTe3hGu6ZMR4CV7LqK1llhB18pndwpKoafQKb1et2DCJAOW20Q==}
@@ -8338,14 +8629,12 @@ packages:
       '@formatjs/ecma402-abstract': 1.14.3
       '@formatjs/icu-skeleton-parser': 1.3.18
       tslib: 2.4.1
-    dev: false
 
   /@formatjs/icu-skeleton-parser@1.3.18:
     resolution: {integrity: sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.14.3
       tslib: 2.4.1
-    dev: false
 
   /@formatjs/icu-skeleton-parser@1.3.6:
     resolution: {integrity: sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==}
@@ -8376,7 +8665,6 @@ packages:
     resolution: {integrity: sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==}
     dependencies:
       tslib: 2.4.1
-    dev: false
 
   /@formatjs/intl@2.2.1(typescript@4.9.4):
     resolution: {integrity: sha512-vgvyUOOrzqVaOFYzTf2d3+ToSkH2JpR7x/4U1RyoHQLmvEaTQvXJ7A2qm1Iy3brGNXC/+/7bUlc3lpH+h/LOJA==}
@@ -8423,7 +8711,6 @@ packages:
       json-stable-stringify: 1.0.2
       tslib: 2.4.1
       typescript: 4.9.4
-    dev: false
 
   /@formatjs/ts-transformer@3.9.4:
     resolution: {integrity: sha512-S5q/zsTodaKtxVxNvbRQ9APenJtm5smXE76usS+5yF2vWQdZHkagmOKWfgvfIbesP4SR2B+i3koqlnlpqSIp5w==}
@@ -9557,7 +9844,6 @@ packages:
   /@humanwhocodes/momoa@2.0.4:
     resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
     engines: {node: '>=10.10.0'}
-    dev: false
 
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
@@ -10816,13 +11102,11 @@ packages:
     resolution: {integrity: sha512-BFwj8ykJY+zc1/jWANsDprDIu2MgwPOIKxNVnrKvPs+f5TPegrVnem8uScND+1veT4B7F6VeqgaNLFW1Hzl9Og==}
     dependencies:
       glob: 7.1.7
-    dev: false
 
   /@next/eslint-plugin-next@13.1.5:
     resolution: {integrity: sha512-3kvLTX35bOWOCKU8KY74Ygczc55Qk/kB2TQy0tH7Rti6hzZ6Aij7WQ8zHdIVjmnlD0n/zXWXrIf5y56RKcLQkQ==}
     dependencies:
       glob: 7.1.7
-    dev: false
 
   /@next/swc-android-arm-eabi@12.3.4:
     resolution: {integrity: sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==}
@@ -11895,7 +12179,6 @@ packages:
       picocolors: 1.0.0
       tiny-glob: 0.2.9
       tslib: 2.4.1
-    dev: false
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(@types/webpack@5.28.0)(react-refresh@0.11.0)(webpack@5.89.0):
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
@@ -12010,7 +12293,6 @@ packages:
 
   /@rushstack/eslint-patch@1.2.0:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
-    dev: false
 
   /@rushstack/ts-command-line@4.13.1:
     resolution: {integrity: sha512-UTQMRyy/jH1IS2U+6pyzyn9xQ2iMcoUKkTcZUzOP/aaMiKlWLwCTDiBVwhw/M1crDx6apF9CwyjuWO9r1SBdJQ==}
@@ -13714,7 +13996,6 @@ packages:
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
-    dev: false
 
   /@types/estree@0.0.50:
     resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
@@ -13819,7 +14100,6 @@ packages:
     dependencies:
       '@types/minimatch': 5.1.2
       '@types/node': 18.15.3
-    dev: false
 
   /@types/glob@8.0.1:
     resolution: {integrity: sha512-8bVUjXZvJacUFkJXHdyZ9iH1Eaj5V7I8c4NdH5sQJsdXkqT4CA5Dhb4yb4VE/3asyx4L9ayZr1NIhTsWHczmMw==}
@@ -14230,7 +14510,6 @@ packages:
 
   /@types/picomatch@2.3.0:
     resolution: {integrity: sha512-O397rnSS9iQI4OirieAtsDqvCj4+3eY1J+EPdNTKuHuRWIfUoGyzX294o8C4KJYaLqgSrd2o60c5EqCU8Zv02g==}
-    dev: false
 
   /@types/pluralize@0.0.29:
     resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==}
@@ -14408,7 +14687,6 @@ packages:
 
   /@types/semver@7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
-    dev: false
 
   /@types/serve-index@1.9.1:
     resolution: {integrity: sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==}
@@ -14592,7 +14870,6 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/parser@5.49.0(eslint@8.32.0)(typescript@4.9.4):
     resolution: {integrity: sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==}
@@ -14612,7 +14889,6 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/scope-manager@5.49.0:
     resolution: {integrity: sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==}
@@ -14620,7 +14896,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.49.0
       '@typescript-eslint/visitor-keys': 5.49.0
-    dev: false
 
   /@typescript-eslint/type-utils@5.49.0(eslint@8.32.0)(typescript@4.9.4):
     resolution: {integrity: sha512-eUgLTYq0tR0FGU5g1YHm4rt5H/+V2IPVkP0cBmbhRyEmyGe4XvJ2YJ6sYTmONfjmdMqyMLad7SB8GvblbeESZA==}
@@ -14640,12 +14915,10 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/types@5.49.0:
     resolution: {integrity: sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
 
   /@typescript-eslint/typescript-estree@5.49.0(typescript@4.9.4):
     resolution: {integrity: sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==}
@@ -14666,7 +14939,6 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/utils@5.49.0(eslint@8.32.0)(typescript@4.9.4):
     resolution: {integrity: sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==}
@@ -14686,7 +14958,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
 
   /@typescript-eslint/visitor-keys@5.49.0:
     resolution: {integrity: sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==}
@@ -14694,7 +14965,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.49.0
       eslint-visitor-keys: 3.4.1
-    dev: false
 
   /@vue/compiler-core@3.2.45:
     resolution: {integrity: sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==}
@@ -15780,7 +16050,6 @@ packages:
       es-abstract: 1.21.1
       get-intrinsic: 1.2.0
       is-string: 1.0.7
-    dev: false
 
   /array-union@1.0.2:
     resolution: {integrity: sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==}
@@ -15820,7 +16089,6 @@ packages:
       define-properties: 1.1.4
       es-abstract: 1.21.1
       es-shim-unscopables: 1.0.0
-    dev: false
 
   /array.prototype.map@1.0.5:
     resolution: {integrity: sha512-gfaKntvwqYIuC7mLLyv2wzZIJqrRhn5PZ9EfFejSx6a78sV7iDsGpG9P+3oUPtm1Rerqm6nrKS4FYuTIvWfo3g==}
@@ -15852,7 +16120,6 @@ packages:
       es-abstract: 1.21.1
       es-shim-unscopables: 1.0.0
       get-intrinsic: 1.2.0
-    dev: false
 
   /arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
@@ -15907,7 +16174,6 @@ packages:
 
   /ast-types-flow@0.0.7:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
-    dev: false
 
   /ast-types@0.14.2:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
@@ -16024,7 +16290,6 @@ packages:
   /axe-core@4.6.3:
     resolution: {integrity: sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==}
     engines: {node: '>=4'}
-    dev: false
 
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
@@ -16044,7 +16309,6 @@ packages:
     resolution: {integrity: sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==}
     dependencies:
       deep-equal: 2.2.0
-    dev: false
 
   /babel-jest@29.5.0(@babel/core@7.22.11):
     resolution: {integrity: sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==}
@@ -16469,7 +16733,6 @@ packages:
       chalk: 4.1.2
       jsonpointer: 5.0.1
       leven: 3.1.0
-    dev: false
 
   /better-opn@2.1.1:
     resolution: {integrity: sha512-kIPXZS5qwyKiX/HcRvDYfmBQUa8XP17I0mYZZ0y4UhpYOSvtsLHDYqmomS+Mj20aDvD3knEiQ0ecQy2nhio3yA==}
@@ -18324,7 +18587,6 @@ packages:
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
-    dev: false
 
   /dashdash@1.14.1:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
@@ -18383,7 +18645,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: false
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -18722,7 +18983,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       esutils: 2.0.3
-    dev: false
 
   /doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -18918,7 +19178,6 @@ packages:
       draft-js: 0.11.7(react-dom@17.0.2)(react@17.0.2)
       draft-js-utils: 1.4.1(draft-js@0.11.7)(immutable@3.7.6)
       immutable: 3.7.6
-    dev: true
 
   /draft-js-export-markdown@1.4.0(draft-js@0.11.7)(immutable@3.7.6):
     resolution: {integrity: sha512-blfAvlhGhjVlHNaZ5WJKlrXhcftnwwC5VC+Eu3ztOGpGLaOom4hxhBjbKEWjvbQZJ9zL+xo57ukm39prYZMG5Q==}
@@ -18941,7 +19200,16 @@ packages:
       draft-js-utils: 1.4.1(draft-js@0.11.7)(immutable@3.7.6)
       immutable: 3.7.6
       synthetic-dom: 1.4.0
-    dev: true
+
+  /draft-js-import-html@1.4.1(immutable@3.7.6):
+    resolution: {integrity: sha512-KOZmtgxZriCDgg5Smr3Y09TjubvXe7rHPy/2fuLSsL+aSzwUDwH/aHDA/k47U+WfpmL4qgyg4oZhqx9TYJV0tg==}
+    peerDependencies:
+      draft-js: '>=0.10.0'
+      immutable: 3.x.x
+    dependencies:
+      draft-js-import-element: 1.4.0(draft-js@0.11.7)(immutable@3.7.6)
+      immutable: 3.7.6
+    dev: false
 
   /draft-js-import-markdown@1.4.1(draft-js@0.11.7)(immutable@3.7.6):
     resolution: {integrity: sha512-58mDXJURrb5dsiN+cIms/gojI9jngE60WAwygYoxrEbsQeIIITOlFLjV/m/7Ko7HVpc5wjngVV2hzJ71T3FpMA==}
@@ -18963,7 +19231,6 @@ packages:
     dependencies:
       draft-js: 0.11.7(react-dom@17.0.2)(react@17.0.2)
       immutable: 3.7.6
-    dev: true
 
   /draft-js@0.11.7(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==}
@@ -19120,7 +19387,6 @@ packages:
 
   /emoji-regex@10.2.1:
     resolution: {integrity: sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==}
-    dev: false
 
   /emoji-regex@7.0.3:
     resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
@@ -19390,7 +19656,6 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-config-prettier@8.6.0(eslint@8.32.0):
     resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
@@ -19399,7 +19664,6 @@ packages:
       eslint: '>=7.0.0'
     dependencies:
       eslint: 8.32.0
-    dev: false
 
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
@@ -19409,7 +19673,6 @@ packages:
       resolve: 1.22.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.27.5)(eslint@8.32.0):
     resolution: {integrity: sha512-njRcKYBc3isE42LaTcJNVANR3R99H9bAxBDMNDr2W7yq5gYPxbU3MkdhsQukxZ/Xg9C2vcyLlDsbKfRDg0QvCQ==}
@@ -19429,7 +19692,6 @@ packages:
       synckit: 0.8.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.49.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.32.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
@@ -19459,7 +19721,6 @@ packages:
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.32.0)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /eslint-plugin-formatjs@4.3.9(eslint@8.32.0):
     resolution: {integrity: sha512-+8kGoTUaNe0qS55eg5XbPDY+eQmeZxnrC8MugQTGUXlqbCyLyG7y4mDsMhAgactVyUMST6Ln1HEm1Tk0KNuIKQ==}
@@ -19479,7 +19740,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - ts-jest
-    dev: false
 
   /eslint-plugin-graphql@4.0.0(@types/node@18.15.3)(graphql@15.8.0)(typescript@4.9.4):
     resolution: {integrity: sha512-d5tQm24YkVvCEk29ZR5ScsgXqAGCjKlMS8lx3mS7FS/EKsWbkvXQImpvic03EpMIvNTBW5e+2xnHzXB/VHNZJw==}
@@ -19531,7 +19791,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-plugin-json-files@2.2.0(eslint@8.32.0):
     resolution: {integrity: sha512-7ETNwGWMtlAqtAIfwrNSm/X8RsHrZcV78YFa/EyYjavFWaVFhi/fsZBjnj4yIf1G0Rbx5f2t+sd037hVPK20WQ==}
@@ -19545,7 +19804,6 @@ packages:
       requireindex: 1.2.0
       semver: 7.3.8
       sort-package-json: 1.57.0
-    dev: false
 
   /eslint-plugin-jsx-a11y@6.7.1(eslint@8.32.0):
     resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
@@ -19570,7 +19828,6 @@ packages:
       object.entries: 1.1.6
       object.fromentries: 2.0.6
       semver: 6.3.1
-    dev: false
 
   /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.6.0)(eslint@8.32.0)(prettier@2.8.3):
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
@@ -19587,7 +19844,6 @@ packages:
       eslint-config-prettier: 8.6.0(eslint@8.32.0)
       prettier: 2.8.3
       prettier-linter-helpers: 1.0.0
-    dev: false
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.32.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
@@ -19596,7 +19852,6 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
       eslint: 8.32.0
-    dev: false
 
   /eslint-plugin-react@7.32.1(eslint@8.32.0):
     resolution: {integrity: sha512-vOjdgyd0ZHBXNsmvU+785xY8Bfe57EFbTYYk8XrROzWpr9QBvpjITvAXt9xqcE6+8cjR/g1+mfumPToxsl1www==}
@@ -19620,7 +19875,6 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.0
       string.prototype.matchall: 4.0.8
-    dev: false
 
   /eslint-plugin-simple-import-sort@9.0.0(eslint@8.32.0):
     resolution: {integrity: sha512-PtrLjyXP8kjRneWT1n0b99y/2Fyup37we7FVoWsI61/O7x4ztLohzhep/pxI/cYlECr/cQ2j6utckdvWpVwXNA==}
@@ -19628,7 +19882,6 @@ packages:
       eslint: '>=5.0.0'
     dependencies:
       eslint: 8.32.0
-    dev: false
 
   /eslint-plugin-unused-imports@2.0.0(@typescript-eslint/eslint-plugin@5.49.0)(eslint@8.32.0):
     resolution: {integrity: sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==}
@@ -19643,12 +19896,10 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.49.0(@typescript-eslint/parser@5.49.0)(eslint@8.32.0)(typescript@4.9.4)
       eslint: 8.32.0
       eslint-rule-composer: 0.3.0
-    dev: false
 
   /eslint-rule-composer@0.3.0:
     resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
     engines: {node: '>=4.0.0'}
-    dev: false
 
   /eslint-scope@4.0.3:
     resolution: {integrity: sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==}
@@ -20111,7 +20362,6 @@ packages:
 
   /fast-diff@1.2.0:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
-    dev: false
 
   /fast-glob@2.2.7:
     resolution: {integrity: sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==}
@@ -20987,7 +21237,6 @@ packages:
 
   /get-tsconfig@4.3.0:
     resolution: {integrity: sha512-YCcF28IqSay3fqpIu5y3Krg/utCBHBeoflkZyHj/QcqI2nrLPC3ZegS9CmIo+hJb8K7aiGsuUl7PwWVjNG2HQQ==}
-    dev: false
 
   /get-value@2.0.6:
     resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
@@ -21004,7 +21253,6 @@ packages:
 
   /git-hooks-list@1.0.3:
     resolution: {integrity: sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==}
-    dev: false
 
   /github-slugger@1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
@@ -21066,7 +21314,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: false
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -21136,7 +21383,6 @@ packages:
 
   /globalyzer@0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
-    dev: false
 
   /globby@10.0.0:
     resolution: {integrity: sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==}
@@ -21150,7 +21396,6 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
-    dev: false
 
   /globby@11.0.3:
     resolution: {integrity: sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==}
@@ -21184,7 +21429,6 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
-    dev: false
 
   /globby@9.2.0:
     resolution: {integrity: sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==}
@@ -21204,7 +21448,6 @@ packages:
 
   /globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-    dev: false
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -22571,7 +22814,6 @@ packages:
   /is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
-    dev: false
 
   /is-plain-obj@3.0.0:
     resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
@@ -23598,7 +23840,6 @@ packages:
   /jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /jsonwebtoken@8.5.1:
     resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
@@ -23694,7 +23935,6 @@ packages:
     dependencies:
       array-includes: 3.1.6
       object.assign: 4.1.4
-    dev: false
 
   /jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
@@ -23838,13 +24078,11 @@ packages:
 
   /language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
-    dev: false
 
   /language-tags@1.0.5:
     resolution: {integrity: sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==}
     dependencies:
       language-subtag-registry: 0.3.22
-    dev: false
 
   /latest-version@5.1.0:
     resolution: {integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==}
@@ -25002,7 +25240,6 @@ packages:
 
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
-    dev: false
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -25391,7 +25628,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.21.1
-    dev: false
 
   /object.fromentries@2.0.6:
     resolution: {integrity: sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==}
@@ -25400,7 +25636,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.21.1
-    dev: false
 
   /object.getownpropertydescriptors@2.1.5:
     resolution: {integrity: sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==}
@@ -25417,7 +25652,6 @@ packages:
     dependencies:
       define-properties: 1.1.4
       es-abstract: 1.21.1
-    dev: false
 
   /object.pick@1.3.0:
     resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
@@ -25433,7 +25667,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.21.1
-    dev: false
 
   /objectorarray@1.0.5:
     resolution: {integrity: sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==}
@@ -26725,7 +26958,6 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       fast-diff: 1.2.0
-    dev: false
 
   /prettier@2.3.0:
     resolution: {integrity: sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==}
@@ -28219,12 +28451,10 @@ packages:
   /requireindex@1.1.0:
     resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
     engines: {node: '>=0.10.5'}
-    dev: false
 
   /requireindex@1.2.0:
     resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
     engines: {node: '>=0.10.5'}
-    dev: false
 
   /requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -28277,7 +28507,6 @@ packages:
       is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: false
 
   /response-iterator@0.2.6:
     resolution: {integrity: sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==}
@@ -28836,7 +29065,6 @@ packages:
   /slash@4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
-    dev: false
 
   /slice-ansi@3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
@@ -28941,7 +29169,6 @@ packages:
 
   /sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
-    dev: false
 
   /sort-package-json@1.57.0:
     resolution: {integrity: sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==}
@@ -28953,7 +29180,6 @@ packages:
       globby: 10.0.0
       is-plain-obj: 2.1.0
       sort-object-keys: 1.1.3
-    dev: false
 
   /source-list-map@2.0.1:
     resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
@@ -29319,7 +29545,6 @@ packages:
       internal-slot: 1.0.4
       regexp.prototype.flags: 1.4.3
       side-channel: 1.0.4
-    dev: false
 
   /string.prototype.padend@3.1.4:
     resolution: {integrity: sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==}
@@ -29730,11 +29955,9 @@ packages:
     dependencies:
       '@pkgr/utils': 2.3.1
       tslib: 2.4.1
-    dev: false
 
   /synthetic-dom@1.4.0:
     resolution: {integrity: sha512-mHv51ZsmZ+ShT/4s5kg+MGUIhY7Ltq4v03xpN1c8T1Krb5pScsh/lzEjyhrVD0soVDbThbd2e+4dD9vnDG4rhg==}
-    dev: true
 
   /tapable@1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
@@ -30022,7 +30245,6 @@ packages:
     dependencies:
       globalyzer: 0.1.0
       globrex: 0.1.2
-    dev: false
 
   /tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
@@ -30432,7 +30654,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.4
-    dev: false
 
   /tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}


### PR DESCRIPTION
This splits up loader into 2 functions to allow caching:
1. extract loaderPayload from blockData (will be used as cacheId)
2. actual loader that doesn't get blockData passed anymore, instead payload from (1)

```
registerBlock("ExampleBlock", {
    loaderPayload(blockData: ExampleBlockData) {
        return blockData.foo;
    },
    async loader(payload, client): Promise<LoadedData | null> {
        ...
    }
```


Pro:

- independent of what loader does, could also fetch a 3rd party api using fetch directly

Con:

- not so easy to use: adds second function to registerBlock every block has to implement

Alternative: #1682 Caching inside the loader itself on graphql-request level.