### PR TITLE
Make userService optional

### DIFF
--- a/.changeset/afraid-horses-hide.md
+++ b/.changeset/afraid-horses-hide.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Make the `UserService`-option of the `UserPermissionsModule` optional.
+
+The service is still necessary though for the Administration-Panel.

--- a/demo/api/src/auth/auth.module.ts
+++ b/demo/api/src/auth/auth.module.ts
@@ -9,7 +9,7 @@ import { UserService } from "./user.service";
 @Module({
     providers: [
         createStaticAuthedUserStrategy({
-            staticAuthedUser: staticUsers[0].id,
+            staticAuthedUser: staticUsers[0],
         }),
         createAuthResolver(),
         {

--- a/docs/docs/migration/migration-from-v5-to-v6.md
+++ b/docs/docs/migration/migration-from-v5-to-v6.md
@@ -86,20 +86,7 @@ It automatically installs the new versions of all `@comet` libraries, runs an ES
     export {};
     ```
 
-4. Create necessary services for the `UserPermissionsModule` (either in a new module or where it fits best)
-
-    ```ts
-    // Attention: might already being provided by the library which syncs the users
-    @Injectable()
-    export class UserService implements UserPermissionsUserServiceInterface {
-        getUser(id: string): User {
-            ...
-        }
-        findUsers(args: FindUsersArgs): Users {
-            ...
-        }
-    }
-    ```
+4. Create necessary the `AccessControlService` for the `UserPermissionsModule` (either in a new module or where it fits best)
 
     ```ts
     @Injectable()
@@ -127,13 +114,12 @@ It automatically installs the new versions of all `@comet` libraries, runs an ES
 
     ```ts
     UserPermissionsModule.forRootAsync({
-        useFactory: (userService: UserService, accessControlService: AccessControlService) => ({
+        useFactory: (accessControlService: AccessControlService) => ({
             availablePermissions: [/* Array of strings defined in interface Permission */],
             availableContentScopes: [/* Array of content Scopes */],
-            userService,
             accessControlService,
         }),
-        inject: [UserService, AccessControlService],
+        inject: [AccessControlService],
         imports: [/* Modules which provide the services injected in useFactory */],
     }),
     ```
@@ -151,6 +137,40 @@ It automatically installs the new versions of all `@comet` libraries, runs an ES
 
     ```diff
     - @AllowForRole(...)
+    ```
+
+7. Optional: Add the `UserService` (required for Administration Panel, see Admin)
+
+    Create a `UserService`:
+
+    ```ts
+    // Attention: might already being provided by the library which syncs the users
+    @Injectable()
+    export class UserService implements UserPermissionsUserServiceInterface {
+        getUser(id: string): User {
+        ...
+        }
+        findUsers(args: FindUsersArgs): Users {
+        ...
+        }
+    }
+    ```
+
+    Add it to the `UserPermissionsModule`:
+
+    ```diff
+      UserPermissionsModule.forRootAsync({
+    +     useFactory: (accessControlService: AccessControlService, userService: UserService) => ({
+    -     useFactory: (accessControlService: AccessControlService) => ({
+              availablePermissions: [/* Array of strings defined in interface Permission */],
+              availableContentScopes: [/* Array of content Scopes */],
+    +         userService,
+              accessControlService,
+          }),
+    +     inject: [AccessControlService, UserService],
+    -     inject: [AccessControlService],
+          imports: [/* Modules which provide the services injected in useFactory */],
+      }),
     ```
 
 ## Admin
@@ -184,7 +204,7 @@ It automatically installs the new versions of all `@comet` libraries, runs an ES
     + const allowedUserDomains = user.allowedContentScopes.map((contentScope) => contentScope.domain);
     ```
 
-3. Add the `UserPermissionsPage`
+3. Optional: Add the Adminstration Panel
 
     ```tsx
     <MenuItemRouterLink

--- a/docs/docs/migration/migration-from-v5-to-v6.md
+++ b/docs/docs/migration/migration-from-v5-to-v6.md
@@ -86,7 +86,7 @@ It automatically installs the new versions of all `@comet` libraries, runs an ES
     export {};
     ```
 
-4. Create necessary the `AccessControlService` for the `UserPermissionsModule` (either in a new module or where it fits best)
+4. Create the `AccessControlService` for the `UserPermissionsModule` (either in a new module or where it fits best)
 
     ```ts
     @Injectable()

--- a/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
@@ -41,7 +41,7 @@ export class UserContentScopesResolver {
         @Args("skipManual", { type: () => Boolean, nullable: true }) skipManual = false,
     ): Promise<ContentScope[]> {
         return this.userService.normalizeContentScopes(
-            await this.userService.getContentScopes(userId, !skipManual),
+            await this.userService.getContentScopes(await this.userService.getUser(userId), !skipManual),
             await this.userService.getAvailableContentScopes(),
         );
     }

--- a/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
@@ -26,7 +26,7 @@ export class UserPermissionResolver {
 
     @Query(() => [UserPermission])
     async userPermissionsPermissionList(@Args() args: UserPermissionListArgs): Promise<UserPermission[]> {
-        return this.service.getPermissions(args.userId);
+        return this.service.getPermissions(await this.service.getUser(args.userId));
     }
 
     @Query(() => UserPermission)
@@ -96,7 +96,7 @@ export class UserPermissionResolver {
         if (!userId) {
             throw new Error(`Permission not found: ${id}`);
         }
-        for (const p of await this.service.getPermissions(userId)) {
+        for (const p of await this.service.getPermissions(await this.service.getUser(userId))) {
             if (p.id === id) return p;
         }
         throw new Error("Permission not found");

--- a/packages/api/cms-api/src/user-permissions/user-permissions.module.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.module.ts
@@ -44,13 +44,17 @@ export class UserPermissionsModule {
                     useValue: options,
                 },
                 {
-                    provide: USER_PERMISSIONS_USER_SERVICE,
-                    useClass: options.UserService,
-                },
-                {
                     provide: ACCESS_CONTROL_SERVICE,
                     useClass: options.AccessControlService,
                 },
+                ...(options.UserService
+                    ? [
+                          {
+                              provide: USER_PERMISSIONS_USER_SERVICE,
+                              useClass: options.UserService,
+                          },
+                      ]
+                    : []),
             ],
         };
     }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -1,6 +1,6 @@
 import { EntityRepository } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Optional } from "@nestjs/common";
 import { isFuture, isPast } from "date-fns";
 import isEqual from "lodash.isequal";
 import getUuid from "uuid-by-string";
@@ -24,7 +24,7 @@ import {
 export class UserPermissionsService {
     constructor(
         @Inject(USER_PERMISSIONS_OPTIONS) private readonly options: UserPermissionsOptions,
-        @Inject(USER_PERMISSIONS_USER_SERVICE) private readonly userService: UserPermissionsUserServiceInterface,
+        @Inject(USER_PERMISSIONS_USER_SERVICE) @Optional() private readonly userService: UserPermissionsUserServiceInterface | undefined,
         @Inject(ACCESS_CONTROL_SERVICE) private readonly accessControlService: AccessControlServiceInterface,
         @InjectRepository(UserPermission) private readonly permissionRepository: EntityRepository<UserPermission>,
         @InjectRepository(UserContentScopes) private readonly contentScopeRepository: EntityRepository<UserContentScopes>,
@@ -41,10 +41,12 @@ export class UserPermissionsService {
     }
 
     async getUser(id: string): Promise<User> {
+        if (!this.userService) throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
         return this.userService.getUser(id);
     }
 
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {
+        if (!this.userService) throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
         return this.userService.findUsers(args);
     }
 
@@ -57,18 +59,17 @@ export class UserPermissionsService {
         });
     }
 
-    async getPermissions(userId: string): Promise<UserPermission[]> {
+    async getPermissions(user: User): Promise<UserPermission[]> {
         const availablePermissions = await this.getAvailablePermissions();
         const permissions = (
             await this.permissionRepository.find({
-                $and: [{ userId }, { permission: { $in: availablePermissions } }],
+                $and: [{ userId: user.id }, { permission: { $in: availablePermissions } }],
             })
         ).map((p) => {
             p.source = UserPermissionSource.MANUAL;
             return p;
         });
         if (this.accessControlService.getPermissionsForUser) {
-            const user = await this.getUser(userId);
             if (user) {
                 let permissionsByRule = await this.accessControlService.getPermissionsForUser(user);
                 if (permissionsByRule === UserPermissions.allPermissions) {
@@ -78,7 +79,7 @@ export class UserPermissionsService {
                     const permission = new UserPermission();
                     permission.id = getUuid(JSON.stringify(p));
                     permission.source = UserPermissionSource.BY_RULE;
-                    permission.userId = userId;
+                    permission.userId = user.id;
                     permission.overrideContentScopes = !!p.contentScopes;
                     permission.assign(p);
                     permissions.push(permission);
@@ -94,24 +95,21 @@ export class UserPermissionsService {
             );
     }
 
-    async getContentScopes(userId: string, includeContentScopesManual = true): Promise<ContentScope[]> {
+    async getContentScopes(user: User, includeContentScopesManual = true): Promise<ContentScope[]> {
         const contentScopes: ContentScope[] = [];
         const availableContentScopes = await this.getAvailableContentScopes();
 
         if (this.accessControlService.getContentScopesForUser) {
-            const user = await this.getUser(userId);
-            if (user) {
-                const userContentScopes = await this.accessControlService.getContentScopesForUser(user);
-                if (userContentScopes === UserPermissions.allContentScopes) {
-                    contentScopes.push(...availableContentScopes);
-                } else {
-                    contentScopes.push(...userContentScopes);
-                }
+            const userContentScopes = await this.accessControlService.getContentScopesForUser(user);
+            if (userContentScopes === UserPermissions.allContentScopes) {
+                contentScopes.push(...availableContentScopes);
+            } else {
+                contentScopes.push(...userContentScopes);
             }
         }
 
         if (includeContentScopesManual) {
-            const entity = await this.contentScopeRepository.findOne({ userId });
+            const entity = await this.contentScopeRepository.findOne({ userId: user.id });
             if (entity) {
                 contentScopes.push(...entity.contentScopes.filter((value) => availableContentScopes.some((cs) => isEqual(cs, value))));
             }
@@ -128,8 +126,8 @@ export class UserPermissionsService {
 
     async createCurrentUser(user: User): Promise<CurrentUser> {
         const availableContentScopes = await this.getAvailableContentScopes();
-        const userContentScopes = await this.getContentScopes(user.id);
-        const permissions = (await this.getPermissions(user.id))
+        const userContentScopes = await this.getContentScopes(user);
+        const permissions = (await this.getPermissions(user))
             .filter((p) => (!p.validFrom || isPast(p.validFrom)) && (!p.validTo || isFuture(p.validTo)))
             .reduce((acc: CurrentUser["permissions"], userPermission) => {
                 const contentScopes = userPermission.overrideContentScopes ? userPermission.contentScopes : userContentScopes;

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -38,12 +38,12 @@ export interface UserPermissionsOptions {
     availableContentScopes?: ContentScope[];
 }
 export interface UserPermissionsModuleSyncOptions extends UserPermissionsOptions {
-    UserService: Type<UserPermissionsUserServiceInterface>;
+    UserService?: Type<UserPermissionsUserServiceInterface>;
     AccessControlService: Type<AccessControlServiceInterface>;
 }
 
 export interface UserPermissionsAsyncOptions extends UserPermissionsOptions {
-    userService: UserPermissionsUserServiceInterface;
+    userService?: UserPermissionsUserServiceInterface;
     accessControlService: AccessControlServiceInterface;
 }
 


### PR DESCRIPTION
Allows easier migration as the userService is only needed for
the UserPermissions administration panel