### PR TITLE
Admin Generator (Future): Support `helperText` `Field` prop in Forms

### DIFF
--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -12,6 +12,7 @@ export const ProductForm: FormConfig<GQLProduct> = {
             label: "Titel", // default is generated from name (camelCaseToHumanReadable)
             required: true, // default is inferred from gql schema
         },
+        { type: "text", name: "packageDimensions.height", label: "Height", helperText: "Enter height in centimeters" },
         { type: "text", name: "slug" },
         { type: "text", name: "description", label: "Description", multiline: true },
         { type: "staticSelect", name: "type", label: "Type" /*, values: from gql schema (TODO overridable)*/ },

--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -12,12 +12,13 @@ export const ProductForm: FormConfig<GQLProduct> = {
             label: "Titel", // default is generated from name (camelCaseToHumanReadable)
             required: true, // default is inferred from gql schema
         },
-        { type: "text", name: "packageDimensions.height", label: "Height", helperText: "Enter height in centimeters" },
+        // "packageDimensions.height" naming is not yet supported.
+        // { type: "text", name: "packageDimensions.height", label: "Height", helperText: "Enter height in centimeters" },
         { type: "text", name: "slug" },
         { type: "text", name: "description", label: "Description", multiline: true },
         { type: "staticSelect", name: "type", label: "Type" /*, values: from gql schema (TODO overridable)*/ },
         //TODO { type: "asyncSelect", name: "category", label: "Category" /*, endpoint: from gql schema (overridable)*/ },
-        { type: "number", name: "price" },
+        { type: "number", name: "price", helperText: "Enter price in this format: 123,45" },
         { type: "boolean", name: "inStock" },
         { type: "date", name: "availableSince" },
         { type: "block", name: "image", label: "Image", block: { name: "PixelImageBlock", import: "@comet/cms-admin" } },

--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -13,8 +13,6 @@ export const ProductForm: FormConfig<GQLProduct> = {
             required: true, // default is inferred from gql schema
             validate: { name: "validateTitle", import: "./validateTitle" },
         },
-        // "packageDimensions.height" naming is not yet supported.
-        // { type: "text", name: "packageDimensions.height", label: "Height", helperText: "Enter height in centimeters" },
         { type: "text", name: "slug" },
         { type: "text", name: "description", label: "Description", multiline: true },
         { type: "staticSelect", name: "type", label: "Type" /*, values: from gql schema (TODO overridable)*/ },

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -205,6 +205,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                             component={FinalFormInput}
                             type="number"
                             label={<FormattedMessage id="product.price" defaultMessage="Price" />}
+                            helperText={<FormattedMessage id="product.price.helperText" defaultMessage="Enter price in this format: 123,45" />}
                         />
                         <Field name="inStock" label="" type="checkbox" fullWidth>
                             {(props) => (

--- a/packages/admin/cms-admin/src/generator/future/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateFormField.ts
@@ -43,6 +43,11 @@ export function generateFormField(
             name="${name}"
             component={FinalFormInput}
             label={<FormattedMessage id="${instanceGqlType}.${name}" defaultMessage="${label}" />}
+            ${
+                config.helperText
+                    ? `helperText={<FormattedMessage id=` + `"${instanceGqlType}.${name}.helperText" ` + `defaultMessage="${config.helperText}" />}`
+                    : ""
+            }
         />`;
     } else if (config.type == "number") {
         code = `
@@ -53,6 +58,13 @@ export function generateFormField(
                 component={FinalFormInput}
                 type="number"
                 label={<FormattedMessage id="${instanceGqlType}.${name}" defaultMessage="${label}" />}
+                ${
+                    config.helperText
+                        ? `helperText={<FormattedMessage id=` +
+                          `"${instanceGqlType}.${name}.helperText" ` +
+                          `defaultMessage="${config.helperText}" />}`
+                        : ""
+                }
             />`;
         //TODO MUI suggest not using type=number https://mui.com/material-ui/react-text-field/#type-quot-number-quot
     } else if (config.type == "boolean") {
@@ -61,6 +73,13 @@ export function generateFormField(
                 <FormControlLabel
                     label={<FormattedMessage id="${instanceGqlType}.${name}" defaultMessage="${label}" />}
                     control={<FinalFormCheckbox {...props} />}
+                    ${
+                        config.helperText
+                            ? `helperText={<FormattedMessage id=` +
+                              `"${instanceGqlType}.${name}.helperText" ` +
+                              `defaultMessage="${config.helperText}" />}`
+                            : ""
+                    }
                 />
             )}
         </Field>`;
@@ -72,6 +91,13 @@ export function generateFormField(
                 name="${name}"
                 component={FinalFormDatePicker}
                 label={<FormattedMessage id="${instanceGqlType}.${name}" defaultMessage="${label}" />}
+                ${
+                    config.helperText
+                        ? `helperText={<FormattedMessage id=` +
+                          `"${instanceGqlType}.${name}.helperText" ` +
+                          `defaultMessage="${config.helperText}" />}`
+                        : ""
+                }
             />`;
     } else if (config.type == "block") {
         imports.push({
@@ -94,6 +120,11 @@ export function generateFormField(
             fullWidth
             name="${name}"
             label={<FormattedMessage id="${instanceGqlType}.${name}" defaultMessage="${label}" />}>
+            ${
+                config.helperText
+                    ? `helperText={<FormattedMessage id=` + `"${instanceGqlType}.${name}.helperText" ` + `defaultMessage="${config.helperText}" />}`
+                    : ""
+            }
             {(props) => 
                 <FinalFormSelect {...props}>
                 ${values

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -22,7 +22,7 @@ export type FormFieldConfig<T> = (
     | { type: "staticSelect"; values?: string[] }
     | { type: "asyncSelect"; values?: string[] }
     | { type: "block"; block: BlockReference }
-) & { name: keyof T; label?: string; required?: boolean };
+) & { name: keyof T; label?: string; required?: boolean; helperText?: string };
 
 export type FormConfig<T extends { __typename?: string }> = {
     type: "form";


### PR DESCRIPTION
Support `helperText` `Field` prop in Forms
<details><summary>Screenshot of Demo:</summary>
<p>

<img width="685" alt="Screenshot 2024-02-15 at 09 06 28" src="https://github.com/vivid-planet/comet/assets/122883866/ca0a1c5b-fc10-4940-83a8-6788e6b4ab18">

</p>
</details> 

- [ ] Add changeset (if necessary)