### PR TITLE
COM-357: Add support for additional content in DAM grid rows

### DIFF
--- a/.changeset/heavy-rules-bow.md
+++ b/.changeset/heavy-rules-bow.md
@@ -1,0 +1,17 @@
+---
+"@comet/cms-admin": minor
+---
+
+Support additional content in DAM Data Grid rows
+
+**Example**
+
+```tsx
+<DamConfigProvider
+    value={{
+        renderAdditionalRowContent: (row) => <Chip size="small" icon={<UnsplashIcon />} label="Unsplash" />,
+    }}
+>
+    ...
+</DamConfigProvider>
+```

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -34,6 +34,7 @@ import { Route, Switch } from "react-router-dom";
 
 import MasterHeader from "./common/MasterHeader";
 import MasterMenu, { masterMenuData, pageTreeDocumentTypes } from "./common/MasterMenu";
+import { renderUnsplashChip } from "./dam/renderUnsplashChip";
 import { getMessages } from "./lang";
 
 const GlobalStyle = () => (
@@ -65,7 +66,13 @@ class App extends React.Component {
                             resolveSiteConfigForScope: (configs, scope: ContentScope) => configs[scope.domain],
                         }}
                     >
-                        <DamConfigProvider value={{ scopeParts: ["domain"], additionalToolbarItems: <ImportFromUnsplash /> }}>
+                        <DamConfigProvider
+                            value={{
+                                scopeParts: ["domain"],
+                                additionalToolbarItems: <ImportFromUnsplash />,
+                                renderAdditionalRowContent: renderUnsplashChip,
+                            }}
+                        >
                             <IntlProvider locale="en" messages={getMessages()}>
                                 <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.domain}>
                                     <MuiThemeProvider theme={theme}>

--- a/demo/admin/src/dam/renderUnsplashChip.tsx
+++ b/demo/admin/src/dam/renderUnsplashChip.tsx
@@ -1,0 +1,14 @@
+import { DamRow } from "@comet/cms-admin";
+import { Chip } from "@mui/material";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+import UnsplashIcon from "./UnsplashIcon";
+
+function renderUnsplashChip(row: DamRow) {
+    return row.__typename === "DamFile" && row.importSourceType === "unsplash" ? (
+        <Chip size="small" icon={<UnsplashIcon />} label={<FormattedMessage id="dam.unsplashImport.chip.label" defaultMessage="Unsplash" />} />
+    ) : null;
+}
+
+export { renderUnsplashChip };

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.gql.ts
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.gql.ts
@@ -31,6 +31,8 @@ export const damFileTableFragment = gql`
             ...DamFileThumbnail
         }
         updatedAt
+        importSourceId
+        importSourceType
     }
     ${damFileThumbnailFragment}
 `;
@@ -60,6 +62,20 @@ export const damFolderQuery = gql`
     ${damFolderTableFragment}
 `;
 
+export const damRowFragment = gql`
+    fragment DamRow on DamItem {
+        ... on DamFile {
+            ...DamFileTable
+        }
+        ... on DamFolder {
+            ...DamFolderTable
+        }
+    }
+
+    ${damFileTableFragment}
+    ${damFolderTableFragment}
+`;
+
 export const damItemsListQuery = gql`
     query DamItemsList(
         $folderId: ID
@@ -82,18 +98,13 @@ export const damItemsListQuery = gql`
             scope: $scope
         ) {
             nodes {
-                ... on DamFile {
-                    ...DamFileTable
-                }
-                ... on DamFolder {
-                    ...DamFolderTable
-                }
+                ...DamRow
             }
             totalCount
         }
     }
-    ${damFileTableFragment}
-    ${damFolderTableFragment}
+
+    ${damRowFragment}
 `;
 
 export const moveDamFilesMutation = gql`

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -36,6 +36,7 @@ import {
     GQLDamItemListPositionQueryVariables,
     GQLDamItemsListQuery,
     GQLDamItemsListQueryVariables,
+    GQLDamRowFragment,
 } from "./FolderDataGrid.gql.generated";
 import * as sc from "./FolderDataGrid.sc";
 import { FolderHead } from "./FolderHead";
@@ -59,6 +60,8 @@ export {
 } from "./FolderDataGrid.gql.generated";
 
 export type DamItemSelectionMap = Map<string, "file" | "folder">;
+
+export type DamRow = GQLDamRowFragment;
 
 interface FolderDataGridProps extends DamConfig {
     id?: string;

--- a/packages/admin/cms-admin/src/dam/DataGrid/label/DamItemLabel.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/label/DamItemLabel.tsx
@@ -1,10 +1,12 @@
 import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
+import { Box } from "@mui/system";
 import * as React from "react";
 
 import { MarkedMatches, TextMatch } from "../../../common/MarkedMatches";
+import { useDamConfig } from "../../config/useDamConfig";
 import { isFile } from "../../helpers/isFile";
-import { GQLDamFileTableFragment, GQLDamFolderTableFragment } from "../FolderDataGrid";
+import { DamRow, GQLDamFileTableFragment, GQLDamFolderTableFragment } from "../FolderDataGrid";
 import { ArchivedTag } from "../tags/ArchivedTag";
 import { LicenseValidityTags } from "../tags/LicenseValidityTags";
 import { DamThumbnail } from "../thumbnail/DamThumbnail";
@@ -29,7 +31,7 @@ const Path = styled(Typography)`
 `;
 
 interface DamItemLabelProps {
-    asset: GQLDamFolderTableFragment | GQLDamFileTableFragment;
+    asset: DamRow;
     showPath?: boolean;
     matches?: TextMatch[];
     showLicenseWarnings?: boolean;
@@ -55,6 +57,8 @@ const getFolderPath = (folder: GQLDamFolderTableFragment) => {
 };
 
 const DamItemLabel = ({ asset, showPath = false, matches, showLicenseWarnings = false }: DamItemLabelProps): React.ReactElement => {
+    const { renderAdditionalRowContent } = useDamConfig();
+
     return (
         <LabelWrapper>
             <DamThumbnail asset={asset} />
@@ -62,15 +66,18 @@ const DamItemLabel = ({ asset, showPath = false, matches, showLicenseWarnings = 
                 <Typography>{matches ? <MarkedMatches text={asset.name} matches={matches} /> : asset.name}</Typography>
                 {showPath && <Path variant="body2">{isFile(asset) ? getFilePath(asset) : getFolderPath(asset)}</Path>}
             </NameWrapper>
-            {isFile(asset) && asset.archived && <ArchivedTag />}
-            {isFile(asset) && showLicenseWarnings && (
-                <LicenseValidityTags
-                    expirationDate={asset.license?.expirationDate ? new Date(asset.license.expirationDate) : undefined}
-                    isNotValidYet={asset.license?.isNotValidYet}
-                    expiresWithinThirtyDays={asset.license?.expiresWithinThirtyDays}
-                    hasExpired={asset.license?.hasExpired}
-                />
-            )}
+            <Box sx={{ display: "flex", alignItems: "center", gap: 2, paddingX: 2 }}>
+                {isFile(asset) && asset.archived && <ArchivedTag />}
+                {isFile(asset) && showLicenseWarnings && (
+                    <LicenseValidityTags
+                        expirationDate={asset.license?.expirationDate ? new Date(asset.license.expirationDate) : undefined}
+                        isNotValidYet={asset.license?.isNotValidYet}
+                        expiresWithinThirtyDays={asset.license?.expiresWithinThirtyDays}
+                        hasExpired={asset.license?.hasExpired}
+                    />
+                )}
+                {renderAdditionalRowContent?.(asset)}
+            </Box>
         </LabelWrapper>
     );
 };

--- a/packages/admin/cms-admin/src/dam/DataGrid/tags/Tag.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/tags/Tag.tsx
@@ -7,7 +7,6 @@ export const Tag = styled("div")<{ type?: "warning" | "error" | "info" | "neutra
     align-items: center;
     height: 20px;
     border-radius: 4px;
-    margin-left: 10px;
     padding: 4px 5px;
     box-sizing: border-box;
     font-size: 12px;

--- a/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
+++ b/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
@@ -1,11 +1,14 @@
 import * as React from "react";
 
+import { DamRow } from "../DataGrid/FolderDataGrid";
+
 export interface DamConfig {
     additionalMimeTypes?: string[];
     scopeParts?: string[];
     enableLicenseFeature?: boolean;
     requireLicense?: boolean;
     additionalToolbarItems?: React.ReactNode;
+    renderAdditionalRowContent?: (row: DamRow) => React.ReactNode;
 }
 
 export const DamConfigContext = React.createContext<DamConfig | undefined>(undefined);

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -51,6 +51,7 @@ export { useDamConfig } from "./dam/config/useDamConfig";
 export { useCurrentDamFolder } from "./dam/CurrentDamFolderProvider";
 export { DamPage } from "./dam/DamPage";
 export { useDamFileUpload } from "./dam/DataGrid/fileUpload/useDamFileUpload";
+export type { DamRow } from "./dam/DataGrid/FolderDataGrid";
 export { DashboardHeader, DashboardHeaderProps } from "./dashboard/DashboardHeader";
 export { DashboardWidgetRoot, DashboardWidgetRootProps } from "./dashboard/widgets/DashboardWidgetRoot";
 export { LatestBuildsDashboardWidget } from "./dashboard/widgets/LatestBuildsDashboardWidget";


### PR DESCRIPTION
We need this for the "External DAM systems" feature to show the import source in the grid.

---

<img width="1888" alt="DAM grid row additional content" src="https://github.com/vivid-planet/comet/assets/48853629/cd381818-f74c-4eb7-81b6-965847074192">
