### PR TITLE
COM-426: use isUrl instead of isHref in validateUrl validator

### DIFF
--- a/packages/admin/cms-admin/src/validation/validateUrl.tsx
+++ b/packages/admin/cms-admin/src/validation/validateUrl.tsx
@@ -1,10 +1,9 @@
+import { isURL } from "class-validator";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { isHref } from "./isHref";
-
 export function validateUrl(url: string) {
-    if (url && !isHref(url)) {
+    if (url && !isURL(url)) {
         return <FormattedMessage id="comet.validation.validateUrl.invalid" defaultMessage="Invalid URL" />;
     }
 }


### PR DESCRIPTION
### Description
Fix `validateUrl` validator by using `isUrl` instead of `isHref` validation.