### PR TITLE
Add AffectedArg-decorator

### DIFF
--- a/.changeset/sixty-boats-turn.md
+++ b/.changeset/sixty-boats-turn.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Add `AffectedArg`-decorator to retrieve ContentScope manually

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -141,6 +141,7 @@ export { createRedirectsResolver } from "./redirects/redirects.resolver";
 export { RedirectsService } from "./redirects/redirects.service";
 export { IsValidRedirectSource, IsValidRedirectSourceConstraint } from "./redirects/validators/isValidRedirectSource";
 export { AbstractAccessControlService } from "./user-permissions/access-control.service";
+export { AffectedArg } from "./user-permissions/decorators/affected-arg.decorator";
 export { AffectedEntity, AffectedEntityMeta, AffectedEntityOptions } from "./user-permissions/decorators/affected-entity.decorator";
 export { RequiredPermission } from "./user-permissions/decorators/required-permission.decorator";
 export { ScopedEntity, ScopedEntityMeta } from "./user-permissions/decorators/scoped-entity.decorator";

--- a/packages/api/cms-api/src/user-permissions/content-scope.service.ts
+++ b/packages/api/cms-api/src/user-permissions/content-scope.service.ts
@@ -7,6 +7,7 @@ import isEqual from "lodash.isequal";
 import { PageTreeService } from "../page-tree/page-tree.service";
 import { ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
+import { AffectedArgSelector } from "./decorators/affected-arg.decorator";
 import { AffectedEntityMeta } from "./decorators/affected-entity.decorator";
 
 @Injectable()
@@ -69,6 +70,15 @@ export class ContentScopeService {
             }
             return contentScope;
         }
+
+        const affectedArg = this.reflector.getAllAndOverride<AffectedArgSelector>("affectedArg", [context.getHandler(), context.getClass()]);
+        if (affectedArg) {
+            if (typeof affectedArg === "function") {
+                return affectedArg(args);
+            }
+            return args[affectedArg];
+        }
+
         if (args.scope) {
             return args.scope;
         }

--- a/packages/api/cms-api/src/user-permissions/decorators/affected-arg.decorator.ts
+++ b/packages/api/cms-api/src/user-permissions/decorators/affected-arg.decorator.ts
@@ -1,0 +1,10 @@
+import { CustomDecorator, SetMetadata } from "@nestjs/common";
+
+import { ContentScope } from "../interfaces/content-scope.interface";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AffectedArgSelector = string | ((args: any) => ContentScope);
+
+export const AffectedArg = (selector: AffectedArgSelector): CustomDecorator<string> => {
+    return SetMetadata("affectedArg", selector);
+};


### PR DESCRIPTION
Current situation is that when a scope-argument is present in a graphql-request this is used to check the content scope. However, in certain situations (e.g. the ContentScope only has one field) we just want to submit the value instead of a scope-Object:
```
    @Query(() => Customers)
    @AffectedArg((tenantId: string) => ({tenantId}))
    async customersForTenant(@Args("tenantId") tenantId: string): Promise<PaginatedNews> {
```