### PR TITLE
Add loading state for edit StackPage in PagesPage

### DIFF
--- a/.changeset/pink-rules-promise.md
+++ b/.changeset/pink-rules-promise.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Add loading state for edit `StackPage` in `PagesPage`
+
+Prevents flash of "Document not found" error message when reloading the page editor

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -220,6 +220,10 @@ export function PagesPage({
                         {(selectedId) => {
                             const page = data?.pages.find((page) => page.id == selectedId);
 
+                            if (loading) {
+                                return <Loading behavior="fillPageHeight" />;
+                            }
+
                             if (!page) {
                                 return (
                                     <MainContent>


### PR DESCRIPTION
Add loading state for edit `StackPage` in `PagesPage`

Prevents flash of "Document not found" error message when reloading the page editor

---

Previously:


https://github.com/vivid-planet/comet/assets/13380047/8f401034-f5a3-40df-a52e-7039a936cef7


Now:


https://github.com/vivid-planet/comet/assets/13380047/ac68b2ca-71b3-4c9e-9a9f-676dfb189b2b


---

Closes COM-469