### PR TITLE
COM-466: Change width of default dialog variant to 680px to match updated design

### DIFF
--- a/.changeset/gentle-pots-perform.md
+++ b/.changeset/gentle-pots-perform.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": minor
+---
+
+Slightly increase the default size of dialogs

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialog.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialog.ts
@@ -18,7 +18,7 @@ export const getMuiDialog: GetMuiComponentTheme<"MuiDialog"> = (component, { spa
             maxWidth: 350,
         },
         paperWidthSm: {
-            maxWidth: 600,
+            maxWidth: 680,
         },
         paperWidthMd: {
             maxWidth: 1024,

--- a/storybook/src/admin/mui/Dialog.tsx
+++ b/storybook/src/admin/mui/Dialog.tsx
@@ -16,8 +16,6 @@ const dialogSizeOptions: DialogSizeOptions = {
     "XS (350px)": "xs",
     "SM (680px)": "sm",
     "MD (1024px)": "md",
-    "LG (1280px)": "lg",
-    "XL (1920px)": "xl",
     FullWidth: "fullWidth",
 };
 

--- a/storybook/src/admin/mui/Dialog.tsx
+++ b/storybook/src/admin/mui/Dialog.tsx
@@ -14,7 +14,7 @@ type DialogSizeOptions = {
 
 const dialogSizeOptions: DialogSizeOptions = {
     "XS (350px)": "xs",
-    "SM (600px)": "sm",
+    "SM (680px)": "sm",
     "MD (1024px)": "md",
     "LG (1280px)": "lg",
     "XL (1920px)": "xl",


### PR DESCRIPTION
Also remove dialog sizes above MD from story. 
Sizes above 1024px (other than `fullWidth`) should not be used, according to the design guidelines. 