### PR TITLE
COM-284: Refactor theming of `BlockTypesControls`

### DIFF
--- a/packages/admin/admin-rte/src/core/Controls/BlockTypesControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/BlockTypesControls.tsx
@@ -95,7 +95,7 @@ export function StyledBlockTypesControls(inProps: Props) {
     );
 }
 
-//If there are no dropdown-features, this must return null not just an empty component, to prevent an empty item from being rendered in Toolbar
+// If there are no dropdown-features, this must return null not just an empty component, to prevent an empty item from being rendered in Toolbar
 export default (p: IControlProps) => {
     const { editorState, setEditorState, editorRef, options } = p;
     const { supports: supportedThings, blocktypeMap, standardBlockType } = options;

--- a/packages/admin/admin-rte/src/core/Controls/BlockTypesControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/BlockTypesControls.tsx
@@ -30,7 +30,7 @@ const Root = styled(FormControl, {
         return [styles.root];
     },
 })(css`
-    & .${inputBaseClasses.root} {
+    .${inputBaseClasses.root} {
         background-color: transparent;
         height: auto;
         border: none;
@@ -42,7 +42,7 @@ const Root = styled(FormControl, {
             }
         }
     }
-    & .${selectClasses.icon} {
+    .${selectClasses.icon} {
         top: auto;
         color: inherit;
     }

--- a/packages/admin/admin-rte/src/core/Controls/BlockTypesControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/BlockTypesControls.tsx
@@ -1,24 +1,83 @@
-import { ComponentsOverrides, FormControl, inputBaseClasses, MenuItem, Select, selectClasses, Theme } from "@mui/material";
-import { createStyles, WithStyles, withStyles } from "@mui/styles";
+import { ThemedComponentBaseProps } from "@comet/admin";
+import {
+    ComponentsOverrides,
+    css,
+    FormControl,
+    inputBaseClasses,
+    MenuItem,
+    Select as MuiSelect,
+    selectClasses,
+    styled,
+    Theme,
+    useThemeProps,
+} from "@mui/material";
 import * as React from "react";
 
 import { IControlProps } from "../types";
 import getRteTheme from "../utils/getRteTheme";
 import useBlockTypes, { BlockTypesApi } from "./useBlockTypes";
 
-interface Props extends IControlProps {
+interface Props extends ThemedComponentBaseProps<{ root: typeof FormControl; select: typeof MuiSelect }>, IControlProps {
     blockTypes: BlockTypesApi;
 }
 
-function BlockTypesControls({ disabled, blockTypes, classes }: Props & WithStyles<typeof styles>) {
+export type RteBlockTypeControlsClassKey = "root" | "select";
+
+const Root = styled(FormControl, {
+    name: "CometAdminRteBlockTypeControls",
+    slot: "root",
+    overridesResolver(_, styles) {
+        return [styles.root];
+    },
+})(css`
+    & .${inputBaseClasses.root} {
+        background-color: transparent;
+        height: auto;
+        border: none;
+        &,
+        &:hover {
+            &:before,
+            &:after {
+                border-bottom-width: 0;
+            }
+        }
+    }
+    & .${selectClasses.icon} {
+        top: auto;
+        color: inherit;
+    }
+`);
+
+const Select = styled(MuiSelect, {
+    name: "CometAdminRteBlockTypeControls",
+    slot: "select",
+    overridesResolver(_, styles) {
+        return [styles.select];
+    },
+})(
+    ({ theme }) =>
+        css`
+            .${selectClasses.select}.${inputBaseClasses.input} {
+                min-height: 0;
+                color: ${getRteTheme(theme.components?.CometAdminRte?.defaultProps).colors.buttonIcon};
+                min-width: 180px;
+                line-height: 24px;
+                font-size: 14px;
+                padding: 0;
+            }
+        `,
+);
+
+export function StyledBlockTypesControls(inProps: Props) {
+    const { disabled, blockTypes, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminRteBlockTypeControls" });
     const { dropdownFeatures, activeDropdownBlockType, handleBlockTypeChange } = blockTypes;
 
     const blockTypesListItems: Array<{ name: string; label: React.ReactNode }> = dropdownFeatures.map((c) => ({ name: c.name, label: c.label }));
 
     return (
-        <FormControl classes={{ root: classes.root }}>
+        <Root {...slotProps?.root} {...restProps}>
             <Select
-                classes={{ select: classes.select }}
+                {...slotProps?.select}
                 disabled={disabled}
                 value={activeDropdownBlockType}
                 displayEmpty
@@ -32,49 +91,11 @@ function BlockTypesControls({ disabled, blockTypes, classes }: Props & WithStyle
                     </MenuItem>
                 ))}
             </Select>
-        </FormControl>
+        </Root>
     );
 }
 
-export type RteBlockTypeControlsClassKey = "root" | "select";
-
-const styles = (theme: Theme) => {
-    const rteTheme = getRteTheme(theme.components?.CometAdminRte?.defaultProps);
-
-    return createStyles<RteBlockTypeControlsClassKey, Props>({
-        root: {
-            [`& .${inputBaseClasses.root}`]: {
-                backgroundColor: "transparent",
-                height: "auto",
-                border: "none",
-                "&, &:hover": {
-                    "&:before, &:after": {
-                        borderBottomWidth: 0,
-                    },
-                },
-            },
-            [`& .${selectClasses.icon}`]: {
-                top: "auto",
-                color: "inherit",
-            },
-        },
-        select: {
-            color: rteTheme.colors.buttonIcon,
-            minWidth: 180,
-            lineHeight: "24px",
-            fontSize: 14,
-            padding: 0,
-
-            [`&.${selectClasses.select}`]: {
-                minHeight: 0,
-            },
-        },
-    });
-};
-
-const StyledBlockTypesControls = withStyles(styles, { name: "CometAdminRteBlockTypeControls" })(BlockTypesControls);
-
-// If there are no dropdown-features, this must return null not just an empty component, to prevent an empty item from being rendered in Toolbar
+//If there are no dropdown-features, this must return null not just an empty component, to prevent an empty item from being rendered in Toolbar
 export default (p: IControlProps) => {
     const { editorState, setEditorState, editorRef, options } = p;
     const { supports: supportedThings, blocktypeMap, standardBlockType } = options;
@@ -83,7 +104,6 @@ export default (p: IControlProps) => {
     if (!blockTypes.dropdownFeatures.length) {
         return null;
     }
-
     return <StyledBlockTypesControls {...p} blockTypes={blockTypes} />;
 };
 


### PR DESCRIPTION
<img width="675" alt="Screenshot 2024-02-20 at 11 03 52" src="https://github.com/vivid-planet/comet/assets/109900447/6ef65283-10de-4736-bbd2-5d24fc365a27">



<img width="681" alt="Screenshot 2024-02-20 at 11 03 59" src="https://github.com/vivid-planet/comet/assets/109900447/a0663357-328d-4850-88df-bb9685c9865d">
