### PR TITLE
Demo: Remove product package dimensions

### DIFF
--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -104,7 +104,6 @@ function ProductForm({ id }: FormProps): React.ReactElement {
             variants: [],
             articleNumbers: [],
             discounts: [],
-            packageDimensions: { width: 0, height: 0, depth: 0 },
             statistics: { views: 0 },
         };
         if (mode === "edit") {

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -165,7 +165,7 @@ function ProductsGrid() {
                                             })),
                                             articleNumbers: input.articleNumbers,
                                             discounts: input.discounts,
-                                            packageDimensions: input.packageDimensions,
+                                            packageDimensions: { width: 0, height: 0, depth: 0 },
                                             statistics: { views: 0 },
                                         },
                                     },
@@ -244,11 +244,6 @@ const productsFragment = gql`
         discounts {
             quantity
             price
-        }
-        packageDimensions {
-            width
-            height
-            depth
         }
     }
 `;

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -165,7 +165,6 @@ function ProductsGrid() {
                                             })),
                                             articleNumbers: input.articleNumbers,
                                             discounts: input.discounts,
-                                            packageDimensions: { width: 0, height: 0, depth: 0 },
                                             statistics: { views: 0 },
                                         },
                                     },

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -1135,17 +1135,10 @@ input ProductInput {
   discounts: [ProductDiscountsInput!]! = []
   articleNumbers: [String!]! = []
   dimensions: ProductDimensionsInput
-  packageDimensions: ProductPackageDimensionsInput!
   statistics: ProductStatisticsInput
   variants: [ProductVariantInput!]! = []
   category: ID = null
   tags: [ID!]! = []
-}
-
-input ProductPackageDimensionsInput {
-  width: Float!
-  height: Float!
-  depth: Float!
 }
 
 input ProductStatisticsInput {
@@ -1168,7 +1161,6 @@ input ProductUpdateInput {
   discounts: [ProductDiscountsInput!]
   articleNumbers: [String!]
   dimensions: ProductDimensionsInput
-  packageDimensions: ProductPackageDimensionsInput
   statistics: ProductStatisticsInput
   variants: [ProductVariantInput!]
   category: ID

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -473,7 +473,7 @@ type Product implements DocumentInterface {
   discounts: [ProductDiscounts!]!
   articleNumbers: [String!]!
   dimensions: ProductDimensions
-  packageDimensions: ProductPackageDimensions
+  packageDimensions: ProductPackageDimensions!
   statistics: ProductStatistics
   createdAt: DateTime!
   category: ProductCategory
@@ -1148,7 +1148,7 @@ input ProductInput {
   discounts: [ProductDiscountsInput!]! = []
   articleNumbers: [String!]! = []
   dimensions: ProductDimensionsInput
-  packageDimensions: ProductPackageDimensionsInput
+  packageDimensions: ProductPackageDimensionsInput!
   statistics: ProductStatisticsInput
   variants: [ProductVariantInput!]! = []
   category: ID = null

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -452,12 +452,6 @@ type ProductDimensions {
   depth: Float!
 }
 
-type ProductPackageDimensions {
-  width: Float!
-  height: Float!
-  depth: Float!
-}
-
 type Product implements DocumentInterface {
   id: ID!
   updatedAt: DateTime!
@@ -473,7 +467,6 @@ type Product implements DocumentInterface {
   discounts: [ProductDiscounts!]!
   articleNumbers: [String!]!
   dimensions: ProductDimensions
-  packageDimensions: ProductPackageDimensions!
   statistics: ProductStatistics
   createdAt: DateTime!
   category: ProductCategory
@@ -590,12 +583,6 @@ input ProductDiscountsInput {
 }
 
 input ProductDimensionsInput {
-  width: Float!
-  height: Float!
-  depth: Float!
-}
-
-input ProductPackageDimensionsInput {
   width: Float!
   height: Float!
   depth: Float!
@@ -1153,6 +1140,12 @@ input ProductInput {
   variants: [ProductVariantInput!]! = []
   category: ID = null
   tags: [ID!]! = []
+}
+
+input ProductPackageDimensionsInput {
+  width: Float!
+  height: Float!
+  depth: Float!
 }
 
 input ProductStatisticsInput {

--- a/demo/api/src/db/migrations/Migration20240222081515.ts
+++ b/demo/api/src/db/migrations/Migration20240222081515.ts
@@ -1,0 +1,10 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20240222081515 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "Product" drop column "packageDimensions_width";');
+    this.addSql('alter table "Product" drop column "packageDimensions_height";');
+    this.addSql('alter table "Product" drop column "packageDimensions_depth";');
+  }
+}

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -147,9 +147,9 @@ export class Product extends BaseEntity<Product, "id"> implements DocumentInterf
     @Field(() => ProductDimensions, { nullable: true })
     dimensions?: ProductDimensions = undefined;
 
-    @Embedded(() => ProductPackageDimensions, { nullable: true })
-    @Field(() => ProductPackageDimensions, { nullable: true })
-    packageDimensions?: ProductPackageDimensions = undefined;
+    @Embedded(() => ProductPackageDimensions)
+    @Field(() => ProductPackageDimensions)
+    packageDimensions: ProductPackageDimensions;
 
     @OneToOne(() => ProductStatistics, { inversedBy: "product", owner: true, ref: true, nullable: true })
     @Field(() => ProductStatistics, { nullable: true })

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -148,7 +148,6 @@ export class Product extends BaseEntity<Product, "id"> implements DocumentInterf
     dimensions?: ProductDimensions = undefined;
 
     @Embedded(() => ProductPackageDimensions)
-    @Field(() => ProductPackageDimensions)
     packageDimensions: ProductPackageDimensions;
 
     @OneToOne(() => ProductStatistics, { inversedBy: "product", owner: true, ref: true, nullable: true })

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -3,8 +3,6 @@ import { CrudField, CrudGenerator, DamImageBlock, DocumentInterface, RootBlockDa
 import {
     BaseEntity,
     Collection,
-    Embeddable,
-    Embedded,
     Entity,
     Enum,
     ManyToMany,
@@ -50,26 +48,6 @@ export class ProductDimensions {
     @IsNumber()
     height: number;
 
-    @Field()
-    @IsNumber()
-    depth: number;
-}
-
-@Embeddable()
-@ObjectType()
-@InputType("ProductPackageDimensionsInput")
-export class ProductPackageDimensions {
-    @Property({ type: types.integer })
-    @Field()
-    @IsNumber()
-    width: number;
-
-    @Property({ type: types.integer })
-    @Field()
-    @IsNumber()
-    height: number;
-
-    @Property({ type: types.integer })
     @Field()
     @IsNumber()
     depth: number;
@@ -146,9 +124,6 @@ export class Product extends BaseEntity<Product, "id"> implements DocumentInterf
     @Property({ type: "json", nullable: true })
     @Field(() => ProductDimensions, { nullable: true })
     dimensions?: ProductDimensions = undefined;
-
-    @Embedded(() => ProductPackageDimensions)
-    packageDimensions: ProductPackageDimensions;
 
     @OneToOne(() => ProductStatistics, { inversedBy: "product", owner: true, ref: true, nullable: true })
     @Field(() => ProductStatistics, { nullable: true })

--- a/demo/api/src/products/generated/dto/product.input.ts
+++ b/demo/api/src/products/generated/dto/product.input.ts
@@ -6,7 +6,7 @@ import { Field, ID, InputType } from "@nestjs/graphql";
 import { Transform, Type } from "class-transformer";
 import { IsArray, IsBoolean, IsEnum, IsNotEmpty, IsNumber, IsString, IsUUID, ValidateNested } from "class-validator";
 
-import { ProductDimensions, ProductDiscounts, ProductPackageDimensions } from "../../entities/product.entity";
+import { ProductDimensions, ProductDiscounts } from "../../entities/product.entity";
 import { ProductType } from "../../entities/product-type.enum";
 import { ProductStatisticsInput } from "./product-statistics.nested.input";
 import { ProductVariantInput } from "./product-variant.nested.input";
@@ -68,12 +68,6 @@ export class ProductInput {
     @Type(() => ProductDimensions)
     @Field(() => ProductDimensions, { nullable: true })
     dimensions?: ProductDimensions;
-
-    @IsNotEmpty()
-    @ValidateNested()
-    @Type(() => ProductPackageDimensions)
-    @Field(() => ProductPackageDimensions)
-    packageDimensions: ProductPackageDimensions;
 
     @IsNullable()
     @Field(() => ProductStatisticsInput, { nullable: true })

--- a/demo/api/src/products/generated/dto/product.input.ts
+++ b/demo/api/src/products/generated/dto/product.input.ts
@@ -69,11 +69,11 @@ export class ProductInput {
     @Field(() => ProductDimensions, { nullable: true })
     dimensions?: ProductDimensions;
 
-    @IsNullable()
+    @IsNotEmpty()
     @ValidateNested()
     @Type(() => ProductPackageDimensions)
-    @Field(() => ProductPackageDimensions, { nullable: true })
-    packageDimensions?: ProductPackageDimensions;
+    @Field(() => ProductPackageDimensions)
+    packageDimensions: ProductPackageDimensions;
 
     @IsNullable()
     @Field(() => ProductStatisticsInput, { nullable: true })


### PR DESCRIPTION
- `packageDimensions` was nullable, although the database fields aren't nullable (caused an DB error if null was saved)
- Admin Generator (present and future) doesn't support nested fields (for future it is WIP, present will never get it)
- Easy solution: remove it
- #1729 will showcase nested fields and everything (as replacement for packageDimensions)