### PR TITLE
Refactor `@comet/admin-icons` generator to accept a broader variation of SVGs

### DIFF
--- a/packages/admin/admin-icons/generate-icons.ts
+++ b/packages/admin/admin-icons/generate-icons.ts
@@ -65,22 +65,15 @@ const getComponentName = (fileName: string) => pascalCase(fileName.split(".")[0]
 
 const getSVGData = (icon: Icon) => {
     const fileContents = readFileSync(icon.path);
-    const parsedXml = new XMLParser({ ignoreAttributes: false }).parse(fileContents.toString());
+    const parsedXml = new XMLParser({
+        ignoreAttributes: false,
+        updateTag(_, __, attrs) {
+            delete attrs["@_fill"];
+            return true;
+        },
+    }).parse(fileContents.toString());
 
-    removeFillAttributes(parsedXml.svg);
     return parsedXml.svg;
-};
-
-const removeFillAttributes = (obj: any) => {
-    if (typeof obj === "object") {
-        Object.keys(obj).forEach((key) => {
-            if (key === "@_fill") {
-                delete obj[key];
-            } else if (typeof obj[key] === "object") {
-                removeFillAttributes(obj[key]);
-            }
-        });
-    }
 };
 
 const getFormattedText = async (text: string) => {


### PR DESCRIPTION
COM-366  
Change the icon generator to accept icons with more than one path, as well as circles etc. and more complex structures like: 
```
<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16">
  <g clip-path="url(#a)">
    <path fill="#242424" fill-rule="evenodd" d="M7.529.401a.5.5 0 0 1 .275.082l.076.06 3.647 3.574a.5.5 0 0 1-.63.772l-.07-.058-3.501-3.43-5.99.015.003 5.968 7.474 7.475 5.994-5.994-1.578-1.681a.5.5 0 0 1-.038-.64l.06-.067a.5.5 0 0 1 .64-.038l.067.06 1.91 2.034a.5.5 0 0 1 .046.628l-.056.068-6.69 6.69a.5.5 0 0 1-.639.058l-.069-.057L.486 7.945a.5.5 0 0 1-.14-.274l-.007-.08L.335.918a.5.5 0 0 1 .41-.492l.09-.008L7.528.4ZM5 4a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z" clip-rule="evenodd"/>
  </g>
  <defs>
    <clipPath id="a">
      <path fill="#fff" d="M0 0h16v16H0z"/>
    </clipPath>
  </defs>
</svg>
```
The new icons have the same structure as the input svg files but without the `fill` prop. All other props are kept. 
I tested resizing and coloring, both work. 




