### PR TITLE
Prevent the document editor from losing its state when (re)gaining focus

### DIFF
--- a/.changeset/metal-penguins-tease.md
+++ b/.changeset/metal-penguins-tease.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-admin": patch
+---
+
+Prevent the document editor from losing its state when (re)gaining focus
+
+In v6.1.0 a loading indicator was added to the document editor (in `PagesPage`). 
+This had an unwanted side effect: Focusing the edit page automatically causes a GraphQL request to check for a newer version of the document. This request also caused the loading indicator to render, thus unmounting the editor (`EditComponent`). Consequently, the local state of the editor was lost.

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -220,7 +220,7 @@ export function PagesPage({
                         {(selectedId) => {
                             const page = data?.pages.find((page) => page.id == selectedId);
 
-                            if (loading) {
+                            if (loading && isInitialLoad.current) {
                                 return <Loading behavior="fillPageHeight" />;
                             }
 


### PR DESCRIPTION
Prevent the document editor from losing its state when (re)gaining focus

In v6.1.0 a loading indicator was added to the document editor (in `PagesPage`). 
This had an unwanted side effect: Focusing the edit page automatically causes a GraphQL request to check for a newer version of the document. This request also caused the loading indicator to render, thus unmounting the editor (`EditComponent`). Consequently, the local state of the editor was lost.

This didn't strike when testing locally because the focus aware polling is disabled in dev mode.

---

Before:

https://github.com/vivid-planet/comet/assets/13380047/d72c7286-e5f3-434c-ad9c-5c32b95a6135

After:

https://github.com/vivid-planet/comet/assets/13380047/c2658da2-b8e6-438d-b770-c108ac21a344

---

Closes COM-482