### PR TITLE
Prevent the document editor from losing its state when (re)gaining focus (v5)

### DIFF
--- a/.changeset/metal-penguins-tease.md
+++ b/.changeset/metal-penguins-tease.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-admin": patch
+---
+
+Prevent the document editor from losing its state when (re)gaining focus
+
+In v5.6.1 a loading indicator was added to the document editor (in `PagesPage`). 
+This had an unwanted side effect: Focusing the edit page automatically causes a GraphQL request to check for a newer version of the document. This request also caused the loading indicator to render, thus unmounting the editor (`EditComponent`). Consequently, the local state of the editor was lost.

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -220,7 +220,7 @@ export function PagesPage({
                         {(selectedId) => {
                             const page = data?.pages.find((page) => page.id == selectedId);
 
-                            if (loading) {
+                            if (loading && isInitialLoad.current) {
                                 return <Loading behavior="fillPageHeight" />;
                             }
 


### PR DESCRIPTION
Backport of #1745

---

COM-482