### PR TITLE
COM-357: Add import source as column in DAM grid

### DIFF
--- a/.changeset/light-candles-sparkle.md
+++ b/.changeset/light-candles-sparkle.md
@@ -1,0 +1,20 @@
+---
+"@comet/cms-admin": minor
+---
+
+Show DAM import source in grid
+
+To show the "Source" column in the DAM's data grid, provide `importSourceTypeLabels` in `DamConfigProvider`:
+
+```tsx
+<DamConfigProvider
+    value={{
+        ...
+        importSourceTypeLabels: {
+            unsplash: <FormattedMessage id="dam.importSourceLabel.unsplash" defaultMessage="Unsplash" />,
+        },
+    }}
+>
+    ...
+</DamConfigProvider>
+```

--- a/.changeset/light-candles-sparkle.md
+++ b/.changeset/light-candles-sparkle.md
@@ -4,14 +4,16 @@
 
 Show DAM import source in grid
 
-To show the "Source" column in the DAM's data grid, provide `importSourceTypeLabels` in `DamConfigProvider`:
+To show the "Source" column in the DAM's data grid, provide `importSources` in `DamConfigProvider`:
 
 ```tsx
 <DamConfigProvider
     value={{
         ...
-        importSourceTypeLabels: {
-            unsplash: <FormattedMessage id="dam.importSourceLabel.unsplash" defaultMessage="Unsplash" />,
+        importSources: {
+            unsplash: {
+                label: <FormattedMessage id="dam.importSource.unsplash.label" defaultMessage="Unsplash" />,
+            },
         },
     }}
 >

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -29,7 +29,7 @@ import * as React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import * as ReactDOM from "react-dom";
-import { IntlProvider } from "react-intl";
+import { FormattedMessage, IntlProvider } from "react-intl";
 import { Route, Switch } from "react-router-dom";
 
 import MasterHeader from "./common/MasterHeader";
@@ -65,7 +65,15 @@ class App extends React.Component {
                             resolveSiteConfigForScope: (configs, scope: ContentScope) => configs[scope.domain],
                         }}
                     >
-                        <DamConfigProvider value={{ scopeParts: ["domain"], additionalToolbarItems: <ImportFromUnsplash /> }}>
+                        <DamConfigProvider
+                            value={{
+                                scopeParts: ["domain"],
+                                additionalToolbarItems: <ImportFromUnsplash />,
+                                importSourceTypeLabels: {
+                                    unsplash: <FormattedMessage id="dam.importSourceLabel.unsplash" defaultMessage="Unsplash" />,
+                                },
+                            }}
+                        >
                             <IntlProvider locale="en" messages={getMessages()}>
                                 <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.domain}>
                                     <MuiThemeProvider theme={theme}>

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -69,8 +69,10 @@ class App extends React.Component {
                             value={{
                                 scopeParts: ["domain"],
                                 additionalToolbarItems: <ImportFromUnsplash />,
-                                importSourceTypeLabels: {
-                                    unsplash: <FormattedMessage id="dam.importSourceLabel.unsplash" defaultMessage="Unsplash" />,
+                                importSources: {
+                                    unsplash: {
+                                        label: <FormattedMessage id="dam.importSource.unsplash.label" defaultMessage="Unsplash" />,
+                                    },
                                 },
                             }}
                         >

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.gql.ts
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.gql.ts
@@ -31,6 +31,7 @@ export const damFileTableFragment = gql`
             ...DamFileThumbnail
         }
         updatedAt
+        importSourceType
     }
     ${damFileThumbnailFragment}
 `;

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -19,6 +19,7 @@ import { useDebouncedCallback } from "use-debounce";
 
 import { GQLDamItemType } from "../../graphql.generated";
 import { useDamAcceptedMimeTypes } from "../config/useDamAcceptedMimeTypes";
+import { useDamConfig } from "../config/useDamConfig";
 import { useDamScope } from "../config/useDamScope";
 import { DamConfig, DamFilter } from "../DamTable";
 import AddFolder from "../FolderForm/AddFolder";
@@ -30,8 +31,10 @@ import DamContextMenu from "./DamContextMenu";
 import { useDamFileUpload } from "./fileUpload/useDamFileUpload";
 import { damFolderQuery, damItemListPosition, damItemsListQuery } from "./FolderDataGrid.gql";
 import {
+    GQLDamFileTableFragment,
     GQLDamFolderQuery,
     GQLDamFolderQueryVariables,
+    GQLDamFolderTableFragment,
     GQLDamItemListPositionQuery,
     GQLDamItemListPositionQueryVariables,
     GQLDamItemsListQuery,
@@ -84,6 +87,7 @@ const FolderDataGrid = ({
     const damSelectionActionsApi = useDamSelectionApi();
     const scope = useDamScope();
     const snackbarApi = useSnackbarApi();
+    const { importSourceTypeLabels } = useDamConfig();
 
     const [redirectedToId, setRedirectedToId] = useStoredState<string | null>("FolderDataGrid-redirectedToId", null, window.sessionStorage);
 
@@ -338,7 +342,7 @@ const FolderDataGrid = ({
         return "";
     };
 
-    const dataGridColumns: GridColumns = [
+    const dataGridColumns: GridColumns<GQLDamFileTableFragment | GQLDamFolderTableFragment> = [
         {
             field: "name",
             headerName: intl.formatMessage({
@@ -368,6 +372,26 @@ const FolderDataGrid = ({
                     />
                 );
             },
+            sortable: false,
+            hideSortIcons: true,
+            disableColumnMenu: true,
+        },
+        {
+            field: "importSourceType",
+            headerName: intl.formatMessage({
+                id: "comet.dam.file.importSourceType",
+                defaultMessage: "Source",
+            }),
+            renderCell: ({ row }) => {
+                if (row.__typename === "DamFile") {
+                    if (row.importSourceType) {
+                        return importSourceTypeLabels?.[row.importSourceType];
+                    } else {
+                        return <FormattedMessage id="comet.dam.file.importSourceType.cmsAsset" defaultMessage="CMS Asset" />;
+                    }
+                }
+            },
+            // TODO enable sorting/filtering in API
             sortable: false,
             hideSortIcons: true,
             disableColumnMenu: true,
@@ -463,6 +487,7 @@ const FolderDataGrid = ({
                     selectionModel={Array.from(damSelectionActionsApi.selectionMap.keys())}
                     onSelectionModelChange={handleSelectionModelChange}
                     autoHeight={true}
+                    initialState={{ columns: { columnVisibilityModel: { importSourceType: importSourceTypeLabels !== undefined } } }}
                 />
             </sc.FolderOuterHoverHighlight>
             <DamSelectionFooter open={damSelectionActionsApi.selectionMap.size > 0} />

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -383,10 +383,8 @@ const FolderDataGrid = ({
                 defaultMessage: "Source",
             }),
             renderCell: ({ row }) => {
-                if (isFile(row)) {
-                    if (row.importSourceType && importSources?.[row.importSourceType]) {
-                        return importSources[row.importSourceType].label;
-                    }
+                if (isFile(row) && row.importSourceType && importSources?.[row.importSourceType]) {
+                    return importSources[row.importSourceType].label;
                 }
             },
             // TODO enable sorting/filtering in API

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -383,7 +383,7 @@ const FolderDataGrid = ({
                 defaultMessage: "Source",
             }),
             renderCell: ({ row }) => {
-                if (row.__typename === "DamFile") {
+                if (isFile(row)) {
                     if (row.importSourceType && importSources?.[row.importSourceType]) {
                         return importSources[row.importSourceType].label;
                     }

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -87,7 +87,7 @@ const FolderDataGrid = ({
     const damSelectionActionsApi = useDamSelectionApi();
     const scope = useDamScope();
     const snackbarApi = useSnackbarApi();
-    const { importSourceTypeLabels } = useDamConfig();
+    const { importSources } = useDamConfig();
 
     const [redirectedToId, setRedirectedToId] = useStoredState<string | null>("FolderDataGrid-redirectedToId", null, window.sessionStorage);
 
@@ -384,8 +384,8 @@ const FolderDataGrid = ({
             }),
             renderCell: ({ row }) => {
                 if (row.__typename === "DamFile") {
-                    if (row.importSourceType) {
-                        return importSourceTypeLabels?.[row.importSourceType];
+                    if (row.importSourceType && importSources?.[row.importSourceType]) {
+                        return importSources[row.importSourceType].label;
                     }
                 }
             },
@@ -485,7 +485,7 @@ const FolderDataGrid = ({
                     selectionModel={Array.from(damSelectionActionsApi.selectionMap.keys())}
                     onSelectionModelChange={handleSelectionModelChange}
                     autoHeight={true}
-                    initialState={{ columns: { columnVisibilityModel: { importSourceType: importSourceTypeLabels !== undefined } } }}
+                    initialState={{ columns: { columnVisibilityModel: { importSourceType: importSources !== undefined } } }}
                 />
             </sc.FolderOuterHoverHighlight>
             <DamSelectionFooter open={damSelectionActionsApi.selectionMap.size > 0} />

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -386,8 +386,6 @@ const FolderDataGrid = ({
                 if (row.__typename === "DamFile") {
                     if (row.importSourceType) {
                         return importSourceTypeLabels?.[row.importSourceType];
-                    } else {
-                        return <FormattedMessage id="comet.dam.file.importSourceType.cmsAsset" defaultMessage="CMS Asset" />;
                     }
                 }
             },

--- a/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
+++ b/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
@@ -6,6 +6,7 @@ export interface DamConfig {
     enableLicenseFeature?: boolean;
     requireLicense?: boolean;
     additionalToolbarItems?: React.ReactNode;
+    importSourceTypeLabels?: Record<string, React.ReactNode>;
 }
 
 export const DamConfigContext = React.createContext<DamConfig | undefined>(undefined);

--- a/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
+++ b/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
@@ -6,7 +6,7 @@ export interface DamConfig {
     enableLicenseFeature?: boolean;
     requireLicense?: boolean;
     additionalToolbarItems?: React.ReactNode;
-    importSourceTypeLabels?: Record<string, React.ReactNode>;
+    importSources?: Record<string, { label: React.ReactNode }>;
 }
 
 export const DamConfigContext = React.createContext<DamConfig | undefined>(undefined);


### PR DESCRIPTION
The import source column is only shown if `importSources` is provided via `DamConfigProvider`. This is done to not show the column if no external DAMs are supported.

---

<img width="1304" alt="image" src="https://github.com/vivid-planet/comet/assets/48853629/33e9fb39-49a3-429b-bea5-082c7f9d8bdd">

- [x] Add changeset (if necessary)

Alternative to #1697 