### PR TITLE
COM-394: Refactor theming of remaining admin components and remove module augmentation of `DefaultTheme`

### DIFF
--- a/.changeset/quick-foxes-notice.md
+++ b/.changeset/quick-foxes-notice.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": major
+---
+
+Remove `componentsProps` prop from `FieldSet`, use `slotProps` instead

--- a/.changeset/strange-steaks-pull.md
+++ b/.changeset/strange-steaks-pull.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": major
+---
+
+Remove `message` class-key from `Alert`
+
+Use the `.MuiAlert-message` selector instead to style the message of the underlying MUI `Alert` component.

--- a/.changeset/yellow-houses-talk.md
+++ b/.changeset/yellow-houses-talk.md
@@ -73,5 +73,14 @@ Change the method of overriding the styling of Admin components
 +/>
 ```
 
+-   The module augmentation for the `DefaultTheme` type from `@mui/styles/defaultTheme` is no longer needed and needs to be removed from the admins theme file, usually located in `admin/src/theme.ts`:
+
+```diff
+-declare module "@mui/styles/defaultTheme" {
+-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+-    export interface DefaultTheme extends Theme {}
+-}
+```
+
 -   The required changes we made to the theming method of admin components may cause missing or broken styles when using `styleOverrides` in `createCometTheme()`.
 -   For more details, see MUI's migration guide: https://mui.com/material-ui/migration/v5-style-changes/#mui-styles

--- a/demo/admin/src/theme.ts
+++ b/demo/admin/src/theme.ts
@@ -1,10 +1,4 @@
 import { createCometTheme } from "@comet/admin-theme";
 import type {} from "@mui/lab/themeAugmentation";
-import { Theme } from "@mui/material";
 
 export default createCometTheme();
-
-declare module "@mui/styles/defaultTheme" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface DefaultTheme extends Theme {}
-}

--- a/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
+++ b/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
@@ -1,19 +1,29 @@
+import { ThemedComponentBaseProps } from "@comet/admin";
 import { ArrowLeft, ArrowRight, ChevronDown } from "@comet/admin-icons";
 import { Box, Button, buttonClasses, ComponentsOverrides, IconButton, Menu, menuClasses, MenuItem } from "@mui/material";
-import { Theme } from "@mui/material/styles";
-import { createStyles, WithStyles, withStyles } from "@mui/styles";
-import clsx from "clsx";
+import { css, styled, Theme, useThemeProps } from "@mui/material/styles";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
-export interface DatePickerNavigationProps {
+export interface DatePickerNavigationProps
+    extends ThemedComponentBaseProps<{
+        root: "div";
+        selectMonthButton: typeof Button;
+        selectYearButton: typeof Button;
+        selectMonthMenu: typeof Menu;
+        selectYearMenu: typeof Menu;
+    }> {
     focusedDate: Date;
     changeShownDate: (value: number, mode: "setYear" | "setMonth" | "monthOffset") => void;
     minDate: Date;
     maxDate: Date;
 }
 
-const DatePickerNavigation = ({ classes, focusedDate, changeShownDate, minDate, maxDate }: DatePickerNavigationProps & WithStyles<typeof styles>) => {
+export const DatePickerNavigation = (inProps: DatePickerNavigationProps) => {
+    const { focusedDate, changeShownDate, minDate, maxDate, slotProps, ...restProps } = useThemeProps({
+        props: inProps,
+        name: "CometAdminDatePickerNavigation",
+    });
     const intl = useIntl();
 
     const [showMonthSelect, setShowMonthSelect] = React.useState<boolean>(false);
@@ -23,26 +33,25 @@ const DatePickerNavigation = ({ classes, focusedDate, changeShownDate, minDate, 
     const yearSelectRef = React.useRef<HTMLButtonElement>(null);
 
     return (
-        <Box className={classes.root}>
+        <Root {...slotProps?.root} {...restProps}>
             <IconButton onClick={() => changeShownDate(-1, "monthOffset")}>
                 <ArrowLeft />
             </IconButton>
-
             <Box>
-                <Button
+                <SelectMonthButton
                     size="small"
-                    className={clsx(classes.selectButton, classes.selectMonthButton)}
                     onClick={() => setShowMonthSelect(true)}
                     ref={monthSelectRef}
                     endIcon={<ChevronDown />}
+                    {...slotProps?.selectMonthButton}
                 >
                     {intl.formatDate(focusedDate, { month: "long" })}
-                </Button>
-                <Menu
-                    className={clsx(classes.selectMenu, classes.selectMonthMenu)}
+                </SelectMonthButton>
+                <SelectMonthMenu
                     open={showMonthSelect}
                     onClose={() => setShowMonthSelect(false)}
                     anchorEl={monthSelectRef.current}
+                    {...slotProps?.selectMonthMenu}
                 >
                     {new Array(12).fill(null).map((_, month: number) => (
                         <MenuItem
@@ -57,21 +66,21 @@ const DatePickerNavigation = ({ classes, focusedDate, changeShownDate, minDate, 
                             {intl.formatDate(new Date(focusedDate.getFullYear(), month), { month: "long" })}
                         </MenuItem>
                     ))}
-                </Menu>
-                <Button
+                </SelectMonthMenu>
+                <SelectYearButton
                     size="small"
-                    className={clsx(classes.selectButton, classes.selectYearButton)}
                     ref={yearSelectRef}
                     onClick={() => setShowYearSelect(true)}
                     endIcon={<ChevronDown />}
+                    {...slotProps?.selectYearButton}
                 >
                     {focusedDate.getFullYear()}
-                </Button>
-                <Menu
-                    className={clsx(classes.selectMenu, classes.selectYearMenu)}
+                </SelectYearButton>
+                <SelectYearMenu
                     open={showYearSelect}
                     onClose={() => setShowYearSelect(false)}
                     anchorEl={yearSelectRef.current}
+                    {...slotProps?.selectYearMenu}
                 >
                     {new Array(maxDate.getFullYear() - minDate.getFullYear() + 1).fill(maxDate.getFullYear()).map((val, i) => {
                         const year = val - i;
@@ -89,12 +98,12 @@ const DatePickerNavigation = ({ classes, focusedDate, changeShownDate, minDate, 
                             </MenuItem>
                         );
                     })}
-                </Menu>
+                </SelectYearMenu>
             </Box>
             <IconButton onClick={() => changeShownDate(+1, "monthOffset")}>
                 <ArrowRight />
             </IconButton>
-        </Box>
+        </Root>
     );
 };
 
@@ -107,46 +116,93 @@ export type DatePickerNavigationClassKey =
     | "selectMonthMenu"
     | "selectYearMenu";
 
-export const styles = ({ palette, spacing, typography }: Theme) => {
-    return createStyles<DatePickerNavigationClassKey, DatePickerNavigationProps>({
-        root: {
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            paddingLeft: spacing(2),
-            paddingRight: spacing(2),
-            borderBottom: `1px solid ${palette.grey[50]}`,
-            height: 50,
-        },
-        selectButton: {
-            padding: 10,
-            borderRadius: 4,
-            fontWeight: typography.fontWeightBold,
+const Root = styled("div", {
+    name: "CometAdminDatePickerNavigation",
+    slot: "root",
+    overridesResolver(_, styles) {
+        return [styles.root];
+    },
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-left: ${theme.spacing(2)};
+        padding-right: ${theme.spacing(2)};
+        border-bottom: 1px solid ${theme.palette.grey[50]};
+        height: 50px;
+    `,
+);
 
-            "&:hover": {
-                backgroundColor: palette.grey[50],
-            },
+const SelectMonthButton = styled(Button, {
+    name: "CometAdminDatePickerNavigation",
+    slot: "selectMonthButton",
+    overridesResolver(_, styles) {
+        return [styles.selectButton, styles.selectMonthButton];
+    },
+})(
+    ({ theme }) => css`
+        padding: 10px;
+        border-radius: 4;
+        font-weight: ${theme.typography.fontWeightBold};
 
-            [`& .${buttonClasses.endIcon}`]: {
-                marginLeft: 2,
-            },
-        },
-        selectMonthButton: {},
-        selectYearButton: {},
-        selectMenu: {
-            [`& .${menuClasses.paper}`]: {
-                minWidth: 110,
-                maxHeight: 400,
-            },
-        },
-        selectMonthMenu: {},
-        selectYearMenu: {},
-    });
-};
+        :hover {
+            background-color: ${theme.palette.grey[50]};
+        }
 
-const DatePickerNavigationWithStyles = withStyles(styles, { name: "CometAdminDatePickerNavigation" })(DatePickerNavigation);
+        & .${buttonClasses.endIcon} {
+            margin-left: 2px;
+        }
+    `,
+);
 
-export { DatePickerNavigationWithStyles as DatePickerNavigation };
+const SelectYearButton = styled(Button, {
+    name: "CometAdminDatePickerNavigation",
+    slot: "selectYearButton",
+    overridesResolver(_, styles) {
+        return [styles.selectButton, styles.selectYearButton];
+    },
+})(
+    ({ theme }) => css`
+        padding: 10px;
+        border-radius: 4;
+        font-weight: ${theme.typography.fontWeightBold};
+
+        :hover {
+            background-color: ${theme.palette.grey[50]};
+        }
+
+        & .${buttonClasses.endIcon} {
+            margin-left: 2px;
+        }
+    `,
+);
+
+const SelectMonthMenu = styled(Menu, {
+    name: "CometAdminDatePickerNavigation",
+    slot: "selectMonthMenu",
+    overridesResolver(_, styles) {
+        return [styles.selectMenu, styles.selectMonthMenu];
+    },
+})(css`
+    & .${menuClasses.paper} {
+        min-width: 110px;
+        max-height: 400px;
+    }
+`);
+
+const SelectYearMenu = styled(Menu, {
+    name: "CometAdminDatePickerNavigation",
+    slot: "selectYearMenu",
+    overridesResolver(_, styles) {
+        return [styles.selectMenu, styles.selectYearMenu];
+    },
+})(css`
+    & .${menuClasses.paper} {
+        min-width: 110px;
+        max-height: 400px;
+    }
+`);
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {

--- a/packages/admin/admin/src/alert/Alert.tsx
+++ b/packages/admin/admin/src/alert/Alert.tsx
@@ -1,11 +1,18 @@
 import { Close } from "@comet/admin-icons";
 // eslint-disable-next-line no-restricted-imports
-import { Alert as MuiAlert, AlertTitle, buttonClasses, IconButton, Theme, Typography } from "@mui/material";
-import { createStyles, WithStyles, withStyles } from "@mui/styles";
-import clsx from "clsx";
+import { Alert as MuiAlert, alertClasses, AlertTitle, buttonClasses, IconButton, Typography } from "@mui/material";
+import { css, styled, useThemeProps } from "@mui/material/styles";
+import { ThemedComponentBaseProps } from "helpers/ThemedComponentBaseProps";
 import * as React from "react";
 
-export interface AlertProps {
+export interface AlertProps
+    extends ThemedComponentBaseProps<{
+        root: typeof MuiAlert;
+        title: typeof AlertTitle;
+        text: typeof Typography;
+        action: "div";
+        closeIcon: typeof IconButton;
+    }> {
     severity?: "info" | "warning" | "error" | "success";
     title?: React.ReactNode;
     children?: React.ReactNode;
@@ -13,84 +20,140 @@ export interface AlertProps {
     action?: React.ReactNode;
 }
 
-export type AlertClassKey = "root" | "message" | "title" | "text" | "action" | "closeIcon" | "hasTitle" | "singleRow";
+export type AlertClassKey = "root" | "title" | "text" | "action" | "closeIcon" | "hasTitle" | "singleRow";
 
-const styles = (theme: Theme) =>
-    createStyles<AlertClassKey, AlertProps>({
-        root: {
-            padding: theme.spacing(4, "12px", 4, 4),
-        },
-        message: {
-            display: "flex",
-            alignItems: "center",
-            flexGrow: 1,
-        },
-        title: {},
-        text: {
-            flexGrow: 1,
-        },
-        action: {},
-        closeIcon: {},
-        hasTitle: {
-            position: "relative",
-            alignItems: "flex-start",
-            padding: theme.spacing(4, 6, "8px", 3),
+type OwnerState = {
+    hasTitle: boolean;
+    renderAsSingleRow: boolean;
+};
 
-            [`& .${buttonClasses.text}`]: {
-                marginLeft: -15,
-            },
+export const Alert = React.forwardRef<HTMLDivElement, AlertProps>((inProps, ref) => {
+    const {
+        severity = "info",
+        title,
+        children,
+        onClose,
+        action,
+        slotProps,
+        ...restProps
+    } = useThemeProps({ props: inProps, name: "CometAdminAlert" });
+    const singleRow = !title && (action || onClose);
 
-            "& $action": {
-                marginTop: theme.spacing(2),
-            },
+    const ownerState: OwnerState = {
+        hasTitle: Boolean(title),
+        renderAsSingleRow: Boolean(singleRow),
+    };
 
-            "& $closeIcon": {
-                position: "absolute",
-                right: 2,
-                top: 2,
-            },
-            "& $message": {
-                flexDirection: "column",
-                alignItems: "flex-start",
-            },
-        },
-        singleRow: {
-            display: "flex",
-            alignItems: "center",
-            padding: theme.spacing(2, "12px", 2, 4),
-        },
-    });
+    return (
+        <Root ref={ref} ownerState={ownerState} severity={severity} {...slotProps?.root} {...restProps}>
+            {Boolean(title) && <Title {...slotProps?.title}>{title}</Title>}
+            <Text variant="body2" {...slotProps?.text}>
+                {children}
+            </Text>
+            {action && (
+                <Action ownerState={ownerState} {...slotProps?.action}>
+                    {action}
+                </Action>
+            )}
+            {onClose && (
+                <CloseIcon onClick={onClose} ownerState={ownerState} {...slotProps?.closeIcon}>
+                    <Close />
+                </CloseIcon>
+            )}
+        </Root>
+    );
+});
 
-const Alert = React.forwardRef<HTMLDivElement, AlertProps & WithStyles<typeof styles>>(
-    ({ severity = "info", title, children, classes, onClose, action }, ref) => {
-        const singleRow = !title && (action || onClose);
-        return (
-            <MuiAlert
-                ref={ref}
-                classes={{
-                    root: clsx(classes.root, Boolean(title) && classes.hasTitle, singleRow && classes.singleRow),
-                    message: classes.message,
-                }}
-                severity={severity}
-            >
-                {Boolean(title) && <AlertTitle className={classes.title}>{title}</AlertTitle>}
-                <Typography className={classes.text} variant="body2">
-                    {children}
-                </Typography>
-                {action && <div className={classes.action}>{action}</div>}
-                {onClose && (
-                    <IconButton className={classes.closeIcon} onClick={onClose}>
-                        <Close />
-                    </IconButton>
-                )}
-            </MuiAlert>
-        );
+const Root = styled(MuiAlert, {
+    name: "CometAdminAlert",
+    slot: "root",
+    overridesResolver({ hasTitle, renderAsSingleRow }: OwnerState, styles) {
+        return [styles.root, hasTitle && styles.hasTitle, renderAsSingleRow && styles.singleRow];
     },
+})<{ ownerState: OwnerState }>(
+    ({ theme, ownerState }) => css`
+        padding: ${theme.spacing(4, "12px", 4, 4)};
+
+        & .${alertClasses.message} {
+            display: flex;
+            align-items: center;
+            flex-grow: 1;
+        }
+
+        ${ownerState.hasTitle &&
+        css`
+            position: relative;
+            align-items: flex-start;
+            padding: ${theme.spacing(4, 6, "8px", 3)};
+
+            & .${buttonClasses.text} {
+                margin-left: -15px;
+            }
+
+            & .${alertClasses.message} {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+        `}
+
+        ${ownerState.renderAsSingleRow &&
+        css`
+            display: flex;
+            align-items: center;
+            padding: ${theme.spacing(2, "12px", 2, 4)};
+        `}
+    `,
 );
 
-const AdminComponentWithStyles = withStyles(styles, { name: "CometAdminAlert" })(Alert);
+const Title = styled(AlertTitle, {
+    name: "CometAdminAlert",
+    slot: "title",
+    overridesResolver(_, styles) {
+        return [styles.title];
+    },
+})();
 
-export { AdminComponentWithStyles as Alert };
+const Text = styled(Typography, {
+    name: "CometAdminAlert",
+    slot: "text",
+    overridesResolver(_, styles) {
+        return [styles.text];
+    },
+})(css`
+    flex-grow: 1;
+`);
+
+const Action = styled("div", {
+    name: "CometAdminAlert",
+    slot: "action",
+    overridesResolver(_, styles) {
+        return [styles.action];
+    },
+})<{ ownerState: OwnerState }>(
+    ({ theme, ownerState }) => css`
+        ${ownerState.hasTitle &&
+        css`
+            margin-top: ${theme.spacing(2)};
+        `}
+    `,
+);
+
+const CloseIcon = styled(IconButton, {
+    name: "CometAdminAlert",
+    slot: "closeIcon",
+    overridesResolver(_, styles) {
+        return [styles.closeIcon];
+    },
+})<{ ownerState: OwnerState }>(
+    ({ ownerState }) => css`
+        ${ownerState.hasTitle &&
+        css`
+            position: absolute;
+            right: 2px;
+            top: 2px;
+        `}
+    `,
+);
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {

--- a/packages/admin/admin/src/common/FieldSet.tsx
+++ b/packages/admin/admin/src/common/FieldSet.tsx
@@ -1,25 +1,29 @@
 import ArrowForwardIosSharpIcon from "@mui/icons-material/ArrowForwardIosSharp";
 import { ComponentsOverrides, Theme } from "@mui/material";
-import MuiAccordion, { AccordionProps } from "@mui/material/Accordion";
-import MuiAccordionDetails, { AccordionDetailsProps } from "@mui/material/AccordionDetails";
-import MuiAccordionSummary, { AccordionSummaryProps } from "@mui/material/AccordionSummary";
-import { createStyles, WithStyles, withStyles } from "@mui/styles";
-import clsx from "clsx";
+import MuiAccordion from "@mui/material/Accordion";
+import MuiAccordionDetails from "@mui/material/AccordionDetails";
+import MuiAccordionSummary from "@mui/material/AccordionSummary";
+import { css, styled, useThemeProps } from "@mui/material/styles";
+import { ThemedComponentBaseProps } from "helpers/ThemedComponentBaseProps";
 import * as React from "react";
 
-interface FieldSetComponentsProps {
-    root?: Partial<AccordionProps>;
-    summary?: Partial<AccordionSummaryProps>;
-    details?: Partial<AccordionDetailsProps>;
-}
-export interface FieldSetProps {
+export interface FieldSetProps
+    extends ThemedComponentBaseProps<{
+        root: typeof MuiAccordion;
+        summary: typeof MuiAccordionSummary;
+        headerColumn: "div";
+        title: "div";
+        supportText: "div";
+        placeholder: "div";
+        endAdornment: "div";
+        children: typeof MuiAccordionDetails;
+    }> {
     title: React.ReactNode;
     supportText?: React.ReactNode;
     endAdornment?: React.ReactNode;
     collapsible?: boolean;
     initiallyExpanded?: boolean;
     disablePadding?: boolean;
-    componentsProps?: FieldSetComponentsProps;
 }
 
 export type FieldSetClassKey =
@@ -33,81 +37,34 @@ export type FieldSetClassKey =
     | "children"
     | "disablePadding";
 
-const styles = (theme: Theme) =>
-    createStyles<FieldSetClassKey, FieldSetProps>({
-        root: {},
-        summary: {
-            display: "flex",
-            flexDirection: "row-reverse",
-            padding: "0 10px",
-            height: "80px",
-            [theme.breakpoints.up("sm")]: {
-                padding: "0 20px",
-            },
-        },
-        headerColumn: {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-start",
-            alignContent: "center",
-            padding: "0px",
-            [theme.breakpoints.up("sm")]: {
-                padding: "10px",
-            },
-        },
-        title: {
-            display: "flex",
-            alignItems: "center",
-            fontWeight: theme.typography.fontWeightMedium,
-            fontSize: "16px",
-            textTransform: "uppercase",
-            color: theme.palette.text.primary,
-        },
-        supportText: {
-            fontSize: "12px",
-            lineHeight: "18px",
-            color: theme.palette.text.secondary,
-        },
-        endAdornment: { display: "flex", alignItems: "center" },
-        placeholder: {
-            flexGrow: 1,
-            boxSizing: "inherit",
-            userSelect: "none",
-        },
-        children: {
-            display: "flex",
-            flexDirection: "column",
-            borderTop: `1px solid ${theme.palette.divider}`,
-            padding: "20px",
-            [theme.breakpoints.up("sm")]: {
-                padding: "40px",
-            },
-            "&$disablePadding": {
-                padding: "0px",
-            },
-        },
-        disablePadding: {},
-    });
+type OwnerState = {
+    disablePadding: boolean;
+};
 
-function FieldSet({
-    title,
-    supportText,
-    endAdornment,
-    children,
-    collapsible = true,
-    initiallyExpanded = true,
-    disablePadding = false,
-    componentsProps,
-    classes,
-}: React.PropsWithChildren<FieldSetProps> & WithStyles<typeof styles>): React.ReactElement {
+export function FieldSet(inProps: React.PropsWithChildren<FieldSetProps>): React.ReactElement {
+    const {
+        title,
+        supportText,
+        endAdornment,
+        children,
+        collapsible = true,
+        initiallyExpanded = true,
+        disablePadding = false,
+        slotProps,
+        ...restProps
+    } = useThemeProps({ props: inProps, name: "CometAdminFieldSet" });
     const [expanded, setExpanded] = React.useState(initiallyExpanded);
 
     const handleChange = (event: React.SyntheticEvent, isExpanded: boolean) => {
         setExpanded(isExpanded);
     };
 
+    const ownerState: OwnerState = {
+        disablePadding,
+    };
+
     return (
-        <MuiAccordion
+        <Root
             expanded={expanded}
             onChange={
                 collapsible
@@ -116,31 +73,153 @@ function FieldSet({
                           /* do nothing */
                       }
             }
-            className={classes.root}
-            {...componentsProps?.root}
+            {...slotProps?.root}
+            {...restProps}
         >
-            <MuiAccordionSummary
-                classes={{ root: classes.summary }}
-                expandIcon={collapsible && <ArrowForwardIosSharpIcon />}
-                {...componentsProps?.summary}
-            >
-                <div className={classes.headerColumn}>
-                    <div className={classes.title}>{title}</div>
-                    <div className={classes.supportText}>{supportText}</div>
-                </div>
-                <div className={classes.placeholder} />
-                <div className={classes.endAdornment}>{endAdornment}</div>
-            </MuiAccordionSummary>
-            <MuiAccordionDetails className={clsx(classes.children, disablePadding && classes.disablePadding)} {...componentsProps?.details}>
+            <Summary expandIcon={collapsible && <ArrowForwardIosSharpIcon />} {...slotProps?.summary}>
+                <HeaderColumn {...slotProps?.headerColumn}>
+                    <Title {...slotProps?.title}>{title}</Title>
+                    <SupportText {...slotProps?.supportText}>{supportText}</SupportText>
+                </HeaderColumn>
+                <Placeholder {...slotProps?.placeholder} />
+                <EndAdornment {...slotProps?.endAdornment}>{endAdornment}</EndAdornment>
+            </Summary>
+            <Children ownerState={ownerState} {...slotProps?.children}>
+                {disablePadding ? "disablePadding" : "not disablePadding"}
                 {children}
-            </MuiAccordionDetails>
-        </MuiAccordion>
+            </Children>
+        </Root>
     );
 }
 
-const FieldSetWithStyles = withStyles(styles, { name: "CometAdminFieldSet" })(FieldSet);
+const Root = styled(MuiAccordion, {
+    name: "CometAdminFieldSet",
+    slot: "root",
+    overridesResolver(_, styles) {
+        return [styles.root];
+    },
+})();
 
-export { FieldSetWithStyles as FieldSet };
+const Summary = styled(MuiAccordionSummary, {
+    name: "CometAdminFieldSet",
+    slot: "summary",
+    overridesResolver(_, styles) {
+        return [styles.summary];
+    },
+})(
+    ({ theme }) => css`
+        display: flex;
+        flex-direction: row-reverse;
+        padding: 0 10px;
+        height: 80px;
+
+        ${theme.breakpoints.up("sm")} {
+            padding: 0 20px;
+        }
+    `,
+);
+
+const HeaderColumn = styled("div", {
+    name: "CometAdminFieldSet",
+    slot: "headerColumn",
+    overridesResolver(_, styles) {
+        return [styles.headerColumn];
+    },
+})(
+    ({ theme }) => css`
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        align-content: center;
+        padding: 0px;
+
+        ${theme.breakpoints.up("sm")} {
+            padding: 10px;
+        }
+    `,
+);
+
+const Title = styled("div", {
+    name: "CometAdminFieldSet",
+    slot: "title",
+    overridesResolver(_, styles) {
+        return [styles.title];
+    },
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+        font-weight: ${theme.typography.fontWeightMedium};
+        font-size: 16px;
+        text-transform: uppercase;
+        color: ${theme.palette.text.primary};
+    `,
+);
+
+const SupportText = styled("div", {
+    name: "CometAdminFieldSet",
+    slot: "supportText",
+    overridesResolver(_, styles) {
+        return [styles.supportText];
+    },
+})(
+    ({ theme }) => css`
+        font-size: 12px;
+        line-height: 18px;
+        color: ${theme.palette.text.secondary};
+    `,
+);
+
+const Placeholder = styled("div", {
+    name: "CometAdminFieldSet",
+    slot: "placeholder",
+    overridesResolver(_, styles) {
+        return [styles.placeholder];
+    },
+})(css`
+    flex-grow: 1;
+    box-sizing: inherit;
+    user-select: none;
+`);
+
+const EndAdornment = styled("div", {
+    name: "CometAdminFieldSet",
+    slot: "endAdornment",
+    overridesResolver(_, styles) {
+        return [styles.endAdornment];
+    },
+})(css`
+    display: flex;
+    align-items: center;
+`);
+
+const Children = styled(MuiAccordionDetails, {
+    name: "CometAdminFieldSet",
+    slot: "children",
+    overridesResolver({ disablePadding }: OwnerState, styles) {
+        return [styles.children, disablePadding && styles.disablePadding];
+    },
+})<{ ownerState: OwnerState }>(
+    ({ theme, ownerState }) => css`
+        display: flex;
+        flex-direction: column;
+        border-top: 1px solid ${theme.palette.divider};
+        padding: 20px;
+
+        ${theme.breakpoints.up("sm")} {
+            padding: 40px;
+        }
+
+        ${ownerState.disablePadding &&
+        css`
+            padding: 0;
+
+            ${theme.breakpoints.up("sm")} {
+                padding: 0;
+            }
+        `}
+    `,
+);
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {

--- a/storybook/src/admin/FieldSet.tsx
+++ b/storybook/src/admin/FieldSet.tsx
@@ -1,0 +1,46 @@
+import { FieldSet, Tooltip } from "@comet/admin";
+import { Info } from "@mui/icons-material";
+import { Chip, Stack } from "@mui/material";
+import { Box } from "@mui/system";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+const textContent =
+    "FieldSet content. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+storiesOf("@comet/admin/FieldSet", module).add("FieldSet", () => (
+    <Stack spacing={4}>
+        <FieldSet title="FieldSet Title" supportText="Support text">
+            {textContent}
+        </FieldSet>
+
+        <FieldSet
+            title={
+                <>
+                    FieldSet with an icon
+                    <Tooltip title="Lorem ipsum info." sx={{ ml: 1 }}>
+                        <Info />
+                    </Tooltip>
+                </>
+            }
+        >
+            {textContent}
+        </FieldSet>
+
+        <FieldSet title="FieldSet closed by default" initiallyExpanded={false}>
+            {textContent}
+        </FieldSet>
+
+        <FieldSet title="FieldSet with a chip" endAdornment={<Chip color="default" label="Chip text" />}>
+            {textContent}
+        </FieldSet>
+
+        <FieldSet title="FieldSet with full-width content" disablePadding>
+            <Box sx={({ palette }) => ({ p: 4, background: palette.primary.light })}>{textContent}</Box>
+        </FieldSet>
+
+        <FieldSet title="FieldSet not collapsible" collapsible={false}>
+            {textContent}
+        </FieldSet>
+    </Stack>
+));


### PR DESCRIPTION
### Refactor theming of remaining admin-components
- COM-487: `FieldSet` (Also added a dev-story)
- COM-488: `Alert`
- COM-489: `DatePickerNavigation`

### Remove module augmentation of `DefaultTheme` type
As the `@mui/styles` package is no longer used for the styling-implementation of admin-components the `DefaultTheme` from `@mui/styles/defaultTheme` is no longer needed and would cause a typescript error when augmented.