### PR TITLE
Uniform delete option in context menus

### DIFF
--- a/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
@@ -1,6 +1,6 @@
 import { ApolloClient, RefetchQueriesOptions, useApolloClient } from "@apollo/client";
 import { Copy, Delete as DeleteIcon, Domain, Paste, ThreeDotSaving } from "@comet/admin-icons";
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Divider } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -151,6 +151,7 @@ export function CrudContextMenu<CopyData>({ url, onPaste, onDelete, refetchQueri
                             {intl.formatMessage(messages.paste)}
                         </RowActionsItem>
                     )}
+                    {onDelete && (onPaste || copyData || url) && <Divider />}
                     {onDelete && (
                         <RowActionsItem
                             icon={<DeleteIcon />}

--- a/packages/admin/cms-admin/src/dam/DataGrid/DamContextMenu.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/DamContextMenu.tsx
@@ -88,6 +88,7 @@ const FolderInnerMenu = ({ folder, openMoveDialog }: FolderInnerMenuProps): Reac
                     >
                         <FormattedMessage id="comet.pages.dam.move" defaultMessage="Move" />
                     </RowActionsItem>
+                    <Divider />
                     <RowActionsItem
                         icon={<Delete />}
                         onClick={() => {


### PR DESCRIPTION
COM-485

Added a `<Divider />` before any  `<RowActionsItem icon={<Delete />} />` inside a `RowActionsMenu` that didn't have one. The now are all uniform. 

<img width="300" src="https://github.com/vivid-planet/comet/assets/69114037/6355fc6e-3247-4d97-a2e6-e1b70578af56">
