### PR TITLE
Ignore user permissions when using system user

### DIFF
--- a/.changeset/moody-falcons-fix.md
+++ b/.changeset/moody-falcons-fix.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Ignore user permissions when using system user
+
+The `UserPermissionsGuard` didn't allow request when using a system user (e.g., basic authorization during site build).

--- a/packages/api/cms-api/src/access-log/access-log.module.ts
+++ b/packages/api/cms-api/src/access-log/access-log.module.ts
@@ -3,10 +3,11 @@ import { APP_INTERCEPTOR } from "@nestjs/core";
 import { Request } from "express";
 
 import { CurrentUser } from "../user-permissions/dto/current-user";
+import { SystemUser } from "../user-permissions/user-permissions.types";
 import { SHOULD_LOG_REQUEST } from "./access-log.constants";
 import { AccessLogInterceptor } from "./access-log.interceptor";
 
-export type ShouldLogRequest = ({ user, req }: { user?: CurrentUser | true; req: Request }) => boolean;
+export type ShouldLogRequest = ({ user, req }: { user?: CurrentUser | SystemUser; req: Request }) => boolean;
 
 interface AccessLogModuleOptions {
     shouldLogRequest?: ShouldLogRequest;

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -13,6 +13,8 @@ export enum UserPermissions {
 
 export type Users = [User[], number];
 
+export type SystemUser = true;
+
 type PermissionForUser = {
     permission: string;
     contentScopes?: ContentScope[];
@@ -22,7 +24,7 @@ export type PermissionsForUser = PermissionForUser[] | UserPermissions.allPermis
 export type ContentScopesForUser = ContentScope[] | UserPermissions.allContentScopes;
 
 export interface AccessControlServiceInterface {
-    isAllowed(user: CurrentUser, permission: string, contentScope?: ContentScope): boolean;
+    isAllowed(user: CurrentUser | SystemUser, permission: string, contentScope?: ContentScope): boolean;
     getPermissionsForUser?: (user: User) => Promise<PermissionsForUser> | PermissionsForUser;
     getContentScopesForUser?: (user: User) => Promise<ContentScopesForUser> | ContentScopesForUser;
 }


### PR DESCRIPTION
The `UserPermissionsGuard` didn't allow request when using a system user (e.g., basic authorization during site build).