### PR TITLE
Allow overriding the block context in `BlocksTransformerService#transformToPlain`

### DIFF
--- a/.changeset/flat-laws-decide.md
+++ b/.changeset/flat-laws-decide.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Allow overriding the block context in `BlocksTransformerService#transformToPlain`

--- a/packages/api/cms-api/src/blocks/blocks-transformer.service.ts
+++ b/packages/api/cms-api/src/blocks/blocks-transformer.service.ts
@@ -42,7 +42,7 @@ export class BlocksTransformerService {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async transformToPlain(block: BlockDataInterface): Promise<any> {
-        return transformToPlain(block, this.dependencies, this.blockContext);
+    async transformToPlain(block: BlockDataInterface, context?: BlockContext): Promise<any> {
+        return transformToPlain(block, this.dependencies, context ?? this.blockContext);
     }
 }


### PR DESCRIPTION
This is needed for storing public block content (i.e. no preview URLs, no invisible content) even if a mutation is called by an authenticated user. For example, when saving a newsletter's content to a third party provider, as needed in the [comet-brevo-module](https://github.com/vivid-planet/comet-brevo-module/blob/main/packages/api/src/email-campaign/email-campaigns.service.ts#L43).

---

- [x] Add changeset (if necessary)