### PR TITLE
Adapt `ChangesCheckerInterceptor` to more strict checking of content scopes

### DIFF
--- a/.changeset/tough-onions-march.md
+++ b/.changeset/tough-onions-march.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Don't fail in ChangesCheckerInterceptor because of stricter content scope check

--- a/packages/api/cms-api/src/builds/changes-checker.interceptor.ts
+++ b/packages/api/cms-api/src/builds/changes-checker.interceptor.ts
@@ -50,6 +50,14 @@ export class ChangesCheckerInterceptor implements NestInterceptor {
                             await this.buildsService.setChangesSinceLastBuild(scope);
                         }
                     } else {
+                        if (process.env.NODE_ENV === "development") {
+                            if (operation.name) {
+                                console.warn(`Mutation "${operation.name.value}" affects all scopes. Are you sure this is correct?`);
+                            } else {
+                                console.warn(`Unknown mutation affects all scopes. Are you sure this is correct?`);
+                            }
+                        }
+
                         await this.buildsService.setChangesSinceLastBuild("all");
                     }
                 }


### PR DESCRIPTION
It's ugly but since the ChangesCheckerInterceptor will be deleted in v7 anyway this will serve as a workaround meanwhile.