### PR TITLE
Use locale as primary source for currentUser

### DIFF
--- a/packages/api/cms-api/src/auth/strategies/auth-proxy-jwt.strategy.ts
+++ b/packages/api/cms-api/src/auth/strategies/auth-proxy-jwt.strategy.ts
@@ -39,7 +39,7 @@ export function createAuthProxyJwtStrategy({
                 id: data.sub,
                 name: data.name,
                 email: data.email,
-                language: data.language,
+                language: data.locale || data.language,
             });
         }
     }


### PR DESCRIPTION
Since locale is standardized in an OIDC ID-Token

Proper update in https://github.com/vivid-planet/comet/pull/1777