### PR TITLE
Execute JSON.parse() twice to parse escaped JSON string in `KubernetesService#getContentScope`

### DIFF
--- a/.changeset/kind-sloths-relate.md
+++ b/.changeset/kind-sloths-relate.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix parsing of `contentScopeAnnotation` in `KubernetesService#getContentScope`

--- a/packages/api/cms-api/src/kubernetes/kubernetes.service.ts
+++ b/packages/api/cms-api/src/kubernetes/kubernetes.service.ts
@@ -160,6 +160,19 @@ export class KubernetesService {
 
     getContentScope(resource: V1Job | V1CronJob): ContentScope | null {
         const contentScopeAnnotation = resource.metadata?.annotations?.[CONTENT_SCOPE_ANNOTATION];
-        return contentScopeAnnotation ? JSON.parse(contentScopeAnnotation) : null;
+
+        if (contentScopeAnnotation) {
+            let json = JSON.parse(contentScopeAnnotation);
+
+            // the contentScopeAnnotation is an escaped json string (e.g. "{ \"domain\": \"main\", \"language\": \"en\" }")
+            // therefore JSON.parse() must be executed twice (https://stackoverflow.com/a/25721227)
+            if (typeof json !== "object") {
+                json = JSON.parse(json);
+            }
+
+            return json;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Fix parsing of `contentScopeAnnotation` in `KubernetesService#getContentScope`

---

You can see that only `json2` (after the second JSON.parse()) is an object

<img width="572" alt="Bildschirmfoto 2024-02-28 um 15 14 47" src="https://github.com/vivid-planet/comet/assets/13380047/668b073e-226e-497b-a4f7-894a1372c016">

---

This bug is new in v6, but I don't know yet why it occurs now. This is a workaround so updating to v6 is possible for content websites. I'll still try to figure out the reason so maybe we can remove this again in the future.