### PR TITLE
Admin Generator (Future): Adjust column-sizing of generated grids to make the grid span over the full width and align the actions to the right

### DIFF
--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -6,11 +6,11 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
     gqlType: "Product",
     fragmentName: "ProductsGridFuture", // configurable as it must be unique across project
     columns: [
-        { type: "text", name: "title", headerName: "Titel" },
+        { type: "text", name: "title", headerName: "Titel", minWidth: 200, maxWidth: 250 },
         { type: "text", name: "description", headerName: "Description" },
-        { type: "number", name: "price", headerName: "Price", width: 140 },
-        { type: "staticSelect", name: "type", width: 140 /*, values: from gql schema (TODO overridable)*/ },
-        { type: "date", name: "availableSince", width: 170 },
+        { type: "number", name: "price", headerName: "Price", maxWidth: 150 },
+        { type: "staticSelect", name: "type", maxWidth: 150 /*, values: from gql schema (TODO overridable)*/ },
+        { type: "date", name: "availableSince", width: 140 },
         { type: "dateTime", name: "createdAt", width: 170 },
     ],
 };

--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -6,11 +6,11 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
     gqlType: "Product",
     fragmentName: "ProductsGridFuture", // configurable as it must be unique across project
     columns: [
-        { type: "text", name: "title", headerName: "Titel", width: 150 },
-        { type: "text", name: "description", headerName: "Description", width: 150 },
-        { type: "number", name: "price", headerName: "Price", width: 150 },
-        { type: "staticSelect", name: "type" /*, values: from gql schema (TODO overridable)*/ },
-        { type: "date", name: "availableSince" },
-        { type: "dateTime", name: "createdAt" },
+        { type: "text", name: "title", headerName: "Titel" },
+        { type: "text", name: "description", headerName: "Description" },
+        { type: "number", name: "price", headerName: "Price", width: 140 },
+        { type: "staticSelect", name: "type", width: 140 /*, values: from gql schema (TODO overridable)*/ },
+        { type: "date", name: "availableSince", width: 170 },
+        { type: "dateTime", name: "createdAt", width: 170 },
     ],
 };

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -104,9 +104,14 @@ export function ProductsGrid(): React.ReactElement {
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };
 
     const columns: GridColDef<GQLProductsGridFutureFragment>[] = [
-        { field: "title", headerName: intl.formatMessage({ id: "product.title", defaultMessage: "Titel" }), flex: 1 },
-        { field: "description", headerName: intl.formatMessage({ id: "product.description", defaultMessage: "Description" }), flex: 1 },
-        { field: "price", headerName: intl.formatMessage({ id: "product.price", defaultMessage: "Price" }), width: 140 },
+        { field: "title", headerName: intl.formatMessage({ id: "product.title", defaultMessage: "Titel" }), flex: 1, maxWidth: 250, minWidth: 200 },
+        {
+            field: "description",
+            headerName: intl.formatMessage({ id: "product.description", defaultMessage: "Description" }),
+            flex: 1,
+            minWidth: 150,
+        },
+        { field: "price", headerName: intl.formatMessage({ id: "product.price", defaultMessage: "Price" }), flex: 1, maxWidth: 150, minWidth: 150 },
         {
             field: "type",
             headerName: intl.formatMessage({ id: "product.type", defaultMessage: "Type" }),
@@ -116,14 +121,16 @@ export function ProductsGrid(): React.ReactElement {
                 { value: "Shirt", label: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }) },
                 { value: "Tie", label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }) },
             ],
-            width: 140,
+            flex: 1,
+            maxWidth: 150,
+            minWidth: 150,
         },
         {
             field: "availableSince",
             headerName: intl.formatMessage({ id: "product.availableSince", defaultMessage: "Available Since" }),
             type: "date",
             valueGetter: ({ value }) => value && new Date(value),
-            width: 170,
+            width: 140,
         },
         {
             field: "createdAt",

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -104,9 +104,9 @@ export function ProductsGrid(): React.ReactElement {
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };
 
     const columns: GridColDef<GQLProductsGridFutureFragment>[] = [
-        { field: "title", headerName: intl.formatMessage({ id: "product.title", defaultMessage: "Titel" }), width: 150 },
-        { field: "description", headerName: intl.formatMessage({ id: "product.description", defaultMessage: "Description" }), width: 150 },
-        { field: "price", headerName: intl.formatMessage({ id: "product.price", defaultMessage: "Price" }), width: 150 },
+        { field: "title", headerName: intl.formatMessage({ id: "product.title", defaultMessage: "Titel" }), flex: 1 },
+        { field: "description", headerName: intl.formatMessage({ id: "product.description", defaultMessage: "Description" }), flex: 1 },
+        { field: "price", headerName: intl.formatMessage({ id: "product.price", defaultMessage: "Price" }), width: 140 },
         {
             field: "type",
             headerName: intl.formatMessage({ id: "product.type", defaultMessage: "Type" }),
@@ -116,21 +116,21 @@ export function ProductsGrid(): React.ReactElement {
                 { value: "Shirt", label: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }) },
                 { value: "Tie", label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }) },
             ],
-            width: 150,
+            width: 140,
         },
         {
             field: "availableSince",
             headerName: intl.formatMessage({ id: "product.availableSince", defaultMessage: "Available Since" }),
             type: "date",
             valueGetter: ({ value }) => value && new Date(value),
-            width: 150,
+            width: 170,
         },
         {
             field: "createdAt",
             headerName: intl.formatMessage({ id: "product.createdAt", defaultMessage: "Created At" }),
             type: "dateTime",
             valueGetter: ({ value }) => value && new Date(value),
-            width: 150,
+            width: 170,
         },
         {
             field: "actions",
@@ -138,6 +138,7 @@ export function ProductsGrid(): React.ReactElement {
             sortable: false,
             filterable: false,
             type: "actions",
+            align: "right",
             renderCell: (params) => {
                 return (
                     <>

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -372,7 +372,7 @@ export function generateGrid(
 
                     if (typeof column.width === "undefined") {
                         const defaultMinWidth = 150;
-                        columnDefinition.flex = "1";
+                        columnDefinition.flex = 1;
                         columnDefinition.maxWidth = typeof column.maxWidth === "undefined" ? undefined : column.maxWidth;
 
                         if (

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -366,14 +366,14 @@ export function generateGrid(
                         valueGetter: column.valueGetter,
                         valueOptions: column.valueOptions,
                         renderCell: column.renderCell,
-                        width: typeof column.width === "undefined" ? undefined : column.width,
-                        flex: typeof column.flex === "undefined" ? undefined : column.flex,
+                        width: column.width,
+                        flex: column.flex,
                     };
 
                     if (typeof column.width === "undefined") {
                         const defaultMinWidth = 150;
                         columnDefinition.flex = 1;
-                        columnDefinition.maxWidth = typeof column.maxWidth === "undefined" ? undefined : column.maxWidth;
+                        columnDefinition.maxWidth = column.maxWidth;
 
                         if (
                             typeof column.minWidth === "undefined" &&

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -357,8 +357,9 @@ export function generateGrid(
                         sortable: !sortFields.includes(column.name) ? `false` : undefined,
                         valueGetter: column.valueGetter,
                         valueOptions: column.valueOptions,
-                        width: column.width ? String(column.width) : "150",
                         renderCell: column.renderCell,
+                        width: typeof column.width === "undefined" ? undefined : String(column.width),
+                        flex: typeof column.width === "undefined" ? "1" : undefined,
                     }),
                 )
                 .join(",\n")},
@@ -368,6 +369,7 @@ export function generateGrid(
                 sortable: false,
                 filterable: false,
                 type: "actions",
+                align: "right",
                 renderCell: (params) => {
                     return (
                         <>

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -191,6 +191,7 @@ export function generateGrid(
                 type,
                 gridType: "singleSelect" as const,
                 valueOptions,
+                width: column.width,
             };
         }
 

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -12,7 +12,9 @@ import { GeneratorReturn, GridConfig } from "./generator";
 import { camelCaseToHumanReadable } from "./utils/camelCaseToHumanReadable";
 import { findRootBlocks } from "./utils/findRootBlocks";
 
-function tsCodeRecordToString(object: Record<string, string | undefined>) {
+type TsCodeRecordToStringObject = Record<string, string | number | undefined>;
+
+function tsCodeRecordToString(object: TsCodeRecordToStringObject) {
     return `{${Object.entries(object)
         .filter(([key, value]) => value !== undefined)
         .map(([key, value]) => `${key}: ${value},`)
@@ -353,7 +355,7 @@ export function generateGrid(
         const columns: GridColDef<GQL${fragmentName}Fragment>[] = [
             ${gridColumnFields
                 .map((column) => {
-                    const columnDefinition: Record<string, string | undefined> = {
+                    const columnDefinition: TsCodeRecordToStringObject = {
                         field: `"${column.name}"`,
                         headerName: `intl.formatMessage({ id: "${instanceGqlType}.${column.name}",  defaultMessage: "${
                             column.headerName || camelCaseToHumanReadable(column.name)
@@ -364,22 +366,22 @@ export function generateGrid(
                         valueGetter: column.valueGetter,
                         valueOptions: column.valueOptions,
                         renderCell: column.renderCell,
-                        width: typeof column.width === "undefined" ? undefined : String(column.width),
-                        flex: typeof column.flex === "undefined" ? undefined : String(column.flex),
+                        width: typeof column.width === "undefined" ? undefined : column.width,
+                        flex: typeof column.flex === "undefined" ? undefined : column.flex,
                     };
 
                     if (typeof column.width === "undefined") {
                         const defaultMinWidth = 150;
                         columnDefinition.flex = "1";
-                        columnDefinition.maxWidth = typeof column.maxWidth === "undefined" ? undefined : String(column.maxWidth);
+                        columnDefinition.maxWidth = typeof column.maxWidth === "undefined" ? undefined : column.maxWidth;
 
                         if (
                             typeof column.minWidth === "undefined" &&
                             (typeof column.maxWidth === "undefined" || column.maxWidth >= defaultMinWidth)
                         ) {
-                            columnDefinition.minWidth = String(defaultMinWidth);
+                            columnDefinition.minWidth = defaultMinWidth;
                         } else if (typeof column.minWidth !== "undefined") {
-                            columnDefinition.minWidth = String(column.minWidth);
+                            columnDefinition.minWidth = column.minWidth;
                         }
                     }
 

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -1,5 +1,6 @@
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 import { loadSchema } from "@graphql-tools/load";
+import { GridColDef } from "@mui/x-data-grid";
 import { glob } from "glob";
 import { introspectionFromSchema } from "graphql";
 import { basename, dirname } from "path";
@@ -34,6 +35,8 @@ export type FormConfig<T extends { __typename?: string }> = {
 
 export type TabsConfig = { type: "tabs"; tabs: { name: string; content: GeneratorConfig }[] };
 
+type DataGridSettings = Pick<GridColDef, "headerName" | "width" | "minWidth" | "maxWidth" | "flex">;
+
 export type GridColumnConfig<T> = (
     | { type: "text" }
     | { type: "number" }
@@ -42,7 +45,7 @@ export type GridColumnConfig<T> = (
     | { type: "dateTime" }
     | { type: "staticSelect"; values?: string[] }
     | { type: "block"; block: ImportReference }
-) & { name: keyof T; headerName?: string; width?: number; minWidth?: number; maxWidth?: number; flex?: number };
+) & { name: keyof T } & DataGridSettings;
 export type GridConfig<T extends { __typename?: string }> = {
     type: "grid";
     gqlType: T["__typename"];

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -42,7 +42,7 @@ export type GridColumnConfig<T> = (
     | { type: "dateTime" }
     | { type: "staticSelect"; values?: string[] }
     | { type: "block"; block: ImportReference }
-) & { name: keyof T; headerName?: string; width?: number };
+) & { name: keyof T; headerName?: string; width?: number; minWidth?: number; maxWidth?: number; flex?: number };
 export type GridConfig<T extends { __typename?: string }> = {
     type: "grid";
     gqlType: T["__typename"];


### PR DESCRIPTION
By default, columns no longer have a fixed width and instead grow to fill the available space and push the action icon buttons all the way to the right. 

In addition to `width`, the `minWidth`, `maxWidth`, and `flex` settings are now exposed to the grid's column definition to allow more customization. 

## Previously

<img width="1613" alt="Previously" src="https://github.com/vivid-planet/comet/assets/6264317/13c4456e-b823-46e1-8ce8-57696e47e9da">

## Now

<img width="1613" alt="Now" src="https://github.com/vivid-planet/comet/assets/6264317/e796047c-935e-49aa-bddc-b9a4d940e25f">

