### PR TITLE
Admin Generator (Future): Add settings to restrict user-actions in grid generator

### DIFF
--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -152,7 +152,6 @@ export function ProductsGrid(): React.ReactElement {
                         <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
                             <Edit color="primary" />
                         </IconButton>
-
                         <CrudContextMenu
                             copyData={() => {
                                 const row = params.row;

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -152,6 +152,7 @@ export function ProductsGrid(): React.ReactElement {
                         <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
                             <Edit color="primary" />
                         </IconButton>
+
                         <CrudContextMenu
                             copyData={() => {
                                 const row = params.row;

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -414,10 +414,9 @@ export function generateGrid(
                                             <Edit color="primary" />
                                         </IconButton>`
                                         : ""
-                                }
-                                ${
-                                    allowCopyPaste || allowDeleting
-                                        ? `
+                                }${
+                              allowCopyPaste || allowDeleting
+                                  ? `
                                         <CrudContextMenu
                                             ${
                                                 allowCopyPaste
@@ -461,8 +460,8 @@ export function generateGrid(
                                             refetchQueries={[${instanceGqlTypePlural}Query]}
                                         />
                                     `
-                                        : ""
-                                }
+                                  : ""
+                          }
                                 </>
                             );
                         },

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -354,7 +354,7 @@ export function generateGrid(
 
 
     export function ${gqlTypePlural}Grid(): React.ReactElement {
-        ${allowCopyPaste ? "const client = useApolloClient();" : ""}
+        ${allowCopyPaste || allowDeleting ? "const client = useApolloClient();" : ""}
         const intl = useIntl();
         const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("${gqlTypePlural}Grid") };
         ${hasScope ? `const { scope } = useContentScope();` : ""}

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -50,6 +50,8 @@ export type GridConfig<T extends { __typename?: string }> = {
     type: "grid";
     gqlType: T["__typename"];
     fragmentName?: string;
+    disableCopyPaste?: boolean;
+    readOnly?: boolean;
     columns: GridColumnConfig<T>[];
 };
 

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -50,9 +50,12 @@ export type GridConfig<T extends { __typename?: string }> = {
     type: "grid";
     gqlType: T["__typename"];
     fragmentName?: string;
-    disableCopyPaste?: boolean;
-    readOnly?: boolean;
     columns: GridColumnConfig<T>[];
+    add?: boolean;
+    edit?: boolean;
+    delete?: boolean;
+    copyPaste?: boolean;
+    readOnly?: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
- Individual settings `add`,  `edit`, `delete`, `copyPaste` to disable those individual features, they are enabled by default. 
- Additional `readOnly` setting to disable all those features at once.