### PR TITLE
Add number of selected files to `DamMoreActions`

### DIFF
--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -35,7 +35,8 @@ import FolderDataGrid, {
 } from "./DataGrid/FolderDataGrid";
 import { RenderDamLabelOptions } from "./DataGrid/label/DamItemLabelColumn";
 import { DamMoreActions } from "./DataGrid/selection/DamMoreActions";
-import { DamSelectionProvider } from "./DataGrid/selection/DamSelectionContext";
+import { DamSelectionProvider, useDamSelectionApi } from "./DataGrid/selection/DamSelectionContext";
+import { SelectedItemsChip } from "./DataGrid/selection/SelectedItemsChip";
 import EditFile from "./FileForm/EditFile";
 
 interface FolderProps extends DamConfig {
@@ -55,6 +56,8 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
     const intl = useIntl();
     const stackApi = useStackApi();
     const [, , editDialogApi, selectionApi] = useEditDialog();
+    const { selectionMap } = useDamSelectionApi();
+    const selectionSize = selectionMap.size;
 
     // The selectedFolderId is only used to determine the name of a folder for the "folder" stack page
     // If you want to use the id of the current folder in the "table" stack page, use the id prop
@@ -88,6 +91,7 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
                                     button={
                                         <Button variant="text" color="inherit" endIcon={<MoreVertical />} sx={{ mx: 2 }}>
                                             <FormattedMessage id="comet.pages.dam.moreActions" defaultMessage="More actions" />
+                                            {selectionSize > 0 && <SelectedItemsChip>{selectionSize}</SelectedItemsChip>}
                                         </Button>
                                     }
                                     anchorOrigin={{

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
@@ -3,7 +3,6 @@ import { AddFolder as AddFolderIcon, Archive, Delete, Download, Move, Restore, U
 import { Box, Divider, ListItemIcon, ListItemText, Menu, MenuItem, MenuList, Slide, Snackbar, Typography } from "@mui/material";
 import { PopoverOrigin } from "@mui/material/Popover/Popover";
 import { SlideProps } from "@mui/material/Slide/Slide";
-import { styled } from "@mui/material/styles";
 import * as React from "react";
 import { FileRejection, useDropzone } from "react-dropzone";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -11,6 +10,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { useDamAcceptedMimeTypes } from "../../config/useDamAcceptedMimeTypes";
 import { useDamFileUpload } from "../fileUpload/useDamFileUpload";
 import { useDamSelectionApi } from "./DamSelectionContext";
+import { SelectedItemsChip } from "./SelectedItemsChip";
 
 interface DamMoreActionsProps {
     transformOrigin?: PopoverOrigin;
@@ -156,7 +156,7 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
                                     <ListItemText
                                         primary={<FormattedMessage id="comet.dam.moreActions.downloadSelected" defaultMessage="Download" />}
                                     />
-                                    <NumberSelectedChip>{lengthOfSelectedFiles}</NumberSelectedChip>
+                                    <SelectedItemsChip>{lengthOfSelectedFiles}</SelectedItemsChip>
                                 </MenuItem>
                                 <Divider sx={{ my: 1, borderColor: (theme) => theme.palette.grey[50] }} />
                             </>
@@ -166,28 +166,28 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
                                 <Move />
                             </ListItemIcon>
                             <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.moveItems" defaultMessage="Move" />} />
-                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
+                            {itemsSelected && <SelectedItemsChip>{selectionSize}</SelectedItemsChip>}
                         </MenuItem>
                         <MenuItem disabled={!itemsSelected} onClick={handleArchiveClick}>
                             <ListItemIcon>
                                 <Archive />
                             </ListItemIcon>
                             <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.archiveItems" defaultMessage="Archive" />} />
-                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
+                            {itemsSelected && <SelectedItemsChip>{selectionSize}</SelectedItemsChip>}
                         </MenuItem>
                         <MenuItem disabled={!itemsSelected} onClick={handleRestoreClick}>
                             <ListItemIcon>
                                 <Restore />
                             </ListItemIcon>
                             <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.restoreItems" defaultMessage="Restore" />} />
-                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
+                            {itemsSelected && <SelectedItemsChip>{selectionSize}</SelectedItemsChip>}
                         </MenuItem>
                         <MenuItem disabled={!itemsSelected} onClick={handleDeleteClick}>
                             <ListItemIcon>
                                 <Delete />
                             </ListItemIcon>
                             <ListItemText primary={<FormattedMessage id="comet.dam.moreActions.deleteItems" defaultMessage="Delete" />} />
-                            {itemsSelected && <NumberSelectedChip>{selectionSize}</NumberSelectedChip>}
+                            {itemsSelected && <SelectedItemsChip>{selectionSize}</SelectedItemsChip>}
                         </MenuItem>
                     </MenuList>
                 </Box>
@@ -200,16 +200,3 @@ export const DamMoreActions = ({ button, transformOrigin, anchorOrigin, folderId
         </>
     );
 };
-
-const NumberSelectedChip = styled("div")`
-    display: flex;
-    align-items: center;
-    height: 24px;
-    background-color: ${({ theme }) => theme.palette.primary.main};
-    margin-left: 10px;
-    padding: 0 10px;
-    border-radius: 12px;
-    font-size: 12px;
-    font-weight: 400;
-    color: ${({ theme }) => theme.palette.grey[900]};
-`;

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/SelectedItemsChip.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/SelectedItemsChip.tsx
@@ -1,0 +1,15 @@
+import { styled } from "@mui/material";
+
+export const SelectedItemsChip = styled("div")`
+    display: flex;
+    align-items: center;
+    height: 24px;
+    width: 24px;
+    background-color: ${({ theme }) => theme.palette.primary.main};
+    margin-left: 10px;
+    justify-content: center;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 400;
+    color: ${({ theme }) => theme.palette.grey[900]};
+`;


### PR DESCRIPTION
The More options button for the DAM file system now shows the number of selected items

<details>
<summary>Screenshot</summary>

![image](https://github.com/vivid-planet/comet/assets/72387685/37abae4c-ea7e-46cf-9ab7-f98b67388544)

</details>