### PR TITLE
Support using a service in `@ScopedEntity()` decorator

### DIFF
--- a/.changeset/cuddly-penguins-try.md
+++ b/.changeset/cuddly-penguins-try.md
@@ -1,0 +1,10 @@
+---
+"@comet/cms-api": minor
+---
+
+Support using a service in `@ScopedEntity()` decorator
+
+This can be useful when an entity's scope cannot be derived directly from the passed entity.
+For example, a `Page` document's scope is derived by the `PageTreeNode` the document is attached to, but there is no database relation between the two entities.
+
+For page tree document types you can use the provided `PageTreeNodeDocumentEntityScopeService`.

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -605,6 +605,7 @@ type Query {
   builds(limit: Float): [Build!]!
   autoBuildStatus: AutoBuildStatus!
   link(linkId: ID!): Link
+  page(id: ID!): Page!
   pages(offset: Int! = 0, limit: Int! = 25, sortColumnName: String, sortDirection: SortDirection! = ASC): PaginatedPages!
   pageTreeNode(id: ID!): PageTreeNode
   pageTreeNodeByPath(path: String!, scope: PageTreeNodeScopeInput!): PageTreeNode

--- a/demo/api/src/links/entities/link.entity.ts
+++ b/demo/api/src/links/entities/link.entity.ts
@@ -1,5 +1,5 @@
 import { BlockDataInterface } from "@comet/blocks-api";
-import { DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
+import { DocumentInterface, PageTreeNodeDocumentEntityScopeService, RootBlockDataScalar, RootBlockType, ScopedEntity } from "@comet/cms-api";
 import { BaseEntity, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { LinkBlock } from "@src/common/blocks/linkBlock/link.block";
@@ -9,6 +9,7 @@ import { v4 as uuid } from "uuid";
 @ObjectType({
     implements: () => [DocumentInterface],
 })
+@ScopedEntity(PageTreeNodeDocumentEntityScopeService)
 export class Link extends BaseEntity<Link, "id"> implements DocumentInterface {
     [OptionalProps]?: "createdAt" | "updatedAt";
 

--- a/demo/api/src/links/links.resolver.ts
+++ b/demo/api/src/links/links.resolver.ts
@@ -1,4 +1,4 @@
-import { AffectedEntity, PageTreeNodeVisibility, PageTreeService, validateNotModified } from "@comet/cms-api";
+import { AffectedEntity, PageTreeNodeVisibility, PageTreeService, RequiredPermission, validateNotModified } from "@comet/cms-api";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
 import { UnauthorizedException } from "@nestjs/common";
@@ -8,6 +8,7 @@ import { LinkInput } from "./dto/link.input";
 import { Link } from "./entities/link.entity";
 
 @Resolver(() => Link)
+@RequiredPermission("pageTree")
 export class LinksResolver {
     constructor(@InjectRepository(Link) readonly repository: EntityRepository<Link>, private readonly pageTreeService: PageTreeService) {}
 

--- a/demo/api/src/pages/entities/page.entity.ts
+++ b/demo/api/src/pages/entities/page.entity.ts
@@ -1,5 +1,5 @@
 import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
-import { DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
+import { DocumentInterface, PageTreeNodeDocumentEntityScopeService, RootBlockDataScalar, RootBlockType, ScopedEntity } from "@comet/cms-api";
 import { BaseEntity, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
@@ -12,6 +12,7 @@ import { SeoBlock } from "../blocks/seo.block";
     implements: () => [DocumentInterface],
 })
 @RootBlockEntity()
+@ScopedEntity(PageTreeNodeDocumentEntityScopeService)
 export class Page extends BaseEntity<Page, "id"> implements DocumentInterface {
     [OptionalProps]?: "createdAt" | "updatedAt";
 

--- a/demo/api/src/pages/pages.resolver.ts
+++ b/demo/api/src/pages/pages.resolver.ts
@@ -27,6 +27,12 @@ export class PagesArgs extends IntersectionType(OffsetBasedPaginationArgs, SortA
 export class PagesResolver {
     constructor(@InjectRepository(Page) private readonly repository: EntityRepository<Page>, private readonly pageTreeService: PageTreeService) {}
 
+    @Query(() => Page)
+    @AffectedEntity(Page)
+    async page(@Args("id", { type: () => ID }) id: string): Promise<Page> {
+        return this.repository.findOneOrFail({ id });
+    }
+
     // TODO add scope argument (who uses this anyway? probably dashboard)
     @Query(() => PaginatedPages)
     @RequiredPermission(["pageTree"], { skipScopeCheck: true })

--- a/demo/api/src/predefined-page/entities/predefined-page.entity.ts
+++ b/demo/api/src/predefined-page/entities/predefined-page.entity.ts
@@ -1,4 +1,4 @@
-import { DocumentInterface } from "@comet/cms-api";
+import { DocumentInterface, PageTreeNodeDocumentEntityScopeService, ScopedEntity } from "@comet/cms-api";
 import { BaseEntity, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
@@ -7,6 +7,7 @@ import { v4 as uuid } from "uuid";
 @ObjectType({
     implements: () => [DocumentInterface],
 })
+@ScopedEntity(PageTreeNodeDocumentEntityScopeService)
 export class PredefinedPage extends BaseEntity<PredefinedPage, "id"> implements DocumentInterface {
     [OptionalProps]?: "createdAt" | "updatedAt";
 

--- a/demo/api/src/predefined-page/predefined-page.resolver.ts
+++ b/demo/api/src/predefined-page/predefined-page.resolver.ts
@@ -5,6 +5,7 @@ import {
     PageTreeService,
     RequestContext,
     RequestContextInterface,
+    RequiredPermission,
     validateNotModified,
 } from "@comet/cms-api";
 import { InjectRepository } from "@mikro-orm/nestjs";
@@ -19,6 +20,7 @@ import { PredefinedPage } from "./entities/predefined-page.entity";
 import { PredefinedPageService } from "./predefined-page.service";
 
 @Resolver(() => PredefinedPage)
+@RequiredPermission("pageTree")
 export class PredefinedPageResolver {
     constructor(
         @InjectRepository(PredefinedPage) private readonly repository: EntityRepository<PredefinedPage>,

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -129,6 +129,7 @@ export { PageTreeNodeBase } from "./page-tree/entities/page-tree-node-base.entit
 export { PAGE_TREE_REPOSITORY } from "./page-tree/page-tree.constants";
 export { PageTreeModule } from "./page-tree/page-tree.module";
 export { PageTreeReadApi, PageTreeService } from "./page-tree/page-tree.service";
+export { PageTreeNodeDocumentEntityScopeService } from "./page-tree/page-tree-node-document-entity-scope.service";
 export { PageTreeReadApiService } from "./page-tree/page-tree-read-api.service";
 export { PageTreeNodeCategory, PageTreeNodeInterface, PageTreeNodeVisibility, ScopeInterface } from "./page-tree/types";
 export { PageExists, PageExistsConstraint } from "./page-tree/validators/page-exists.validator";

--- a/packages/api/cms-api/src/page-tree/page-tree-node-document-entity-scope.service.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree-node-document-entity-scope.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from "@nestjs/common";
+
+import { DocumentInterface } from "../document/dto/document-interface";
+import { EntityScopeServiceInterface } from "../user-permissions/decorators/scoped-entity.decorator";
+import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
+import { PageTreeService } from "./page-tree.service";
+
+@Injectable()
+export class PageTreeNodeDocumentEntityScopeService implements EntityScopeServiceInterface<DocumentInterface> {
+    constructor(private readonly pageTreeService: PageTreeService) {}
+
+    async getEntityScope(document: DocumentInterface): Promise<ContentScope> {
+        const pageTreeReadApiService = this.pageTreeService.createReadApi({ visibility: "all" });
+
+        const pageTreeNode = await pageTreeReadApiService.getFirstNodeByAttachedPageId(document.id);
+
+        if (!pageTreeNode) {
+            throw new Error(`PageTreeNode not found for document with id: ${document.id}`);
+        }
+
+        return pageTreeNode?.scope ?? {};
+    }
+}

--- a/packages/api/cms-api/src/page-tree/page-tree.module.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.module.ts
@@ -12,6 +12,7 @@ import { AttachedDocument } from "./entities/attached-document.entity";
 import { PageTreeNodeBase } from "./entities/page-tree-node-base.entity";
 import { defaultReservedPaths, PAGE_TREE_CONFIG, PAGE_TREE_ENTITY, PAGE_TREE_REPOSITORY } from "./page-tree.constants";
 import { PageTreeService } from "./page-tree.service";
+import { PageTreeNodeDocumentEntityScopeService } from "./page-tree-node-document-entity-scope.service";
 import { PageTreeReadApiService } from "./page-tree-read-api.service";
 import type { PageTreeNodeInterface, ScopeInterface } from "./types";
 import { PageExistsConstraint } from "./validators/page-exists.validator";
@@ -84,8 +85,9 @@ export class PageTreeModule {
                     inject: [PageTreeService],
                 },
                 documentSubscriber,
+                PageTreeNodeDocumentEntityScopeService,
             ],
-            exports: [PageTreeService, PageTreeReadApiService, AttachedDocumentLoaderService],
+            exports: [PageTreeService, PageTreeReadApiService, AttachedDocumentLoaderService, PageTreeNodeDocumentEntityScopeService],
         };
     }
 }

--- a/packages/api/cms-api/src/user-permissions/decorators/scoped-entity.decorator.ts
+++ b/packages/api/cms-api/src/user-permissions/decorators/scoped-entity.decorator.ts
@@ -1,13 +1,17 @@
-import { CustomDecorator, SetMetadata } from "@nestjs/common";
+import { AnyEntity } from "@mikro-orm/core";
+import { CustomDecorator, SetMetadata, Type } from "@nestjs/common";
 
 import { ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
 
-export interface ScopedEntityMeta {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fn: (entity: any) => Promise<ContentScope | ContentScope[]>;
+export type GetEntityScope<Entity extends AnyEntity = AnyEntity> = (
+    item: Entity,
+) => ContentScope | ContentScope[] | Promise<ContentScope | ContentScope[]>;
+export interface EntityScopeServiceInterface<Entity extends AnyEntity = AnyEntity> {
+    getEntityScope: GetEntityScope<Entity>;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const ScopedEntity = (fn: (entity: any) => Promise<ContentScope | ContentScope[]>): CustomDecorator<string> => {
-    return SetMetadata("scopedEntity", { fn });
-};
+export type ScopedEntityMeta<Entity extends AnyEntity = AnyEntity> = GetEntityScope<Entity> | Type<EntityScopeServiceInterface<Entity>>;
+
+export function ScopedEntity<Entity extends AnyEntity = AnyEntity>(value: ScopedEntityMeta<Entity>): CustomDecorator<string> {
+    return SetMetadata<string, ScopedEntityMeta<Entity>>("scopedEntity", value);
+}


### PR DESCRIPTION
We need this for use cases where an entity's scope can't be directly derived from the passed entity. For example, a `Page` document's scope is derived by the `PageTreeNode` the document is attached to, but there's no direct relation between the `Page` and the `PageTreeNode` entities.