### PR TITLE
Allow path changes within `SaveBoundary` (e.g., `RouterTabs`) by automatically creating a `SubRoute`

### DIFF
--- a/.changeset/brown-kids-develop.md
+++ b/.changeset/brown-kids-develop.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": major
+---
+
+SaveBoundary now creates a subroute by default
+
+default path is ./save, change it using subRoutePath prop

--- a/.changeset/brown-kids-develop.md
+++ b/.changeset/brown-kids-develop.md
@@ -2,6 +2,6 @@
 "@comet/admin": major
 ---
 
-SaveBoundary now creates a subroute by default
+Create a subroute by default in `SaveBoundary`
 
-default path is ./save, change it using subRoutePath prop
+The default path is `./save`, you can change it using the `subRoutePath` prop.

--- a/.changeset/poor-dragons-sing.md
+++ b/.changeset/poor-dragons-sing.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Support relative paths in SubRoute component using ./subroute notation

--- a/.changeset/poor-dragons-sing.md
+++ b/.changeset/poor-dragons-sing.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-Support relative paths in SubRoute component using ./subroute notation
+Support relative paths in `SubRoute` component using `./subroute` notation

--- a/packages/admin/admin/src/router/Prompt.tsx
+++ b/packages/admin/admin/src/router/Prompt.tsx
@@ -6,7 +6,7 @@ import { v4 as uuid } from "uuid";
 
 import { RouterContext } from "./Context";
 import { SaveAction } from "./PromptHandler";
-import { SubRoute } from "./SubRoute";
+import { SubRoute, useSubRoutePrefix } from "./SubRoute";
 
 // react-router Prompt doesn't support multiple Prompts, this one does
 interface IProps {
@@ -23,6 +23,10 @@ export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, saveAct
     const reactRouterContext = React.useContext(__RouterContext); // reactRouterContext can be undefined if no router is used, don't fail in that case
     const path: string | undefined = reactRouterContext?.match?.path;
     const context = React.useContext(RouterContext);
+    const subRoutePrefix = useSubRoutePrefix();
+    if (subRoutePath && subRoutePath.startsWith("./")) {
+        subRoutePath = subRoutePrefix + subRoutePath.substring(1);
+    }
     React.useEffect(() => {
         if (context) {
             context.register({ id, message, saveAction, path, subRoutePath });

--- a/packages/admin/admin/src/router/SubRoute.tsx
+++ b/packages/admin/admin/src/router/SubRoute.tsx
@@ -23,6 +23,10 @@ export function SubRouteIndexRoute({ children }: { children: React.ReactNode }) 
 }
 
 export function SubRoute({ children, path }: { children: React.ReactNode; path: string }) {
+    const subRoutePrefix = useSubRoutePrefix();
+    if (path.startsWith("./")) {
+        path = subRoutePrefix + path.substring(1);
+    }
     return <SubRoutesContext.Provider value={{ path }}>{children}</SubRoutesContext.Provider>;
 }
 

--- a/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
+++ b/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
@@ -41,6 +41,8 @@ export function SaveBoundary({ onAfterSave, ...props }: SaveBoundaryProps) {
     const saveStates = React.useRef<Record<string, SavableProps>>({});
     const intl = useIntl();
 
+    const subRoutePath = props.subRoutePath ?? "./save";
+
     const save = React.useCallback(async (): Promise<SaveActionSuccess> => {
         setHasErrors(false);
         setSaving(true);
@@ -95,7 +97,7 @@ export function SaveBoundary({ onAfterSave, ...props }: SaveBoundaryProps) {
                 return true;
             }}
             saveAction={save}
-            subRoutePath={props.subRoutePath}
+            subRoutePath={subRoutePath}
         >
             <SavableContext.Provider
                 value={{


### PR DESCRIPTION
to reproduce: Demo -> Products Handmade -> Edit -> modify name -> select "Price" Tab -> wonder why you get a Save? Prompt

This will modify the url and add and additional /save for nested routes