### PR TITLE
SaveBoundary: Submit multiple Savables sequentially instead of parallel

### DIFF
--- a/.changeset/pink-forks-fold.md
+++ b/.changeset/pink-forks-fold.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+SaveBoundary: submit multiple Savables sequentially instead of paralell

--- a/.changeset/pink-forks-fold.md
+++ b/.changeset/pink-forks-fold.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-SaveBoundary: submit multiple Savables sequentially instead of paralell
+SaveBoundary: Submit multiple Savables sequentially instead of parallel

--- a/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
+++ b/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
@@ -45,13 +45,13 @@ export function SaveBoundary({ onAfterSave, ...props }: SaveBoundaryProps) {
         setHasErrors(false);
         setSaving(true);
         try {
-            const saveSuccess = !(
-                await Promise.all(
-                    Object.values(saveStates.current).map((state) => {
-                        return state.doSave();
-                    }),
-                )
-            ).some((saveSuccess) => !saveSuccess);
+            let saveSuccess = true;
+            for (const state of Object.values(saveStates.current)) {
+                const result = await state.doSave();
+                if (!result) {
+                    saveSuccess = false;
+                }
+            }
             if (!saveSuccess) {
                 setHasErrors(true);
             } else {


### PR DESCRIPTION
Else we will have issues with updating apollo cache with mutation responses if multiple saves occur on the same entity
