### PR TITLE
Mobile styling for `AppHeader`

### DIFF
--- a/.changeset/rare-boxes-guess.md
+++ b/.changeset/rare-boxes-guess.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Adapt `Header` and `UserHeaderItem` used in `AppHeader` for mobile devices (<900px)

--- a/packages/admin/cms-admin/src/common/header/Header.tsx
+++ b/packages/admin/cms-admin/src/common/header/Header.tsx
@@ -1,4 +1,4 @@
-import { AppHeader, AppHeaderFillSpace, AppHeaderMenuButton } from "@comet/admin";
+import { AppHeader, AppHeaderFillSpace, AppHeaderMenuButton, useWindowSize } from "@comet/admin";
 import * as React from "react";
 
 import { Logo } from "./Logo";
@@ -9,10 +9,13 @@ interface Props {
 }
 
 function Header({ children, logo }: Props): React.ReactElement {
+    const window = useWindowSize();
+    const isMobile = window.width <= 900; //MUI medium breakpoint 900px
+
     return (
         <AppHeader>
             <AppHeaderMenuButton />
-            {logo || <Logo />}
+            {!isMobile && (logo || <Logo />)}
             <AppHeaderFillSpace />
             {children}
         </AppHeader>

--- a/packages/admin/cms-admin/src/common/header/Header.tsx
+++ b/packages/admin/cms-admin/src/common/header/Header.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 function Header({ children, logo }: Props): React.ReactElement {
     const theme = useTheme();
-    const isMobile = useMediaQuery(theme.breakpoints.up("sm"));
+    const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
     return (
         <AppHeader>

--- a/packages/admin/cms-admin/src/common/header/Header.tsx
+++ b/packages/admin/cms-admin/src/common/header/Header.tsx
@@ -1,4 +1,5 @@
-import { AppHeader, AppHeaderFillSpace, AppHeaderMenuButton, useWindowSize } from "@comet/admin";
+import { AppHeader, AppHeaderFillSpace, AppHeaderMenuButton } from "@comet/admin";
+import { useMediaQuery, useTheme } from "@mui/material";
 import * as React from "react";
 
 import { Logo } from "./Logo";
@@ -9,8 +10,8 @@ interface Props {
 }
 
 function Header({ children, logo }: Props): React.ReactElement {
-    const window = useWindowSize();
-    const isMobile = window.width <= 900; //MUI medium breakpoint 900px
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.up("sm"));
 
     return (
         <AppHeader>

--- a/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
+++ b/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
@@ -40,7 +40,7 @@ export function UserHeaderItem(props: UserHeaderItemProps): React.ReactElement {
     const { aboutModalLogo } = props;
 
     const theme = useTheme();
-    const isMobile = useMediaQuery(theme.breakpoints.up("sm"));
+    const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
     const user = useCurrentUser();
     const [showAboutModal, setShowAboutModal] = React.useState(false);

--- a/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
+++ b/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
@@ -1,7 +1,7 @@
 import { gql, useMutation } from "@apollo/client";
-import { AppHeaderDropdown, Loading, useWindowSize } from "@comet/admin";
+import { AppHeaderDropdown, Loading } from "@comet/admin";
 import { Account, Info, Logout } from "@comet/admin-icons";
-import { Box, Button as MUIButton } from "@mui/material";
+import { Box, Button as MUIButton, useMediaQuery, useTheme } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import React from "react";
 import { FormattedMessage } from "react-intl";
@@ -39,8 +39,8 @@ interface UserHeaderItemProps {
 export function UserHeaderItem(props: UserHeaderItemProps): React.ReactElement {
     const { aboutModalLogo } = props;
 
-    const window = useWindowSize();
-    const isMobile = window.width <= 900; //MUI medium breakpoint 900px
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.up("sm"));
 
     const user = useCurrentUser();
     const [showAboutModal, setShowAboutModal] = React.useState(false);

--- a/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
+++ b/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
@@ -47,7 +47,7 @@ export function UserHeaderItem(props: UserHeaderItemProps): React.ReactElement {
     const [signOut, { loading: isSigningOut }] = useMutation<GQLSignOutMutation>(signOutMutation);
 
     return (
-        <AppHeaderDropdown buttonChildren={isMobile ? undefined : user.name} startIcon={<Account />}>
+        <AppHeaderDropdown buttonChildren={isMobile ? <Account /> : user.name} startIcon={isMobile ? undefined : <Account />}>
             <DropdownContent padding={4}>
                 <Button
                     fullWidth={true}

--- a/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
+++ b/packages/admin/cms-admin/src/common/header/UserHeaderItem.tsx
@@ -1,10 +1,12 @@
-import { AppHeaderDropdown, Loading } from "@comet/admin";
+import { gql, useMutation } from "@apollo/client";
+import { AppHeaderDropdown, Loading, useWindowSize } from "@comet/admin";
 import { Account, Info, Logout } from "@comet/admin-icons";
 import { Box, Button as MUIButton } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { useCurrentUser } from "../../userPermissions/hooks/currentUser";
 import { AboutModal } from "./about/AboutModal";
 import { GQLSignOutMutation } from "./UserHeaderItem.generated";
 
@@ -24,10 +26,6 @@ const Separator = styled(Box)`
     margin-bottom: 20px;
 `;
 
-import { gql, useMutation } from "@apollo/client";
-
-import { useCurrentUser } from "../../userPermissions/hooks/currentUser";
-
 const signOutMutation = gql`
     mutation SignOut {
         currentUserSignOut
@@ -41,12 +39,15 @@ interface UserHeaderItemProps {
 export function UserHeaderItem(props: UserHeaderItemProps): React.ReactElement {
     const { aboutModalLogo } = props;
 
+    const window = useWindowSize();
+    const isMobile = window.width <= 900; //MUI medium breakpoint 900px
+
     const user = useCurrentUser();
     const [showAboutModal, setShowAboutModal] = React.useState(false);
     const [signOut, { loading: isSigningOut }] = useMutation<GQLSignOutMutation>(signOutMutation);
 
     return (
-        <AppHeaderDropdown buttonChildren={user.name} startIcon={<Account />}>
+        <AppHeaderDropdown buttonChildren={isMobile ? undefined : user.name} startIcon={<Account />}>
             <DropdownContent padding={4}>
                 <Button
                     fullWidth={true}


### PR DESCRIPTION
SVK-186

The `AppHeader` is styled to match its mobile design. The mobile design is used up to MUIs' medium breakpoint (900px). This has been discussed with the UX team.

<details><summary>Video:</summary>
<p>

https://github.com/vivid-planet/comet/assets/122883866/d2351b26-04eb-4ef4-ac82-750b85495ae6

</p>
</details> 