### PR TITLE
Pass `disabled` prop to children of `Field`

### DIFF
--- a/.changeset/weak-moles-destroy.md
+++ b/.changeset/weak-moles-destroy.md
@@ -2,4 +2,4 @@
 "@comet/admin": patch
 ---
 
-Fix a bug where the `disabled` prop would not be applied to the children of `Field`
+Fix a bug where the `disabled` prop would not be passed to the children of `Field`

--- a/.changeset/weak-moles-destroy.md
+++ b/.changeset/weak-moles-destroy.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin": minor
+"@comet/admin": patch
 ---
 
-The `disabled` prop for `Field` is now applied to all children
+Fix a bug where the `disabled` prop would not be applied to the children of `Field`

--- a/.changeset/weak-moles-destroy.md
+++ b/.changeset/weak-moles-destroy.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+The `disabled` prop for `Field` is now applied to all children

--- a/demo/admin/src/common/ComponentDemo.tsx
+++ b/demo/admin/src/common/ComponentDemo.tsx
@@ -139,7 +139,15 @@ export function ComponentDemo(): React.ReactElement {
 
                             <TextField name="text" label="Input with label" fullWidth />
 
+                            <TextField name="textDisabled" label="Input disabled" placeholder="Input" fullWidth disabled />
+
                             <SelectField name="select" label="Select with label" fullWidth>
+                                <MenuItem value="Option 1">Option 1</MenuItem>
+                                <MenuItem value="Option 2">Option 2</MenuItem>
+                                <MenuItem value="Option 3">Option 3</MenuItem>
+                            </SelectField>
+
+                            <SelectField name="selectDisabled" label="SelectField disabled" fullWidth disabled>
                                 <MenuItem value="Option 1">Option 1</MenuItem>
                                 <MenuItem value="Option 2">Option 2</MenuItem>
                                 <MenuItem value="Option 3">Option 3</MenuItem>
@@ -199,16 +207,22 @@ export function ComponentDemo(): React.ReactElement {
                                 <Field name="single-choice" type="radio" value="Option 3" fullWidth>
                                     {(props) => <FormControlLabel label="Option 3" control={<FinalFormRadio {...props} />} />}
                                 </Field>
+                                <Field name="single-choice" type="radio" value="Option 4 disabled" fullWidth disabled>
+                                    {(props) => <FormControlLabel label="Option 4 disabled" control={<FinalFormRadio {...props} />} />}
+                                </Field>
                             </FieldContainer>
                             <FieldContainer label="Multiple choice">
                                 <CheckboxField name="multiple-choice-1" label="Option 1" fullWidth />
                                 <CheckboxField name="multiple-choice-2" label="Option 2" fullWidth />
                                 <CheckboxField name="multiple-choice-3" label="Option 3" fullWidth />
+                                <CheckboxField name="multiple-choice-4-disabled" label="Option 4 disabled" fullWidth disabled />
                             </FieldContainer>
 
                             <SwitchField name="switch" fieldLabel="Switch with label" />
 
                             <SwitchField name="switch" label="Switch with inline label" />
+
+                            <SwitchField name="switch" fieldLabel="Switch disabled" disabled />
 
                             <Field
                                 name="button-group-row"
@@ -332,6 +346,7 @@ export function ComponentDemo(): React.ReactElement {
                                         <MenuItem value="10%">10%</MenuItem>
                                         <MenuItem value="20%">20%</MenuItem>
                                     </SelectField>
+
                                     <SwitchField name="shadow" fieldLabel="Shadow" />
                                 </BlocksFinalForm>
                             </AdminComponentPaper>

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -57,15 +57,20 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
     const shouldShowWarning = passedShouldShowWarning ?? finalFormContext.shouldShowFieldWarning;
     const shouldScrollToField = passedShouldScrollTo ?? finalFormContext.shouldScrollToField;
 
-    function renderField({ input, meta, fieldContainerProps, ...rest }: FieldRenderProps<FieldValue, FieldElement> & { warning?: string }) {
+    function renderField({
+        input,
+        meta,
+        fieldContainerProps,
+        ...rest
+    }: FieldRenderProps<FieldValue, FieldElement> & { warning?: string; disabled?: boolean }) {
         function render() {
             if (component) {
-                return React.createElement(component, { ...rest, input, meta });
+                return React.createElement(component, { ...rest, input, meta, disabled });
             } else {
                 if (typeof children !== "function") {
                     throw new Error(`Warning: Must specify either a render function as children, or a component prop to ${name}`);
                 }
-                return children({ input, meta });
+                return children({ input, meta, disabled });
             }
         }
         return (

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -65,7 +65,7 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
     }: FieldRenderProps<FieldValue, FieldElement> & { warning?: string; disabled?: boolean }) {
         function render() {
             if (component) {
-                return React.createElement(component, { ...rest, input, meta, disabled });
+                return React.createElement(component, { ...rest, input, meta });
             } else {
                 if (typeof children !== "function") {
                     throw new Error(`Warning: Must specify either a render function as children, or a component prop to ${name}`);

--- a/storybook/src/admin/form/Checkbox.tsx
+++ b/storybook/src/admin/form/Checkbox.tsx
@@ -34,16 +34,12 @@ function Story() {
                                             <Field name="checked" type="checkbox" fullWidth>
                                                 {(props) => <FormControlLabel label="Checked" control={<FinalFormCheckbox {...props} />} />}
                                             </Field>
-                                            <Field name="disabledUnchecked" type="checkbox" fullWidth>
-                                                {(props) => <FormControlLabel label="Disabled" disabled control={<FinalFormCheckbox {...props} />} />}
+                                            <Field name="disabledUnchecked" type="checkbox" fullWidth disabled>
+                                                {(props) => <FormControlLabel label="Disabled" control={<FinalFormCheckbox {...props} />} />}
                                             </Field>
-                                            <Field name="disabledChecked" type="checkbox" fullWidth>
+                                            <Field name="disabledChecked" type="checkbox" fullWidth disabled>
                                                 {(props) => (
-                                                    <FormControlLabel
-                                                        label="Disabled & Checked"
-                                                        disabled
-                                                        control={<FinalFormCheckbox {...props} />}
-                                                    />
+                                                    <FormControlLabel label="Disabled & Checked" control={<FinalFormCheckbox {...props} />} />
                                                 )}
                                             </Field>
                                         </FieldContainer>
@@ -67,21 +63,16 @@ function Story() {
                                                     <FormControlLabel label="Checked" control={<FinalFormCheckbox {...props} color="secondary" />} />
                                                 )}
                                             </Field>
-                                            <Field name="disabledUncheckedSecondary" type="checkbox" fullWidth>
+                                            <Field name="disabledUncheckedSecondary" type="checkbox" fullWidth disabled>
                                                 {(props) => (
-                                                    <FormControlLabel
-                                                        label="Disabled"
-                                                        control={<FinalFormCheckbox {...props} color="secondary" />}
-                                                        disabled
-                                                    />
+                                                    <FormControlLabel label="Disabled" control={<FinalFormCheckbox {...props} color="secondary" />} />
                                                 )}
                                             </Field>
-                                            <Field name="disabledCheckedSecondary" type="checkbox" fullWidth>
+                                            <Field name="disabledCheckedSecondary" type="checkbox" fullWidth disabled>
                                                 {(props) => (
                                                     <FormControlLabel
                                                         label="Disabled & Checked"
                                                         control={<FinalFormCheckbox {...props} color="secondary" />}
-                                                        disabled
                                                     />
                                                 )}
                                             </Field>

--- a/storybook/src/admin/form/Radio.tsx
+++ b/storybook/src/admin/form/Radio.tsx
@@ -30,13 +30,11 @@ function Story() {
                                             <Field name="foo1" type="radio" value="bar2" fullWidth>
                                                 {(props) => <FormControlLabel label="Checked" control={<FinalFormRadio {...props} />} />}
                                             </Field>
-                                            <Field name="foo2" type="radio" value="bar1" fullWidth>
-                                                {(props) => <FormControlLabel label="Disabled" disabled control={<FinalFormRadio {...props} />} />}
+                                            <Field name="foo2" type="radio" value="bar1" fullWidth disabled>
+                                                {(props) => <FormControlLabel label="Disabled" control={<FinalFormRadio {...props} />} />}
                                             </Field>
-                                            <Field name="foo2" type="radio" value="bar2" fullWidth>
-                                                {(props) => (
-                                                    <FormControlLabel label="Disabled & Checked" disabled control={<FinalFormRadio {...props} />} />
-                                                )}
+                                            <Field name="foo2" type="radio" value="bar2" fullWidth disabled>
+                                                {(props) => <FormControlLabel label="Disabled & Checked" control={<FinalFormRadio {...props} />} />}
                                             </Field>
                                         </FieldContainer>
                                     </CardContent>
@@ -56,20 +54,15 @@ function Story() {
                                                     <FormControlLabel label="Checked" control={<FinalFormRadio {...props} color="secondary" />} />
                                                 )}
                                             </Field>
-                                            <Field name="foo4" type="radio" value="bar1" fullWidth>
+                                            <Field name="foo4" type="radio" value="bar1" fullWidth disabled>
                                                 {(props) => (
-                                                    <FormControlLabel
-                                                        label="Disabled"
-                                                        disabled
-                                                        control={<FinalFormRadio {...props} color="secondary" />}
-                                                    />
+                                                    <FormControlLabel label="Disabled" control={<FinalFormRadio {...props} color="secondary" />} />
                                                 )}
                                             </Field>
-                                            <Field name="foo4" type="radio" value="bar2" fullWidth>
+                                            <Field name="foo4" type="radio" value="bar2" fullWidth disabled>
                                                 {(props) => (
                                                     <FormControlLabel
                                                         label="Disabled & Checked"
-                                                        disabled
                                                         control={<FinalFormRadio {...props} color="secondary" />}
                                                     />
                                                 )}

--- a/storybook/src/admin/form/Select.tsx
+++ b/storybook/src/admin/form/Select.tsx
@@ -86,9 +86,9 @@ function Story() {
                                         )}
                                     </Field>
 
-                                    <Field name="flavorDisabled" label="Disabled Flavor" fullWidth>
+                                    <Field name="flavorDisabled" label="Disabled Flavor" fullWidth disabled>
                                         {(props) => (
-                                            <FinalFormSelect {...props} fullWidth disabled>
+                                            <FinalFormSelect {...props} fullWidth>
                                                 {options.map((option) => (
                                                     <MenuItem value={option.value} key={option.value}>
                                                         {option.label}

--- a/storybook/src/docs/form/components/stories/FinalFormFields.stories.tsx
+++ b/storybook/src/docs/form/components/stories/FinalFormFields.stories.tsx
@@ -192,6 +192,20 @@ storiesOf("stories/form/FinalForm Fields", module)
                     label="Select multiple values"
                     fullWidth
                 />
+
+                <Field
+                    component={FinalFormSelect}
+                    getOptionLabel={(option: Option) => option.label}
+                    getOptionSelected={(option: Option, value: Option) => {
+                        return option.value === value.value;
+                    }}
+                    options={options}
+                    name="selectDisabled"
+                    label="Select disabled"
+                    fullWidth
+                    disabled
+                />
+
                 <Button color="primary" variant="contained" type="submit">
                     Submit
                 </Button>
@@ -209,6 +223,9 @@ storiesOf("stories/form/FinalForm Fields", module)
                 <Field name="checkbox" label="FinalFormCheckbox" type="checkbox" fullWidth>
                     {(props) => <FormControlLabel label="Confirm" control={<FinalFormCheckbox {...props} />} />}
                 </Field>
+                <Field name="checkboxDisabled" label="FinalFormCheckbox disabled" type="checkbox" fullWidth disabled>
+                    {(props) => <FormControlLabel label="Confirm" control={<FinalFormCheckbox {...props} />} />}
+                </Field>
                 <Button color="primary" variant="contained" type="submit">
                     Submit
                 </Button>
@@ -224,6 +241,9 @@ storiesOf("stories/form/FinalForm Fields", module)
                 }}
             >
                 <Field name="switch" label="FinalFormSwitch" fullWidth>
+                    {(props) => <FormControlLabel label={props.input.value ? "On" : "Off"} control={<FinalFormSwitch {...props} />} />}
+                </Field>
+                <Field name="switchDisabled" label="FinalFormSwitch disabled" fullWidth disabled>
                     {(props) => <FormControlLabel label={props.input.value ? "On" : "Off"} control={<FinalFormSwitch {...props} />} />}
                 </Field>
                 <Button color="primary" variant="contained" type="submit">
@@ -246,6 +266,14 @@ storiesOf("stories/form/FinalForm Fields", module)
                     </Field>
                     <Field name="radio" type="radio" value="option2">
                         {(props) => <FormControlLabel label="Option 2" control={<FinalFormRadio {...props} />} />}
+                    </Field>
+                </FieldContainer>
+                <FieldContainer label="FinalFormRadio disabled" fullWidth disabled>
+                    <Field name="radio" type="radio" value="disabledOption1" disabled>
+                        {(props) => <FormControlLabel label="Disabled Option 1" control={<FinalFormRadio {...props} />} />}
+                    </Field>
+                    <Field name="radio" type="radio" value="disabledOption2" disabled>
+                        {(props) => <FormControlLabel label="Disabled Option 2" control={<FinalFormRadio {...props} />} />}
                     </Field>
                 </FieldContainer>
                 <Button color="primary" variant="contained" type="submit">


### PR DESCRIPTION
Allows all field types in `packages/admin/admin/src/form/fields` to be disabled. Examples of disabled components have been added to `ComponentDemo` and `FinalFormFields.stories`.

---

COM-503

No visual changes.

