### PR TITLE
Responsive Headlines for `Typography`

### DIFF
--- a/.changeset/smooth-chefs-flow.md
+++ b/.changeset/smooth-chefs-flow.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": major
+---
+
+Mobile theming for medium screen sizes (<900px) is added to `Typography` headlines

--- a/.changeset/smooth-chefs-flow.md
+++ b/.changeset/smooth-chefs-flow.md
@@ -2,4 +2,4 @@
 "@comet/admin-theme": major
 ---
 
-Mobile theming for medium screen sizes (<900px) is added to `Typography` headlines
+Adapt `Typography` headlines for mobile devices (<900px)

--- a/packages/admin/admin-theme/src/typographyOptions.ts
+++ b/packages/admin/admin-theme/src/typographyOptions.ts
@@ -4,6 +4,7 @@ const fontFamily = "Roboto, Helvetica, Arial, sans-serif";
 
 export const fontWeights = {
     fontWeightLight: 100,
+    fontWeightSemiLight: 200,
     fontWeightRegular: 300,
     fontWeightMedium: 400,
     fontWeightBold: 500,
@@ -13,39 +14,75 @@ export const typographyOptions: TypographyOptions = {
     ...fontWeights,
     h1: {
         fontFamily,
-        fontSize: 55,
-        lineHeight: "64px",
+        fontSize: 36,
+        lineHeight: "42px",
         fontWeight: fontWeights.fontWeightLight,
+
+        "@media (min-width: 900px)": {
+            fontSize: 55,
+            lineHeight: "64px",
+            fontWeight: fontWeights.fontWeightLight,
+        },
     },
     h2: {
         fontFamily,
-        fontSize: 44,
-        lineHeight: "52px",
-        fontWeight: fontWeights.fontWeightLight,
+        fontSize: 30,
+        lineHeight: "38px",
+        fontWeight: fontWeights.fontWeightSemiLight,
+
+        "@media (min-width: 900px)": {
+            fontSize: 44,
+            lineHeight: "52px",
+            fontWeight: fontWeights.fontWeightLight,
+        },
     },
     h3: {
         fontFamily,
-        fontSize: 33,
-        lineHeight: "39px",
-        fontWeight: fontWeights.fontWeightLight,
+        fontSize: 24,
+        lineHeight: "28px",
+        fontWeight: fontWeights.fontWeightRegular,
+
+        "@media (min-width: 900px)": {
+            fontSize: 33,
+            lineHeight: "39px",
+            fontWeight: fontWeights.fontWeightLight,
+        },
     },
     h4: {
         fontFamily,
-        fontSize: 24,
-        lineHeight: "28px",
-        fontWeight: fontWeights.fontWeightLight,
+        fontSize: 20,
+        lineHeight: "26px",
+        fontWeight: fontWeights.fontWeightRegular,
+
+        "@media (min-width: 900px)": {
+            fontSize: 24,
+            lineHeight: "28px",
+            fontWeight: fontWeights.fontWeightSemiLight,
+        },
     },
     h5: {
         fontFamily,
-        fontSize: 18,
-        lineHeight: "21px",
-        fontWeight: fontWeights.fontWeightRegular,
+        fontSize: 16,
+        lineHeight: "20px",
+        fontWeight: fontWeights.fontWeightMedium,
+
+        "@media (min-width: 900px)": {
+            fontSize: 18,
+            lineHeight: "21px",
+            fontWeight: fontWeights.fontWeightRegular,
+        },
     },
     h6: {
         fontFamily,
-        fontSize: 16,
-        lineHeight: "20px",
+        fontSize: 14,
+        lineHeight: "18px",
         fontWeight: fontWeights.fontWeightBold,
+
+        "@media (min-width: 900px)": {
+            fontSize: 16,
+            lineHeight: "20px",
+            fontWeight: fontWeights.fontWeightBold,
+        },
     },
     body1: {
         fontFamily,

--- a/packages/admin/admin-theme/src/typographyOptions.ts
+++ b/packages/admin/admin-theme/src/typographyOptions.ts
@@ -21,7 +21,6 @@ export const typographyOptions: TypographyOptions = {
         "@media (min-width: 900px)": {
             fontSize: 55,
             lineHeight: "64px",
-            fontWeight: fontWeights.fontWeightLight,
         },
     },
     h2: {
@@ -81,7 +80,6 @@ export const typographyOptions: TypographyOptions = {
         "@media (min-width: 900px)": {
             fontSize: 16,
             lineHeight: "20px",
-            fontWeight: fontWeights.fontWeightBold,
         },
     },
     body1: {


### PR DESCRIPTION
SVK-188

Typography headlines now have mobile theming according to Figma via media breakpoints. The MUI medium breakpoint (900px) is used.

<details><summary>Video of theming switch:</summary>
<p>

https://github.com/vivid-planet/comet/assets/122883866/5cf68687-a7f3-4f04-af3e-19fbe0be1c3b

</p>
</details> 