### PR TITLE
Implement a server side cache for api requests in site

### DIFF
--- a/demo/site/preBuild/src/createRedirects.ts
+++ b/demo/site/preBuild/src/createRedirects.ts
@@ -3,7 +3,7 @@ import { Redirect } from "next/dist/lib/load-custom-routes";
 
 import { ExternalLinkBlockData, InternalLinkBlockData, NewsLinkBlockData, RedirectsLinkBlockData } from "../../src/blocks.generated";
 import { domain } from "../../src/config";
-import createGraphQLClient from "../../src/util/createGraphQLClient";
+import { createGraphQLClient } from "../../src/util/graphQLClient";
 import { GQLRedirectsQuery, GQLRedirectsQueryVariables } from "./createRedirects.generated";
 
 const createRedirects = async () => {

--- a/demo/site/preBuild/src/publicGenerator/sitemap.xml.ts
+++ b/demo/site/preBuild/src/publicGenerator/sitemap.xml.ts
@@ -1,10 +1,10 @@
 import { createWriteStream } from "fs";
-import { gql } from "graphql-request/dist";
+import { gql } from "graphql-request";
 import { resolve } from "path";
 import { SitemapStream } from "sitemap";
 
 import { SeoBlockData } from "../../../src/blocks.generated";
-import createGraphQLClient from "../../../src/util/createGraphQLClient";
+import { createGraphQLClient } from "../../../src/util/graphQLClient";
 import createPublicGeneratedDirectory from "./createPublicGeneratedDirectory";
 import { GQLSitemapPageDataQuery, GQLSitemapPageDataQueryVariables } from "./sitemap.xml.generated";
 

--- a/demo/site/src/pages/404.tsx
+++ b/demo/site/src/pages/404.tsx
@@ -1,13 +1,9 @@
 import * as React from "react";
 
-interface NotFound404Props {
-    children: React.ReactNode;
-}
-export default function NotFound404({ children }: NotFound404Props): JSX.Element {
+export default function NotFound404(): JSX.Element {
     return (
         <>
             <h1>404 - Page Not Found</h1>
-            {children}
         </>
     );
 }

--- a/demo/site/src/pages/[[...path]].tsx
+++ b/demo/site/src/pages/[[...path]].tsx
@@ -4,26 +4,24 @@ import { documentTypes } from "@src/documentTypes";
 import NotFound404 from "@src/pages/404";
 import createGraphQLClient from "@src/util/createGraphQLClient";
 import { gql } from "graphql-request";
-import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { ParsedUrlQuery } from "querystring";
 import * as React from "react";
 
-import { GQLDocumentTypeQuery, GQLDocumentTypeQueryVariables, GQLPagesQuery, GQLPagesQueryVariables } from "./[[...path]].generated";
+import { GQLDocumentTypeQuery, GQLDocumentTypeQueryVariables } from "./[[...path]].generated";
 
 type PageProps = {
     documentType: string;
     id: string;
 } & Record<string, unknown>;
 
-export default function Page(props: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element {
-    if (!documentTypes[props.documentType]) {
-        return (
-            <NotFound404>
-                <div>
-                    unknown documentType: <em>{props.documentType}</em>
-                </div>
-            </NotFound404>
-        );
+export interface NotFoundProps {
+    notFound: true;
+}
+
+export default function Page(props: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
+    if ("notFound" in props || !documentTypes[props.documentType]) {
+        return <NotFound404 />;
     }
     const { component: Component } = documentTypes[props.documentType];
 
@@ -39,64 +37,42 @@ const documentTypeQuery = gql`
     }
 `;
 
-export const getStaticProps: GetStaticProps<PageProps, ParsedUrlQuery, PreviewData> = async ({ params, previewData, locale = defaultLanguage }) => {
-    const client = createGraphQLClient(previewData);
-    const path = params?.path ?? "";
+export const getServerSideProps: GetServerSideProps<PageProps | NotFoundProps, ParsedUrlQuery, PreviewData> = async (context) => {
+    const client = createGraphQLClient(context.previewData);
+    const locale = context.locale ?? defaultLanguage;
     const scope = { domain, language: locale };
+    const path = context.params?.path ?? "";
+
     //fetch documentType
     const data = await client.request<GQLDocumentTypeQuery, GQLDocumentTypeQueryVariables>(documentTypeQuery, {
         path: `/${Array.isArray(path) ? path.join("/") : path}`,
         scope,
     });
     if (!data.pageTreeNodeByPath?.documentType) {
-        // eslint-disable-next-line no-console
-        console.log("got no data from api", data, path);
-        return { notFound: true };
+        // next 404 page cannot be generated server-side, see: https://nextjs.org/docs/messages/404-get-initial-props
+        // (except when using next 13: https://nextjs.org/docs/app/api-reference/file-conventions/not-found)
+        // that's why we return a custom props object here for the 404 page which will render the custom 404 page
+
+        context.res.statusCode = 404;
+        return {
+            props: {
+                notFound: true,
+            },
+        };
     }
+
+    context.res.setHeader("Cache-Control", "s-maxage=900, stale-while-revalidate=86400");
+
     const pageTreeNodeId = data.pageTreeNodeByPath.id;
 
-    //documentType dependent query
+    //documentType dependent loader
     const { loader: loaderForPageType } = documentTypes[data.pageTreeNodeByPath.documentType];
+
     return {
         props: {
             ...(await loaderForPageType({ client, scope, pageTreeNodeId })),
             documentType: data.pageTreeNodeByPath.documentType,
             id: pageTreeNodeId,
         },
-    };
-};
-
-const pagesQuery = gql`
-    query Pages($scope: PageTreeNodeScopeInput!) {
-        pageTreeNodeList(scope: $scope) {
-            id
-            path
-            documentType
-        }
-    }
-`;
-
-export const getStaticPaths: GetStaticPaths = async ({ locales = [] }) => {
-    const paths: Array<{ params: { path: string[] }; locale: string }> = [];
-
-    for (const locale of locales) {
-        const data = await createGraphQLClient().request<GQLPagesQuery, GQLPagesQueryVariables>(pagesQuery, {
-            scope: { domain, language: locale },
-        });
-
-        paths.push(
-            ...data.pageTreeNodeList
-                .filter((page) => page.documentType === "Page")
-                .map((page) => {
-                    const path = page.path.split("/");
-                    path.shift(); // Remove "" caused by leading slash
-                    return { params: { path }, locale };
-                }),
-        );
-    }
-
-    return {
-        paths,
-        fallback: false,
     };
 };

--- a/demo/site/src/pages/[[...path]].tsx
+++ b/demo/site/src/pages/[[...path]].tsx
@@ -2,7 +2,7 @@ import { PreviewData } from "@comet/cms-site";
 import { defaultLanguage, domain } from "@src/config";
 import { documentTypes } from "@src/documentTypes";
 import NotFound404 from "@src/pages/404";
-import createGraphQLClient from "@src/util/createGraphQLClient";
+import { createGraphQLClient, graphqlClient } from "@src/util/graphQLClient";
 import { gql } from "graphql-request";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { ParsedUrlQuery } from "querystring";
@@ -38,7 +38,7 @@ const documentTypeQuery = gql`
 `;
 
 export const getServerSideProps: GetServerSideProps<PageProps | NotFoundProps, ParsedUrlQuery, PreviewData> = async (context) => {
-    const client = createGraphQLClient(context.previewData);
+    const client = context.previewData ? createGraphQLClient({ previewData: context.previewData }) : graphqlClient;
     const locale = context.locale ?? defaultLanguage;
     const scope = { domain, language: locale };
     const path = context.params?.path ?? "";

--- a/demo/site/src/pages/api/site-preview.ts
+++ b/demo/site/src/pages/api/site-preview.ts
@@ -1,5 +1,5 @@
 import { getValidatedSitePreviewParams } from "@comet/cms-site";
-import createGraphQLClient from "@src/util/createGraphQLClient";
+import { createGraphQLClient } from "@src/util/graphQLClient";
 
 export default async function handler(req, res) {
     const params = await getValidatedSitePreviewParams(req, res, createGraphQLClient());

--- a/demo/site/src/util/createGraphQLClient.ts
+++ b/demo/site/src/util/createGraphQLClient.ts
@@ -1,5 +1,0 @@
-import { createGraphQLClient as libraryCreateGraphQLClient, PreviewData } from "@comet/cms-site";
-
-export default function createGraphQLClient(previewData?: PreviewData) {
-    return libraryCreateGraphQLClient(`${process.env.API_URL_INTERNAL}/graphql`, previewData);
-}

--- a/demo/site/src/util/graphQLClient.ts
+++ b/demo/site/src/util/graphQLClient.ts
@@ -1,0 +1,16 @@
+import { createGraphQLClient as libraryCreateGraphQLClient, inMemorySwrCachingFetch, PreviewData } from "@comet/cms-site";
+import { GraphQLClient } from "graphql-request";
+
+type RequestConfig = ConstructorParameters<typeof GraphQLClient>[1]; //graphql-request doesn't export RequestConfig
+
+export function createGraphQLClient(options?: RequestConfig & { previewData?: PreviewData }) {
+    return libraryCreateGraphQLClient(`${process.env.API_URL_INTERNAL}/graphql`, options);
+}
+
+export const fetch =
+    typeof window === "undefined"
+        ? inMemorySwrCachingFetch //server side: caching fetch
+        : window.fetch; //client side: default fetch
+export const graphqlClient = createGraphQLClient({
+    fetch,
+});

--- a/packages/site/cms-site/src/graphql/graphqlClient.ts
+++ b/packages/site/cms-site/src/graphql/graphqlClient.ts
@@ -2,7 +2,10 @@ import { GraphQLClient } from "graphql-request";
 
 import { PreviewData } from "../sitePreview/SitePreviewApiHelper";
 
-export function createGraphQLClient(url: string, previewData?: PreviewData): GraphQLClient {
+type RequestConfig = ConstructorParameters<typeof GraphQLClient>[1]; //graphql-request doesn't export RequestConfig
+
+export function createGraphQLClient(url: string, options?: RequestConfig & { previewData?: PreviewData }): GraphQLClient {
+    const { previewData, ...gqlOptions } = options ?? {};
     const { includeInvisibleBlocks, includeInvisiblePages, previewDamUrls } = {
         includeInvisiblePages: !!previewData,
         includeInvisibleBlocks: previewData && previewData.includeInvisible,
@@ -35,5 +38,6 @@ export function createGraphQLClient(url: string, previewData?: PreviewData): Gra
 
     return new GraphQLClient(url, {
         headers,
+        ...gqlOptions,
     });
 }

--- a/packages/site/cms-site/src/graphql/swrCachingFetch.ts
+++ b/packages/site/cms-site/src/graphql/swrCachingFetch.ts
@@ -1,0 +1,111 @@
+const fetchCache: Record<string, { timestamp: number; ttl: number; swrTime: number; size: number; response: Response; updating?: true }> = {};
+
+const defaultSwrTime = 60 * 5; //5 minutes
+const defaultTtl = 60 * 5; //30 minutes
+const maxCacheSize = 1024 * 1024 * 100; //100MB
+const stats = {
+    uncachable: 0,
+    hit: 0,
+    miss: 0,
+    refresh: 0,
+    timeout: 0,
+};
+
+interface SwrOptions {
+    ttl?: number; //no cache if <= 0
+    swrTime?: number; //no swr if <= 0
+}
+
+//cleanup cache every 5 minutes
+// 1. remove all expired entries
+// 2. if cache is too large, remove oldest entries
+let cleanupStarted = false;
+function avtivateCleanup() {
+    if (cleanupStarted) return;
+    cleanupStarted = true;
+
+    setInterval(() => {
+        let totalSize = 0;
+        const now = new Date().getTime() / 1000;
+        for (const key in fetchCache) {
+            if (fetchCache[key].timestamp + fetchCache[key].ttl < now) {
+                stats.timeout++;
+                delete fetchCache[key];
+            } else {
+                totalSize += fetchCache[key].size;
+            }
+        }
+        while (totalSize > maxCacheSize) {
+            let oldestKey = "";
+            let oldestTimestamp = now;
+            for (const key in fetchCache) {
+                if (fetchCache[key].timestamp < oldestTimestamp) {
+                    oldestKey = key;
+                    oldestTimestamp = fetchCache[key].timestamp;
+                }
+            }
+            totalSize -= fetchCache[oldestKey].size;
+            delete fetchCache[oldestKey];
+        }
+        // eslint-disable-next-line no-console
+        console.log("swr fetch cache: ", Object.keys(fetchCache).length, "entries", `${Math.round(totalSize / 1024 / 1024)}MB`, stats);
+    }, 1000 * 60 * 5);
+}
+
+export async function inMemorySwrCachingFetch(input: RequestInfo | URL, init?: RequestInit & SwrOptions): Promise<Response> {
+    let cacheKey: string | undefined;
+    if (init?.method?.toUpperCase() === "GET") {
+        //cache all get requests
+        cacheKey = input.toString();
+    } else if (init?.body) {
+        const body = JSON.parse(init.body.toString());
+        if (body.query && body.variables) {
+            //looks like a gql query, cache any method
+            cacheKey = `${input.toString()}#${init.body.toString()}`;
+        }
+    }
+
+    const ttl = init?.ttl ?? defaultTtl;
+    const swrTime = init?.swrTime ?? defaultSwrTime;
+    if (!cacheKey || ttl <= 0) {
+        //uncachable, fetch live
+        stats.uncachable++;
+        return fetch(input, init);
+    }
+
+    const cachedResponse = fetchCache[cacheKey];
+    if (cachedResponse) {
+        if (ttl > 0 && new Date().getTime() / 1000 - cachedResponse.timestamp < cachedResponse.ttl) {
+            if (new Date().getTime() / 1000 - cachedResponse.timestamp > cachedResponse.swrTime && !cachedResponse.updating) {
+                //update cache in background
+                cachedResponse.updating = true;
+                stats.refresh++;
+                fetch(input, init).then((response) => {
+                    fetchCache[cacheKey as string] = {
+                        timestamp: new Date().getTime() / 1000,
+                        ttl,
+                        swrTime,
+                        size: response.headers.get("content-length") ? parseInt(response.headers.get("content-length") as string) : 5120, //random default of 5kb
+                        response, //no clone, we don't return the response
+                    };
+                });
+            }
+            stats.hit++;
+            return cachedResponse.response.clone();
+        }
+    }
+
+    //fetch in foreground (still async)
+    stats.miss++;
+    const fetchPromise = fetch(input, init);
+    const response = await fetchPromise;
+    fetchCache[cacheKey] = {
+        timestamp: new Date().getTime() / 1000,
+        ttl,
+        swrTime,
+        size: response.headers.get("content-length") ? parseInt(response.headers.get("content-length") as string) : 5120, //random default of 5kb
+        response: response.clone(),
+    };
+    avtivateCleanup(); //activate cleanup on first cache entry
+    return fetchPromise;
+}

--- a/packages/site/cms-site/src/index.ts
+++ b/packages/site/cms-site/src/index.ts
@@ -12,6 +12,7 @@ export { hasRichTextBlockContent } from "./blocks/RichTextBlock";
 export { SvgImageBlock } from "./blocks/SvgImageBlock";
 export { YouTubeVideoBlock } from "./blocks/YouTubeVideoBlock";
 export { createGraphQLClient } from "./graphql/graphqlClient";
+export { inMemorySwrCachingFetch } from "./graphql/swrCachingFetch";
 export { IFrameBridgeProvider } from "./iframebridge/IFrameBridge";
 export { IFrameMessageType } from "./iframebridge/IFrameMessage";
 export { Preview } from "./iframebridge/Preview";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6986,6 +6986,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       requireindex: 1.1.0
+    dev: false
 
   /@changesets/apply-release-plan@6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
@@ -7203,49 +7204,6 @@ packages:
       wait-on: 6.0.1
     transitivePeerDependencies:
       - debug
-    dev: true
-
-  /@comet/eslint-config@6.3.0(eslint@8.32.0)(prettier@2.8.3)(typescript@4.9.4):
-    resolution: {integrity: sha512-Gi5BABuLV5+/hNZX4ebDdAEZDc4SvxpSV4kgeRwRg4qY/swhqwnMHRdYqFgWc6eL1PZSdBp1yEs8ueH6YaJ4XQ==}
-    peerDependencies:
-      eslint: '>= 8'
-      next: '*'
-      prettier: '>= 2'
-    peerDependenciesMeta:
-      next:
-        optional: true
-    dependencies:
-      '@calm/eslint-plugin-react-intl': 1.4.1
-      '@comet/eslint-plugin': 6.3.0(eslint@8.32.0)
-      '@next/eslint-plugin-next': 12.3.4
-      '@typescript-eslint/eslint-plugin': 5.49.0(@typescript-eslint/parser@5.49.0)(eslint@8.32.0)(typescript@4.9.4)
-      '@typescript-eslint/parser': 5.49.0(eslint@8.32.0)(typescript@4.9.4)
-      eslint: 8.32.0
-      eslint-config-next: 13.1.5(eslint@8.32.0)(typescript@4.9.4)
-      eslint-config-prettier: 8.6.0(eslint@8.32.0)
-      eslint-plugin-formatjs: 4.3.9(eslint@8.32.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.49.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.32.0)
-      eslint-plugin-json-files: 2.2.0(eslint@8.32.0)
-      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.6.0)(eslint@8.32.0)(prettier@2.8.3)
-      eslint-plugin-react: 7.32.1(eslint@8.32.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.32.0)
-      eslint-plugin-simple-import-sort: 9.0.0(eslint@8.32.0)
-      eslint-plugin-unused-imports: 2.0.0(@typescript-eslint/eslint-plugin@5.49.0)(eslint@8.32.0)
-      prettier: 2.8.3
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-      - ts-jest
-      - typescript
-    dev: true
-
-  /@comet/eslint-plugin@6.3.0(eslint@8.32.0):
-    resolution: {integrity: sha512-PT3O50+gOVcbS3Z+Y0DajXM/mFe6NaqAQX7o5X5Y5JFeK5lcq+UYdgs290SiiPC32J3Qd8Ba45VGIY2Y2zrc7w==}
-    peerDependencies:
-      eslint: '8'
-    dependencies:
-      eslint: 8.32.0
     dev: true
 
   /@cspotcode/source-map-support@0.8.1:
@@ -8488,6 +8446,7 @@ packages:
     dependencies:
       '@formatjs/intl-localematcher': 0.2.32
       tslib: 2.4.1
+    dev: false
 
   /@formatjs/ecma402-abstract@1.5.0:
     resolution: {integrity: sha512-wXv36yo+mfWllweN0Fq7sUs7PUiNopn7I0JpLTe3hGu6ZMR4CV7LqK1llhB18pndwpKoafQKb1et2DCJAOW20Q==}
@@ -8513,12 +8472,14 @@ packages:
       '@formatjs/ecma402-abstract': 1.14.3
       '@formatjs/icu-skeleton-parser': 1.3.18
       tslib: 2.4.1
+    dev: false
 
   /@formatjs/icu-skeleton-parser@1.3.18:
     resolution: {integrity: sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.14.3
       tslib: 2.4.1
+    dev: false
 
   /@formatjs/icu-skeleton-parser@1.3.6:
     resolution: {integrity: sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==}
@@ -8549,6 +8510,7 @@ packages:
     resolution: {integrity: sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==}
     dependencies:
       tslib: 2.4.1
+    dev: false
 
   /@formatjs/intl@2.2.1(typescript@4.9.4):
     resolution: {integrity: sha512-vgvyUOOrzqVaOFYzTf2d3+ToSkH2JpR7x/4U1RyoHQLmvEaTQvXJ7A2qm1Iy3brGNXC/+/7bUlc3lpH+h/LOJA==}
@@ -8595,6 +8557,7 @@ packages:
       json-stable-stringify: 1.0.2
       tslib: 2.4.1
       typescript: 4.9.4
+    dev: false
 
   /@formatjs/ts-transformer@3.9.4:
     resolution: {integrity: sha512-S5q/zsTodaKtxVxNvbRQ9APenJtm5smXE76usS+5yF2vWQdZHkagmOKWfgvfIbesP4SR2B+i3koqlnlpqSIp5w==}
@@ -9621,6 +9584,7 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
+    dev: false
 
   /@grpc/grpc-js@1.8.12:
     resolution: {integrity: sha512-MbUMvpVvakeKhdYux6gbSIPJaFMLNSY8jw4PqLI+FFztGrQRrYYAnHlR94+ncBQQewkpXQaW449m3tpH/B/ZnQ==}
@@ -9727,6 +9691,7 @@ packages:
   /@humanwhocodes/momoa@2.0.4:
     resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
     engines: {node: '>=10.10.0'}
+    dev: false
 
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
@@ -10988,11 +10953,13 @@ packages:
     resolution: {integrity: sha512-BFwj8ykJY+zc1/jWANsDprDIu2MgwPOIKxNVnrKvPs+f5TPegrVnem8uScND+1veT4B7F6VeqgaNLFW1Hzl9Og==}
     dependencies:
       glob: 7.1.7
+    dev: false
 
   /@next/eslint-plugin-next@13.1.5:
     resolution: {integrity: sha512-3kvLTX35bOWOCKU8KY74Ygczc55Qk/kB2TQy0tH7Rti6hzZ6Aij7WQ8zHdIVjmnlD0n/zXWXrIf5y56RKcLQkQ==}
     dependencies:
       glob: 7.1.7
+    dev: false
 
   /@next/swc-android-arm-eabi@12.3.4:
     resolution: {integrity: sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==}
@@ -12075,6 +12042,7 @@ packages:
       picocolors: 1.0.0
       tiny-glob: 0.2.9
       tslib: 2.4.1
+    dev: false
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(@types/webpack@5.28.0)(react-refresh@0.11.0)(webpack@5.88.2):
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
@@ -12189,6 +12157,7 @@ packages:
 
   /@rushstack/eslint-patch@1.2.0:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
+    dev: false
 
   /@rushstack/ts-command-line@4.13.1:
     resolution: {integrity: sha512-UTQMRyy/jH1IS2U+6pyzyn9xQ2iMcoUKkTcZUzOP/aaMiKlWLwCTDiBVwhw/M1crDx6apF9CwyjuWO9r1SBdJQ==}
@@ -13892,6 +13861,7 @@ packages:
     dependencies:
       '@types/estree': 0.0.51
       '@types/json-schema': 7.0.11
+    dev: false
 
   /@types/estree@0.0.50:
     resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
@@ -13993,6 +13963,7 @@ packages:
     dependencies:
       '@types/minimatch': 5.1.2
       '@types/node': 18.15.3
+    dev: false
 
   /@types/glob@8.0.1:
     resolution: {integrity: sha512-8bVUjXZvJacUFkJXHdyZ9iH1Eaj5V7I8c4NdH5sQJsdXkqT4CA5Dhb4yb4VE/3asyx4L9ayZr1NIhTsWHczmMw==}
@@ -14400,6 +14371,7 @@ packages:
 
   /@types/picomatch@2.3.0:
     resolution: {integrity: sha512-O397rnSS9iQI4OirieAtsDqvCj4+3eY1J+EPdNTKuHuRWIfUoGyzX294o8C4KJYaLqgSrd2o60c5EqCU8Zv02g==}
+    dev: false
 
   /@types/pluralize@0.0.29:
     resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==}
@@ -14578,6 +14550,7 @@ packages:
 
   /@types/semver@7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+    dev: false
 
   /@types/serve-index@1.9.1:
     resolution: {integrity: sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==}
@@ -14766,6 +14739,7 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/parser@5.49.0(eslint@8.32.0)(typescript@4.9.4):
     resolution: {integrity: sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==}
@@ -14785,6 +14759,7 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/scope-manager@5.49.0:
     resolution: {integrity: sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==}
@@ -14792,6 +14767,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.49.0
       '@typescript-eslint/visitor-keys': 5.49.0
+    dev: false
 
   /@typescript-eslint/type-utils@5.49.0(eslint@8.32.0)(typescript@4.9.4):
     resolution: {integrity: sha512-eUgLTYq0tR0FGU5g1YHm4rt5H/+V2IPVkP0cBmbhRyEmyGe4XvJ2YJ6sYTmONfjmdMqyMLad7SB8GvblbeESZA==}
@@ -14811,10 +14787,12 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/types@5.49.0:
     resolution: {integrity: sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
 
   /@typescript-eslint/typescript-estree@5.49.0(typescript@4.9.4):
     resolution: {integrity: sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==}
@@ -14835,6 +14813,7 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/utils@5.49.0(eslint@8.32.0)(typescript@4.9.4):
     resolution: {integrity: sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==}
@@ -14854,6 +14833,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: false
 
   /@typescript-eslint/visitor-keys@5.49.0:
     resolution: {integrity: sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==}
@@ -14861,6 +14841,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.49.0
       eslint-visitor-keys: 3.4.1
+    dev: false
 
   /@vue/compiler-core@3.2.45:
     resolution: {integrity: sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==}
@@ -15944,6 +15925,7 @@ packages:
       es-abstract: 1.21.1
       get-intrinsic: 1.2.0
       is-string: 1.0.7
+    dev: false
 
   /array-union@1.0.2:
     resolution: {integrity: sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==}
@@ -15984,6 +15966,7 @@ packages:
       define-properties: 1.1.4
       es-abstract: 1.21.1
       es-shim-unscopables: 1.0.0
+    dev: false
 
   /array.prototype.map@1.0.5:
     resolution: {integrity: sha512-gfaKntvwqYIuC7mLLyv2wzZIJqrRhn5PZ9EfFejSx6a78sV7iDsGpG9P+3oUPtm1Rerqm6nrKS4FYuTIvWfo3g==}
@@ -16015,6 +15998,7 @@ packages:
       es-abstract: 1.21.1
       es-shim-unscopables: 1.0.0
       get-intrinsic: 1.2.0
+    dev: false
 
   /arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
@@ -16070,6 +16054,7 @@ packages:
 
   /ast-types-flow@0.0.7:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
+    dev: false
 
   /ast-types@0.14.2:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
@@ -16186,6 +16171,7 @@ packages:
   /axe-core@4.6.3:
     resolution: {integrity: sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==}
     engines: {node: '>=4'}
+    dev: false
 
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
@@ -16205,6 +16191,7 @@ packages:
     resolution: {integrity: sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==}
     dependencies:
       deep-equal: 2.2.0
+    dev: false
 
   /babel-jest@29.5.0(@babel/core@7.22.11):
     resolution: {integrity: sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==}
@@ -16629,6 +16616,7 @@ packages:
       chalk: 4.1.2
       jsonpointer: 5.0.1
       leven: 3.1.0
+    dev: false
 
   /better-opn@2.1.1:
     resolution: {integrity: sha512-kIPXZS5qwyKiX/HcRvDYfmBQUa8XP17I0mYZZ0y4UhpYOSvtsLHDYqmomS+Mj20aDvD3knEiQ0ecQy2nhio3yA==}
@@ -18507,6 +18495,7 @@ packages:
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+    dev: false
 
   /dashdash@1.14.1:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
@@ -18565,6 +18554,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
+    dev: false
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -18905,6 +18895,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       esutils: 2.0.3
+    dev: false
 
   /doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -19311,6 +19302,7 @@ packages:
 
   /emoji-regex@10.2.1:
     resolution: {integrity: sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==}
+    dev: false
 
   /emoji-regex@7.0.3:
     resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
@@ -19579,6 +19571,7 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
+    dev: false
 
   /eslint-config-prettier@8.6.0(eslint@8.32.0):
     resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
@@ -19587,6 +19580,7 @@ packages:
       eslint: '>=7.0.0'
     dependencies:
       eslint: 8.32.0
+    dev: false
 
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
@@ -19596,6 +19590,7 @@ packages:
       resolve: 1.22.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.27.5)(eslint@8.32.0):
     resolution: {integrity: sha512-njRcKYBc3isE42LaTcJNVANR3R99H9bAxBDMNDr2W7yq5gYPxbU3MkdhsQukxZ/Xg9C2vcyLlDsbKfRDg0QvCQ==}
@@ -19615,6 +19610,7 @@ packages:
       synckit: 0.8.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.49.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.32.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
@@ -19644,6 +19640,7 @@ packages:
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.32.0)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /eslint-plugin-formatjs@4.3.9(eslint@8.32.0):
     resolution: {integrity: sha512-+8kGoTUaNe0qS55eg5XbPDY+eQmeZxnrC8MugQTGUXlqbCyLyG7y4mDsMhAgactVyUMST6Ln1HEm1Tk0KNuIKQ==}
@@ -19663,6 +19660,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - ts-jest
+    dev: false
 
   /eslint-plugin-graphql@4.0.0(@types/node@18.15.3)(graphql@15.8.0)(typescript@4.9.4):
     resolution: {integrity: sha512-d5tQm24YkVvCEk29ZR5ScsgXqAGCjKlMS8lx3mS7FS/EKsWbkvXQImpvic03EpMIvNTBW5e+2xnHzXB/VHNZJw==}
@@ -19714,6 +19712,7 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: false
 
   /eslint-plugin-json-files@2.2.0(eslint@8.32.0):
     resolution: {integrity: sha512-7ETNwGWMtlAqtAIfwrNSm/X8RsHrZcV78YFa/EyYjavFWaVFhi/fsZBjnj4yIf1G0Rbx5f2t+sd037hVPK20WQ==}
@@ -19727,6 +19726,7 @@ packages:
       requireindex: 1.2.0
       semver: 7.3.8
       sort-package-json: 1.57.0
+    dev: false
 
   /eslint-plugin-jsx-a11y@6.7.1(eslint@8.32.0):
     resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
@@ -19751,6 +19751,7 @@ packages:
       object.entries: 1.1.6
       object.fromentries: 2.0.6
       semver: 6.3.1
+    dev: false
 
   /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.6.0)(eslint@8.32.0)(prettier@2.8.3):
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
@@ -19767,6 +19768,7 @@ packages:
       eslint-config-prettier: 8.6.0(eslint@8.32.0)
       prettier: 2.8.3
       prettier-linter-helpers: 1.0.0
+    dev: false
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.32.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
@@ -19775,6 +19777,7 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
       eslint: 8.32.0
+    dev: false
 
   /eslint-plugin-react@7.32.1(eslint@8.32.0):
     resolution: {integrity: sha512-vOjdgyd0ZHBXNsmvU+785xY8Bfe57EFbTYYk8XrROzWpr9QBvpjITvAXt9xqcE6+8cjR/g1+mfumPToxsl1www==}
@@ -19798,6 +19801,7 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.0
       string.prototype.matchall: 4.0.8
+    dev: false
 
   /eslint-plugin-simple-import-sort@9.0.0(eslint@8.32.0):
     resolution: {integrity: sha512-PtrLjyXP8kjRneWT1n0b99y/2Fyup37we7FVoWsI61/O7x4ztLohzhep/pxI/cYlECr/cQ2j6utckdvWpVwXNA==}
@@ -19805,6 +19809,7 @@ packages:
       eslint: '>=5.0.0'
     dependencies:
       eslint: 8.32.0
+    dev: false
 
   /eslint-plugin-unused-imports@2.0.0(@typescript-eslint/eslint-plugin@5.49.0)(eslint@8.32.0):
     resolution: {integrity: sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==}
@@ -19819,10 +19824,12 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.49.0(@typescript-eslint/parser@5.49.0)(eslint@8.32.0)(typescript@4.9.4)
       eslint: 8.32.0
       eslint-rule-composer: 0.3.0
+    dev: false
 
   /eslint-rule-composer@0.3.0:
     resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
     engines: {node: '>=4.0.0'}
+    dev: false
 
   /eslint-scope@4.0.3:
     resolution: {integrity: sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==}
@@ -20287,6 +20294,7 @@ packages:
 
   /fast-diff@1.2.0:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
+    dev: false
 
   /fast-glob@2.2.7:
     resolution: {integrity: sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==}
@@ -21176,6 +21184,7 @@ packages:
 
   /get-tsconfig@4.3.0:
     resolution: {integrity: sha512-YCcF28IqSay3fqpIu5y3Krg/utCBHBeoflkZyHj/QcqI2nrLPC3ZegS9CmIo+hJb8K7aiGsuUl7PwWVjNG2HQQ==}
+    dev: false
 
   /get-value@2.0.6:
     resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
@@ -21192,6 +21201,7 @@ packages:
 
   /git-hooks-list@1.0.3:
     resolution: {integrity: sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==}
+    dev: false
 
   /github-slugger@1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
@@ -21265,6 +21275,7 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+    dev: false
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -21334,6 +21345,7 @@ packages:
 
   /globalyzer@0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
+    dev: false
 
   /globby@10.0.0:
     resolution: {integrity: sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==}
@@ -21347,6 +21359,7 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
+    dev: false
 
   /globby@11.0.3:
     resolution: {integrity: sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==}
@@ -21380,6 +21393,7 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
+    dev: false
 
   /globby@9.2.0:
     resolution: {integrity: sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==}
@@ -21399,6 +21413,7 @@ packages:
 
   /globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: false
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -21573,6 +21588,7 @@ packages:
       graphql: 15.8.0
     transitivePeerDependencies:
       - encoding
+    dev: false
 
   /graphql-tag@2.12.6(graphql@15.8.0):
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
@@ -22798,6 +22814,7 @@ packages:
   /is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
+    dev: false
 
   /is-plain-obj@3.0.0:
     resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
@@ -23829,6 +23846,7 @@ packages:
   /jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /jsonwebtoken@8.5.1:
     resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
@@ -23924,6 +23942,7 @@ packages:
     dependencies:
       array-includes: 3.1.6
       object.assign: 4.1.4
+    dev: false
 
   /jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
@@ -24068,11 +24087,13 @@ packages:
 
   /language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
+    dev: false
 
   /language-tags@1.0.5:
     resolution: {integrity: sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==}
     dependencies:
       language-subtag-registry: 0.3.22
+    dev: false
 
   /latest-version@5.1.0:
     resolution: {integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==}
@@ -25258,6 +25279,7 @@ packages:
 
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
+    dev: false
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -25646,6 +25668,7 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.21.1
+    dev: false
 
   /object.fromentries@2.0.6:
     resolution: {integrity: sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==}
@@ -25654,6 +25677,7 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.21.1
+    dev: false
 
   /object.getownpropertydescriptors@2.1.5:
     resolution: {integrity: sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==}
@@ -25670,6 +25694,7 @@ packages:
     dependencies:
       define-properties: 1.1.4
       es-abstract: 1.21.1
+    dev: false
 
   /object.pick@1.3.0:
     resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
@@ -25685,6 +25710,7 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.21.1
+    dev: false
 
   /objectorarray@1.0.5:
     resolution: {integrity: sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==}
@@ -26991,6 +27017,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       fast-diff: 1.2.0
+    dev: false
 
   /prettier@2.3.0:
     resolution: {integrity: sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==}
@@ -28491,10 +28518,12 @@ packages:
   /requireindex@1.1.0:
     resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
     engines: {node: '>=0.10.5'}
+    dev: false
 
   /requireindex@1.2.0:
     resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
     engines: {node: '>=0.10.5'}
+    dev: false
 
   /requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -28547,6 +28576,7 @@ packages:
       is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: false
 
   /response-iterator@0.2.6:
     resolution: {integrity: sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==}
@@ -29095,6 +29125,7 @@ packages:
   /slash@4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
+    dev: false
 
   /slice-ansi@3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
@@ -29199,6 +29230,7 @@ packages:
 
   /sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
+    dev: false
 
   /sort-package-json@1.57.0:
     resolution: {integrity: sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==}
@@ -29210,6 +29242,7 @@ packages:
       globby: 10.0.0
       is-plain-obj: 2.1.0
       sort-object-keys: 1.1.3
+    dev: false
 
   /source-list-map@2.0.1:
     resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
@@ -29578,6 +29611,7 @@ packages:
       internal-slot: 1.0.4
       regexp.prototype.flags: 1.4.3
       side-channel: 1.0.4
+    dev: false
 
   /string.prototype.padend@3.1.4:
     resolution: {integrity: sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==}
@@ -29989,6 +30023,7 @@ packages:
     dependencies:
       '@pkgr/utils': 2.3.1
       tslib: 2.4.1
+    dev: false
 
   /synthetic-dom@1.4.0:
     resolution: {integrity: sha512-mHv51ZsmZ+ShT/4s5kg+MGUIhY7Ltq4v03xpN1c8T1Krb5pScsh/lzEjyhrVD0soVDbThbd2e+4dD9vnDG4rhg==}
@@ -30247,6 +30282,7 @@ packages:
     dependencies:
       globalyzer: 0.1.0
       globrex: 0.1.2
+    dev: false
 
   /tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
@@ -30660,6 +30696,7 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.4
+    dev: false
 
   /tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}


### PR DESCRIPTION
depends on #1818 as this does work only together with ssr

This adds a SWR fetch cache that will be used to cache all server side api requests (also made by graphql-request).

TODO
- [ ] Add changeset