### PR TITLE
Disable GraphQL field suggestions in production

### DIFF
--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -63,7 +63,6 @@ export class AppModule {
                         debug: config.debug,
                         playground: config.debug,
                         autoSchemaFile: "schema.gql",
-                        introspection: process.env.NODE_ENV === "development",
                         formatError: (error) => {
                             if (process.env.NODE_ENV !== "development") {
                                 if (error instanceof ValidationError) {

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -64,6 +64,7 @@ export class AppModule {
                         playground: config.debug,
                         autoSchemaFile: "schema.gql",
                         formatError: (error) => {
+                            // Disable GraphQL field suggestions in production
                             if (process.env.NODE_ENV !== "development") {
                                 if (error instanceof ValidationError) {
                                     return new ValidationError("Invalid request.");


### PR DESCRIPTION
---
## Description
This PR disables `introspection` and hides field suggestions in graphql error messages for non-dev environments.

## Screenshots
### Before
![image](https://github.com/vivid-planet/comet/assets/56400587/43de0d9c-b4f3-471b-872a-3707834f77ac)
### After
![image](https://github.com/vivid-planet/comet/assets/56400587/967c67f3-b6b3-4c34-82e0-8d3dc124ac2a)

COM-493