### PR TITLE
Add `@RequiredPermission()` decorator to `dependencies` and `dependents` field resolver

### DIFF
--- a/.changeset/brave-dots-cough.md
+++ b/.changeset/brave-dots-cough.md
@@ -1,0 +1,13 @@
+---
+"@comet/cms-api": patch
+---
+
+Add `@RequiredPermission()` decorator to `dependencies` and `dependents` field resolver
+
+Uses camel-cased entity name by default (e.g. `ProductVariant` -> `"productVariant"`).
+To override the default behavior, pass the required permission as option in the respective factory:
+
+```diff
+- DependentsResolverFactory.create(ProductVariant)
++ DependentsResolverFactory.create({ classRef: ProductVariant, requiredPermission: "product" })
+```

--- a/.changeset/brave-dots-cough.md
+++ b/.changeset/brave-dots-cough.md
@@ -9,5 +9,5 @@ To override the default behavior, pass the required permission as option in the 
 
 ```diff
 - DependentsResolverFactory.create(ProductVariant)
-+ DependentsResolverFactory.create({ classRef: ProductVariant, requiredPermission: "product" })
++ DependentsResolverFactory.create({ entity: ProductVariant, requiredPermission: "product" })
 ```

--- a/demo/api/src/footer/footer.module.ts
+++ b/demo/api/src/footer/footer.module.ts
@@ -9,6 +9,6 @@ import { FootersService } from "./generated/footers.service";
 
 @Module({
     imports: [MikroOrmModule.forFeature([Footer, FooterContentScope])],
-    providers: [FooterResolver, FootersService, DependenciesResolverFactory.create({ classRef: Footer, requiredPermission: "pageTree" })],
+    providers: [FooterResolver, FootersService, DependenciesResolverFactory.create({ entity: Footer, requiredPermission: "pageTree" })],
 })
 export class FooterModule {}

--- a/demo/api/src/footer/footer.module.ts
+++ b/demo/api/src/footer/footer.module.ts
@@ -9,6 +9,6 @@ import { FootersService } from "./generated/footers.service";
 
 @Module({
     imports: [MikroOrmModule.forFeature([Footer, FooterContentScope])],
-    providers: [FooterResolver, FootersService, DependenciesResolverFactory.create(Footer)],
+    providers: [FooterResolver, FootersService, DependenciesResolverFactory.create({ classRef: Footer, requiredPermission: "pageTree" })],
 })
 export class FooterModule {}

--- a/demo/api/src/menus/menus.module.ts
+++ b/demo/api/src/menus/menus.module.ts
@@ -9,6 +9,6 @@ import { MenusResolver } from "./menus.resolver";
 
 @Module({
     imports: [PagesModule, MikroOrmModule.forFeature([MainMenuItem])],
-    providers: [MenusResolver, MainMenuItemResolver, DependenciesResolverFactory.create({ classRef: MainMenuItem, requiredPermission: "pageTree" })],
+    providers: [MenusResolver, MainMenuItemResolver, DependenciesResolverFactory.create({ entity: MainMenuItem, requiredPermission: "pageTree" })],
 })
 export class MenusModule {}

--- a/demo/api/src/menus/menus.module.ts
+++ b/demo/api/src/menus/menus.module.ts
@@ -9,6 +9,6 @@ import { MenusResolver } from "./menus.resolver";
 
 @Module({
     imports: [PagesModule, MikroOrmModule.forFeature([MainMenuItem])],
-    providers: [MenusResolver, MainMenuItemResolver, DependenciesResolverFactory.create(MainMenuItem)],
+    providers: [MenusResolver, MainMenuItemResolver, DependenciesResolverFactory.create({ classRef: MainMenuItem, requiredPermission: "pageTree" })],
 })
 export class MenusModule {}

--- a/demo/api/src/pages/pages.module.ts
+++ b/demo/api/src/pages/pages.module.ts
@@ -7,7 +7,7 @@ import { PagesResolver } from "./pages.resolver";
 
 @Module({
     imports: [MikroOrmModule.forFeature([Page]), forwardRef(() => BlocksModule), RedirectsModule],
-    providers: [PagesResolver, DependenciesResolverFactory.create(Page)],
+    providers: [PagesResolver, DependenciesResolverFactory.create({ classRef: Page, requiredPermission: "pageTree" })],
     exports: [MikroOrmModule],
 })
 export class PagesModule {}

--- a/demo/api/src/pages/pages.module.ts
+++ b/demo/api/src/pages/pages.module.ts
@@ -7,7 +7,7 @@ import { PagesResolver } from "./pages.resolver";
 
 @Module({
     imports: [MikroOrmModule.forFeature([Page]), forwardRef(() => BlocksModule), RedirectsModule],
-    providers: [PagesResolver, DependenciesResolverFactory.create({ classRef: Page, requiredPermission: "pageTree" })],
+    providers: [PagesResolver, DependenciesResolverFactory.create({ entity: Page, requiredPermission: "pageTree" })],
     exports: [MikroOrmModule],
 })
 export class PagesModule {}

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -41,6 +41,7 @@
         "@opentelemetry/api": "^1.4.0",
         "@types/get-image-colors": "^4.0.0",
         "base64url": "^3.0.0",
+        "change-case": "^4.1.2",
         "class-validator": "0.13.2",
         "commander": "^9.3.0",
         "cron-parser": "^3.0.0",

--- a/packages/api/cms-api/src/dam/dam.module.ts
+++ b/packages/api/cms-api/src/dam/dam.module.ts
@@ -74,7 +74,7 @@ export class DamModule {
 
         const DamItemsResolver = createDamItemsResolver({ File, Folder, Scope });
         const FilesResolver = createFilesResolver({ File, Scope });
-        const FileDependentsResolver = DependentsResolverFactory.create({ classRef: File, requiredPermission: "dam" });
+        const FileDependentsResolver = DependentsResolverFactory.create({ entity: File, requiredPermission: "dam" });
         const FoldersResolver = createFoldersResolver({ Folder, Scope });
 
         if (Scope) {

--- a/packages/api/cms-api/src/dam/dam.module.ts
+++ b/packages/api/cms-api/src/dam/dam.module.ts
@@ -74,7 +74,7 @@ export class DamModule {
 
         const DamItemsResolver = createDamItemsResolver({ File, Folder, Scope });
         const FilesResolver = createFilesResolver({ File, Scope });
-        const FileDependentsResolver = DependentsResolverFactory.create(File);
+        const FileDependentsResolver = DependentsResolverFactory.create({ classRef: File, requiredPermission: "dam" });
         const FoldersResolver = createFoldersResolver({ Folder, Scope });
 
         if (Scope) {

--- a/packages/api/cms-api/src/dependencies/dependencies.resolver.factory.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.resolver.factory.ts
@@ -1,6 +1,7 @@
 import { AnyEntity } from "@mikro-orm/core";
 import { Type } from "@nestjs/common";
 import { Args, Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { camelCase } from "change-case";
 
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { DependenciesService } from "./dependencies.service";
@@ -8,9 +9,20 @@ import { DependenciesArgs } from "./dto/dependencies.args";
 import { PaginatedDependencies } from "./dto/paginated-dependencies";
 
 export class DependenciesResolverFactory {
-    static create<T extends Type<AnyEntity<{ id: string }>>>(classRef: T) {
+    static create<T extends Type<AnyEntity<{ id: string }>>>(options: T | { classRef: T; requiredPermission: string[] | string }) {
+        let classRef: T;
+        let requiredPermission: string[] | string;
+
+        if (typeof options === "object") {
+            classRef = options.classRef;
+            requiredPermission = options.requiredPermission;
+        } else {
+            classRef = options;
+            requiredPermission = camelCase(classRef.name);
+        }
+
         @Resolver(() => classRef)
-        @RequiredPermission("dependencies")
+        @RequiredPermission(requiredPermission)
         class DependenciesResolver {
             constructor(readonly dependenciesService: DependenciesService) {}
 

--- a/packages/api/cms-api/src/dependencies/dependencies.resolver.factory.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.resolver.factory.ts
@@ -9,19 +9,19 @@ import { DependenciesArgs } from "./dto/dependencies.args";
 import { PaginatedDependencies } from "./dto/paginated-dependencies";
 
 export class DependenciesResolverFactory {
-    static create<T extends Type<AnyEntity<{ id: string }>>>(options: T | { classRef: T; requiredPermission: string[] | string }) {
-        let classRef: T;
+    static create<T extends Type<AnyEntity<{ id: string }>>>(options: T | { entity: T; requiredPermission: string[] | string }) {
+        let entity: T;
         let requiredPermission: string[] | string;
 
         if (typeof options === "object") {
-            classRef = options.classRef;
+            entity = options.entity;
             requiredPermission = options.requiredPermission;
         } else {
-            classRef = options;
-            requiredPermission = camelCase(classRef.name);
+            entity = options;
+            requiredPermission = camelCase(entity.name);
         }
 
-        @Resolver(() => classRef)
+        @Resolver(() => entity)
         @RequiredPermission(requiredPermission)
         class DependenciesResolver {
             constructor(readonly dependenciesService: DependenciesService) {}

--- a/packages/api/cms-api/src/dependencies/dependents.resolver.factory.ts
+++ b/packages/api/cms-api/src/dependencies/dependents.resolver.factory.ts
@@ -9,19 +9,19 @@ import { DependentsArgs } from "./dto/dependencies.args";
 import { PaginatedDependencies } from "./dto/paginated-dependencies";
 
 export class DependentsResolverFactory {
-    static create<T extends Type<AnyEntity<{ id: string }>>>(options: T | { classRef: T; requiredPermission: string[] | string }) {
-        let classRef: T;
+    static create<T extends Type<AnyEntity<{ id: string }>>>(options: T | { entity: T; requiredPermission: string[] | string }) {
+        let entity: T;
         let requiredPermission: string[] | string;
 
         if (typeof options === "object") {
-            classRef = options.classRef;
+            entity = options.entity;
             requiredPermission = options.requiredPermission;
         } else {
-            classRef = options;
-            requiredPermission = camelCase(classRef.name);
+            entity = options;
+            requiredPermission = camelCase(entity.name);
         }
 
-        @Resolver(() => classRef)
+        @Resolver(() => entity)
         @RequiredPermission(requiredPermission)
         class DependentsResolver {
             constructor(readonly dependenciesService: DependenciesService) {}

--- a/packages/api/cms-api/src/dependencies/dependents.resolver.factory.ts
+++ b/packages/api/cms-api/src/dependencies/dependents.resolver.factory.ts
@@ -1,6 +1,7 @@
 import { AnyEntity } from "@mikro-orm/core";
 import { Type } from "@nestjs/common";
 import { Args, Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { camelCase } from "change-case";
 
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { DependenciesService } from "./dependencies.service";
@@ -8,9 +9,20 @@ import { DependentsArgs } from "./dto/dependencies.args";
 import { PaginatedDependencies } from "./dto/paginated-dependencies";
 
 export class DependentsResolverFactory {
-    static create<T extends Type<AnyEntity<{ id: string }>>>(classRef: T) {
+    static create<T extends Type<AnyEntity<{ id: string }>>>(options: T | { classRef: T; requiredPermission: string[] | string }) {
+        let classRef: T;
+        let requiredPermission: string[] | string;
+
+        if (typeof options === "object") {
+            classRef = options.classRef;
+            requiredPermission = options.requiredPermission;
+        } else {
+            classRef = options;
+            requiredPermission = camelCase(classRef.name);
+        }
+
         @Resolver(() => classRef)
-        @RequiredPermission("dependencies")
+        @RequiredPermission(requiredPermission)
         class DependentsResolver {
             constructor(readonly dependenciesService: DependenciesService) {}
 

--- a/packages/api/cms-api/src/page-tree/page-tree.module.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.module.ts
@@ -48,7 +48,7 @@ export class PageTreeModule {
             PageTreeNodeCreateInput,
             PageTreeNodeUpdateInput,
         });
-        const PageTreeDependentsResolver = DependentsResolverFactory.create({ classRef: PageTreeNode, requiredPermission: "pageTree" });
+        const PageTreeDependentsResolver = DependentsResolverFactory.create({ entity: PageTreeNode, requiredPermission: "pageTree" });
 
         const repositoryProvider = {
             provide: PAGE_TREE_REPOSITORY,

--- a/packages/api/cms-api/src/page-tree/page-tree.module.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.module.ts
@@ -48,7 +48,7 @@ export class PageTreeModule {
             PageTreeNodeCreateInput,
             PageTreeNodeUpdateInput,
         });
-        const PageTreeDependentsResolver = DependentsResolverFactory.create(PageTreeNode);
+        const PageTreeDependentsResolver = DependentsResolverFactory.create({ classRef: PageTreeNode, requiredPermission: "pageTree" });
 
         const repositoryProvider = {
             provide: PAGE_TREE_REPOSITORY,

--- a/packages/api/cms-api/src/redirects/redirects.module.ts
+++ b/packages/api/cms-api/src/redirects/redirects.module.ts
@@ -37,7 +37,7 @@ export class RedirectsModule {
         const Redirect = RedirectEntityFactory.create({ linkBlock, Scope });
         const RedirectInput = RedirectInputFactory.create({ linkBlock });
         const RedirectsResolver = createRedirectsResolver({ Redirect, RedirectInput, Scope });
-        const RedirectsDependenciesResolver = DependenciesResolverFactory.create({ classRef: Redirect, requiredPermission: "pageTree" });
+        const RedirectsDependenciesResolver = DependenciesResolverFactory.create({ entity: Redirect, requiredPermission: "pageTree" });
 
         const linkBlockProvider: ValueProvider<RedirectsLinkBlock> = {
             provide: REDIRECTS_LINK_BLOCK,

--- a/packages/api/cms-api/src/redirects/redirects.module.ts
+++ b/packages/api/cms-api/src/redirects/redirects.module.ts
@@ -37,7 +37,7 @@ export class RedirectsModule {
         const Redirect = RedirectEntityFactory.create({ linkBlock, Scope });
         const RedirectInput = RedirectInputFactory.create({ linkBlock });
         const RedirectsResolver = createRedirectsResolver({ Redirect, RedirectInput, Scope });
-        const RedirectsDependenciesResolver = DependenciesResolverFactory.create(Redirect);
+        const RedirectsDependenciesResolver = DependenciesResolverFactory.create({ classRef: Redirect, requiredPermission: "pageTree" });
 
         const linkBlockProvider: ValueProvider<RedirectsLinkBlock> = {
             provide: REDIRECTS_LINK_BLOCK,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2202,6 +2202,9 @@ importers:
       base64url:
         specifier: ^3.0.0
         version: 3.0.1
+      change-case:
+        specifier: ^4.1.2
+        version: 4.1.2
       class-validator:
         specifier: 0.13.2
         version: 0.13.2
@@ -4342,7 +4345,7 @@ packages:
       '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.21
@@ -4365,10 +4368,10 @@ packages:
       '@babel/helpers': 7.20.13
       '@babel/parser': 7.20.13
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -4390,7 +4393,7 @@ packages:
       '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4531,7 +4534,7 @@ packages:
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/traverse': 7.22.11
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.1
@@ -4547,7 +4550,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.1
@@ -4562,7 +4565,7 @@ packages:
       '@babel/core': 7.22.11
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.1
@@ -4638,7 +4641,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -4813,7 +4816,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -6831,23 +6834,6 @@ packages:
       '@babel/parser': 7.22.14
       '@babel/types': 7.22.11
 
-  /@babel/traverse@7.20.13:
-    resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.13
-      '@babel/types': 7.20.7
-      debug: 4.3.4(supports-color@9.3.1)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   /@babel/traverse@7.20.13(supports-color@5.5.0):
     resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
     engines: {node: '>=6.9.0'}
@@ -6877,7 +6863,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.14
       '@babel/types': 7.22.11
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7187,7 +7173,7 @@ packages:
       '@babel/preset-typescript': 7.18.6(@babel/core@7.22.11)
       '@babel/runtime': 7.20.13
       '@babel/runtime-corejs3': 7.22.6
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@docusaurus/cssnano-preset': 2.4.1
       '@docusaurus/logger': 2.4.1
       '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.2)(react@17.0.2)
@@ -8247,7 +8233,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       espree: 9.5.2
       globals: 13.19.0
       ignore: 5.2.4
@@ -8263,7 +8249,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       espree: 9.5.2
       globals: 13.19.0
       ignore: 5.2.4
@@ -9263,7 +9249,7 @@ packages:
       '@types/json-stable-stringify': 1.0.34
       '@types/jsonwebtoken': 9.0.1
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       dotenv: 16.0.3
       graphql: 15.8.0
       graphql-request: 5.1.0(graphql@15.8.0)
@@ -9614,7 +9600,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10274,7 +10260,7 @@ packages:
     dependencies:
       '@open-draft/until': 1.0.3
       '@xmldom/xmldom': 0.7.10
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       headers-utils: 3.0.2
       outvariant: 1.4.0
       strict-event-emitter: 0.2.8
@@ -13070,7 +13056,7 @@ packages:
       typescript: '>= 3.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
@@ -14639,7 +14625,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.49.0
       '@typescript-eslint/type-utils': 5.49.0(eslint@8.32.0)(typescript@4.9.4)
       '@typescript-eslint/utils': 5.49.0(eslint@8.32.0)(typescript@4.9.4)
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.32.0
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
@@ -14664,7 +14650,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.49.0
       '@typescript-eslint/types': 5.49.0
       '@typescript-eslint/typescript-estree': 5.49.0(typescript@4.9.4)
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.32.0
       typescript: 4.9.4
     transitivePeerDependencies:
@@ -14691,7 +14677,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.49.0(typescript@4.9.4)
       '@typescript-eslint/utils': 5.49.0(eslint@8.32.0)(typescript@4.9.4)
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.32.0
       tsutils: 3.21.0(typescript@4.9.4)
       typescript: 4.9.4
@@ -14715,7 +14701,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.49.0
       '@typescript-eslint/visitor-keys': 5.49.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
@@ -15351,7 +15337,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15360,7 +15346,7 @@ packages:
     resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       depd: 1.1.2
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -17105,7 +17091,6 @@ packages:
       no-case: 3.0.4
       tslib: 2.4.1
       upper-case-first: 2.0.2
-    dev: true
 
   /capture-exit@2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -17200,7 +17185,6 @@ packages:
       sentence-case: 3.0.4
       snake-case: 3.0.4
       tslib: 2.4.1
-    dev: true
 
   /change-case@5.2.0:
     resolution: {integrity: sha512-L6VzznESnMIKKdKhVzCG+KPz4+x1FWbjOs1AdhoHStV3qo8aySMRGPUoqC0aL1ThKaQNGhAu6ZfHL/QAyQRuiw==}
@@ -17732,7 +17716,6 @@ packages:
       no-case: 3.0.4
       tslib: 2.4.1
       upper-case: 2.0.2
-    dev: true
 
   /constants-browserify@1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
@@ -18491,6 +18474,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 9.3.1
+    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -18729,7 +18713,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -19154,7 +19138,7 @@ packages:
       basic-auth: 2.0.1
       cookie: 0.5.0
       core-util-is: 1.0.3
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       elastic-apm-http-client: 11.2.0
       end-of-stream: 1.4.4
       error-callsites: 2.0.4
@@ -19510,7 +19494,7 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       enhanced-resolve: 5.15.0
       eslint: 8.32.0
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.49.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.32.0)
@@ -19797,7 +19781,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -19847,7 +19831,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -21432,7 +21416,7 @@ packages:
     peerDependencies:
       graphql: '>=0.9 <0.14 || ^14.0.2 || ^15.4.0 || ^16.3.0'
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       graphql: 15.8.0
       tslib: 2.4.1
     transitivePeerDependencies:
@@ -21740,7 +21724,6 @@ packages:
     dependencies:
       capital-case: 1.0.4
       tslib: 2.4.1
-    dev: true
 
   /headers-utils@3.0.2:
     resolution: {integrity: sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==}
@@ -21967,7 +21950,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22028,7 +22011,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22955,7 +22938,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -23844,7 +23827,7 @@ packages:
     dependencies:
       '@types/express': 4.17.16
       '@types/jsonwebtoken': 9.0.1
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       jose: 4.11.2
       limiter: 1.1.5
       lru-memoizer: 2.1.4
@@ -23936,7 +23919,7 @@ packages:
     dependencies:
       colorette: 2.0.19
       commander: 9.5.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       escalade: 3.1.1
       esm: 3.2.25
       get-package-type: 0.1.0
@@ -26019,7 +26002,6 @@ packages:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.4.1
-    dev: true
 
   /path-dirname@1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
@@ -28341,7 +28323,7 @@ packages:
     resolution: {integrity: sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==}
     engines: {node: '>=6'}
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       module-details-from-path: 1.0.3
       resolve: 1.22.1
     transitivePeerDependencies:
@@ -28728,7 +28710,6 @@ packages:
       no-case: 3.0.4
       tslib: 2.4.1
       upper-case-first: 2.0.2
-    dev: true
 
   /serialize-javascript@4.0.0:
     resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
@@ -29011,7 +28992,6 @@ packages:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.4.1
-    dev: true
 
   /snapdragon-node@2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -29172,7 +29152,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -29185,7 +29165,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@5.5.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -29778,6 +29758,7 @@ packages:
   /supports-color@9.3.1:
     resolution: {integrity: sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==}
     engines: {node: '>=12'}
+    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -30947,13 +30928,11 @@ packages:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
       tslib: 2.4.1
-    dev: true
 
   /upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
       tslib: 2.4.1
-    dev: true
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}


### PR DESCRIPTION
Uses camel-cased entity name by default (e.g. `ProductVariant` -> `"productVariant"`). To override the default behavior, pass the required permission as option in the respective factory:

```diff
- DependentsResolverFactory.create(ProductVariant)
+ DependentsResolverFactory.create({ entity: ProductVariant, requiredPermission: "product" })
```