### PR TITLE
Disable content translation where it doesn't make sense

### DIFF
--- a/demo/admin/src/news/blocks/NewsLinkBlock.tsx
+++ b/demo/admin/src/news/blocks/NewsLinkBlock.tsx
@@ -17,7 +17,7 @@ const NewsLinkBlock: BlockInterface<NewsLinkBlockData, State, NewsLinkBlockInput
     AdminComponent: ({ state, updateState }) => {
         return (
             <BlocksFinalForm onSubmit={updateState} initialValues={state}>
-                <TextField name="id" label="ID" fullWidth />
+                <TextField name="id" label="ID" fullWidth disableContentTranslation />
             </BlocksFinalForm>
         );
     },

--- a/packages/admin/admin/src/form/FinalFormInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormInput.tsx
@@ -22,7 +22,9 @@ export function FinalFormInput({
     disableContentTranslation,
     ...props
 }: FinalFormInputProps): React.ReactElement {
-    const { enabled, translate } = useContentTranslationService();
+    const type = props.type ?? input.type ?? "text";
+    const { enabled: translationEnabled, translate } = useContentTranslationService();
+    const isTranslatable = translationEnabled && !disableContentTranslation && type === "text";
 
     return (
         <InputBase
@@ -33,7 +35,7 @@ export function FinalFormInput({
                     {clearable && (
                         <ClearInputAdornment position="end" hasClearableContent={Boolean(input.value)} onClick={() => input.onChange("")} />
                     )}
-                    {enabled && !disableContentTranslation && (
+                    {isTranslatable && (
                         <Tooltip title={<FormattedMessage id="comet.translate" defaultMessage="Translate" />}>
                             <IconButton onClick={async () => input.onChange(await translate(input.value))}>
                                 <Translate />

--- a/packages/admin/admin/src/form/FinalFormInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormInput.tsx
@@ -1,5 +1,5 @@
 import { Translate } from "@comet/admin-icons";
-import { Button, InputBase, InputBaseProps, Tooltip } from "@mui/material";
+import { IconButton, InputBase, InputBaseProps, Tooltip } from "@mui/material";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
@@ -35,9 +35,9 @@ export function FinalFormInput({
                     )}
                     {enabled && !disableContentTranslation && (
                         <Tooltip title={<FormattedMessage id="comet.translate" defaultMessage="Translate" />}>
-                            <Button onClick={async () => input.onChange(await translate(input.value))}>
+                            <IconButton onClick={async () => input.onChange(await translate(input.value))}>
                                 <Translate />
-                            </Button>
+                            </IconButton>
                         </Tooltip>
                     )}
                     {endAdornment}

--- a/packages/admin/admin/src/form/FinalFormInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormInput.tsx
@@ -24,7 +24,7 @@ export function FinalFormInput({
 }: FinalFormInputProps): React.ReactElement {
     const type = props.type ?? input.type ?? "text";
     const { enabled: translationEnabled, translate } = useContentTranslationService();
-    const isTranslatable = translationEnabled && !disableContentTranslation && type === "text";
+    const isTranslatable = translationEnabled && !disableContentTranslation && type === "text" && !props.disabled;
 
     return (
         <InputBase

--- a/packages/admin/blocks-admin/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/YouTubeVideoBlock.tsx
@@ -69,6 +69,7 @@ export const YouTubeVideoBlock: BlockInterface<YouTubeVideoBlockData, State, You
                             name="youtubeIdentifier"
                             component={FinalFormInput}
                             fullWidth
+                            disableContentTranslation
                         />
                         <FieldContainer label={intl.formatMessage({ id: "comet.blocks.youTubeVideo.aspectRatio", defaultMessage: "Aspect Ratio" })}>
                             <Field name="aspectRatio" type="radio" value="16X9">

--- a/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
@@ -69,6 +69,7 @@ export const ExternalLinkBlock: BlockInterface<ExternalLinkBlockData, State, Ext
                         component={FinalFormInput}
                         fullWidth
                         validate={(url) => validateUrl(url)}
+                        disableContentTranslation
                     />
                     <Field name="openInNewWindow" type="checkbox">
                         {(props) => (

--- a/packages/admin/cms-admin/src/dam/DataGrid/filter/DamTableFilter.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/filter/DamTableFilter.tsx
@@ -26,7 +26,7 @@ export const DamTableFilter = ({ filterApi, hideArchiveFilter }: DamTableFilterP
     return (
         <TableFilterFinalForm filterApi={filterApi}>
             <FilterBar>
-                <Field name="searchText" component={FinalFormSearchTextField} clearable />
+                <Field name="searchText" component={FinalFormSearchTextField} clearable disableContentTranslation />
                 {!hideArchiveFilter && (
                     <FilterBarPopoverFilter label={intl.formatMessage({ id: "comet.pages.dam.archived", defaultMessage: "Archived" })}>
                         <Field name="archived" type="checkbox">

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -308,6 +308,7 @@ export function createEditPageNode({
                                                         fieldRenderProps.input.onChange(event.target.value);
                                                     }}
                                                     fullWidth
+                                                    disableContentTranslation
                                                 />
                                             );
                                         }}

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -254,6 +254,8 @@ export const RedirectForm = ({ mode, id, linkBlock, scope }: Props): JSX.Element
                                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
                                             validate={validateSource as any}
                                             fullWidth
+                                            placeholder="/example-path"
+                                            disableContentTranslation
                                         />
                                     </Grid>
                                     <Grid item xs={3}>

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/PermissionDialog.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/PermissionDialog.tsx
@@ -158,6 +158,7 @@ export const PermissionDialog: React.FC<FormProps> = ({ userId, permissionId, ha
                                     component={FinalFormInput}
                                     disabled={disabled}
                                     label={<FormattedMessage id="comet.userPermissions.reason" defaultMessage="Reason" />}
+                                    disableContentTranslation
                                 />
                                 <Field
                                     fullWidth
@@ -165,6 +166,7 @@ export const PermissionDialog: React.FC<FormProps> = ({ userId, permissionId, ha
                                     component={FinalFormInput}
                                     disabled={disabled}
                                     label={<FormattedMessage id="comet.userPermissions.requestedBy" defaultMessage="Requested by" />}
+                                    disableContentTranslation
                                 />
                                 <Field
                                     fullWidth
@@ -172,6 +174,7 @@ export const PermissionDialog: React.FC<FormProps> = ({ userId, permissionId, ha
                                     component={FinalFormInput}
                                     disabled={disabled}
                                     label={<FormattedMessage id="comet.userPermissions.approvedBy" defaultMessage="Approved by" />}
+                                    disableContentTranslation
                                 />
                             </FormSection>
                         </DialogContent>


### PR DESCRIPTION

Automatically disable content translation for
- disabled input fields
- non-text inputs (I checked [all input types](https://www.w3schools.com/html/html_form_input_types.asp) and only text really makes sense IMO)

Explicitly disable content translations in multiple places in the library where it doesn't make sense, e.g.
- URLs
- Names
- Search Text