### PR TITLE
COM-457: Use new field components in Admin Generator 

### DIFF
--- a/demo/admin/src/news/generated/NewsForm.tsx
+++ b/demo/admin/src/news/generated/NewsForm.tsx
@@ -5,12 +5,12 @@ import { useApolloClient, useQuery } from "@apollo/client";
 import {
     Field,
     FinalForm,
-    FinalFormInput,
     FinalFormSaveSplitButton,
     FinalFormSelect,
     FinalFormSubmitEvent,
     Loading,
     MainContent,
+    TextField,
     Toolbar,
     ToolbarActions,
     ToolbarFillSpace,
@@ -20,7 +20,7 @@ import {
     useStackApi,
     useStackSwitchApi,
 } from "@comet/admin";
-import { FinalFormDatePicker } from "@comet/admin-date-time";
+import { DateField } from "@comet/admin-date-time";
 import { ArrowLeft } from "@comet/admin-icons";
 import { BlockState, createFinalFormBlock } from "@comet/blocks-admin";
 import { DamImageBlock, EditPageLayout, queryUpdatedAt, resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
@@ -160,27 +160,9 @@ export function NewsForm({ id }: FormProps): React.ReactElement {
                         </ToolbarActions>
                     </Toolbar>
                     <MainContent>
-                        <Field
-                            required
-                            fullWidth
-                            name="slug"
-                            component={FinalFormInput}
-                            label={<FormattedMessage id="news.slug" defaultMessage="Slug" />}
-                        />
-                        <Field
-                            required
-                            fullWidth
-                            name="title"
-                            component={FinalFormInput}
-                            label={<FormattedMessage id="news.title" defaultMessage="Title" />}
-                        />
-                        <Field
-                            required
-                            fullWidth
-                            name="date"
-                            component={FinalFormDatePicker}
-                            label={<FormattedMessage id="news.date" defaultMessage="Date" />}
-                        />
+                        <TextField fullWidth name="slug" label={<FormattedMessage id="news.slug" defaultMessage="Slug" />} />
+                        <TextField fullWidth name="title" label={<FormattedMessage id="news.title" defaultMessage="Title" />} />
+                        <DateField fullWidth name="date" label={<FormattedMessage id="news.date" defaultMessage="Date" />} />
                         <Field fullWidth name="category" label={<FormattedMessage id="news.category" defaultMessage="Category" />}>
                             {(props) => (
                                 <FinalFormSelect {...props}>

--- a/demo/admin/src/news/generated/NewsForm.tsx
+++ b/demo/admin/src/news/generated/NewsForm.tsx
@@ -160,9 +160,9 @@ export function NewsForm({ id }: FormProps): React.ReactElement {
                         </ToolbarActions>
                     </Toolbar>
                     <MainContent>
-                        <TextField fullWidth name="slug" label={<FormattedMessage id="news.slug" defaultMessage="Slug" />} />
-                        <TextField fullWidth name="title" label={<FormattedMessage id="news.title" defaultMessage="Title" />} />
-                        <DateField fullWidth name="date" label={<FormattedMessage id="news.date" defaultMessage="Date" />} />
+                        <TextField required fullWidth name="slug" label={<FormattedMessage id="news.slug" defaultMessage="Slug" />} />
+                        <TextField required fullWidth name="title" label={<FormattedMessage id="news.title" defaultMessage="Title" />} />
+                        <DateField required fullWidth name="date" label={<FormattedMessage id="news.date" defaultMessage="Date" />} />
                         <Field fullWidth name="category" label={<FormattedMessage id="news.category" defaultMessage="Category" />}>
                             {(props) => (
                                 <FinalFormSelect {...props}>

--- a/demo/admin/src/products/generated/ProductForm.tsx
+++ b/demo/admin/src/products/generated/ProductForm.tsx
@@ -12,6 +12,7 @@ import {
     FinalFormSubmitEvent,
     Loading,
     MainContent,
+    TextField,
     Toolbar,
     ToolbarActions,
     ToolbarFillSpace,
@@ -154,27 +155,9 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                         </ToolbarActions>
                     </Toolbar>
                     <MainContent>
-                        <Field
-                            required
-                            fullWidth
-                            name="title"
-                            component={FinalFormInput}
-                            label={<FormattedMessage id="product.title" defaultMessage="Title" />}
-                        />
-                        <Field
-                            required
-                            fullWidth
-                            name="slug"
-                            component={FinalFormInput}
-                            label={<FormattedMessage id="product.slug" defaultMessage="Slug" />}
-                        />
-                        <Field
-                            required
-                            fullWidth
-                            name="description"
-                            component={FinalFormInput}
-                            label={<FormattedMessage id="product.description" defaultMessage="Description" />}
-                        />
+                        <TextField fullWidth name="title" label={<FormattedMessage id="product.title" defaultMessage="Title" />} />
+                        <TextField fullWidth name="slug" label={<FormattedMessage id="product.slug" defaultMessage="Slug" />} />
+                        <TextField fullWidth name="description" label={<FormattedMessage id="product.description" defaultMessage="Description" />} />
                         <Field fullWidth name="type" label={<FormattedMessage id="product.type" defaultMessage="Type" />}>
                             {(props) => (
                                 <FinalFormSelect {...props}>

--- a/demo/admin/src/products/generated/ProductForm.tsx
+++ b/demo/admin/src/products/generated/ProductForm.tsx
@@ -155,9 +155,14 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                         </ToolbarActions>
                     </Toolbar>
                     <MainContent>
-                        <TextField fullWidth name="title" label={<FormattedMessage id="product.title" defaultMessage="Title" />} />
-                        <TextField fullWidth name="slug" label={<FormattedMessage id="product.slug" defaultMessage="Slug" />} />
-                        <TextField fullWidth name="description" label={<FormattedMessage id="product.description" defaultMessage="Description" />} />
+                        <TextField required fullWidth name="title" label={<FormattedMessage id="product.title" defaultMessage="Title" />} />
+                        <TextField required fullWidth name="slug" label={<FormattedMessage id="product.slug" defaultMessage="Slug" />} />
+                        <TextField
+                            required
+                            fullWidth
+                            name="description"
+                            label={<FormattedMessage id="product.description" defaultMessage="Description" />}
+                        />
                         <Field fullWidth name="type" label={<FormattedMessage id="product.type" defaultMessage="Type" />}>
                             {(props) => (
                                 <FinalFormSelect {...props}>

--- a/packages/admin/cms-admin/src/generator/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/generateForm.ts
@@ -352,10 +352,14 @@ function generateField({ entityName, ...generatorConfig }: CrudGeneratorConfig, 
                 )}
             </Field>`;
     } else if (type.kind === "SCALAR" && type.name === "String") {
-        return `<TextField fullWidth name="${field.name}"  label={<FormattedMessage id="${instanceEntityName}.${field.name}" defaultMessage="${label}"/>} />`;
+        return `<TextField ${field.type.kind === "NON_NULL" ? "required" : ""} fullWidth name="${
+            field.name
+        }"  label={<FormattedMessage id="${instanceEntityName}.${field.name}" defaultMessage="${label}"/>} />`;
     } else if (type.kind === "SCALAR" && type.name === "DateTime") {
         //TODO DateTime vs Date
-        return `<DateField fullWidth name="${field.name}"  label={<FormattedMessage id="${instanceEntityName}.${field.name}" defaultMessage="${label}"/>} />`;
+        return `<DateField ${field.type.kind === "NON_NULL" ? "required" : ""} fullWidth name="${
+            field.name
+        }"  label={<FormattedMessage id="${instanceEntityName}.${field.name}" defaultMessage="${label}"/>} />`;
     } else {
         let component;
         let additionalProps = "";

--- a/packages/admin/cms-admin/src/generator/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/generateForm.ts
@@ -113,6 +113,7 @@ export async function writeCrudForm(generatorConfig: CrudGeneratorConfig, schema
     const out = `
     import { useApolloClient, useQuery } from "@apollo/client";
     import {
+        DateTimeField,
         Field,
         FinalForm,
         FinalFormInput,
@@ -121,6 +122,7 @@ export async function writeCrudForm(generatorConfig: CrudGeneratorConfig, schema
         FinalFormSubmitEvent,
         Loading,
         MainContent,
+        TextField,
         Toolbar,
         ToolbarActions,
         ToolbarFillSpace,
@@ -131,8 +133,8 @@ export async function writeCrudForm(generatorConfig: CrudGeneratorConfig, schema
         useStackSwitchApi,
         FinalFormCheckbox,
     } from "@comet/admin";
+    import { DateField } from "@comet/admin-date-time";
     import { ArrowLeft } from "@comet/admin-icons";
-    import { FinalFormDatePicker } from "@comet/admin-date-time";
     import { BlockState, createFinalFormBlock } from "@comet/blocks-admin";
     import { EditPageLayout, resolveHasSaveConflict, useFormSaveConflict, queryUpdatedAt } from "@comet/cms-admin";
     import { IconButton, FormControlLabel, MenuItem } from "@mui/material";
@@ -349,15 +351,15 @@ function generateField({ entityName, ...generatorConfig }: CrudGeneratorConfig, 
                     />
                 )}
             </Field>`;
+    } else if (type.kind === "SCALAR" && type.name === "String") {
+        return `<TextField fullWidth name="${field.name}"  label={<FormattedMessage id="${instanceEntityName}.${field.name}" defaultMessage="${label}"/>} />`;
+    } else if (type.kind === "SCALAR" && type.name === "DateTime") {
+        //TODO DateTime vs Date
+        return `<DateField fullWidth name="${field.name}"  label={<FormattedMessage id="${instanceEntityName}.${field.name}" defaultMessage="${label}"/>} />`;
     } else {
         let component;
         let additionalProps = "";
-        if (type.kind === "SCALAR" && type.name === "DateTime") {
-            //TODO DateTime vs Date
-            component = "FinalFormDatePicker";
-        } else if (type.kind === "SCALAR" && type.name === "String") {
-            component = "FinalFormInput";
-        } else if (type.kind === "SCALAR" && type.name === "Float") {
+        if (type.kind === "SCALAR" && type.name === "Float") {
             component = "FinalFormInput";
             additionalProps += 'type="number"';
             //TODO MUI suggest not using type=number https://mui.com/material-ui/react-text-field/#type-quot-number-quot


### PR DESCRIPTION
Use new field components to simplify forms in admin generator (as in https://github.com/vivid-planet/comet/pull/1678):

- use new field components in generateForm.ts
- run admin generator to update generated forms


Screenshots of new generated forms: 

Products:
<img width="1918" alt="Screenshot 2024-03-13 at 15 27 10" src="https://github.com/vivid-planet/comet/assets/109900447/2e35f105-896a-40c5-b310-9cc3b5a69717">


News:
<img width="1919" alt="Screenshot 2024-03-13 at 15 27 00" src="https://github.com/vivid-planet/comet/assets/109900447/d351f32f-67a3-4e66-b032-f5acb67e2715">



