### PR TITLE
Enable hot-reloading for API packages in Demo

### DIFF
--- a/demo/api/nest-cli.json
+++ b/demo/api/nest-cli.json
@@ -1,4 +1,8 @@
 {
     "collection": "@nestjs/schematics",
-    "sourceRoot": "src"
+    "sourceRoot": "src",
+    "compilerOptions": {
+        "assets": ["node_modules/@comet/**/src/**/*.ts"],
+        "watchAssets": true
+    }
 }


### PR DESCRIPTION
Achieved by declaring package source files as "assets" and enable watching assets.