### PR TITLE
New Toolbar

### DIFF
--- a/.changeset/giant-ladybugs-greet.md
+++ b/.changeset/giant-ladybugs-greet.md
@@ -1,0 +1,18 @@
+---
+"@comet/admin": major
+---
+
+Rework `Toolbar`
+
+-   The `Toolbar` is now split into a top and a bottom bar.
+
+    The top bar displays a scope indicator and breadcrumbs. The bottom bar behaves like the old `Toolbar`.
+
+-   The styling of `Toolbar`, `ToolbarItem`, `ToolbarActions`, `ToolbarAutomaticTitleItem` and `ToolbarBackButton` was adjusted
+
+-   The new `ToolbarActionButton` should be used for buttons inside the `ToolbarActions`
+
+    It automatically switches from a normal `Button` to an `IconButton` for smaller screen sizes.
+
+-   To show a scope indicator, you must pass a `<ContentScopeIndicator />` to the `Toolbar` via the `scopeIndicator` prop
+

--- a/demo/admin/src/dashboard/Dashboard.tsx
+++ b/demo/admin/src/dashboard/Dashboard.tsx
@@ -19,7 +19,7 @@ const Dashboard: React.FC = () => {
                     "2x": backgroundImage2x,
                 }}
             />
-            <Toolbar scopeIndicator={<ContentScopeIndicator global />} hideBottomBar />
+            <Toolbar scopeIndicator={<ContentScopeIndicator global />} />
             <MainContent>
                 <Grid container direction="row" spacing={4}>
                     {isAllowed("pageTree") && <LatestContentUpdates />}

--- a/demo/admin/src/dashboard/Dashboard.tsx
+++ b/demo/admin/src/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { MainContent, Stack } from "@comet/admin";
+import { MainContent, Stack, Toolbar } from "@comet/admin";
 import { ContentScopeIndicator, DashboardHeader, LatestBuildsDashboardWidget, useUserPermissionCheck } from "@comet/cms-admin";
 import { Grid } from "@mui/material";
 import * as React from "react";
@@ -19,8 +19,8 @@ const Dashboard: React.FC = () => {
                     "2x": backgroundImage2x,
                 }}
             />
+            <Toolbar scopeIndicator={<ContentScopeIndicator global />} hideBottomBar />
             <MainContent>
-                <ContentScopeIndicator global />
                 <Grid container direction="row" spacing={4}>
                     {isAllowed("pageTree") && <LatestContentUpdates />}
                     {process.env.NODE_ENV !== "development" && <LatestBuildsDashboardWidget />}

--- a/demo/admin/src/pages/EditPage.tsx
+++ b/demo/admin/src/pages/EditPage.tsx
@@ -6,7 +6,6 @@ import {
     BlockPreviewWithTabs,
     createUsePage,
     DependencyList,
-    EditPageLayout,
     openSitePreviewWindow,
     PageName,
     useBlockPreview,
@@ -126,7 +125,7 @@ export const EditPage: React.FC<Props> = ({ id, category }) => {
     }
 
     return (
-        <EditPageLayout>
+        <>
             {hasChanges && (
                 <RouterPrompt
                     message={(location) => {
@@ -201,6 +200,6 @@ export const EditPage: React.FC<Props> = ({ id, category }) => {
                 </BlockPreviewWithTabs>
             </MainContent>
             {dialogs}
-        </EditPageLayout>
+        </>
     );
 };

--- a/demo/admin/src/pages/mainMenu/components/EditMainMenuItem.tsx
+++ b/demo/admin/src/pages/mainMenu/components/EditMainMenuItem.tsx
@@ -14,7 +14,7 @@ import {
 } from "@comet/admin";
 import { Add, Delete, Preview, Save } from "@comet/admin-icons";
 import { AdminComponentRoot, BlockOutputApi, BlockState, HiddenInSubroute, IFrameBridgeProvider, resolveNewState } from "@comet/blocks-admin";
-import { EditPageLayout, openSitePreviewWindow, SplitPreview, useBlockPreview, useCmsBlockContext, useSiteConfig } from "@comet/cms-admin";
+import { ContentScopeIndicator, openSitePreviewWindow, SplitPreview, useBlockPreview, useCmsBlockContext, useSiteConfig } from "@comet/cms-admin";
 import { Button } from "@mui/material";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import { useContentScope } from "@src/common/ContentScopeProvider";
@@ -121,8 +121,8 @@ const EditMainMenuItem: React.FunctionComponent<EditMainMenuItemProps> = ({ item
     };
 
     return (
-        <EditPageLayout>
-            <Toolbar>
+        <>
+            <Toolbar scopeIndicator={<ContentScopeIndicator />}>
                 <ToolbarBackButton />
                 <ToolbarTitleItem>{item?.node?.name}</ToolbarTitleItem>
                 <ToolbarFillSpace />
@@ -200,7 +200,7 @@ const EditMainMenuItem: React.FunctionComponent<EditMainMenuItemProps> = ({ item
                     </SplitPreview>
                 </IFrameBridgeProvider>
             </MainContent>
-        </EditPageLayout>
+        </>
     );
 };
 

--- a/demo/admin/src/pages/mainMenu/components/MainMenuItems.tsx
+++ b/demo/admin/src/pages/mainMenu/components/MainMenuItems.tsx
@@ -39,8 +39,7 @@ const MainMenuItems: React.FunctionComponent = () => {
 
     return (
         <>
-            <ContentScopeIndicator />
-            <Toolbar>
+            <Toolbar scopeIndicator={<ContentScopeIndicator />}>
                 <ToolbarAutomaticTitleItem />
             </Toolbar>
 

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { MasterLayoutContext } from "../../mui/MasterLayoutContext";
+import { ToolbarBreadcrumbs } from "./ToolbarBreadcrumbs";
 
 export type ToolbarClassKey = "root" | "topBar" | "muiToolbar" | "mainContentContainer";
 
@@ -13,9 +14,13 @@ export interface ToolbarProps
         root: typeof Paper;
         muiToolbar: typeof MuiToolbar;
         mainContentContainer: "div";
+        topBar: "div";
     }> {
     elevation?: number;
     children?: React.ReactNode;
+    scopeIndicator?: React.ReactNode;
+    hideTopBar?: boolean;
+    hideBottomBar?: boolean;
 }
 
 type OwnerState = {
@@ -77,7 +82,15 @@ const MainContentContainer = createComponentSlot("div")<ToolbarClassKey>({
 `);
 
 export const Toolbar = (inProps: ToolbarProps) => {
-    const { children, elevation = 1, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbar" });
+    const {
+        children,
+        hideTopBar = false,
+        hideBottomBar = false,
+        elevation = 1,
+        slotProps,
+        scopeIndicator,
+        ...restProps
+    } = useThemeProps({ props: inProps, name: "CometAdminToolbar" });
     const { headerHeight } = React.useContext(MasterLayoutContext);
 
     const ownerState: OwnerState = {
@@ -86,10 +99,16 @@ export const Toolbar = (inProps: ToolbarProps) => {
 
     return (
         <Root elevation={elevation} ownerState={ownerState} {...slotProps?.root} {...restProps}>
-            <TopBar />
-            <StyledToolbar {...slotProps?.muiToolbar}>
-                <MainContentContainer {...slotProps?.mainContentContainer}>{children}</MainContentContainer>
-            </StyledToolbar>
+            {!hideTopBar && (
+                <TopBar>
+                    <ToolbarBreadcrumbs scopeIndicator={scopeIndicator} />
+                </TopBar>
+            )}
+            {!hideBottomBar && (
+                <StyledToolbar {...slotProps?.muiToolbar}>
+                    <MainContentContainer {...slotProps?.mainContentContainer}>{children}</MainContentContainer>
+                </StyledToolbar>
+            )}
         </Root>
     );
 };

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -85,13 +85,14 @@ export const Toolbar = (inProps: ToolbarProps) => {
     const {
         children,
         hideTopBar = false,
-        hideBottomBar = false,
+        hideBottomBar: passedHideBottomBar,
         elevation = 1,
         slotProps,
         scopeIndicator,
         ...restProps
     } = useThemeProps({ props: inProps, name: "CometAdminToolbar" });
     const { headerHeight } = React.useContext(MasterLayoutContext);
+    const hideBottomBar = passedHideBottomBar ?? React.Children.count(children) === 0 ?? false;
 
     const ownerState: OwnerState = {
         headerHeight,

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -6,7 +6,7 @@ import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { MasterLayoutContext } from "../../mui/MasterLayoutContext";
 
-export type ToolbarClassKey = "root" | "muiToolbar" | "mainContentContainer";
+export type ToolbarClassKey = "root" | "topBar" | "muiToolbar" | "mainContentContainer";
 
 export interface ToolbarProps
     extends ThemedComponentBaseProps<{
@@ -34,18 +34,39 @@ const Root = createComponentSlot(Paper)<ToolbarClassKey, OwnerState>({
         justify-content: center;
         top: ${ownerState.headerHeight}px;
         padding: 0;
-        min-height: 80px;
     `,
 );
+
+const TopBar = createComponentSlot("div")<ToolbarClassKey>({
+    componentName: "Toolbar",
+    slotName: "topBar",
+})(css`
+    min-height: 40px;
+`);
 
 const StyledToolbar = createComponentSlot(MuiToolbar)<ToolbarClassKey>({
     componentName: "Toolbar",
     slotName: "muiToolbar",
-})(css`
-    display: flex;
-    flex: 1;
-    align-items: stretch;
-`);
+})(
+    ({ theme }) => css`
+        display: flex;
+        flex: 1;
+        align-items: stretch;
+        border-top: solid 1px ${theme.palette.grey["50"]};
+        box-sizing: border-box;
+        min-height: 60px;
+        padding: 0 5px;
+
+        ${theme.breakpoints.up("sm")} {
+            min-height: 60px;
+            padding: 0 10px;
+        }
+
+        @media (min-width: 0px) and (orientation: landscape) {
+            min-height: 60px;
+        }
+    `,
+);
 
 const MainContentContainer = createComponentSlot("div")<ToolbarClassKey>({
     componentName: "Toolbar",
@@ -65,6 +86,7 @@ export const Toolbar = (inProps: ToolbarProps) => {
 
     return (
         <Root elevation={elevation} ownerState={ownerState} {...slotProps?.root} {...restProps}>
+            <TopBar />
             <StyledToolbar {...slotProps?.muiToolbar}>
                 <MainContentContainer {...slotProps?.mainContentContainer}>{children}</MainContentContainer>
             </StyledToolbar>

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -102,7 +102,7 @@ export const Toolbar = (inProps: ToolbarProps) => {
     return (
         <Root elevation={elevation} ownerState={ownerState} {...slotProps?.root} {...restProps}>
             {!hideTopBar && (
-                <TopBar>
+                <TopBar {...slotProps?.topBar}>
                     <ToolbarBreadcrumbs scopeIndicator={scopeIndicator} />
                 </TopBar>
             )}

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -7,7 +7,7 @@ import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps
 import { MasterLayoutContext } from "../../mui/MasterLayoutContext";
 import { ToolbarBreadcrumbs } from "./ToolbarBreadcrumbs";
 
-export type ToolbarClassKey = "root" | "topBar" | "bottomBar" | "mainContentContainer";
+export type ToolbarClassKey = "root" | "topBar" | "bottomBar" | "mainContentContainer" | "breadcrumbs";
 
 export interface ToolbarProps
     extends ThemedComponentBaseProps<{
@@ -15,6 +15,7 @@ export interface ToolbarProps
         bottomBar: typeof MuiToolbar;
         mainContentContainer: "div";
         topBar: "div";
+        breadcrumbs: typeof ToolbarBreadcrumbs;
     }> {
     elevation?: number;
     children?: React.ReactNode;
@@ -82,6 +83,11 @@ const MainContentContainer = createComponentSlot("div")<ToolbarClassKey>({
     flex: 1;
 `);
 
+const Breadcrumbs = createComponentSlot(ToolbarBreadcrumbs)<ToolbarClassKey>({
+    componentName: "Toolbar",
+    slotName: "breadcrumbs",
+})();
+
 export const Toolbar = (inProps: ToolbarProps) => {
     const {
         children,
@@ -103,7 +109,7 @@ export const Toolbar = (inProps: ToolbarProps) => {
         <Root elevation={elevation} ownerState={ownerState} {...slotProps?.root} {...restProps}>
             {!hideTopBar && (
                 <TopBar {...slotProps?.topBar}>
-                    <ToolbarBreadcrumbs scopeIndicator={scopeIndicator} />
+                    <Breadcrumbs scopeIndicator={scopeIndicator} {...slotProps?.breadcrumbs} />
                 </TopBar>
             )}
             {!hideBottomBar && (

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -67,6 +67,7 @@ const StyledToolbar = createComponentSlot(MuiToolbar)<ToolbarClassKey>({
             padding: 0 10px;
         }
 
+        // necessary to override strange MUI default styling
         @media (min-width: 0px) and (orientation: landscape) {
             min-height: 60px;
         }

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -7,12 +7,12 @@ import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps
 import { MasterLayoutContext } from "../../mui/MasterLayoutContext";
 import { ToolbarBreadcrumbs } from "./ToolbarBreadcrumbs";
 
-export type ToolbarClassKey = "root" | "topBar" | "muiToolbar" | "mainContentContainer";
+export type ToolbarClassKey = "root" | "topBar" | "bottomBar" | "mainContentContainer";
 
 export interface ToolbarProps
     extends ThemedComponentBaseProps<{
         root: typeof Paper;
-        muiToolbar: typeof MuiToolbar;
+        bottomBar: typeof MuiToolbar;
         mainContentContainer: "div";
         topBar: "div";
     }> {
@@ -49,9 +49,9 @@ const TopBar = createComponentSlot("div")<ToolbarClassKey>({
     min-height: 40px;
 `);
 
-const StyledToolbar = createComponentSlot(MuiToolbar)<ToolbarClassKey>({
+const BottomBar = createComponentSlot(MuiToolbar)<ToolbarClassKey>({
     componentName: "Toolbar",
-    slotName: "muiToolbar",
+    slotName: "bottomBar",
 })(
     ({ theme }) => css`
         display: flex;
@@ -107,9 +107,9 @@ export const Toolbar = (inProps: ToolbarProps) => {
                 </TopBar>
             )}
             {!hideBottomBar && (
-                <StyledToolbar {...slotProps?.muiToolbar}>
+                <BottomBar {...slotProps?.bottomBar}>
                     <MainContentContainer {...slotProps?.mainContentContainer}>{children}</MainContentContainer>
-                </StyledToolbar>
+                </BottomBar>
             )}
         </Root>
     );

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
@@ -63,8 +63,8 @@ const StyledButton = createComponentSlot(Button)<ToolbarActionButtonClassKey>({
     slotName: "button",
 })();
 
-export const ToolbarActionButton = ({ slotProps = {}, ...inProps }: ToolbarActionButtonProps) => {
-    const { children, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarActionButton" });
+export const ToolbarActionButton = (props: ToolbarActionButtonProps) => {
+    const { children, slotProps = {}, ...restProps } = useThemeProps({ props, name: "CometAdminToolbarActionButton" });
     const { iconButton: iconButtonProps, tooltip: tooltipProps, button: buttonProps } = slotProps;
 
     const windowSize = useWindowSize();

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
@@ -58,9 +58,12 @@ const StyledIconButton = createComponentSlot(IconButton)<ToolbarActionButtonClas
     `,
 );
 
-const StyledButton = createComponentSlot(Button)<ToolbarActionButtonClassKey>({
+const StyledButton = createComponentSlot(Button)<ToolbarActionButtonClassKey, OwnerState>({
     componentName: "ToolbarActionButton",
     slotName: "button",
+    classesResolver(ownerState) {
+        return [ownerState.variant];
+    },
 })();
 
 export const ToolbarActionButton = (props: ToolbarActionButtonProps) => {
@@ -72,15 +75,16 @@ export const ToolbarActionButton = (props: ToolbarActionButtonProps) => {
     const useIconButton: boolean = windowSize.width < theme.breakpoints.values.sm;
 
     const icon = restProps.startIcon ?? restProps.endIcon;
+    const ownerState = { variant: restProps.variant ?? "text" };
 
     return useIconButton && icon ? (
         <StyledTooltip title={children} {...tooltipProps}>
-            <StyledIconButton ownerState={{ variant: restProps.variant ?? "text" }} {...iconButtonProps}>
+            <StyledIconButton ownerState={ownerState} {...iconButtonProps}>
                 {icon}
             </StyledIconButton>
         </StyledTooltip>
     ) : (
-        <StyledButton {...restProps} {...buttonProps}>
+        <StyledButton ownerState={ownerState} {...restProps} {...buttonProps}>
             {children}
         </StyledButton>
     );

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
@@ -1,0 +1,99 @@
+import { Button, ButtonProps, ComponentsOverrides, IconButton, Tooltip } from "@mui/material";
+import { css, Theme, useTheme, useThemeProps } from "@mui/material/styles";
+import React from "react";
+
+import { createComponentSlot } from "../../../helpers/createComponentSlot";
+import { ThemedComponentBaseProps } from "../../../helpers/ThemedComponentBaseProps";
+import { useWindowSize } from "../../../helpers/useWindowSize";
+
+export type ToolbarActionButtonClassKey = "root" | "tooltip" | "button" | "iconButton" | "text" | "outlined" | "contained";
+
+type ToolbarActionButtonProps = ButtonProps &
+    ThemedComponentBaseProps<{
+        tooltip: typeof Tooltip;
+        iconButton: typeof IconButton;
+        button: typeof Button;
+    }>;
+
+type OwnerState = {
+    variant: "text" | "outlined" | "contained";
+};
+
+const StyledTooltip = createComponentSlot(Tooltip)<ToolbarActionButtonClassKey>({
+    componentName: "ToolbarActionButton",
+    slotName: "tooltip",
+})();
+
+const StyledIconButton = createComponentSlot(IconButton)<ToolbarActionButtonClassKey, OwnerState>({
+    componentName: "ToolbarActionButton",
+    slotName: "iconButton",
+    classesResolver(ownerState) {
+        return [ownerState.variant];
+    },
+})(
+    ({ theme, ownerState }) => css`
+        ${ownerState.variant === "contained" &&
+        css`
+            background: ${theme.palette.primary.main};
+            color: ${theme.palette.primary.contrastText};
+            border-radius: 4px;
+
+            &:hover {
+                background: ${theme.palette.primary.dark};
+            }
+        `}
+
+        ${ownerState.variant === "outlined" &&
+        css`
+            border-radius: 4px;
+            border-width: 1px;
+            border-style: solid;
+            border-color: ${theme.palette.grey[200]};
+
+            &:hover {
+                background-color: ${theme.palette.grey[50]};
+                border-color: ${theme.palette.grey[200]};
+            }
+        `}
+    `,
+);
+
+const StyledButton = createComponentSlot(Button)<ToolbarActionButtonClassKey>({
+    componentName: "ToolbarActionButton",
+    slotName: "button",
+})();
+
+export const ToolbarActionButton = ({ slotProps = {}, ...inProps }: ToolbarActionButtonProps) => {
+    const { children, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarActionButton" });
+    const { iconButton: iconButtonProps, tooltip: tooltipProps, button: buttonProps } = slotProps;
+
+    const windowSize = useWindowSize();
+    const theme = useTheme();
+    const useIconButton: boolean = windowSize.width < theme.breakpoints.values.sm;
+
+    const icon = restProps.startIcon ?? restProps.endIcon;
+
+    return useIconButton && icon ? (
+        <StyledTooltip title={children} {...tooltipProps}>
+            <StyledIconButton ownerState={{ variant: restProps.variant ?? "text" }} {...iconButtonProps}>
+                {icon}
+            </StyledIconButton>
+        </StyledTooltip>
+    ) : (
+        <StyledButton {...restProps} {...buttonProps}>
+            {children}
+        </StyledButton>
+    );
+};
+
+declare module "@mui/material/styles" {
+    interface ComponentNameToClassKey {
+        CometAdminToolbarActionButton: ToolbarActionButtonClassKey;
+    }
+
+    interface Components {
+        CometAdminToolbarActionButton?: {
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbarActionButton"];
+        };
+    }
+}

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
@@ -91,12 +91,15 @@ export const ToolbarActionButton = (props: ToolbarActionButtonProps) => {
 };
 
 declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminToolbarActionButton: ToolbarActionButtonProps;
+    }
     interface ComponentNameToClassKey {
         CometAdminToolbarActionButton: ToolbarActionButtonClassKey;
     }
-
     interface Components {
         CometAdminToolbarActionButton?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminToolbarActionButton"]>;
             styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbarActionButton"];
         };
     }

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActions.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActions.tsx
@@ -13,10 +13,17 @@ interface Props extends ThemedComponentBaseProps {
 const Root = createComponentSlot("div")<ToolbarActionsClassKey>({
     componentName: "ToolbarActions",
     slotName: "root",
-})(css`
-    display: flex;
-    align-items: center;
-`);
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing(2)};
+
+        ${theme.breakpoints.up("md")} {
+            gap: 0 ${theme.spacing(4)};
+        }
+    `,
+);
 
 export const ToolbarActions = (inProps: Props) => {
     const { children, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarActions" });

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActions.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActions.tsx
@@ -20,7 +20,7 @@ const Root = createComponentSlot("div")<ToolbarActionsClassKey>({
         gap: ${theme.spacing(2)};
 
         ${theme.breakpoints.up("md")} {
-            gap: 0 ${theme.spacing(4)};
+            gap: ${theme.spacing(4)};
         }
     `,
 );

--- a/packages/admin/admin/src/common/toolbar/automatictitleitem/ToolbarAutomaticTitleItem.tsx
+++ b/packages/admin/admin/src/common/toolbar/automatictitleitem/ToolbarAutomaticTitleItem.tsx
@@ -31,7 +31,7 @@ export const ToolbarAutomaticTitleItem = (inProps: ToolbarAutomaticTitleItemProp
 
     return (
         <Root {...slotProps?.root} {...restProps}>
-            <Typography variant="h4" {...typographyProps} {...slotProps?.typography}>
+            <Typography variant="h5" {...typographyProps} {...slotProps?.typography}>
                 {stackApi?.breadCrumbs != null && stackApi.breadCrumbs.length > 0 && stackApi.breadCrumbs[stackApi?.breadCrumbs.length - 1].title}
             </Typography>
         </Root>

--- a/packages/admin/admin/src/common/toolbar/backbutton/ToolbarBackButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/backbutton/ToolbarBackButton.tsx
@@ -21,7 +21,6 @@ const Root = createComponentSlot("div")<ToolbarBackButtonClassKey>({
 
         .CometAdminToolbarItem-root {
             padding: 0;
-            padding-right: ${theme.spacing(3)};
         }
     `,
 );
@@ -29,7 +28,15 @@ const Root = createComponentSlot("div")<ToolbarBackButtonClassKey>({
 const IconButton = createComponentSlot(MuiIconButton)<ToolbarBackButtonClassKey>({
     componentName: "ToolbarBackButton",
     slotName: "iconButton",
-})();
+})(
+    ({ theme }) => css`
+        padding: 0 ${theme.spacing(1)};
+
+        ${theme.breakpoints.up("sm")} {
+            padding: 0 ${theme.spacing(2)};
+        }
+    `,
+);
 
 const ToolbarItem = createComponentSlot(CommonToolbarItem)<ToolbarBackButtonClassKey>({
     componentName: "ToolbarBackButton",

--- a/packages/admin/admin/src/common/toolbar/item/ToolbarItem.tsx
+++ b/packages/admin/admin/src/common/toolbar/item/ToolbarItem.tsx
@@ -12,11 +12,14 @@ const Root = createComponentSlot("div")<ToolbarItemClassKey>({
     slotName: "root",
 })(
     ({ theme }) => css`
-        padding: 15px;
         display: flex;
         justify-items: center;
         align-items: center;
-        border-right: 1px solid ${theme.palette.grey[50]};
+        padding: 0 ${theme.spacing(1)};
+
+        ${theme.breakpoints.up("sm")} {
+            padding: 0 ${theme.spacing(2)};
+        }
     `,
 );
 

--- a/packages/admin/cms-admin/src/builds/PublisherPage.tsx
+++ b/packages/admin/cms-admin/src/builds/PublisherPage.tsx
@@ -39,8 +39,7 @@ export function PublisherPage(): React.ReactElement {
 
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "comet.pages.publisher", defaultMessage: "Publisher" })}>
-            <ContentScopeIndicator global />
-            <Toolbar>
+            <Toolbar scopeIndicator={<ContentScopeIndicator global />}>
                 <ToolbarTitleItem>
                     <FormattedMessage id="comet.publisher.title" defaultMessage="Publisher" />
                 </ToolbarTitleItem>

--- a/packages/admin/cms-admin/src/cronJobs/CronJobsGrid.tsx
+++ b/packages/admin/cms-admin/src/cronJobs/CronJobsGrid.tsx
@@ -7,6 +7,7 @@ import { parseISO } from "date-fns";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
 import {
     GQLKubernetesCronJobsQuery,
     GQLKubernetesCronJobsQueryVariables,
@@ -52,7 +53,7 @@ const triggerCronJobMutation = gql`
 
 function CronJobsToolbar() {
     return (
-        <Toolbar>
+        <Toolbar scopeIndicator={<ContentScopeIndicator global />}>
             <ToolbarTitleItem>
                 <FormattedMessage id="comet.cronJobs.title" defaultMessage="Cron Jobs" />
             </ToolbarTitleItem>

--- a/packages/admin/cms-admin/src/cronJobs/CronJobsPage.tsx
+++ b/packages/admin/cms-admin/src/cronJobs/CronJobsPage.tsx
@@ -2,7 +2,6 @@ import { Stack, StackPage, StackSwitch } from "@comet/admin";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
-import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
 import { CronJobsGrid } from "./CronJobsGrid";
 import { JobsGrid } from "./JobsGrid";
 
@@ -13,7 +12,6 @@ export function CronJobsPage(): React.ReactElement {
         <Stack topLevelTitle={intl.formatMessage({ id: "comet.pages.cronJobs", defaultMessage: "Cron Jobs" })}>
             <StackSwitch>
                 <StackPage name="grid">
-                    <ContentScopeIndicator global />
                     <CronJobsGrid />
                 </StackPage>
                 <StackPage name="jobs">{(cronJob) => <JobsGrid cronJob={cronJob} />}</StackPage>

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -76,8 +76,7 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
             <StackSwitch initialPage="table">
                 <StackPage name="table">
                     <EditDialogApiContext.Provider value={editDialogApi}>
-                        {props.contentScopeIndicator}
-                        <Toolbar>
+                        <Toolbar scopeIndicator={props.contentScopeIndicator}>
                             <ToolbarItem>
                                 <DamTableFilter hideArchiveFilter={props.hideArchiveFilter} filterApi={filterApi} />
                             </ToolbarItem>

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -136,8 +136,7 @@ export function PagesPage({
             <Stack topLevelTitle={intl.formatMessage({ id: "comet.pages.pages", defaultMessage: "Pages" })}>
                 <StackSwitch>
                     <StackPage name="table">
-                        {renderContentScopeIndicator(scope)}
-                        <Toolbar>
+                        <Toolbar scopeIndicator={renderContentScopeIndicator(scope)}>
                             <PageSearch query={query} onQueryChange={setQuery} pageSearchApi={pageSearchApi} />
                             <FormControlLabel
                                 control={<Switch checked={showArchive} color="primary" onChange={handleArchiveToggleClick} />}

--- a/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsTable.tsx
@@ -23,6 +23,7 @@ import { DataGrid, getGridSingleSelectOperators, GridColDef, GridToolbarQuickFil
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
 import RedirectActiveness from "./RedirectActiveness";
 import { deleteRedirectMutation, paginatedRedirectsQuery } from "./RedirectsTable.gql";
 import { GQLPaginatedRedirectsQuery, GQLPaginatedRedirectsQueryVariables, namedOperations } from "./RedirectsTable.gql.generated";
@@ -34,7 +35,7 @@ interface Props {
 
 function RedirectsTableToolbar() {
     return (
-        <Toolbar>
+        <Toolbar scopeIndicator={<ContentScopeIndicator />}>
             <ToolbarAutomaticTitleItem />
             <ToolbarItem>
                 <GridToolbarQuickFilter />

--- a/storybook/src/admin/toolbar/Toolbar.tsx
+++ b/storybook/src/admin/toolbar/Toolbar.tsx
@@ -1,0 +1,68 @@
+import {
+    Stack,
+    StackLink,
+    StackPage,
+    StackSwitch,
+    Toolbar,
+    ToolbarActions,
+    ToolbarAutomaticTitleItem,
+    ToolbarBackButton,
+    ToolbarFillSpace,
+    ToolbarItem,
+} from "@comet/admin";
+import { ToolbarActionButton } from "@comet/admin/lib/common/toolbar/actions/ToolbarActionButton";
+import { ArrowRight, Save } from "@comet/admin-icons";
+import { Chip } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+function StackWrapper({ children }: { children: React.ReactNode }) {
+    return (
+        <Stack topLevelTitle="Stack Root">
+            <StackSwitch initialPage="root">
+                <StackPage name="root">
+                    {children}
+                    <StackLink pageName="detail" payload="x">
+                        Go to detail page
+                    </StackLink>
+                </StackPage>
+                <StackPage name="detail" title=" Stack Detail">
+                    {children}
+                </StackPage>
+            </StackSwitch>
+        </Stack>
+    );
+}
+
+function Story() {
+    return (
+        <Toolbar>
+            <ToolbarBackButton />
+            <ToolbarAutomaticTitleItem />
+            <ToolbarItem>
+                <Chip label="Chip text" />
+            </ToolbarItem>
+            <ToolbarFillSpace />
+            <ToolbarActions>
+                <ToolbarActionButton startIcon={<ArrowRight />}>Secondary button</ToolbarActionButton>
+                <ToolbarActionButton startIcon={<Save />} variant="contained">
+                    Primary button
+                </ToolbarActionButton>
+                {/*<Button startIcon={<ArrowRight />}>Secondary button</Button>*/}
+                {/*<Button startIcon={<Save />} variant="contained">*/}
+                {/*    Primary button*/}
+                {/*</Button>*/}
+            </ToolbarActions>
+        </Toolbar>
+    );
+}
+
+storiesOf("@comet/admin/toolbar", module)
+    .addDecorator(storyRouterDecorator())
+    .add("Toolbar", () => (
+        <StackWrapper>
+            <Story />
+        </StackWrapper>
+    ));

--- a/storybook/src/admin/toolbar/Toolbar.tsx
+++ b/storybook/src/admin/toolbar/Toolbar.tsx
@@ -50,10 +50,6 @@ function Story() {
                 <ToolbarActionButton startIcon={<Save />} variant="contained">
                     Primary button
                 </ToolbarActionButton>
-                {/*<Button startIcon={<ArrowRight />}>Secondary button</Button>*/}
-                {/*<Button startIcon={<Save />} variant="contained">*/}
-                {/*    Primary button*/}
-                {/*</Button>*/}
             </ToolbarActions>
         </Toolbar>
     );


### PR DESCRIPTION
Rework `Toolbar`

-   The `Toolbar` is now split into a top and a bottom bar.

    The top bar displays a scope indicator and breadcrumbs. The bottom bar behaves like the old `Toolbar`.

-   The styling of `Toolbar`, `ToolbarItem`, `ToolbarActions`, `ToolbarAutomaticTitleItem` and `ToolbarBackButton` was adjusted

-   The new `ToolbarActionButton` should be used for buttons inside the `ToolbarActions`

    It automatically switches from a normal `Button` to an `IconButton` for smaller screen sizes.

-   To show a scope indicator, you must pass a `<ContentScopeIndicator />` to the `Toolbar` via the `scopeIndicator` prop

---

Adding Toolbar to the Admin Generator is done in https://github.com/vivid-planet/comet/pull/1885

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-16
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>

Desktop:

<img width="1920" alt="Bildschirmfoto 2024-03-26 um 10 55 52" src="https://github.com/vivid-planet/comet/assets/13380047/e49c1d83-1740-4119-bfd9-bc2e2872ecb5">

<img width="1920" alt="Bildschirmfoto 2024-03-26 um 10 56 01" src="https://github.com/vivid-planet/comet/assets/13380047/bf783832-7dd7-4108-871e-19e58f35ebda">

Mobile:

<img width="428" alt="Bildschirmfoto 2024-03-26 um 12 33 09" src="https://github.com/vivid-planet/comet/assets/13380047/4705bc41-ba76-4a87-aeda-1e336192dbd4">

<img width="426" alt="Bildschirmfoto 2024-03-26 um 12 35 44" src="https://github.com/vivid-planet/comet/assets/13380047/e5c1855b-aac6-4916-84c5-72fc7d76bde8">



</details>
