### PR TITLE
Admin Generator (Future): Prevent date-picker from crashing with initial-value

### DIFF
--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -80,6 +80,8 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                 ? {
                       ...filter<GQLProductFormDetailsFragment>(productFormFragment, data.product),
                       price: data.product.price ? String(data.product.price) : undefined,
+                      createdAt: data.product.createdAt ? new Date(data.product.createdAt) : undefined,
+                      availableSince: data.product.availableSince ? new Date(data.product.availableSince) : undefined,
                       image: rootBlocks.image.input2State(data.product.image),
                   }
                 : {

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -203,14 +203,14 @@ export function generateForm(
                     return `${String(field.name)}: ${assignment},`;
                 })
                 .join("\n")}
-                ${dateFields
-                    .map(
-                        (field) =>
-                            `${String(field.name)}: data.${instanceGqlType}.${String(field.name)} ? new Date(data.${instanceGqlType}.${String(
-                                field.name,
-                            )}) : undefined,`,
-                    )
-                    .join("\n")}
+            ${dateFields
+                .map(
+                    (field) =>
+                        `${String(field.name)}: data.${instanceGqlType}.${String(field.name)} ? new Date(data.${instanceGqlType}.${String(
+                            field.name,
+                        )}) : undefined,`,
+                )
+                .join("\n")}
             ${Object.keys(rootBlocks)
                 .map((rootBlockKey) => `${rootBlockKey}: rootBlocks.${rootBlockKey}.input2State(data.${instanceGqlType}.${rootBlockKey}),`)
                 .join("\n")}

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -28,6 +28,7 @@ export function generateForm(
 
     const numberFields = config.fields.filter((field) => field.type == "number");
     const booleanFields = config.fields.filter((field) => field.type == "boolean");
+    const dateFields = config.fields.filter((field) => field.type == "date");
     const readOnlyFields = config.fields.filter((field) => field.readOnly);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -202,6 +203,14 @@ export function generateForm(
                     return `${String(field.name)}: ${assignment},`;
                 })
                 .join("\n")}
+                ${dateFields
+                    .map(
+                        (field) =>
+                            `${String(field.name)}: data.${instanceGqlType}.${String(field.name)} ? new Date(data.${instanceGqlType}.${String(
+                                field.name,
+                            )}) : undefined,`,
+                    )
+                    .join("\n")}
             ${Object.keys(rootBlocks)
                 .map((rootBlockKey) => `${rootBlockKey}: rootBlocks.${rootBlockKey}.input2State(data.${instanceGqlType}.${rootBlockKey}),`)
                 .join("\n")}


### PR DESCRIPTION
The date-picker can only handle a value of the type `date`. 
Previously the initial-value of date-fields would be a string.
