### PR TITLE
Remove `Math.random()` key from Snackbar stories

### DIFF
--- a/storybook/src/docs/components/Snackbar/stories/hideSnackbar.stories.tsx
+++ b/storybook/src/docs/components/Snackbar/stories/hideSnackbar.stories.tsx
@@ -12,13 +12,7 @@ storiesOf("stories/components/Snackbar/Hide Snackbar", module)
             const snackbarApi = useSnackbarApi();
             const showCustomSnackbar = () => {
                 snackbarApi.showSnackbar(
-                    <Snackbar
-                        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                        // Use uuid or object id in production
-                        key={Math.random()}
-                        autoHideDuration={5000}
-                        message="Minimal snackbar"
-                    />,
+                    <Snackbar anchorOrigin={{ vertical: "bottom", horizontal: "left" }} autoHideDuration={5000} message="Minimal snackbar" />,
                 );
             };
             return (

--- a/storybook/src/docs/components/Snackbar/stories/showSnackbar.stories.tsx
+++ b/storybook/src/docs/components/Snackbar/stories/showSnackbar.stories.tsx
@@ -12,13 +12,7 @@ storiesOf("stories/components/Snackbar/Show Snackbar", module)
             const snackbarApi = useSnackbarApi();
             const showCustomSnackbar = () => {
                 snackbarApi.showSnackbar(
-                    <Snackbar
-                        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                        // Use uuid or object id in production
-                        key={Math.random()}
-                        autoHideDuration={5000}
-                        message="Minimal snackbar"
-                    />,
+                    <Snackbar anchorOrigin={{ vertical: "bottom", horizontal: "left" }} autoHideDuration={5000} message="Minimal snackbar" />,
                 );
             };
             return <Button onClick={showCustomSnackbar}>Show Snackbar</Button>;

--- a/storybook/src/docs/components/Snackbar/stories/useSnackbarApiHook.stories.tsx
+++ b/storybook/src/docs/components/Snackbar/stories/useSnackbarApiHook.stories.tsx
@@ -18,8 +18,6 @@ storiesOf("stories/components/Snackbar/useSnackbarApi()", module)
                 snackbarApi.showSnackbar(
                     <Snackbar
                         anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                        // Use uuid or object id in production
-                        key={Math.random()}
                         autoHideDuration={5000}
                         message="This is a completely customizable snackbar"
                         action={


### PR DESCRIPTION
Generating component keys on the fly is considered a bad practice which we shouldn't promote. Also, the key is [overridden by SnackbarProvider](https://github.com/vivid-planet/comet/blob/main/packages/admin/admin/src/snackbar/SnackbarProvider.tsx#L66), so manually providing a key isn't necessary.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)