### PR TITLE
Fix a crash when using the `Alert` component inside a MUI `Snackbar` (v5)

### DIFF
--- a/.changeset/big-items-serve.md
+++ b/.changeset/big-items-serve.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix a crash when using the `Alert` component inside a MUI `Snackbar`

--- a/packages/admin/admin-stories/src/admin/alert/AlertInSnackbar.tsx
+++ b/packages/admin/admin-stories/src/admin/alert/AlertInSnackbar.tsx
@@ -1,0 +1,24 @@
+import { Alert } from "@comet/admin";
+import { Button, Snackbar } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+storiesOf("@comet/admin/alert/Alert", module).add("Alert in Snackbar", () => {
+    const [showSnackbar, setShowSnackbar] = React.useState(false);
+    return (
+        <>
+            <Button
+                onClick={() => {
+                    setShowSnackbar(true);
+                }}
+            >
+                Show snackbar
+            </Button>
+            <Snackbar open={showSnackbar} onClose={() => setShowSnackbar(false)} autoHideDuration={2000}>
+                <Alert severity="success" onClose={() => setShowSnackbar(false)}>
+                    Notification Text
+                </Alert>
+            </Snackbar>
+        </>
+    );
+});

--- a/packages/admin/admin/src/alert/Alert.tsx
+++ b/packages/admin/admin/src/alert/Alert.tsx
@@ -72,28 +72,31 @@ const styles = (theme: Theme) =>
         },
     });
 
-function Alert({ severity = "info", title, children, classes, onClose, action }: AlertProps & WithStyles<typeof styles>): React.ReactElement {
-    return (
-        <MuiAlert
-            classes={{
-                root: clsx(classes.root, Boolean(title) && classes.hasTitle),
-                message: classes.message,
-            }}
-            severity={severity}
-        >
-            {Boolean(title) && <AlertTitle className={classes.title}>{title}</AlertTitle>}
-            <Typography className={classes.text} variant="body2">
-                {children}
-            </Typography>
-            <div className={classes.action}>{action}</div>
-            {onClose && (
-                <IconButton className={classes.closeIcon} onClick={onClose}>
-                    <Close />
-                </IconButton>
-            )}
-        </MuiAlert>
-    );
-}
+const Alert = React.forwardRef<HTMLDivElement, AlertProps & WithStyles<typeof styles>>(
+    ({ severity = "info", title, children, classes, onClose, action }, ref) => {
+        return (
+            <MuiAlert
+                ref={ref}
+                classes={{
+                    root: clsx(classes.root, Boolean(title) && classes.hasTitle),
+                    message: classes.message,
+                }}
+                severity={severity}
+            >
+                {Boolean(title) && <AlertTitle className={classes.title}>{title}</AlertTitle>}
+                <Typography className={classes.text} variant="body2">
+                    {children}
+                </Typography>
+                <div className={classes.action}>{action}</div>
+                {onClose && (
+                    <IconButton className={classes.closeIcon} onClick={onClose}>
+                        <Close />
+                    </IconButton>
+                )}
+            </MuiAlert>
+        );
+    },
+);
 
 const AdminComponentWithStyles = withStyles(styles, { name: "CometAdminAlert" })(Alert);
 


### PR DESCRIPTION
Backport #1650 into v5.
