### PR TITLE
End adornments for `FinalFormAutocomplete`

### DIFF
--- a/.changeset/fifty-ghosts-relax.md
+++ b/.changeset/fifty-ghosts-relax.md
@@ -2,6 +2,4 @@
 "@comet/admin": minor
 ---
 
-The prop `endAdornmentIcon` is added to `FinalFormAutocomplete`, it is shown instead of the dropdown chevron
-
-The prop `disabledEndAdornmentIcon` is added to `FinalFormAutocomplete`, it is shown instead of the dropdown chevron when the field is disabled
+The prop `endAdornment` is added to `FinalFormAutocomplete`, it is shown instead of the dropdown chevron

--- a/.changeset/fifty-ghosts-relax.md
+++ b/.changeset/fifty-ghosts-relax.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": minor
+---
+
+The prop `endAdornmentIcon` is added to `FinalFormAutocomplete`, it is shown instead of the dropdown chevron
+
+The prop `disabledEndAdornmentIcon` is added to `FinalFormAutocomplete`, it is shown instead of the dropdown chevron when the field is disabled

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -35,6 +35,7 @@ export const FinalFormAutocomplete = <
     return (
         <Autocomplete
             popupIcon={popupIcon}
+            forcePopupIcon={endAdornment ? false : undefined}
             disableClearable
             isOptionEqualToValue={(option: T, value: T) => {
                 if (!value) return false;

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown } from "@comet/admin-icons";
-import { Autocomplete, AutocompleteProps, AutocompleteRenderInputParams, CircularProgress, InputBase } from "@mui/material";
+import { Autocomplete, AutocompleteProps, AutocompleteRenderInputParams, InputBase } from "@mui/material";
+import CircularProgress from "@mui/material/CircularProgress";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
@@ -28,8 +29,7 @@ export const FinalFormAutocomplete = <
     isAsync = false,
     clearable,
     popupIcon = <ChevronDown />,
-    endAdornmentIcon,
-    disabledEndAdornmentIcon,
+    endAdornment,
     ...rest
 }: FinalFormAutocompleteProps<T, Multiple, DisableClearable, FreeSolo>) => {
     return (
@@ -52,18 +52,16 @@ export const FinalFormAutocomplete = <
                     {...params}
                     {...params.InputProps}
                     endAdornment={
-                        rest.disabled && disabledEndAdornmentIcon ? (
-                            disabledEndAdornmentIcon
-                        ) : loading || clearable ? (
+                        loading || clearable ? (
                             <>
                                 {loading && <CircularProgress color="inherit" size={16} />}
                                 {clearable && (
                                     <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange("")} />
                                 )}
-                                {endAdornmentIcon ? endAdornmentIcon : params.InputProps.endAdornment}
+                                {endAdornment ? endAdornment : params.InputProps.endAdornment}
                             </>
-                        ) : endAdornmentIcon ? (
-                            endAdornmentIcon
+                        ) : endAdornment ? (
+                            endAdornment
                         ) : (
                             params.InputProps.endAdornment
                         )

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -28,6 +28,8 @@ export const FinalFormAutocomplete = <
     isAsync = false,
     clearable,
     popupIcon = <ChevronDown />,
+    endAdornmentIcon,
+    disabledEndAdornmentIcon,
     ...rest
 }: FinalFormAutocompleteProps<T, Multiple, DisableClearable, FreeSolo>) => {
     return (
@@ -50,14 +52,18 @@ export const FinalFormAutocomplete = <
                     {...params}
                     {...params.InputProps}
                     endAdornment={
-                        loading || clearable ? (
+                        rest.disabled && disabledEndAdornmentIcon ? (
+                            disabledEndAdornmentIcon
+                        ) : loading || clearable ? (
                             <>
                                 {loading && <CircularProgress color="inherit" size={16} />}
                                 {clearable && (
                                     <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange("")} />
                                 )}
-                                {params.InputProps.endAdornment}
+                                {endAdornmentIcon ? endAdornmentIcon : params.InputProps.endAdornment}
                             </>
+                        ) : endAdornmentIcon ? (
+                            endAdornmentIcon
                         ) : (
                             params.InputProps.endAdornment
                         )

--- a/storybook/src/docs/form/components/stories/FinalFormFields.stories.tsx
+++ b/storybook/src/docs/form/components/stories/FinalFormFields.stories.tsx
@@ -12,8 +12,8 @@ import {
     FinalFormSwitch,
     useAsyncOptionsProps,
 } from "@comet/admin";
-import { Calendar, Locked } from "@comet/admin-icons";
-import { Button, FormControlLabel } from "@mui/material";
+import { Music } from "@comet/admin-icons";
+import { Button, FormControlLabel, InputAdornment } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
@@ -78,9 +78,9 @@ storiesOf("stories/form/FinalForm Fields", module)
             () => ({
                 autocomplete: { value: "strawberry", label: "Strawberry" },
                 autocompleteWithEndAdornment: { value: "strawberry", label: "Strawberry" },
-                autocompleteWithDisabledEndAdornment: { value: "strawberry", label: "Strawberry" },
                 autocompleteAsync: { value: "strawberry", label: "Strawberry" },
                 autocompleteMultiple: [{ value: "strawberry", label: "Strawberry" }],
+                autocompleteMultipleWithEndAdornment: [{ value: "strawberry", label: "Strawberry" }],
             }),
             [],
         );
@@ -112,20 +112,13 @@ storiesOf("stories/form/FinalForm Fields", module)
                     isOptionEqualToValue={(option: Option, value: Option) => option.value === value.value}
                     options={options}
                     name="autocompleteWithEndAdornment"
-                    label="Autocomplete with custom Icon"
+                    label="Autocomplete with end adornment"
                     fullWidth
-                    endAdornmentIcon={<Calendar />}
-                />
-                <Field
-                    component={FinalFormAutocomplete}
-                    getOptionLabel={(option: Option) => option.label}
-                    isOptionEqualToValue={(option: Option, value: Option) => option.value === value.value}
-                    options={options}
-                    name="autocompleteWithDisabledEndAdornment"
-                    label="Autocomplete with custom Icon when disabled"
-                    fullWidth
-                    disabledEndAdornmentIcon={<Locked color="disabled" />}
-                    disabled
+                    endAdornment={
+                        <InputAdornment position="end">
+                            <Music />
+                        </InputAdornment>
+                    }
                 />
                 <Field
                     component={FinalFormAutocomplete}
@@ -145,6 +138,21 @@ storiesOf("stories/form/FinalForm Fields", module)
                     name="autocompleteMultiple"
                     label="Autocomplete multiple select"
                     fullWidth
+                />
+                <Field
+                    component={FinalFormAutocomplete}
+                    multiple
+                    getOptionLabel={(option: Option) => option.label}
+                    isOptionEqualToValue={(option: Option, value: Option) => option.value === value.value}
+                    options={options}
+                    name="autocompleteMultipleWithEndAdornment"
+                    label="Autocomplete multiple select with end adornment"
+                    fullWidth
+                    endAdornment={
+                        <InputAdornment position="end">
+                            <Music />
+                        </InputAdornment>
+                    }
                 />
                 <Button color="primary" variant="contained" type="submit">
                     Submit

--- a/storybook/src/docs/form/components/stories/FinalFormFields.stories.tsx
+++ b/storybook/src/docs/form/components/stories/FinalFormFields.stories.tsx
@@ -12,6 +12,7 @@ import {
     FinalFormSwitch,
     useAsyncOptionsProps,
 } from "@comet/admin";
+import { Calendar, Locked } from "@comet/admin-icons";
 import { Button, FormControlLabel } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
@@ -76,6 +77,8 @@ storiesOf("stories/form/FinalForm Fields", module)
             // Case 2: the initial values are hardcoded => hardcode them outside of React Component => useMemo() not necessary
             () => ({
                 autocomplete: { value: "strawberry", label: "Strawberry" },
+                autocompleteWithEndAdornment: { value: "strawberry", label: "Strawberry" },
+                autocompleteWithDisabledEndAdornment: { value: "strawberry", label: "Strawberry" },
                 autocompleteAsync: { value: "strawberry", label: "Strawberry" },
                 autocompleteMultiple: [{ value: "strawberry", label: "Strawberry" }],
             }),
@@ -102,6 +105,27 @@ storiesOf("stories/form/FinalForm Fields", module)
                     name="autocomplete"
                     label="Autocomplete"
                     fullWidth
+                />
+                <Field
+                    component={FinalFormAutocomplete}
+                    getOptionLabel={(option: Option) => option.label}
+                    isOptionEqualToValue={(option: Option, value: Option) => option.value === value.value}
+                    options={options}
+                    name="autocompleteWithEndAdornment"
+                    label="Autocomplete with custom Icon"
+                    fullWidth
+                    endAdornmentIcon={<Calendar />}
+                />
+                <Field
+                    component={FinalFormAutocomplete}
+                    getOptionLabel={(option: Option) => option.label}
+                    isOptionEqualToValue={(option: Option, value: Option) => option.value === value.value}
+                    options={options}
+                    name="autocompleteWithDisabledEndAdornment"
+                    label="Autocomplete with custom Icon when disabled"
+                    fullWidth
+                    disabledEndAdornmentIcon={<Locked color="disabled" />}
+                    disabled
                 />
                 <Field
                     component={FinalFormAutocomplete}


### PR DESCRIPTION
FinalFormAutocomplete now supports the `endAdornment` prop. It is shown instead of the dropdown chevron.


<details>
    <summary>Current behaviour of Story</summary>

https://github.com/vivid-planet/comet/assets/122883866/e5e95ca3-664a-4dee-a93f-19024ddfe3f8

</details>

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-412
-   [x] Provide screenshots/screencasts if the change contains visual changes

