### PR TITLE
Make headers in `includeInvisibleContentContext` overridable in query

### DIFF
--- a/.changeset/ten-schools-buy.md
+++ b/.changeset/ten-schools-buy.md
@@ -1,0 +1,19 @@
+---
+"@comet/cms-admin": patch
+---
+
+Make headers in `includeInvisibleContentContext` overridable in query
+
+You can now override the headers `x-include-invisible-content` and `x-preview-dam-urls` in your query like this:
+
+```tsx
+const { loading, data, error } = useQuery(exampleQuery, {
+    // ...
+    context: {
+        headers: {
+            "x-include-invisible-content": [],
+            "x-preview-dam-urls": 0,
+        },
+    },
+});
+```

--- a/packages/admin/cms-admin/src/common/apollo/links/includeInvisibleContentContext.ts
+++ b/packages/admin/cms-admin/src/common/apollo/links/includeInvisibleContentContext.ts
@@ -3,12 +3,25 @@ import { setContext } from "@apollo/client/link/context";
 /**
  * adds http header "x-include-invisible-content" flag with Unpublished and Archive values, so we can fetch Unpublished and Archived Content from API
  */
-export const includeInvisibleContentContext = setContext((request, prevContext) => {
+export const includeInvisibleContentContext = setContext((request, prevContext: { headers: Record<string, unknown> | undefined }) => {
+    const headers: Record<string, unknown> = {
+        "x-include-invisible-content": ["Pages:Unpublished", "Pages:Archived", "Blocks:Invisible"],
+        "x-preview-dam-urls": "1",
+    };
+    const overrideHeaders = prevContext?.headers ? { ...prevContext.headers } : {};
+
+    const xPreviewDamUrlsIsOverridden = Object.prototype.hasOwnProperty.call(overrideHeaders, "x-preview-dam-urls");
+    const xPreviewDamUrlsEvaluatesToFalse = xPreviewDamUrlsIsOverridden && !overrideHeaders["x-preview-dam-urls"];
+    delete overrideHeaders["x-preview-dam-urls"];
+
+    if (xPreviewDamUrlsIsOverridden && xPreviewDamUrlsEvaluatesToFalse) {
+        delete headers["x-preview-dam-urls"];
+    }
+
     return {
         headers: {
-            ...prevContext.headers,
-            "x-include-invisible-content": ["Pages:Unpublished", "Pages:Archived", "Blocks:Invisible"],
-            "x-preview-dam-urls": "1",
+            ...headers,
+            ...overrideHeaders,
         },
     };
 });

--- a/packages/admin/cms-admin/src/common/apollo/links/includeInvisibleContentContext.ts
+++ b/packages/admin/cms-admin/src/common/apollo/links/includeInvisibleContentContext.ts
@@ -14,7 +14,7 @@ export const includeInvisibleContentContext = setContext((request, prevContext: 
     const xPreviewDamUrlsEvaluatesToFalse = xPreviewDamUrlsIsOverridden && !overrideHeaders["x-preview-dam-urls"];
     delete overrideHeaders["x-preview-dam-urls"];
 
-    if (xPreviewDamUrlsIsOverridden && xPreviewDamUrlsEvaluatesToFalse) {
+    if (xPreviewDamUrlsEvaluatesToFalse) {
         delete headers["x-preview-dam-urls"];
     }
 

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -72,7 +72,12 @@ const useInitialValues = (id: string) => {
     const { loading, data, error } = useQuery<GQLDamFileDetailQuery, GQLDamFileDetailQueryVariables>(damFileDetailQuery, {
         variables: { id: id },
         skip: !id,
-        context: LocalErrorScopeApolloContext,
+        context: {
+            headers: {
+                "x-preview-dam-urls": 0,
+            },
+            ...LocalErrorScopeApolloContext,
+        },
     });
     return { loading, data, error };
 };

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -72,12 +72,7 @@ const useInitialValues = (id: string) => {
     const { loading, data, error } = useQuery<GQLDamFileDetailQuery, GQLDamFileDetailQueryVariables>(damFileDetailQuery, {
         variables: { id: id },
         skip: !id,
-        context: {
-            headers: {
-                "x-preview-dam-urls": 0,
-            },
-            ...LocalErrorScopeApolloContext,
-        },
+        context: LocalErrorScopeApolloContext,
     });
     return { loading, data, error };
 };


### PR DESCRIPTION
You can now override the headers `x-include-invisible-content` and `x-preview-dam-urls` like this:

```tsx
const { loading, data, error } = useQuery(exampleQuery, {
    // ...
    context: {
        headers: {
            "x-include-invisible-content": [],
            "x-preview-dam-urls": 0,
        },
    },
});
```

The real-life use case is overriding `x-preview-dam-urls` to get public file URLs instead of private preview URLs


---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->
</details>
