### PR TITLE
Remove incorrect `DocumentInterface` usages

### DIFF
--- a/demo/admin/src/news/generated/NewsGrid.tsx
+++ b/demo/admin/src/news/generated/NewsGrid.tsx
@@ -40,7 +40,6 @@ import {
 const newsFragment = gql`
     fragment NewsList on News {
         id
-        updatedAt
         slug
         title
         date
@@ -49,6 +48,7 @@ const newsFragment = gql`
         image
         content
         createdAt
+        updatedAt
     }
 `;
 
@@ -105,13 +105,6 @@ export function NewsGrid(): React.ReactElement {
     const { scope } = useContentScope();
 
     const columns: GridColDef<GQLNewsListFragment>[] = [
-        {
-            field: "updatedAt",
-            headerName: intl.formatMessage({ id: "news.updatedAt", defaultMessage: "Updated At" }),
-            type: "dateTime",
-            valueGetter: ({ value }) => value && new Date(value),
-            width: 150,
-        },
         { field: "slug", headerName: intl.formatMessage({ id: "news.slug", defaultMessage: "Slug" }), width: 150 },
         { field: "title", headerName: intl.formatMessage({ id: "news.title", defaultMessage: "Title" }), width: 150 },
         {
@@ -156,6 +149,13 @@ export function NewsGrid(): React.ReactElement {
         {
             field: "createdAt",
             headerName: intl.formatMessage({ id: "news.createdAt", defaultMessage: "Created At" }),
+            type: "dateTime",
+            valueGetter: ({ value }) => value && new Date(value),
+            width: 150,
+        },
+        {
+            field: "updatedAt",
+            headerName: intl.formatMessage({ id: "news.updatedAt", defaultMessage: "Updated At" }),
             type: "dateTime",
             valueGetter: ({ value }) => value && new Date(value),
             width: 150,

--- a/demo/admin/src/products/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/generated/ProductsGrid.tsx
@@ -38,7 +38,6 @@ import {
 const productsFragment = gql`
     fragment ProductsList on Product {
         id
-        updatedAt
         title
         visible
         slug
@@ -49,6 +48,7 @@ const productsFragment = gql`
         soldCount
         image
         createdAt
+        updatedAt
     }
 `;
 
@@ -104,13 +104,6 @@ export function ProductsGrid(): React.ReactElement {
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };
 
     const columns: GridColDef<GQLProductsListFragment>[] = [
-        {
-            field: "updatedAt",
-            headerName: intl.formatMessage({ id: "product.updatedAt", defaultMessage: "Updated At" }),
-            type: "dateTime",
-            valueGetter: ({ value }) => value && new Date(value),
-            width: 150,
-        },
         { field: "title", headerName: intl.formatMessage({ id: "product.title", defaultMessage: "Title" }), width: 150 },
         { field: "visible", headerName: intl.formatMessage({ id: "product.visible", defaultMessage: "Visible" }), type: "boolean", width: 150 },
         { field: "slug", headerName: intl.formatMessage({ id: "product.slug", defaultMessage: "Slug" }), width: 150 },
@@ -142,6 +135,13 @@ export function ProductsGrid(): React.ReactElement {
         {
             field: "createdAt",
             headerName: intl.formatMessage({ id: "product.createdAt", defaultMessage: "Created At" }),
+            type: "dateTime",
+            valueGetter: ({ value }) => value && new Date(value),
+            width: 150,
+        },
+        {
+            field: "updatedAt",
+            headerName: intl.formatMessage({ id: "product.updatedAt", defaultMessage: "Updated At" }),
             type: "dateTime",
             valueGetter: ({ value }) => value && new Date(value),
             width: 150,

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -333,12 +333,12 @@ type FooterContentScope {
   language: String!
 }
 
-type Footer implements DocumentInterface {
+type Footer {
   id: ID!
-  updatedAt: DateTime!
   content: FooterContentBlockData!
   scope: FooterContentScope!
   createdAt: DateTime!
+  updatedAt: DateTime!
   dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
@@ -361,11 +361,11 @@ type MainMenu {
   items: [MainMenuItem!]!
 }
 
-type NewsComment implements DocumentInterface {
+type NewsComment {
   id: ID!
-  updatedAt: DateTime!
   comment: String!
   createdAt: DateTime!
+  updatedAt: DateTime!
 }
 
 type NewsContentScope {
@@ -373,9 +373,8 @@ type NewsContentScope {
   language: String!
 }
 
-type News implements DocumentInterface {
+type News {
   id: ID!
-  updatedAt: DateTime!
   scope: NewsContentScope!
   slug: String!
   title: String!
@@ -385,6 +384,7 @@ type News implements DocumentInterface {
   image: DamImageBlockData!
   content: NewsContentBlockData!
   createdAt: DateTime!
+  updatedAt: DateTime!
   comments: [NewsComment!]!
   dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
   dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
@@ -407,12 +407,12 @@ type PaginatedNews {
   totalCount: Int!
 }
 
-type ProductCategory implements DocumentInterface {
+type ProductCategory {
   id: ID!
-  updatedAt: DateTime!
   title: String!
   slug: String!
   createdAt: DateTime!
+  updatedAt: DateTime!
   products: [Product!]!
 }
 
@@ -423,20 +423,20 @@ type ProductStatistics {
   updatedAt: DateTime!
 }
 
-type ProductTag implements DocumentInterface {
+type ProductTag {
   id: ID!
-  updatedAt: DateTime!
   title: String!
   createdAt: DateTime!
+  updatedAt: DateTime!
   products: [Product!]!
 }
 
-type ProductVariant implements DocumentInterface {
+type ProductVariant {
   id: ID!
-  updatedAt: DateTime!
   name: String!
   image: DamImageBlockData!
   createdAt: DateTime!
+  updatedAt: DateTime!
 }
 
 type ProductDiscounts {
@@ -450,9 +450,8 @@ type ProductDimensions {
   depth: Float!
 }
 
-type Product implements DocumentInterface {
+type Product {
   id: ID!
-  updatedAt: DateTime!
   title: String!
   visible: Boolean!
   slug: String!
@@ -467,6 +466,7 @@ type Product implements DocumentInterface {
   dimensions: ProductDimensions
   statistics: ProductStatistics
   createdAt: DateTime!
+  updatedAt: DateTime!
   category: ProductCategory
   variants: [ProductVariant!]!
   tags: [ProductTag!]!
@@ -502,9 +502,8 @@ type PaginatedPageTreeNodes {
   totalCount: Int!
 }
 
-type Redirect implements DocumentInterface {
+type Redirect {
   id: ID!
-  updatedAt: DateTime!
   sourceType: RedirectSourceTypeValues!
   source: String!
   target: JSONObject!
@@ -512,6 +511,7 @@ type Redirect implements DocumentInterface {
   active: Boolean!
   generationType: RedirectGenerationType!
   createdAt: DateTime!
+  updatedAt: DateTime!
   scope: RedirectScope!
   dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }

--- a/demo/api/src/footer/entities/footer.entity.ts
+++ b/demo/api/src/footer/entities/footer.entity.ts
@@ -1,5 +1,5 @@
 import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
-import { CrudSingleGenerator, DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
+import { CrudSingleGenerator, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import { BaseEntity, Embedded, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
@@ -8,12 +8,10 @@ import { FooterContentBlock } from "../blocks/footer-content.block";
 import { FooterContentScope } from "./footer-content-scope.entity";
 
 @Entity()
-@ObjectType({
-    implements: () => [DocumentInterface],
-})
+@ObjectType()
 @RootBlockEntity()
 @CrudSingleGenerator({ targetDirectory: `${__dirname}/../generated/`, requiredPermission: ["pageTree"] })
-export class Footer extends BaseEntity<Footer, "id"> implements DocumentInterface {
+export class Footer extends BaseEntity<Footer, "id"> {
     [OptionalProps]?: "createdAt" | "updatedAt";
 
     @PrimaryKey({ columnType: "uuid" })

--- a/demo/api/src/menus/entities/main-menu-item.entity.ts
+++ b/demo/api/src/menus/entities/main-menu-item.entity.ts
@@ -1,5 +1,5 @@
 import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
-import { DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
+import { RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import { BaseEntity, Entity, OneToOne, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { RichTextBlock } from "@src/common/blocks/rich-text.block";
@@ -9,7 +9,7 @@ import { v4 as uuid } from "uuid";
 @Entity()
 @ObjectType()
 @RootBlockEntity()
-export class MainMenuItem extends BaseEntity<MainMenuItem, "id"> implements DocumentInterface {
+export class MainMenuItem extends BaseEntity<MainMenuItem, "id"> {
     [OptionalProps]?: "createdAt" | "updatedAt";
 
     @PrimaryKey({ columnType: "uuid" })

--- a/demo/api/src/news/entities/news-comment.entity.ts
+++ b/demo/api/src/news/entities/news-comment.entity.ts
@@ -1,4 +1,4 @@
-import { DocumentInterface, ScopedEntity } from "@comet/cms-api";
+import { ScopedEntity } from "@comet/cms-api";
 import { BaseEntity, Entity, ManyToOne, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
@@ -6,9 +6,7 @@ import { v4 as uuid } from "uuid";
 import { News } from "./news.entity";
 
 @Entity()
-@ObjectType({
-    implements: () => [DocumentInterface],
-})
+@ObjectType()
 @ScopedEntity(async (newsComment: NewsComment) => {
     const scope = (await newsComment.news.init()).scope;
     return {
@@ -16,7 +14,7 @@ import { News } from "./news.entity";
         language: scope.language,
     };
 })
-export class NewsComment extends BaseEntity<NewsComment, "id"> implements DocumentInterface {
+export class NewsComment extends BaseEntity<NewsComment, "id"> {
     [OptionalProps]?: "createdAt" | "updatedAt";
 
     @PrimaryKey({ type: "uuid" })

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -1,5 +1,5 @@
 import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
-import { CrudField, CrudGenerator, DamImageBlock, DocumentInterface, EntityInfo, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
+import { CrudField, CrudGenerator, DamImageBlock, EntityInfo, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import { BaseEntity, Collection, Embeddable, Embedded, Entity, Enum, OneToMany, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, InputType, ObjectType, registerEnumType } from "@nestjs/graphql";
 import { IsString } from "class-validator";
@@ -34,12 +34,10 @@ export class NewsContentScope {
 
 @EntityInfo<News>((news) => ({ name: news.title, secondaryInformation: news.slug }))
 @RootBlockEntity()
-@ObjectType({
-    implements: () => [DocumentInterface],
-})
+@ObjectType()
 @Entity()
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/` })
-export class News extends BaseEntity<News, "id"> implements DocumentInterface {
+export class News extends BaseEntity<News, "id"> {
     [OptionalProps]?: "createdAt" | "updatedAt" | "category"; // TODO remove "category" once CRUD generator supports enums
 
     @PrimaryKey({ type: "uuid" })

--- a/demo/api/src/products/entities/product-category.entity.ts
+++ b/demo/api/src/products/entities/product-category.entity.ts
@@ -1,16 +1,14 @@
-import { CrudField, CrudGenerator, DocumentInterface } from "@comet/cms-api";
+import { CrudField, CrudGenerator } from "@comet/cms-api";
 import { BaseEntity, Collection, Entity, OneToMany, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
 
 import { Product } from "./product.entity";
 
-@ObjectType({
-    implements: () => [DocumentInterface],
-})
+@ObjectType()
 @Entity()
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/`, requiredPermission: ["products"] })
-export class ProductCategory extends BaseEntity<ProductCategory, "id"> implements DocumentInterface {
+export class ProductCategory extends BaseEntity<ProductCategory, "id"> {
     [OptionalProps]?: "createdAt" | "updatedAt";
 
     @PrimaryKey({ type: "uuid" })

--- a/demo/api/src/products/entities/product-tag.entity.ts
+++ b/demo/api/src/products/entities/product-tag.entity.ts
@@ -1,16 +1,14 @@
-import { CrudField, CrudGenerator, DocumentInterface } from "@comet/cms-api";
+import { CrudField, CrudGenerator } from "@comet/cms-api";
 import { BaseEntity, Collection, Entity, ManyToMany, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
 
 import { Product } from "./product.entity";
 
-@ObjectType({
-    implements: () => [DocumentInterface],
-})
+@ObjectType()
 @Entity()
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/`, requiredPermission: ["products"] })
-export class ProductTag extends BaseEntity<ProductTag, "id"> implements DocumentInterface {
+export class ProductTag extends BaseEntity<ProductTag, "id"> {
     [OptionalProps]?: "createdAt" | "updatedAt";
 
     @PrimaryKey({ type: "uuid" })

--- a/demo/api/src/products/entities/product-variant.entity.ts
+++ b/demo/api/src/products/entities/product-variant.entity.ts
@@ -1,17 +1,15 @@
 import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
-import { CrudField, DamImageBlock, DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
+import { CrudField, DamImageBlock, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import { BaseEntity, Entity, ManyToOne, OptionalProps, PrimaryKey, Property, Ref } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
 
 import { Product } from "./product.entity";
 
-@ObjectType({
-    implements: () => [DocumentInterface],
-})
+@ObjectType()
 @Entity()
 @RootBlockEntity()
-export class ProductVariant extends BaseEntity<ProductVariant, "id"> implements DocumentInterface {
+export class ProductVariant extends BaseEntity<ProductVariant, "id"> {
     [OptionalProps]?: "createdAt" | "updatedAt";
 
     @PrimaryKey({ type: "uuid" })

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -1,5 +1,5 @@
 import { BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/blocks-api";
-import { CrudField, CrudGenerator, DamImageBlock, DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
+import { CrudField, CrudGenerator, DamImageBlock, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
 import {
     BaseEntity,
     Collection,
@@ -53,13 +53,11 @@ export class ProductDimensions {
     depth: number;
 }
 
-@ObjectType({
-    implements: () => [DocumentInterface],
-})
+@ObjectType()
 @Entity()
 @RootBlockEntity()
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/` })
-export class Product extends BaseEntity<Product, "id"> implements DocumentInterface {
+export class Product extends BaseEntity<Product, "id"> {
     [OptionalProps]?: "createdAt" | "updatedAt";
 
     @PrimaryKey({ type: "uuid" })

--- a/docs/docs/dependencies/index.md
+++ b/docs/docs/dependencies/index.md
@@ -11,7 +11,7 @@ All fields containing block data need to be annotated with `@RootBlock()`. The B
 ```ts
 //...
 @RootBlockEntity()
-export class News extends BaseEntity<News, "id"> implements DocumentInterface {
+export class News extends BaseEntity<News, "id"> {
     // ...
 
     @RootBlock(DamImageBlock)

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -229,9 +229,8 @@ input DependentFilter {
   rootColumnName: String
 }
 
-type Redirect implements DocumentInterface {
+type Redirect {
   id: ID!
-  updatedAt: DateTime!
   sourceType: RedirectSourceTypeValues!
   source: String!
   target: JSONObject!
@@ -239,6 +238,7 @@ type Redirect implements DocumentInterface {
   active: Boolean!
   generationType: RedirectGenerationType!
   createdAt: DateTime!
+  updatedAt: DateTime!
   dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 

--- a/packages/api/cms-api/src/redirects/entities/redirect-entity.factory.ts
+++ b/packages/api/cms-api/src/redirects/entities/redirect-entity.factory.ts
@@ -6,7 +6,6 @@ import { GraphQLJSONObject } from "graphql-type-json";
 import { v4 as uuid } from "uuid";
 
 import { RootBlockType } from "../../blocks/root-block-type";
-import { DocumentInterface } from "../../document/dto/document-interface";
 import { RedirectGenerationType, RedirectSourceTypeValues } from "../redirects.enum";
 import { RedirectScopeInterface } from "../types";
 
@@ -27,11 +26,8 @@ export interface RedirectInterface {
 export class RedirectEntityFactory {
     static create({ linkBlock, Scope: RedirectScope }: { linkBlock: Block; Scope?: Type<RedirectScopeInterface> }): Type<RedirectInterface> {
         @Entity({ abstract: true })
-        @ObjectType({
-            implements: () => [DocumentInterface],
-            isAbstract: true,
-        })
-        class RedirectBase implements RedirectInterface, DocumentInterface {
+        @ObjectType({ isAbstract: true })
+        class RedirectBase implements RedirectInterface {
             [OptionalProps]?: "createdAt" | "updatedAt" | "active";
 
             @PrimaryKey({ columnType: "uuid" })
@@ -84,9 +80,7 @@ export class RedirectEntityFactory {
 
         if (RedirectScope) {
             @Entity()
-            @ObjectType({
-                implements: () => [DocumentInterface],
-            })
+            @ObjectType()
             @RootBlockEntity()
             class Redirect extends RedirectBase {
                 @Embedded(() => RedirectScope)
@@ -96,9 +90,7 @@ export class RedirectEntityFactory {
             return Redirect;
         } else {
             @Entity()
-            @ObjectType({
-                implements: () => [DocumentInterface],
-            })
+            @ObjectType()
             @RootBlockEntity()
             class Redirect extends RedirectBase {}
             return Redirect;


### PR DESCRIPTION
The interface should only be used for documents that are attached to the page tree.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [ ] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [ ] Link to the respective task if one exists: <!-- For instance, COM-123 -->
-   [ ] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->
</details>
