### PR TITLE
 Add setting signInUrl to createErrorDialogApolloLink

### DIFF
--- a/.changeset/nervous-sloths-thank.md
+++ b/.changeset/nervous-sloths-thank.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Add setting `signInUrl` to `createErrorDialogApolloLink`

--- a/packages/admin/admin/src/error/errordialog/createErrorDialogApolloLink.tsx
+++ b/packages/admin/admin/src/error/errordialog/createErrorDialogApolloLink.tsx
@@ -10,7 +10,7 @@ import { ErrorType } from "./ErrorDialog";
 import { errorDialogVar } from "./errorDialogVar";
 import { ErrorScope, errorScopeForOperationContext } from "./ErrorScope";
 
-export const createErrorDialogApolloLink = () => {
+export const createErrorDialogApolloLink = (config?: { signInUrl?: string }) => {
     return onError(({ graphQLErrors, networkError, operation }) => {
         const errorScope = errorScopeForOperationContext(operation.getContext());
 
@@ -56,7 +56,7 @@ export const createErrorDialogApolloLink = () => {
                     <Typography gutterBottom>
                         <FormattedMessage id="comet.errorDialog.sessionExpired.message" defaultMessage="Your login-session has expired." />
                     </Typography>
-                    <Button href="/" color="info" variant="outlined">
+                    <Button href={config?.signInUrl ?? "/"} color="info" variant="outlined">
                         <FormattedMessage id="comet.errorDialog.sessionExpired.button" defaultMessage="Re-login" />
                     </Button>
                 </>


### PR DESCRIPTION
Use-Case: Auth-Proxy Session is still active but validation (e.g. expiryDate of JWT) in API fails. In these cases the client should be redirected to a specific endpoint of the AuthProxy which restarts the login-process.

--
Depends on https://github.com/vivid-planet/comet/pull/1909