### PR TITLE
Fix Demo i18n workflow

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -25,20 +25,6 @@ jobs:
                   token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
                   path: "demo/admin/lang/comet-lang"
 
-            - name: "Demo Admin: Clone translations"
-              uses: actions/checkout@v3
-              with:
-                  repository: vivid-planet/comet-demo-lang
-                  token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
-                  path: "demo/admin/lang/comet-demo-lang"
-
-            - name: "Demo Site: Clone translations"
-              uses: actions/checkout@v3
-              with:
-                  repository: vivid-planet/comet-demo-lang
-                  token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
-                  path: "demo/site/lang/comet-demo-lang"
-
             - uses: pnpm/action-setup@v2
               with:
                   version: 8
@@ -62,22 +48,36 @@ jobs:
               with:
                   cwd: "./demo/admin/lang/comet-lang"
 
+            - name: "Demo Admin: Clone translations"
+              uses: actions/checkout@v3
+              with:
+                  repository: vivid-planet/comet-demo-lang
+                  token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
+                  path: "demo/admin/lang/comet-demo-lang"
+
             - name: "Demo Admin: Extract i18n strings"
               run: |
                   cd demo/admin
                   pnpm run intl:extract
                   cp -r lang-extracted/* lang/comet-demo-lang/admin
 
+            - name: "Demo Admin: Update translatable strings"
+              uses: EndBug/add-and-commit@v9
+              with:
+                  cwd: "./demo/admin/lang/comet-demo-lang"
+
+            - name: "Demo Site: Clone translations"
+              uses: actions/checkout@v3
+              with:
+                  repository: vivid-planet/comet-demo-lang
+                  token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
+                  path: "demo/site/lang/comet-demo-lang"
+
             - name: "Demo Site: Extract i18n strings"
               run: |
                   cd demo/site
                   pnpm run intl:extract
                   cp -r lang-extracted/* lang/comet-demo-lang/site
-
-            - name: "Demo Admin: Update translatable strings"
-              uses: EndBug/add-and-commit@v9
-              with:
-                  cwd: "./demo/admin/lang/comet-demo-lang"
 
             - name: "Demo Site: Update translatable strings"
               uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
The language repository in site needs to be cloned after pushing updated translations for admin to prevent a "Updates were rejected because the tip of your current branch is behind" error when pushing updated translations for site.