### PR TITLE
Add configuration-options to AccessLogModule

### DIFF
--- a/.changeset/quiet-tables-notice.md
+++ b/.changeset/quiet-tables-notice.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Add `userToLog`-option to AccessLogModule

--- a/docs/docs/auth/access-logging.md
+++ b/docs/docs/auth/access-logging.md
@@ -36,6 +36,8 @@ When logging is active, all sensitive (confidential or personal) data must be en
 
 The `shouldLogRequest` callback can be used to prevent logging for specific requests. For example, requests executed during a build should not be logged. In this function, you have access to the user and the request object. If the function returns `false`, no log will be emitted for this request.
 
+The optional `userToLog` callback can be used to log additional user info (e.g. session-id). The default format is `user: ${user.id}`
+
 There are two ways to integrate logging into an application:
 
 **First option: Use the default implementation**
@@ -58,6 +60,7 @@ imports: [
             // do something
             return true; //or false
         },
+        userToLog: (user: CurrentUser) => `user: ${user.id}`,
     }),
     ...
 ]

--- a/packages/api/cms-api/src/access-log/access-log.constants.ts
+++ b/packages/api/cms-api/src/access-log/access-log.constants.ts
@@ -1,1 +1,1 @@
-export const SHOULD_LOG_REQUEST = "should-log-request";
+export const ACCESS_LOG_CONFIG = "access-log-config";

--- a/packages/api/cms-api/src/access-log/access-log.interceptor.ts
+++ b/packages/api/cms-api/src/access-log/access-log.interceptor.ts
@@ -13,7 +13,7 @@ const IGNORED_PATHS = ["/dam/images/:hash/:fileId", "/dam/files/:hash/:fileId", 
 export class AccessLogInterceptor implements NestInterceptor {
     protected readonly logger = new Logger(AccessLogInterceptor.name);
 
-    constructor(@Optional() @Inject(ACCESS_LOG_CONFIG) private readonly config: AccessLogConfig) {}
+    constructor(@Optional() @Inject(ACCESS_LOG_CONFIG) private readonly config?: AccessLogConfig) {}
 
     intercept(context: ExecutionContext, next: CallHandler) {
         const requestType = context.getType().toString();

--- a/packages/api/cms-api/src/access-log/access-log.module.ts
+++ b/packages/api/cms-api/src/access-log/access-log.module.ts
@@ -4,13 +4,15 @@ import { Request } from "express";
 
 import { CurrentUser } from "../user-permissions/dto/current-user";
 import { SystemUser } from "../user-permissions/user-permissions.types";
-import { SHOULD_LOG_REQUEST } from "./access-log.constants";
+import { ACCESS_LOG_CONFIG } from "./access-log.constants";
 import { AccessLogInterceptor } from "./access-log.interceptor";
 
 export type ShouldLogRequest = ({ user, req }: { user?: CurrentUser | SystemUser; req: Request }) => boolean;
 
-interface AccessLogModuleOptions {
+type AccessLogModuleOptions = AccessLogConfig;
+export interface AccessLogConfig {
     shouldLogRequest?: ShouldLogRequest;
+    userToLog?: (user: CurrentUser) => string;
 }
 
 @Global()
@@ -23,13 +25,13 @@ interface AccessLogModuleOptions {
     ],
 })
 export class AccessLogModule {
-    static forRoot({ shouldLogRequest }: AccessLogModuleOptions): DynamicModule {
+    static forRoot(options: AccessLogModuleOptions): DynamicModule {
         return {
             module: AccessLogModule,
             providers: [
                 {
-                    provide: SHOULD_LOG_REQUEST,
-                    useValue: shouldLogRequest,
+                    provide: ACCESS_LOG_CONFIG,
+                    useValue: options,
                 },
             ],
         };

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -154,6 +154,7 @@ export { FindUsersArgs } from "./user-permissions/dto/paginated-user-list";
 export { User } from "./user-permissions/dto/user";
 export { ContentScope } from "./user-permissions/interfaces/content-scope.interface";
 export { UserPermissionsModule } from "./user-permissions/user-permissions.module";
+export { UserPermissionsService } from "./user-permissions/user-permissions.service";
 export {
     AccessControlServiceInterface,
     ContentScopesForUser,

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -154,7 +154,6 @@ export { FindUsersArgs } from "./user-permissions/dto/paginated-user-list";
 export { User } from "./user-permissions/dto/user";
 export { ContentScope } from "./user-permissions/interfaces/content-scope.interface";
 export { UserPermissionsModule } from "./user-permissions/user-permissions.module";
-export { UserPermissionsService } from "./user-permissions/user-permissions.service";
 export {
     AccessControlServiceInterface,
     ContentScopesForUser,


### PR DESCRIPTION
Use case: an IDP of on of our clients provides a `transient_session_id` which should be used specifically for logging.

---

COM-663