### PR TITLE
Change `DatePicker` and `DateRangePicker` values from `Date` to `string`

### DIFF
--- a/.changeset/fresh-buckets-begin.md
+++ b/.changeset/fresh-buckets-begin.md
@@ -1,0 +1,31 @@
+---
+"@comet/admin-date-time": major
+---
+
+Change `DatePicker` and `DateRangePicker` values from `Date` to `string`
+
+This affects the `value` prop and the value returned by the `onChange` event.
+
+The value of `DatePicker` is a string in the format `YYYY-MM-DD`.
+The value of `DateRangePicker` is an object with `start` and `end` keys, each as a string in the format `YYYY-MM-DD`.
+
+The code that handles values from these components may need to be adjusted.
+This may include how the values are stored in or sent to the database.
+
+```diff
+-   const [date, setDate] = useState<Date | undefined>(new Date("2024-03-10"));
++   const [date, setDate] = useState<string | undefined>("2024-03-10");
+    return <DatePicker value={date} onChange={setDate} />;
+```
+
+```diff
+    const [dateRange, setDateRange] = useState<DateRange | undefined>({
+-       start: new Date("2024-03-10"),
+-       end: new Date("2024-03-16"),
++       start: "2024-03-10",
++       end: "2024-03-16",
+    });
+    return <DateRangePicker value={dateRange} onChange={setDateRange} />;
+```
+
+The reason for this change is that when selecting a date like `2024-04-10` in a timezone ahead of UTC, it would be stored in a `Date` object as e.g. `2024-04-09T22:00:00.000Z`. When only the date is saved to the database, without the time, it would be saved as `2024-04-09`, which differs from the selected date.

--- a/packages/admin/admin-date-time/src/datePicker/DatePicker.tsx
+++ b/packages/admin/admin-date-time/src/datePicker/DatePicker.tsx
@@ -10,7 +10,7 @@ import { FormatDateOptions, useIntl } from "react-intl";
 
 import { DatePickerNavigation } from "../DatePickerNavigation";
 import { useDateFnsLocale } from "../utils/DateFnsLocaleProvider";
-import { defaultMaxDate, defaultMinDate, getDateString } from "../utils/datePickerHelpers";
+import { defaultMaxDate, defaultMinDate, getIsoDateString } from "../utils/datePickerHelpers";
 import { Calendar, DatePickerClassKey, Root, SlotProps, StartAdornment } from "./DatePicker.slots";
 
 export interface DatePickerProps extends Omit<InputWithPopperProps, "children" | "value" | "onChange" | "slotProps"> {
@@ -80,7 +80,7 @@ export const DatePicker = (inProps: DatePickerProps) => {
                     date={dateValue}
                     onChange={(date) => {
                         closePopper(true);
-                        onChange?.(getDateString(date));
+                        onChange?.(getIsoDateString(date));
                     }}
                     {...slotProps?.calendar}
                 />

--- a/packages/admin/admin-date-time/src/datePicker/DatePicker.tsx
+++ b/packages/admin/admin-date-time/src/datePicker/DatePicker.tsx
@@ -10,12 +10,12 @@ import { FormatDateOptions, useIntl } from "react-intl";
 
 import { DatePickerNavigation } from "../DatePickerNavigation";
 import { useDateFnsLocale } from "../utils/DateFnsLocaleProvider";
-import { defaultMaxDate, defaultMinDate } from "../utils/datePickerHelpers";
+import { defaultMaxDate, defaultMinDate, getDateString } from "../utils/datePickerHelpers";
 import { Calendar, DatePickerClassKey, Root, SlotProps, StartAdornment } from "./DatePicker.slots";
 
 export interface DatePickerProps extends Omit<InputWithPopperProps, "children" | "value" | "onChange" | "slotProps"> {
-    onChange?: (date?: Date) => void;
-    value?: Date;
+    onChange?: (date?: string) => void;
+    value?: string;
     formatDateOptions?: FormatDateOptions;
     clearable?: boolean;
     monthsToShow?: number;
@@ -40,6 +40,7 @@ export const DatePicker = (inProps: DatePickerProps) => {
     } = useThemeProps({ props: inProps, name: "CometAdminDatePicker" });
     const intl = useIntl();
     const dateFnsLocale = useDateFnsLocale();
+    const dateValue = value ? new Date(value) : undefined;
 
     return (
         <Root
@@ -76,10 +77,10 @@ export const DatePicker = (inProps: DatePickerProps) => {
                     navigatorRenderer={(focusedDate, changeShownDate) => (
                         <DatePickerNavigation focusedDate={focusedDate} changeShownDate={changeShownDate} minDate={minDate} maxDate={maxDate} />
                     )}
-                    date={value}
+                    date={dateValue}
                     onChange={(date) => {
                         closePopper(true);
-                        onChange && onChange(date);
+                        onChange?.(getDateString(date));
                     }}
                     {...slotProps?.calendar}
                 />

--- a/packages/admin/admin-date-time/src/datePicker/FinalFormDatePicker.tsx
+++ b/packages/admin/admin-date-time/src/datePicker/FinalFormDatePicker.tsx
@@ -3,7 +3,7 @@ import { FieldRenderProps } from "react-final-form";
 
 import { DatePicker, DatePickerProps } from "./DatePicker";
 
-export type FinalFormDatePickerProps = DatePickerProps & FieldRenderProps<Date, HTMLInputElement | HTMLTextAreaElement>;
+export type FinalFormDatePickerProps = DatePickerProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
 
 export const FinalFormDatePicker = ({ meta, input, ...restProps }: FinalFormDatePickerProps): React.ReactElement => {
     return <DatePicker {...input} {...restProps} />;

--- a/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.tsx
@@ -11,12 +11,12 @@ import { FormatDateOptions, useIntl } from "react-intl";
 
 import { DatePickerNavigation } from "../DatePickerNavigation";
 import { useDateFnsLocale } from "../utils/DateFnsLocaleProvider";
-import { defaultMaxDate, defaultMinDate } from "../utils/datePickerHelpers";
+import { defaultMaxDate, defaultMinDate, getDateString } from "../utils/datePickerHelpers";
 import { DateRange, DateRangePickerClassKey, Root, SlotProps, StartAdornment } from "./DateRangePicker.slots";
 
 export type DateRange = {
-    start: Date;
-    end: Date;
+    start: string;
+    end: string;
 };
 
 export interface DateRangePickerProps extends Omit<InputWithPopperProps, "children" | "value" | "onChange" | "slotProps"> {
@@ -52,10 +52,11 @@ const rangeKey = "pickedDateRange";
 
 const getRangeFromValue = (value: undefined | DateRange): Range => {
     if (value?.start) {
+        const startDate = new Date(value.start);
         return {
             key: rangeKey,
-            startDate: value.start,
-            endDate: value.end ?? value.start,
+            startDate,
+            endDate: value.end ? new Date(value.end) : startDate,
         };
     }
 
@@ -133,11 +134,10 @@ export const DateRangePicker = (inProps: DateRangePickerProps) => {
                     onChange={(ranges) => {
                         const pickedRange = ranges[rangeKey];
                         if (pickedRange.startDate && pickedRange.endDate) {
-                            onChange &&
-                                onChange({
-                                    start: pickedRange.startDate,
-                                    end: pickedRange.endDate,
-                                });
+                            onChange?.({
+                                start: getDateString(pickedRange.startDate),
+                                end: getDateString(pickedRange.endDate),
+                            });
                         }
                     }}
                     showDateDisplay={false}

--- a/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.tsx
@@ -11,7 +11,7 @@ import { FormatDateOptions, useIntl } from "react-intl";
 
 import { DatePickerNavigation } from "../DatePickerNavigation";
 import { useDateFnsLocale } from "../utils/DateFnsLocaleProvider";
-import { defaultMaxDate, defaultMinDate, getDateString } from "../utils/datePickerHelpers";
+import { defaultMaxDate, defaultMinDate, getIsoDateString } from "../utils/datePickerHelpers";
 import { DateRange, DateRangePickerClassKey, Root, SlotProps, StartAdornment } from "./DateRangePicker.slots";
 
 export type DateRange = {
@@ -135,8 +135,8 @@ export const DateRangePicker = (inProps: DateRangePickerProps) => {
                         const pickedRange = ranges[rangeKey];
                         if (pickedRange.startDate && pickedRange.endDate) {
                             onChange?.({
-                                start: getDateString(pickedRange.startDate),
-                                end: getDateString(pickedRange.endDate),
+                                start: getIsoDateString(pickedRange.startDate),
+                                end: getIsoDateString(pickedRange.endDate),
                             });
                         }
                     }}

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
@@ -6,6 +6,7 @@ import { useIntl } from "react-intl";
 
 import { DatePicker as DatePickerBase } from "../datePicker/DatePicker";
 import { TimePicker as TimePickerBase } from "../timePicker/TimePicker";
+import { getDateString } from "../utils/datePickerHelpers";
 import { getDateWithNewTime, getTimeStringFromDate } from "../utils/timePickerHelpers";
 
 export type DateTimePickerClassKey = "root" | "dateFormControl" | "timeFormControl" | "datePicker" | "timePicker";
@@ -67,13 +68,13 @@ export const DateTimePicker = (inProps: DateTimePickerProps) => {
     const datePickerRef = React.useRef<HTMLElement>(null);
     const timePickerRef = React.useRef<HTMLElement>(null);
 
-    const onChangeDate = (newDate?: Date) => {
+    const onChangeDate = (newDate?: string) => {
         if (newDate === undefined) {
             onChange?.(undefined);
         } else {
             const timePickerShouldBeFocused = !value;
             const time = getTimeStringFromDate(value ? value : new Date());
-            const newDateTime = getDateWithNewTime(newDate, time);
+            const newDateTime = getDateWithNewTime(new Date(newDate), time);
             onChange?.(newDateTime);
 
             if (timePickerShouldBeFocused) {
@@ -102,7 +103,7 @@ export const DateTimePicker = (inProps: DateTimePickerProps) => {
             <DateFormControl {...slotProps?.dateFormControl}>
                 <DatePicker
                     inputRef={datePickerRef}
-                    value={value}
+                    value={value ? getDateString(value) : undefined}
                     onChange={onChangeDate}
                     fullWidth
                     clearable={clearable}

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
@@ -6,7 +6,7 @@ import { useIntl } from "react-intl";
 
 import { DatePicker as DatePickerBase } from "../datePicker/DatePicker";
 import { TimePicker as TimePickerBase } from "../timePicker/TimePicker";
-import { getDateString } from "../utils/datePickerHelpers";
+import { getIsoDateString } from "../utils/datePickerHelpers";
 import { getDateWithNewTime, getTimeStringFromDate } from "../utils/timePickerHelpers";
 
 export type DateTimePickerClassKey = "root" | "dateFormControl" | "timeFormControl" | "datePicker" | "timePicker";
@@ -103,7 +103,7 @@ export const DateTimePicker = (inProps: DateTimePickerProps) => {
             <DateFormControl {...slotProps?.dateFormControl}>
                 <DatePicker
                     inputRef={datePickerRef}
-                    value={value ? getDateString(value) : undefined}
+                    value={value ? getIsoDateString(value) : undefined}
                     onChange={onChangeDate}
                     fullWidth
                     clearable={clearable}

--- a/packages/admin/admin-date-time/src/utils/datePickerHelpers.ts
+++ b/packages/admin/admin-date-time/src/utils/datePickerHelpers.ts
@@ -3,3 +3,10 @@ defaultMinDate.setFullYear(defaultMinDate.getFullYear() - 120);
 
 export const defaultMaxDate = new Date();
 defaultMaxDate.setFullYear(defaultMaxDate.getFullYear() + 40);
+
+export const getDateString = (date: Date) => {
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return `${year}-${month < 10 ? "0" : ""}${month}-${day < 10 ? "0" : ""}${day}`;
+};

--- a/packages/admin/admin-date-time/src/utils/datePickerHelpers.ts
+++ b/packages/admin/admin-date-time/src/utils/datePickerHelpers.ts
@@ -1,12 +1,11 @@
+import { format } from "date-fns";
+
 export const defaultMinDate = new Date();
 defaultMinDate.setFullYear(defaultMinDate.getFullYear() - 120);
 
 export const defaultMaxDate = new Date();
 defaultMaxDate.setFullYear(defaultMaxDate.getFullYear() + 40);
 
-export const getDateString = (date: Date) => {
-    const year = date.getFullYear();
-    const month = date.getMonth() + 1;
-    const day = date.getDate();
-    return `${year}-${month < 10 ? "0" : ""}${month}-${day < 10 ? "0" : ""}${day}`;
+export const getIsoDateString = (date: Date) => {
+    return format(date, "yyyy-MM-dd");
 };

--- a/storybook/src/admin-date-time/AllDateAndTimePickers.tsx
+++ b/storybook/src/admin-date-time/AllDateAndTimePickers.tsx
@@ -1,0 +1,87 @@
+import { DateField, DateRange, DateRangeField, DateTimeField, TimeField, TimeRange, TimeRangeField } from "@comet/admin-date-time";
+import { Box, Card, CardContent } from "@mui/material";
+import { boolean } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { Form } from "react-final-form";
+
+const Story = () => {
+    type FormValues = {
+        date: Date;
+        dateRange: DateRange;
+        dateTime: Date;
+        time: string;
+        timeRange: TimeRange;
+    };
+
+    return (
+        <Box width={550}>
+            <Form<FormValues>
+                onSubmit={() => {}}
+                initialValues={
+                    boolean("Show Initial Values", false)
+                        ? {
+                              date: new Date(),
+                              dateRange: {
+                                  start: new Date(),
+                                  end: new Date(),
+                              },
+                              dateTime: new Date(),
+                              time: "11:30",
+                              timeRange: {
+                                  start: "11:30",
+                                  end: "12:30",
+                              },
+                          }
+                        : {}
+                }
+            >
+                {({ values }) => (
+                    <form>
+                        <Card>
+                            <CardContent>
+                                <DateField
+                                    name="date"
+                                    label="Date"
+                                    fullWidth
+                                    clearable
+                                    helperText={`Stringified value: ${JSON.stringify(values.date)}`}
+                                />
+                                <DateRangeField
+                                    name="dateRange"
+                                    label="DateRange"
+                                    fullWidth
+                                    clearable
+                                    helperText={`Stringified value: ${JSON.stringify(values.dateRange)}`}
+                                />
+                                <DateTimeField
+                                    name="dateTime"
+                                    label="DateTime"
+                                    fullWidth
+                                    clearable
+                                    helperText={`Stringified value: ${JSON.stringify(values.dateTime)}`}
+                                />
+                                <TimeField
+                                    name="time"
+                                    label="Time"
+                                    fullWidth
+                                    clearable
+                                    helperText={`Stringified value: ${JSON.stringify(values.time)}`}
+                                />
+                                <TimeRangeField
+                                    name="timeRange"
+                                    label="TimeRange"
+                                    fullWidth
+                                    clearable
+                                    helperText={`Stringified value: ${JSON.stringify(values.timeRange)}`}
+                                />
+                            </CardContent>
+                        </Card>
+                    </form>
+                )}
+            </Form>
+        </Box>
+    );
+};
+
+storiesOf("@comet/admin-date-time", module).add("All Pickers", () => <Story />);

--- a/storybook/src/admin-date-time/AllDateAndTimePickers.tsx
+++ b/storybook/src/admin-date-time/AllDateAndTimePickers.tsx
@@ -7,7 +7,7 @@ import { Form } from "react-final-form";
 
 const Story = () => {
     type FormValues = {
-        date: Date;
+        date: string;
         dateRange: DateRange;
         dateTime: Date;
         time: string;
@@ -21,10 +21,10 @@ const Story = () => {
                 initialValues={
                     boolean("Show Initial Values", false)
                         ? {
-                              date: new Date(),
+                              date: "2024-03-01",
                               dateRange: {
-                                  start: new Date(),
-                                  end: new Date(),
+                                  start: "2024-03-01",
+                                  end: "2024-03-05",
                               },
                               dateTime: new Date(),
                               time: "11:30",

--- a/storybook/src/admin-date-time/DatePicker.tsx
+++ b/storybook/src/admin-date-time/DatePicker.tsx
@@ -6,20 +6,20 @@ import * as React from "react";
 import { Form } from "react-final-form";
 
 const Story = () => {
-    interface Values {
-        dateOne?: Date | null;
-        dateTwo?: Date | null;
-    }
-
-    const initialValues: Partial<Values> = {
-        dateOne: null,
-        dateTwo: new Date(),
+    type Values = {
+        dateOne: string;
+        dateTwo: string;
     };
 
     return (
         <div style={{ width: 500 }}>
-            <Form<Values> onSubmit={() => {}} initialValues={initialValues}>
-                {({ values, form: { change } }) => (
+            <Form<Values>
+                onSubmit={() => {}}
+                initialValues={{
+                    dateTwo: "2024-04-01",
+                }}
+            >
+                {({ values }) => (
                     <form>
                         <Card>
                             <CardContent>

--- a/storybook/src/admin-date-time/DateRangePicker.tsx
+++ b/storybook/src/admin-date-time/DateRangePicker.tsx
@@ -7,22 +7,19 @@ import { Form } from "react-final-form";
 
 const Story = () => {
     interface Values {
-        dateRangeOne?: DateRange | null;
-        dateRangeTwo?: DateRange | null;
+        dateRangeOne: DateRange;
+        dateRangeTwo: DateRange;
     }
-
-    const today = new Date();
-    const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
-
-    const initialValues: Partial<Values> = {
-        dateRangeOne: null,
-        dateRangeTwo: { start: today, end: tomorrow },
-    };
 
     return (
         <div style={{ width: 500 }}>
-            <Form<Values> onSubmit={() => {}} initialValues={initialValues}>
-                {({ values, form: { change } }) => (
+            <Form<Values>
+                onSubmit={() => {}}
+                initialValues={{
+                    dateRangeTwo: { start: "2024-02-10", end: "2024-02-20" },
+                }}
+            >
+                {({ values }) => (
                     <form>
                         <Card>
                             <CardContent>

--- a/storybook/src/docs/form/components/DateAndTimePickers/01_DatePicker.stories.mdx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/01_DatePicker.stories.mdx
@@ -9,7 +9,7 @@ To use the `DatePicker` and `FinalFormDatePicker` components, install the `@come
 
 ## Value type
 
-The `value` prop and the value returned by `onChange` are of type `Date`.
+The `value` prop and the value returned by `onChange` are a string in the format `YYYY-MM-DD`.
 
 <DatePickerLocalisation />
 

--- a/storybook/src/docs/form/components/DateAndTimePickers/04_DateRangePicker.stories.mdx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/04_DateRangePicker.stories.mdx
@@ -9,12 +9,12 @@ To use the `DateRangePicker` and `FinalFormDateRangePicker` components, install 
 
 ## Value type
 
-The `value` prop and the value returned by `onChange` are objects with `start` and `end` values, each with the type `Date`.
+The `value` prop and the value returned by `onChange` are objects with `start` and `end` values, each as a string in the format `YYYY-MM-DD`.
 
 ```ts
 type DateRange = {
-    start: Date;
-    end: Date;
+    start: string;
+    end: string;
 };
 ```
 

--- a/storybook/src/docs/form/components/DateAndTimePickers/stories/DatePicker.stories.tsx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/stories/DatePicker.stories.tsx
@@ -7,10 +7,10 @@ import { Form } from "react-final-form";
 
 storiesOf("stories/form/components/Date & Time Pickers/Date Picker", module)
     .add("Basic", () => {
-        const [dateOne, setDateOne] = React.useState<Date | undefined>();
-        const [dateTwo, setDateTwo] = React.useState<Date | undefined>();
-        const [dateThree, setDateThree] = React.useState<Date | undefined>(new Date());
-        const [dateFour, setDateFour] = React.useState<Date | undefined>(new Date());
+        const [dateOne, setDateOne] = React.useState<string | undefined>();
+        const [dateTwo, setDateTwo] = React.useState<string | undefined>();
+        const [dateThree, setDateThree] = React.useState<string | undefined>("2024-03-10");
+        const [dateFour, setDateFour] = React.useState<string | undefined>("2024-03-10");
 
         return (
             <Grid container spacing={4}>
@@ -44,14 +44,14 @@ storiesOf("stories/form/components/Date & Time Pickers/Date Picker", module)
     })
     .add("Final Form", () => {
         type Values = {
-            dateOne?: Date;
-            dateTwo?: Date;
-            dateThree?: Date;
-            dateFour?: Date;
+            dateOne: string;
+            dateTwo: string;
+            dateThree: string;
+            dateFour: string;
         };
 
         return (
-            <Form<Values> initialValues={{ dateThree: new Date(), dateFour: new Date() }} onSubmit={() => {}}>
+            <Form<Values> initialValues={{ dateThree: "2024-03-10", dateFour: "2024-03-10" }} onSubmit={() => {}}>
                 {() => (
                     <Grid container spacing={4}>
                         <Grid item xs={6} md={3}>

--- a/storybook/src/docs/form/components/DateAndTimePickers/stories/DateRangePicker.stories.tsx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/stories/DateRangePicker.stories.tsx
@@ -8,8 +8,8 @@ import { Form } from "react-final-form";
 storiesOf("stories/form/components/Date & Time Pickers/Date-Range Picker", module)
     .add("Basic", () => {
         const [dateOne, setDateOne] = React.useState<DateRange | undefined>();
-        const [dateTwo, setDateTwo] = React.useState<DateRange | undefined>({ start: new Date(), end: new Date() });
-        const [dateThree, setDateThree] = React.useState<DateRange | undefined>({ start: new Date(), end: new Date() });
+        const [dateTwo, setDateTwo] = React.useState<DateRange | undefined>({ start: "2024-03-10", end: "2024-03-16" });
+        const [dateThree, setDateThree] = React.useState<DateRange | undefined>({ start: "2024-03-10", end: "2024-03-16" });
 
         return (
             <Grid container spacing={4}>
@@ -45,7 +45,7 @@ storiesOf("stories/form/components/Date & Time Pickers/Date-Range Picker", modul
 
         return (
             <Form<Values>
-                initialValues={{ dateTwo: { start: new Date(), end: new Date() }, dateThree: { start: new Date(), end: new Date() } }}
+                initialValues={{ dateTwo: { start: "2024-03-10", end: "2024-03-16" }, dateThree: { start: "2024-03-10", end: "2024-03-16" } }}
                 onSubmit={() => {}}
             >
                 {() => (


### PR DESCRIPTION
The reason for this change is that when selecting a date like `2024-04-10` in a timezone ahead of UTC, it would be stored in a `Date` object as e.g. `2024-04-09T22:00:00.000Z`. When only the date is saved to the database, without the time, it would be saved as `2024-04-09`, which differs from the selected date.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-640