### PR TITLE
Fix the key for accessing the themes `styleOverrides` and `defaultProps` of `CometAdminMenu`

### DIFF
--- a/.changeset/sharp-poems-shave.md
+++ b/.changeset/sharp-poems-shave.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix the key for accessing the themes `styleOverrides` and `defaultProps` of `CometAdminMenu`

--- a/packages/admin/admin/src/mui/menu/Menu.tsx
+++ b/packages/admin/admin/src/mui/menu/Menu.tsx
@@ -112,7 +112,7 @@ declare module "@mui/material/styles" {
     }
 
     interface Components {
-        CometAdminenu?: {
+        CometAdminMenu?: {
             defaultProps?: ComponentsPropsList["CometAdminMenu"];
             styleOverrides?: ComponentsOverrides<Theme>["CometAdminMenu"];
         };


### PR DESCRIPTION
---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)