### PR TITLE
Admin Generator Future: Allow using custom query for generating grid

### DIFF
--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -135,7 +135,7 @@ export function generateGrid(
     //const title = config.title ?? camelCaseToHumanReadable(gqlType);
     const instanceGqlType = gqlType[0].toLowerCase() + gqlType.substring(1);
     const instanceGqlTypePlural = gqlTypePlural[0].toLowerCase() + gqlTypePlural.substring(1);
-    const gridQuery = instanceGqlType != instanceGqlTypePlural ? instanceGqlTypePlural : `${instanceGqlTypePlural}List`;
+    const gridQuery = config.query ? config.query : instanceGqlType != instanceGqlTypePlural ? instanceGqlTypePlural : `${instanceGqlTypePlural}List`;
     const gqlDocuments: Record<string, string> = {};
     //const imports: Imports = [];
 

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -46,11 +46,11 @@ export type GridColumnConfig<T> = (
     | { type: "staticSelect"; values?: string[] }
     | { type: "block"; block: ImportReference }
 ) & { name: keyof T } & DataGridSettings;
-export type GridConfig<T extends { __typename?: string }, Queries extends { __typename?: "Query" } = { __typename: "Query" }> = {
+export type GridConfig<T extends { __typename?: string }> = {
     type: "grid";
     gqlType: T["__typename"];
     fragmentName?: string;
-    query?: keyof Omit<Queries, "__typename">;
+    query?: string;
     columns: GridColumnConfig<T>[];
     add?: boolean;
     edit?: boolean;

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -46,10 +46,11 @@ export type GridColumnConfig<T> = (
     | { type: "staticSelect"; values?: string[] }
     | { type: "block"; block: ImportReference }
 ) & { name: keyof T } & DataGridSettings;
-export type GridConfig<T extends { __typename?: string }> = {
+export type GridConfig<T extends { __typename?: string }, Queries extends { __typename?: "Query" } = { __typename: "Query" }> = {
     type: "grid";
     gqlType: T["__typename"];
     fragmentName?: string;
+    query?: keyof Omit<Queries, "__typename">;
     columns: GridColumnConfig<T>[];
     add?: boolean;
     edit?: boolean;


### PR DESCRIPTION
this allows to use any query, also probably future api-generated additional queries.

for now the developer needs to make sure gqlType-value and response-type of query do match. I didn't see a simple solution to enforce this with typescript types. maybe we should add some warnings/errors in future.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: <!-- For instance, COM-123 -->
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->
</details>
