### PR TITLE
Admin Gen Future: Fix missing type in generated columns config

### DIFF
--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -7,6 +7,7 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
     fragmentName: "ProductsGridFuture", // configurable as it must be unique across project
     filterProp: true,
     columns: [
+        { type: "boolean", name: "inStock", headerName: "In stock", width: 90 },
         { type: "text", name: "title", headerName: "Titel", minWidth: 200, maxWidth: 250 },
         { type: "text", name: "description", headerName: "Description" },
         { type: "number", name: "price", headerName: "Price", maxWidth: 150 },

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -109,6 +109,7 @@ export function ProductsGrid({ filter }: Props): React.ReactElement {
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };
 
     const columns: GridColDef<GQLProductsGridFutureFragment>[] = [
+        { field: "inStock", headerName: intl.formatMessage({ id: "product.inStock", defaultMessage: "In stock" }), type: "boolean", width: 90 },
         { field: "title", headerName: intl.formatMessage({ id: "product.title", defaultMessage: "Titel" }), flex: 1, maxWidth: 250, minWidth: 200 },
         {
             field: "description",
@@ -116,7 +117,14 @@ export function ProductsGrid({ filter }: Props): React.ReactElement {
             flex: 1,
             minWidth: 150,
         },
-        { field: "price", headerName: intl.formatMessage({ id: "product.price", defaultMessage: "Price" }), flex: 1, maxWidth: 150, minWidth: 150 },
+        {
+            field: "price",
+            headerName: intl.formatMessage({ id: "product.price", defaultMessage: "Price" }),
+            type: "number",
+            flex: 1,
+            maxWidth: 150,
+            minWidth: 150,
+        },
         {
             field: "type",
             headerName: intl.formatMessage({ id: "product.type", defaultMessage: "Type" }),

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -231,6 +231,10 @@ export function generateGrid(
         } else if (type == "date") {
             valueGetter = `({ value }) => value && new Date(value)`;
             gridType = "date";
+        } else if (type == "number") {
+            gridType = "number";
+        } else if (type == "boolean") {
+            gridType = "boolean";
         } else if (type == "block") {
             if (rootBlocks[name]) {
                 renderCell = `(params) => {


### PR DESCRIPTION
Adding type: number and type: boolean to improve filter-options support to prevent adding incompatible filters like "contains" for boolean or number.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: <!-- For instance, COM-123 -->
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->
</details>
