### PR TITLE
Improve typing of `@RootBlockEntity()` decorator

### DIFF
--- a/.changeset/rare-jars-add.md
+++ b/.changeset/rare-jars-add.md
@@ -1,0 +1,14 @@
+---
+"@comet/blocks-api": minor
+---
+
+Improve typing of `@RootBlockEntity()` decorator
+
+The target entity can now be passed as generic to have the correct type in `isVisible`:
+
+```ts
+@RootBlockEntity<Product>({
+    isVisible: (product) => product.visible,
+})
+export class Product extends BaseEntity<Product, "id"> {}
+```

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -55,7 +55,7 @@ export class ProductDimensions {
 
 @ObjectType()
 @Entity()
-@RootBlockEntity()
+@RootBlockEntity<Product>({ isVisible: (product) => product.visible })
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/` })
 export class Product extends BaseEntity<Product, "id"> {
     [OptionalProps]?: "createdAt" | "updatedAt";

--- a/packages/api/blocks-api/src/blocks/decorators/root-block-entity.ts
+++ b/packages/api/blocks-api/src/blocks/decorators/root-block-entity.ts
@@ -1,7 +1,14 @@
-export interface RootBlockEntityOptions {
-    isVisible?: (entity: unknown) => boolean;
+// Copied from @mikro-orm/core since we don't have a dependency on it in @comet/blocks-api.
+// TODO Remove type once we merge @comet/cms-api and @comet/blocks-api.
+// https://github.com/mikro-orm/mikro-orm/blob/master/packages/core/src/typings.ts#L237
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyEntity<T = any> = Partial<T>;
+
+export interface RootBlockEntityOptions<Entity extends AnyEntity = AnyEntity> {
+    isVisible?: (entity: Entity) => boolean;
 }
-export function RootBlockEntity(options: RootBlockEntityOptions = {}): ClassDecorator {
+export function RootBlockEntity<Entity extends AnyEntity = AnyEntity>(options: RootBlockEntityOptions<Entity> = {}): ClassDecorator {
     // eslint-disable-next-line @typescript-eslint/ban-types
     return function (target: Function) {
         Reflect.defineMetadata(`data:rootBlockEntityOptions`, options, target);


### PR DESCRIPTION
The target entity can now be passed as generic to have the correct type in `isVisible`:

```ts
@RootBlockEntity<Product>({
    isVisible: (product) => product.visible,
})
export class Product extends BaseEntity<Product, "id"> {}
```

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)