### PR TITLE
Site BlockLoader: add BlockLoaderDependencies, an interface with dependencies that get passed through recursivelyLoadBlockData into loader functions

### DIFF
--- a/.changeset/selfish-dolls-beg.md
+++ b/.changeset/selfish-dolls-beg.md
@@ -11,3 +11,4 @@ New Apis:
 - `recursivelyLoadBlockData`: used to call loaders for a block data tree
 - `BlockLoader`: type of a loader function that is responsible for one block
 - `useBlockPreviewFetch`: helper hook for block preview that creates client-side caching graphQLFetch/fetch
+- `BlockLoaderDependencies`: interface with dependencies that get passed through recursivelyLoadBlockData into loader functions. Can be extended using module augmentation in application to inject eg. pageTreeNodeId.

--- a/demo/site/src/app/block-preview/page/page.tsx
+++ b/demo/site/src/app/block-preview/page/page.tsx
@@ -23,6 +23,7 @@ const PreviewPage: React.FunctionComponent = () => {
                 blockData: iFrameBridge.block,
                 graphQLFetch,
                 fetch,
+                pageTreeNodeId: undefined, //we don't have a pageTreeNodeId in preview
             });
             setBlockData(newData);
         }

--- a/demo/site/src/documentTypes/Page.tsx
+++ b/demo/site/src/documentTypes/Page.tsx
@@ -69,12 +69,14 @@ export default async function Page({ pageTreeNodeId, scope }: { pageTreeNodeId: 
             blockData: data.pageContent.document.content,
             graphQLFetch,
             fetch,
+            pageTreeNodeId,
         }),
         recursivelyLoadBlockData({
             blockType: "Seo",
             blockData: data.pageContent.document.seo,
             graphQLFetch,
             fetch,
+            pageTreeNodeId,
         }),
     ]);
 

--- a/demo/site/src/recursivelyLoadBlockData.ts
+++ b/demo/site/src/recursivelyLoadBlockData.ts
@@ -1,13 +1,19 @@
-import { BlockLoader, GraphQLFetch, recursivelyLoadBlockData as cometRecursivelyLoadBlockData } from "@comet/cms-site";
+import { BlockLoader, BlockLoaderDependencies, recursivelyLoadBlockData as cometRecursivelyLoadBlockData } from "@comet/cms-site";
 
 import { loader as newsDetailLoader } from "./news/blocks/NewsDetailBlock.loader";
 
-const blockLoaders: Record<string, BlockLoader> = {
+declare module "@comet/cms-site" {
+    export interface BlockLoaderDependencies {
+        pageTreeNodeId?: string;
+    }
+}
+
+export const blockLoaders: Record<string, BlockLoader> = {
     NewsDetail: newsDetailLoader,
 };
 
 //small wrapper for @comet/cms-site recursivelyLoadBlockData that injects blockMeta from block-meta.json
-export async function recursivelyLoadBlockData(options: { blockType: string; blockData: unknown; graphQLFetch: GraphQLFetch; fetch: typeof fetch }) {
+export async function recursivelyLoadBlockData(options: { blockType: string; blockData: unknown } & BlockLoaderDependencies) {
     const blocksMeta = await import("../block-meta.json"); //dynamic import to avoid this json in client bundle
     return cometRecursivelyLoadBlockData({ ...options, blocksMeta: blocksMeta.default, loaders: blockLoaders });
 }

--- a/packages/site/cms-site/src/index.ts
+++ b/packages/site/cms-site/src/index.ts
@@ -1,4 +1,4 @@
-export { BlockLoader, recursivelyLoadBlockData } from "./blockLoader/blockLoader";
+export { BlockLoader, BlockLoaderDependencies, recursivelyLoadBlockData } from "./blockLoader/blockLoader";
 export { ExternalLinkBlock } from "./blocks/ExternalLinkBlock";
 export { BlocksBlock } from "./blocks/factories/BlocksBlock";
 export { ListBlock } from "./blocks/factories/ListBlock";


### PR DESCRIPTION
Can be extended using module augmentation in application to inject eg. pageTreeNodeId.

Add pageTreeNodeId in demo, although there is no loader that actually uses it.
