### PR TITLE
Add inital filter to useDataGridRemote hook

### DIFF
--- a/.changeset/late-tools-design.md
+++ b/.changeset/late-tools-design.md
@@ -1,0 +1,13 @@
+---
+"@comet/admin": minor
+---
+
+Add optional `initalFilter` Prop for useDataGridRemote hook
+
+**Example usage:**
+
+```diff
+const dataGridProps = useDataGridRemote({
+    initialFilter: { items: [{ columnField: "description", operatorValue: "contains", value: "text" }] },
+});
+```

--- a/.changeset/late-tools-design.md
+++ b/.changeset/late-tools-design.md
@@ -2,11 +2,11 @@
 "@comet/admin": minor
 ---
 
-Add optional `initalFilter` Prop for useDataGridRemote hook
+Add optional `initalFilter` prop for useDataGridRemote hook
 
 **Example usage:**
 
-```diff
+```tsx
 const dataGridProps = useDataGridRemote({
     initialFilter: { items: [{ columnField: "description", operatorValue: "contains", value: "text" }] },
 });

--- a/.changeset/late-tools-design.md
+++ b/.changeset/late-tools-design.md
@@ -2,7 +2,7 @@
 "@comet/admin": minor
 ---
 
-Add optional `initalFilter` prop for useDataGridRemote hook
+useDataGridRemote: Add `initialFilter` option
 
 **Example usage:**
 

--- a/packages/admin/admin/src/dataGrid/useDataGridRemote.test.ts
+++ b/packages/admin/admin/src/dataGrid/useDataGridRemote.test.ts
@@ -187,4 +187,27 @@ describe("useDataGridRemote", () => {
 
         expect(result.current.sortModel).toEqual(mockedUrlSortModel);
     });
+
+    it("should set empty initial filter if not provided", () => {
+        const { result } = renderHook(() => useDataGridRemote());
+
+        expect(result.current.filterModel).toEqual({ items: [] });
+    });
+
+    it("uses initial filter if no filter is set in the URL", () => {
+        const { result } = renderHook(() => useDataGridRemote({ initialFilter: mockedFilterModel }));
+
+        expect(result.current.filterModel).toBe(mockedFilterModel);
+    });
+
+    it("doesn't use initial default filter if filter is set in the URL", () => {
+        const mockedUrlFilterModel = { items: [{ columnField: "description", id: 1, operatorValue: "equal", value: "Test" }] };
+        useLocation.mockReturnValue({
+            search: queryString.stringify({ filter: '{"items":[{"columnField":"description","id":1,"operatorValue":"equal","value":"Test"}]}' }),
+        });
+
+        const { result } = renderHook(() => useDataGridRemote({ initialFilter: mockedFilterModel }));
+
+        expect(result.current.filterModel).toEqual(mockedUrlFilterModel);
+    });
 });

--- a/packages/admin/admin/src/dataGrid/useDataGridRemote.tsx
+++ b/packages/admin/admin/src/dataGrid/useDataGridRemote.tsx
@@ -8,10 +8,12 @@ export function useDataGridRemote({
     queryParamsPrefix = "",
     pageSize: initialPageSize = 25,
     initialSort,
+    initialFilter,
 }: {
     queryParamsPrefix?: string;
     pageSize?: number;
     initialSort?: Array<{ field: string; sort: GridSortDirection }>;
+    initialFilter?: GridFilterModel;
 } = {}): Omit<DataGridProps, "rows" | "columns"> & { page: number; pageSize: number; sortModel: GridSortModel } {
     const history = useHistory();
     const location = useLocation();
@@ -59,7 +61,7 @@ export function useDataGridRemote({
         [history, location, parsedSearch, sortParamName],
     );
 
-    const filterModel = parsedSearch[filterParamName] ? JSON.parse(parsedSearch[filterParamName] as string) : { items: [] };
+    const filterModel = parsedSearch[filterParamName] ? JSON.parse(parsedSearch[filterParamName] as string) : initialFilter ?? { items: [] };
     const handleFilterChange = React.useCallback(
         (filterModel: GridFilterModel) => {
             history.replace({ ...location, search: queryString.stringify({ ...parsedSearch, [filterParamName]: JSON.stringify(filterModel) }) });

--- a/storybook/src/docs/components/DataGrid/DataGrid.stories.mdx
+++ b/storybook/src/docs/components/DataGrid/DataGrid.stories.mdx
@@ -23,6 +23,7 @@ It's up to the application code to pass filterModel, sortModel and page/pageSize
 | pageSize          | number | Number of items per page, defaults to 20.                                        |
 | queryParamsPrefix | string | Prefix used for query parameters, useful when multiple DataGrid are on one page. |
 | initialSort       | Array<{ field: string; sort: GridSortDirection }> | Initial sort columns and directions. Used when no sort query params are present. |
+| initialFilter       | GridFilterModel | Initial grid filter. Used when no filter query params are present. |
 
 #### Example
 
@@ -34,6 +35,12 @@ It's up to the application code to pass filterModel, sortModel and page/pageSize
 
 <Canvas>
     <Story id="stories-components-datagrid--usedatagridremoteinitialsort" />
+</Canvas>
+
+#### Example Initial Filter
+
+<Canvas>
+    <Story id="stories-components-datagrid--usedatagridremoteinitialfilter" />
 </Canvas>
 
 ## usePersistentColumnState

--- a/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
+++ b/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
@@ -2,6 +2,7 @@ import { gql, useQuery } from "@apollo/client";
 import {
     CrudContextMenu,
     GridFilterButton,
+    muiGridFilterToGql,
     Toolbar,
     ToolbarFillSpace,
     ToolbarItem,
@@ -127,6 +128,58 @@ storiesOf("stories/components/DataGrid", module)
                     offset: dataGridProps.page * dataGridProps.pageSize,
                     sort: dataGridProps.sortModel[0]?.field,
                     order: dataGridProps.sortModel[0]?.sort,
+                },
+            },
+        );
+
+        const rows = data?.launchesPastResult.data ?? [];
+        const rowCount = useBufferedRowCount(data?.launchesPastResult.result.totalCount);
+
+        return (
+            <Box sx={{ height: 200, width: "100%" }}>
+                <DataGrid {...dataGridProps} rows={rows} rowCount={rowCount} columns={columns} loading={loading} error={error} />
+            </Box>
+        );
+    })
+    .add("useDataGridRemoteInitialFilter", () => {
+        const columns: GridColDef[] = [
+            {
+                field: "mission_name",
+                headerName: "Mission Name",
+                flex: 1,
+            },
+            {
+                field: "launch_date_local",
+                headerName: "Launch Date",
+                type: "dateTime",
+                flex: 1,
+            },
+        ];
+
+        const dataGridProps = useDataGridRemote({
+            initialFilter: { items: [{ columnField: "mission_name", operatorValue: "contains", value: "able" }] },
+        });
+
+        const { data, loading, error } = useQuery(
+            gql`
+                query LaunchesPast($limit: Int, $offset: Int, $filter: LaunchesPastFilter) {
+                    launchesPastResult(limit: $limit, offset: $offset, filter: $filter) {
+                        data {
+                            id
+                            mission_name
+                            launch_date_local
+                        }
+                        result {
+                            totalCount
+                        }
+                    }
+                }
+            `,
+            {
+                variables: {
+                    limit: dataGridProps.pageSize,
+                    offset: dataGridProps.page * dataGridProps.pageSize,
+                    filter: muiGridFilterToGql(columns, dataGridProps.filterModel).filter,
                 },
             },
         );


### PR DESCRIPTION
This PR enhances the `useDataGridRemote` hook with an additional `initialFilter` prop.
With this prop inital filter can be set to the dataGrid.

Why? In my projects it is often the case that I initially want to filter by data.


<details>
    <summary>Screenshots/screencasts</summary>


https://github.com/vivid-planet/comet/assets/34998750/9388c71c-792f-4945-8f8e-2e0fae4ae47b


</details>
