### PR TITLE
Fix calculation of `totalCount` in `DependenciesService#getDependents`

### DIFF
--- a/.changeset/dirty-cups-repair.md
+++ b/.changeset/dirty-cups-repair.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix calculation of `totalCount` in `DependenciesService#getDependents`

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -209,7 +209,7 @@ export class DependenciesService {
             ret.push(dependency);
         }
 
-        const countResult = await this.withCount(qb).select("rootId").groupBy(["rootId", "rootEntityName"]);
+        const countResult = await this.withCount(qb).select("targetId").groupBy(["targetId", "targetEntityName"]);
         const totalCount = countResult[0]?.count ?? 0;
 
         return new PaginatedDependencies(ret, Number(totalCount));


### PR DESCRIPTION
---

Previously:

<img width="475" alt="Bildschirmfoto 2024-04-16 um 23 52 48" src="https://github.com/vivid-planet/comet/assets/13380047/0f259169-98a4-4cb0-adfd-feb51ee6e5ee">


Now:

<img width="635" alt="Bildschirmfoto 2024-04-16 um 23 46 51" src="https://github.com/vivid-planet/comet/assets/13380047/91909685-c9fb-42b2-8929-225c840cd0f4">

