### PR TITLE
Use workspace version of `@comet/eslint-config` in `@comet/cli`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
         "prettier": "^2.7.1"
     },
     "devDependencies": {
-        "@comet/eslint-config": "^6.6.1",
+        "@comet/eslint-config": "workspace:^6.6.1",
         "@types/node": "^18.0.0",
         "eslint": "^8.0.0",
         "npm-run-all": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2436,7 +2436,7 @@ importers:
         version: 2.8.3
     devDependencies:
       '@comet/eslint-config':
-        specifier: ^6.6.1
+        specifier: workspace:^6.6.1
         version: link:../eslint-config
       '@types/node':
         specifier: ^18.0.0


### PR DESCRIPTION
Found this while changing a dependency in `next`.