### PR TITLE
Hide the "Dependents" tab in the DAM if the `DependenciesConfigProvider` is not configured

### DIFF
--- a/.changeset/blue-owls-learn.md
+++ b/.changeset/blue-owls-learn.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-admin": patch
+---
+
+Hide the "Dependents" tab in the DAM if the `DependenciesConfigProvider` is not configured
+
+Previously, the tab was always shown, even if the feature wasn't configured. Though it didn't cause an error, the tab showed no valuable information.
+
+Now, we hide the tab if no configuration is passed via the `DependenciesConfigProvider`.

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -27,6 +27,7 @@ import { Link as RouterLink } from "react-router-dom";
 import ReactSplit from "react-split";
 
 import { useContentScope } from "../../contentScope/Provider";
+import { useDependenciesConfig } from "../../dependencies/DependenciesConfig";
 import { DependencyList } from "../../dependencies/DependencyList";
 import { GQLFocalPoint, GQLImageCropAreaInput, GQLLicenseInput } from "../../graphql.generated";
 import { useDamConfig } from "../config/useDamConfig";
@@ -117,6 +118,7 @@ interface EditFileInnerProps {
 }
 
 const EditFileInner = ({ file, id }: EditFileInnerProps) => {
+    const dependencyMap = useDependenciesConfig();
     const intl = useIntl();
     const stackApi = useStackApi();
     const damConfig = useDamConfig();
@@ -279,18 +281,20 @@ const EditFileInner = ({ file, id }: EditFileInnerProps) => {
                                 >
                                     <Duplicates fileId={file.id} />
                                 </RouterTab>
-                                <RouterTab
-                                    key="dependents"
-                                    label={intl.formatMessage({ id: "comet.dam.file.dependents", defaultMessage: "Dependents" })}
-                                    path="/dependents"
-                                >
-                                    <DependencyList
-                                        query={damFileDependentsQuery}
-                                        variables={{
-                                            id: id,
-                                        }}
-                                    />
-                                </RouterTab>
+                                {Object.keys(dependencyMap).length > 0 && (
+                                    <RouterTab
+                                        key="dependents"
+                                        label={intl.formatMessage({ id: "comet.dam.file.dependents", defaultMessage: "Dependents" })}
+                                        path="/dependents"
+                                    >
+                                        <DependencyList
+                                            query={damFileDependentsQuery}
+                                            variables={{
+                                                id: id,
+                                            }}
+                                        />
+                                    </RouterTab>
+                                )}
                             </RouterTabs>
                         </ReactSplit>
                     </MainContent>


### PR DESCRIPTION
Previously, the tab was always shown, even if the feature wasn't configured. Though it didn't cause an error, the tab showed no valuable information. This basically forced projects to configure the feature or risk bad UX.

Now, we hide the tab completely if no configuration is passed via the `DependenciesConfigProvider`.