### PR TITLE
Router Prompt: actively reset form state when choosing discard in the prompt dialog

### DIFF
--- a/.changeset/metal-seas-listen.md
+++ b/.changeset/metal-seas-listen.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Router Prompt: actively reset form state when choosing discard in the prompt dialog

--- a/packages/admin/admin/src/FinalForm.tsx
+++ b/packages/admin/admin/src/FinalForm.tsx
@@ -87,6 +87,7 @@ function RouterPromptIf({
                 return true;
             }}
             saveAction={doSave}
+            resetAction={() => formApi.reset()}
             subRoutePath={subRoutePath}
         >
             {children}
@@ -198,14 +199,16 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
 
             return true;
         }, [formRenderProps.form]);
-
+        const doReset = React.useCallback(() => {
+            formRenderProps.form.reset();
+        }, [formRenderProps.form]);
         return (
             <FinalFormContextProvider {...formContext}>
                 {saveBoundaryApi && (
                     <FormSpy subscription={{ dirty: true }}>
                         {(props) => (
                             <>
-                                <Savable hasChanges={props.dirty} doSave={doSave} />
+                                <Savable hasChanges={props.dirty} doSave={doSave} doReset={doReset} />
                             </>
                         )}
                     </FormSpy>

--- a/packages/admin/admin/src/router/Context.tsx
+++ b/packages/admin/admin/src/router/Context.tsx
@@ -1,13 +1,14 @@
 import * as History from "history";
 import * as React from "react";
 
-import { SaveAction } from "./PromptHandler";
+import { ResetAction, SaveAction } from "./PromptHandler";
 
 interface IContext {
     register: (options: {
         id: string;
         message: (location: History.Location, action: History.Action) => string | boolean;
         saveAction?: SaveAction;
+        resetAction?: ResetAction;
         path: string;
         subRoutePath?: string;
     }) => void;

--- a/packages/admin/admin/src/router/Prompt.tsx
+++ b/packages/admin/admin/src/router/Prompt.tsx
@@ -5,7 +5,7 @@ import useConstant from "use-constant";
 import { v4 as uuid } from "uuid";
 
 import { RouterContext } from "./Context";
-import { SaveAction } from "./PromptHandler";
+import { ResetAction, SaveAction } from "./PromptHandler";
 import { SubRoute, useSubRoutePrefix } from "./SubRoute";
 
 // react-router Prompt doesn't support multiple Prompts, this one does
@@ -16,9 +16,10 @@ interface IProps {
      */
     message: (location: History.Location, action: History.Action) => boolean | string;
     saveAction?: SaveAction;
+    resetAction?: ResetAction;
     subRoutePath?: string;
 }
-export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, saveAction, subRoutePath, children }) => {
+export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, saveAction, resetAction, subRoutePath, children }) => {
     const id = useConstant<string>(() => uuid());
     const reactRouterContext = React.useContext(__RouterContext); // reactRouterContext can be undefined if no router is used, don't fail in that case
     const path: string | undefined = reactRouterContext?.match?.path;
@@ -29,7 +30,7 @@ export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, saveAct
     }
     React.useEffect(() => {
         if (context) {
-            context.register({ id, message, saveAction, path, subRoutePath });
+            context.register({ id, message, saveAction, resetAction, path, subRoutePath });
         } else {
             console.error("Can't register RouterPrompt, missing <RouterPromptHandler>");
         }

--- a/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
+++ b/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
@@ -68,6 +68,12 @@ export function SaveBoundary({ onAfterSave, ...props }: SaveBoundaryProps) {
         }
     }, [onAfterSave]);
 
+    const reset = React.useCallback(() => {
+        for (const savable of Object.values(saveStates.current)) {
+            savable.doReset?.();
+        }
+    }, []);
+
     const onSaveStatesChanged = React.useCallback(() => {
         const hasChanges = Object.values(saveStates.current).some((saveState) => saveState.hasChanges);
         setHasChanges(hasChanges);
@@ -97,6 +103,7 @@ export function SaveBoundary({ onAfterSave, ...props }: SaveBoundaryProps) {
                 return true;
             }}
             saveAction={save}
+            resetAction={reset}
             subRoutePath={subRoutePath}
         >
             <SavableContext.Provider
@@ -123,17 +130,18 @@ export function SaveBoundary({ onAfterSave, ...props }: SaveBoundaryProps) {
 export interface SavableProps {
     hasChanges: boolean;
     doSave: () => Promise<SaveActionSuccess> | SaveActionSuccess;
+    doReset?: () => void;
 }
 
-export function Savable({ doSave, hasChanges }: SavableProps) {
+export function Savable({ doSave, doReset, hasChanges }: SavableProps) {
     const id = useConstant<string>(() => uuid());
     const saveBoundaryApi = useSaveBoundaryApi();
     if (!saveBoundaryApi) throw new Error("Savable must be inside SaveBoundary");
     React.useEffect(() => {
-        saveBoundaryApi.register(id, { doSave, hasChanges });
+        saveBoundaryApi.register(id, { doSave, doReset, hasChanges });
         return function cleanup() {
             saveBoundaryApi.unregister(id);
         };
-    }, [id, doSave, hasChanges, saveBoundaryApi]);
+    }, [id, doSave, doReset, hasChanges, saveBoundaryApi]);
     return null;
 }


### PR DESCRIPTION
Fixes an issue where a form that doesn't unmount doesn't lose its state although the user chooses "Discard" in the prompt dialog.