### PR TITLE
Enable quote search in `searchToMikroOrmQuery`

### DIFF
--- a/.changeset/tiny-clouds-switch.md
+++ b/.changeset/tiny-clouds-switch.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Extend `searchToMikroOrmQuery` function to support quoted search strings.
+
+Quotes searches can be done with single (`'...'`) or double quotation marks (`"..."`).

--- a/packages/api/cms-api/src/common/filter/mikro-orm.ts
+++ b/packages/api/cms-api/src/common/filter/mikro-orm.ts
@@ -150,12 +150,21 @@ export function filtersToMikroOrmQuery(
     return genericFilter(filter);
 }
 
+const splitSearchString = (search: string) => {
+    const regex = /(["'])(?:(?=(\\?))\2.)*?\1|\S+/g;
+    const matches = search.match(regex) || [];
+
+    return matches.map((match) => {
+        const unescaped = match.replace(/\\(['"])/g, "$1");
+        const isQuoted = (unescaped.startsWith('"') && unescaped.endsWith('"')) || (unescaped.startsWith("'") && unescaped.endsWith("'"));
+        const content = isQuoted ? unescaped.slice(1, -1) : unescaped;
+        return `%${content.replace(/([%_\\])/g, "\\$1")}%`;
+    });
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function searchToMikroOrmQuery(search: string, fields: string[]): ObjectQuery<any> {
-    const quotedSearchParts = search
-        .trim()
-        .split(/ /)
-        .map((searchString) => `%${searchString.replace(/([%_\\])/g, "\\$1")}%`);
+    const quotedSearchParts = splitSearchString(search);
 
     const ors = [];
     for (const field of fields) {

--- a/packages/api/cms-api/src/common/filter/mikro-orm.ts
+++ b/packages/api/cms-api/src/common/filter/mikro-orm.ts
@@ -151,6 +151,8 @@ export function filtersToMikroOrmQuery(
 }
 
 const splitSearchString = (search: string) => {
+    // regex to match all single tokens or quotes in a string => "This is a 'quoted string'" will result in ["This", "is", "a", "quoted string"]
+    // it will also take escaped quotes (prepended with a backslash => \) into account
     const regex = /(["'])(?:(?=(\\?))\2.)*?\1|\S+/g;
     const matches = search.match(regex) || [];
 
@@ -158,6 +160,7 @@ const splitSearchString = (search: string) => {
         const unescaped = match.replace(/\\(['"])/g, "$1");
         const isQuoted = (unescaped.startsWith('"') && unescaped.endsWith('"')) || (unescaped.startsWith("'") && unescaped.endsWith("'"));
         const content = isQuoted ? unescaped.slice(1, -1) : unescaped;
+
         return `%${content.replace(/([%_\\])/g, "\\$1")}%`;
     });
 };


### PR DESCRIPTION
This extend `searchToMikroOrmQuery` function to support quoted search strings. Quotes searches can be done with single (`'...'`) or double quotation marks (`"..."`).

---

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-582
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screencast</summary>

https://github.com/vivid-planet/comet/assets/56400587/9eb75b5b-a865-47e6-b6e8-7bfcf8e63ea6

</details>
