### PR TITLE
Reduce access log spam

### DIFF
--- a/.changeset/purple-phones-visit.md
+++ b/.changeset/purple-phones-visit.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Enhanced the access log functionality to now skip logging for field resolvers in GraphQL context. This change improves the readability and relevance of our logs by reducing unnecessary entries.

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -161,7 +161,7 @@ export class AppModule {
                 ProductsModule,
                 AccessLogModule.forRoot({
                     shouldLogRequest: ({ user }) => {
-                        // ignore Basic Authed User
+                        // Ignore system user
                         if (user === true) {
                             return false;
                         }

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -159,7 +159,15 @@ export class AppModule {
                 PredefinedPageModule,
                 CronJobsModule,
                 ProductsModule,
-                AccessLogModule,
+                AccessLogModule.forRoot({
+                    shouldLogRequest: ({ user }) => {
+                        // ignore Basic Authed User
+                        if (user === true) {
+                            return false;
+                        }
+                        return true;
+                    },
+                }),
             ],
         };
     }


### PR DESCRIPTION
COM-660

This PR enhanced two things:
- the access log functionality to now skip logging for field resolvers
- in demo-api skip basic authed user in access log