### PR TITLE
Api Generator: add list option to @CrudGenerator to allow disabling the list query

### DIFF
--- a/.changeset/cyan-ladybugs-bathe.md
+++ b/.changeset/cyan-ladybugs-bathe.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Api Generator: add list option to @CrudGenerator to allow disabling the list query
+
+Related dto classes will still be generated, as they might be useful for application code

--- a/.changeset/cyan-ladybugs-bathe.md
+++ b/.changeset/cyan-ladybugs-bathe.md
@@ -2,6 +2,6 @@
 "@comet/cms-api": minor
 ---
 
-Api Generator: add list option to @CrudGenerator to allow disabling the list query
+API Generator: Add `list` option to `@CrudGenerator()` to allow disabling the list query
 
-Related dto classes will still be generated, as they might be useful for application code
+Related DTO classes will still be generated as they might be useful for application code.

--- a/packages/api/cms-api/src/generator/crud-generator.decorator.ts
+++ b/packages/api/cms-api/src/generator/crud-generator.decorator.ts
@@ -4,6 +4,7 @@ export interface CrudGeneratorOptions {
     create?: boolean;
     update?: boolean;
     delete?: boolean;
+    list?: boolean;
 }
 
 export function CrudGenerator({
@@ -12,10 +13,15 @@ export function CrudGenerator({
     create = true,
     update = true,
     delete: deleteMutation = true,
+    list = true,
 }: CrudGeneratorOptions): ClassDecorator {
     // eslint-disable-next-line @typescript-eslint/ban-types
     return function (target: Function) {
-        Reflect.defineMetadata(`data:crudGeneratorOptions`, { targetDirectory, requiredPermission, create, update, delete: deleteMutation }, target);
+        Reflect.defineMetadata(
+            `data:crudGeneratorOptions`,
+            { targetDirectory, requiredPermission, create, update, delete: deleteMutation, list },
+            target,
+        );
     };
 }
 

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -1072,6 +1072,7 @@ export async function generateCrud(generatorOptionsParam: CrudGeneratorOptions, 
         create: generatorOptionsParam.create ?? true,
         update: generatorOptionsParam.update ?? true,
         delete: generatorOptionsParam.delete ?? true,
+        list: generatorOptionsParam.list ?? true,
     };
 
     const generatedFiles: GeneratedFile[] = [];

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -903,6 +903,9 @@ function generateResolver({ generatorOptions, metadata }: { generatorOptions: Cr
                 : ""
         }
 
+        ${
+            generatorOptions.list
+                ? `
         @Query(() => Paginated${classNamePlural})
         ${rootArgProps
             .map((rootArgProp) => {
@@ -984,7 +987,9 @@ function generateResolver({ generatorOptions, metadata }: { generatorOptions: Cr
 
             const [entities, totalCount] = await this.repository.findAndCount(where, options);
             return new Paginated${classNamePlural}(entities, totalCount);
-
+        }
+        `
+                : ""
         }
 
         ${

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -970,8 +970,8 @@ function generateResolver({ generatorOptions, metadata }: { generatorOptions: Cr
 
             ${hasOutputRelations ? `// eslint-disable-next-line @typescript-eslint/no-explicit-any` : ""}
             const options: FindOptions<${metadata.className}${hasOutputRelations ? `, any` : ""}> = { offset, limit${
-        hasOutputRelations ? `, populate` : ""
-    }};
+                      hasOutputRelations ? `, populate` : ""
+                  }};
 
             ${
                 hasSortArg


### PR DESCRIPTION
Sometimes the list query is not needed because special fooByBar are created in application code