### PR TITLE
Fix scope check for DAM bulk actions

### DIFF
--- a/.changeset/chatty-eagles-visit.md
+++ b/.changeset/chatty-eagles-visit.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Add `nullable` param to `@AffectedEntity` to support id args that can be `null` or `undefined`

--- a/.changeset/cool-toys-mix.md
+++ b/.changeset/cool-toys-mix.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix mutations `moveDamFiles`, `copyFilesToScope`, `archiveDamFiles` and `restoreDamFiles` by adding `@AffectedEntity` to enable scope checks

--- a/packages/api/cms-api/src/dam/dam.module.ts
+++ b/packages/api/cms-api/src/dam/dam.module.ts
@@ -73,7 +73,7 @@ export class DamModule {
         };
 
         const DamItemsResolver = createDamItemsResolver({ File, Folder, Scope });
-        const FilesResolver = createFilesResolver({ File, Scope });
+        const FilesResolver = createFilesResolver({ File, Folder, Scope });
         const FileDependentsResolver = DependentsResolverFactory.create(File);
         const FoldersResolver = createFoldersResolver({ Folder, Scope });
 

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -124,7 +124,7 @@ export function createFilesResolver({
         }
 
         @Mutation(() => [File])
-        @AffectedEntity(Folder, { idArg: "targetFolderId" })
+        @AffectedEntity(Folder, { idArg: "targetFolderId", nullable: true })
         @AffectedEntity(File, { idArg: "fileIds" })
         @SkipBuild()
         async moveDamFiles(

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -29,7 +29,15 @@ import { FileValidationService } from "./file-validation.service";
 import { FilesService } from "./files.service";
 import { slugifyFilename } from "./files.utils";
 
-export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<FileInterface>; Scope?: Type<DamScopeInterface> }): Type<unknown> {
+export function createFilesResolver({
+    File,
+    Folder,
+    Scope: PassedScope,
+}: {
+    File: Type<FileInterface>;
+    Folder: Type<FolderInterface>;
+    Scope?: Type<DamScopeInterface>;
+}): Type<unknown> {
     const Scope = PassedScope ?? EmptyDamScope;
     const hasNonEmptyScope = PassedScope != null;
 
@@ -116,6 +124,8 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
         }
 
         @Mutation(() => [File])
+        @AffectedEntity(Folder, { idArg: "targetFolderId" })
+        @AffectedEntity(File, { idArg: "fileIds" })
         @SkipBuild()
         async moveDamFiles(
             @Args({ type: () => MoveDamFilesArgs }) { fileIds, targetFolderId }: MoveDamFilesArgs,
@@ -124,28 +134,16 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
             let targetFolder = null;
             if (targetFolderId !== null) {
                 targetFolder = await this.foldersRepository.findOneOrFail(targetFolderId);
-
-                if (targetFolder.scope !== undefined && !this.accessControlService.isAllowed(user, "dam", targetFolder.scope)) {
-                    throw new Error("Can't access parent folder");
-                }
             }
 
-            const files = [];
-
-            for (const id of fileIds) {
-                const file = await this.filesRepository.findOneOrFail(id);
-
-                if (file.scope !== undefined && !this.accessControlService.isAllowed(user, "dam", file.scope)) {
-                    throw new Error("Can't access file");
-                }
-
-                files.push(file);
-            }
+            const files = await this.filesRepository.find({ id: { $in: fileIds } });
 
             return this.filesService.moveBatch(files, targetFolder);
         }
 
         @Mutation(() => CopyFilesResponse)
+        @AffectedEntity(File, { idArg: "fileIds" })
+        @AffectedEntity(Folder, { idArg: "inboxFolderId" })
         @SkipBuild()
         async copyFilesToScope(
             @GetCurrentUser() user: CurrentUser,
@@ -155,7 +153,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
             })
             inboxFolderId: string,
         ): Promise<CopyFilesResponseInterface> {
-            return this.filesService.copyFilesToScope({ fileIds, inboxFolderId, user });
+            return this.filesService.copyFilesToScope({ fileIds, inboxFolderId });
         }
 
         @Mutation(() => File)
@@ -170,6 +168,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
         }
 
         @Mutation(() => [File])
+        @AffectedEntity(File, { idArg: "ids" })
         @SkipBuild()
         async archiveDamFiles(@Args("ids", { type: () => [ID] }) ids: string[]): Promise<FileInterface[]> {
             const entities = await this.filesRepository.find({ id: { $in: ids } });
@@ -194,6 +193,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
         }
 
         @Mutation(() => [File])
+        @AffectedEntity(File, { idArg: "ids" })
         @SkipBuild()
         async restoreDamFiles(@Args("ids", { type: () => [ID] }) ids: string[]): Promise<FileInterface[]> {
             const entities = await this.filesRepository.find({ id: { $in: ids } });

--- a/packages/api/cms-api/src/user-permissions/decorators/affected-entity.decorator.ts
+++ b/packages/api/cms-api/src/user-permissions/decorators/affected-entity.decorator.ts
@@ -3,6 +3,7 @@ import { EntityClass, EntityName } from "@mikro-orm/core";
 export interface AffectedEntityOptions {
     idArg?: string;
     pageTreeNodeIdArg?: string;
+    nullable?: boolean;
 }
 export type AffectedEntityMeta = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -13,11 +14,11 @@ export type AffectedEntityMeta = {
 export const AffectedEntity = (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entity: EntityName<any>,
-    { idArg, pageTreeNodeIdArg }: AffectedEntityOptions = { idArg: "id" },
+    { idArg, pageTreeNodeIdArg, nullable }: AffectedEntityOptions = { idArg: "id" },
 ): MethodDecorator => {
     return (target: object, key: string | symbol, descriptor: PropertyDescriptor) => {
         const metadata = Reflect.getOwnMetadata("affectedEntities", descriptor.value) || [];
-        metadata.push({ entity, options: { idArg, pageTreeNodeIdArg } });
+        metadata.push({ entity, options: { idArg, pageTreeNodeIdArg, nullable } });
         Reflect.defineMetadata("affectedEntities", metadata, descriptor.value);
         return descriptor;
     };


### PR DESCRIPTION
Currently, the mutations `moveDamFiles`, `copyFilesToScope`, `archiveDamFiles` and `restoreDamFiles` all cause an error because they don't have `@AffectedEntity` or `skipScopeCheck`.

This PR adds `@AffectedEntity` to all of them and removes previously added custom scope validation logic. It further adds a `nullable` param to `@AffectedEntity` for idArgs that can be null or undefined.

---

An alternative (for `moveDamFiles` and `copyFilesToScope`) would have been to skip the scope check and rely on the custom scope logic. But I thought it's nicer to use the built-in solution.