### PR TITLE
Add `GridCellText` component

### DIFF
--- a/.changeset/modern-glasses-sort.md
+++ b/.changeset/modern-glasses-sort.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": minor
+---
+
+Add the `GridCellText` component
+
+Used to display primary and secondary values in a `DataGrid` cell using the columns `renderCell` function.

--- a/packages/admin/admin/src/dataGrid/GridCellText.tsx
+++ b/packages/admin/admin/src/dataGrid/GridCellText.tsx
@@ -1,0 +1,106 @@
+import { ComponentsOverrides, css, Theme, Typography, useThemeProps } from "@mui/material";
+import React from "react";
+
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+
+export type GridCellTextClassKey = "root" | "hasSecondaryText" | "primaryText" | "secondaryText";
+
+export interface GridCellTextProps
+    extends ThemedComponentBaseProps<{
+        root: "div";
+        primaryText: typeof Typography;
+        secondaryText: typeof Typography;
+    }> {
+    primary: React.ReactNode;
+    secondary?: React.ReactNode;
+}
+
+type OwnerState = {
+    hasSecondaryText: boolean;
+};
+
+export const GridCellText = (inProps: GridCellTextProps) => {
+    const { primary, secondary, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminGridCellText" });
+
+    const ownerState: OwnerState = {
+        hasSecondaryText: Boolean(secondary),
+    };
+
+    return (
+        <Root ownerState={ownerState} {...slotProps?.root} {...restProps}>
+            <PrimaryText ownerState={ownerState} {...slotProps?.primaryText}>
+                {primary}
+            </PrimaryText>
+            {ownerState.hasSecondaryText && <SecondaryText {...slotProps?.secondaryText}>{secondary}</SecondaryText>}
+        </Root>
+    );
+};
+
+const Root = createComponentSlot("div")<GridCellTextClassKey, OwnerState>({
+    componentName: "GridCellText",
+    slotName: "root",
+    classesResolver(ownerState) {
+        return [ownerState.hasSecondaryText && "hasSecondaryText"];
+    },
+})(css`
+    overflow: hidden;
+`);
+
+const ellipsisStyles = css`
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+`;
+
+const PrimaryText = createComponentSlot(Typography)<GridCellTextClassKey, OwnerState>({
+    componentName: "GridCellText",
+    slotName: "primaryText",
+})(
+    ({ theme, ownerState }) => css`
+        color: ${theme.palette.grey[800]};
+        font-size: 12px;
+        font-weight: ${ownerState.hasSecondaryText ? 400 : 300};
+        line-height: 16px;
+        ${ellipsisStyles}
+
+        ${theme.breakpoints.up("md")} {
+            font-size: 14px;
+            line-height: 20px;
+        }
+    `,
+);
+
+const SecondaryText = createComponentSlot(Typography)<GridCellTextClassKey>({
+    componentName: "GridCellText",
+    slotName: "secondaryText",
+})(
+    ({ theme }) => css`
+        color: ${theme.palette.grey[300]};
+        font-size: 10px;
+        font-weight: 400;
+        line-height: 16px;
+        ${ellipsisStyles}
+
+        ${theme.breakpoints.up("md")} {
+            font-size: 12px;
+        }
+    `,
+);
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminGridCellText: GridCellTextProps;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminGridCellText: GridCellTextClassKey;
+    }
+
+    interface Components {
+        CometAdminGridCellText?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminGridCellText"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminGridCellText"];
+        };
+    }
+}

--- a/packages/admin/admin/src/dataGrid/GridCellText.tsx
+++ b/packages/admin/admin/src/dataGrid/GridCellText.tsx
@@ -31,7 +31,7 @@ export const GridCellText = (inProps: GridCellTextProps) => {
     return (
         <Root ownerState={ownerState} {...slotProps?.root} {...restProps}>
             <PrimaryText ownerState={ownerState} {...slotProps?.primaryText}>
-                {children ? children : primary}
+                {primary ? primary : children}
             </PrimaryText>
             {ownerState.hasSecondaryText && <SecondaryText {...slotProps?.secondaryText}>{secondary}</SecondaryText>}
         </Root>

--- a/packages/admin/admin/src/dataGrid/GridCellText.tsx
+++ b/packages/admin/admin/src/dataGrid/GridCellText.tsx
@@ -12,8 +12,9 @@ export interface GridCellTextProps
         primaryText: typeof Typography;
         secondaryText: typeof Typography;
     }> {
-    primary: React.ReactNode;
+    primary?: React.ReactNode;
     secondary?: React.ReactNode;
+    children?: React.ReactNode;
 }
 
 type OwnerState = {
@@ -21,7 +22,7 @@ type OwnerState = {
 };
 
 export const GridCellText = (inProps: GridCellTextProps) => {
-    const { primary, secondary, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminGridCellText" });
+    const { children, primary, secondary, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminGridCellText" });
 
     const ownerState: OwnerState = {
         hasSecondaryText: Boolean(secondary),
@@ -30,7 +31,7 @@ export const GridCellText = (inProps: GridCellTextProps) => {
     return (
         <Root ownerState={ownerState} {...slotProps?.root} {...restProps}>
             <PrimaryText ownerState={ownerState} {...slotProps?.primaryText}>
-                {primary}
+                {children ? children : primary}
             </PrimaryText>
             {ownerState.hasSecondaryText && <SecondaryText {...slotProps?.secondaryText}>{secondary}</SecondaryText>}
         </Root>

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -40,6 +40,7 @@ export { Tooltip, TooltipClassKey, TooltipProps } from "./common/Tooltip";
 export { ContentOverflow, ContentOverflowClassKey, ContentOverflowProps } from "./ContentOverflow";
 export { CrudContextMenu } from "./dataGrid/CrudContextMenu";
 export { CrudVisibility, CrudVisibilityProps } from "./dataGrid/CrudVisibility";
+export { GridCellText, GridCellTextClassKey, GridCellTextProps } from "./dataGrid/GridCellText";
 export { GridFilterButton } from "./dataGrid/GridFilterButton";
 export { muiGridFilterToGql } from "./dataGrid/muiGridFilterToGql";
 export { muiGridPagingToGql } from "./dataGrid/muiGridPagingToGql";

--- a/storybook/src/docs/components/GridCellText/GridCellText.stories.mdx
+++ b/storybook/src/docs/components/GridCellText/GridCellText.stories.mdx
@@ -1,0 +1,11 @@
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
+
+<Meta title="Docs/Components/GridCellText" />
+
+# GridCellText
+
+Used to display primary and secondary values in a `DataGrid` cell using the columns `renderCell` function.
+
+<Canvas>
+    <Story id="stories-components-gridcelltext--gridcelltext" />
+</Canvas>

--- a/storybook/src/docs/components/GridCellText/GridCellText.stories.tsx
+++ b/storybook/src/docs/components/GridCellText/GridCellText.stories.tsx
@@ -1,0 +1,36 @@
+import { GridCellText } from "@comet/admin";
+import { faker } from "@faker-js/faker";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+storiesOf("stories/components/GridCellText", module).add("GridCellText", () => {
+    const gridRows = Array.from({ length: 5 }).map((_, index) => ({
+        id: index + 1,
+        name: faker.name.fullName(),
+        occupation: faker.name.jobTitle(),
+        company: faker.company.name(),
+        email: faker.internet.email(),
+    }));
+
+    const gridColumns: GridColDef[] = [
+        {
+            field: "person",
+            headerName: "Person",
+            flex: 1,
+            renderCell: ({ row }) => <GridCellText primary={row.name} secondary={row.occupation} />,
+        },
+        {
+            field: "company",
+            headerName: "Company",
+            flex: 1,
+        },
+        {
+            field: "email",
+            headerName: "Email",
+            flex: 1,
+        },
+    ];
+
+    return <DataGrid autoHeight rows={gridRows} columns={gridColumns} disableSelectionOnClick />;
+});


### PR DESCRIPTION
Used to display primary and secondary values in a `DataGrid` cell using the columns `renderCell` function.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: SVK-236
-   [x] Provide screenshots/screencasts if the change contains visual changes

<img width="938" alt="DataGrid using GridCellText to display a persons name and occupation in a single column" src="https://github.com/vivid-planet/comet/assets/6264317/d9cc061c-5627-45d7-99c8-5cdd1af77522">
