### PR TITLE
Fix `RichTextBlock` draft content validation

### DIFF
--- a/.changeset/poor-cooks-protect.md
+++ b/.changeset/poor-cooks-protect.md
@@ -1,0 +1,7 @@
+---
+"@comet/blocks-api": patch
+---
+
+Fix `RichTextBlock` draft content validation
+
+Extend validation to validate inline links in draft content.

--- a/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
+++ b/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
@@ -205,11 +205,8 @@ function IsDraftContent(link: Block, validationOptions?: ValidationOptions) {
                 async validate(value: unknown, args: ValidationArguments) {
                     const LinkBlock = args.constraints[0] as Block;
 
-                    if (typeof value === "object" && value !== null) {
-                        // TODO check if object matches RawDraftContentState
-                        const { entityMap } = value as DraftJsInput<ExtractBlockInput<typeof LinkBlock>>;
-
-                        for (const entity of Object.values(entityMap)) {
+                    if (isDraftJsInput(value)) {
+                        for (const entity of Object.values(value.entityMap)) {
                             const validationErrors = await validate(LinkBlock.blockInputFactory(entity.data), {
                                 forbidNonWhitelisted: true,
                                 whitelist: true,
@@ -229,4 +226,17 @@ function IsDraftContent(link: Block, validationOptions?: ValidationOptions) {
             },
         });
     };
+}
+
+function isDraftJsInput(value: unknown): value is DraftJsInput<BlockInputInterface> {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "blocks" in value &&
+        "entityMap" in value &&
+        Array.isArray(value.blocks) &&
+        typeof value.entityMap === "object" &&
+        value.entityMap !== null &&
+        Object.values(value.entityMap).every((entity) => typeof entity === "object" && entity !== null && entity.type === "LINK")
+    );
 }

--- a/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
+++ b/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
@@ -213,7 +213,6 @@ function IsDraftContent(link: Block, validationOptions?: ValidationOptions) {
                             });
 
                             if (validationErrors.length > 0) {
-                                // TODO better error message
                                 return false;
                             }
                         }

--- a/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
+++ b/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
@@ -1,5 +1,5 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
-import { Allow, IsObject } from "class-validator";
+import { registerDecorator, validate, ValidationArguments, ValidationOptions } from "class-validator";
 import type { DraftBlockType, DraftEntityMutability, DraftInlineStyleType, RawDraftContentState, RawDraftEntityRange } from "draft-js";
 
 import { createAppliedMigrationsBlockDataFactoryDecorator } from "../migrations/createAppliedMigrationsBlockDataFactoryDecorator";
@@ -106,8 +106,7 @@ export function createRichTextBlock<LinkBlock extends Block>(
     }
 
     class RichTextBlockInput implements RichTextBlockInputInterface<ExtractBlockInput<LinkBlock>> {
-        @Allow()
-        @IsObject()
+        @IsDraftContent(LinkBlock)
         @BlockField({ type: "json" })
         draftContent: DraftJsInput<ExtractBlockInput<LinkBlock>>;
 
@@ -191,4 +190,43 @@ export function createRichTextBlock<LinkBlock extends Block>(
     registerBlock(RichTextBlock);
 
     return RichTextBlock;
+}
+
+function IsDraftContent(link: Block, validationOptions?: ValidationOptions) {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    return function (object: Object, propertyName: string) {
+        registerDecorator({
+            name: "isDraftContent",
+            target: object.constructor,
+            propertyName,
+            constraints: [link],
+            options: validationOptions,
+            validator: {
+                async validate(value: unknown, args: ValidationArguments) {
+                    const LinkBlock = args.constraints[0] as Block;
+
+                    if (typeof value === "object" && value !== null) {
+                        // TODO check if object matches RawDraftContentState
+                        const { entityMap } = value as DraftJsInput<ExtractBlockInput<typeof LinkBlock>>;
+
+                        for (const entity of Object.values(entityMap)) {
+                            const validationErrors = await validate(LinkBlock.blockInputFactory(entity.data), {
+                                forbidNonWhitelisted: true,
+                                whitelist: true,
+                            });
+
+                            if (validationErrors.length > 0) {
+                                // TODO better error message
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    }
+
+                    return false;
+                },
+            },
+        });
+    };
 }


### PR DESCRIPTION
Extend validation to validate inline links in draft content.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-707
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    

https://github.com/vivid-planet/comet/assets/48853629/7c953d90-99a5-47a7-a2ea-91222ff10e1b


</details>
