### PR TITLE
Prevent block-meta.json write in read-only file systems

### DIFF
--- a/.changeset/kind-spiders-kneel.md
+++ b/.changeset/kind-spiders-kneel.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Prevent block-meta.json write in read-only file systems

--- a/packages/api/cms-api/src/blocks/blocks-meta.service.ts
+++ b/packages/api/cms-api/src/blocks/blocks-meta.service.ts
@@ -4,7 +4,18 @@ import { promises as fs } from "fs";
 
 export class BlocksMetaService implements OnModuleInit {
     async onModuleInit(): Promise<void> {
-        const metaJson = getBlocksMeta();
-        await fs.writeFile("block-meta.json", JSON.stringify(metaJson, null, 4));
+        let canWrite: boolean;
+
+        try {
+            await fs.access("block-meta.json", fs.constants.W_OK);
+            canWrite = true;
+        } catch {
+            canWrite = false;
+        }
+
+        if (canWrite) {
+            const metaJson = getBlocksMeta();
+            await fs.writeFile("block-meta.json", JSON.stringify(metaJson, null, 4));
+        }
     }
 }


### PR DESCRIPTION
This issue came up in one of our customer projects that has a read-only file system. Use `fs.access` to check if we can write before writing the file.
