### PR TITLE
Prevent block-meta.json write in read-only file systems (v5)

### DIFF
--- a/.changeset/kind-spiders-kneel.md
+++ b/.changeset/kind-spiders-kneel.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Prevent block-meta.json write in read-only file systems

--- a/packages/api/cms-api/src/blocks/blocks-meta.service.ts
+++ b/packages/api/cms-api/src/blocks/blocks-meta.service.ts
@@ -1,9 +1,24 @@
 import { getBlocksMeta } from "@comet/blocks-api";
-import { OnModuleInit } from "@nestjs/common";
+import { Logger, OnModuleInit } from "@nestjs/common";
 import { promises as fs } from "fs";
+
 export class BlocksMetaService implements OnModuleInit {
+    private readonly logger = new Logger(BlocksMetaService.name);
+
     async onModuleInit(): Promise<void> {
-        const metaJson = getBlocksMeta();
-        await fs.writeFile("block-meta.json", JSON.stringify(metaJson, null, 4));
+        let canWrite: boolean;
+
+        try {
+            await fs.access("block-meta.json", fs.constants.W_OK);
+            canWrite = true;
+        } catch (error) {
+            this.logger.warn("Cannot write block-meta.json file");
+            canWrite = false;
+        }
+
+        if (canWrite) {
+            const metaJson = getBlocksMeta();
+            await fs.writeFile("block-meta.json", JSON.stringify(metaJson, null, 4));
+        }
     }
 }


### PR DESCRIPTION
Backport #1983 into v5.
