### PR TITLE
Remove list-exports scripts

### DIFF
--- a/packages/api/blocks-api/list-exports.ts
+++ b/packages/api/blocks-api/list-exports.ts
@@ -1,5 +1,0 @@
-import * as all from "./src";
-
-Object.keys(all).forEach((i) => {
-    console.log(i);
-});

--- a/packages/api/blocks-api/package.json
+++ b/packages/api/blocks-api/package.json
@@ -21,7 +21,6 @@
         "lint": "run-p lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0 src/ package.json",
         "lint:tsc": "tsc --noEmit",
-        "list-exports": "ts-node list-exports.ts",
         "test": "jest --verbose=true",
         "test:watch": "jest -w"
     },

--- a/packages/api/cms-api/list-exports.ts
+++ b/packages/api/cms-api/list-exports.ts
@@ -1,5 +1,0 @@
-import * as all from "./src";
-
-Object.keys(all).forEach((i) => {
-    console.log(i);
-});

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -27,7 +27,6 @@
         "generate-schema:watch": "chokidar \"src/\" -c \"$npm_execpath generate-schema\"",
         "generate-block-meta": "ts-node generate-block-meta.ts",
         "generate-block-meta:watch": "chokidar \"src/\" -c \"$npm_execpath generate-block-meta\"",
-        "list-exports": "ts-node list-exports.ts",
         "test": "jest",
         "test:watch": "jest --watch"
     },


### PR DESCRIPTION
This is not needed anymore since all our exports are in `src/index.ts`.