### PR TITLE
Don't remove references to `DamFile` from blocks when copying a document from one scope to another if DAM scoping is not enabled

### DIFF
--- a/.changeset/new-mugs-compare.md
+++ b/.changeset/new-mugs-compare.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Don't remove references to `DamFile` from blocks when copying a document from one scope to another if DAM scoping is not enabled

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
@@ -418,6 +418,7 @@ function unhandledDependenciesFromDocument(
 ) {
     const unhandledDependencies = documentType.dependencies(document).filter((dependency) => {
         if (dependency.targetGraphqlObjectType === "DamFile" && !hasDamScope) {
+            // If there is no DAM scoping (DAM = global), the dependency is not unhandled. It's handled correctly by doing nothing
             return false;
         }
 

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
@@ -413,16 +413,17 @@ function createPageTreeNodeIdReplacements(nodes: PageClipboard[]): ReplaceDepend
 function unhandledDependenciesFromDocument(
     documentType: DocumentInterface,
     document: GQLDocument,
-    { existingReplacements }: { existingReplacements: ReplaceDependencyObject[] },
+    { existingReplacements, hasDamScope = false }: { existingReplacements: ReplaceDependencyObject[]; hasDamScope?: boolean },
 ) {
-    const unhandledDependencies = documentType
-        .dependencies(document)
-        .filter(
-            (dependency) =>
-                !existingReplacements.some(
-                    (replacement) => replacement.originalId === dependency.id && replacement.type === dependency.targetGraphqlObjectType,
-                ),
+    const unhandledDependencies = documentType.dependencies(document).filter((dependency) => {
+        if (dependency.targetGraphqlObjectType === "DamFile" && !hasDamScope) {
+            return false;
+        }
+
+        return !existingReplacements.some(
+            (replacement) => replacement.originalId === dependency.id && replacement.type === dependency.targetGraphqlObjectType,
         );
+    });
 
     return unhandledDependencies;
 }

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
@@ -359,6 +359,7 @@ export async function sendPages(
             if (sourcePage.document && !isEqual(sourceContentScope, targetContentScope)) {
                 const unhandledDependencies = unhandledDependenciesFromDocument(documentType, sourcePage.document, {
                     existingReplacements: dependencyReplacements,
+                    hasDamScope,
                 });
                 const replacementsForUnhandledDependencies = createUndefinedReplacementsForDependencies(unhandledDependencies);
                 dependencyReplacements.push(...replacementsForUnhandledDependencies);


### PR DESCRIPTION
COM-658