### PR TITLE
Handle DAM scope correctly in the `findCopiesOfFileInScope` query and the `importDamFileByDownload` mutation

### DIFF
--- a/.changeset/odd-lions-cover.md
+++ b/.changeset/odd-lions-cover.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Handle DAM scope correctly in the `findCopiesOfFileInScope` query and the `importDamFileByDownload` mutation
+
+Previously, these endpoints would cause errors if no DAM scoping was used.

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -89,7 +89,7 @@ export function createFilesResolver({
         async findCopiesOfFileInScope(
             @Args({ type: () => FindCopiesOfFileInScopeArgs }) { id, scope, imageCropArea }: FindCopiesOfFileInScopeArgsInterface,
         ): Promise<FileInterface[]> {
-            return this.filesService.findCopiesOfFileInScope(id, imageCropArea, scope);
+            return this.filesService.findCopiesOfFileInScope(id, imageCropArea, nonEmptyScopeOrNothing(scope));
         }
 
         @Mutation(() => File)
@@ -118,7 +118,7 @@ export function createFilesResolver({
                 ...input,
                 imageCropArea: imageInput?.cropArea,
                 folderId: input.folderId ? input.folderId : undefined,
-                scope,
+                scope: nonEmptyScopeOrNothing(scope),
             });
             return uploadedFile;
         }


### PR DESCRIPTION
---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-658
