### PR TITLE
Handle DAM scope correctly in the `findCopiesOfFileInScope` query and the `importDamFileByDownload` mutation

### DIFF
--- a/.changeset/odd-lions-cover.md
+++ b/.changeset/odd-lions-cover.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Handle DAM scope correctly in the `findCopiesOfFileInScope` query and the `importDamFileByDownload` mutation
+
+Previously, these endpoints would cause errors if no DAM scoping was used.

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -80,7 +80,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
         async findCopiesOfFileInScope(
             @Args({ type: () => FindCopiesOfFileInScopeArgs }) { id, scope, imageCropArea }: FindCopiesOfFileInScopeArgsInterface,
         ): Promise<FileInterface[]> {
-            return this.filesService.findCopiesOfFileInScope(id, imageCropArea, scope);
+            return this.filesService.findCopiesOfFileInScope(id, imageCropArea, nonEmptyScopeOrNothing(scope));
         }
 
         @Mutation(() => File)
@@ -109,7 +109,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
                 ...input,
                 imageCropArea: imageInput?.cropArea,
                 folderId: input.folderId ? input.folderId : undefined,
-                scope,
+                scope: nonEmptyScopeOrNothing(scope),
             });
             return uploadedFile;
         }


### PR DESCRIPTION
Backport of https://github.com/vivid-planet/comet/pull/1996