### PR TITLE
Don't remove references to `DamFile` from blocks when copying a document from one scope to another if DAM scoping is not enabled (v5)

### DIFF
--- a/.changeset/new-mugs-compare.md
+++ b/.changeset/new-mugs-compare.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Don't remove references to `DamFile` from blocks when copying a document from one scope to another if DAM scoping is not enabled


### PR DESCRIPTION
Backport https://github.com/vivid-planet/comet/pull/1992