### PR TITLE
Fix losing custom block types when converting between editor state and HTML

### DIFF
--- a/.changeset/over-nine-thousand.md
+++ b/.changeset/over-nine-thousand.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": minor
+---
+
+Add support for block styles for the rte translation
+
+

--- a/.changeset/over-nine-thousand.md
+++ b/.changeset/over-nine-thousand.md
@@ -1,7 +1,5 @@
 ---
-"@comet/admin": minor
+"@comet/admin-rte": patch
 ---
 
-Add support for block styles for the rte translation
-
-
+Fix losing custom block types when converting between editor state and HTML

--- a/packages/admin/admin-rte/src/core/translation/htmlToState.spec.ts
+++ b/packages/admin/admin-rte/src/core/translation/htmlToState.spec.ts
@@ -146,6 +146,16 @@ describe("htmlToState", () => {
                 entityRanges: [],
                 data: {},
             },
+            // Custom Block Style
+            {
+                key: "7l334",
+                text: "A rte text with custom block styling",
+                type: "header-custom-green",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
         ];
         const rawContent = {
             entityMap: {},

--- a/packages/admin/admin-rte/src/core/translation/htmlToState.ts
+++ b/packages/admin/admin-rte/src/core/translation/htmlToState.ts
@@ -12,6 +12,11 @@ export function htmlToState({
     }[];
 }) {
     const translatedContentState = stateFromHTML(html, {
+        customBlockFn: (element) => {
+            if (element.className) {
+                return { type: element.className };
+            }
+        },
         customInlineFn: (element, { Style, Entity }) => {
             if (element.tagName === "SUB") {
                 return Style("SUB");

--- a/packages/admin/admin-rte/src/core/translation/stateToHtml.spec.ts
+++ b/packages/admin/admin-rte/src/core/translation/stateToHtml.spec.ts
@@ -9,7 +9,10 @@ function trimHtml(html: string) {
 }
 
 describe("stateToHtml", () => {
-    const options = { customInlineStyles: { HIGHLIGHT: { label: "Highlight!", style: { backgroundColor: "yellow" } } } } as unknown as IRteOptions;
+    const options = {
+        customInlineStyles: { HIGHLIGHT: { label: "Highlight!", style: { backgroundColor: "yellow" } } },
+        blocktypeMap: { "header-custom-green": { label: "Header Custom Green", renderConfig: { element: "p" } } },
+    } as unknown as IRteOptions;
 
     it("should convert the rte editor state with styling into html while keeping the format via tags - formats part 1", () => {
         const blocks = [
@@ -335,6 +338,37 @@ describe("stateToHtml", () => {
         });
 
         const expectedHtml = `<p><span class="HIGHLIGHT">A rte text with custom styling</span></p>`;
+
+        expect(trimHtml(html)).toEqual(trimHtml(expectedHtml));
+    });
+
+    it("should convert the rte editor state with formating into html while keeping the format via tags - formats part 6 (custom block styles)", () => {
+        const blocks = [
+            {
+                key: "7l334",
+                text: "A rte text with custom block styling",
+                type: "header-custom-green",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+        ];
+
+        const rawContent = {
+            entityMap: {},
+            blocks,
+        } as RawDraftContentState;
+
+        const content = convertFromRaw(rawContent);
+        const editorState = EditorState.createWithContent(content);
+
+        const { html } = stateToHtml({
+            editorState,
+            options,
+        });
+
+        const expectedHtml = `<p class="header-custom-green">A rte text with custom block styling</p>`;
 
         expect(trimHtml(html)).toEqual(trimHtml(expectedHtml));
     });

--- a/packages/admin/admin-rte/src/core/translation/stateToHtml.ts
+++ b/packages/admin/admin-rte/src/core/translation/stateToHtml.ts
@@ -1,6 +1,7 @@
 import { EditorState } from "draft-js";
 import { RenderConfig, stateToHTML } from "draft-js-export-html";
 
+import defaultBlocktypeMap from "../defaultBlocktypeMap";
 import { IRteOptions } from "../Rte";
 
 export function stateToHtml({ editorState, options }: { editorState: EditorState; options: IRteOptions }) {
@@ -22,7 +23,11 @@ export function stateToHtml({ editorState, options }: { editorState: EditorState
     const html = stateToHTML(contentState, {
         inlineStyles,
         blockStyleFn: (block) => {
-            return { attributes: { class: block.getType() } };
+            const type = block.getType();
+
+            if (!Object.keys(defaultBlocktypeMap).includes(type)) {
+                return { attributes: { class: type } };
+            }
         },
         entityStyleFn: (entity) => {
             const entityType = entity.getType();

--- a/packages/admin/admin-rte/src/core/translation/stateToHtml.ts
+++ b/packages/admin/admin-rte/src/core/translation/stateToHtml.ts
@@ -21,6 +21,9 @@ export function stateToHtml({ editorState, options }: { editorState: EditorState
 
     const html = stateToHTML(contentState, {
         inlineStyles,
+        blockStyleFn: (block) => {
+            return { attributes: { class: block.getType() } };
+        },
         entityStyleFn: (entity) => {
             const entityType = entity.getType();
             const data = entity.getData();


### PR DESCRIPTION
COM-704

<details>
    <summary>Screenshots/screencasts</summary>

https://github.com/vivid-planet/comet/assets/118435139/22547e01-dfc8-4185-957f-de335f1b947d

</details>