### PR TITLE
Require `aspectRatio` prop for `PixelImageBlock` and `Image`

### DIFF
--- a/.changeset/mean-coats-matter.md
+++ b/.changeset/mean-coats-matter.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": major
+---
+
+Enforce aspect ratio for `PixelImageBlock` and `Image`

--- a/.changeset/mean-coats-matter.md
+++ b/.changeset/mean-coats-matter.md
@@ -2,4 +2,18 @@
 "@comet/cms-site": major
 ---
 
-Enforce aspect ratio for `PixelImageBlock` and `Image`
+Require `aspectRatio` prop for `PixelImageBlock` and `Image`
+
+The `16x9` default aspect ratio has repeatedly led to incorrectly displayed images on the site.
+Therefore, it has been removed.
+Instead, consider which aspect ratio to use for each image.
+
+**Example**
+
+```diff
+<PixelImageBlock
+  data={teaser}
+  layout="fill"
++ aspectRatio="16x9"
+/>
+```

--- a/demo/site/src/blocks/ColumnsBlock.tsx
+++ b/demo/site/src/blocks/ColumnsBlock.tsx
@@ -13,7 +13,7 @@ const supportedBlocks: SupportedBlocks = {
     space: (props) => <SpaceBlock data={props} />,
     richtext: (props) => <RichTextBlock data={props} />,
     headline: (props) => <HeadlineBlock data={props} />,
-    image: (props) => <DamImageBlock data={props} />,
+    image: (props) => <DamImageBlock data={props} aspectRatio="inherit" />,
 };
 
 const ColumnsContentBlock = withPreview(

--- a/demo/site/src/blocks/DamImageBlock.tsx
+++ b/demo/site/src/blocks/DamImageBlock.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 
 type Props = PropsWithData<DamImageBlockData> &
     Omit<ImageProps, "src" | "width" | "height" | "alt"> & {
-        aspectRatio?: string | "inherit";
+        aspectRatio: string | "inherit";
     } & (
         | { layout?: "fixed" | "intrinsic" }
         // The sizes prop must be specified for images with layout "fill" or "responsive", as recommended in the next/image documentation

--- a/demo/site/src/blocks/FullWidthImageBlock.tsx
+++ b/demo/site/src/blocks/FullWidthImageBlock.tsx
@@ -11,7 +11,7 @@ export const FullWidthImageBlock = withPreview(
     ({ data: { image, content } }: PropsWithData<FullWidthImageBlockData>) => {
         return (
             <Root>
-                <DamImageBlock data={image} layout="responsive" sizes="100vw" />
+                <DamImageBlock data={image} layout="responsive" sizes="100vw" aspectRatio="16x9" />
                 <OptionalBlock
                     block={(props) => (
                         <Content>

--- a/demo/site/src/blocks/MediaBlock.tsx
+++ b/demo/site/src/blocks/MediaBlock.tsx
@@ -7,7 +7,7 @@ import { DamImageBlock } from "./DamImageBlock";
 import DamVideoBlock from "./DamVideoBlock";
 
 const supportedBlocks: SupportedBlocks = {
-    image: (props) => <DamImageBlock data={props} />,
+    image: (props) => <DamImageBlock data={props} aspectRatio="inherit" />,
     video: (props) => <DamVideoBlock data={props} />,
 };
 

--- a/demo/site/src/blocks/PageContentBlock.tsx
+++ b/demo/site/src/blocks/PageContentBlock.tsx
@@ -22,7 +22,7 @@ const supportedBlocks: SupportedBlocks = {
     space: (props) => <SpaceBlock data={props} />,
     richtext: (props) => <RichTextBlock data={props} />,
     headline: (props) => <HeadlineBlock data={props} />,
-    image: (props) => <DamImageBlock data={props} />,
+    image: (props) => <DamImageBlock data={props} aspectRatio="inherit" />,
     textImage: (props) => <TextImageBlock data={props} />,
     damVideo: (props) => <DamVideoBlock data={props} />,
     youTubeVideo: (props) => <YouTubeVideoBlock data={props} />,

--- a/demo/site/src/documents/pages/blocks/TeaserBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/TeaserBlock.tsx
@@ -10,7 +10,7 @@ const TeaserBlock = withPreview(
         return (
             <Root>
                 <HeadlineBlock data={headline} />
-                <DamImageBlock data={image} />
+                <DamImageBlock data={image} aspectRatio="1x1" />
                 <LinkListBlock data={links} />
                 <LinkListBlock data={buttons} />
             </Root>

--- a/demo/site/src/news/blocks/NewsContentBlock.tsx
+++ b/demo/site/src/news/blocks/NewsContentBlock.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 const supportedBlocks: SupportedBlocks = {
     headline: (props) => <HeadlineBlock data={props} />,
     richtext: (props) => <RichTextBlock data={props} />,
-    image: (props) => <DamImageBlock data={props} />,
+    image: (props) => <DamImageBlock data={props} aspectRatio="inherit" />,
     textImage: (props) => <TextImageBlock data={props} />,
 };
 

--- a/packages/site/cms-site/src/blocks/PixelImageBlock.tsx
+++ b/packages/site/cms-site/src/blocks/PixelImageBlock.tsx
@@ -10,7 +10,7 @@ import { PreviewSkeleton } from "../previewskeleton/PreviewSkeleton";
 import { PropsWithData } from "./PropsWithData";
 
 interface PixelImageBlockProps extends PropsWithData<PixelImageBlockData>, Omit<ImageProps, "src" | "width" | "height" | "alt"> {
-    aspectRatio?: string | "inherit";
+    aspectRatio: string | "inherit";
     layout: "fill" | "fixed" | "intrinsic" | "responsive";
     // Workaround to prevent flicker on already loaded images.
     // See https://github.com/vercel/next.js/issues/27539 for more information.
@@ -18,13 +18,7 @@ interface PixelImageBlockProps extends PropsWithData<PixelImageBlockData>, Omit<
 }
 
 export const PixelImageBlock = withPreview(
-    ({
-        aspectRatio = "16x9",
-        data: { damFile, cropArea, urlTemplate },
-        layout,
-        disableBlurPlaceholder = false,
-        ...nextImageProps
-    }: PixelImageBlockProps) => {
+    ({ aspectRatio, data: { damFile, cropArea, urlTemplate }, layout, disableBlurPlaceholder = false, ...nextImageProps }: PixelImageBlockProps) => {
         if (!damFile || !damFile.image) return <PreviewSkeleton type="media" hasContent={false} />;
 
         // If we have a crop area set, DAM setting are overwritten, so we use that

--- a/packages/site/cms-site/src/image/Image.tsx
+++ b/packages/site/cms-site/src/image/Image.tsx
@@ -70,9 +70,9 @@ type Props = Omit<NextImageProps, "loader"> &
               layout?: "fill" | "responsive";
               sizes: string;
           }
-    ) & { aspectRatio?: string };
+    ) & { aspectRatio: string };
 
-export function Image({ aspectRatio = "16x9", ...nextImageProps }: Props): React.ReactElement {
+export function Image({ aspectRatio, ...nextImageProps }: Props): React.ReactElement {
     const usedAspectRatio = parseAspectRatio(aspectRatio);
 
     return <NextImage loader={(loaderProps) => generateImageUrl(loaderProps, usedAspectRatio)} {...nextImageProps} />;


### PR DESCRIPTION
We repeatedly have the problem that an image is not displayed in the site as the customer would expect. It is then claimed that our smart focus point feature doesn't work properly. In most cases, however, the error is due to an incorrectly used image in the site. For instance, an image that should fill a mobile screen (roughly 1x2) may be used with `layout="fill"` but specifying no aspect ratio, which then results in using the default aspect ratio 16x9. 

I suspect that these problems could be solved by enforcing the aspect ratio for the `PixelImageBlock` and the `Image` component in the site. This would force our frontend devs to pause and think about which aspect ratio to use every time they use an image block or image.