### PR TITLE
API-Generator: Remove unnecessary await for delete mutation

### DIFF
--- a/.changeset/big-pots-protect.md
+++ b/.changeset/big-pots-protect.md
@@ -2,4 +2,4 @@
 "@comet/cms-api": patch
 ---
 
-Crud-Generator: Remove unnecessary await for delete mutation
+API-Generator: Remove unnecessary await for delete mutation

--- a/.changeset/big-pots-protect.md
+++ b/.changeset/big-pots-protect.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Crud-Generator: Remove unnecessary await for delete mutation

--- a/demo/api/src/news/generated/news.resolver.ts
+++ b/demo/api/src/news/generated/news.resolver.ts
@@ -116,7 +116,7 @@ export class NewsResolver {
     @AffectedEntity(News)
     async deleteNews(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
         const news = await this.repository.findOneOrFail(id);
-        await this.entityManager.remove(news);
+        this.entityManager.remove(news);
         await this.entityManager.flush();
         return true;
     }

--- a/demo/api/src/products/generated/product-category.resolver.ts
+++ b/demo/api/src/products/generated/product-category.resolver.ts
@@ -118,7 +118,7 @@ export class ProductCategoryResolver {
     @AffectedEntity(ProductCategory)
     async deleteProductCategory(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
         const productCategory = await this.repository.findOneOrFail(id);
-        await this.entityManager.remove(productCategory);
+        this.entityManager.remove(productCategory);
         await this.entityManager.flush();
         return true;
     }

--- a/demo/api/src/products/generated/product-tag.resolver.ts
+++ b/demo/api/src/products/generated/product-tag.resolver.ts
@@ -111,7 +111,7 @@ export class ProductTagResolver {
     @AffectedEntity(ProductTag)
     async deleteProductTag(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
         const productTag = await this.repository.findOneOrFail(id);
-        await this.entityManager.remove(productTag);
+        this.entityManager.remove(productTag);
         await this.entityManager.flush();
         return true;
     }

--- a/demo/api/src/products/generated/product.resolver.ts
+++ b/demo/api/src/products/generated/product.resolver.ts
@@ -193,7 +193,7 @@ export class ProductResolver {
     @AffectedEntity(Product)
     async deleteProduct(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
         const product = await this.repository.findOneOrFail(id);
-        await this.entityManager.remove(product);
+        this.entityManager.remove(product);
         await this.entityManager.flush();
         return true;
     }

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -874,7 +874,7 @@ function generateResolver({ generatorOptions, metadata }: { generatorOptions: Cr
                           : `@Args("id", { type: () => ID }) id: string`
                   }): Promise<boolean> {
             const ${instanceNameSingular} = await this.repository.findOneOrFail(id);
-            await this.entityManager.remove(${instanceNameSingular});
+            this.entityManager.remove(${instanceNameSingular});
             await this.entityManager.flush();
             return true;
         }


### PR DESCRIPTION
As per https://mikro-orm.io/api/5.9/core/class/EntityManager#remove, em.remove is not async