### PR TITLE
Fix site preview secret in client side

### DIFF
--- a/packages/site/cms-site/src/sitePreview/SitePreviewUtils.ts
+++ b/packages/site/cms-site/src/sitePreview/SitePreviewUtils.ts
@@ -18,12 +18,15 @@ export type SitePreviewParams = {
     previewData?: SitePreviewData;
 };
 
-if (!process.env.SITE_PREVIEW_SECRET && process.env.NODE_ENV === "production") {
-    throw new Error("SITE_PREVIEW_SECRET environment variable is required in production mode");
+function getPreviewScopeSigningKey() {
+    if (!process.env.SITE_PREVIEW_SECRET && process.env.NODE_ENV === "production") {
+        throw new Error("SITE_PREVIEW_SECRET environment variable is required in production mode");
+    }
+    return process.env.SITE_PREVIEW_SECRET || "secret";
 }
-const previewScopeSigningKey = process.env.SITE_PREVIEW_SECRET || "secret";
 
 export async function sitePreviewRoute(request: NextRequest, graphQLFetch: GraphQLFetch) {
+    const previewScopeSigningKey = getPreviewScopeSigningKey();
     const params = request.nextUrl.searchParams;
     const settingsParam = params.get("settings");
     const scopeParam = params.get("scope");
@@ -62,6 +65,8 @@ export async function sitePreviewRoute(request: NextRequest, graphQLFetch: Graph
 }
 
 export function previewParams(): SitePreviewParams | null {
+    const previewScopeSigningKey = getPreviewScopeSigningKey();
+
     if (!draftMode().isEnabled) return null;
     const cookie = cookies().get("__comet_preview");
     if (cookie) {


### PR DESCRIPTION
Currently, the client also requires the SITE_PREVIEW_SECRET. 
As far as I understand it, however, this should only be required on the server side.

Client-Error when running production build:

![Screenshot 2024-04-30 at 10 17 38](https://github.com/vivid-planet/comet/assets/44967610/f4cc817c-028f-4fd0-814a-2c37ee4c7d02)

