### PR TITLE
Support 20 migrations in `typesafeMigrationPipe`

### DIFF
--- a/.changeset/old-shirts-develop.md
+++ b/.changeset/old-shirts-develop.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-api": minor
+---
+
+typesafeMigrationPipe: Add support for 20 migrations

--- a/packages/api/blocks-api/src/migrations/typesafeMigrationPipe.ts
+++ b/packages/api/blocks-api/src/migrations/typesafeMigrationPipe.ts
@@ -6,6 +6,240 @@ import { BlockMigrationInterface, BlockMigrationTransformFn } from "./types";
 type MigrationClass<T extends BlockMigrationTransformFn = any> = ClassConstructor<BlockMigrationInterface<T>>; // alias
 
 // For type-safety
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+        MigrationClass<(arg: R10) => R11>,
+        MigrationClass<(arg: R11) => R12>,
+        MigrationClass<(arg: R12) => R13>,
+        MigrationClass<(arg: R13) => R14>,
+        MigrationClass<(arg: R14) => R15>,
+        MigrationClass<(arg: R15) => R16>,
+        MigrationClass<(arg: R16) => R17>,
+        MigrationClass<(arg: R17) => R18>,
+        MigrationClass<(arg: R18) => R19>,
+        MigrationClass<(arg: R19) => R20>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+        MigrationClass<(arg: R10) => R11>,
+        MigrationClass<(arg: R11) => R12>,
+        MigrationClass<(arg: R12) => R13>,
+        MigrationClass<(arg: R13) => R14>,
+        MigrationClass<(arg: R14) => R15>,
+        MigrationClass<(arg: R15) => R16>,
+        MigrationClass<(arg: R16) => R17>,
+        MigrationClass<(arg: R17) => R18>,
+        MigrationClass<(arg: R18) => R19>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+        MigrationClass<(arg: R10) => R11>,
+        MigrationClass<(arg: R11) => R12>,
+        MigrationClass<(arg: R12) => R13>,
+        MigrationClass<(arg: R13) => R14>,
+        MigrationClass<(arg: R14) => R15>,
+        MigrationClass<(arg: R15) => R16>,
+        MigrationClass<(arg: R16) => R17>,
+        MigrationClass<(arg: R17) => R18>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+        MigrationClass<(arg: R10) => R11>,
+        MigrationClass<(arg: R11) => R12>,
+        MigrationClass<(arg: R12) => R13>,
+        MigrationClass<(arg: R13) => R14>,
+        MigrationClass<(arg: R14) => R15>,
+        MigrationClass<(arg: R15) => R16>,
+        MigrationClass<(arg: R16) => R17>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+        MigrationClass<(arg: R10) => R11>,
+        MigrationClass<(arg: R11) => R12>,
+        MigrationClass<(arg: R12) => R13>,
+        MigrationClass<(arg: R13) => R14>,
+        MigrationClass<(arg: R14) => R15>,
+        MigrationClass<(arg: R15) => R16>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+        MigrationClass<(arg: R10) => R11>,
+        MigrationClass<(arg: R11) => R12>,
+        MigrationClass<(arg: R12) => R13>,
+        MigrationClass<(arg: R13) => R14>,
+        MigrationClass<(arg: R14) => R15>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+        MigrationClass<(arg: R10) => R11>,
+        MigrationClass<(arg: R11) => R12>,
+        MigrationClass<(arg: R12) => R13>,
+        MigrationClass<(arg: R13) => R14>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+        MigrationClass<(arg: R10) => R11>,
+        MigrationClass<(arg: R11) => R12>,
+        MigrationClass<(arg: R12) => R13>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+        MigrationClass<(arg: R10) => R11>,
+        MigrationClass<(arg: R11) => R12>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+        MigrationClass<(arg: R10) => R11>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+        MigrationClass<(arg: R9) => R10>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8, R9>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+        MigrationClass<(arg: R8) => R9>,
+    ],
+): typeof migrations;
+export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7, R8>(
+    migrations: [
+        MigrationClass<(arg: A1) => R1>,
+        MigrationClass<(arg: R1) => R2>,
+        MigrationClass<(arg: R2) => R3>,
+        MigrationClass<(arg: R3) => R4>,
+        MigrationClass<(arg: R4) => R5>,
+        MigrationClass<(arg: R5) => R6>,
+        MigrationClass<(arg: R6) => R7>,
+        MigrationClass<(arg: R7) => R8>,
+    ],
+): typeof migrations;
 export function typesafeMigrationPipe<A1, R1, R2, R3, R4, R5, R6, R7>(
     migrations: [
         MigrationClass<(arg: A1) => R1>,
@@ -45,6 +279,6 @@ export function typesafeMigrationPipe<A1, R1, R2, R3>(
 export function typesafeMigrationPipe<A1, R1, R2>(migrations: [MigrationClass<(arg: A1) => R1>, MigrationClass<(arg: R1) => R2>]): typeof migrations;
 export function typesafeMigrationPipe<A1, R1>(migrations: [MigrationClass<(arg: A1) => R1>]): typeof migrations;
 export function typesafeMigrationPipe(migrations: MigrationClass[]): typeof migrations {
-    // type-safety is limited to 7 Migrations
+    // type-safety is limited to 20 Migrations
     return migrations;
 }


### PR DESCRIPTION
Increase the number of migrations in `typesafeMigrationPipe` from 7 to 20.

---

I've invested quite some time trying to get it to work with an infinite amount of migrations, but I didn't get it work with generics. Solutions I found in the internet and got from ChatGPT didn't work either. Since we're planning to switch to timestamp-based migrations, which in theory would work in any order, I decided to not further waste my time here. Feel free to give it a try as well 😁 

COM-679