### PR TITLE
Next App Router: Fix news detail page by moving `FormattedDate` into client component

### DIFF
--- a/demo/site/src/app/[lang]/news/[slug]/content.tsx
+++ b/demo/site/src/app/[lang]/news/[slug]/content.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { gql } from "@comet/cms-site";
+import { DamImageBlock } from "@src/blocks/DamImageBlock";
+import { NewsContentBlock } from "@src/news/blocks/NewsContentBlock";
+import { FormattedDate } from "react-intl";
+
+import { GQLNewsDetailPageFragment } from "./content.generated";
+
+export const fragment = gql`
+    fragment NewsDetailPage on News {
+        title
+        image
+        createdAt
+        content
+    }
+`;
+
+type Props = {
+    news: GQLNewsDetailPageFragment;
+};
+export function Content({ news }: Props) {
+    return (
+        <div>
+            <DamImageBlock data={news.image} layout="responsive" sizes="100vw" aspectRatio="16x9" />
+            <h1>{news.title}</h1>
+            <p>
+                <FormattedDate value={news.createdAt} />
+            </p>
+            <hr />
+            <NewsContentBlock data={news.content} />
+        </div>
+    );
+}

--- a/demo/site/src/app/[lang]/news/[slug]/page.tsx
+++ b/demo/site/src/app/[lang]/news/[slug]/page.tsx
@@ -1,12 +1,10 @@
 import { gql, previewParams } from "@comet/cms-site";
-import { DamImageBlock } from "@src/blocks/DamImageBlock";
 import { domain } from "@src/config";
 import { GQLNewsContentScopeInput } from "@src/graphql.generated";
-import { NewsContentBlock } from "@src/news/blocks/NewsContentBlock";
 import { createGraphQLFetch } from "@src/util/graphQLClient";
 import { notFound } from "next/navigation";
-import { FormattedDate } from "react-intl";
 
+import { Content, fragment } from "./content";
 import { GQLNewsDetailPageQuery, GQLNewsDetailPageQueryVariables } from "./page.generated";
 
 export default async function NewsDetailPage({ params }: { params: { slug: string; lang: string } }) {
@@ -18,12 +16,10 @@ export default async function NewsDetailPage({ params }: { params: { slug: strin
             query NewsDetailPage($slug: String!, $scope: NewsContentScopeInput!) {
                 newsBySlug(slug: $slug, scope: $scope) {
                     id
-                    title
-                    image
-                    createdAt
-                    content
+                    ...NewsDetailPage
                 }
             }
+            ${fragment}
         `,
         { slug: params.slug, scope: scope as GQLNewsContentScopeInput },
     );
@@ -32,17 +28,5 @@ export default async function NewsDetailPage({ params }: { params: { slug: strin
         notFound();
     }
 
-    const { newsBySlug: news } = data;
-
-    return (
-        <div>
-            <DamImageBlock data={news.image} layout="responsive" sizes="100vw" aspectRatio="16x9" />
-            <h1>{news.title}</h1>
-            <p>
-                <FormattedDate value={news.createdAt} />
-            </p>
-            <hr />
-            <NewsContentBlock data={news.content} />
-        </div>
-    );
+    return <Content news={data.newsBySlug} />;
 }


### PR DESCRIPTION
page.tsx is a server component and can't use FormattedDate that accesses intl context and thus must be a client component. As it doesn't specify "use client" on it's own, we have to move it into a client component