### PR TITLE
Fix API Generator Linting

### DIFF
--- a/packages/api/cms-api/src/generator/utils/write-generated-file.ts
+++ b/packages/api/cms-api/src/generator/utils/write-generated-file.ts
@@ -7,6 +7,8 @@ export async function writeGeneratedFile(filePath: string, contents: string): Pr
     // You may choose to use this file as scaffold by moving this file out of generated folder and removing this comment.
     `;
     await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, contents);
+
     const eslint = new ESLint({
         cwd: process.cwd(),
         fix: true,
@@ -16,6 +18,8 @@ export async function writeGeneratedFile(filePath: string, contents: string): Pr
     });
 
     const output = lintResult[0] && lintResult[0].output ? lintResult[0].output : lintResult[0].source;
-    await fs.writeFile(filePath, output ?? contents);
+    if (output) {
+        await fs.writeFile(filePath, output);
+    }
     console.log(`generated ${filePath}`);
 }


### PR DESCRIPTION
## Previously

While linting the generated files, an error like this occured:

```
Parsing error: ESLint was configured to run on `` using `parserOptions.project`: \n' +
      'However, that TSConfig does not include this file. Either:\n' +
      "- Change ESLint's list of included files to not include this file\n" +
      '- Change that TSConfig to include this file\n' +
      '- Create a new TSConfig that includes this file and include it in your parserOptions.project\n'
```

This resulted in unformatted files, causing linting errors later on.

The TSConfig is needed by the `@typescript-eslint/naming-convention` rule (see https://github.com/vivid-planet/comet/pull/1656). 

## Reason

Apparently, the reason for this behavior was that the file wasn't created before executing the lint. It seems like ESLint tried to get type data for the file via TSConfig but couldn't because the file didn't exist.

## Fix

Now the file is created, then the lint is executed, then the file is overwritten with the formatted code.
