### PR TITLE
Loosen peer dependency on react-intl to allow using v6

### DIFF
--- a/.changeset/thick-zoos-tie.md
+++ b/.changeset/thick-zoos-tie.md
@@ -1,0 +1,10 @@
+---
+"@comet/admin-color-picker": minor
+"@comet/admin-date-time": minor
+"@comet/blocks-admin": minor
+"@comet/admin-rte": minor
+"@comet/cms-admin": minor
+"@comet/admin": minor
+---
+
+Loosen peer dependency on `react-intl` to allow using v6

--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -74,7 +74,7 @@
         "react-final-form-listeners": "^1.0.0",
         "react-hotkeys-hook": "^3.0.0",
         "react-image-crop": "^8.0.0",
-        "react-intl": "^5.0.0",
+        "react-intl": "^6.0.0",
         "react-is": "^17.0.2",
         "react-router": "^5.0.0",
         "react-router-dom": "^5.0.0",
@@ -91,7 +91,7 @@
     "devDependencies": {
         "@comet/cli": "workspace:*",
         "@comet/eslint-config": "workspace:*",
-        "@formatjs/cli": "^2.0.0",
+        "@formatjs/cli": "^6.0.0",
         "@gitbeaker/node": "^25.0.0",
         "@graphql-codegen/add": "^3.0.0",
         "@graphql-codegen/cli": "^2.0.0",

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@comet/cms-site": "workspace:*",
-        "@formatjs/cli": "^6.2.8",
+        "@formatjs/cli": "^6.0.0",
         "@googlemaps/js-api-loader": "^1.0.0",
         "@googlemaps/markerclustererplus": "^1.0.0",
         "@opentelemetry/api": "^1.4.0",
@@ -44,7 +44,7 @@
         "pure-react-carousel": "^1.0.0",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-intl": "^5.0.0",
+        "react-intl": "^6.0.0",
         "react-is": "^17.0.2",
         "react-select": "^4.0.0",
         "redraft": "^0.10.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -62,7 +62,7 @@
         "react-dnd-html5-backend": "^16.0.0",
         "react-dom": "^17.0.2",
         "react-final-form": "^6.5.9",
-        "react-intl": "^5.0.0",
+        "react-intl": "^6.0.0",
         "react-live": "^2.4.1",
         "react-router": "^5.0.0",
         "react-router-dom": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@comet/dev-process-manager": "^2.5.1",
         "@comet/eslint-plugin": "workspace:*",
-        "@formatjs/cli": "^4.8.3",
+        "@formatjs/cli": "^6.0.0",
         "@types/node": "^18.0.0",
         "dotenv-cli": "^5.1.0",
         "husky": "^7.0.4",

--- a/packages/admin/admin-color-picker/package.json
+++ b/packages/admin/admin-color-picker/package.json
@@ -50,7 +50,7 @@
         "react": "^17.0",
         "react-dom": "^17.0",
         "react-final-form": "^6.3.1",
-        "react-intl": "^5.24.6",
+        "react-intl": "^6.0.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.0.0"
     },
@@ -61,7 +61,7 @@
         "react": "^17.0",
         "react-dom": "^17.0",
         "react-final-form": "^6.3.1",
-        "react-intl": "^5.24.6"
+        "react-intl": "^5.0.0 || ^6.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/admin/admin-date-time/package.json
+++ b/packages/admin/admin-date-time/package.json
@@ -49,7 +49,7 @@
         "react": "^17.0",
         "react-dom": "^17.0",
         "react-final-form": "^6.5.7",
-        "react-intl": "^5.24.6",
+        "react-intl": "^6.0.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.0.0"
     },
@@ -59,7 +59,7 @@
         "react": "^17.0",
         "react-dom": "^17.0",
         "react-final-form": "^6.5.7",
-        "react-intl": "^5.24.6"
+        "react-intl": "^5.0.0 || ^6.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/admin/admin-rte/package.json
+++ b/packages/admin/admin-rte/package.json
@@ -62,7 +62,7 @@
         "react": "^17.0",
         "react-dom": "^17.0",
         "react-final-form": "^6.3.1",
-        "react-intl": "^5.10.0",
+        "react-intl": "^6.0.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^29.0.0",
         "typescript": "^4.0.0"
@@ -76,7 +76,7 @@
         "react": "^17.0",
         "react-dom": "^17.0",
         "react-final-form": "^6.3.1",
-        "react-intl": "^5.10.0"
+        "react-intl": "^5.0.0 || ^6.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -87,7 +87,7 @@
         "react-dnd": "^16.0.0",
         "react-dom": "^17.0.0",
         "react-final-form": "^6.3.1",
-        "react-intl": "^5.10.0",
+        "react-intl": "^6.0.0",
         "react-router": "^5.1.2",
         "react-router-dom": "^5.1.2",
         "rimraf": "^3.0.2",
@@ -111,7 +111,7 @@
         "react-dnd": "^16.0.0",
         "react-dom": "^17.0",
         "react-final-form": "^6.3.1",
-        "react-intl": "^5.10.0",
+        "react-intl": "^5.0.0 || ^6.0.0",
         "react-router": "^5.1.2",
         "react-router-dom": "^5.1.2"
     },

--- a/packages/admin/blocks-admin/package.json
+++ b/packages/admin/blocks-admin/package.json
@@ -70,7 +70,7 @@
         "react-dnd": "^16.0.0",
         "react-dom": "^16.8.0 || ^17.0.0",
         "react-final-form": "^6.0.0",
-        "react-intl": "^5.0.0",
+        "react-intl": "^6.0.0",
         "react-router": "^5.0.0",
         "react-router-dom": "^5.0.0",
         "ts-jest": "^29.0.5",
@@ -83,7 +83,7 @@
         "react-dnd": "^16.0.0",
         "react-dom": "^16.8.0 || ^17.0.0",
         "react-final-form": "^6.0.0",
-        "react-intl": "^5.0.0",
+        "react-intl": "^5.0.0 || ^6.0.0",
         "react-router": "^5.0.0",
         "react-router-dom": "^5.0.0"
     },

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -134,7 +134,7 @@
         "react-dnd-html5-backend": "^16.0.0",
         "react-dom": "^17.0.0",
         "react-final-form": "^6.5.9",
-        "react-intl": "^5.0.0",
+        "react-intl": "^6.0.0",
         "react-router": "^5.0.0",
         "react-router-dom": "^5.0.0",
         "ts-jest": "^29.0.5",
@@ -157,7 +157,7 @@
         "react-dnd-html5-backend": "^16.0.0",
         "react-dom": "^16.8.0 || ^17.0.0",
         "react-final-form": "^6.0.0",
-        "react-intl": "^5.0.0",
+        "react-intl": "^5.0.0 || ^6.0.0",
         "react-router": "^5.0.0",
         "react-router-dom": "^5.0.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: workspace:*
         version: link:packages/eslint-plugin
       '@formatjs/cli':
-        specifier: ^4.8.3
-        version: 4.8.4
+        specifier: ^6.0.0
+        version: 6.2.8
       '@types/node':
         specifier: ^18.0.0
         version: 18.15.3
@@ -210,8 +210,8 @@ importers:
         specifier: ^8.0.0
         version: 8.6.12(react@17.0.2)
       react-intl:
-        specifier: ^5.0.0
-        version: 5.25.1(react@17.0.2)(typescript@4.9.4)
+        specifier: ^6.0.0
+        version: 6.6.6(react@17.0.2)(typescript@4.9.4)
       react-is:
         specifier: ^17.0.2
         version: 17.0.2
@@ -256,8 +256,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/eslint-config
       '@formatjs/cli':
-        specifier: ^2.0.0
-        version: 2.15.0
+        specifier: ^6.0.0
+        version: 6.2.8
       '@gitbeaker/node':
         specifier: ^25.0.0
         version: 25.6.0
@@ -644,7 +644,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/site/cms-site
       '@formatjs/cli':
-        specifier: ^6.2.8
+        specifier: ^6.0.0
         version: 6.2.8
       '@googlemaps/js-api-loader':
         specifier: ^1.0.0
@@ -698,8 +698,8 @@ importers:
         specifier: ^17.0.0
         version: 17.0.2(react@17.0.2)
       react-intl:
-        specifier: ^5.0.0
-        version: 5.25.1(react@17.0.2)(typescript@4.9.4)
+        specifier: ^6.0.0
+        version: 6.6.6(react@17.0.2)(typescript@4.9.4)
       react-is:
         specifier: ^17.0.2
         version: 17.0.2
@@ -906,8 +906,8 @@ importers:
         specifier: ^6.5.9
         version: 6.5.9(final-form@4.20.9)(react@17.0.2)
       react-intl:
-        specifier: ^5.0.0
-        version: 5.25.1(react@17.0.2)(typescript@4.9.4)
+        specifier: ^6.0.0
+        version: 6.6.6(react@17.0.2)(typescript@4.9.4)
       react-live:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@17.0.2)(react@17.0.2)
@@ -1136,8 +1136,8 @@ importers:
         specifier: ^6.3.1
         version: 6.5.9(final-form@4.20.9)(react@17.0.2)
       react-intl:
-        specifier: ^5.10.0
-        version: 5.25.1(react@17.0.2)(typescript@4.9.4)
+        specifier: ^6.0.0
+        version: 6.6.6(react@17.0.2)(typescript@4.9.4)
       react-router:
         specifier: ^5.1.2
         version: 5.3.4(react@17.0.2)
@@ -1251,8 +1251,8 @@ importers:
         specifier: ^6.3.1
         version: 6.5.9(final-form@4.20.9)(react@17.0.2)
       react-intl:
-        specifier: ^5.24.6
-        version: 5.25.1(react@17.0.2)(typescript@4.9.4)
+        specifier: ^6.0.0
+        version: 6.6.6(react@17.0.2)(typescript@4.9.4)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1330,8 +1330,8 @@ importers:
         specifier: ^6.5.7
         version: 6.5.9(final-form@4.20.9)(react@17.0.2)
       react-intl:
-        specifier: ^5.24.6
-        version: 5.25.1(react@17.0.2)(typescript@4.9.4)
+        specifier: ^6.0.0
+        version: 6.6.6(react@17.0.2)(typescript@4.9.4)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1575,8 +1575,8 @@ importers:
         specifier: ^6.3.1
         version: 6.5.9(final-form@4.20.9)(react@17.0.2)
       react-intl:
-        specifier: ^5.10.0
-        version: 5.25.1(react@17.0.2)(typescript@4.9.4)
+        specifier: ^6.0.0
+        version: 6.6.6(react@17.0.2)(typescript@4.9.4)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1766,8 +1766,8 @@ importers:
         specifier: ^6.0.0
         version: 6.5.9(final-form@4.20.9)(react@17.0.2)
       react-intl:
-        specifier: ^5.0.0
-        version: 5.25.1(react@17.0.2)(typescript@4.9.4)
+        specifier: ^6.0.0
+        version: 6.6.6(react@17.0.2)(typescript@4.9.4)
       react-router:
         specifier: ^5.0.0
         version: 5.3.4(react@17.0.2)
@@ -2076,8 +2076,8 @@ importers:
         specifier: ^6.5.9
         version: 6.5.9(final-form@4.20.9)(react@17.0.2)
       react-intl:
-        specifier: ^5.0.0
-        version: 5.25.1(react@17.0.2)(typescript@4.9.4)
+        specifier: ^6.0.0
+        version: 6.6.6(react@17.0.2)(typescript@4.9.4)
       react-router:
         specifier: ^5.0.0
         version: 5.3.4(react@17.0.2)
@@ -2756,8 +2756,8 @@ importers:
         specifier: ^6.3.1
         version: 6.5.9(final-form@4.20.9)(react@17.0.2)
       react-intl:
-        specifier: ^5.10.0
-        version: 5.25.1(react@17.0.2)(typescript@4.9.4)
+        specifier: ^6.0.0
+        version: 6.6.6(react@17.0.2)(typescript@4.9.4)
       react-select:
         specifier: ^3.0.4
         version: 3.2.0(react-dom@17.0.2)(react@17.0.2)
@@ -8526,55 +8526,6 @@ packages:
     resolution: {integrity: sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA==}
     dev: false
 
-  /@formatjs/cli@2.15.0:
-    resolution: {integrity: sha512-Hv7Z3xeGcgTpn1jA1/x7tc9UYbF9Udn/77xRf7E22Vn1mGJM/DftVqnpgLeNpd0d3xSftYw+rhaShNO19BsT6A==}
-    hasBin: true
-    dependencies:
-      '@formatjs/ts-transformer': 2.13.0
-      '@types/json-stable-stringify': 1.0.34
-      '@types/lodash': 4.14.191
-      '@types/loud-rejection': 2.0.0
-      '@types/node': 14.18.36
-      '@vue/compiler-core': 3.2.45
-      '@vue/compiler-sfc': 3.2.45
-      chalk: 4.1.2
-      commander: 6.2.1
-      fast-glob: 3.2.12
-      fs-extra: 9.1.0
-      intl-messageformat-parser: 6.1.2
-      json-stable-stringify: 1.0.2
-      lodash: 4.17.21
-      loud-rejection: 2.2.0
-      tslib: 2.4.1
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - ts-jest
-    dev: true
-
-  /@formatjs/cli@4.8.4:
-    resolution: {integrity: sha512-zZI8QYVl5CHaT6j9OHjS+0mMnWzopBVH0un4n5b4IhIJRzIKnxwFTkxBp5Ifqj6FntrwzIGqP+D6v8u7MPYsmw==}
-    hasBin: true
-    dependencies:
-      '@formatjs/icu-messageformat-parser': 2.1.0
-      '@formatjs/ts-transformer': 3.9.4
-      '@types/estree': 0.0.50
-      '@types/fs-extra': 9.0.13
-      '@types/json-stable-stringify': 1.0.34
-      '@types/node': 14.18.36
-      '@vue/compiler-core': 3.2.45
-      chalk: 4.1.2
-      commander: 8.3.0
-      fast-glob: 3.2.12
-      fs-extra: 10.1.0
-      json-stable-stringify: 1.0.2
-      loud-rejection: 2.2.0
-      tslib: 2.4.1
-      typescript: 4.9.4
-      vue: 3.2.45
-    transitivePeerDependencies:
-      - ts-jest
-    dev: true
-
   /@formatjs/cli@6.2.8:
     resolution: {integrity: sha512-sGtFehlHpNL5xbCkP5/zz5lgIVPPdQFqhY6Pcc9+whpBawln6VDzbaGA5ttWjtBDVVKZbEukiCFk8HW2H0OVxQ==}
     engines: {node: '>= 16'}
@@ -8584,13 +8535,6 @@ packages:
     peerDependenciesMeta:
       vue:
         optional: true
-    dev: false
-
-  /@formatjs/ecma402-abstract@1.11.4:
-    resolution: {integrity: sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==}
-    dependencies:
-      '@formatjs/intl-localematcher': 0.2.25
-      tslib: 2.4.1
 
   /@formatjs/ecma402-abstract@1.14.3:
     resolution: {integrity: sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==}
@@ -8599,22 +8543,15 @@ packages:
       tslib: 2.4.1
     dev: false
 
-  /@formatjs/ecma402-abstract@1.5.0:
-    resolution: {integrity: sha512-wXv36yo+mfWllweN0Fq7sUs7PUiNopn7I0JpLTe3hGu6ZMR4CV7LqK1llhB18pndwpKoafQKb1et2DCJAOW20Q==}
+  /@formatjs/ecma402-abstract@1.18.2:
+    resolution: {integrity: sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==}
     dependencies:
-      tslib: 2.4.1
-    dev: true
-
-  /@formatjs/fast-memoize@1.2.1:
-    resolution: {integrity: sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==}
-    dependencies:
+      '@formatjs/intl-localematcher': 0.5.4
       tslib: 2.4.1
 
-  /@formatjs/icu-messageformat-parser@2.1.0:
-    resolution: {integrity: sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==}
+  /@formatjs/fast-memoize@2.2.0:
+    resolution: {integrity: sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==}
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/icu-skeleton-parser': 1.3.6
       tslib: 2.4.1
 
   /@formatjs/icu-messageformat-parser@2.1.14:
@@ -8625,6 +8562,13 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@formatjs/icu-messageformat-parser@2.7.6:
+    resolution: {integrity: sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.18.2
+      '@formatjs/icu-skeleton-parser': 1.8.0
+      tslib: 2.4.1
+
   /@formatjs/icu-skeleton-parser@1.3.18:
     resolution: {integrity: sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==}
     dependencies:
@@ -8632,29 +8576,24 @@ packages:
       tslib: 2.4.1
     dev: false
 
-  /@formatjs/icu-skeleton-parser@1.3.6:
-    resolution: {integrity: sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==}
+  /@formatjs/icu-skeleton-parser@1.8.0:
+    resolution: {integrity: sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==}
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
+      '@formatjs/ecma402-abstract': 1.18.2
       tslib: 2.4.1
 
-  /@formatjs/intl-displaynames@5.4.3:
-    resolution: {integrity: sha512-4r12A3mS5dp5hnSaQCWBuBNfi9Amgx2dzhU4lTFfhSxgb5DOAiAbMpg6+7gpWZgl4ahsj3l2r/iHIjdmdXOE2Q==}
+  /@formatjs/intl-displaynames@6.6.6:
+    resolution: {integrity: sha512-Dg5URSjx0uzF8VZXtHb6KYZ6LFEEhCbAbKoYChYHEOnMFTw/ZU3jIo/NrujzQD2EfKPgQzIq73LOUvW6Z/LpFA==}
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/intl-localematcher': 0.2.25
+      '@formatjs/ecma402-abstract': 1.18.2
+      '@formatjs/intl-localematcher': 0.5.4
       tslib: 2.4.1
 
-  /@formatjs/intl-listformat@6.5.3:
-    resolution: {integrity: sha512-ozpz515F/+3CU+HnLi5DYPsLa6JoCfBggBSSg/8nOB5LYSFW9+ZgNQJxJ8tdhKYeODT+4qVHX27EeJLoxLGLNg==}
+  /@formatjs/intl-listformat@7.5.5:
+    resolution: {integrity: sha512-XoI52qrU6aBGJC9KJddqnacuBbPlb/bXFN+lIFVFhQ1RnFHpzuFrlFdjD9am2O7ZSYsyqzYRpkVcXeT1GHkwDQ==}
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/intl-localematcher': 0.2.25
-      tslib: 2.4.1
-
-  /@formatjs/intl-localematcher@0.2.25:
-    resolution: {integrity: sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==}
-    dependencies:
+      '@formatjs/ecma402-abstract': 1.18.2
+      '@formatjs/intl-localematcher': 0.5.4
       tslib: 2.4.1
 
   /@formatjs/intl-localematcher@0.2.32:
@@ -8663,35 +8602,27 @@ packages:
       tslib: 2.4.1
     dev: false
 
-  /@formatjs/intl@2.2.1(typescript@4.9.4):
-    resolution: {integrity: sha512-vgvyUOOrzqVaOFYzTf2d3+ToSkH2JpR7x/4U1RyoHQLmvEaTQvXJ7A2qm1Iy3brGNXC/+/7bUlc3lpH+h/LOJA==}
+  /@formatjs/intl-localematcher@0.5.4:
+    resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
+    dependencies:
+      tslib: 2.4.1
+
+  /@formatjs/intl@2.10.2(typescript@4.9.4):
+    resolution: {integrity: sha512-raPGWr3JRv3neXV78SqPFrGC05fIbhhNzVghHNxFde27ls2KkXiMhtP7HBybjGpikVSjjhdhaZto+4p1vmm9bQ==}
     peerDependencies:
-      typescript: ^4.5
+      typescript: ^4.7 || 5
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/fast-memoize': 1.2.1
-      '@formatjs/icu-messageformat-parser': 2.1.0
-      '@formatjs/intl-displaynames': 5.4.3
-      '@formatjs/intl-listformat': 6.5.3
-      intl-messageformat: 9.13.0
+      '@formatjs/ecma402-abstract': 1.18.2
+      '@formatjs/fast-memoize': 2.2.0
+      '@formatjs/icu-messageformat-parser': 2.7.6
+      '@formatjs/intl-displaynames': 6.6.6
+      '@formatjs/intl-listformat': 7.5.5
+      intl-messageformat: 10.5.12
       tslib: 2.4.1
       typescript: 4.9.4
-
-  /@formatjs/ts-transformer@2.13.0:
-    resolution: {integrity: sha512-mu7sHXZk1NWZrQ3eUqugpSYo8x5/tXkrI4uIbFqCEC0eNgQaIcoKgVeDFgDAcgG+cEme2atAUYSFF+DFWC4org==}
-    peerDependencies:
-      ts-jest: ^26.4.0
-    peerDependenciesMeta:
-      ts-jest:
-        optional: true
-    dependencies:
-      intl-messageformat-parser: 6.1.2
-      tslib: 2.4.1
-      typescript: 4.9.4
-    dev: true
 
   /@formatjs/ts-transformer@3.11.5:
     resolution: {integrity: sha512-cAmvKzgPqdetAr/RsxoXYhfNhMf5tERlXzJTsQw+j6tddPwIAbihACQx6KaajyJJ4aNssiziWNmcaHtjTqrrVw==}
@@ -8709,21 +8640,6 @@ packages:
       tslib: 2.4.1
       typescript: 4.9.4
     dev: false
-
-  /@formatjs/ts-transformer@3.9.4:
-    resolution: {integrity: sha512-S5q/zsTodaKtxVxNvbRQ9APenJtm5smXE76usS+5yF2vWQdZHkagmOKWfgvfIbesP4SR2B+i3koqlnlpqSIp5w==}
-    peerDependencies:
-      ts-jest: '27'
-    peerDependenciesMeta:
-      ts-jest:
-        optional: true
-    dependencies:
-      '@formatjs/icu-messageformat-parser': 2.1.0
-      '@types/node': 17.0.45
-      chalk: 4.1.2
-      tslib: 2.4.1
-      typescript: 4.9.4
-    dev: true
 
   /@gar/promisify@1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -14253,10 +14169,6 @@ packages:
       '@types/json-schema': 7.0.11
     dev: false
 
-  /@types/estree@0.0.50:
-    resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
-    dev: true
-
   /@types/estree@0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
 
@@ -14624,13 +14536,6 @@ packages:
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
     dev: false
 
-  /@types/loud-rejection@2.0.0:
-    resolution: {integrity: sha512-oTHISsIybJGoh3b3Ay/10csbAd2k0su7G7DGrE1QWciC+IdydPm0WMw1+Gr9YMYjPiJ5poB3g5Ev73IlLoavLw==}
-    deprecated: This is a stub types definition. loud-rejection provides its own type definitions, so you do not need this installed.
-    dependencies:
-      loud-rejection: 2.2.0
-    dev: true
-
   /@types/mdast@3.0.10:
     resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
     dependencies:
@@ -14694,9 +14599,11 @@ packages:
 
   /@types/node@14.18.36:
     resolution: {integrity: sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==}
+    dev: false
 
   /@types/node@17.0.45:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+    dev: false
 
   /@types/node@18.15.3:
     resolution: {integrity: sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==}
@@ -15257,89 +15164,6 @@ packages:
       vite: 5.1.6(@types/node@18.15.3)
     transitivePeerDependencies:
       - '@swc/helpers'
-    dev: true
-
-  /@vue/compiler-core@3.2.45:
-    resolution: {integrity: sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==}
-    dependencies:
-      '@babel/parser': 7.20.13
-      '@vue/shared': 3.2.45
-      estree-walker: 2.0.2
-      source-map: 0.6.1
-    dev: true
-
-  /@vue/compiler-dom@3.2.45:
-    resolution: {integrity: sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==}
-    dependencies:
-      '@vue/compiler-core': 3.2.45
-      '@vue/shared': 3.2.45
-    dev: true
-
-  /@vue/compiler-sfc@3.2.45:
-    resolution: {integrity: sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==}
-    dependencies:
-      '@babel/parser': 7.20.13
-      '@vue/compiler-core': 3.2.45
-      '@vue/compiler-dom': 3.2.45
-      '@vue/compiler-ssr': 3.2.45
-      '@vue/reactivity-transform': 3.2.45
-      '@vue/shared': 3.2.45
-      estree-walker: 2.0.2
-      magic-string: 0.25.9
-      postcss: 8.4.21
-      source-map: 0.6.1
-    dev: true
-
-  /@vue/compiler-ssr@3.2.45:
-    resolution: {integrity: sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==}
-    dependencies:
-      '@vue/compiler-dom': 3.2.45
-      '@vue/shared': 3.2.45
-    dev: true
-
-  /@vue/reactivity-transform@3.2.45:
-    resolution: {integrity: sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==}
-    dependencies:
-      '@babel/parser': 7.22.14
-      '@vue/compiler-core': 3.2.45
-      '@vue/shared': 3.2.45
-      estree-walker: 2.0.2
-      magic-string: 0.25.9
-    dev: true
-
-  /@vue/reactivity@3.2.45:
-    resolution: {integrity: sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==}
-    dependencies:
-      '@vue/shared': 3.2.45
-    dev: true
-
-  /@vue/runtime-core@3.2.45:
-    resolution: {integrity: sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==}
-    dependencies:
-      '@vue/reactivity': 3.2.45
-      '@vue/shared': 3.2.45
-    dev: true
-
-  /@vue/runtime-dom@3.2.45:
-    resolution: {integrity: sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==}
-    dependencies:
-      '@vue/runtime-core': 3.2.45
-      '@vue/shared': 3.2.45
-      csstype: 2.6.21
-    dev: true
-
-  /@vue/server-renderer@3.2.45(vue@3.2.45):
-    resolution: {integrity: sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==}
-    peerDependencies:
-      vue: 3.2.45
-    dependencies:
-      '@vue/compiler-ssr': 3.2.45
-      '@vue/shared': 3.2.45
-      vue: 3.2.45
-    dev: true
-
-  /@vue/shared@3.2.45:
-    resolution: {integrity: sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==}
     dev: true
 
   /@webassemblyjs/ast@1.11.1:
@@ -16298,6 +16122,9 @@ packages:
   /array-find-index@1.0.2:
     resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -16496,6 +16323,7 @@ packages:
   /at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
+    dev: false
 
   /atob@2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -18050,6 +17878,7 @@ packages:
   /commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
+    dev: false
 
   /commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -18823,8 +18652,11 @@ packages:
   /currently-unhandled@0.4.1:
     resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       array-find-index: 1.0.2
+    dev: false
+    optional: true
 
   /cwise-compiler@1.1.3:
     resolution: {integrity: sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==}
@@ -21367,6 +21199,7 @@ packages:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
+    dev: false
 
   /fs-jetpack@4.3.1:
     resolution: {integrity: sha512-dbeOK84F6BiQzk2yqqCVwCPWTxAvVGJ3fMQc6E2wuEohS28mR6yHngbrKuVCK1KHRx/ccByDylqu4H5PCP2urQ==}
@@ -22775,20 +22608,12 @@ packages:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
 
-  /intl-messageformat-parser@6.1.2:
-    resolution: {integrity: sha512-4GQDEPhl/ZMNDKwMsLqyw1LG2IAWjmLJXdmnRcHKeLQzpgtNYZI6lVw1279pqIkRk2MfKb9aDsVFzm565azK5A==}
-    deprecated: We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser
+  /intl-messageformat@10.5.12:
+    resolution: {integrity: sha512-izl0uxhy/melhw8gP2r8pGiVieviZmM4v5Oqx3c1/R7g9cwER2smmGfSjcIsp8Y3Q53bfciL/gkxacJRx/dUvg==}
     dependencies:
-      '@formatjs/ecma402-abstract': 1.5.0
-      tslib: 2.4.1
-    dev: true
-
-  /intl-messageformat@9.13.0:
-    resolution: {integrity: sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==}
-    dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/fast-memoize': 1.2.1
-      '@formatjs/icu-messageformat-parser': 2.1.0
+      '@formatjs/ecma402-abstract': 1.18.2
+      '@formatjs/fast-memoize': 2.2.0
+      '@formatjs/icu-messageformat-parser': 2.7.6
       tslib: 2.4.1
 
   /invariant@2.2.4:
@@ -24880,14 +24705,6 @@ packages:
     dev: false
     optional: true
 
-  /loud-rejection@2.2.0:
-    resolution: {integrity: sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      currently-unhandled: 0.4.1
-      signal-exit: 3.0.7
-    dev: true
-
   /lower-case-first@2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
@@ -24970,6 +24787,7 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: false
 
   /magic-string@0.26.7:
     resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
@@ -27348,6 +27166,7 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: false
 
   /postcss@8.4.35:
     resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
@@ -28147,24 +27966,24 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-intl@5.25.1(react@17.0.2)(typescript@4.9.4):
-    resolution: {integrity: sha512-pkjdQDvpJROoXLMltkP/5mZb0/XqrqLoPGKUCfbdkP8m6U9xbK40K51Wu+a4aQqTEvEK5lHBk0fWzUV72SJ3Hg==}
+  /react-intl@6.6.6(react@17.0.2)(typescript@4.9.4):
+    resolution: {integrity: sha512-dKXQNUrhZTlCp8uelYW8PHiM4saNKyLmHCfsJYWK0N/kZ/Ien35wjPHB8x9yQcTJbeN/hBOmb4x16iKUrdL9MA==}
     peerDependencies:
-      react: ^16.3.0 || 17 || 18
-      typescript: ^4.5
+      react: ^16.6.0 || 17 || 18
+      typescript: ^4.7 || 5
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/icu-messageformat-parser': 2.1.0
-      '@formatjs/intl': 2.2.1(typescript@4.9.4)
-      '@formatjs/intl-displaynames': 5.4.3
-      '@formatjs/intl-listformat': 6.5.3
+      '@formatjs/ecma402-abstract': 1.18.2
+      '@formatjs/icu-messageformat-parser': 2.7.6
+      '@formatjs/intl': 2.10.2(typescript@4.9.4)
+      '@formatjs/intl-displaynames': 6.6.6
+      '@formatjs/intl-listformat': 7.5.5
       '@types/hoist-non-react-statics': 3.3.1
       '@types/react': 17.0.53
       hoist-non-react-statics: 3.3.2
-      intl-messageformat: 9.13.0
+      intl-messageformat: 10.5.12
       react: 17.0.2
       tslib: 2.4.1
       typescript: 4.9.4
@@ -31878,16 +31697,6 @@ packages:
   /vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
     dev: false
-
-  /vue@3.2.45:
-    resolution: {integrity: sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==}
-    dependencies:
-      '@vue/compiler-dom': 3.2.45
-      '@vue/compiler-sfc': 3.2.45
-      '@vue/runtime-dom': 3.2.45
-      '@vue/server-renderer': 3.2.45(vue@3.2.45)
-      '@vue/shared': 3.2.45
-    dev: true
 
   /w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -54,7 +54,7 @@
         "react": "^17.0",
         "react-dom": "^17.0.2",
         "react-final-form": "^6.3.1",
-        "react-intl": "^5.10.0",
+        "react-intl": "^6.0.0",
         "react-select": "^3.0.4",
         "require-from-string": "^2.0.2",
         "use-debounce": "^6.0.0",


### PR DESCRIPTION
Prevents a warning when upgrading to TypeScript v5.