### PR TITLE
Ignore local storage quota exceeded error in `writeClipboardText`

### DIFF
--- a/.changeset/lovely-timers-heal.md
+++ b/.changeset/lovely-timers-heal.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Ignore local storage quota exceeded error in `writeClipboardText`

--- a/packages/admin/admin/src/clipboard/writeClipboardText.ts
+++ b/packages/admin/admin/src/clipboard/writeClipboardText.ts
@@ -1,6 +1,15 @@
 export async function writeClipboardText(data: string): Promise<void> {
     // Always write to local storage, which is used as a fallback when reading from the clipboard is not supported/allowed.
-    window.localStorage.setItem("comet_clipboard", data);
+    try {
+        window.localStorage.setItem("comet_clipboard", data);
+    } catch (error) {
+        if (error instanceof DOMException && error.name === "QuotaExceededError") {
+            // Ignore error when data size exceeds the local storage limit.
+            // TODO fix by splitting the data into smaller chunks and storing them separately.
+        } else {
+            throw error;
+        }
+    }
 
     if (!("clipboard" in navigator)) {
         return;


### PR DESCRIPTION
Temporary workaround to enable copying of large page tree parts in one of our customer projects.
