### PR TITLE
Add custom action to handmade products grid

### DIFF
--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -38,6 +38,7 @@ import {
     GQLUpdateProductStatusMutation,
     GQLUpdateProductStatusMutationVariables,
 } from "./ProductsGrid.generated";
+import { ProductsGridPreviewAction } from "./ProductsGridPreviewAction";
 
 function ProductsGridToolbar() {
     return (
@@ -139,9 +140,11 @@ export function ProductsGrid() {
             headerName: "",
             sortable: false,
             filterable: false,
+            width: 96,
             renderCell: (params) => {
                 return (
                     <>
+                        <ProductsGridPreviewAction product={params.row} />
                         <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
                             <Edit color="primary" />
                         </IconButton>

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -140,7 +140,7 @@ export function ProductsGrid() {
             headerName: "",
             sortable: false,
             filterable: false,
-            width: 96,
+            width: 106,
             renderCell: (params) => {
                 return (
                     <>

--- a/demo/admin/src/products/ProductsGridPreviewAction.tsx
+++ b/demo/admin/src/products/ProductsGridPreviewAction.tsx
@@ -1,0 +1,34 @@
+import { Tooltip } from "@comet/admin";
+import { View } from "@comet/admin-icons";
+import { Dialog, DialogContent, DialogTitle, IconButton, Typography } from "@mui/material";
+import { GQLProductsListManualFragment } from "@src/products/ProductsGrid.generated";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+type Props = {
+    product: GQLProductsListManualFragment;
+};
+
+export const ProductsGridPreviewAction = ({ product }: Props) => {
+    const [showDetails, setShowDetails] = React.useState(false);
+    return (
+        <>
+            <Tooltip title="View Details">
+                <IconButton onClick={() => setShowDetails(true)}>
+                    <View />
+                </IconButton>
+            </Tooltip>
+            <Dialog open={showDetails} onClose={() => setShowDetails(false)}>
+                <DialogTitle>
+                    <FormattedMessage id="productsGrid.detailsDialog.title" defaultMessage="Product Details" />
+                </DialogTitle>
+                <DialogContent>
+                    <Typography variant="h3" gutterBottom>
+                        {product.title}
+                    </Typography>
+                    <Typography>{product.description}</Typography>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+};


### PR DESCRIPTION
We need to manually set the width of the actions column, depending on the number of `IconButton` components shown, 32px per `IconButton`.  DataGrid columns do not scale automatically, depending on their content. 

We cannot use `getActions` from the [special property types](https://mui.com/x/react-data-grid/column-definition/#special-properties) for this:

- Every item returned by `getActions` must be the `GridActionsCellItem` component directly. This would not allow us to wrap the item with a `Tooltip` or add a Fragment that contains the item so we can add a `Dialog` that opens when clicking the item. 

- Additionally, `CrudContextMenu` is not currently implemented with `GridActionsCellItem` so it cannot be used inside `getActions` in it's current state. Simply replacing the items with `GridActionsCellItem` would not work, as `getActions` requires an array of items and cannot handle multiple items inside one element or fragment. 

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: SVK-211
-   [x] Provide screenshots/screencasts if the change contains visual changes


https://github.com/vivid-planet/comet/assets/6264317/e500c050-0474-404f-b4f3-5f22e9d6df23