### PR TITLE
Correctly set the disabled styles in the MuiChip styleOverrides

### DIFF
--- a/packages/admin/admin-theme/src/componentsTheme/MuiChip.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiChip.tsx
@@ -10,6 +10,9 @@ export const getMuiChip: GetMuiComponentTheme<"MuiChip"> = (component, { palette
     styleOverrides: mergeOverrideStyles<"MuiChip">(component?.styleOverrides, {
         root: {
             borderRadius: 12,
+            "&.Mui-disabled": {
+                opacity: 0.5,
+            },
         },
         sizeMedium: {
             height: 24,
@@ -48,9 +51,6 @@ export const getMuiChip: GetMuiComponentTheme<"MuiChip"> = (component, { palette
         deleteIconSmall: {
             margin: 0,
             fontSize: 12,
-        },
-        disabled: {
-            opacity: 0.5,
         },
         deleteIconColorPrimary: {
             color: palette.primary.contrastText,


### PR DESCRIPTION
Previously, the following error appeared:

```
MUI: The `MuiChip` component increases the CSS specificity of the `disabled` internal state.
You can not override it like this: 
{
  "root": {
    "borderRadius": 12
  },
  "sizeMedium": {
    "height": 24,
    "padding": "4px 10px"
  },
  "iconMedium": {
    "margin": 0,
    "fontSize": 16,
    "paddingRight": "6px"
  },
  "labelMedium": {
    "fontSize": 12,
    "lineHeight": "16px",
    "paddingLeft": 0,
    "paddingRight": "6px"
  },
  "deleteIconMedium": {
    "margin": 0,
    "fontSize": 16
  },
  "sizeSmall": {
    "height": 20,
    "padding": "4px 7px"
  },
  "iconSmall": {
    "margin": 0,
    "fontSize": 12,
    "paddingRight": "5px"
  },
  "labelSmall": {
    "fontSize": 10,
    "lineHeight": "10px",
    "paddingLeft": 0,
    "paddingRight": "5px"
  },
  "deleteIconSmall": {
    "margin": 0,
    "fontSize": 12
  },
  "disabled": {
    "opacity": 0.5
  },
  "deleteIconColorPrimary": {
    "color": "#000000",
    "&:hover": {
      "color": "#000000"
    }
  },
  "deleteIconColorSecondary": {
    "color": "#000000",
    "&:hover": {
      "color": "#000000"
    }
  },
  "deleteIconColorDefault": {
    "color": "black",
    "&:hover": {
      "color": "black"
    }
  },
  "deleteIconColorSuccess": {
    "color": "#000000",
    "&:hover": {
      "color": "#000000"
    }
  },
  "deleteIconColorError": {
    "color": "#ffffff",
    "&:hover": {
      "color": "#ffffff"
    }
  },
  "deleteIconColorWarning": {
    "color": "#000000",
    "&:hover": {
      "color": "#000000"
    }
  },
  "deleteIconColorInfo": {
    "color": "#000000",
    "&:hover": {
      "color": "#000000"
    }
  },
  "filledDefault": {
    "backgroundColor": "#D9D9D9"
  },
  "outlinedDefault": {
    "borderColor": "#D9D9D9"
  },
  "clickableColorDefault": {
    "&.MuiChip-filled:hover": {
      "backgroundColor": "#B3B3B3"
    },
    "&.MuiChip-outlined:hover": {
      "backgroundColor": "#F2F2F2"
    }
  }
}

Instead, you need to use the '&.Mui-disabled' syntax:
{
  "root": {
    "&.Mui-disabled": {
      "opacity": 0.5
    }
  }
}

https://mui.com/r/state-classes-guide
```

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-689
