### PR TITLE
Only return duplicates within the same scope in the `FilesResolver#duplicates` field resolver

### DIFF
--- a/.changeset/wild-clocks-dress.md
+++ b/.changeset/wild-clocks-dress.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Only return duplicates within the same scope in the `FilesResolver#duplicates` field resolver
+
+As a side effect `FilesService#findAllByHash` now accepts an optional scope parameter.

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -263,7 +263,7 @@ export function createFilesResolver({
 
         @ResolveField(() => [File])
         async duplicates(@Parent() file: FileInterface): Promise<FileInterface[]> {
-            const files = await this.filesService.findAllByHash(file.contentHash);
+            const files = await this.filesService.findAllByHash(file.contentHash, { scope: file.scope });
             return files.filter((f) => f.id !== file.id);
         }
 

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -176,8 +176,8 @@ export class FilesService {
         return [files, totalCount];
     }
 
-    async findAllByHash(contentHash: string): Promise<FileInterface[]> {
-        return withFilesSelect(this.selectQueryBuilder(), { contentHash }).getResult();
+    async findAllByHash(contentHash: string, options?: { scope?: DamScopeInterface }): Promise<FileInterface[]> {
+        return withFilesSelect(this.selectQueryBuilder(), { contentHash, scope: options?.scope }).getResult();
     }
 
     async findMultipleByIds(ids: string[]) {


### PR DESCRIPTION
Previously, duplicates in all scopes were returned

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-735
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Previously:

<img width="1917" alt="Bildschirmfoto 2024-05-08 um 16 48 23" src="https://github.com/vivid-planet/comet/assets/13380047/6474b546-69fd-4ca9-a9e7-846cde6c14e2">


Now:

<img width="1917" alt="Bildschirmfoto 2024-05-08 um 16 47 47" src="https://github.com/vivid-planet/comet/assets/13380047/44e74eb5-a3a7-4bed-8744-d6b593e77d54">


</details>
