### PR TITLE
DAM: Fix the duplicate name check when updating a file

### DIFF
--- a/.changeset/khaki-beans-clean.md
+++ b/.changeset/khaki-beans-clean.md
@@ -1,0 +1,14 @@
+---
+"@comet/cms-api": patch
+"@comet/cms-admin": patch
+---
+
+DAM: Fix the duplicate name check when updating a file
+
+Previously, there were two bugs:
+
+1. In the `EditFile` form, the `folderId` wasn't passed to the mutation
+2. In `FilesService#updateByEntity`, the duplicate check was always done against the root folder if no `folderId` was passed
+
+This caused an error when saving a file in any folder if there was another file with the same name in the root folder.
+And it was theoretically possible to create two files with the same name in one folder (though this was still prevented by admin-side validation).

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -160,11 +160,12 @@ const EditFileInner = ({ file, id }: EditFileInnerProps) => {
                             cropArea,
                         },
                         license: values.license?.type === "NO_LICENSE" ? null : { ...values.license, type: values.license?.type },
+                        folderId: file.folder?.id ?? null,
                     },
                 },
             });
         },
-        [id, updateDamFile],
+        [file.folder?.id, id, updateDamFile],
     );
 
     const initialBlockListWidth = 100 / 3;

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -243,7 +243,8 @@ export class FilesService {
         return this.updateByEntity(file, data);
     }
 
-    async updateByEntity(entity: FileInterface, { folderId, image, ...input }: UpdateFileInput): Promise<FileInterface> {
+    async updateByEntity(entity: FileInterface, { image, ...input }: UpdateFileInput): Promise<FileInterface> {
+        const folderId = input.folderId !== undefined ? input.folderId : entity.folder?.id;
         const folder = folderId ? await this.foldersService.findOneById(folderId) : null;
 
         if (entity.image && image?.cropArea) {


### PR DESCRIPTION
Previously, there were two bugs:

1. In the `EditFile` form, the `folderId` wasn't passed to the mutation
2. In `FilesService#updateByEntity`, the duplicate check was always done against the root folder if no `folderId` was passed

This caused an error when saving a file in any folder if there was another file with the same name in the root folder.
And it was theoretically possible to create two files with the same name in one folder (though this was still prevented by admin-side validation).

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-735
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>

Previously:


https://github.com/vivid-planet/comet/assets/13380047/87c5340a-c650-4aea-8292-eb39b3f4a65f



Now:


https://github.com/vivid-planet/comet/assets/13380047/51e23b21-d071-4d01-8145-ab80a4d1b26e



</details>
