### PR TITLE
Add `DataGridToolbar`

### DIFF
--- a/.changeset/curly-pillows-decide.md
+++ b/.changeset/curly-pillows-decide.md
@@ -4,6 +4,9 @@
 
 Add new `DataGridToolbar` component
 
+The "normal" `Toolbar` is meant to be used on page-level to show the current scope, breadcrumbs and page-wide action buttons (like save).
+The `DataGridToolbar`, however, is meant to be used in DataGrids to contain a search input, filter options, bulk actions and an add button.
+
 You can use it like this:
 
 ```tsx

--- a/.changeset/curly-pillows-decide.md
+++ b/.changeset/curly-pillows-decide.md
@@ -12,7 +12,7 @@ You can use it like this:
     components={{
         Toolbar: () => (
             <DataGridToolbar>
-                {/* // ... */}
+                {/* ... */}
             </DataGridToolbar>
         ),
     }}

--- a/.changeset/curly-pillows-decide.md
+++ b/.changeset/curly-pillows-decide.md
@@ -1,0 +1,20 @@
+---
+"@comet/admin": minor
+---
+
+Add new `DataGridToolbar` component
+
+You can use it like this:
+
+```tsx
+<DataGrid
+    // ...
+    components={{
+        Toolbar: () => (
+            <DataGridToolbar>
+                {/* // ... */}
+            </DataGridToolbar>
+        ),
+    }}
+/>
+```

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -6,7 +6,7 @@ import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { Toolbar, ToolbarProps } from "./Toolbar";
 
-export type DataGridToolbarClassKey = "root";
+export type DataGridToolbarClassKey = "root" | "standard" | "comfortable";
 
 export type DataGridToolbarProps = { density?: "standard" | "comfortable" } & Omit<
     ToolbarProps,
@@ -23,6 +23,9 @@ type OwnerState = {
 const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey, OwnerState>({
     componentName: "DataGridToolbar",
     slotName: "root",
+    classesResolver(ownerState) {
+        return [ownerState.density === "standard" ? "standard" : "comfortable"];
+    },
 })(
     ({ ownerState, theme }) => css`
         ${ownerState.density === "comfortable" &&

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -1,5 +1,5 @@
 import { ComponentsOverrides } from "@mui/material";
-import { Theme, useThemeProps } from "@mui/material/styles";
+import { css, Theme, useThemeProps } from "@mui/material/styles";
 import * as React from "react";
 
 import { createComponentSlot } from "../../helpers/createComponentSlot";
@@ -8,19 +8,47 @@ import { Toolbar, ToolbarProps } from "./Toolbar";
 
 export type DataGridToolbarClassKey = "root";
 
-export type DataGridToolbarProps = Omit<ToolbarProps, "slotProps" | "scopeIndicator" | "hideTopBar" | "hideBottomBar"> &
+export type DataGridToolbarProps = { density?: "standard" | "comfortable" } & Omit<
+    ToolbarProps,
+    "slotProps" | "scopeIndicator" | "hideTopBar" | "hideBottomBar"
+> &
     ThemedComponentBaseProps<{
         root: typeof Toolbar;
     }>;
 
-const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey>({
+type OwnerState = {
+    density: "standard" | "comfortable";
+};
+
+const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey, OwnerState>({
     componentName: "DataGridToolbar",
     slotName: "root",
-})();
+})(
+    ({ ownerState, theme }) => css`
+        ${ownerState.density === "comfortable" &&
+        css`
+            min-height: 80px;
+
+            ${theme.breakpoints.up("sm")} {
+                min-height: 80px;
+            }
+
+            // necessary to override strange MUI default styling
+            @media (min-width: 0px) and (orientation: landscape) {
+                min-height: 80px;
+            }
+        `}
+    `,
+);
 
 export const DataGridToolbar = (inProps: DataGridToolbarProps) => {
-    const props = useThemeProps({ props: inProps, name: "CometAdminDataGridToolbar" });
-    return <Root {...props} hideTopBar />;
+    const { density = "standard", ...restProps } = useThemeProps({ props: inProps, name: "CometAdminDataGridToolbar" });
+
+    const ownerState: OwnerState = {
+        density,
+    };
+
+    return <Root {...restProps} hideTopBar ownerState={ownerState} />;
 };
 
 declare module "@mui/material/styles" {

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -24,7 +24,7 @@ const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey, OwnerState>({
     componentName: "DataGridToolbar",
     slotName: "root",
     classesResolver(ownerState) {
-        return [ownerState.density === "standard" ? "standard" : "comfortable"];
+        return [ownerState.density];
     },
 })(
     ({ ownerState, theme }) => css`

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -45,13 +45,13 @@ const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey, OwnerState>({
 );
 
 export const DataGridToolbar = (inProps: DataGridToolbarProps) => {
-    const { density = "standard", ...restProps } = useThemeProps({ props: inProps, name: "CometAdminDataGridToolbar" });
+    const { density = "standard", slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminDataGridToolbar" });
 
     const ownerState: OwnerState = {
         density,
     };
 
-    return <Root {...restProps} hideTopBar ownerState={ownerState} />;
+    return <Root ownerState={ownerState} hideTopBar {...slotProps?.root} {...restProps} />;
 };
 
 declare module "@mui/material/styles" {

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -1,0 +1,41 @@
+import { ComponentsOverrides } from "@mui/material";
+import { Theme, useThemeProps } from "@mui/material/styles";
+import * as React from "react";
+
+import { createComponentSlot } from "../../helpers/createComponentSlot";
+import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
+import { Toolbar, ToolbarProps } from "./Toolbar";
+
+export type DataGridToolbarClassKey = "root";
+
+export type DataGridToolbarProps = Omit<ToolbarProps, "slotProps" | "scopeIndicator" | "hideTopBar" | "hideBottomBar"> &
+    ThemedComponentBaseProps<{
+        root: typeof Toolbar;
+    }>;
+
+const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey>({
+    componentName: "DataGridToolbar",
+    slotName: "root",
+})();
+
+export const DataGridToolbar = (inProps: DataGridToolbarProps) => {
+    const props = useThemeProps({ props: inProps, name: "CometAdminDataGridToolbar" });
+    return <Root {...props} hideTopBar />;
+};
+
+declare module "@mui/material/styles" {
+    interface ComponentNameToClassKey {
+        CometAdminDataGridToolbar: DataGridToolbarClassKey;
+    }
+
+    interface ComponentsPropsList {
+        CometAdminDataGridToolbar: DataGridToolbarProps;
+    }
+
+    interface Components {
+        CometAdminDataGridToolbar?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminDataGridToolbar"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDataGridToolbar"];
+        };
+    }
+}

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -32,6 +32,7 @@ export {
 } from "./common/toolbar/automatictitleitem/ToolbarAutomaticTitleItem";
 export { ToolbarBackButton, ToolbarBackButtonClassKey, ToolbarBackButtonProps } from "./common/toolbar/backbutton/ToolbarBackButton";
 export { ToolbarBreadcrumbs, ToolbarBreadcrumbsClassKey, ToolbarBreadcrumbsProps } from "./common/toolbar/breadcrumb/ToolbarBreadcrumbs";
+export { DataGridToolbar, DataGridToolbarClassKey, DataGridToolbarProps } from "./common/toolbar/DataGridToolbar";
 export { ToolbarFillSpace, ToolbarFillSpaceClassKey, ToolbarFillSpaceProps } from "./common/toolbar/fillspace/ToolbarFillSpace";
 export { ToolbarItem, ToolbarItemClassKey, ToolbarItemProps } from "./common/toolbar/item/ToolbarItem";
 export { StackToolbar } from "./common/toolbar/StackToolbar";

--- a/storybook/src/admin/toolbar/DataGridToolbar.tsx
+++ b/storybook/src/admin/toolbar/DataGridToolbar.tsx
@@ -1,0 +1,56 @@
+import { DataGridToolbar, GridFilterButton, StackLink, ToolbarActions, ToolbarFillSpace, ToolbarItem } from "@comet/admin";
+import { Add as AddIcon } from "@comet/admin-icons";
+import { Button } from "@mui/material";
+import { DataGrid, GridToolbarQuickFilter } from "@mui/x-data-grid";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+const data = [
+    { id: "1f30a6a0-5b9d-4b25-8307-9e8b4a4d2b1c", firstname: "Emily", lastname: "Smith" },
+    { id: "28b9bdf3-5646-4a22-9449-74112db67b5f", firstname: "Daniel", lastname: "Johnson" },
+    { id: "e60900ec-3c69-4e67-8d78-83a10c7573d3", firstname: "Sophia", lastname: "Williams" },
+];
+
+storiesOf("@comet/admin/DataGridToolbar", module)
+    .addDecorator(storyRouterDecorator())
+    .add("DataGrid Toolbar", () => {
+        const columns = [
+            { field: "firstname", headerName: "First Name", width: 150 },
+            { field: "lastname", headerName: "Last Name", width: 150 },
+        ];
+
+        return (
+            <DataGrid
+                autoHeight
+                columns={columns}
+                rows={data}
+                components={{
+                    Toolbar: () => (
+                        <DataGridToolbar>
+                            <ToolbarItem>
+                                <GridToolbarQuickFilter />
+                            </ToolbarItem>
+                            <ToolbarItem>
+                                <GridFilterButton />
+                            </ToolbarItem>
+                            <ToolbarFillSpace />
+                            <ToolbarActions>
+                                <Button
+                                    startIcon={<AddIcon />}
+                                    component={StackLink}
+                                    pageName="add"
+                                    payload="add"
+                                    variant="contained"
+                                    color="primary"
+                                >
+                                    Add person
+                                </Button>
+                            </ToolbarActions>
+                        </DataGridToolbar>
+                    ),
+                }}
+            />
+        );
+    });


### PR DESCRIPTION
Add `DataGridToolbar`, a thin wrapper around `Toolbar` intended to be used in DataGrids

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-693
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

<img width="1665" alt="Bildschirmfoto 2024-05-09 um 14 06 00" src="https://github.com/vivid-planet/comet/assets/13380047/3202e8ed-9042-4864-8010-8e863177c7f2">

</details>
