### PR TITLE
Make it possible to remove the "Hide in menu" field from `createEditPageNode`

### DIFF
--- a/.changeset/breezy-suns-nail.md
+++ b/.changeset/breezy-suns-nail.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Make it possible to remove the "Hide in menu" field from `createEditPageNode`

--- a/.changeset/breezy-suns-nail.md
+++ b/.changeset/breezy-suns-nail.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": minor
 ---
 
-Make it possible to remove the "Hide in menu" field from `createEditPageNode`
+Add `disableHideInMenu` option to `createEditPageNode` to hide the "Hide in menu" checkbox 

--- a/demo/admin/src/common/EditPageNode.tsx
+++ b/demo/admin/src/common/EditPageNode.tsx
@@ -32,6 +32,7 @@ export const additionalPageTreeNodeFieldsFragment = {
 };
 
 export const EditPageNode = createEditPageNode({
+    disableHideInMenu: false,
     valuesToInput: ({ values }: { values: { userGroup: string } }) => {
         return {
             userGroup: values.userGroup,

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -39,6 +39,7 @@ interface CreateEditPageNodeProps {
     additionalFormFields?: React.ReactNode;
     nodeFragment?: { name: string; fragment: DocumentNode };
     valuesToInput?: (values: EditPageNodeFinalFormValues) => EditPageNodeFinalFormValues;
+    disableHideInMenu?: boolean;
 }
 
 export interface EditPageNodeProps {
@@ -52,6 +53,7 @@ export function createEditPageNode({
     additionalFormFields,
     nodeFragment,
     valuesToInput,
+    disableHideInMenu = false,
 }: CreateEditPageNodeProps): (props: EditPageNodeProps) => JSX.Element {
     const editPageNodeQuery = gql`
         query EditPageNode($id: ID!) {
@@ -446,25 +448,27 @@ export function createEditPageNode({
                                         </FinalFormSelect>
                                     )}
                                 </Field>
-                                <Field
-                                    label={intl.formatMessage({
-                                        id: "comet.pages.pages.page.menuVisibility",
-                                        defaultMessage: "Menu Visibility",
-                                    })}
-                                    name="hideInMenu"
-                                    type="checkbox"
-                                    variant="horizontal"
-                                >
-                                    {(props) => (
-                                        <FormControlLabel
-                                            label={intl.formatMessage({
-                                                id: "comet.pages.pages.page.hideInMenu",
-                                                defaultMessage: "Hide in Menu",
-                                            })}
-                                            control={<FinalFormCheckbox {...props} />}
-                                        />
-                                    )}
-                                </Field>
+                                {!disableHideInMenu && (
+                                    <Field
+                                        label={intl.formatMessage({
+                                            id: "comet.pages.pages.page.menuVisibility",
+                                            defaultMessage: "Menu Visibility",
+                                        })}
+                                        name="hideInMenu"
+                                        type="checkbox"
+                                        variant="horizontal"
+                                    >
+                                        {(props) => (
+                                            <FormControlLabel
+                                                label={intl.formatMessage({
+                                                    id: "comet.pages.pages.page.hideInMenu",
+                                                    defaultMessage: "Hide in Menu",
+                                                })}
+                                                control={<FinalFormCheckbox {...props} />}
+                                            />
+                                        )}
+                                    </Field>
+                                )}
 
                                 {additionalFormFields}
                             </>


### PR DESCRIPTION

In some of our projects, the menu isn't generated directly from the PageTree (but can be built separately). In that case it doesn't make sense to have a "Hide in menu" checkbox and it's confusing to the users. Thus, I added this option.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-700
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Default:

<img width="1917" alt="Bildschirmfoto 2024-05-10 um 11 25 00" src="https://github.com/vivid-planet/comet/assets/13380047/336a4bed-1466-4671-bd09-c20ea7bf90bd">

`disableHideInMenu === true`

<img width="1917" alt="Bildschirmfoto 2024-05-10 um 11 24 47" src="https://github.com/vivid-planet/comet/assets/13380047/d92b8b91-8600-49c0-9888-ac1b4e9821b5">

</details>
