### PR TITLE
Admin Generator Future: Remove `MainContent` from generated grid code

### DIFF
--- a/.changeset/tall-experts-approve.md
+++ b/.changeset/tall-experts-approve.md
@@ -1,7 +1,0 @@
----
-"@comet/cms-admin": minor
----
-
-Remove `MainContent` from generated Grids
-
-Grid size is now determined by the size of its container

--- a/.changeset/tall-experts-approve.md
+++ b/.changeset/tall-experts-approve.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": minor
+---
+
+Remove `MainContent` from generated Grids
+
+Grid size is now determined by the size of their container

--- a/.changeset/tall-experts-approve.md
+++ b/.changeset/tall-experts-approve.md
@@ -4,4 +4,4 @@
 
 Remove `MainContent` from generated Grids
 
-Grid size is now determined by the size of their container
+Grid size is now determined by the size of its container

--- a/demo/admin/src/products/future/ManufacturersPage.tsx
+++ b/demo/admin/src/products/future/ManufacturersPage.tsx
@@ -1,4 +1,4 @@
-import { Stack, StackPage, StackSwitch } from "@comet/admin";
+import { MainContent, Stack, StackPage, StackSwitch } from "@comet/admin";
 import { ManufacturersGrid } from "@src/products/future/generated/ManufacturersGrid";
 import * as React from "react";
 import { useIntl } from "react-intl";
@@ -9,7 +9,9 @@ export function ManufacturersPage(): React.ReactElement {
         <Stack topLevelTitle={intl.formatMessage({ id: "manufacturers.manufacturers", defaultMessage: "Manufacturers" })}>
             <StackSwitch>
                 <StackPage name="grid">
-                    <ManufacturersGrid />
+                    <MainContent fullHeight disablePadding>
+                        <ManufacturersGrid />
+                    </MainContent>
                 </StackPage>
                 <StackPage name="add" title={intl.formatMessage({ id: "manufacturers.addManufacturer", defaultMessage: "Add Manufacturer" })}>
                     <div>Add Manufacturer</div>

--- a/demo/admin/src/products/future/ProductsPage.tsx
+++ b/demo/admin/src/products/future/ProductsPage.tsx
@@ -1,4 +1,5 @@
 import {
+    MainContent,
     RouterTab,
     RouterTabs,
     SaveBoundary,
@@ -26,7 +27,9 @@ export function ProductsPage(): React.ReactElement {
         <Stack topLevelTitle={intl.formatMessage({ id: "products.products", defaultMessage: "Products" })}>
             <StackSwitch>
                 <StackPage name="grid">
-                    <ProductsGrid />
+                    <MainContent fullHeight disablePadding>
+                        <ProductsGrid />
+                    </MainContent>
                 </StackPage>
                 <StackPage name="edit" title={intl.formatMessage({ id: "products.editProduct", defaultMessage: "Edit Product" })}>
                     {(selectedProductId) => (
@@ -59,7 +62,11 @@ export function ProductsPage(): React.ReactElement {
                     )}
                 </StackPage>
                 <StackPage name="variants" title={intl.formatMessage({ id: "products.editProduct", defaultMessage: "Product variants" })}>
-                    {(selectedId) => <ProductVariantsGrid product={selectedId} />}
+                    {(selectedId) => (
+                        <MainContent fullHeight disablePadding>
+                            <ProductVariantsGrid product={selectedId} />
+                        </MainContent>
+                    )}
                 </StackPage>
                 <StackPage name="add" title={intl.formatMessage({ id: "products.addProduct", defaultMessage: "Add Product" })}>
                     <ProductForm />

--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -5,7 +5,6 @@ import {
     CrudContextMenu,
     filterByFragment,
     GridFilterButton,
-    MainContent,
     muiGridFilterToGql,
     muiGridSortToGql,
     StackLink,
@@ -242,18 +241,18 @@ export function ManufacturersGrid(): React.ReactElement {
     const rows = data?.manufacturers.nodes ?? [];
 
     return (
-        <MainContent fullHeight disablePadding>
-            <DataGridPro
-                {...dataGridProps}
-                disableSelectionOnClick
-                rows={rows}
-                rowCount={rowCount}
-                columns={columns}
-                loading={loading}
-                components={{
-                    Toolbar: ManufacturersGridToolbar,
-                }}
-            />
-        </MainContent>
+        // <MainContent fullHeight disablePadding>
+        <DataGridPro
+            {...dataGridProps}
+            disableSelectionOnClick
+            rows={rows}
+            rowCount={rowCount}
+            columns={columns}
+            loading={loading}
+            components={{
+                Toolbar: ManufacturersGridToolbar,
+            }}
+        />
+        // </MainContent>
     );
 }

--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -241,7 +241,6 @@ export function ManufacturersGrid(): React.ReactElement {
     const rows = data?.manufacturers.nodes ?? [];
 
     return (
-        // <MainContent fullHeight disablePadding>
         <DataGridPro
             {...dataGridProps}
             disableSelectionOnClick
@@ -253,6 +252,5 @@ export function ManufacturersGrid(): React.ReactElement {
                 Toolbar: ManufacturersGridToolbar,
             }}
         />
-        // </MainContent>
     );
 }

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -173,7 +173,6 @@ export function ProductVariantsGrid({ product }: Props): React.ReactElement {
     const rows = data?.productVariants.nodes ?? [];
 
     return (
-        // <MainContent fullHeight disablePadding>
         <DataGridPro
             {...dataGridProps}
             disableSelectionOnClick
@@ -185,6 +184,5 @@ export function ProductVariantsGrid({ product }: Props): React.ReactElement {
                 Toolbar: ProductVariantsGridToolbar,
             }}
         />
-        // </MainContent>
     );
 }

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -5,7 +5,6 @@ import {
     CrudContextMenu,
     filterByFragment,
     GridFilterButton,
-    MainContent,
     muiGridFilterToGql,
     muiGridSortToGql,
     StackLink,
@@ -174,18 +173,18 @@ export function ProductVariantsGrid({ product }: Props): React.ReactElement {
     const rows = data?.productVariants.nodes ?? [];
 
     return (
-        <MainContent fullHeight disablePadding>
-            <DataGridPro
-                {...dataGridProps}
-                disableSelectionOnClick
-                rows={rows}
-                rowCount={rowCount}
-                columns={columns}
-                loading={loading}
-                components={{
-                    Toolbar: ProductVariantsGridToolbar,
-                }}
-            />
-        </MainContent>
+        // <MainContent fullHeight disablePadding>
+        <DataGridPro
+            {...dataGridProps}
+            disableSelectionOnClick
+            rows={rows}
+            rowCount={rowCount}
+            columns={columns}
+            loading={loading}
+            components={{
+                Toolbar: ProductVariantsGridToolbar,
+            }}
+        />
+        // </MainContent>
     );
 }

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -205,7 +205,6 @@ export function ProductsGrid({ filter }: Props): React.ReactElement {
     const rows = data?.products.nodes ?? [];
 
     return (
-        // <MainContent fullHeight disablePadding>
         <DataGridPro
             {...dataGridProps}
             disableSelectionOnClick
@@ -217,6 +216,5 @@ export function ProductsGrid({ filter }: Props): React.ReactElement {
                 Toolbar: ProductsGridToolbar,
             }}
         />
-        // </MainContent>
     );
 }

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -5,7 +5,6 @@ import {
     CrudContextMenu,
     filterByFragment,
     GridFilterButton,
-    MainContent,
     muiGridFilterToGql,
     muiGridSortToGql,
     StackLink,
@@ -206,18 +205,18 @@ export function ProductsGrid({ filter }: Props): React.ReactElement {
     const rows = data?.products.nodes ?? [];
 
     return (
-        <MainContent fullHeight disablePadding>
-            <DataGridPro
-                {...dataGridProps}
-                disableSelectionOnClick
-                rows={rows}
-                rowCount={rowCount}
-                columns={columns}
-                loading={loading}
-                components={{
-                    Toolbar: ProductsGridToolbar,
-                }}
-            />
-        </MainContent>
+        // <MainContent fullHeight disablePadding>
+        <DataGridPro
+            {...dataGridProps}
+            disableSelectionOnClick
+            rows={rows}
+            rowCount={rowCount}
+            columns={columns}
+            loading={loading}
+            components={{
+                Toolbar: ProductsGridToolbar,
+            }}
+        />
+        // </MainContent>
     );
 }

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -305,7 +305,6 @@ export function generateGrid(
         CrudContextMenu,
         filterByFragment,
         GridFilterButton,
-        MainContent,
         muiGridFilterToGql,
         muiGridSortToGql,
         StackLink,

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -599,19 +599,17 @@ export function generateGrid(
         const rows = data?.${gridQuery}.nodes ?? [];
 
         return (
-            <MainContent fullHeight disablePadding>
-                <DataGridPro
-                    {...dataGridProps}
-                    disableSelectionOnClick
-                    rows={rows}
-                    rowCount={rowCount}
-                    columns={columns}
-                    loading={loading}
-                    components={{
-                        Toolbar: ${gqlTypePlural}GridToolbar,
-                    }}
-                />
-            </MainContent>
+            <DataGridPro
+                {...dataGridProps}
+                disableSelectionOnClick
+                rows={rows}
+                rowCount={rowCount}
+                columns={columns}
+                loading={loading}
+                components={{
+                    Toolbar: ${gqlTypePlural}GridToolbar,
+                }}
+            />
         );
     }
     `;


### PR DESCRIPTION
Grids are generated without `MainContent`, allowing them to adjust their size to their container.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: SVK-253
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
Behaviour of small Grid:

https://github.com/vivid-planet/comet/assets/122883866/503cff1f-86c1-4db1-897c-735200844d03

Fullsize Grid with MainContent:

<img width="2174" alt="Screenshot 2024-05-10 at 13 32 39" src="https://github.com/vivid-planet/comet/assets/122883866/2b421801-af31-4003-bf2f-6a782aceeada">

</details>




