### PR TITLE
Only return duplicates within the same scope in the `FilesResolver#duplicates` field resolver (v5)

### DIFF
--- a/.changeset/wild-clocks-dress.md
+++ b/.changeset/wild-clocks-dress.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Only return duplicates within the same scope in the `FilesResolver#duplicates` field resolver
+
+As a side effect `FilesService#findAllByHash` now accepts an optional scope parameter.

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -262,7 +262,7 @@ export function createFilesResolver({ File, Scope: PassedScope }: { File: Type<F
 
         @ResolveField(() => [File])
         async duplicates(@Parent() file: FileInterface): Promise<FileInterface[]> {
-            const files = await this.filesService.findAllByHash(file.contentHash);
+            const files = await this.filesService.findAllByHash(file.contentHash, { scope: file.scope });
             return files.filter((f) => f.id !== file.id);
         }
 

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -175,8 +175,8 @@ export class FilesService {
         return [files, totalCount];
     }
 
-    async findAllByHash(contentHash: string): Promise<FileInterface[]> {
-        return withFilesSelect(this.selectQueryBuilder(), { contentHash }).getResult();
+    async findAllByHash(contentHash: string, options?: { scope?: DamScopeInterface }): Promise<FileInterface[]> {
+        return withFilesSelect(this.selectQueryBuilder(), { contentHash, scope: options?.scope }).getResult();
     }
 
     async findMultipleByIds(ids: string[]) {


### PR DESCRIPTION
Backport of https://github.com/vivid-planet/comet/pull/2048