### PR TITLE
Change muiGridFilterToGql fallback operator to 'and' 

### DIFF
--- a/.changeset/fair-hats-decide.md
+++ b/.changeset/fair-hats-decide.md
@@ -2,4 +2,4 @@
 "@comet/admin": patch
 ---
 
-muiGridFilterToGql: change fallback operator to 'and'
+muiGridFilterToGql: change fallback operator to 'and' to match MUI default

--- a/.changeset/fair-hats-decide.md
+++ b/.changeset/fair-hats-decide.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+muiGridFilterToGql: change fallback operator to 'and'

--- a/packages/admin/admin/src/dataGrid/muiGridFilterToGql.test.ts
+++ b/packages/admin/admin/src/dataGrid/muiGridFilterToGql.test.ts
@@ -1,0 +1,78 @@
+import { GridColDef, GridLinkOperator } from "@mui/x-data-grid";
+import { GridFilterModel } from "@mui/x-data-grid/models/gridFilterModel";
+
+import { muiGridFilterToGql } from "./muiGridFilterToGql";
+
+const columns: GridColDef<{ tag: string }>[] = [{ field: "tag" }];
+
+const mockedFilterModelAndOperator: GridFilterModel = {
+    items: [
+        {
+            columnField: "tag",
+            operatorValue: "contains",
+            id: 1,
+            value: "de",
+        },
+        {
+            columnField: "tag",
+            operatorValue: "contains",
+            id: 2,
+            value: "en",
+        },
+    ],
+    linkOperator: GridLinkOperator.And,
+};
+
+const mockedFilterModelOrOperator: GridFilterModel = {
+    items: [
+        {
+            columnField: "tag",
+            operatorValue: "contains",
+            id: 1,
+            value: "de",
+        },
+        {
+            columnField: "tag",
+            operatorValue: "contains",
+            id: 2,
+            value: "en",
+        },
+    ],
+    linkOperator: GridLinkOperator.Or,
+};
+const mockedFilterModelWithoutOperator: GridFilterModel = {
+    items: [
+        {
+            columnField: "tag",
+            operatorValue: "contains",
+            id: 1,
+            value: "de",
+        },
+        {
+            columnField: "tag",
+            operatorValue: "contains",
+            id: 2,
+            value: "en",
+        },
+    ],
+};
+
+describe("muiGridFilterToGql", () => {
+    it("should use correct and filter for specified and operator", () => {
+        const result = muiGridFilterToGql(columns, mockedFilterModelAndOperator);
+
+        expect(result).toEqual({ filter: { and: [{ tag: { contains: "de" } }, { tag: { contains: "en" } }] } });
+    });
+
+    it("should use correct or filter for specified or operator", () => {
+        const result = muiGridFilterToGql(columns, mockedFilterModelOrOperator);
+
+        expect(result).toEqual({ filter: { or: [{ tag: { contains: "de" } }, { tag: { contains: "en" } }] } });
+    });
+
+    it("should use correct and filter for no operator specified ", () => {
+        const result = muiGridFilterToGql(columns, mockedFilterModelWithoutOperator);
+
+        expect(result).toEqual({ filter: { and: [{ tag: { contains: "de" } }, { tag: { contains: "en" } }] } });
+    });
+});

--- a/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
+++ b/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
@@ -73,7 +73,7 @@ export function muiGridFilterToGql(columns: GridColDef[], filterModel?: GridFilt
             };
         });
     const filter: GqlFilter = {};
-    const op: "and" | "or" = filterModel.linkOperator ?? "or";
+    const op: "and" | "or" = filterModel.linkOperator ?? "and";
     filter[op] = filterItems;
 
     let search: undefined | string = undefined;


### PR DESCRIPTION
Mui uses and per default, not or

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: <!-- For instance, COM-123 -->
-   [x] Provide screenshots/screencasts if the change contains visual changes

