### PR TITLE
COM-723: Fix MenuItems not working without MenuItemGroups

### DIFF
--- a/packages/admin/admin/src/mui/menu/Menu.tsx
+++ b/packages/admin/admin/src/mui/menu/Menu.tsx
@@ -4,7 +4,10 @@ import { useHistory } from "react-router";
 
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { MasterLayoutContext } from "../MasterLayoutContext";
+import { MenuChild, MenuCollapsibleItemProps } from "./CollapsibleItem";
 import { MenuContext } from "./Context";
+import { MenuItemProps } from "./Item";
+import { MenuItemRouterLinkProps } from "./ItemRouterLink";
 import { MenuClassKey, OwnerState, PermanentDrawer, TemporaryDrawer } from "./Menu.styles";
 
 export const DEFAULT_DRAWER_WIDTH = 300;
@@ -73,6 +76,16 @@ export const Menu = (inProps: MenuProps) => {
         headerHeight,
     };
 
+    const childElements = React.useMemo(
+        () =>
+            React.Children.map(children, (child: MenuChild) => {
+                return React.cloneElement<MenuCollapsibleItemProps | MenuItemRouterLinkProps | MenuItemProps>(child, {
+                    isMenuOpen: open,
+                });
+            }),
+        [children, open],
+    );
+
     // Always render both temporary and permanent drawers to make sure, the opening and closing animations run fully when switching between variants.
     return (
         <>
@@ -84,7 +97,7 @@ export const Menu = (inProps: MenuProps) => {
                 {...slotProps?.temporaryDrawer}
                 {...restProps}
             >
-                {children}
+                {childElements}
             </TemporaryDrawer>
             <PermanentDrawer
                 variant="permanent"
@@ -98,7 +111,7 @@ export const Menu = (inProps: MenuProps) => {
                 }}
                 {...restProps}
             >
-                {children}
+                {childElements}
             </PermanentDrawer>
         </>
     );


### PR DESCRIPTION
This fixes a bug where menu items that are not in a group would display as only the collapsed icons all the time.

---

## PR Checklist
-   [x] Link to the respective task if one exists: <!-- For instance, COM-123 -->
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->


### Before
![image](https://github.com/vivid-planet/comet/assets/56400587/1d359389-59a9-4f58-9e17-89a641290985)

### After
![image](https://github.com/vivid-planet/comet/assets/56400587/4542dc24-7f00-4496-8c05-c77ae14e6618)

</details>
