### PR TITLE
Refactor theming of `FinalFormFileSelect`

### DIFF
--- a/packages/admin/admin/src/form/FinalFormFileSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormFileSelect.tsx
@@ -1,7 +1,8 @@
 import { Delete, Error, Select } from "@comet/admin-icons";
-import { Button, Chip, ComponentsOverrides, FormHelperText, IconButton, Theme, Typography } from "@mui/material";
-import { createStyles, WithStyles, withStyles } from "@mui/styles";
-import clsx from "clsx";
+import { Button, Chip, ComponentsOverrides, FormHelperText, IconButton, Typography } from "@mui/material";
+import { css, styled, Theme, useThemeProps } from "@mui/material/styles";
+import { PrettyBytes } from "../helpers/PrettyBytes";
+import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 import * as React from "react";
 import { Accept, useDropzone } from "react-dropzone";
 import { FieldRenderProps } from "react-final-form";
@@ -9,7 +10,6 @@ import { FormattedMessage } from "react-intl";
 
 import { Alert } from "../alert/Alert";
 import { Tooltip } from "../common/Tooltip";
-import { PrettyBytes } from "../helpers/PrettyBytes";
 
 export type FinalFormFileSelectClassKey =
     | "root"
@@ -22,115 +22,235 @@ export type FinalFormFileSelectClassKey =
     | "fileListItemInfos"
     | "rejectedFileListItem"
     | "errorMessage"
-    | "droppableAreaIsDisabled"
-    | "droppableAreaHasError"
     | "fileListText"
     | "selectButton";
 
-const styles = ({ palette }: Theme) => {
-    return createStyles<FinalFormFileSelectClassKey, FinalFormFileSelectProps>({
-        root: {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-start",
-            gap: "10px",
-        },
-        dropzone: {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-start",
-            gap: "10px",
-            width: "100%",
-        },
-        droppableArea: {
-            position: "relative",
-            display: "flex",
-            height: "80px",
-            justifyContent: "center",
-            alignItems: "center",
-            alignSelf: "stretch",
-            borderRadius: "4px",
-            border: `1px dashed ${palette.grey[200]}`,
-            cursor: "pointer",
-            "&$droppableAreaIsDisabled": {
-                cursor: "default",
-            },
-            "&$droppableAreaHasError": {
-                border: `1px dashed ${palette.error.main}`,
-            },
-        },
-        droppableAreaCaption: {
-            padding: "30px",
-            color: palette.grey[400],
-        },
-        droppableAreaError: {
-            position: "absolute",
-            top: 0,
-            right: 0,
-            padding: "10px",
-            color: palette.error.main,
-        },
-        fileList: {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-start",
-            gap: "2px",
-            width: "100%",
-        },
-        fileListItem: {
-            display: "flex",
-            padding: "8px 7px 8px 15px",
-            alignItems: "center",
-            gap: "10px",
-            borderRadius: "4px",
-            background: palette.grey[50],
-            justifyContent: "space-between",
-            width: "100%",
-            boxSizing: "border-box",
-        },
-        fileListItemInfos: {
-            display: "flex",
-            justifyContent: "end",
-            gap: "10px",
-        },
-        rejectedFileListItem: {
-            display: "flex",
-            padding: "14px 15px",
-            alignItems: "center",
-            gap: "10px",
-            borderRadius: "4px",
-            background: palette.grey[50],
-            justifyContent: "space-between",
-            border: `1px dashed ${palette.error.main}`,
-            color: palette.error.main,
-            width: "100%",
-            boxSizing: "border-box",
-        },
-        errorMessage: {
-            display: "flex",
-            alignItems: "center",
-            color: palette.error.main,
-            gap: "5px",
-        },
-        droppableAreaIsDisabled: {},
-        droppableAreaHasError: {},
-        fileListText: {
-            textOverflow: "ellipsis",
-            overflow: "hidden",
-            whiteSpace: "nowrap",
-        },
-        selectButton: {
-            backgroundColor: palette.grey[800],
-            color: palette.common.white,
-            "&:hover": {
-                backgroundColor: palette.grey[800],
-                color: palette.common.white,
-            },
-        },
-    });
-};
+type OwnerState = { droppableAreaIsDisabled: boolean; droppableAreaHasError: boolean };
 
-export interface FinalFormFileSelectProps extends FieldRenderProps<File | File[], HTMLInputElement> {
+const Root = styled("div", {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "root",
+    overridesResolver(_, styles) {
+        return [styles.root];
+    },
+})(
+    () => css`
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    `,
+);
+
+const Dropzone = styled("div", {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "dropzone",
+    overridesResolver(_, styles) {
+        return [styles.dropzone];
+    },
+})(
+    () => css`
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+        width: 100%;
+    `,
+);
+
+const DroppableArea = styled("div", {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "droppableArea",
+    overridesResolver({ ownerState }: { ownerState: OwnerState }, styles) {
+        return [styles.droppableArea];
+    },
+})<{ ownerState: OwnerState }>(
+    ({ theme, ownerState }) => css`
+        position: relative;
+        display: flex;
+        height: 80px;
+        justify-content: center;
+        align-items: center;
+        align-self: stretch;
+        border-radius: 4px;
+        border: 1px dashed ${theme.palette.grey[200]};
+        cursor: pointer;
+        ${ownerState.droppableAreaIsDisabled &&
+        css`
+            cursor: default;
+        `}
+        ${ownerState.droppableAreaHasError &&
+        css`
+            border: 1px dashed ${theme.palette.error.main};
+        `}
+    `,
+);
+
+const DroppableAreaCaption = styled(Typography, {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "droppableAreaCaption",
+    overridesResolver(_, styles) {
+        return [styles.droppableAreaCaption];
+    },
+})(
+    ({ theme }) => css`
+        padding: 30px;
+        color: ${theme.palette.grey[400]};
+    `,
+);
+
+const DroppableAreaError = styled("div", {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "droppableAreaError",
+    overridesResolver(_, styles) {
+        return [styles.droppableAreaError];
+    },
+})(
+    ({ theme }) => css`
+        position: absolute;
+        top: 0;
+        right: 0;
+        padding: 10px;
+        color: ${theme.palette.error.main};
+    `,
+);
+
+const FileList = styled("div", {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "fileList",
+    overridesResolver(_, styles) {
+        return [styles.fileList];
+    },
+})(
+    () => css`
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2px;
+        width: 100%;
+    `,
+);
+
+const FileListItem = styled("div", {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "fileListItem",
+    overridesResolver(_, styles) {
+        return [styles.fileListItem];
+    },
+})(
+    ({ theme }) => css`
+        display: flex;
+        padding: 4px 7px 4px 15px;
+        align-items: center;
+        gap: 10px;
+        border-radius: 4px;
+        background: ${theme.palette.grey[50]};
+        justify-content: space-between;
+        width: 100%;
+        box-sizing: border-box;
+    `,
+);
+
+const FileListItemInfos = styled("div", {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "fileListItemInfos",
+    overridesResolver(_, styles) {
+        return [styles.fileListItemInfos];
+    },
+})(
+    () => css`
+        display: flex;
+        align-items: center;
+        justify-content: end;
+        gap: 10px;
+    `,
+);
+
+const RejectedFileListItem = styled("div", {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "rejectedFileListItem",
+    overridesResolver(_, styles) {
+        return [styles.rejectedFileListItem];
+    },
+})(
+    ({ theme }) => css`
+        display: flex;
+        padding: 9px 15px;
+        align-items: center;
+        gap: 10px;
+        border-radius: 4px;
+        background: ${theme.palette.grey[50]};
+        justify-content: space-between;
+        border: 1px dashed ${theme.palette.error.main};
+        color: ${theme.palette.error.main};
+        width: 100%;
+        box-sizing: border-box;
+    `,
+);
+
+const ErrorMessage = styled("div", {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "errorMessage",
+    overridesResolver(_, styles) {
+        return [styles.errorMessage];
+    },
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+        color: ${theme.palette.error.main};
+        gap: 5px;
+    `,
+);
+
+const FileListText = styled("div", {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "fileListText",
+    overridesResolver(_, styles) {
+        return [styles.fileListText];
+    },
+})(
+    () => css`
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+    `,
+);
+
+const SelectButton = styled(Button, {
+    name: "CometAdminFinalFormFileSelect",
+    slot: "selectButton",
+    overridesResolver(_, styles) {
+        return [styles.selectButton];
+    },
+})(
+    ({ theme }) => css`
+        background-color: ${theme.palette.grey[800]};
+        color: ${theme.palette.common.white};
+        gap: 5px;
+        &:hover {
+            background-color: ${theme.palette.grey[800]};
+            color: ${theme.palette.common.white};
+        }
+    `,
+);
+
+export interface FinalFormFileSelectProps
+    extends FieldRenderProps<File | File[], HTMLInputElement>,
+        ThemedComponentBaseProps<{
+            root: "div";
+            dropzone: "div";
+            droppableArea: "div";
+            droppableAreaCaption: typeof Typography;
+            droppableAreaError: "div";
+            fileList: "div";
+            fileListItem: "div";
+            fileListItemInfos: "div";
+            rejectedFileListItem: "div";
+            errorMessage: "div";
+            fileListText: "div";
+            selectButton: typeof Button;
+        }> {
     disableDropzone?: boolean;
     disableSelectFileButton?: boolean;
     accept?: Accept;
@@ -143,17 +263,22 @@ export interface FinalFormFileSelectProps extends FieldRenderProps<File | File[]
     };
 }
 
-const FinalFormFileSelectComponent: React.FunctionComponent<WithStyles<typeof styles> & FinalFormFileSelectProps> = ({
-    classes,
-    disabled,
-    disableDropzone,
-    disableSelectFileButton,
-    accept,
-    maxSize = 50 * 1024 * 1024,
-    maxFiles,
-    input: { onChange, value: fieldValue, multiple: multipleFiles },
-    iconMapping = {},
-}) => {
+export function FinalFormFileSelect(inProps: FinalFormFileSelectProps) {
+    const {
+        disabled,
+        disableDropzone,
+        disableSelectFileButton,
+        accept,
+        maxSize = 50 * 1024 * 1024,
+        maxFiles,
+        input: { onChange, value: fieldValue, multiple: multipleFiles },
+        iconMapping = {},
+        ...restProps
+    } = useThemeProps({
+        props: inProps,
+        name: "CometAdminFinalFormFileSelect",
+    });
+
     const { delete: deleteIcon = <Delete />, error: errorIcon = <Error color="error" />, select: selectIcon = <Select /> } = iconMapping;
 
     const dropzoneDisabled = disabled || (maxFiles && fieldValue.length >= maxFiles);
@@ -189,6 +314,11 @@ const FinalFormFileSelectComponent: React.FunctionComponent<WithStyles<typeof st
         maxFiles,
     });
 
+    const ownerState: OwnerState = {
+        droppableAreaIsDisabled: dropzoneDisabled,
+        droppableAreaHasError: isDragReject,
+    };
+
     let acceptedFiles: File[] = [];
 
     if (Array.isArray(fieldValue)) {
@@ -198,16 +328,16 @@ const FinalFormFileSelectComponent: React.FunctionComponent<WithStyles<typeof st
     }
 
     const rejectedFiles = fileRejections.map((rejectedFile, index) => (
-        <div key={index} className={classes.rejectedFileListItem}>
+        <RejectedFileListItem key={index}>
             <Tooltip trigger="hover" title={rejectedFile.file.name}>
-                <div className={classes.fileListText}>{rejectedFile.file.name}</div>
+                <FileListText>{rejectedFile.file.name}</FileListText>
             </Tooltip>
             {errorIcon}
-        </div>
+        </RejectedFileListItem>
     ));
 
     return (
-        <div className={classes.root}>
+        <Root {...restProps}>
             {maxFiles && fieldValue.length >= maxFiles ? (
                 <Alert title={<FormattedMessage id="comet.finalFormFileSelect.maximumReached" defaultMessage="Maximum reached" />} severity="info">
                     <FormattedMessage
@@ -216,56 +346,44 @@ const FinalFormFileSelectComponent: React.FunctionComponent<WithStyles<typeof st
                     />
                 </Alert>
             ) : (
-                <div {...getRootProps()} className={classes.dropzone}>
+                <Dropzone {...getRootProps()}>
                     <input {...getInputProps()} />
                     {!disableDropzone && (
-                        <div
-                            className={clsx(
-                                classes.droppableArea,
-                                dropzoneDisabled && classes.droppableAreaIsDisabled,
-                                isDragReject && classes.droppableAreaHasError,
-                            )}
-                        >
-                            {isDragReject && <div className={classes.droppableAreaError}>{errorIcon}</div>}
-                            <Typography variant="body2" className={classes.droppableAreaCaption}>
+                        <DroppableArea ownerState={ownerState}>
+                            {isDragReject && <DroppableAreaError>{errorIcon}</DroppableAreaError>}
+                            <DroppableAreaCaption variant="body2">
                                 <FormattedMessage id="comet.finalFormFileSelect.dropfiles" defaultMessage="Drop files here to upload" />
-                            </Typography>
-                        </div>
+                            </DroppableAreaCaption>
+                        </DroppableArea>
                     )}
                     {!disableSelectFileButton && (
-                        <Button
-                            disabled={dropzoneDisabled}
-                            variant="contained"
-                            color="secondary"
-                            startIcon={selectIcon}
-                            className={classes.selectButton}
-                        >
+                        <SelectButton disabled={dropzoneDisabled} variant="contained" color="secondary" startIcon={selectIcon}>
                             <FormattedMessage id="comet.finalFormFileSelect.selectfile" defaultMessage="Select file" />
-                        </Button>
+                        </SelectButton>
                     )}
-                </div>
+                </Dropzone>
             )}
             {acceptedFiles.length > 0 && (
-                <div className={classes.fileList}>
+                <FileList>
                     {acceptedFiles.map((file, index) => (
-                        <div key={index} className={classes.fileListItem}>
+                        <FileListItem key={index}>
                             <Tooltip trigger="hover" title={file.name}>
-                                <div className={classes.fileListText}>{file.name}</div>
+                                <FileListText>{file.name}</FileListText>
                             </Tooltip>
-                            <div className={classes.fileListItemInfos}>
+                            <FileListItemInfos>
                                 <Chip label={<PrettyBytes value={file.size} />} />
                                 <IconButton onClick={removeFile(file)}>{deleteIcon}</IconButton>
-                            </div>
-                        </div>
+                            </FileListItemInfos>
+                        </FileListItem>
                     ))}
-                </div>
+                </FileList>
             )}
-            {fileRejections.length > 0 && <div className={classes.fileList}>{rejectedFiles}</div>}
+            {fileRejections.length > 0 && <FileList>{rejectedFiles}</FileList>}
             {(fileRejections.length > 0 || isDragReject) && (
-                <div className={classes.errorMessage}>
+                <ErrorMessage>
                     {errorIcon}
                     <FormattedMessage id="comet.finalFormFileSelect.errors.unknownError" defaultMessage="Something went wrong." />
-                </div>
+                </ErrorMessage>
             )}
             <FormHelperText sx={{ margin: 0 }}>
                 <FormattedMessage
@@ -276,11 +394,9 @@ const FinalFormFileSelectComponent: React.FunctionComponent<WithStyles<typeof st
                     }}
                 />
             </FormHelperText>
-        </div>
+        </Root>
     );
-};
-
-export const FinalFormFileSelect = withStyles(styles, { name: "CometAdminFinalFormFileSelect" })(FinalFormFileSelectComponent);
+}
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {

--- a/packages/admin/admin/src/form/FinalFormFileSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormFileSelect.tsx
@@ -31,7 +31,7 @@ export type FinalFormFileSelectClassKey =
 type OwnerState = { droppableAreaIsDisabled: boolean; droppableAreaHasError: boolean };
 
 const Root = createComponentSlot("div")<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "root",
 })(
     () => css`
@@ -43,7 +43,7 @@ const Root = createComponentSlot("div")<FinalFormFileSelectClassKey>({
 );
 
 const Dropzone = createComponentSlot("div")<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "dropzone",
 })(
     () => css`
@@ -56,7 +56,7 @@ const Dropzone = createComponentSlot("div")<FinalFormFileSelectClassKey>({
 );
 
 const DroppableArea = createComponentSlot("div")<FinalFormFileSelectClassKey, OwnerState>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "droppableArea",
     classesResolver(ownerState) {
         return [ownerState.droppableAreaHasError && "droppableAreaHasError", ownerState.droppableAreaIsDisabled && "droppableAreaIsDisabled"];
@@ -84,7 +84,7 @@ const DroppableArea = createComponentSlot("div")<FinalFormFileSelectClassKey, Ow
 );
 
 const DroppableAreaCaption = createComponentSlot(Typography)<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "droppableAreaCaption",
 })(
     ({ theme }) => css`
@@ -94,7 +94,7 @@ const DroppableAreaCaption = createComponentSlot(Typography)<FinalFormFileSelect
 );
 
 const DroppableAreaError = createComponentSlot("div")<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "droppableAreaError",
 })(
     ({ theme }) => css`
@@ -107,7 +107,7 @@ const DroppableAreaError = createComponentSlot("div")<FinalFormFileSelectClassKe
 );
 
 const FileList = createComponentSlot("div")<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "fileList",
 })(
     () => css`
@@ -120,7 +120,7 @@ const FileList = createComponentSlot("div")<FinalFormFileSelectClassKey>({
 );
 
 const FileListItem = createComponentSlot("div")<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "fileListItem",
 })(
     ({ theme }) => css`
@@ -137,7 +137,7 @@ const FileListItem = createComponentSlot("div")<FinalFormFileSelectClassKey>({
 );
 
 const FileListItemInfos = createComponentSlot("div")<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "fileListItemInfos",
 })(
     () => css`
@@ -149,7 +149,7 @@ const FileListItemInfos = createComponentSlot("div")<FinalFormFileSelectClassKey
 );
 
 const RejectedFileListItem = createComponentSlot("div")<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "rejectedFileListItem",
 })(
     ({ theme }) => css`
@@ -168,7 +168,7 @@ const RejectedFileListItem = createComponentSlot("div")<FinalFormFileSelectClass
 );
 
 const ErrorMessage = createComponentSlot("div")<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "errorMessage",
 })(
     ({ theme }) => css`
@@ -180,7 +180,7 @@ const ErrorMessage = createComponentSlot("div")<FinalFormFileSelectClassKey>({
 );
 
 const FileListText = createComponentSlot("div")<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "fileListText",
 })(
     () => css`
@@ -191,7 +191,7 @@ const FileListText = createComponentSlot("div")<FinalFormFileSelectClassKey>({
 );
 
 const SelectButton = createComponentSlot(Button)<FinalFormFileSelectClassKey>({
-    componentName: "CometAdminFinalFormFileSelect",
+    componentName: "FinalFormFileSelect",
     slotName: "selectButton",
 })(
     ({ theme }) => css`

--- a/packages/admin/admin/src/form/FinalFormFileSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormFileSelect.tsx
@@ -1,8 +1,6 @@
 import { Delete, Error, Select } from "@comet/admin-icons";
 import { Button, Chip, ComponentsOverrides, FormHelperText, IconButton, Typography } from "@mui/material";
 import { css, styled, Theme, useThemeProps } from "@mui/material/styles";
-import { PrettyBytes } from "../helpers/PrettyBytes";
-import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 import * as React from "react";
 import { Accept, useDropzone } from "react-dropzone";
 import { FieldRenderProps } from "react-final-form";
@@ -10,6 +8,8 @@ import { FormattedMessage } from "react-intl";
 
 import { Alert } from "../alert/Alert";
 import { Tooltip } from "../common/Tooltip";
+import { PrettyBytes } from "../helpers/PrettyBytes";
+import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
 export type FinalFormFileSelectClassKey =
     | "root"

--- a/packages/admin/admin/src/form/FinalFormFileSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormFileSelect.tsx
@@ -1,6 +1,6 @@
 import { Delete, Error, Select } from "@comet/admin-icons";
 import { Button, Chip, ComponentsOverrides, FormHelperText, IconButton, Typography } from "@mui/material";
-import { css, styled, Theme, useThemeProps } from "@mui/material/styles";
+import { css, Theme, useThemeProps } from "@mui/material/styles";
 import * as React from "react";
 import { Accept, useDropzone } from "react-dropzone";
 import { FieldRenderProps } from "react-final-form";
@@ -8,6 +8,7 @@ import { FormattedMessage } from "react-intl";
 
 import { Alert } from "../alert/Alert";
 import { Tooltip } from "../common/Tooltip";
+import { createComponentSlot } from "../helpers/createComponentSlot";
 import { PrettyBytes } from "../helpers/PrettyBytes";
 import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
@@ -23,16 +24,15 @@ export type FinalFormFileSelectClassKey =
     | "rejectedFileListItem"
     | "errorMessage"
     | "fileListText"
-    | "selectButton";
+    | "selectButton"
+    | "droppableAreaIsDisabled"
+    | "droppableAreaHasError";
 
 type OwnerState = { droppableAreaIsDisabled: boolean; droppableAreaHasError: boolean };
 
-const Root = styled("div", {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "root",
-    overridesResolver(_, styles) {
-        return [styles.root];
-    },
+const Root = createComponentSlot("div")<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "root",
 })(
     () => css`
         display: flex;
@@ -42,12 +42,9 @@ const Root = styled("div", {
     `,
 );
 
-const Dropzone = styled("div", {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "dropzone",
-    overridesResolver(_, styles) {
-        return [styles.dropzone];
-    },
+const Dropzone = createComponentSlot("div")<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "dropzone",
 })(
     () => css`
         display: flex;
@@ -58,13 +55,13 @@ const Dropzone = styled("div", {
     `,
 );
 
-const DroppableArea = styled("div", {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "droppableArea",
-    overridesResolver({ ownerState }: { ownerState: OwnerState }, styles) {
-        return [styles.droppableArea];
+const DroppableArea = createComponentSlot("div")<FinalFormFileSelectClassKey, OwnerState>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "droppableArea",
+    classesResolver(ownerState) {
+        return [ownerState.droppableAreaHasError && "droppableAreaHasError", ownerState.droppableAreaIsDisabled && "droppableAreaIsDisabled"];
     },
-})<{ ownerState: OwnerState }>(
+})(
     ({ theme, ownerState }) => css`
         position: relative;
         display: flex;
@@ -86,12 +83,9 @@ const DroppableArea = styled("div", {
     `,
 );
 
-const DroppableAreaCaption = styled(Typography, {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "droppableAreaCaption",
-    overridesResolver(_, styles) {
-        return [styles.droppableAreaCaption];
-    },
+const DroppableAreaCaption = createComponentSlot(Typography)<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "droppableAreaCaption",
 })(
     ({ theme }) => css`
         padding: 30px;
@@ -99,12 +93,9 @@ const DroppableAreaCaption = styled(Typography, {
     `,
 );
 
-const DroppableAreaError = styled("div", {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "droppableAreaError",
-    overridesResolver(_, styles) {
-        return [styles.droppableAreaError];
-    },
+const DroppableAreaError = createComponentSlot("div")<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "droppableAreaError",
 })(
     ({ theme }) => css`
         position: absolute;
@@ -115,12 +106,9 @@ const DroppableAreaError = styled("div", {
     `,
 );
 
-const FileList = styled("div", {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "fileList",
-    overridesResolver(_, styles) {
-        return [styles.fileList];
-    },
+const FileList = createComponentSlot("div")<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "fileList",
 })(
     () => css`
         display: flex;
@@ -131,12 +119,9 @@ const FileList = styled("div", {
     `,
 );
 
-const FileListItem = styled("div", {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "fileListItem",
-    overridesResolver(_, styles) {
-        return [styles.fileListItem];
-    },
+const FileListItem = createComponentSlot("div")<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "fileListItem",
 })(
     ({ theme }) => css`
         display: flex;
@@ -151,12 +136,9 @@ const FileListItem = styled("div", {
     `,
 );
 
-const FileListItemInfos = styled("div", {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "fileListItemInfos",
-    overridesResolver(_, styles) {
-        return [styles.fileListItemInfos];
-    },
+const FileListItemInfos = createComponentSlot("div")<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "fileListItemInfos",
 })(
     () => css`
         display: flex;
@@ -166,12 +148,9 @@ const FileListItemInfos = styled("div", {
     `,
 );
 
-const RejectedFileListItem = styled("div", {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "rejectedFileListItem",
-    overridesResolver(_, styles) {
-        return [styles.rejectedFileListItem];
-    },
+const RejectedFileListItem = createComponentSlot("div")<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "rejectedFileListItem",
 })(
     ({ theme }) => css`
         display: flex;
@@ -188,12 +167,9 @@ const RejectedFileListItem = styled("div", {
     `,
 );
 
-const ErrorMessage = styled("div", {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "errorMessage",
-    overridesResolver(_, styles) {
-        return [styles.errorMessage];
-    },
+const ErrorMessage = createComponentSlot("div")<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "errorMessage",
 })(
     ({ theme }) => css`
         display: flex;
@@ -203,12 +179,9 @@ const ErrorMessage = styled("div", {
     `,
 );
 
-const FileListText = styled("div", {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "fileListText",
-    overridesResolver(_, styles) {
-        return [styles.fileListText];
-    },
+const FileListText = createComponentSlot("div")<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "fileListText",
 })(
     () => css`
         text-overflow: ellipsis;
@@ -217,12 +190,9 @@ const FileListText = styled("div", {
     `,
 );
 
-const SelectButton = styled(Button, {
-    name: "CometAdminFinalFormFileSelect",
-    slot: "selectButton",
-    overridesResolver(_, styles) {
-        return [styles.selectButton];
-    },
+const SelectButton = createComponentSlot(Button)<FinalFormFileSelectClassKey>({
+    componentName: "CometAdminFinalFormFileSelect",
+    slotName: "selectButton",
 })(
     ({ theme }) => css`
         background-color: ${theme.palette.grey[800]};
@@ -265,6 +235,7 @@ export interface FinalFormFileSelectProps
 
 export function FinalFormFileSelect(inProps: FinalFormFileSelectProps) {
     const {
+        slotProps,
         disabled,
         disableDropzone,
         disableSelectFileButton,
@@ -328,16 +299,16 @@ export function FinalFormFileSelect(inProps: FinalFormFileSelectProps) {
     }
 
     const rejectedFiles = fileRejections.map((rejectedFile, index) => (
-        <RejectedFileListItem key={index}>
+        <RejectedFileListItem {...slotProps?.rejectedFileListItem} key={index}>
             <Tooltip trigger="hover" title={rejectedFile.file.name}>
-                <FileListText>{rejectedFile.file.name}</FileListText>
+                <FileListText {...slotProps?.fileListText}>{rejectedFile.file.name}</FileListText>
             </Tooltip>
             {errorIcon}
         </RejectedFileListItem>
     ));
 
     return (
-        <Root {...restProps}>
+        <Root {...slotProps?.root} {...restProps}>
             {maxFiles && fieldValue.length >= maxFiles ? (
                 <Alert title={<FormattedMessage id="comet.finalFormFileSelect.maximumReached" defaultMessage="Maximum reached" />} severity="info">
                     <FormattedMessage
@@ -346,31 +317,37 @@ export function FinalFormFileSelect(inProps: FinalFormFileSelectProps) {
                     />
                 </Alert>
             ) : (
-                <Dropzone {...getRootProps()}>
+                <Dropzone {...slotProps?.dropzone} {...getRootProps()}>
                     <input {...getInputProps()} />
                     {!disableDropzone && (
-                        <DroppableArea ownerState={ownerState}>
-                            {isDragReject && <DroppableAreaError>{errorIcon}</DroppableAreaError>}
-                            <DroppableAreaCaption variant="body2">
+                        <DroppableArea {...slotProps?.droppableArea} ownerState={ownerState}>
+                            {isDragReject && <DroppableAreaError {...slotProps?.droppableAreaError}>{errorIcon}</DroppableAreaError>}
+                            <DroppableAreaCaption {...slotProps?.droppableAreaCaption} variant="body2">
                                 <FormattedMessage id="comet.finalFormFileSelect.dropfiles" defaultMessage="Drop files here to upload" />
                             </DroppableAreaCaption>
                         </DroppableArea>
                     )}
                     {!disableSelectFileButton && (
-                        <SelectButton disabled={dropzoneDisabled} variant="contained" color="secondary" startIcon={selectIcon}>
+                        <SelectButton
+                            {...slotProps?.selectButton}
+                            disabled={dropzoneDisabled}
+                            variant="contained"
+                            color="secondary"
+                            startIcon={selectIcon}
+                        >
                             <FormattedMessage id="comet.finalFormFileSelect.selectfile" defaultMessage="Select file" />
                         </SelectButton>
                     )}
                 </Dropzone>
             )}
             {acceptedFiles.length > 0 && (
-                <FileList>
+                <FileList {...slotProps?.fileList}>
                     {acceptedFiles.map((file, index) => (
-                        <FileListItem key={index}>
+                        <FileListItem {...slotProps?.fileListItem} key={index}>
                             <Tooltip trigger="hover" title={file.name}>
-                                <FileListText>{file.name}</FileListText>
+                                <FileListText {...slotProps?.fileListText}>{file.name}</FileListText>
                             </Tooltip>
-                            <FileListItemInfos>
+                            <FileListItemInfos {...slotProps?.fileListItemInfos}>
                                 <Chip label={<PrettyBytes value={file.size} />} />
                                 <IconButton onClick={removeFile(file)}>{deleteIcon}</IconButton>
                             </FileListItemInfos>
@@ -380,7 +357,7 @@ export function FinalFormFileSelect(inProps: FinalFormFileSelectProps) {
             )}
             {fileRejections.length > 0 && <FileList>{rejectedFiles}</FileList>}
             {(fileRejections.length > 0 || isDragReject) && (
-                <ErrorMessage>
+                <ErrorMessage {...slotProps?.errorMessage}>
                     {errorIcon}
                     <FormattedMessage id="comet.finalFormFileSelect.errors.unknownError" defaultMessage="Something went wrong." />
                 </ErrorMessage>


### PR DESCRIPTION
Theme refactoring for FinalFormFileSelect. Changed padding for fileListItem and rejectedFileListItem because of the new Chip design in next

<img width="762" alt="Screenshot 2024-05-16 at 10 33 41" src="https://github.com/vivid-planet/comet/assets/72875628/85fe29a4-851d-4299-bf6e-90fe63bec4d9">

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. 
-   [x] Link to the respective task if one exists: COM-579
