### PR TITLE
Move assigning previewData into createGraphQLFetch

### DIFF
--- a/.changeset/plenty-cougars-warn.md
+++ b/.changeset/plenty-cougars-warn.md
@@ -4,18 +4,19 @@
 
 Add GraphQL fetch client
 
-- `createGraphQLFetch`: simple graphql client around fetch, usage: createGraphQLFetch(fetch, url)(gql, variables)
-- `type GraphQLFetch = <T, V>(query: string, variables?: V, init?: RequestInit) => Promise<T>`
-- `gql` for tagging queries
-- `createFetchWithDefaults` fetch decorator that adds default values (eg. headers or next.revalidate)
-- `createFetchWithPreviewHeaders` fetch decorator that adds comet preview headers (based on SitePreviewData)
+-   `createGraphQLFetch`: simple graphql client around fetch, usage: createGraphQLFetch(fetch, url)(gql, variables)
+-   `type GraphQLFetch = <T, V>(query: string, variables?: V, init?: RequestInit) => Promise<T>`
+-   `gql` for tagging queries
+-   `createFetchWithDefaults` fetch decorator that adds default values (eg. headers or next.revalidate)
+-   `createFetchWithPreviewHeaders` fetch decorator that adds comet preview headers (based on SitePreviewData)
 
 Example helper in application:
+
 ```
 export const graphQLApiUrl = `${typeof window === "undefined" ? process.env.API_URL_INTERNAL : process.env.NEXT_PUBLIC_API_URL}/graphql`;
-export function createGraphQLFetch(previewData?: SitePreviewData) {
+export function createGraphQLFetch() {
     return createGraphQLFetchLibrary(
-        createFetchWithDefaults(createFetchWithPreviewHeaders(fetch, previewData), { next: { revalidate: 15 * 60 } }),
+        createFetchWithDefaults(createFetchWithPreviewHeaders(fetch), { next: { revalidate: 15 * 60 } }),
         graphQLApiUrl,
     );
 
@@ -23,8 +24,9 @@ export function createGraphQLFetch(previewData?: SitePreviewData) {
 ```
 
 Usage example:
+
 ```
-const graphqlFetch = createGraphQLFetch(previewData);
+const graphqlFetch = createGraphQLFetch();
 const data = await graphqlFetch<GQLExampleQuery, GQLExampleQueryVariables>(
     exampleQuery,
     {

--- a/demo/site/src/app/[lang]/[[...path]]/page.tsx
+++ b/demo/site/src/app/[lang]/[[...path]]/page.tsx
@@ -18,8 +18,8 @@ const documentTypeQuery = gql`
 `;
 
 async function fetchPageTreeNode(params: { path: string[]; lang: string }) {
-    const { scope, previewData } = (await previewParams()) || { scope: { domain, language: params.lang }, previewData: undefined };
-    const graphQLFetch = createGraphQLFetch(previewData);
+    const { scope } = (await previewParams()) || { scope: { domain, language: params.lang } };
+    const graphQLFetch = await createGraphQLFetch();
     return graphQLFetch<GQLDocumentTypeQuery, GQLDocumentTypeQueryVariables>(
         documentTypeQuery,
         {

--- a/demo/site/src/app/[lang]/news/[slug]/page.tsx
+++ b/demo/site/src/app/[lang]/news/[slug]/page.tsx
@@ -8,8 +8,8 @@ import { Content, fragment } from "./content";
 import { GQLNewsDetailPageQuery, GQLNewsDetailPageQueryVariables } from "./page.generated";
 
 export default async function NewsDetailPage({ params }: { params: { slug: string; lang: string } }) {
-    const { scope, previewData } = (await previewParams()) || { scope: { domain, language: params.lang }, previewData: undefined };
-    const graphqlFetch = createGraphQLFetch(previewData);
+    const { scope } = (await previewParams()) || { scope: { domain, language: params.lang } };
+    const graphqlFetch = await createGraphQLFetch();
 
     const data = await graphqlFetch<GQLNewsDetailPageQuery, GQLNewsDetailPageQueryVariables>(
         gql`

--- a/demo/site/src/app/[lang]/news/page.tsx
+++ b/demo/site/src/app/[lang]/news/page.tsx
@@ -9,8 +9,8 @@ import { GQLNewsIndexPageQuery, GQLNewsIndexPageQueryVariables } from "./page.ge
 
 export default async function NewsIndexPage({ params }: { params: { lang: string } }) {
     // TODO support multiple domains, get domain by Host header
-    const { scope, previewData } = (await previewParams()) || { scope: { domain, language: params.lang }, previewData: undefined };
-    const graphqlFetch = createGraphQLFetch(previewData);
+    const { scope } = (await previewParams()) || { scope: { domain, language: params.lang } };
+    const graphqlFetch = await createGraphQLFetch();
 
     const { newsList } = await graphqlFetch<GQLNewsIndexPageQuery, GQLNewsIndexPageQueryVariables>(
         gql`

--- a/demo/site/src/app/api/site-preview/route.ts
+++ b/demo/site/src/app/api/site-preview/route.ts
@@ -5,5 +5,5 @@ import { type NextRequest } from "next/server";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
-    return sitePreviewRoute(request, createGraphQLFetch());
+    return sitePreviewRoute(request, await createGraphQLFetch());
 }

--- a/demo/site/src/app/sitemap.ts
+++ b/demo/site/src/app/sitemap.ts
@@ -7,7 +7,7 @@ import { GQLPrebuildPageDataListSitemapQuery, GQLPrebuildPageDataListSitemapQuer
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const sitemap: MetadataRoute.Sitemap = [];
-    const graphqlFetch = createGraphQLFetch();
+    const graphqlFetch = await createGraphQLFetch();
 
     for (const lang of languages) {
         const scope = { domain, language: lang };

--- a/demo/site/src/documentTypes/Link.tsx
+++ b/demo/site/src/documentTypes/Link.tsx
@@ -1,4 +1,4 @@
-import { gql, previewParams } from "@comet/cms-site";
+import { gql } from "@comet/cms-site";
 import { ExternalLinkBlockData, InternalLinkBlockData } from "@src/blocks.generated";
 import { GQLPageTreeNodeScopeInput } from "@src/graphql.generated";
 import { createGraphQLFetch } from "@src/util/graphQLClient";
@@ -25,8 +25,7 @@ interface Props {
 }
 
 export async function Link({ pageTreeNodeId }: Props): Promise<JSX.Element> {
-    const { previewData } = (await previewParams()) || { previewData: undefined };
-    const graphqlFetch = createGraphQLFetch(previewData);
+    const graphqlFetch = await createGraphQLFetch();
 
     const { pageTreeNode } = await graphqlFetch<GQLLinkRedirectQuery, GQLLinkRedirectQueryVariables>(linkRedirectQuery, {
         id: pageTreeNodeId,

--- a/demo/site/src/documentTypes/Page.tsx
+++ b/demo/site/src/documentTypes/Page.tsx
@@ -1,4 +1,4 @@
-import { generateImageUrl, gql, previewParams } from "@comet/cms-site";
+import { generateImageUrl, gql } from "@comet/cms-site";
 import { PageContentBlock } from "@src/blocks/PageContentBlock";
 import Breadcrumbs from "@src/components/Breadcrumbs";
 import { breadcrumbsFragment } from "@src/components/Breadcrumbs.fragment";
@@ -45,8 +45,7 @@ const pageQuery = gql`
 type Props = { pageTreeNodeId: string; scope: GQLPageTreeNodeScopeInput };
 
 async function fetchData({ pageTreeNodeId, scope }: Props) {
-    const { previewData } = (await previewParams()) || { previewData: undefined };
-    const graphQLFetch = createGraphQLFetch(previewData);
+    const graphQLFetch = await createGraphQLFetch();
 
     const props = await graphQLFetch<GQLPageQuery, GQLPageQueryVariables>(
         pageQuery,
@@ -110,8 +109,7 @@ export async function generateMetadata({ pageTreeNodeId, scope }: Props, parent:
 }
 
 export async function Page({ pageTreeNodeId, scope }: { pageTreeNodeId: string; scope: GQLPageTreeNodeScopeInput }) {
-    const { previewData } = (await previewParams()) || { previewData: undefined };
-    const graphQLFetch = createGraphQLFetch(previewData);
+    const graphQLFetch = await createGraphQLFetch();
 
     const data = await fetchData({ pageTreeNodeId, scope });
     const document = data?.pageContent?.document;

--- a/demo/site/src/redirects/redirects.ts
+++ b/demo/site/src/redirects/redirects.ts
@@ -19,8 +19,6 @@ const redirectsQuery = gql`
     }
 `;
 
-const graphQLFetch = createGraphQLFetch();
-
 const createInternalRedirects = async (): Promise<Map<string, Redirect>> => {
     const redirectsMap = new Map<string, Redirect>();
     const adminUrl = process.env.ADMIN_URL;
@@ -37,6 +35,7 @@ async function* fetchApiRedirects(scope: GQLRedirectScope) {
     let offset = 0;
     const limit = 100;
 
+    const graphQLFetch = await createGraphQLFetch();
     while (true) {
         const { paginatedRedirects } = await graphQLFetch<GQLRedirectsQuery, GQLRedirectsQueryVariables>(redirectsQuery, {
             filter: { active: { equal: true } },

--- a/demo/site/src/util/graphQLClient.ts
+++ b/demo/site/src/util/graphQLClient.ts
@@ -2,17 +2,24 @@ import {
     createFetchWithDefaults,
     createFetchWithPreviewHeaders,
     createGraphQLFetch as createGraphQLFetchLibrary,
+    previewParams,
     SitePreviewData,
 } from "@comet/cms-site";
 
 const isServerSide = typeof window === "undefined";
 export const graphQLApiUrl = `${isServerSide ? process.env.API_URL_INTERNAL : process.env.NEXT_PUBLIC_API_URL}/graphql`;
-export function createGraphQLFetch(previewData?: SitePreviewData) {
+export async function createGraphQLFetch() {
     const headers = isServerSide
         ? {
               authorization: `Basic ${Buffer.from(`vivid:${process.env.API_PASSWORD}`).toString("base64")}`,
           }
         : undefined;
+    let previewData: SitePreviewData | undefined = undefined;
+    if (isServerSide) {
+        if ((await previewParams())?.previewData?.includeInvisible) {
+            previewData = { includeInvisible: true };
+        }
+    }
     return createGraphQLFetchLibrary(
         createFetchWithDefaults(createFetchWithPreviewHeaders(fetch, previewData), { next: { revalidate: 15 * 60 }, headers }),
         graphQLApiUrl,


### PR DESCRIPTION
Passing previewParams every time is cumbersome and error prone, furthermore there is no use case where this possibility adds value. Downside is that createGraphQLFetch is async now.