### PR TITLE
Don't build sitemap at build-time

### DIFF
--- a/demo/site/src/app/sitemap.ts
+++ b/demo/site/src/app/sitemap.ts
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic"; // don't generate at build time
+
 import { gql } from "@comet/cms-site";
 import { domain, languages } from "@src/config";
 import { createGraphQLFetch } from "@src/util/graphQLClient";


### PR DESCRIPTION
- don't generate at build time although it is a static url
  - because we don't have api access and build time
  - by adding dynamic = force-dynamic

Demo is not built usually, still we should implement demo as we would in real applications