### PR TITLE
API Generator: Fix imports in generated code for more than one level deep relations

### DIFF
--- a/.changeset/five-hotels-suffer.md
+++ b/.changeset/five-hotels-suffer.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Crud Generator: Fix imports in generated code for more than one level deep relations

--- a/.changeset/five-hotels-suffer.md
+++ b/.changeset/five-hotels-suffer.md
@@ -2,4 +2,4 @@
 "@comet/cms-api": patch
 ---
 
-Crud Generator: Fix imports in generated code for more than one level deep relations
+API Generator: Fix imports in generated code for more than one level deep relations

--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -263,7 +263,7 @@ export async function generateCrudInput(
                 generatedFiles.push(...nestedInputFiles);
                 imports.push({
                     name: inputNameClassName,
-                    importPath: nestedInputFiles[0].name.replace(/^dto/, ".").replace(/\.ts$/, ""),
+                    importPath: nestedInputFiles[nestedInputFiles.length - 1].name.replace(/^dto/, ".").replace(/\.ts$/, ""),
                 });
             }
             decorators.push(`@Field(() => ${inputNameClassName}${prop.nullable ? ", { nullable: true }" : ""})`);

--- a/packages/api/cms-api/src/generator/generate-crud-relations-two-levels.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-two-levels.spec.ts
@@ -1,0 +1,139 @@
+import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property, Ref } from "@mikro-orm/core";
+import { MikroORM } from "@mikro-orm/postgresql";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { v4 as uuid } from "uuid";
+
+import { generateCrud } from "./generate-crud";
+import { lintGeneratedFiles, parseSource } from "./utils/test-helper";
+
+@Entity()
+class ProductVariant extends BaseEntity<ProductVariant, "id"> {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @Property()
+    title: string;
+
+    @ManyToOne(() => ProductData, { ref: true })
+    product: Ref<ProductData>;
+}
+
+@Entity()
+class ProductData extends BaseEntity<ProductData, "id"> {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @OneToOne(() => Product, { ref: true })
+    product: Ref<Product>;
+
+    @OneToMany(() => ProductVariant, (variant) => variant.product, { orphanRemoval: true })
+    variants = new Collection<ProductVariant>(this);
+}
+
+@Entity()
+class Product extends BaseEntity<Product, "id"> {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @Property()
+    title: string;
+
+    @OneToOne(() => ProductData, { ref: true })
+    data: Ref<ProductData>;
+}
+
+describe("generate-crud relations two levels", () => {
+    it("should be a valid generated ts file", async () => {
+        LazyMetadataStorage.load();
+        const orm = await MikroORM.init({
+            type: "postgresql",
+            dbName: "test-db",
+            entities: [Product, ProductData, ProductVariant],
+        });
+
+        const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("Product"));
+        const lintedOut = await lintGeneratedFiles(out);
+
+        {
+            const file = lintedOut.find((file) => file.name === "product.resolver.ts");
+            if (!file) throw new Error("File not found");
+            const source = parseSource(file.content);
+
+            const classes = source.getClasses();
+            expect(classes.length).toBe(1);
+
+            const cls = classes[0];
+            expect(cls.getName()).toBe("ProductResolver");
+            const structure = cls.getStructure();
+
+            expect(structure.properties?.length).toBe(0);
+            expect(structure.methods?.length).toBe(6);
+
+            const imports: string[] = [];
+            for (const tsImport of source.getImportDeclarations()) {
+                for (const namedImport of tsImport.getNamedImports()) {
+                    imports.push(namedImport.getNameNode().getText());
+                }
+            }
+            expect(imports).toContain("ProductData"); //import for repository
+            expect(imports).toContain("ProductVariant"); //import for repository
+        }
+
+        {
+            const file = lintedOut.find((file) => file.name === "dto/product.input.ts");
+            if (!file) throw new Error("File not found");
+            const source = parseSource(file.content);
+
+            const classes = source.getClasses();
+            expect(classes.length).toBe(2);
+
+            expect(classes[0].getName()).toBe("ProductInput");
+            expect(classes[1].getName()).toBe("ProductUpdateInput");
+
+            const structure = classes[0].getStructure();
+
+            expect(structure.properties?.length).toBe(2);
+            expect(structure.properties?.[1].type).toBe("ProductNestedProductDataInput");
+
+            const imports: Record<string, string> = {};
+            for (const tsImport of source.getImportDeclarations()) {
+                for (const namedImport of tsImport.getNamedImports()) {
+                    imports[namedImport.getNameNode().getText()] = tsImport.getModuleSpecifierValue();
+                }
+            }
+            expect(imports["ProductNestedProductDataInput"]).toBe("./product-nested-product-data.input");
+        }
+
+        {
+            const file = lintedOut.find((file) => file.name === "dto/product-data-nested-product-variant.input.ts");
+            if (!file) throw new Error("File not found");
+            const source = parseSource(file.content);
+
+            const classes = source.getClasses();
+            expect(classes.length).toBe(1);
+
+            expect(classes[0].getName()).toBe("ProductDataNestedProductVariantInput");
+
+            const structure = classes[0].getStructure();
+
+            expect(structure.properties?.length).toBe(1);
+        }
+
+        {
+            const file = lintedOut.find((file) => file.name === "dto/product-data-nested-product-variant.input.ts");
+            if (!file) throw new Error("File not found");
+            const source = parseSource(file.content);
+
+            const classes = source.getClasses();
+            expect(classes.length).toBe(1);
+
+            expect(classes[0].getName()).toBe("ProductDataNestedProductVariantInput");
+
+            const structure = classes[0].getStructure();
+
+            expect(structure.properties?.length).toBe(1);
+        }
+
+        orm.close();
+    });
+});

--- a/packages/api/cms-api/src/generator/generate-crud-relations-two-levels.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-two-levels.spec.ts
@@ -15,7 +15,7 @@ class ProductVariant extends BaseEntity<ProductVariant, "id"> {
     title: string;
 
     @ManyToOne(() => ProductData, { ref: true })
-    product: Ref<ProductData>;
+    productData: Ref<ProductData>;
 }
 
 @Entity()
@@ -26,7 +26,7 @@ class ProductData extends BaseEntity<ProductData, "id"> {
     @OneToOne(() => Product, { ref: true })
     product: Ref<Product>;
 
-    @OneToMany(() => ProductVariant, (variant) => variant.product, { orphanRemoval: true })
+    @OneToMany(() => ProductVariant, (variant) => variant.productData, { orphanRemoval: true })
     variants = new Collection<ProductVariant>(this);
 }
 


### PR DESCRIPTION
Fix two related issues:
- input class: for more than one level deep nested impouts use the last entry from nestedInputFiles as that is the correct file
- resolver imports: collect injectRepositories not only for generating constructor injects but also generate imports from it