### PR TITLE
Admin Generator (Future): generate form using different create mutation

### DIFF
--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -14,6 +14,7 @@ import { getForwardedGqlArgs } from "./generateGrid/getForwardedGqlArgs";
 import { getPropsForFilterProp } from "./generateGrid/getPropsForFilterProp";
 import { GeneratorReturn, GridConfig } from "./generator";
 import { camelCaseToHumanReadable } from "./utils/camelCaseToHumanReadable";
+import { findMutationType } from "./utils/findMutationType";
 import { findRootBlocks } from "./utils/findRootBlocks";
 import { generateImportsCode, Imports } from "./utils/generateImportsCode";
 
@@ -38,13 +39,6 @@ function findQueryTypeOrThrow(queryName: string, schema: IntrospectionQuery) {
     const ret = findQueryType(queryName, schema);
     if (!ret) throw new Error(`Can't find query ${queryName} in gql schema`);
     return ret;
-}
-
-function findMutationType(mutationName: string, schema: IntrospectionQuery) {
-    if (!schema.__schema.mutationType) throw new Error("Schema has no Mutation type");
-    const queryType = schema.__schema.types.find((type) => type.name === schema.__schema.mutationType?.name) as IntrospectionObjectType | undefined;
-    if (!queryType) throw new Error("Can't find Mutation type in gql schema");
-    return queryType.fields.find((field) => field.name === mutationName);
 }
 
 export type Prop = { type: string; optional: boolean; name: string };

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -31,6 +31,7 @@ export type FormConfig<T extends { __typename?: string }> = {
     gqlType: T["__typename"];
     mode?: "edit" | "add" | "all";
     fragmentName?: string;
+    createMutation?: string;
     fields: FormFieldConfig<T>[];
 };
 

--- a/packages/admin/cms-admin/src/generator/future/utils/findMutationType.ts
+++ b/packages/admin/cms-admin/src/generator/future/utils/findMutationType.ts
@@ -1,0 +1,14 @@
+import { IntrospectionObjectType, IntrospectionQuery } from "graphql";
+
+export function findMutationType(mutationName: string, schema: IntrospectionQuery) {
+    if (!schema.__schema.mutationType) throw new Error("Schema has no Mutation type");
+    const queryType = schema.__schema.types.find((type) => type.name === schema.__schema.mutationType?.name) as IntrospectionObjectType | undefined;
+    if (!queryType) throw new Error("Can't find Mutation type in gql schema");
+    return queryType.fields.find((field) => field.name === mutationName);
+}
+
+export function findMutationTypeOrThrow(mutationName: string, schema: IntrospectionQuery) {
+    const ret = findMutationType(mutationName, schema);
+    if (!ret) throw new Error(`Can't find Mutation ${mutationName} in gql schema`);
+    return ret;
+}


### PR DESCRIPTION
usecase: if relational data can be used for EntityTypeA or EntityTypeB two different create-mutations will exist. e.g. `createProductForEntityTypeA(entityTypeAId, input)` and `createProductForEntityTypeB(entityTypeBId, input)`