### PR TITLE
Fix link target validation in `ExternalLinkBlock`

### DIFF
--- a/.changeset/six-meals-lie.md
+++ b/.changeset/six-meals-lie.md
@@ -2,4 +2,7 @@
 "@comet/cms-admin": patch
 ---
 
-Improve URL validation in `ExternalLinkBlock` and `SeoBlock`
+Fix link target validation in `ExternalLinkBlock`
+
+Previously, two different validation checks were used.
+This resulted in an error when saving an invalid link target but no error message was shown.

--- a/.changeset/six-meals-lie.md
+++ b/.changeset/six-meals-lie.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Improve URL validation in `ExternalLinkBlock` and `SeoBlock`

--- a/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
@@ -6,7 +6,7 @@ import { FormattedMessage } from "react-intl";
 
 import { ExternalLinkBlockData, ExternalLinkBlockInput } from "../blocks.generated";
 import { isLinkTarget } from "../validation/isLinkTarget";
-import { validateUrl } from "../validation/validateUrl";
+import { validateLinkTarget } from "../validation/validateLinkTarget";
 
 type State = ExternalLinkBlockData;
 
@@ -68,7 +68,7 @@ export const ExternalLinkBlock: BlockInterface<ExternalLinkBlockData, State, Ext
                         name="targetUrl"
                         component={FinalFormInput}
                         fullWidth
-                        validate={(url) => validateUrl(url)}
+                        validate={(url) => validateLinkTarget(url)}
                         disableContentTranslation
                     />
                     <Field name="openInNewWindow" type="checkbox">

--- a/packages/admin/cms-admin/src/validation/validateLinkTarget.tsx
+++ b/packages/admin/cms-admin/src/validation/validateLinkTarget.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { isLinkTarget } from "./isLinkTarget";
+
+export function validateLinkTarget(linkTarget: string) {
+    if (!isLinkTarget(linkTarget)) {
+        return <FormattedMessage id="comet.validation.validateLinkTarget.invalid" defaultMessage="Invalid link target" />;
+    }
+}

--- a/packages/admin/cms-admin/src/validation/validateUrl.tsx
+++ b/packages/admin/cms-admin/src/validation/validateUrl.tsx
@@ -1,10 +1,9 @@
+import { isURL } from "class-validator";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { isLinkTarget } from "./isLinkTarget";
-
 export function validateUrl(url: string) {
-    if (url && !isLinkTarget(url)) {
+    if (url && !isURL(url)) {
         return <FormattedMessage id="comet.validation.validateUrl.invalid" defaultMessage="Invalid URL" />;
     }
 }

--- a/packages/admin/cms-admin/src/validation/validateUrl.tsx
+++ b/packages/admin/cms-admin/src/validation/validateUrl.tsx
@@ -1,9 +1,10 @@
-import { isURL } from "class-validator";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { isLinkTarget } from "./isLinkTarget";
+
 export function validateUrl(url: string) {
-    if (url && !isURL(url)) {
+    if (url && !isLinkTarget(url)) {
         return <FormattedMessage id="comet.validation.validateUrl.invalid" defaultMessage="Invalid URL" />;
     }
 }


### PR DESCRIPTION
## Problem:

The validation in the ExternalLinkBlock was broken. The `isValid` check uses `isLinkTarget` for validation:

https://github.com/vivid-planet/comet/blob/9867242fa6bad4849de58ccce1c28b816cc109a3/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx#L42-L44

The `targetUrl` field uses `validateUrl`:

https://github.com/vivid-planet/comet/blob/9867242fa6bad4849de58ccce1c28b816cc109a3/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx#L66-L73

The problem was that `validateUrl` internally used `isUrl` from class validator. `isUrl` is less strict than `isLinkTarget`. This resulted in no validation error in the UI but an error when trying to save the block:

https://github.com/vivid-planet/comet/assets/13380047/a6c91ce1-94a5-4aac-a755-ef497a506504

## Solution:

I added `validateLinkTarget` using the stricter `isLinkTarget` check.
