### PR TITLE
Toolbar: Remove `hideBottomBar` prop

### DIFF
--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -8,10 +8,7 @@ import { Toolbar, ToolbarProps } from "./Toolbar";
 
 export type DataGridToolbarClassKey = "root" | "standard" | "comfortable";
 
-export type DataGridToolbarProps = { density?: "standard" | "comfortable" } & Omit<
-    ToolbarProps,
-    "slotProps" | "scopeIndicator" | "hideTopBar" | "hideBottomBar"
-> &
+export type DataGridToolbarProps = { density?: "standard" | "comfortable" } & Omit<ToolbarProps, "slotProps" | "scopeIndicator" | "hideTopBar"> &
     ThemedComponentBaseProps<{
         root: typeof Toolbar;
     }>;

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -21,7 +21,6 @@ export interface ToolbarProps
     children?: React.ReactNode;
     scopeIndicator?: React.ReactNode;
     hideTopBar?: boolean;
-    hideBottomBar?: boolean;
 }
 
 type OwnerState = {
@@ -92,14 +91,12 @@ export const Toolbar = (inProps: ToolbarProps) => {
     const {
         children,
         hideTopBar = false,
-        hideBottomBar: passedHideBottomBar,
         elevation = 1,
         slotProps,
         scopeIndicator,
         ...restProps
     } = useThemeProps({ props: inProps, name: "CometAdminToolbar" });
     const { headerHeight } = React.useContext(MasterLayoutContext);
-    const hideBottomBar = passedHideBottomBar ?? React.Children.count(children) === 0 ?? false;
 
     const ownerState: OwnerState = {
         headerHeight,
@@ -112,7 +109,7 @@ export const Toolbar = (inProps: ToolbarProps) => {
                     <Breadcrumbs scopeIndicator={scopeIndicator} {...slotProps?.breadcrumbs} />
                 </TopBar>
             )}
-            {!hideBottomBar && (
+            {children && (
                 <BottomBar {...slotProps?.bottomBar}>
                     <MainContentContainer {...slotProps?.mainContentContainer}>{children}</MainContentContainer>
                 </BottomBar>


### PR DESCRIPTION
`hideBottomBar` is actually unnecessary. Now, the bottom bar is only shown if there are children that can be rendered in the bottom bar. No children -> no content -> no render.
