### PR TITLE
Fix ExternalLinkBlock

### DIFF
--- a/packages/admin/cms-admin/src/validation/validateLinkTarget.tsx
+++ b/packages/admin/cms-admin/src/validation/validateLinkTarget.tsx
@@ -3,8 +3,8 @@ import { FormattedMessage } from "react-intl";
 
 import { isLinkTarget } from "./isLinkTarget";
 
-export function validateLinkTarget(linkTarget: string) {
-    if (!isLinkTarget(linkTarget)) {
+export function validateLinkTarget(linkTarget?: string) {
+    if (linkTarget && !isLinkTarget(linkTarget)) {
         return <FormattedMessage id="comet.validation.validateLinkTarget.invalid" defaultMessage="Invalid link target" />;
     }
 }

--- a/packages/admin/cms-admin/src/validation/validateUrl.tsx
+++ b/packages/admin/cms-admin/src/validation/validateUrl.tsx
@@ -2,7 +2,7 @@ import { isURL } from "class-validator";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
-export function validateUrl(url: string) {
+export function validateUrl(url?: string) {
     if (url && !isURL(url)) {
         return <FormattedMessage id="comet.validation.validateUrl.invalid" defaultMessage="Invalid URL" />;
     }


### PR DESCRIPTION
In #2102 I missed that the url can be undefined because it has an any type and the typing of validateUrl was also incorrect. Now the `ExternalLinkBlock` breaks when the URL is emptied. This PR fixes that by checking if url is defined.

---

A changeset isn't necessary because #2102 wasn't released yet.
