### PR TITLE
Change default value of automatic redirects checkbox based on page visibility

### DIFF
--- a/.changeset/few-roses-worry.md
+++ b/.changeset/few-roses-worry.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Automatic Redirects are now set to false if the page is unpublished or archived

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -66,6 +66,7 @@ export function createEditPageNode({
                 hideInMenu
                 parentId
                 numberOfDescendants
+                visibility
                 document {
                     ... on DocumentInterface {
                         id
@@ -189,6 +190,8 @@ export function createEditPageNode({
                 }
             }
         };
+
+        const isActivePage = data?.page?.visibility === "Published";
 
         // Use `p-debounce` instead of `use-debounce`
         // because Final Form expects all validate calls to be resolved.
@@ -384,7 +387,11 @@ export function createEditPageNode({
                                                                 </>
                                                             }
                                                         >
-                                                            <Field name="createAutomaticRedirectsOnSlugChange" type="checkbox" initialValue={true}>
+                                                            <Field
+                                                                name="createAutomaticRedirectsOnSlugChange"
+                                                                type="checkbox"
+                                                                initialValue={isActivePage}
+                                                            >
                                                                 {(props) => (
                                                                     <FormControlLabel
                                                                         label={


### PR DESCRIPTION
Change the Behaviour of the Automatic Redirect to default to false if the corresponding Page is unpublished or archived.
