### PR TITLE
Fix service instantiation in block transformer

### DIFF
--- a/packages/api/cms-api/src/blocks/blocks-transformer.ts
+++ b/packages/api/cms-api/src/blocks/blocks-transformer.ts
@@ -30,7 +30,9 @@ export async function transformToPlain(block: BlockDataInterface, blockContext: 
                         if (moduleRef.introspect(transformResponse).scope === Scope.DEFAULT) {
                             service = moduleRef.get(transformResponse, { strict: false });
                         } else {
-                            service = await moduleRef.resolve(transformResponse, ContextIdFactory.getByRequest(context), { strict: false });
+                            const contextId = ContextIdFactory.create();
+                            moduleRef.registerRequestByContextId(context, contextId);
+                            service = await moduleRef.resolve(transformResponse, contextId, { strict: false });
                         }
 
                         entries = Object.entries(await service.transformToPlain(json, blockContext));


### PR DESCRIPTION
## Problem

An error occurred when opening the redirects page or the block preview:

<details>
    <summary>Screenshots/screencasts</summary>
    <img width="1728" alt="Bildschirmfoto 2024-05-23 um 23 39 30" src="https://github.com/vivid-planet/comet/assets/13380047/dd862954-0a68-4d46-9a77-df7125a75193">

<img width="1728" alt="Bildschirmfoto 2024-05-23 um 23 41 35" src="https://github.com/vivid-planet/comet/assets/13380047/3f03d4c5-5616-408d-8203-1caf0864badb">
</details>

The reason was that `pageTreeReadApiService` in `InternalLinkBlockTransformerService` wasn't correctly instantiated:

<img width="483" alt="Bildschirmfoto 2024-05-23 um 23 43 25" src="https://github.com/vivid-planet/comet/assets/13380047/b37c283f-085f-43bb-a6f9-044629ecadac">

https://github.com/vivid-planet/comet/blob/e1592759458bb9c9b47b1eb3e997bf9a0cb40cc8/packages/api/cms-api/src/page-tree/blocks/internal-link-block-transformer.service.ts#L29


## Solution

Apparently, outside the lifecycle of a standard HTTP request you can't use `ContextIdFactory.getByRequest`. Instead, you must manually register a context via `ContextIdFactory.registerRequestByContextId`.

Now it works correctly for me:

<details>
    <summary>Screenshots/screencasts</summary>

<img width="1728" alt="Bildschirmfoto 2024-05-23 um 23 41 59" src="https://github.com/vivid-planet/comet/assets/13380047/4c5eb182-de9d-4a11-8366-a2c1e9b26a38">

<img width="1728" alt="Bildschirmfoto 2024-05-23 um 23 41 53" src="https://github.com/vivid-planet/comet/assets/13380047/df819d11-bdcc-4d95-b9c0-8d597b117b4f">

</details>

This time ChatGPT was actually helpful for once, directing me in the right direction:

> When to Use registerRequestByContextId
> - Non-HTTP Requests: For non-HTTP request contexts, such as WebSocket or microservice contexts, where NestJS does not automatically manage the request context.
> - Custom Contexts: When you manually create a context (e.g., **GraphQL field middleware**) and need to ensure that dependencies are resolved within that custom context.

> When to use getByRequest
> - Within Standard HTTP Middleware: When you are in standard HTTP middleware, NestJS automatically handles the request context for you.
> - In Request Scopes: When you have request-scoped providers and you are operating within the boundaries of a request lifecycle.
> - In Controllers and Services: When you are within a controller or a service that is part of the request lifecycle.
