### PR TITLE
Fix context ID retrieval for `BlocksTransformerMiddlewareFactory`

### DIFF
--- a/packages/api/cms-api/src/blocks/blocks-transformer-middleware.factory.ts
+++ b/packages/api/cms-api/src/blocks/blocks-transformer-middleware.factory.ts
@@ -1,5 +1,6 @@
 import { isBlockDataInterface } from "@comet/blocks-api";
-import { ModuleRef } from "@nestjs/core";
+import { ContextId, ContextIdFactory, ModuleRef } from "@nestjs/core";
+import { REQUEST_CONTEXT_ID } from "@nestjs/core/router/request/request-constants";
 import { FieldMiddleware, MiddlewareContext, NextFn } from "@nestjs/graphql";
 
 import { getRequestContextHeadersFromRequest } from "../common/decorators/request-context.decorator";
@@ -12,11 +13,32 @@ export class BlocksTransformerMiddlewareFactory {
 
             if (isBlockDataInterface(fieldValue)) {
                 const { includeInvisibleBlocks, previewDamUrls, relativeDamUrls } = getRequestContextHeadersFromRequest(context.req);
+
+                let contextId: ContextId;
+
+                if (context[REQUEST_CONTEXT_ID]) {
+                    /**
+                     * The request is already registered by either using
+                     * a request-scoped service or the request provider
+                     * (`CONTEXT`) in the root GraphQL resolver. We can
+                     * reuse the context ID.
+                     */
+                    contextId = ContextIdFactory.getByRequest(context);
+                } else {
+                    /**
+                     * We need to generate a context ID and register the
+                     * middleware context as "request" to be able to
+                     * resolve request-scoped services.
+                     */
+                    contextId = ContextIdFactory.create();
+                    moduleRef.registerRequestByContextId(context, contextId);
+                }
+
                 return transformToPlain(
                     fieldValue,
                     { includeInvisibleContent: includeInvisibleBlocks, previewDamUrls, relativeDamUrls },
                     moduleRef,
-                    context,
+                    contextId,
                 );
             } else {
                 return fieldValue;

--- a/packages/api/cms-api/src/blocks/blocks-transformer.service.ts
+++ b/packages/api/cms-api/src/blocks/blocks-transformer.service.ts
@@ -1,6 +1,6 @@
 import { BlockContext, BlockDataInterface } from "@comet/blocks-api";
 import { Inject, Injectable } from "@nestjs/common";
-import { ModuleRef } from "@nestjs/core";
+import { ContextIdFactory, ModuleRef } from "@nestjs/core";
 import { CONTEXT } from "@nestjs/graphql";
 
 import { getRequestContextHeadersFromRequest } from "../common/decorators/request-context.decorator";
@@ -39,6 +39,7 @@ export class BlocksTransformerService {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async transformToPlain(block: BlockDataInterface, context?: BlockContext): Promise<any> {
-        return transformToPlain(block, context ?? this.blockContext, this.moduleRef, this.context);
+        const contextId = ContextIdFactory.getByRequest(this.context);
+        return transformToPlain(block, context ?? this.blockContext, this.moduleRef, contextId);
     }
 }

--- a/packages/api/cms-api/src/blocks/blocks-transformer.ts
+++ b/packages/api/cms-api/src/blocks/blocks-transformer.ts
@@ -7,13 +7,18 @@ import {
 } from "@comet/blocks-api";
 import { Scope, Type } from "@nestjs/common";
 import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
-import { ContextIdFactory, ModuleRef } from "@nestjs/core";
+import { ContextId, ModuleRef } from "@nestjs/core";
 import opentelemetry from "@opentelemetry/api";
 
 const tracer = opentelemetry.trace.getTracer("@comet/cms-api");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function transformToPlain(block: BlockDataInterface, blockContext: BlockContext, moduleRef: ModuleRef, context: any): Promise<unknown> {
+export async function transformToPlain(
+    block: BlockDataInterface,
+    blockContext: BlockContext,
+    moduleRef: ModuleRef,
+    contextId: ContextId,
+): Promise<unknown> {
     return tracer.startActiveSpan("BlockTransformer", async (span) => {
         async function traverse(json: unknown): Promise<unknown> {
             if (Array.isArray(json)) {
@@ -30,7 +35,7 @@ export async function transformToPlain(block: BlockDataInterface, blockContext: 
                         if (moduleRef.introspect(transformResponse).scope === Scope.DEFAULT) {
                             service = moduleRef.get(transformResponse, { strict: false });
                         } else {
-                            service = await moduleRef.resolve(transformResponse, ContextIdFactory.getByRequest(context), { strict: false });
+                            service = await moduleRef.resolve(transformResponse, contextId, { strict: false });
                         }
 
                         entries = Object.entries(await service.transformToPlain(json, blockContext));


### PR DESCRIPTION
Using `ContextIdFactory.getByRequest` doesn't work for requests that aren't already registered in the module ref. A request is only registered when using the request provider (`CONTEXT`)  or a request-scoped service in the root GraphQL resolver. We need to register the request ourselves for other scenarios.

---

Alternative to #2109.