### PR TITLE
Make `documentTypes` prop of `PagesPage` also accept a function mapping categories to document types

### DIFF
--- a/.changeset/little-bats-glow.md
+++ b/.changeset/little-bats-glow.md
@@ -2,27 +2,30 @@
 "@comet/cms-admin": minor
 ---
 
-Add `categoryToDocumentTypesMap` to `PagesPage`
+The `documentTypes` prop of `PagesPage` now also accepts a function mapping categories to document types
 
-Previously, only the supported documentTypes of the current category were passed to the `PagesPage`.
+Previously, only the supported documentTypes of the current category could be passed to the `PagesPage`.
 That made it impossible to verify if a document can be moved to another category.
 If a document was moved to a category that didn't support its type, the PageTree crashed.
 
-If `categoryToDocumentTypesMap` is set, documents can now only be moved to categories that support their type.
+If a mapping function is passed to `documentTypes`, documents can only be moved to categories that support their type.
 
 ```diff
 <PagesPage
 -   documentTypes={pageTreeDocumentTypes}
-+   categoryToDocumentTypesMap={{
-+       MainNavigation: {
++   documentTypes={(category): Record<DocumentType, DocumentInterface> => {
++       if (category === "TopMenu") {
++           return {
++               Page,
++               PredefinedPage,
++           };
++       }
++
++       return {
 +           Page,
++           PredefinedPage,
 +           Link,
-+           PredefinedPage,
-+       },
-+       TopMenu: {
-+           Page,
-+           PredefinedPage,
-+       },
++       };
 +   }}
     // ...
 />

--- a/.changeset/little-bats-glow.md
+++ b/.changeset/little-bats-glow.md
@@ -1,0 +1,29 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `categoryToDocumentTypesMap` to `PagesPage`
+
+Previously, only the supported documentTypes of the current category were passed to the `PagesPage`.
+That made it impossible to verify if a document can be moved to another category.
+If a document was moved to a category that didn't support its type, the PageTree crashed.
+
+If `categoryToDocumentTypesMap` is set, documents can now only be moved to categories that support their type.
+
+```diff
+<PagesPage
+-   documentTypes={pageTreeDocumentTypes}
++   categoryToDocumentTypesMap={{
++       MainNavigation: {
++           Page,
++           Link,
++           PredefinedPage,
++       },
++       TopMenu: {
++           Page,
++           PredefinedPage,
++       },
++   }}
+    // ...
+/>
+```

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -68,7 +68,17 @@ export const masterMenuData: MasterMenuData = [
                     <PagesPage
                         path={`/pages/pagetree/${match.params.category}`}
                         allCategories={pageTreeCategories}
-                        documentTypes={pageTreeDocumentTypes}
+                        categoryToDocumentTypesMap={{
+                            MainNavigation: {
+                                Page,
+                                Link,
+                                PredefinedPage,
+                            },
+                            TopMenu: {
+                                Page,
+                                PredefinedPage,
+                            },
+                        }}
                         editPageNode={EditPageNode}
                         category={category}
                         renderContentScopeIndicator={(scope) => <ContentScopeIndicator scope={scope} variant="toolbar" />}

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -3,6 +3,8 @@ import {
     createRedirectsPage,
     CronJobsPage,
     DamPage,
+    DocumentInterface,
+    DocumentType,
     MasterMenu as CometMasterMenu,
     MasterMenuData,
     PagesPage,
@@ -68,16 +70,19 @@ export const masterMenuData: MasterMenuData = [
                     <PagesPage
                         path={`/pages/pagetree/${match.params.category}`}
                         allCategories={pageTreeCategories}
-                        categoryToDocumentTypesMap={{
-                            MainNavigation: {
+                        documentTypes={(category): Record<DocumentType, DocumentInterface> => {
+                            if (category === "TopMenu") {
+                                return {
+                                    Page,
+                                    PredefinedPage,
+                                };
+                            }
+
+                            return {
                                 Page,
+                                PredefinedPage,
                                 Link,
-                                PredefinedPage,
-                            },
-                            TopMenu: {
-                                Page,
-                                PredefinedPage,
-                            },
+                            };
                         }}
                         editPageNode={EditPageNode}
                         category={category}

--- a/packages/admin/cms-admin/src/pages/pageTree/MovePageMenuItem.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/MovePageMenuItem.tsx
@@ -1,10 +1,11 @@
 import { gql, useMutation } from "@apollo/client";
-import { RowActionsItem, RowActionsMenu } from "@comet/admin";
+import { RowActionsItem, RowActionsMenu, useErrorDialog } from "@comet/admin";
 import { MovePage } from "@comet/admin-icons";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { useContentScope } from "../../contentScope/Provider";
+import { DocumentInterface, DocumentType } from "../../documents/types";
 import { GQLUpdatePageTreeNodeCategoryMutation, GQLUpdatePageTreeNodeCategoryMutationVariables } from "./MovePageMenuItem.generated";
 import { PageTreePage } from "./usePageTree";
 import { usePageTreeContext } from "./usePageTreeContext";
@@ -26,13 +27,19 @@ export function MovePageMenuItem({ page }: Props): React.ReactElement | null {
         }
     `);
     const { scope } = useContentScope();
-    const { allCategories, query } = usePageTreeContext();
+    const { allCategories, query, categoryToDocumentTypesMap } = usePageTreeContext();
+    const errorDialogApi = useErrorDialog();
 
     if (allCategories.length <= 1) {
         return null;
     }
 
     const handleSubMenuItemClick = async (category: string) => {
+        if (!categorySupportsDocumentType(category, page.documentType, categoryToDocumentTypesMap)) {
+            errorDialogApi?.showError({ error: `Cannot move: Target category doesn't support documentType ${page.documentType}` });
+            return;
+        }
+
         const refetchQueries = [
             { query, variables: { contentScope: scope, category } },
             { query, variables: { contentScope: scope, category: page.category } },
@@ -46,11 +53,35 @@ export function MovePageMenuItem({ page }: Props): React.ReactElement | null {
 
     return (
         <RowActionsMenu icon={<MovePage />} text={<FormattedMessage id="comet.pages.pages.page.movePage" defaultMessage="Move page" />}>
-            {allCategories.map(({ category, label }) => (
-                <RowActionsItem key={category} disabled={category === page.category || submitting} onClick={() => handleSubMenuItemClick(category)}>
-                    {label}
-                </RowActionsItem>
-            ))}
+            {allCategories.map(({ category, label }) => {
+                const canMoveToTargetCategory = categorySupportsDocumentType(category, page.documentType, categoryToDocumentTypesMap);
+
+                return (
+                    <RowActionsItem
+                        key={category}
+                        disabled={category === page.category || !canMoveToTargetCategory || submitting}
+                        onClick={() => handleSubMenuItemClick(category)}
+                    >
+                        {label}
+                    </RowActionsItem>
+                );
+            })}
         </RowActionsMenu>
     );
 }
+
+const categorySupportsDocumentType = (
+    category: string,
+    documentType: string,
+    categoryToDocumentTypesMap?: {
+        [category: string]: Record<DocumentType, DocumentInterface>;
+    },
+) => {
+    if (categoryToDocumentTypesMap === undefined) {
+        // fallback because categoryToDocumentTypesMap can be undefined
+        return true;
+    }
+
+    const supportedDocumentTypes = Object.keys(categoryToDocumentTypesMap[category]);
+    return supportedDocumentTypes.includes(documentType);
+};

--- a/packages/admin/cms-admin/src/pages/pageTree/MovePageMenuItem.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/MovePageMenuItem.tsx
@@ -1,5 +1,5 @@
 import { gql, useMutation } from "@apollo/client";
-import { RowActionsItem, RowActionsMenu, useErrorDialog } from "@comet/admin";
+import { RowActionsItem, RowActionsMenu } from "@comet/admin";
 import { MovePage } from "@comet/admin-icons";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
@@ -28,7 +28,6 @@ export function MovePageMenuItem({ page }: Props): React.ReactElement | null {
     `);
     const { scope } = useContentScope();
     const { allCategories, query, getDocumentTypesByCategory } = usePageTreeContext();
-    const errorDialogApi = useErrorDialog();
 
     if (allCategories.length <= 1) {
         return null;
@@ -36,8 +35,7 @@ export function MovePageMenuItem({ page }: Props): React.ReactElement | null {
 
     const handleSubMenuItemClick = async (category: string) => {
         if (!categorySupportsDocumentType(category, page.documentType, getDocumentTypesByCategory)) {
-            errorDialogApi?.showError({ error: `Cannot move: Target category doesn't support documentType ${page.documentType}` });
-            return;
+            throw new Error(`Cannot move: Target category doesn't support documentType ${page.documentType}`);
         }
 
         const refetchQueries = [

--- a/packages/admin/cms-admin/src/pages/pageTree/MovePageMenuItem.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/MovePageMenuItem.tsx
@@ -27,7 +27,7 @@ export function MovePageMenuItem({ page }: Props): React.ReactElement | null {
         }
     `);
     const { scope } = useContentScope();
-    const { allCategories, query, categoryToDocumentTypesMap } = usePageTreeContext();
+    const { allCategories, query, getDocumentTypesByCategory } = usePageTreeContext();
     const errorDialogApi = useErrorDialog();
 
     if (allCategories.length <= 1) {
@@ -35,7 +35,7 @@ export function MovePageMenuItem({ page }: Props): React.ReactElement | null {
     }
 
     const handleSubMenuItemClick = async (category: string) => {
-        if (!categorySupportsDocumentType(category, page.documentType, categoryToDocumentTypesMap)) {
+        if (!categorySupportsDocumentType(category, page.documentType, getDocumentTypesByCategory)) {
             errorDialogApi?.showError({ error: `Cannot move: Target category doesn't support documentType ${page.documentType}` });
             return;
         }
@@ -54,7 +54,7 @@ export function MovePageMenuItem({ page }: Props): React.ReactElement | null {
     return (
         <RowActionsMenu icon={<MovePage />} text={<FormattedMessage id="comet.pages.pages.page.movePage" defaultMessage="Move page" />}>
             {allCategories.map(({ category, label }) => {
-                const canMoveToTargetCategory = categorySupportsDocumentType(category, page.documentType, categoryToDocumentTypesMap);
+                const canMoveToTargetCategory = categorySupportsDocumentType(category, page.documentType, getDocumentTypesByCategory);
 
                 return (
                     <RowActionsItem
@@ -73,15 +73,13 @@ export function MovePageMenuItem({ page }: Props): React.ReactElement | null {
 const categorySupportsDocumentType = (
     category: string,
     documentType: string,
-    categoryToDocumentTypesMap?: {
-        [category: string]: Record<DocumentType, DocumentInterface>;
-    },
+    getDocumentTypesByCategory?: (category: string) => Record<DocumentType, DocumentInterface>,
 ) => {
-    if (categoryToDocumentTypesMap === undefined) {
-        // fallback because categoryToDocumentTypesMap can be undefined
+    if (getDocumentTypesByCategory === undefined) {
+        // fallback if no category->documentTypes mapping function was passed
         return true;
     }
 
-    const supportedDocumentTypes = Object.keys(categoryToDocumentTypesMap[category]);
+    const supportedDocumentTypes = Object.keys(getDocumentTypesByCategory(category));
     return supportedDocumentTypes.includes(documentType);
 };

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTreeContext.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTreeContext.ts
@@ -11,6 +11,9 @@ export interface PageTreeContext {
     allCategories: AllCategories;
     currentCategory: string;
     documentTypes: Record<DocumentType, DocumentInterface>;
+    categoryToDocumentTypesMap?: {
+        [category: string]: Record<DocumentType, DocumentInterface>;
+    };
     tree: TreeMap<GQLPageTreePageFragment>;
     query: DocumentNode;
 }

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTreeContext.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTreeContext.ts
@@ -11,9 +11,7 @@ export interface PageTreeContext {
     allCategories: AllCategories;
     currentCategory: string;
     documentTypes: Record<DocumentType, DocumentInterface>;
-    categoryToDocumentTypesMap?: {
-        [category: string]: Record<DocumentType, DocumentInterface>;
-    };
+    getDocumentTypesByCategory?: (category: string) => Record<DocumentType, DocumentInterface>;
     tree: TreeMap<GQLPageTreePageFragment>;
     query: DocumentNode;
 }

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -39,6 +39,9 @@ interface Props {
     category: string;
     path: string;
     allCategories: AllCategories;
+    /**
+     * @deprecated Use categoryToDocumentTypesMap instead
+     */
     documentTypes?: Record<DocumentType, DocumentInterface>;
     categoryToDocumentTypesMap?: {
         [category: string]: Record<DocumentType, DocumentInterface>;

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -39,13 +39,7 @@ interface Props {
     category: string;
     path: string;
     allCategories: AllCategories;
-    /**
-     * @deprecated Use categoryToDocumentTypesMap instead
-     */
-    documentTypes?: Record<DocumentType, DocumentInterface>;
-    categoryToDocumentTypesMap?: {
-        [category: string]: Record<DocumentType, DocumentInterface>;
-    };
+    documentTypes: Record<DocumentType, DocumentInterface> | ((category: string) => Record<DocumentType, DocumentInterface>);
     editPageNode?: React.ComponentType<EditPageNodeProps>;
     renderContentScopeIndicator: (scope: ContentScopeInterface) => React.ReactNode;
 }
@@ -56,8 +50,7 @@ export function PagesPage({
     category,
     path,
     allCategories,
-    documentTypes: passedLegacyDocumentTypes,
-    categoryToDocumentTypesMap,
+    documentTypes: passedDocumentTypes,
     editPageNode: EditPageNode = DefaultEditPageNode,
     renderContentScopeIndicator,
 }: Props): React.ReactElement {
@@ -68,11 +61,7 @@ export function PagesPage({
 
     const siteConfig = useSiteConfig({ scope });
     const pagesQuery = React.useMemo(() => createPagesQuery({ additionalPageTreeNodeFragment }), [additionalPageTreeNodeFragment]);
-    const documentTypes = categoryToDocumentTypesMap?.[category] ?? passedLegacyDocumentTypes;
-
-    if (documentTypes === undefined) {
-        throw new Error("You must pass either categoryToDocumentTypesMap or documentTypes");
-    }
+    const documentTypes = typeof passedDocumentTypes === "function" ? passedDocumentTypes(category) : passedDocumentTypes;
 
     React.useEffect(() => {
         setRedirectPathAfterChange(path);
@@ -170,7 +159,14 @@ export function PagesPage({
                             </ToolbarActions>
                         </Toolbar>
                         <PageTreeContext.Provider
-                            value={{ allCategories, currentCategory: category, documentTypes, categoryToDocumentTypesMap, tree, query: pagesQuery }}
+                            value={{
+                                allCategories,
+                                currentCategory: category,
+                                documentTypes,
+                                getDocumentTypesByCategory: typeof passedDocumentTypes === "function" ? passedDocumentTypes : undefined,
+                                tree,
+                                query: pagesQuery,
+                            }}
                         >
                             <PageTreeContent fullHeight>
                                 <ActionToolbarBox>

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -39,7 +39,10 @@ interface Props {
     category: string;
     path: string;
     allCategories: AllCategories;
-    documentTypes: Record<DocumentType, DocumentInterface>;
+    documentTypes?: Record<DocumentType, DocumentInterface>;
+    categoryToDocumentTypesMap?: {
+        [category: string]: Record<DocumentType, DocumentInterface>;
+    };
     editPageNode?: React.ComponentType<EditPageNodeProps>;
     renderContentScopeIndicator: (scope: ContentScopeInterface) => React.ReactNode;
 }
@@ -50,7 +53,8 @@ export function PagesPage({
     category,
     path,
     allCategories,
-    documentTypes,
+    documentTypes: passedLegacyDocumentTypes,
+    categoryToDocumentTypesMap,
     editPageNode: EditPageNode = DefaultEditPageNode,
     renderContentScopeIndicator,
 }: Props): React.ReactElement {
@@ -61,6 +65,11 @@ export function PagesPage({
 
     const siteConfig = useSiteConfig({ scope });
     const pagesQuery = React.useMemo(() => createPagesQuery({ additionalPageTreeNodeFragment }), [additionalPageTreeNodeFragment]);
+    const documentTypes = categoryToDocumentTypesMap?.[category] ?? passedLegacyDocumentTypes;
+
+    if (documentTypes === undefined) {
+        throw new Error("You must pass either categoryToDocumentTypesMap or documentTypes");
+    }
 
     React.useEffect(() => {
         setRedirectPathAfterChange(path);
@@ -157,7 +166,9 @@ export function PagesPage({
                                 </Button>
                             </ToolbarActions>
                         </Toolbar>
-                        <PageTreeContext.Provider value={{ allCategories, currentCategory: category, documentTypes, tree, query: pagesQuery }}>
+                        <PageTreeContext.Provider
+                            value={{ allCategories, currentCategory: category, documentTypes, categoryToDocumentTypesMap, tree, query: pagesQuery }}
+                        >
                             <PageTreeContent fullHeight>
                                 <ActionToolbarBox>
                                     <PagesPageActionToolbar


### PR DESCRIPTION
Previously, only the supported documentTypes of the current category could be passed to the `PagesPage`.
That made it impossible to verify if a document can be moved to another category.
If a document was moved to a category that didn't support its type, the PageTree crashed.

If a mapping function is passed to `documentTypes`, documents can only be moved to categories that support their type.

```diff
<PagesPage
-   documentTypes={pageTreeDocumentTypes}
+   documentTypes={(category): Record<DocumentType, DocumentInterface> => {
+       if (category === "TopMenu") {
+           return {
+               Page,
+               PredefinedPage,
+           };
+       }
+
+       return {
+           Page,
+           PredefinedPage,
+           Link,
+       };
+   }}
    // ...
/>
```

Note: If the move is valid is still only verified in the admin interface. However, you have to work actively against the UI to make the move.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-701
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>

Previously:

https://github.com/vivid-planet/comet/assets/13380047/4a8311e7-b4b9-46f0-a631-dda601366c34


Now:


https://github.com/vivid-planet/comet/assets/13380047/d3021ba3-3615-4286-82d3-d3f6991a5000



</details>
