### PR TITLE
API Generator: Support relation with primary key type `int` (in addition to `integer`)

### DIFF
--- a/.changeset/nine-comics-design.md
+++ b/.changeset/nine-comics-design.md
@@ -2,4 +2,4 @@
 "@comet/cms-api": patch
 ---
 
-CRUD Generator: support relation with primaryKey type int (in addition to integer)
+API Generator: Support relation with primary key type `int` (in addition to `integer`)

--- a/.changeset/nine-comics-design.md
+++ b/.changeset/nine-comics-design.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+CRUD Generator: support relation with primaryKey type int (in addition to integer)

--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -32,7 +32,7 @@ function findReferenceTargetType(
         return "uuid";
     } else if (referencedColumnProp.type == "string") {
         return "string";
-    } else if (referencedColumnProp.type == "integer") {
+    } else if (referencedColumnProp.type == "integer" || referencedColumnProp.type == "int") {
         return "integer";
     } else {
         return null;


### PR DESCRIPTION
improves test from https://github.com/vivid-planet/comet/pull/1285

The PrimaryKey decorator with type integer works fine:   `@PrimaryKey({ columnType: "int", type: "integer" })`
However, the PrimaryKey decorator with type int causes a generation issue:     `@PrimaryKey({ columnType: "int", type: "int" })`

The input file for type int should be generated exactly the same, and there is now a new test for this.