### PR TITLE
Site Middleware: use cache-manager for redirects cache for background refresh

### DIFF
--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -27,6 +27,7 @@
         "@opentelemetry/auto-instrumentations-node": "^0.36.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.35.1",
         "@opentelemetry/sdk-node": "^0.35.1",
+        "cache-manager": "^5.5.3",
         "express": "^4.0.0",
         "fs-extra": "^9.0.0",
         "graphql": "^15.0.0",

--- a/demo/site/src/redirects/cache.ts
+++ b/demo/site/src/redirects/cache.ts
@@ -1,0 +1,13 @@
+import { createCache, memoryStore } from "cache-manager";
+
+export const memoryCache = createCache(
+    memoryStore({
+        ttl: 15 * 60 * 1000, // 15 minutes,
+    }),
+    {
+        refreshThreshold: 5 * 60 * 1000, // refresh if less than 5 minutes TTL are remaining,
+        onBackgroundRefreshError: (error) => {
+            console.error("Error refreshing cache in background", error);
+        },
+    },
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,6 +646,9 @@ importers:
       '@opentelemetry/sdk-node':
         specifier: ^0.35.1
         version: 0.35.1(@opentelemetry/api@1.4.0)
+      cache-manager:
+        specifier: ^5.5.3
+        version: 5.5.3
       express:
         specifier: ^4.0.0
         version: 4.18.2
@@ -17690,6 +17693,15 @@ packages:
       unset-value: 1.0.0
     dev: false
 
+  /cache-manager@5.5.3:
+    resolution: {integrity: sha512-Td6F8lZE/YCciSi8xmdBjur6zlKIcoLMZp9jTmJNc44DrXIIcEhr9gra5j1T7RRbtWHaG5tJMEBKS+0S1+T2NQ==}
+    dependencies:
+      eventemitter3: 5.0.1
+      lodash.clonedeep: 4.5.0
+      lru-cache: 10.2.2
+      promise-coalesce: 1.1.2
+    dev: false
+
   /cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
     engines: {node: '>=10.6.0'}
@@ -20940,6 +20952,10 @@ packages:
 
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    dev: false
+
+  /eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
     dev: false
 
   /events@3.3.0:
@@ -25449,6 +25465,11 @@ packages:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
 
+  /lru-cache@10.2.2:
+    resolution: {integrity: sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==}
+    engines: {node: 14 || >=16.14}
+    dev: false
+
   /lru-cache@4.0.2:
     resolution: {integrity: sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==}
     dependencies:
@@ -28391,6 +28412,11 @@ packages:
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+    dev: false
+
+  /promise-coalesce@1.1.2:
+    resolution: {integrity: sha512-zLaJ9b8hnC564fnJH6NFSOGZYYdzrAJn2JUUIwzoQb32fG2QAakpDNM+CZo1km6keXkRXRM+hml1BFAPVnPkxg==}
+    engines: {node: '>=16'}
     dev: false
 
   /promise-inflight@1.0.1(bluebird@3.7.2):


### PR DESCRIPTION
Before: after ttl one (or multiple paralell) requests where slow because the redirects where fetched blocking the request

Now: refresh is triggered after 10 minutes in background updating the cache for future requests

Central Store / Redis:
I don't think we should use a central cache store for this data used in middleware - even if we use redis for nextjs cache-handler. That would ideally need a multi-layer cache (redis is slower than in-memory) but that doesn't work well with cache-manager (in my tests only in-memory was refrehed)