### PR TITLE
Admin Form Generator: Add `required` for `staticSelect` fields

### DIFF
--- a/demo/admin/src/products/future/CreateProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/CreateProductForm.cometGen.ts
@@ -17,7 +17,7 @@ export const CreateProductForm: FormConfig<GQLProduct> = {
         { type: "text", name: "slug" },
         { type: "date", name: "createdAt", label: "Created", readOnly: true },
         { type: "text", name: "description", label: "Description", multiline: true },
-        { type: "staticSelect", name: "type", label: "Type" /*, values: from gql schema (TODO overridable)*/ },
+        { type: "staticSelect", name: "type", label: "Type", required: true /*, values: from gql schema (TODO overridable)*/ },
         { type: "asyncSelect", name: "category", rootQuery: "productCategories" },
         { type: "boolean", name: "inStock" },
         { type: "date", name: "availableSince" },

--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -16,7 +16,7 @@ export const ProductForm: FormConfig<GQLProduct> = {
         { type: "text", name: "slug" },
         { type: "date", name: "createdAt", label: "Created", readOnly: true },
         { type: "text", name: "description", label: "Description", multiline: true },
-        { type: "staticSelect", name: "type", label: "Type" /*, values: from gql schema (TODO overridable)*/ },
+        { type: "staticSelect", name: "type", label: "Type", required: true /*, values: from gql schema (TODO overridable)*/ },
         { type: "asyncSelect", name: "category", rootQuery: "productCategories" },
         { type: "boolean", name: "inStock" },
         { type: "date", name: "availableSince" },

--- a/demo/admin/src/products/future/generated/CreateProductForm.tsx
+++ b/demo/admin/src/products/future/generated/CreateProductForm.tsx
@@ -124,7 +124,7 @@ export function CreateProductForm(): React.ReactElement {
                             name="description"
                             label={<FormattedMessage id="product.description" defaultMessage="Description" />}
                         />
-                        <Field fullWidth name="type" label={<FormattedMessage id="product.type" defaultMessage="Type" />}>
+                        <Field required fullWidth name="type" label={<FormattedMessage id="product.type" defaultMessage="Type" />}>
                             {(props) => (
                                 <FinalFormSelect {...props}>
                                     <MenuItem value="Cap">

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -178,7 +178,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                             name="description"
                             label={<FormattedMessage id="product.description" defaultMessage="Description" />}
                         />
-                        <Field fullWidth name="type" label={<FormattedMessage id="product.type" defaultMessage="Type" />}>
+                        <Field required fullWidth name="type" label={<FormattedMessage id="product.type" defaultMessage="Type" />}>
                             {(props) => (
                                 <FinalFormSelect {...props}>
                                     <MenuItem value="Cap">

--- a/packages/admin/cms-admin/src/generator/future/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateFormField.ts
@@ -147,6 +147,7 @@ export function generateFormField(
         if (!enumType) throw new Error(`Enum type ${(introspectionFieldType as IntrospectionNamedTypeRef).name} not found for field ${name}`);
         const values = enumType.enumValues.map((i) => i.name);
         code = `<Field
+            ${required ? "required" : ""}
             fullWidth
             name="${name}"
             label={<FormattedMessage id="${instanceGqlType}.${name}" defaultMessage="${label}" />}>


### PR DESCRIPTION
Admin Form Generator: `staticSelect` fields can now be generated with `required`.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [ ] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-824
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
`Type` is now required. 

<img width="1270" alt="Screenshot 2024-06-03 at 12 26 09" src="https://github.com/vivid-planet/comet/assets/122883866/01b9e397-ba99-47c1-80df-61c1a665671b">

</details>
