### PR TITLE
Use string as pattern in site-configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "license": "BSD-2-Clause",
     "scripts": {
-        "create-site-configs-env": "npx @comet/cli inject-site-configs -i .env.site-configs.tpl -o .env.site-configs",
+        "create-site-configs-env": "npx @comet/cli inject-site-configs -i .env.site-configs.tpl -o .env.site-configs -d",
         "build:storybook": "pnpm recursive --filter '@comet/*admin*' --filter '@comet/eslint-plugin' --filter '@comet/cli' run build && pnpm --filter comet-storybook run build-storybook",
         "build:packages": "pnpm recursive --filter '@comet/*' run build",
         "build:docs": "pnpm recursive --filter '@comet/eslint-plugin' --filter '@comet/admin*' --filter 'comet-docs' run build",

--- a/packages/cli/src/commands/site-configs.ts
+++ b/packages/cli/src/commands/site-configs.ts
@@ -10,6 +10,7 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
     .description("Inject site-configs into a file")
     .requiredOption("-i, --in-file <file>", "The filename of a template file to inject.")
     .requiredOption("-o, --out-file <file>", "Write the injected template to a file.")
+    .option("-d --dotenv", "dotenv compatibility") // https://github.com/motdotla/dotenv/issues/521#issuecomment-999016064
     .option("-f, --site-config-file <file>", "Path to ts-file which provides a default export with (env: string) => SiteConfig[]")
     .action(async (options) => {
         const configFile = options.siteConfigFile ?? `${process.cwd()}/site-configs.ts`;
@@ -51,7 +52,9 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
                 console.error(`inject-site-configs: ERROR: type must be ${Object.keys(replacerFunctions).join("|")} (got ${type})`);
                 return substr;
             }
-            return JSON.stringify(replacerFunctions[type](siteConfigs)).replace(/\$/g, "\\$");
+            const ret = JSON.stringify(replacerFunctions[type](siteConfigs)).replace(/\\/g, "\\\\");
+            if (options.dotenv) return ret.replace(/\$/g, "\\$");
+            return ret;
         });
 
         str = str.replace(/"({{ site:\/\/domains\/.*\/.* }})"/g, "$1"); // remove quotes in array

--- a/packages/cli/src/site-configs.types.ts
+++ b/packages/cli/src/site-configs.types.ts
@@ -4,7 +4,7 @@ export type BaseSiteConfig = {
     domains: {
         main: string;
         preliminary?: string;
-        pattern?: RegExp;
+        pattern?: string; // No RegExp because it's not serializable (necessary for Next.JS, see https://react.dev/reference/rsc/use-server#serializable-parameters-and-return-values)
         additional?: string[];
         preview: string;
     };


### PR DESCRIPTION
RegExp does not serialize correctly in JSON.stringify

Other solutions are somewhat more complicated (e.g. https://stackoverflow.com/a/33416684, which would require a special parse operation in api/admin/site).

However, this solution also needs a workaround for a dotenv-issue.