### PR TITLE
Fix `requiredPermissions` getting passed to a DOM element

### DIFF
--- a/packages/admin/admin/src/mui/menu/CollapsibleItem.styles.ts
+++ b/packages/admin/admin/src/mui/menu/CollapsibleItem.styles.ts
@@ -38,7 +38,7 @@ export const MenuItem = createComponentSlot(CometMenuItem)<MenuCollapsibleItemCl
         ${ownerState.childSelected &&
         css`
             .CometAdminMenuItem-text,
-            .CometAdminMenuItem-root .CometAdminMenuItem-icon {
+            .CometAdminMenuItem-icon {
                 color: ${theme.palette.primary.main};
             }
             .CometAdminMenuItem-primary {

--- a/packages/admin/admin/src/mui/menu/CollapsibleItem.tsx
+++ b/packages/admin/admin/src/mui/menu/CollapsibleItem.tsx
@@ -61,7 +61,7 @@ export const MenuCollapsibleItem = (inProps: MenuCollapsibleItemProps) => {
     const location = useLocation();
 
     const [isSubmenuOpen, setIsSubmenuOpen] = React.useState<boolean>(openByDefault || hasSelectedChild.current);
-    const [anchorEl, setAnchorEl] = React.useState<HTMLElement | undefined>(undefined);
+    const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
 
     React.useEffect(() => {
         // set open state manually to false to avoid a menu opening when isMenuOpen state changes
@@ -98,7 +98,7 @@ export const MenuCollapsibleItem = (inProps: MenuCollapsibleItemProps) => {
     }, [children, isMenuOpen, isSubmenuOpen, itemLevel, location.pathname]);
 
     const closeMenu = () => {
-        setAnchorEl(undefined);
+        setAnchorEl(null);
         setIsSubmenuOpen(false);
     };
 
@@ -185,8 +185,8 @@ export const MenuCollapsibleItem = (inProps: MenuCollapsibleItemProps) => {
                     sx={{
                         pointerEvents: "none",
                     }}
-                    open={isSubmenuOpen}
-                    anchorEl={anchorEl}
+                    open={isSubmenuOpen && anchorEl !== null}
+                    anchorEl={anchorEl ?? null}
                     TransitionComponent={Fade}
                     anchorOrigin={{
                         vertical: "center",

--- a/packages/admin/admin/src/mui/menu/CollapsibleItem.tsx
+++ b/packages/admin/admin/src/mui/menu/CollapsibleItem.tsx
@@ -186,7 +186,7 @@ export const MenuCollapsibleItem = (inProps: MenuCollapsibleItemProps) => {
                         pointerEvents: "none",
                     }}
                     open={isSubmenuOpen && anchorEl !== null}
-                    anchorEl={anchorEl ?? null}
+                    anchorEl={anchorEl}
                     TransitionComponent={Fade}
                     anchorOrigin={{
                         vertical: "center",

--- a/packages/admin/admin/src/mui/menu/ItemGroup.tsx
+++ b/packages/admin/admin/src/mui/menu/ItemGroup.tsx
@@ -6,7 +6,6 @@ import { Tooltip as CommonTooltip } from "../../common/Tooltip";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { MenuChild, MenuCollapsibleItemProps } from "./CollapsibleItem";
-import { MenuContext } from "./Context";
 import { MenuItemProps } from "./Item";
 import { MenuItemRouterLinkProps } from "./ItemRouterLink";
 
@@ -98,15 +97,18 @@ export interface MenuItemGroupProps
     shortTitle?: React.ReactNode;
     helperIcon?: React.ReactNode;
     children?: React.ReactNode;
+    isMenuOpen?: boolean;
 }
 
 export const MenuItemGroup = (inProps: MenuItemGroupProps) => {
-    const { title, shortTitle, helperIcon, children, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminMenuItemGroup" });
+    const { title, shortTitle, helperIcon, children, isMenuOpen, slotProps, ...restProps } = useThemeProps({
+        props: inProps,
+        name: "CometAdminMenuItemGroup",
+    });
 
-    const { open: menuOpen } = React.useContext(MenuContext);
     const intl = useIntl();
 
-    const ownerState: OwnerState = { open: menuOpen };
+    const ownerState: OwnerState = { open: Boolean(isMenuOpen) };
 
     function isFormattedMessage(node: React.ReactNode): node is React.ReactElement<MessageDescriptor> {
         return !!node && React.isValidElement(node) && node.type === FormattedMessage;
@@ -138,19 +140,19 @@ export const MenuItemGroup = (inProps: MenuItemGroupProps) => {
         () =>
             React.Children.map(children, (child: MenuChild) => {
                 return React.cloneElement<MenuCollapsibleItemProps | MenuItemRouterLinkProps | MenuItemProps>(child, {
-                    isMenuOpen: menuOpen,
+                    isMenuOpen,
                 });
             }),
-        [children, menuOpen],
+        [children, isMenuOpen],
     );
 
     return (
         <Root ownerState={ownerState} {...slotProps?.root} {...restProps}>
             <Tooltip
                 placement="right"
-                disableHoverListener={menuOpen}
-                disableFocusListener={menuOpen}
-                disableTouchListener={menuOpen}
+                disableHoverListener={isMenuOpen}
+                disableFocusListener={isMenuOpen}
+                disableTouchListener={isMenuOpen}
                 title={title}
                 {...slotProps?.tooltip}
             >
@@ -161,7 +163,7 @@ export const MenuItemGroup = (inProps: MenuItemGroupProps) => {
                     <Title variant="subtitle2" ownerState={ownerState} {...slotProps?.title}>
                         {title}
                     </Title>
-                    {menuOpen && !!helperIcon && helperIcon}
+                    {isMenuOpen && !!helperIcon && helperIcon}
                 </TitleContainer>
             </Tooltip>
             {childElements}

--- a/packages/admin/cms-admin/src/common/MasterMenu.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenu.tsx
@@ -83,34 +83,32 @@ export function useMenuFromMasterMenuData(items: MasterMenuData): MenuItem[] {
     const checkPermission = (item: MasterMenuItem): boolean => !item.requiredPermission || isAllowed(item.requiredPermission);
 
     const mapFn = (item: MasterMenuItem): MenuItem => {
-        const { type } = item;
-
-        if (type === "externalLink") {
-            const { requiredPermission, ...menuElement } = item;
-            return { type: "externalLink", menuElement };
+        if (item.type === "externalLink") {
+            const { requiredPermission, type, ...menuElement } = item;
+            return { type, menuElement };
         }
 
-        if (type === "group") {
-            const { items, requiredPermission, ...menuElement } = item;
+        if (item.type === "group") {
+            const { items, requiredPermission, type, ...menuElement } = item;
             return {
-                type: "group",
+                type,
                 menuElement,
                 items: items.filter(checkPermission).map(mapFn),
             };
         }
 
-        if (type === "collapsible") {
-            const { route, items, requiredPermission, ...menuElement } = item;
+        if (item.type === "collapsible") {
+            const { route, items, requiredPermission, type, ...menuElement } = item;
             return {
-                type: "collapsible",
+                type,
                 menuElement,
                 items: items ? items.filter(checkPermission).map(mapFn) : [],
             };
         }
 
-        const { route, to, requiredPermission, ...menuItem } = item;
+        const { route, to, requiredPermission, type, ...menuItem } = item;
         return {
-            type: "route",
+            type,
             menuElement: {
                 ...menuItem,
                 to: to ?? route?.path?.toString() ?? "",

--- a/packages/admin/cms-admin/src/common/MasterMenu.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenu.tsx
@@ -83,12 +83,15 @@ export function useMenuFromMasterMenuData(items: MasterMenuData): MenuItem[] {
     const checkPermission = (item: MasterMenuItem): boolean => !item.requiredPermission || isAllowed(item.requiredPermission);
 
     const mapFn = (item: MasterMenuItem): MenuItem => {
-        if (item.type === "externalLink") {
-            return { type: "externalLink", menuElement: item };
+        const { type } = item;
+
+        if (type === "externalLink") {
+            const { requiredPermission, ...menuElement } = item;
+            return { type: "externalLink", menuElement };
         }
 
-        if (item.type === "group") {
-            const { items, ...menuElement } = item;
+        if (type === "group") {
+            const { items, requiredPermission, ...menuElement } = item;
             return {
                 type: "group",
                 menuElement,
@@ -96,8 +99,8 @@ export function useMenuFromMasterMenuData(items: MasterMenuData): MenuItem[] {
             };
         }
 
-        if (item.type === "collapsible") {
-            const { route, items, ...menuElement } = item;
+        if (type === "collapsible") {
+            const { route, items, requiredPermission, ...menuElement } = item;
             return {
                 type: "collapsible",
                 menuElement,
@@ -105,7 +108,7 @@ export function useMenuFromMasterMenuData(items: MasterMenuData): MenuItem[] {
             };
         }
 
-        const { route, to, ...menuItem } = item;
+        const { route, to, requiredPermission, ...menuItem } = item;
         return {
             type: "route",
             menuElement: {


### PR DESCRIPTION
Also, `isMenuOpen` and `type` was passed to some menu icons. This has also been resolved in this PR.

---

This also fixes two bugs. The first one is about the `anchorEl` being passed as undefined prop. The second one is concerning the menu icon, which was not in the main color when a subitem of a `CollapsibleItem` is selected.

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist
-   [x] Link to the respective task if one exists: COM-828
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

### Icon Fix
#### Before
<img width="427" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/1f5cd273-479d-447a-8b62-c6dd4adb86f4">

#### After

<img width="311" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/72e6aa9c-9bd2-4148-bd10-c3bdfe0a0d43">
<img width="436" alt="image" src="https://github.com/vivid-planet/comet/assets/56400587/10f94a90-5b9e-4403-b28d-a998e514e859">

</details>
