### PR TITLE
Replace `additionalMimeTypes` and `overrideAcceptedMimeTypes` with `acceptedMimeTypes`

### DIFF
--- a/.changeset/giant-humans-lick.md
+++ b/.changeset/giant-humans-lick.md
@@ -1,0 +1,27 @@
+---
+"@comet/cms-api": major
+---
+
+Replace `additionalMimeTypes` and `overrideAcceptedMimeTypes` in `DamModule#damConfig` with `acceptedMimeTypes`
+
+You can now add mime types like this:
+
+```ts
+DamModule.register({
+    damConfig: {
+        acceptedMimeTypes: [...damDefaultAcceptedMimetypes, "something-else"],
+    },
+});
+```
+
+And remove them like this:
+
+```ts
+DamModule.register({
+    damConfig: {
+        acceptedMimeTypes: damDefaultAcceptedMimetypes.filter((mimeType) => mimeType !== "application/zip"),
+    },
+});
+```
+
+Don't forget to also remove/add the mime types in the admin's `DamConfigProvider`

--- a/.changeset/hot-carpets-eat.md
+++ b/.changeset/hot-carpets-eat.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": major
+---
+
+Rename `defaultDamAcceptedMimetypes` to `damDefaultAcceptedMimetypes`

--- a/.changeset/strange-clouds-pretend.md
+++ b/.changeset/strange-clouds-pretend.md
@@ -1,0 +1,31 @@
+---
+"@comet/cms-admin": major
+---
+
+Replace `additionalMimeTypes` and `overrideAcceptedMimeTypes` in `DamConfigProvider` with `acceptedMimeTypes`
+
+You can now add mime types like this:
+
+```tsx
+<DamConfigProvider
+    value={{
+        acceptedMimeTypes: [...damDefaultAcceptedMimetypes, "something-else"],
+    }}
+>
+    {/* ... */}
+</DamConfigProvider>
+```
+
+And remove them like this:
+
+```tsx
+<DamConfigProvider
+    value={{
+        acceptedMimeTypes: damDefaultAcceptedMimetypes.filter((mimeType) => mimeType !== "application/zip"),
+    }}
+>
+    {/* ... */}
+</DamConfigProvider>
+```
+
+Don't forget to also remove/add the mime types in the API's `DamModule`

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -122,7 +122,6 @@ export class AppModule {
                         secret: config.dam.secret,
                         allowedImageSizes: config.dam.allowedImageSizes,
                         allowedAspectRatios: config.dam.allowedImageAspectRatios,
-                        additionalMimeTypes: config.dam.additionalMimetypes,
                         filesDirectory: `${config.blob.storageDirectoryPrefix}-files`,
                         cacheDirectory: `${config.blob.storageDirectoryPrefix}-cache`,
                         maxFileSize: config.dam.uploadsMaxFileSize,

--- a/demo/api/src/comet-config.json
+++ b/demo/api/src/comet-config.json
@@ -7,7 +7,6 @@
         "quality": 80
     },
     "dam": {
-        "additionalMimetypes": [],
         "uploadsMaxFileSize": 500,
         "allowedImageSizes": [320, 420, 768, 1024, 1200, 2048],
         "allowedImageAspectRatios": ["16x9", "4x3", "3x2", "3x1", "2x1", "1x1", "1x2", "1x3", "2x3", "3x4", "9x16", "1200x630"]

--- a/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
+++ b/packages/admin/cms-admin/src/dam/config/DamConfigContext.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 
 export interface DamConfig {
-    additionalMimeTypes?: string[];
-    overrideAcceptedMimeTypes?: string[];
+    acceptedMimeTypes?: string[];
     scopeParts?: string[];
     enableLicenseFeature?: boolean;
     requireLicense?: boolean;

--- a/packages/admin/cms-admin/src/dam/config/damDefaultAcceptedMimeTypes.ts
+++ b/packages/admin/cms-admin/src/dam/config/damDefaultAcceptedMimeTypes.ts
@@ -1,5 +1,5 @@
 // -------- IMPORTANT --------
-// this mimetype list is a duplicate of api/cms-api/src/dam/common/mimeTypes/default-dam-accepted-mimetypes.ts
+// this mimetype list is a duplicate of api/cms-api/src/dam/common/mimeTypes/dam-default-accepted-mimetypes.ts
 // if you change this file, change the api file too
 // -------- IMPORTANT --------
 

--- a/packages/admin/cms-admin/src/dam/config/useDamAcceptedMimeTypes.tsx
+++ b/packages/admin/cms-admin/src/dam/config/useDamAcceptedMimeTypes.tsx
@@ -35,7 +35,7 @@ interface UseDamAcceptedMimeTypesApi {
 
 export const useDamAcceptedMimeTypes = (): UseDamAcceptedMimeTypesApi => {
     const damConfig = useDamConfig();
-    const allAcceptedMimeTypes = damConfig.overrideAcceptedMimeTypes ?? [...damDefaultAcceptedMimeTypes, ...(damConfig.additionalMimeTypes ?? [])];
+    const allAcceptedMimeTypes = damConfig.acceptedMimeTypes ?? damDefaultAcceptedMimeTypes;
 
     return {
         allAcceptedMimeTypes,

--- a/packages/api/cms-api/src/dam/common/mimeTypes/dam-default-accepted-mimetypes.ts
+++ b/packages/api/cms-api/src/dam/common/mimeTypes/dam-default-accepted-mimetypes.ts
@@ -3,7 +3,7 @@
 // if you change this file, change the admin file too
 // -------- IMPORTANT --------
 
-export const defaultDamAcceptedMimetypes = [
+export const damDefaultAcceptedMimetypes = [
     // svg
     "image/svg+xml",
     // pixel image

--- a/packages/api/cms-api/src/dam/dam.config.ts
+++ b/packages/api/cms-api/src/dam/dam.config.ts
@@ -5,7 +5,6 @@ export interface DamConfig {
     allowedAspectRatios: string[];
     filesDirectory: string;
     cacheDirectory: string;
-    additionalMimeTypes?: string[];
-    overrideAcceptedMimeTypes?: string[];
+    acceptedMimeTypes?: string[];
     maxFileSize: number;
 }

--- a/packages/api/cms-api/src/dam/dam.module.ts
+++ b/packages/api/cms-api/src/dam/dam.module.ts
@@ -2,7 +2,7 @@ import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { DynamicModule, Global, Module, Type, ValueProvider } from "@nestjs/common";
 import { TypeMetadataStorage } from "@nestjs/graphql";
 
-import { BlobStorageModule, defaultDamAcceptedMimetypes, DependentsResolverFactory } from "..";
+import { BlobStorageModule, damDefaultAcceptedMimetypes, DependentsResolverFactory } from "..";
 import { DamFileDownloadLinkBlockTransformerService } from "./blocks/dam-file-download-link-block-transformer.service";
 import { DamVideoBlockTransformerService } from "./blocks/dam-video-block-transformer.service";
 import { PixelImageBlockTransformerService } from "./blocks/pixel-image-block-transformer.service";
@@ -72,7 +72,7 @@ export class DamModule {
             provide: DAM_FILE_VALIDATION_SERVICE,
             useValue: new FileValidationService({
                 maxFileSize: damConfig.maxFileSize,
-                acceptedMimeTypes: damConfig.overrideAcceptedMimeTypes ?? [...defaultDamAcceptedMimetypes, ...(damConfig.additionalMimeTypes ?? [])],
+                acceptedMimeTypes: damConfig.acceptedMimeTypes ?? damDefaultAcceptedMimetypes,
             }),
         };
 

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -66,7 +66,7 @@ export { SvgImageBlock } from "./dam/blocks/svg-image.block";
 export { ScaledImagesCacheService } from "./dam/cache/scaled-images-cache.service";
 export { FocalPoint } from "./dam/common/enums/focal-point.enum";
 export { CometImageResolutionException } from "./dam/common/errors/image-resolution.exception";
-export { defaultDamAcceptedMimetypes } from "./dam/common/mimeTypes/default-dam-accepted-mimetypes";
+export { damDefaultAcceptedMimetypes } from "./dam/common/mimeTypes/dam-default-accepted-mimetypes";
 export { DamConfig } from "./dam/dam.config";
 export { DAM_CONFIG, IMGPROXY_CONFIG } from "./dam/dam.constants";
 export { DamModule } from "./dam/dam.module";


### PR DESCRIPTION

You can now add mime types like this:

```ts
DamModule.register({
    damConfig: {
        acceptedMimeTypes: [...damDefaultAcceptedMimetypes, "something-else"],
    },
});
```

```tsx
<DamConfigProvider
    value={{
        acceptedMimeTypes: [...damDefaultAcceptedMimetypes, "something-else"],
    }}
>
    {/* ... */}
</DamConfigProvider>
```

And remove them like this:

```ts
DamModule.register({
    damConfig: {
        acceptedMimeTypes: damDefaultAcceptedMimetypes.filter((mimeType) => mimeType !== "application/zip"),
    },
});
```

```tsx
<DamConfigProvider
    value={{
        acceptedMimeTypes: damDefaultAcceptedMimetypes.filter((mimeType) => mimeType !== "application/zip"),
    }}
>
    {/* ... */}
</DamConfigProvider>
```

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-722
