### PR TITLE
Admin Stack: update parent breadcrumb url in state to not forget filters and other states when going back

### DIFF
--- a/.changeset/sharp-zebras-hear.md
+++ b/.changeset/sharp-zebras-hear.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-Admin Stack: update parent breadcrumb url in state to not forget filters and other states when going back
+Stack: Update parent breadcrumb URL in state to not forget filters and other states when going back

--- a/.changeset/sharp-zebras-hear.md
+++ b/.changeset/sharp-zebras-hear.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Admin Stack: update parent breadcrumb url in state to not forget filters and other states when going back

--- a/packages/admin/admin/src/stack/Breadcrumb.tsx
+++ b/packages/admin/admin/src/stack/Breadcrumb.tsx
@@ -6,7 +6,6 @@ import { StackApiContext } from "./Api";
 interface IProps {
     url: string;
     title: React.ReactNode;
-    invisible?: boolean;
     ignoreParentId?: boolean;
 }
 
@@ -32,12 +31,12 @@ export class StackBreadcrumb extends React.Component<IProps> {
     }
 
     public componentDidMount() {
-        this.context.addBreadcrumb(this.id, this.parentId, this.props.url, this.props.title, !!this.props.invisible);
+        this.context.addBreadcrumb(this.id, this.parentId, this.props.url, this.props.title);
     }
 
     public componentDidUpdate(prevProps: IProps) {
         if (this.props.url !== prevProps.url || this.props.title !== prevProps.title) {
-            this.context.updateBreadcrumb(this.id, this.parentId, this.props.url, this.props.title, !!this.props.invisible);
+            this.context.updateBreadcrumb(this.id, this.parentId, this.props.url, this.props.title);
         }
     }
 

--- a/packages/admin/admin/src/stack/Stack.tsx
+++ b/packages/admin/admin/src/stack/Stack.tsx
@@ -75,7 +75,7 @@ export function Stack(props: StackProps) {
 
     const getVisibleBreadcrumbs = React.useCallback(() => {
         return sortByParentId(breadcrumbs).map((i) => {
-            return { ...i, url: i.stateUrl ?? i.url }; // clone so we can modify in filter below
+            return { ...i, url: i.stateUrl ?? i.url };
         });
     }, [breadcrumbs]);
 

--- a/packages/admin/admin/src/stack/Stack.tsx
+++ b/packages/admin/admin/src/stack/Stack.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Route, RouteComponentProps, useHistory } from "react-router";
+import { Route, RouteComponentProps, useHistory, useLocation } from "react-router";
 
 import { StackApiContext } from "./Api";
 import { StackBreadcrumb } from "./Breadcrumb";
@@ -57,7 +57,7 @@ export interface BreadcrumbItem {
     parentId: string;
     url: string;
     title: React.ReactNode;
-    invisible: boolean;
+    stateUrl?: string;
 }
 
 export interface SwitchItem {
@@ -71,21 +71,12 @@ export function Stack(props: StackProps) {
     const [breadcrumbs, setBreadcrumbs] = React.useState<BreadcrumbItem[]>([]);
     const [switches, setSwitches] = React.useState<SwitchItem[]>([]);
     const history = useHistory();
+    const location = useLocation();
 
     const getVisibleBreadcrumbs = React.useCallback(() => {
-        let prev: BreadcrumbItem;
-        return sortByParentId(breadcrumbs)
-            .map((i) => {
-                return { ...i }; // clone so we can modify in filter below
-            })
-            .filter((i) => {
-                if (i.invisible) {
-                    prev.url = i.url;
-                    return false;
-                }
-                prev = i;
-                return true;
-            });
+        return sortByParentId(breadcrumbs).map((i) => {
+            return { ...i, url: i.stateUrl ?? i.url }; // clone so we can modify in filter below
+        });
     }, [breadcrumbs]);
 
     const goBack = React.useCallback(() => {
@@ -101,7 +92,7 @@ export function Stack(props: StackProps) {
         history.push(breadcrumbs[0].url);
     }, [history, breadcrumbs]);
 
-    const addBreadcrumb = React.useCallback((id: string, parentId: string, url: string, title: React.ReactNode, invisible: boolean) => {
+    const addBreadcrumb = React.useCallback((id: string, parentId: string, url: string, title: React.ReactNode) => {
         setBreadcrumbs((old) => {
             return [
                 ...old,
@@ -110,16 +101,15 @@ export function Stack(props: StackProps) {
                     parentId,
                     url,
                     title,
-                    invisible,
                 },
             ];
         });
     }, []);
 
-    const updateBreadcrumb = React.useCallback((id: string, parentId: string, url: string, title: React.ReactNode, invisible: boolean) => {
+    const updateBreadcrumb = React.useCallback((id: string, parentId: string, url: string, title: React.ReactNode) => {
         setBreadcrumbs((old) => {
             return old.map((crumb) => {
-                return crumb.id === id ? { id, parentId, url, title, invisible } : crumb;
+                return crumb.id === id ? { ...crumb, parentId, url, title } : crumb;
             });
         });
     }, []);
@@ -150,6 +140,15 @@ export function Stack(props: StackProps) {
             return old.filter((item) => item.id !== id);
         });
     }, []);
+
+    React.useEffect(() => {
+        // execute on location change, set stateUrl for the last breadcrumb to the current location
+        setBreadcrumbs((old) => {
+            const sorted = sortByParentId(old);
+            sorted[sorted.length - 1].stateUrl = location.pathname + location.search; // modify object in place
+            return [...old]; // clone (with modified object) to new array to trigger a state update
+        });
+    }, [location]);
 
     const visibleBreadcrumbs = getVisibleBreadcrumbs();
 

--- a/packages/admin/admin/src/stack/Stack.tsx
+++ b/packages/admin/admin/src/stack/Stack.tsx
@@ -57,7 +57,7 @@ export interface BreadcrumbItem {
     parentId: string;
     url: string;
     title: React.ReactNode;
-    stateUrl?: string;
+    locationUrl?: string;
 }
 
 export interface SwitchItem {
@@ -75,7 +75,7 @@ export function Stack(props: StackProps) {
 
     const getVisibleBreadcrumbs = React.useCallback(() => {
         return sortByParentId(breadcrumbs).map((i) => {
-            return { ...i, url: i.stateUrl ?? i.url };
+            return { ...i, url: i.locationUrl ?? i.url };
         });
     }, [breadcrumbs]);
 
@@ -142,10 +142,10 @@ export function Stack(props: StackProps) {
     }, []);
 
     React.useEffect(() => {
-        // execute on location change, set stateUrl for the last breadcrumb to the current location
+        // execute on location change, set locationUrl for the last breadcrumb to the current location
         setBreadcrumbs((old) => {
             const sorted = sortByParentId(old);
-            sorted[sorted.length - 1].stateUrl = location.pathname + location.search; // modify object in place
+            sorted[sorted.length - 1].locationUrl = location.pathname + location.search; // modify object in place
             return [...old]; // clone (with modified object) to new array to trigger a state update
         });
     }, [location]);

--- a/packages/admin/admin/src/stack/Stack.tsx
+++ b/packages/admin/admin/src/stack/Stack.tsx
@@ -74,7 +74,7 @@ export function Stack(props: StackProps) {
     const location = useLocation();
 
     const getVisibleBreadcrumbs = React.useCallback(() => {
-        return sortByParentId(breadcrumbs).map((i) => {
+        return breadcrumbs.map((i) => {
             return { ...i, url: i.locationUrl ?? i.url };
         });
     }, [breadcrumbs]);
@@ -94,7 +94,7 @@ export function Stack(props: StackProps) {
 
     const addBreadcrumb = React.useCallback((id: string, parentId: string, url: string, title: React.ReactNode) => {
         setBreadcrumbs((old) => {
-            return [
+            return sortByParentId([
                 ...old,
                 {
                     id,
@@ -102,23 +102,27 @@ export function Stack(props: StackProps) {
                     url,
                     title,
                 },
-            ];
+            ]);
         });
     }, []);
 
     const updateBreadcrumb = React.useCallback((id: string, parentId: string, url: string, title: React.ReactNode) => {
         setBreadcrumbs((old) => {
-            return old.map((crumb) => {
-                return crumb.id === id ? { ...crumb, parentId, url, title } : crumb;
-            });
+            return sortByParentId(
+                old.map((crumb) => {
+                    return crumb.id === id ? { ...crumb, parentId, url, title } : crumb;
+                }),
+            );
         });
     }, []);
 
     const removeBreadcrumb = React.useCallback((id: string) => {
         setBreadcrumbs((old) => {
-            return old.filter((crumb) => {
-                return crumb.id !== id;
-            });
+            return sortByParentId(
+                old.filter((crumb) => {
+                    return crumb.id !== id;
+                }),
+            );
         });
     }, []);
 
@@ -144,9 +148,7 @@ export function Stack(props: StackProps) {
     React.useEffect(() => {
         // execute on location change, set locationUrl for the last breadcrumb to the current location
         setBreadcrumbs((old) => {
-            const sorted = sortByParentId(old);
-            sorted[sorted.length - 1].locationUrl = location.pathname + location.search; // modify object in place
-            return [...old]; // clone (with modified object) to new array to trigger a state update
+            return [...old.slice(0, -1), { ...old[old.length - 1], locationUrl: location.pathname + location.search }];
         });
     }, [location]);
 

--- a/packages/admin/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/admin/src/tabs/RouterTabs.tsx
@@ -7,7 +7,6 @@ import { createComponentSlot } from "../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 import { useSubRoutePrefix } from "../router/SubRoute";
 import { useStackApi } from "../stack/Api";
-import { StackBreadcrumb } from "../stack/Breadcrumb";
 import { useStackSwitchApi } from "../stack/Switch";
 import { TabScrollButton } from "./TabScrollButton";
 
@@ -165,33 +164,22 @@ export function RouterTabs(inProps: Props) {
                 return (
                     <Route path={path}>
                         {({ match }) => {
-                            let ret = null;
-
                             if (match && !foundFirstMatch) {
                                 foundFirstMatch = true;
-                                ret = (
+                                return (
                                     <Content ownerState={{ contentHidden: false }} {...slotProps?.content}>
                                         {child.props.children}
                                     </Content>
                                 );
                             } else if (child.props.forceRender) {
-                                ret = (
+                                return (
                                     <Content ownerState={{ contentHidden: true }} {...slotProps?.content}>
                                         {child.props.children}
                                     </Content>
                                 );
                             } else {
-                                // don't render tab contents, return early as we don't need StackBreadcrumb either
+                                // don't render tab contents
                                 return null;
-                            }
-                            if (stackApi && stackSwitchApi) {
-                                return (
-                                    <StackBreadcrumb url={path} title={child.props.label} invisible={true}>
-                                        {ret}
-                                    </StackBreadcrumb>
-                                );
-                            } else {
-                                return ret;
                             }
                         }}
                     </Route>

--- a/storybook/src/admin/stack/StackBreadcrumbs.tsx
+++ b/storybook/src/admin/stack/StackBreadcrumbs.tsx
@@ -5,19 +5,19 @@ import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
-const singleItem: BreadcrumbItem[] = [{ id: "one", parentId: "", url: "/one", title: "Breadcrumb One", invisible: false }];
-const twoItems: BreadcrumbItem[] = [...singleItem, { id: "two", parentId: "one", url: "/two", title: "BC 2", invisible: false }];
-const threeItems: BreadcrumbItem[] = [...twoItems, { id: "three", parentId: "two", url: "/three", title: "BrdCrmb 3", invisible: false }];
+const singleItem: BreadcrumbItem[] = [{ id: "one", parentId: "", url: "/one", title: "Breadcrumb One" }];
+const twoItems: BreadcrumbItem[] = [...singleItem, { id: "two", parentId: "one", url: "/two", title: "BC 2" }];
+const threeItems: BreadcrumbItem[] = [...twoItems, { id: "three", parentId: "two", url: "/three", title: "BrdCrmb 3" }];
 const fiveItems: BreadcrumbItem[] = [
     ...threeItems,
-    { id: "four", parentId: "three", url: "/four", title: "Really long Breadcrumb Number Four", invisible: false },
-    { id: "five", parentId: "four", url: "/five", title: "Breadcrumb Five", invisible: false },
+    { id: "four", parentId: "three", url: "/four", title: "Really long Breadcrumb Number Four" },
+    { id: "five", parentId: "four", url: "/five", title: "Breadcrumb Five" },
 ];
 const eightItems: BreadcrumbItem[] = [
     ...fiveItems,
-    { id: "six", parentId: "five", url: "/six", title: "Breadcrumb Six", invisible: false },
-    { id: "seven", parentId: "six", url: "/seven", title: "BrdCrmb 7", invisible: false },
-    { id: "eight", parentId: "seven", url: "/eight", title: "Breadcrumb Eight", invisible: false },
+    { id: "six", parentId: "five", url: "/six", title: "Breadcrumb Six" },
+    { id: "seven", parentId: "six", url: "/seven", title: "BrdCrmb 7" },
+    { id: "eight", parentId: "seven", url: "/eight", title: "Breadcrumb Eight" },
 ];
 
 const allBradcrumbItemsGroupOne: Record<string, BreadcrumbItem[]> = {

--- a/storybook/src/admin/stack/StackBreadcrumbsTabs.tsx
+++ b/storybook/src/admin/stack/StackBreadcrumbsTabs.tsx
@@ -1,0 +1,41 @@
+import { RouterTab, RouterTabs, Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch } from "@comet/admin";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { useLocation } from "react-router";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+function Story() {
+    const location = useLocation();
+
+    return (
+        <>
+            <p>Pathname: {location.pathname}</p>
+            <Stack topLevelTitle="Root Stack">
+                <StackBreadcrumbs />
+                <StackSwitch>
+                    <StackPage name="table">
+                        <RouterTabs>
+                            <RouterTab label="Tab 1" path="">
+                                <p>Tab 1</p>
+                            </RouterTab>
+                            <RouterTab label="Tab 2" path="/tab2">
+                                <p>Tab 2</p>
+                                <StackLink pageName="edit" payload="test">
+                                    Edit
+                                </StackLink>
+                            </RouterTab>
+                        </RouterTabs>
+                    </StackPage>
+                    <StackPage name="edit" title="Edit">
+                        Edit
+                    </StackPage>
+                </StackSwitch>
+            </Stack>
+        </>
+    );
+}
+
+storiesOf("@comet/admin/stack", module)
+    .addDecorator(storyRouterDecorator())
+    .add("Stack Breadcrumbs with nested Tabs", () => <Story />);


### PR DESCRIPTION
This adds to Stack a mechanism that watches the current location and updates the last breadcrumb item with the new url. This fixes back button (or any breadcrumb link) to go to the expected, previously open url, to preserve states that are stored in the url - such as filter in grid:

[Bildschirmaufzeichnung vom 2024-06-10, 12:59:01.webm](https://github.com/vivid-planet/comet/assets/50764/92feecb7-60a9-4170-b771-d61a3735accf)

This PR removes "invisible" Breadcrumbs (which is theoretically an incompatible change) which where used (only) in RouterTabs - to support a similar feature like this PR - but every component (as RouterTabs) had to add support for it. The new solution doesn't need that as it watches the location. Drawback: this doesn't work when refreshing, then the stored state is lost.

