### PR TITLE
Remove preview-domain from site-configs

### DIFF
--- a/packages/cli/src/commands/site-configs.ts
+++ b/packages/cli/src/commands/site-configs.ts
@@ -29,7 +29,6 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
                     (({ public: publicVars, ...rest }) => ({
                         ...rest,
                         url: getUrlFromDomain(siteConfig.domains.preliminary ?? siteConfig.domains.main),
-                        previewUrl: getUrlFromDomain(siteConfig.domains.preview),
                     }))(siteConfig),
                 ),
             public: (siteConfigs: BaseSiteConfig[]): ExtractPublicSiteConfig<BaseSiteConfig>[] =>
@@ -40,7 +39,6 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
                     preloginEnabled: siteConfig.preloginEnabled || false,
                     public: siteConfig.public,
                     url: getUrlFromDomain(siteConfig.domains.preliminary ?? siteConfig.domains.main),
-                    previewUrl: getUrlFromDomain(siteConfig.domains.preview),
                 })),
         };
         str = str.replace(/"({{ site:\/\/configs\/.*\/.* }})"/g, "'$1'"); // convert to single quotes

--- a/packages/cli/src/site-configs.types.ts
+++ b/packages/cli/src/site-configs.types.ts
@@ -6,16 +6,13 @@ export type BaseSiteConfig = {
         preliminary?: string;
         pattern?: RegExp;
         additional?: string[];
-        preview: string;
     };
     preloginEnabled?: boolean;
     public?: Record<string, unknown>;
 };
 export type ExtractPrivateSiteConfig<S extends BaseSiteConfig> = S & {
     url: string;
-    previewUrl: string;
 };
 export type ExtractPublicSiteConfig<S extends BaseSiteConfig> = Pick<S, "name" | "contentScope" | "domains" | "preloginEnabled" | "public"> & {
     url: string;
-    previewUrl: string;
 };

--- a/site-configs.ts
+++ b/site-configs.ts
@@ -10,7 +10,6 @@ export default (): SiteConfig[] => [
         },
         domains: {
             main: "localhost:3000",
-            preview: "localhost:3000",
         },
     },
     {
@@ -21,7 +20,6 @@ export default (): SiteConfig[] => [
         },
         domains: {
             main: "en.localhost:3000",
-            preview: "localhost:3000",
         },
     },
     {
@@ -32,7 +30,6 @@ export default (): SiteConfig[] => [
         },
         domains: {
             main: "secondary-de.localhost:3000",
-            preview: "localhost:3000",
         },
     },
     {
@@ -43,7 +40,6 @@ export default (): SiteConfig[] => [
         },
         domains: {
             main: "secondary-en.localhost:3000",
-            preview: "localhost:3000",
         },
     },
 ];


### PR DESCRIPTION
With SSR there is only one preview-domain for all sites which should be set via .env instead of the site-config.