### PR TITLE
Prevent parallel release workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
     release:
         name: Release
         runs-on: ubuntu-latest
+        concurrency:
+            group: release
+            cancel-in-progress: true
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v3


### PR DESCRIPTION
We repeatedly encounter rate limits when the changesets action uses the GitHub API. Preventing parallel workflow runs (which happen when merging multiple PRs to `main` in a short time) may resolve the issue.
