### PR TITLE
Fix error about using React fragment as children in `FinalFormLayoutSelect`

### DIFF
--- a/demo/admin/src/pages/blocks/ColumnsBlock.tsx
+++ b/demo/admin/src/pages/blocks/ColumnsBlock.tsx
@@ -10,6 +10,7 @@ import { DamImageBlock } from "@comet/cms-admin";
 import { HeadlineBlock } from "@src/common/blocks/HeadlineBlock";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import * as React from "react";
+import { FormattedMessage } from "react-intl";
 
 const ColumnsContentBlock = createBlocksBlock({
     name: "ColumnsContent",
@@ -48,6 +49,10 @@ const ColumnsBlock = createColumnsBlock({
                     <ColumnsLayoutPreviewContent width={10} />
                 </ColumnsLayoutPreview>
             ),
+            section: {
+                name: "same-width",
+                label: <FormattedMessage id="columnsBlock.layouts.twoColumns.section.sameWidth" defaultMessage="Same width" />,
+            },
         },
         {
             name: "two-columns-12-6",
@@ -62,6 +67,10 @@ const ColumnsBlock = createColumnsBlock({
                     <ColumnsLayoutPreviewSpacing width={2} />
                 </ColumnsLayoutPreview>
             ),
+            section: {
+                name: "different-width",
+                label: <FormattedMessage id="columnsBlock.layouts.twoColumns.section.differentWidth" defaultMessage="Different width" />,
+            },
         },
     ],
     contentBlock: ColumnsContentBlock,

--- a/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/FinalFormLayoutSelect.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/FinalFormLayoutSelect.tsx
@@ -72,16 +72,16 @@ export function FinalFormLayoutSelect({ input: { value, onChange }, layouts }: P
     return (
         <Select value={value.name} onChange={handleChange} fullWidth>
             {sections.map((section, i) => [
-                hasMultipleSections ? (
-                    <>
-                        {i > 0 ? <SectionDivider /> : null}
-                        <ListSubheader key={`section-${section.name}`}>
-                            <Typography variant="body2" fontWeight="bold" color="text.primary">
-                                {section.label}
-                            </Typography>
-                        </ListSubheader>
-                    </>
-                ) : null,
+                ...(hasMultipleSections
+                    ? [
+                          i > 0 ? <SectionDivider /> : null,
+                          <ListSubheader key={`section-${section.name}`}>
+                              <Typography variant="body2" fontWeight="bold" color="text.primary">
+                                  {section.label}
+                              </Typography>
+                          </ListSubheader>,
+                      ]
+                    : []),
                 ...section.layouts.map((layout) => (
                     <MenuItem key={layout.name} value={layout.name}>
                         <MenuItemContent>


### PR DESCRIPTION
Error: `MUI: The Select component doesn't accept a Fragment as a child.
Consider providing an array instead.`