### PR TITLE
Fix `SvgImageBlock` in site by always loading `fileUrl`

### DIFF
--- a/.changeset/popular-ducks-vanish.md
+++ b/.changeset/popular-ducks-vanish.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix `SvgImageBlock` in site by always loading `fileUrl`

--- a/packages/api/cms-api/src/dam/blocks/svg-image-block-transformer.service.ts
+++ b/packages/api/cms-api/src/dam/blocks/svg-image-block-transformer.service.ts
@@ -35,7 +35,7 @@ export class SvgImageBlockTransformerService implements BlockTransformerServiceI
             return {};
         }
 
-        const fileUrl = includeInvisibleContent ? await this.filesService.createFileUrl(file, { previewDamUrls, relativeDamUrls }) : undefined;
+        const fileUrl = await this.filesService.createFileUrl(file, { previewDamUrls, relativeDamUrls });
 
         return {
             damFile: {


### PR DESCRIPTION
Previously, the fileUrl was only loaded in the preview but not on the actual site:

<img width="438" alt="Bildschirmfoto 2024-06-12 um 11 01 05" src="https://github.com/vivid-planet/comet/assets/13380047/cf13864b-d912-4025-9f2d-ec5f92950ce9">



<img width="215" alt="Bildschirmfoto 2024-06-12 um 11 01 18" src="https://github.com/vivid-planet/comet/assets/13380047/e0d2b585-d81d-419c-82e0-f91eca4840cb">

