### PR TITLE
Fix find label for scope part in content scope indicator

### DIFF
--- a/.changeset/hip-garlics-press.md
+++ b/.changeset/hip-garlics-press.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Make the `ContentScopeIndicator` show the scope label instead of the scope value

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
@@ -22,7 +22,10 @@ export const ContentScopeIndicator = ({ global = false, scope: passedScope, chil
     const scope = passedScope ?? contentScope;
 
     const findLabelForScopePart = (scopePart: keyof ContentScopeInterface) => {
-        const label = values.find(({ value }) => value === scope[scopePart])?.label;
+        const label = values.find((value) => {
+            return value[scopePart].value === scope[scopePart];
+        })?.[scopePart].label;
+
         return label ?? capitalizeString(scope[scopePart]);
     };
 


### PR DESCRIPTION
In v7 we changed the structure of the scope's values object. The method for getting the correct label wasn't correctly adjusted.


---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Previously:

<img width="232" alt="Bildschirmfoto 2024-06-13 um 13 57 16" src="https://github.com/vivid-planet/comet/assets/13380047/13afee44-efbc-49b9-af24-ee9b0f83068f">

Now:

<img width="243" alt="Bildschirmfoto 2024-06-13 um 13 56 34" src="https://github.com/vivid-planet/comet/assets/13380047/9de973f8-fee1-46b4-86e0-16b4d29b54de">

</details>
