### PR TITLE
Grid independent of Stack: Inject stack-specific click handler from page into grid

### DIFF
--- a/demo/admin/src/products/future/ProductsPage.tsx
+++ b/demo/admin/src/products/future/ProductsPage.tsx
@@ -7,6 +7,7 @@ import {
     Stack,
     StackPage,
     StackSwitch,
+    StackSwitchApiContext,
     StackToolbar,
     ToolbarActions,
     ToolbarAutomaticTitleItem,
@@ -23,20 +24,31 @@ import { ProductsGrid } from "./generated/ProductsGrid";
 
 export function ProductsPage(): React.ReactElement {
     const intl = useIntl();
+
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "products.products", defaultMessage: "Products" })}>
             <StackSwitch>
                 <StackPage name="grid">
-                    <MainContent fullHeight disablePadding>
-                        <ProductsGrid
-                            onAddClick={() => {
-                                console.log("Add clicked");
-                            }}
-                            onEditClick={(params) => {
-                                console.log("Edit clicked", params);
-                            }}
-                        />
-                    </MainContent>
+                    <StackSwitchApiContext.Consumer>
+                        {(stackApi) => {
+                            return (
+                                <MainContent fullHeight disablePadding>
+                                    <ProductsGrid
+                                        onAddClick={() => {
+                                            setTimeout(() => {
+                                                stackApi.activatePage("add", "add");
+                                            });
+                                        }}
+                                        onEditClick={(params) => {
+                                            setTimeout(() => {
+                                                stackApi.activatePage("edit", params.row.id);
+                                            });
+                                        }}
+                                    />
+                                </MainContent>
+                            );
+                        }}
+                    </StackSwitchApiContext.Consumer>
                 </StackPage>
                 <StackPage name="edit" title={intl.formatMessage({ id: "products.editProduct", defaultMessage: "Edit Product" })}>
                     {(selectedProductId) => (

--- a/demo/admin/src/products/future/ProductsPage.tsx
+++ b/demo/admin/src/products/future/ProductsPage.tsx
@@ -28,7 +28,14 @@ export function ProductsPage(): React.ReactElement {
             <StackSwitch>
                 <StackPage name="grid">
                     <MainContent fullHeight disablePadding>
-                        <ProductsGrid />
+                        <ProductsGrid
+                            onAddClick={() => {
+                                console.log("Add clicked");
+                            }}
+                            onEditClick={(params) => {
+                                console.log("Edit clicked", params);
+                            }}
+                        />
                     </MainContent>
                 </StackPage>
                 <StackPage name="edit" title={intl.formatMessage({ id: "products.editProduct", defaultMessage: "Edit Product" })}>

--- a/demo/admin/src/products/future/ProductsPage.tsx
+++ b/demo/admin/src/products/future/ProductsPage.tsx
@@ -35,14 +35,10 @@ export function ProductsPage(): React.ReactElement {
                                 <MainContent fullHeight disablePadding>
                                     <ProductsGrid
                                         onAddClick={() => {
-                                            setTimeout(() => {
-                                                stackApi.activatePage("add", "add");
-                                            });
+                                            stackApi.activatePage("add", "add");
                                         }}
                                         onEditClick={(params) => {
-                                            setTimeout(() => {
-                                                stackApi.activatePage("edit", params.row.id);
-                                            });
+                                            stackApi.activatePage("edit", params.row.id);
                                         }}
                                     />
                                 </MainContent>

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -21,7 +21,7 @@ import {
 import { Add as AddIcon, Edit } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { Button, IconButton } from "@mui/material";
-import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
+import { DataGridPro, GridRenderCellParams, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import { GQLProductFilter } from "@src/graphql.generated";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -75,7 +75,7 @@ const createProductMutation = gql`
     }
 `;
 
-function ProductsGridToolbar() {
+function ProductsGridToolbar({ onAddClick }: { onAddClick?: () => void }) {
     return (
         <Toolbar>
             <ToolbarAutomaticTitleItem />
@@ -87,9 +87,15 @@ function ProductsGridToolbar() {
             </ToolbarItem>
             <ToolbarFillSpace />
             <ToolbarActions>
-                <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-                    <FormattedMessage id="product.newProduct" defaultMessage="New Product" />
-                </Button>
+                {onAddClick ? (
+                    <Button startIcon={<AddIcon />} onClick={onAddClick} variant="contained" color="primary">
+                        <FormattedMessage id="product.newProduct" defaultMessage="New Product" />
+                    </Button>
+                ) : (
+                    <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
+                        <FormattedMessage id="product.newProduct" defaultMessage="New Product" />
+                    </Button>
+                )}
             </ToolbarActions>
         </Toolbar>
     );
@@ -97,9 +103,12 @@ function ProductsGridToolbar() {
 
 type Props = {
     filter?: GQLProductFilter;
+    onAddClick?: () => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onEditClick?: (params: GridRenderCellParams<any, GQLProductsGridFutureFragment, any>) => void;
 };
 
-export function ProductsGrid({ filter }: Props): React.ReactElement {
+export function ProductsGrid({ filter, onAddClick, onEditClick }: Props): React.ReactElement {
     const client = useApolloClient();
     const intl = useIntl();
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };
@@ -158,9 +167,15 @@ export function ProductsGrid({ filter }: Props): React.ReactElement {
             renderCell: (params) => {
                 return (
                     <>
-                        <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
-                            <Edit color="primary" />
-                        </IconButton>
+                        {onEditClick ? (
+                            <IconButton onClick={() => onEditClick(params)}>
+                                <Edit color="primary" />
+                            </IconButton>
+                        ) : (
+                            <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
+                                <Edit color="primary" />
+                            </IconButton>
+                        )}
                         <CrudContextMenu
                             copyData={() => {
                                 // Don't copy id, because we want to create a new entity with this data
@@ -215,6 +230,9 @@ export function ProductsGrid({ filter }: Props): React.ReactElement {
             loading={loading}
             components={{
                 Toolbar: ProductsGridToolbar,
+            }}
+            componentsProps={{
+                toolbar: { onAddClick },
             }}
         />
     );


### PR DESCRIPTION
Make Grid independent of Stack for add and edit functionality, alternative to #2171.

# 1. is this generally a good idea

Currently our (generated and handwritten) Grids directly interact with Stack for edit and add functionality by using a StackLink that navigates to the relevant stack page.

This PR moves that responsibility one level up, to the page.

## Pro

- Grid has no dependency on Stack and specific stack urls, and so get's completely independent and can be rendered everywhere.
- admin generator must not support different variants of how editing should be done (eg in Dialog)

## Con

- 2 new pops that always have to be set, makes grid more verbose to use

# 2. which implementation #2175 vs #2171

```
<ProductsGrid
    onAddClick={() => {
        stackSwitchApi.activatePage("add", "add");
    }}
    onEditClick={(params) => {
        stackSwitchApi.activatePage("edit", params.row.id);
    }}
 />
```
- much less code
- styling of buttons is responsibility of Grid
----

```
<ManufacturersGrid
    addButton={ //could be named primaryButton
        <Button
            startIcon={<AddIcon />}
            component={StackLink}
            pageName="add"
            payload="add"
            variant="contained"
            color="primary"
        >
            <FormattedMessage id="manufacturer.newManufacturer" defaultMessage="New Manufacturer" />
        </Button>
    }
    editButton={(params) => (  //could be named rowAction
        <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
            <Edit color="primary" />
        </IconButton>
    )}
/>
```
- we can use StackLink (working `<a` gets rendered)
- we can pass multiple edit or add buttons
- admin generator doesn't need to support customizing of Button message (eg. if you don't need "New Manufacturer" but "Import Manufacturer" or "Generate Manufacturer")