### PR TITLE
Add new `FileSelect` component as alternative to `FinalFormFileSelect`

### DIFF
--- a/.changeset/four-cobras-shave.md
+++ b/.changeset/four-cobras-shave.md
@@ -1,0 +1,11 @@
+---
+"@comet/admin": minor
+---
+
+Add new `FileSelect`, `FileDropzone` and `FileSelectListItem` components
+
+`FileSelect` combines `FileDropzone` and `FileSelectListItem` to handle the user's selection of files, display those files below, and handle the download and removal actions.
+
+`FileDropzone` is a wrapper around [react-dropzone](https://www.npmjs.com/package/react-dropzone) that manages error and disabled states.
+
+`FileSelectListItem` is used to display a list of files, including loading, skeleton, and error states and options to download and delete the file.

--- a/packages/admin/admin/src/form/file/FileDropzone.tsx
+++ b/packages/admin/admin/src/form/file/FileDropzone.tsx
@@ -187,7 +187,6 @@ const Dropzone = createComponentSlot("div")<FileDropzoneClassKey, OwnerState>({
             }
         `}
 
-
         ${ownerState.disabled &&
         css`
             cursor: default;

--- a/packages/admin/admin/src/form/file/FileDropzone.tsx
+++ b/packages/admin/admin/src/form/file/FileDropzone.tsx
@@ -1,0 +1,265 @@
+import { Error, Select } from "@comet/admin-icons";
+import { Box, Button, ComponentsOverrides, css, Theme, Typography, useThemeProps } from "@mui/material";
+import React from "react";
+import { DropzoneOptions, useDropzone } from "react-dropzone";
+import { FormattedMessage } from "react-intl";
+
+import { createComponentSlot } from "../../helpers/createComponentSlot";
+import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
+
+export type FileDropzoneProps = ThemedComponentBaseProps<{
+    root: "div";
+    dropzone: "div";
+    errorIconContainer: "div";
+    dropzoneText: typeof Typography;
+    selectFileButton: typeof Button;
+}> & {
+    hasError?: boolean;
+    hideDroppableArea?: boolean;
+    hideButton?: boolean;
+    dropzoneText?: React.ReactNode;
+    buttonText?: React.ReactNode;
+    iconMapping?: {
+        error?: React.ReactNode;
+        select?: React.ReactNode;
+    };
+} & DropzoneOptions;
+
+export type FileDropzoneClassKey =
+    | "root"
+    | "disabled"
+    | "error"
+    | "focused"
+    | "dropzone"
+    | "errorIconContainer"
+    | "dropzoneText"
+    | "selectFileButton";
+
+type OwnerState = {
+    disabled: boolean;
+    hasError: boolean;
+    focused: boolean;
+    dragging: boolean;
+};
+
+export const FileDropzone = (inProps: FileDropzoneProps) => {
+    const {
+        disabled,
+        hasError,
+        hideDroppableArea,
+        hideButton,
+        // @ts-expect-error The type should be used from `DropzoneOptions`, however it's missing during lint/build.
+        multiple,
+        dropzoneText = multiple ? (
+            <FormattedMessage id="comet.fileDropzone.dropfiles" defaultMessage="Drop files here to upload" />
+        ) : (
+            <FormattedMessage id="comet.fileDropzone.dropFile" defaultMessage="Drop file here to upload" />
+        ),
+        buttonText = multiple ? (
+            <FormattedMessage id="comet.fileDropzone.selectfiles" defaultMessage="Select files" />
+        ) : (
+            <FormattedMessage id="comet.fileDropzone.selectfile" defaultMessage="Select file" />
+        ),
+        iconMapping = {},
+        slotProps,
+        sx,
+        className,
+        ...restDropzoneOptions
+    } = useThemeProps({
+        props: inProps,
+        name: "CometAdminFileDropzone",
+    });
+    const { error: errorIcon = <Error color="error" />, select: selectIcon = <Select /> } = iconMapping;
+    const [focused, setFocused] = React.useState(false);
+    const [dragging, setDragging] = React.useState(false);
+
+    const ownerState: OwnerState = {
+        disabled: Boolean(disabled),
+        hasError: Boolean(hasError),
+        focused,
+        dragging,
+    };
+
+    const dropzoneState = useDropzone({ ...restDropzoneOptions, disabled, multiple });
+
+    return (
+        <Box display="contents" onDragOver={() => setDragging(true)} onDragLeave={() => setDragging(false)} onDrop={() => setDragging(false)}>
+            <Root
+                {...dropzoneState.getRootProps()}
+                tabIndex={disabled ? -1 : 0}
+                onFocus={() => setFocused(true)}
+                onBlur={() => setFocused(false)}
+                ownerState={ownerState}
+                {...slotProps?.root}
+                sx={sx}
+                className={className}
+            >
+                <input {...dropzoneState.getInputProps()} />
+                {!hideDroppableArea && (
+                    <Dropzone ownerState={ownerState} {...slotProps?.dropzone}>
+                        {hasError && <ErrorIconContainer {...slotProps?.errorIconContainer}>{errorIcon}</ErrorIconContainer>}
+                        <DropzoneText ownerState={ownerState} variant="body2" {...slotProps?.dropzoneText}>
+                            {dropzoneText}
+                        </DropzoneText>
+                    </Dropzone>
+                )}
+                {!hideButton && (
+                    <SelectFileButton
+                        tabIndex={-1}
+                        disabled={disabled}
+                        variant="contained"
+                        color="secondary"
+                        startIcon={selectIcon}
+                        {...slotProps?.selectFileButton}
+                    >
+                        {buttonText}
+                    </SelectFileButton>
+                )}
+            </Root>
+        </Box>
+    );
+};
+
+const Root = createComponentSlot("div")<FileDropzoneClassKey, OwnerState>({
+    componentName: "FileDropzone",
+    slotName: "root",
+    classesResolver: ({ disabled, hasError, focused }) => [disabled && "disabled", hasError && "error", focused && "focused"],
+})(
+    ({ theme, ownerState }) => css`
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: ${theme.spacing(2)};
+        width: 100%;
+
+        &:focus {
+            outline: none;
+        }
+
+        ${ownerState.disabled &&
+        css`
+            pointer-events: none;
+        `}
+    `,
+);
+
+const Dropzone = createComponentSlot("div")<FileDropzoneClassKey, OwnerState>({
+    componentName: "FileDropzone",
+    slotName: "dropzone",
+})(
+    ({ theme, ownerState }) => css`
+        position: relative;
+        display: flex;
+        height: 80px;
+        justify-content: center;
+        align-items: center;
+        align-self: stretch;
+        border-radius: 4px;
+        border: 1px dashed ${theme.palette.grey[200]};
+        background-color: transparent;
+        transition: background-color 200ms, border-color 200ms;
+        cursor: pointer;
+
+        &:hover {
+            border-color: ${theme.palette.grey[400]};
+            background-color: ${theme.palette.grey[50]};
+        }
+
+        ${ownerState.dragging &&
+        css`
+            border-color: ${theme.palette.grey[400]};
+            background-color: ${theme.palette.grey[50]};
+        `}
+
+        ${ownerState.focused &&
+        css`
+            border-color: ${theme.palette.primary.main};
+            background-color: ${theme.palette.grey[50]};
+        `}
+
+        ${ownerState.hasError &&
+        css`
+            border-color: ${theme.palette.error.main};
+
+            &:hover {
+                border-color: ${theme.palette.error.dark};
+                background-color: ${theme.palette.grey[50]};
+            }
+        `}
+
+
+        ${ownerState.disabled &&
+        css`
+            cursor: default;
+            border-color: ${theme.palette.grey[100]};
+            background-color: ${theme.palette.grey[50]};
+        `}
+    `,
+);
+
+const ErrorIconContainer = createComponentSlot("div")<FileDropzoneClassKey>({
+    componentName: "FileDropzone",
+    slotName: "errorIconContainer",
+})(
+    ({ theme }) => css`
+        position: absolute;
+        top: 0;
+        right: 0;
+        padding: 10px;
+        color: ${theme.palette.error.main};
+    `,
+);
+
+const DropzoneText = createComponentSlot(Typography)<FileDropzoneClassKey, OwnerState>({
+    componentName: "FileDropzone",
+    slotName: "dropzoneText",
+})(
+    ({ theme, ownerState }) => css`
+        padding: ${theme.spacing(6, 2)};
+        color: ${theme.palette.grey[400]};
+        text-align: center;
+
+        ${ownerState.disabled &&
+        css`
+            color: ${theme.palette.grey[200]};
+        `}
+    `,
+);
+
+const SelectFileButton = createComponentSlot(Button)<FileDropzoneClassKey>({
+    componentName: "FileDropzone",
+    slotName: "selectFileButton",
+})(
+    ({ theme }) => css`
+        background-color: ${theme.palette.grey[800]};
+        color: ${theme.palette.common.white};
+
+        &:hover {
+            background-color: black;
+            color: ${theme.palette.common.white};
+        }
+
+        &:disabled {
+            background-color: ${theme.palette.grey[800]};
+            color: ${theme.palette.common.white};
+            opacity: 0.2;
+        }
+    `,
+);
+
+declare module "@mui/material/styles" {
+    interface ComponentNameToClassKey {
+        CometAdminFileDropzone: FileDropzoneClassKey;
+    }
+
+    interface ComponentsPropsList {
+        CometAdminFileDropzone: FileDropzoneProps;
+    }
+
+    interface Components {
+        CometAdminFileDropzone?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminFileDropzone"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFileDropzone"];
+        };
+    }
+}

--- a/packages/admin/admin/src/form/file/FileSelect.tsx
+++ b/packages/admin/admin/src/form/file/FileSelect.tsx
@@ -7,10 +7,10 @@ import { FormattedMessage } from "react-intl";
 
 import { Alert } from "../../alert/Alert";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
-import { PrettyBytes } from "../../helpers/PrettyBytes";
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { FileDropzone } from "./FileDropzone";
 import { FileSelectListItem } from "./FileSelectListItem";
+import { getFilesInfoText } from "./getFilesInfoText";
 
 export type FileSelectClassKey =
     | "root"
@@ -60,7 +60,7 @@ export type FileSelectProps<AdditionalFileValues extends object = Record<string,
     onDownload?: (file: FileSelectFileValue<AdditionalFileValues>) => void;
     disabled?: boolean;
     accept?: Accept;
-    maxFileSize?: number;
+    maxFileSize?: number | null;
     maxFiles?: number;
     error?: React.ReactNode;
     iconMapping?: {
@@ -89,10 +89,11 @@ export const FileSelect = <AdditionalFileValues extends object = Record<string, 
 
     const { error: errorIcon = <ErrorIcon color="error" /> } = iconMapping;
 
-    const multiple = typeof maxFiles === "number" && maxFiles > 1;
+    const multiple = typeof maxFiles === "undefined" || maxFiles > 1;
     const numberOfValidFiles = value?.filter((file) => !("error" in file)).length ?? 0;
-    const maxAmountOfFilesSelected = multiple && numberOfValidFiles >= maxFiles;
+    const maxAmountOfFilesSelected = typeof maxFiles !== "undefined" && multiple && numberOfValidFiles >= maxFiles;
     const maxNumberOfFilesToBeAdded = maxFiles ? maxFiles - numberOfValidFiles : undefined;
+    const filesInfoText = getFilesInfoText(maxFiles, maxFileSize);
 
     return (
         <Root {...slotProps?.root} {...restProps}>
@@ -114,7 +115,7 @@ export const FileSelect = <AdditionalFileValues extends object = Record<string, 
                     onDrop={onDrop}
                     accept={accept}
                     multiple={multiple}
-                    maxSize={maxFileSize}
+                    maxSize={maxFileSize === null ? undefined : maxFileSize}
                     maxFiles={maxNumberOfFilesToBeAdded}
                     {...slotProps?.dropzone}
                 />
@@ -152,36 +153,7 @@ export const FileSelect = <AdditionalFileValues extends object = Record<string, 
                     </ErrorMessage>
                 </Error>
             )}
-            <FilesInfoText {...slotProps?.filesInfoText}>
-                {typeof maxFiles === "number" ? (
-                    maxFiles === 1 ? (
-                        <FormattedMessage
-                            id="comet.fileSelect.singleFileMaximumSize"
-                            defaultMessage="Maximum 1 file, {maxFileSize}"
-                            values={{
-                                maxFileSize: <PrettyBytes value={maxFileSize} />,
-                            }}
-                        />
-                    ) : (
-                        <FormattedMessage
-                            id="comet.fileSelect.maximumFileNumberAndSize"
-                            defaultMessage="Maximum {maxFiles, plural, one {# file} other {# files}}, {maxFileSize} per file."
-                            values={{
-                                maxFileSize: <PrettyBytes value={maxFileSize} />,
-                                maxFiles,
-                            }}
-                        />
-                    )
-                ) : (
-                    <FormattedMessage
-                        id="comet.fileSelect.maximumSizePerFile"
-                        defaultMessage="Maximum {maxFileSize} per file."
-                        values={{
-                            maxFileSize: <PrettyBytes value={maxFileSize} />,
-                        }}
-                    />
-                )}
-            </FilesInfoText>
+            {Boolean(filesInfoText) && <FilesInfoText {...slotProps?.filesInfoText}>{filesInfoText}</FilesInfoText>}
         </Root>
     );
 };

--- a/packages/admin/admin/src/form/file/FileSelect.tsx
+++ b/packages/admin/admin/src/form/file/FileSelect.tsx
@@ -29,7 +29,7 @@ export type FileSelectSuccessfulFileValue<AdditionalFileValues extends object = 
 
 export type FileSelectErrorFileValue = {
     name?: string;
-    error: string;
+    error: boolean | React.ReactNode;
 };
 
 export type FileSelectLoadingFileValue = {
@@ -54,7 +54,7 @@ type ThemeProps = ThemedComponentBaseProps<{
 }>;
 
 export type FileSelectProps<AdditionalFileValues extends object = Record<string, unknown>> = {
-    value: undefined | FileSelectFileValue<AdditionalFileValues>[];
+    value: FileSelectFileValue<AdditionalFileValues>[];
     onDrop: DropzoneOptions["onDrop"];
     onRemove: (file: FileSelectFileValue<AdditionalFileValues>) => void;
     onDownload?: (file: FileSelectFileValue<AdditionalFileValues>) => void;
@@ -73,7 +73,7 @@ export const FileSelect = <AdditionalFileValues extends object = Record<string, 
         slotProps,
         disabled,
         accept,
-        maxFileSize = 50 * 1024 * 1024,
+        maxFileSize = 50 * 1024 * 1024, // 50 MB
         maxFiles,
         iconMapping = {},
         onDrop,
@@ -92,7 +92,6 @@ export const FileSelect = <AdditionalFileValues extends object = Record<string, 
     const multiple = typeof maxFiles === "number" && maxFiles > 1;
     const numberOfValidFiles = value?.filter((file) => !("error" in file)).length ?? 0;
     const maxAmountOfFilesSelected = multiple && numberOfValidFiles >= maxFiles;
-    const valuesList = !value ? [] : Array.isArray(value) ? value : [value];
     const maxNumberOfFilesToBeAdded = maxFiles ? maxFiles - numberOfValidFiles : undefined;
 
     return (
@@ -120,9 +119,9 @@ export const FileSelect = <AdditionalFileValues extends object = Record<string, 
                     {...slotProps?.dropzone}
                 />
             )}
-            {valuesList.length > 0 && (
+            {value.length > 0 && (
                 <FileList {...slotProps?.fileList}>
-                    {valuesList.map((file, index) => {
+                    {value.map((file, index) => {
                         return (
                             <FileListItem
                                 key={index}

--- a/packages/admin/admin/src/form/file/FileSelect.tsx
+++ b/packages/admin/admin/src/form/file/FileSelect.tsx
@@ -60,7 +60,7 @@ export type FileSelectProps<AdditionalFileValues extends object = Record<string,
     onDownload?: (file: FileSelectFileValue<AdditionalFileValues>) => void;
     disabled?: boolean;
     accept?: Accept;
-    maxFileSize?: number | null;
+    maxFileSize?: number;
     maxFiles?: number;
     error?: React.ReactNode;
     iconMapping?: {
@@ -73,7 +73,7 @@ export const FileSelect = <AdditionalFileValues extends object = Record<string, 
         slotProps,
         disabled,
         accept,
-        maxFileSize = 50 * 1024 * 1024, // 50 MB
+        maxFileSize,
         maxFiles,
         iconMapping = {},
         onDrop,

--- a/packages/admin/admin/src/form/file/FileSelect.tsx
+++ b/packages/admin/admin/src/form/file/FileSelect.tsx
@@ -1,0 +1,264 @@
+import { Error as ErrorIcon } from "@comet/admin-icons";
+import { ComponentsOverrides, FormHelperText, Typography } from "@mui/material";
+import { css, Theme, useThemeProps } from "@mui/material/styles";
+import * as React from "react";
+import { Accept, DropzoneOptions } from "react-dropzone";
+import { FormattedMessage } from "react-intl";
+
+import { Alert } from "../../alert/Alert";
+import { createComponentSlot } from "../../helpers/createComponentSlot";
+import { PrettyBytes } from "../../helpers/PrettyBytes";
+import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
+import { FileDropzone } from "./FileDropzone";
+import { FileSelectListItem } from "./FileSelectListItem";
+
+export type FileSelectClassKey =
+    | "root"
+    | "maxFilesReachedInfo"
+    | "dropzone"
+    | "fileList"
+    | "fileListItem"
+    | "error"
+    | "errorMessage"
+    | "filesInfoText";
+
+export type FileSelectSuccessfulFileValue<AdditionalFileValues extends object = Record<string, unknown>> = {
+    name: string;
+    size: number;
+} & AdditionalFileValues;
+
+export type FileSelectErrorFileValue = {
+    name?: string;
+    error: string;
+};
+
+export type FileSelectLoadingFileValue = {
+    name?: string;
+    loading: boolean;
+};
+
+export type FileSelectFileValue<AdditionalFileValues extends object = Record<string, unknown>> =
+    | FileSelectSuccessfulFileValue<AdditionalFileValues>
+    | FileSelectErrorFileValue
+    | FileSelectLoadingFileValue;
+
+type ThemeProps = ThemedComponentBaseProps<{
+    root: "div";
+    maxFilesReachedInfo: typeof Alert;
+    dropzone: typeof FileDropzone;
+    fileList: "div";
+    fileListItem: typeof FileSelectListItem;
+    error: "div";
+    errorMessage: typeof Typography;
+    filesInfoText: typeof FormHelperText;
+}>;
+
+export type FileSelectProps<AdditionalFileValues extends object = Record<string, unknown>> = {
+    value: undefined | FileSelectFileValue<AdditionalFileValues>[];
+    onDrop: DropzoneOptions["onDrop"];
+    onRemove: (file: FileSelectFileValue<AdditionalFileValues>) => void;
+    onDownload?: (file: FileSelectFileValue<AdditionalFileValues>) => void;
+    disabled?: boolean;
+    accept?: Accept;
+    maxFileSize?: number;
+    maxFiles?: number;
+    error?: React.ReactNode;
+    iconMapping?: {
+        error?: React.ReactNode;
+    };
+} & ThemeProps;
+
+export const FileSelect = <AdditionalFileValues extends object = Record<string, unknown>>(inProps: FileSelectProps<AdditionalFileValues>) => {
+    const {
+        slotProps,
+        disabled,
+        accept,
+        maxFileSize = 50 * 1024 * 1024,
+        maxFiles,
+        iconMapping = {},
+        onDrop,
+        onRemove,
+        onDownload,
+        value,
+        error,
+        ...restProps
+    } = useThemeProps({
+        props: inProps,
+        name: "CometAdminFileSelect",
+    });
+
+    const { error: errorIcon = <ErrorIcon color="error" /> } = iconMapping;
+
+    const multiple = typeof maxFiles === "number" && maxFiles > 1;
+    const numberOfValidFiles = value?.filter((file) => !("error" in file)).length ?? 0;
+    const maxAmountOfFilesSelected = multiple && numberOfValidFiles >= maxFiles;
+    const valuesList = !value ? [] : Array.isArray(value) ? value : [value];
+    const maxNumberOfFilesToBeAdded = maxFiles ? maxFiles - numberOfValidFiles : undefined;
+
+    return (
+        <Root {...slotProps?.root} {...restProps}>
+            {maxAmountOfFilesSelected ? (
+                <MaxFilesReachedInfo
+                    title={<FormattedMessage id="comet.fileSelect.maximumReached" defaultMessage="Maximum reached" />}
+                    severity="info"
+                    {...slotProps?.maxFilesReachedInfo}
+                >
+                    <FormattedMessage
+                        id="comet.fileSelect.maximumFilesAmount"
+                        defaultMessage="The maximum number of uploads has been reached. Please delete files from the list before uploading new files."
+                    />
+                </MaxFilesReachedInfo>
+            ) : (
+                <Dropzone
+                    disabled={disabled}
+                    hasError={Boolean(error)}
+                    onDrop={onDrop}
+                    accept={accept}
+                    multiple={multiple}
+                    maxSize={maxFileSize}
+                    maxFiles={maxNumberOfFilesToBeAdded}
+                    {...slotProps?.dropzone}
+                />
+            )}
+            {valuesList.length > 0 && (
+                <FileList {...slotProps?.fileList}>
+                    {valuesList.map((file, index) => {
+                        return (
+                            <FileListItem
+                                key={index}
+                                name={file.name}
+                                size={"size" in file ? file.size : undefined}
+                                loading={"loading" in file && Boolean(file.name)}
+                                skeleton={"loading" in file && !file.name}
+                                error={"error" in file && file.error}
+                                onClickDownload={
+                                    "error" in file || !onDownload
+                                        ? undefined
+                                        : () => {
+                                              onDownload(file);
+                                          }
+                                }
+                                onClickDelete={() => onRemove(file)}
+                                {...slotProps?.fileListItem}
+                            />
+                        );
+                    })}
+                </FileList>
+            )}
+            {Boolean(error) && (
+                <Error {...slotProps?.error}>
+                    {errorIcon}
+                    <ErrorMessage variant="caption" color="error" {...slotProps?.errorMessage}>
+                        {error}
+                    </ErrorMessage>
+                </Error>
+            )}
+            <FilesInfoText {...slotProps?.filesInfoText}>
+                {typeof maxFiles === "number" ? (
+                    maxFiles === 1 ? (
+                        <FormattedMessage
+                            id="comet.fileSelect.singleFileMaximumSize"
+                            defaultMessage="Maximum 1 file, {maxFileSize}"
+                            values={{
+                                maxFileSize: <PrettyBytes value={maxFileSize} />,
+                            }}
+                        />
+                    ) : (
+                        <FormattedMessage
+                            id="comet.fileSelect.maximumFileNumberAndSize"
+                            defaultMessage="Maximum {maxFiles, plural, one {# file} other {# files}}, {maxFileSize} per file."
+                            values={{
+                                maxFileSize: <PrettyBytes value={maxFileSize} />,
+                                maxFiles,
+                            }}
+                        />
+                    )
+                ) : (
+                    <FormattedMessage
+                        id="comet.fileSelect.maximumSizePerFile"
+                        defaultMessage="Maximum {maxFileSize} per file."
+                        values={{
+                            maxFileSize: <PrettyBytes value={maxFileSize} />,
+                        }}
+                    />
+                )}
+            </FilesInfoText>
+        </Root>
+    );
+};
+
+const Root = createComponentSlot("div")<FileSelectClassKey>({
+    componentName: "FileSelect",
+    slotName: "root",
+})(css`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+`);
+
+const Dropzone = createComponentSlot(FileDropzone)<FileSelectClassKey>({
+    componentName: "FileSelect",
+    slotName: "dropzone",
+})();
+
+const FileList = createComponentSlot("div")<FileSelectClassKey>({
+    componentName: "FileSelect",
+    slotName: "fileList",
+})(css`
+    width: 100%;
+`);
+
+const FileListItem = createComponentSlot(FileSelectListItem)<FileSelectClassKey>({
+    componentName: "FileSelect",
+    slotName: "fileListItem",
+})();
+
+const MaxFilesReachedInfo = createComponentSlot(Alert)<FileSelectClassKey>({
+    componentName: "FileSelect",
+    slotName: "maxFilesReachedInfo",
+})(css`
+    width: 100%;
+    box-sizing: border-box;
+`);
+
+const Error = createComponentSlot("div")<FileSelectClassKey>({
+    componentName: "FileSelect",
+    slotName: "error",
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+        color: ${theme.palette.error.main};
+        gap: 5px;
+    `,
+);
+
+const ErrorMessage = createComponentSlot(Typography)<FileSelectClassKey>({
+    componentName: "FileSelect",
+    slotName: "errorMessage",
+})();
+
+const FilesInfoText = createComponentSlot(FormHelperText)<FileSelectClassKey>({
+    componentName: "FileSelect",
+    slotName: "filesInfoText",
+})(css`
+    margin: 0;
+`);
+
+declare module "@mui/material/styles" {
+    interface ComponentNameToClassKey {
+        CometAdminFileSelect: FileSelectClassKey;
+    }
+
+    interface ComponentsPropsList {
+        CometAdminFileSelect: FileSelectProps;
+    }
+
+    interface Components {
+        CometAdminFileSelect?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminFileSelect"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFileSelect"];
+        };
+    }
+}

--- a/packages/admin/admin/src/form/file/FileSelect.tsx
+++ b/packages/admin/admin/src/form/file/FileSelect.tsx
@@ -9,6 +9,7 @@ import { Alert } from "../../alert/Alert";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { FileDropzone } from "./FileDropzone";
+import { FileSelectItem } from "./fileSelectItemTypes";
 import { FileSelectListItem } from "./FileSelectListItem";
 import { getFilesInfoText } from "./getFilesInfoText";
 
@@ -22,26 +23,6 @@ export type FileSelectClassKey =
     | "errorMessage"
     | "filesInfoText";
 
-export type FileSelectSuccessfulFileValue<AdditionalFileValues extends object = Record<string, unknown>> = {
-    name: string;
-    size: number;
-} & AdditionalFileValues;
-
-export type FileSelectErrorFileValue = {
-    name?: string;
-    error: boolean | React.ReactNode;
-};
-
-export type FileSelectLoadingFileValue = {
-    name?: string;
-    loading: boolean;
-};
-
-export type FileSelectFileValue<AdditionalFileValues extends object = Record<string, unknown>> =
-    | FileSelectSuccessfulFileValue<AdditionalFileValues>
-    | FileSelectErrorFileValue
-    | FileSelectLoadingFileValue;
-
 type ThemeProps = ThemedComponentBaseProps<{
     root: "div";
     maxFilesReachedInfo: typeof Alert;
@@ -53,11 +34,11 @@ type ThemeProps = ThemedComponentBaseProps<{
     filesInfoText: typeof FormHelperText;
 }>;
 
-export type FileSelectProps<AdditionalFileValues extends object = Record<string, unknown>> = {
-    value: FileSelectFileValue<AdditionalFileValues>[];
+export type FileSelectProps<AdditionalValidFileValues = Record<string, unknown>> = {
+    files: FileSelectItem<AdditionalValidFileValues>[];
     onDrop: DropzoneOptions["onDrop"];
-    onRemove: (file: FileSelectFileValue<AdditionalFileValues>) => void;
-    onDownload?: (file: FileSelectFileValue<AdditionalFileValues>) => void;
+    onRemove: (file: FileSelectItem<AdditionalValidFileValues>) => void;
+    onDownload?: (file: FileSelectItem<AdditionalValidFileValues>) => void;
     disabled?: boolean;
     accept?: Accept;
     maxFileSize?: number;
@@ -68,7 +49,7 @@ export type FileSelectProps<AdditionalFileValues extends object = Record<string,
     };
 } & ThemeProps;
 
-export const FileSelect = <AdditionalFileValues extends object = Record<string, unknown>>(inProps: FileSelectProps<AdditionalFileValues>) => {
+export const FileSelect = <AdditionalValidFileValues = Record<string, unknown>,>(inProps: FileSelectProps<AdditionalValidFileValues>) => {
     const {
         slotProps,
         disabled,
@@ -79,7 +60,7 @@ export const FileSelect = <AdditionalFileValues extends object = Record<string, 
         onDrop,
         onRemove,
         onDownload,
-        value,
+        files,
         error,
         ...restProps
     } = useThemeProps({
@@ -90,7 +71,7 @@ export const FileSelect = <AdditionalFileValues extends object = Record<string, 
     const { error: errorIcon = <ErrorIcon color="error" /> } = iconMapping;
 
     const multiple = typeof maxFiles === "undefined" || maxFiles > 1;
-    const numberOfValidFiles = value?.filter((file) => !("error" in file)).length ?? 0;
+    const numberOfValidFiles = files?.filter((file) => !("error" in file)).length ?? 0;
     const maxAmountOfFilesSelected = typeof maxFiles !== "undefined" && multiple && numberOfValidFiles >= maxFiles;
     const maxNumberOfFilesToBeAdded = maxFiles ? maxFiles - numberOfValidFiles : undefined;
     const filesInfoText = getFilesInfoText(maxFiles, maxFileSize);
@@ -120,17 +101,13 @@ export const FileSelect = <AdditionalFileValues extends object = Record<string, 
                     {...slotProps?.dropzone}
                 />
             )}
-            {value.length > 0 && (
+            {files.length > 0 && (
                 <FileList {...slotProps?.fileList}>
-                    {value.map((file, index) => {
+                    {files.map((file, index) => {
                         return (
                             <FileListItem
                                 key={index}
-                                name={file.name}
-                                size={"size" in file ? file.size : undefined}
-                                loading={"loading" in file && Boolean(file.name)}
-                                skeleton={"loading" in file && !file.name}
-                                error={"error" in file && file.error}
+                                file={file}
                                 onClickDownload={
                                     "error" in file || !onDownload
                                         ? undefined

--- a/packages/admin/admin/src/form/file/FileSelectListItem.tsx
+++ b/packages/admin/admin/src/form/file/FileSelectListItem.tsx
@@ -275,10 +275,6 @@ const FileSize = createComponentSlot(Chip)<FileSelectListItemClassKey>({
         &:not(:last-child) {
             margin-right: ${theme.spacing(1)};
         }
-
-        .MuiChip-label {
-            padding-right: 0; // TODO: Should this be fixed in the theme?
-        }
     `,
 );
 

--- a/packages/admin/admin/src/form/file/FileSelectListItem.tsx
+++ b/packages/admin/admin/src/form/file/FileSelectListItem.tsx
@@ -16,6 +16,7 @@ import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { PrettyBytes } from "../../helpers/PrettyBytes";
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { useElementIsOverflowing } from "../../hooks/useElementIsOverflowing";
+import { FileSelectItem } from "./fileSelectItemTypes";
 
 type OwnerState = {
     hasErrorWithDetails: boolean;
@@ -50,11 +51,7 @@ export type FileSelectListItemProps = ThemedComponentBaseProps<{
     errorDetailsText: typeof Typography;
     iconButton: typeof MuiIconButton;
 }> & {
-    name?: string;
-    size?: number;
-    error?: boolean | React.ReactNode;
-    loading?: boolean;
-    skeleton?: boolean;
+    file: FileSelectItem;
     disabled?: boolean;
     onClickDownload?: () => void;
     onClickDelete?: () => void;
@@ -68,11 +65,7 @@ export type FileSelectListItemProps = ThemedComponentBaseProps<{
 
 export const FileSelectListItem = (inProps: FileSelectListItemProps) => {
     const {
-        name,
-        size,
-        error,
-        skeleton,
-        loading,
+        file,
         disabled,
         onClickDownload,
         onClickDelete,
@@ -93,31 +86,31 @@ export const FileSelectListItem = (inProps: FileSelectListItemProps) => {
         error: errorIcon = <Error fontSize="inherit" />,
     } = iconMapping;
 
-    const ownerState: OwnerState = {
-        hasErrorWithDetails: typeof error !== "boolean" && typeof error !== "undefined",
-        hasErrorWithoutDetails: error === true,
-        disabled: Boolean(disabled),
-    };
-
-    if (skeleton) {
+    if ("loading" in file && !file.name) {
         return <Skeleton variant="rounded" height={35} animation="wave" width="100%" sx={{ borderRadius: 2 }} {...slotProps?.skeleton} />;
     }
+
+    const ownerState: OwnerState = {
+        hasErrorWithDetails: "error" in file && typeof file.error !== "boolean",
+        hasErrorWithoutDetails: "error" in file && typeof file.error === "boolean",
+        disabled: Boolean(disabled),
+    };
 
     return (
         <Root ownerState={ownerState} {...slotProps?.root} {...restProps}>
             <Content {...slotProps?.content}>
-                <Tooltip title={fileNameIsOverflowing ? name : undefined}>
+                <Tooltip title={fileNameIsOverflowing ? file.name : undefined}>
                     <FileName ref={fileNameRef} variant="caption" ownerState={ownerState} {...slotProps?.fileName}>
-                        {name}
+                        {file.name}
                     </FileName>
                 </Tooltip>
                 <FileListItemInfos ownerState={ownerState} {...slotProps?.fileListItemInfos}>
-                    {loading ? (
+                    {"loading" in file ? (
                         loadingIcon
                     ) : (
                         <>
-                            {typeof size !== "undefined" && (
-                                <FileSize label={<PrettyBytes value={size} />} size="small" disabled={disabled} {...slotProps?.fileSize} />
+                            {"size" in file && typeof file.size !== "undefined" && (
+                                <FileSize label={<PrettyBytes value={file.size} />} size="small" disabled={disabled} {...slotProps?.fileSize} />
                             )}
                             {ownerState.hasErrorWithoutDetails && (
                                 <ErrorIconContainer {...slotProps?.errorIconContainer}>{errorIcon}</ErrorIconContainer>
@@ -136,11 +129,11 @@ export const FileSelectListItem = (inProps: FileSelectListItemProps) => {
                     )}
                 </FileListItemInfos>
             </Content>
-            {ownerState.hasErrorWithDetails && (
+            {ownerState.hasErrorWithDetails && "error" in file && (
                 <ErrorDetails {...slotProps?.errorDetails}>
                     {errorIcon}
                     <ErrorDetailsText variant="caption" {...slotProps?.errorDetailsText}>
-                        {error}
+                        {file.error}
                     </ErrorDetailsText>
                 </ErrorDetails>
             )}

--- a/packages/admin/admin/src/form/file/FileSelectListItem.tsx
+++ b/packages/admin/admin/src/form/file/FileSelectListItem.tsx
@@ -1,0 +1,352 @@
+import { Delete, Download, Error, ThreeDotSaving } from "@comet/admin-icons";
+import {
+    Chip,
+    ComponentsOverrides,
+    css,
+    IconButton as MuiIconButton,
+    Skeleton as MuiSkeleton,
+    Theme,
+    Typography,
+    useThemeProps,
+} from "@mui/material";
+import React from "react";
+
+import { Tooltip } from "../../common/Tooltip";
+import { createComponentSlot } from "../../helpers/createComponentSlot";
+import { PrettyBytes } from "../../helpers/PrettyBytes";
+import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
+import { useElementIsOverflowing } from "../../hooks/useElementIsOverflowing";
+
+type OwnerState = {
+    hasErrorWithDetails: boolean;
+    hasErrorWithoutDetails: boolean;
+    disabled: boolean;
+};
+
+export type FileSelectListItemClassKey =
+    | "root"
+    | "hasErrorWithDetails"
+    | "hasErrorWithoutDetails"
+    | "disabled"
+    | "skeleton"
+    | "content"
+    | "fileListItemInfos"
+    | "fileName"
+    | "fileSize"
+    | "errorIconContainer"
+    | "errorDetails"
+    | "errorDetailsText"
+    | "iconButton";
+
+export type FileSelectListItemProps = ThemedComponentBaseProps<{
+    root: "div";
+    content: "div";
+    fileListItemInfos: "div";
+    fileName: typeof Typography;
+    fileSize: typeof Chip;
+    errorIconContainer: "div";
+    errorDetails: "div";
+    errorDetailsText: typeof Typography;
+    iconButton: typeof MuiIconButton;
+}> & {
+    name?: string;
+    size?: number;
+    error?: boolean | React.ReactNode;
+    loading?: boolean;
+    skeleton?: boolean;
+    disabled?: boolean;
+    onClickDownload?: () => void;
+    onClickDelete?: () => void;
+    iconMapping?: {
+        download?: React.ReactNode;
+        loading?: React.ReactNode;
+        delete?: React.ReactNode;
+        error?: React.ReactNode;
+    };
+};
+
+export const FileSelectListItem = (inProps: FileSelectListItemProps) => {
+    const {
+        name,
+        size,
+        error,
+        skeleton,
+        loading,
+        disabled,
+        onClickDownload,
+        onClickDelete,
+        iconMapping = {},
+        slotProps,
+        ...restProps
+    } = useThemeProps({
+        props: inProps,
+        name: "CometAdminFileSelectListItem",
+    });
+    const fileNameRef = React.useRef<HTMLDivElement>(null);
+    const fileNameIsOverflowing = useElementIsOverflowing(fileNameRef);
+
+    const {
+        download: downloadIcon = <Download />,
+        delete: deleteIcon = <Delete />,
+        loading: loadingIcon = <ThreeDotSaving />,
+        error: errorIcon = <Error fontSize="inherit" />,
+    } = iconMapping;
+
+    const ownerState: OwnerState = {
+        hasErrorWithDetails: typeof error !== "boolean" && typeof error !== "undefined",
+        hasErrorWithoutDetails: error === true,
+        disabled: Boolean(disabled),
+    };
+
+    if (skeleton) {
+        return <Skeleton variant="rounded" height={35} animation="wave" width="100%" sx={{ borderRadius: 2 }} />;
+    }
+
+    return (
+        <Root ownerState={ownerState} {...slotProps?.root} {...restProps}>
+            <Content {...slotProps?.content}>
+                <Tooltip title={fileNameIsOverflowing ? name : undefined}>
+                    <FileName ref={fileNameRef} variant="caption" ownerState={ownerState} {...slotProps?.fileName}>
+                        {name}
+                    </FileName>
+                </Tooltip>
+                <FileListItemInfos ownerState={ownerState} {...slotProps?.fileListItemInfos}>
+                    {loading ? (
+                        loadingIcon
+                    ) : (
+                        <>
+                            {typeof size !== "undefined" && (
+                                <FileSize label={<PrettyBytes value={size} />} size="small" disabled={disabled} {...slotProps?.fileSize} />
+                            )}
+                            {ownerState.hasErrorWithoutDetails && (
+                                <ErrorIconContainer {...slotProps?.errorIconContainer}>{errorIcon}</ErrorIconContainer>
+                            )}
+                            {Boolean(onClickDownload) && (
+                                <IconButton onClick={onClickDownload} disabled={disabled} {...slotProps?.iconButton}>
+                                    {downloadIcon}
+                                </IconButton>
+                            )}
+                            {Boolean(onClickDelete) && (
+                                <IconButton onClick={onClickDelete} disabled={disabled} {...slotProps?.iconButton}>
+                                    {deleteIcon}
+                                </IconButton>
+                            )}
+                        </>
+                    )}
+                </FileListItemInfos>
+            </Content>
+            {ownerState.hasErrorWithDetails && (
+                <ErrorDetails {...slotProps?.errorDetails}>
+                    {errorIcon}
+                    <ErrorDetailsText variant="caption" {...slotProps?.errorDetailsText}>
+                        {error}
+                    </ErrorDetailsText>
+                </ErrorDetails>
+            )}
+        </Root>
+    );
+};
+
+const commonItemSpacingStyles = css`
+    &:not(:last-child) {
+        margin-bottom: 2px;
+    }
+`;
+
+const Root = createComponentSlot("div")<FileSelectListItemClassKey, OwnerState>({
+    componentName: "FileSelectListItem",
+    slotName: "root",
+    classesResolver: ({ hasErrorWithDetails, hasErrorWithoutDetails, disabled }) => [
+        hasErrorWithDetails && "hasErrorWithDetails",
+        hasErrorWithoutDetails && "hasErrorWithoutDetails",
+        disabled && "disabled",
+    ],
+})(
+    ({ theme, ownerState }) => css`
+        ${commonItemSpacingStyles};
+        padding-right: ${theme.spacing(2)};
+        padding-left: ${theme.spacing(2)};
+        border-radius: 4px;
+        background-color: ${theme.palette.grey[50]};
+        transition: background-color 200ms;
+        width: 100%;
+        box-sizing: border-box;
+
+        &:hover {
+            background-color: ${theme.palette.grey[100]};
+
+            .CometAdminFileSelectListItem-fileSize {
+                background-color: ${theme.palette.grey[200]};
+            }
+
+            .CometAdminFileSelectListItem-iconButton {
+                color: ${theme.palette.grey[900]};
+            }
+        }
+
+        ${(ownerState.hasErrorWithDetails || ownerState.hasErrorWithoutDetails) &&
+        css`
+            outline: 1px dashed ${theme.palette.error.main};
+            outline-offset: -1px;
+        `}
+
+        ${ownerState.disabled &&
+        css`
+            pointer-events: none;
+        `}
+    `,
+);
+
+const Skeleton = createComponentSlot(MuiSkeleton)<FileSelectListItemClassKey>({
+    componentName: "FileSelectListItem",
+    slotName: "skeleton",
+})(css`
+    ${commonItemSpacingStyles};
+`);
+
+const Content = createComponentSlot("div")<FileSelectListItemClassKey>({
+    componentName: "FileSelectListItem",
+    slotName: "content",
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: ${theme.spacing(1)};
+    `,
+);
+
+const FileListItemInfos = createComponentSlot("div")<FileSelectListItemClassKey, OwnerState>({
+    componentName: "FileSelectListItem",
+    slotName: "fileListItemInfos",
+})(
+    ({ ownerState }) => css`
+        display: flex;
+        align-items: center;
+        justify-content: end;
+        margin-left: auto;
+
+        ${ownerState.hasErrorWithDetails &&
+        css`
+            padding-top: 3.5px;
+            margin-bottom: -3.5px;
+        `};
+    `,
+);
+
+const FileName = createComponentSlot(Typography)<FileSelectListItemClassKey, OwnerState>({
+    componentName: "FileSelectListItem",
+    slotName: "fileName",
+})(
+    ({ ownerState, theme }) => css`
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        flex-grow: 1;
+        line-height: 19px;
+        padding-top: 8px;
+        padding-bottom: 8px;
+
+        ${ownerState.hasErrorWithoutDetails &&
+        css`
+            color: ${theme.palette.error.main};
+        `}
+
+        ${ownerState.hasErrorWithDetails &&
+        css`
+            padding-bottom: 1px;
+        `}
+
+        ${ownerState.disabled &&
+        css`
+            color: ${theme.palette.text.disabled};
+        `}
+    `,
+);
+
+const FileSize = createComponentSlot(Chip)<FileSelectListItemClassKey>({
+    componentName: "FileSelectListItem",
+    slotName: "fileSize",
+})(
+    ({ theme }) => css`
+        transition: background-color 200ms;
+
+        &:not(:last-child) {
+            margin-right: ${theme.spacing(1)};
+        }
+
+        .MuiChip-label {
+            padding-right: 0; // TODO: Should this be fixed in the theme?
+        }
+    `,
+);
+
+const ErrorIconContainer = createComponentSlot("div")<FileSelectListItemClassKey>({
+    componentName: "FileSelectListItem",
+    slotName: "errorIconContainer",
+})(
+    ({ theme }) => css`
+        padding: ${theme.spacing(1)};
+        line-height: 0;
+        font-size: 16px;
+        color: ${theme.palette.error.main};
+
+        &:last-child {
+            padding-right: 0;
+        }
+    `,
+);
+
+const ErrorDetails = createComponentSlot("div")<FileSelectListItemClassKey>({
+    componentName: "FileSelectListItem",
+    slotName: "errorDetails",
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing(1)};
+        color: ${theme.palette.error.main};
+        padding-bottom: 8px;
+        line-height: 0;
+    `,
+);
+const ErrorDetailsText = createComponentSlot(Typography)<FileSelectListItemClassKey>({
+    componentName: "FileSelectListItem",
+    slotName: "errorDetailsText",
+})();
+
+const IconButton = createComponentSlot(MuiIconButton)<FileSelectListItemClassKey>({
+    componentName: "FileSelectListItem",
+    slotName: "iconButton",
+})(
+    ({ theme }) => css`
+        padding: ${theme.spacing(1)};
+        color: ${theme.palette.grey[300]};
+        transition: background-color 200ms;
+
+        &:hover {
+            background-color: ${theme.palette.grey[200]};
+        }
+
+        &:last-child {
+            margin-right: ${theme.spacing(-1)};
+        }
+    `,
+);
+
+declare module "@mui/material/styles" {
+    interface ComponentNameToClassKey {
+        CometAdminFileSelectListItem: FileSelectListItemClassKey;
+    }
+
+    interface ComponentsPropsList {
+        CometAdminFileSelectListItem: FileSelectListItemProps;
+    }
+
+    interface Components {
+        CometAdminFileSelectListItem?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminFileSelectListItem"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFileSelectListItem"];
+        };
+    }
+}

--- a/packages/admin/admin/src/form/file/FileSelectListItem.tsx
+++ b/packages/admin/admin/src/form/file/FileSelectListItem.tsx
@@ -40,6 +40,7 @@ export type FileSelectListItemClassKey =
 
 export type FileSelectListItemProps = ThemedComponentBaseProps<{
     root: "div";
+    skeleton: typeof MuiSkeleton;
     content: "div";
     fileListItemInfos: "div";
     fileName: typeof Typography;
@@ -99,7 +100,7 @@ export const FileSelectListItem = (inProps: FileSelectListItemProps) => {
     };
 
     if (skeleton) {
-        return <Skeleton variant="rounded" height={35} animation="wave" width="100%" sx={{ borderRadius: 2 }} />;
+        return <Skeleton variant="rounded" height={35} animation="wave" width="100%" sx={{ borderRadius: 2 }} {...slotProps?.skeleton} />;
     }
 
     return (
@@ -310,6 +311,7 @@ const ErrorDetails = createComponentSlot("div")<FileSelectListItemClassKey>({
         line-height: 0;
     `,
 );
+
 const ErrorDetailsText = createComponentSlot(Typography)<FileSelectListItemClassKey>({
     componentName: "FileSelectListItem",
     slotName: "errorDetailsText",

--- a/packages/admin/admin/src/form/file/fileSelectItemTypes.ts
+++ b/packages/admin/admin/src/form/file/fileSelectItemTypes.ts
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+
+export type ValidFileSelectItem<AdditionalFileValues = Record<string, unknown>> = {
+    name: string;
+    size: number;
+} & AdditionalFileValues;
+
+export type ErrorFileSelectItem = {
+    name?: string;
+    error: true | ReactNode;
+};
+
+export type LoadingFileSelectItem = {
+    name?: string;
+    loading: true;
+};
+
+export type FileSelectItem<AdditionalValidFileValues = Record<string, unknown>> =
+    | ValidFileSelectItem<AdditionalValidFileValues>
+    | ErrorFileSelectItem
+    | LoadingFileSelectItem;

--- a/packages/admin/admin/src/form/file/getFilesInfoText.tsx
+++ b/packages/admin/admin/src/form/file/getFilesInfoText.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { PrettyBytes } from "../../helpers/PrettyBytes";
+import { FileSelectProps } from "./FileSelect";
+
+export const getFilesInfoText = (maxFiles: FileSelectProps["maxFiles"], maxFileSize: FileSelectProps["maxFileSize"]) => {
+    if (typeof maxFiles === "number" && typeof maxFileSize === "number") {
+        if (maxFiles === 1) {
+            return (
+                <FormattedMessage
+                    id="comet.fileSelect.singleFileMaximumSize"
+                    defaultMessage="Maximum 1 file, {maxFileSize}."
+                    values={{
+                        maxFileSize: <PrettyBytes value={maxFileSize} />,
+                    }}
+                />
+            );
+        }
+
+        return (
+            <FormattedMessage
+                id="comet.fileSelect.multipleFilesMaximumSize"
+                defaultMessage="Maximum {maxFiles} files, {maxFileSize} per file."
+                values={{
+                    maxFileSize: <PrettyBytes value={maxFileSize} />,
+                    maxFiles,
+                }}
+            />
+        );
+    }
+
+    if (typeof maxFiles === "number") {
+        return (
+            <FormattedMessage
+                id="comet.fileSelect.maximumFiles"
+                defaultMessage="Maximum {maxFiles, plural, one {# file} other {# files}}."
+                values={{
+                    maxFiles,
+                }}
+            />
+        );
+    }
+
+    if (typeof maxFileSize === "number") {
+        return (
+            <FormattedMessage
+                id="comet.fileSelect.maximumSize"
+                defaultMessage="Maximum {maxFileSize} per file."
+                values={{
+                    maxFileSize: <PrettyBytes value={maxFileSize} />,
+                }}
+            />
+        );
+    }
+
+    return null;
+};

--- a/packages/admin/admin/src/hooks/useElementIsOverflowing.ts
+++ b/packages/admin/admin/src/hooks/useElementIsOverflowing.ts
@@ -1,0 +1,28 @@
+import React from "react";
+
+export const useElementIsOverflowing = (ref: React.RefObject<HTMLElement>) => {
+    const [isOverflowing, setIsOverflowing] = React.useState(false);
+
+    React.useEffect(() => {
+        const element = ref.current;
+
+        const observer = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                setIsOverflowing(entry.target.clientWidth < entry.target.scrollWidth);
+            }
+        });
+
+        if (element) {
+            observer.observe(element);
+        }
+
+        return () => {
+            if (element) {
+                observer.unobserve(element);
+            }
+            observer.disconnect();
+        };
+    }, [ref]);
+
+    return isOverflowing;
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -87,6 +87,17 @@ export { SelectField, SelectFieldProps } from "./form/fields/SelectField";
 export { SwitchField, SwitchFieldProps } from "./form/fields/SwitchField";
 export { TextAreaField, TextAreaFieldProps } from "./form/fields/TextAreaField";
 export { TextField, TextFieldProps } from "./form/fields/TextField";
+export { FileDropzone, FileDropzoneClassKey, FileDropzoneProps } from "./form/file/FileDropzone";
+export {
+    FileSelect,
+    FileSelectClassKey,
+    FileSelectErrorFileValue,
+    FileSelectFileValue,
+    FileSelectLoadingFileValue,
+    FileSelectProps,
+    FileSelectSuccessfulFileValue,
+} from "./form/file/FileSelect";
+export { FileSelectListItem, FileSelectListItemClassKey, FileSelectListItemProps } from "./form/file/FileSelectListItem";
 export { FinalFormAsyncAutocomplete, FinalFormAsyncAutocompleteProps } from "./form/FinalFormAsyncAutocomplete";
 export { FinalFormAsyncSelect, FinalFormAsyncSelectProps } from "./form/FinalFormAsyncSelect";
 export { FinalFormContext, FinalFormContextProvider, FinalFormContextProviderProps, useFinalFormContext } from "./form/FinalFormContextProvider";

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -88,15 +88,8 @@ export { SwitchField, SwitchFieldProps } from "./form/fields/SwitchField";
 export { TextAreaField, TextAreaFieldProps } from "./form/fields/TextAreaField";
 export { TextField, TextFieldProps } from "./form/fields/TextField";
 export { FileDropzone, FileDropzoneClassKey, FileDropzoneProps } from "./form/file/FileDropzone";
-export {
-    FileSelect,
-    FileSelectClassKey,
-    FileSelectErrorFileValue,
-    FileSelectFileValue,
-    FileSelectLoadingFileValue,
-    FileSelectProps,
-    FileSelectSuccessfulFileValue,
-} from "./form/file/FileSelect";
+export { FileSelect, FileSelectClassKey, FileSelectProps } from "./form/file/FileSelect";
+export { ErrorFileSelectItem, FileSelectItem, LoadingFileSelectItem, ValidFileSelectItem } from "./form/file/fileSelectItemTypes";
 export { FileSelectListItem, FileSelectListItemClassKey, FileSelectListItemProps } from "./form/file/FileSelectListItem";
 export { FinalFormAsyncAutocomplete, FinalFormAsyncAutocompleteProps } from "./form/FinalFormAsyncAutocomplete";
 export { FinalFormAsyncSelect, FinalFormAsyncSelectProps } from "./form/FinalFormAsyncSelect";

--- a/storybook/src/admin/form/FinalFormFileSelect.tsx
+++ b/storybook/src/admin/form/FinalFormFileSelect.tsx
@@ -64,4 +64,4 @@ function Story() {
     );
 }
 
-storiesOf("@comet/admin/form", module).add("FileSelect", () => <Story />);
+storiesOf("@comet/admin/form", module).add("FinalFormFileSelect", () => <Story />);

--- a/storybook/src/admin/form/file/FileDropzone.tsx
+++ b/storybook/src/admin/form/file/FileDropzone.tsx
@@ -1,0 +1,39 @@
+import { FileDropzone, FileDropzoneProps } from "@comet/admin";
+import { Card, CardContent, Stack } from "@mui/material";
+import { boolean } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+type FileRejections = Parameters<Required<FileDropzoneProps>["onDropRejected"]>[0];
+
+storiesOf("@comet/admin/form/File", module)
+    .addDecorator((story) => (
+        <Card sx={{ maxWidth: 440 }}>
+            <CardContent>
+                <Stack spacing={4}>{story()}</Stack>
+            </CardContent>
+        </Card>
+    ))
+    .add("FileDropzone", () => {
+        const [files, setFiles] = React.useState<File[]>([]);
+        const [rejectedFiles, setRejectedFiles] = React.useState<FileRejections>([]);
+
+        return (
+            <>
+                <FileDropzone
+                    disabled={boolean("Disabled", false)}
+                    multiple={boolean("Multiple", false)}
+                    hasError={boolean("Has Error", false)}
+                    onDrop={(files) => {
+                        setFiles(files);
+                        setRejectedFiles([]);
+                    }}
+                    onDropRejected={(rejectedFiles) => {
+                        setFiles([]);
+                        setRejectedFiles(rejectedFiles);
+                    }}
+                />
+                <pre>{JSON.stringify({ files, rejectedFiles }, null, 2)}</pre>
+            </>
+        );
+    });

--- a/storybook/src/admin/form/file/FileSelect.tsx
+++ b/storybook/src/admin/form/file/FileSelect.tsx
@@ -1,4 +1,4 @@
-import { FileSelect, FileSelectFileValue } from "@comet/admin";
+import { FileSelect, FileSelectItem } from "@comet/admin";
 import { Card, CardContent, Grid, Typography } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import React from "react";
@@ -7,7 +7,7 @@ type StoryProps = {
     hasExistingFiles?: boolean;
 };
 
-const dummyFiles: FileSelectFileValue[] = [
+const dummyFiles: FileSelectItem[] = [
     { name: "lorem ipsum.png", size: 3e5 },
     {
         name: "This is a file with a really long name to test truncating in the file list.jpeg",
@@ -24,7 +24,7 @@ const dummyFileDownload = (file: any) => {
 };
 
 const SingleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
-    const [file, setFile] = React.useState<FileSelectFileValue | undefined>(hasExistingFiles ? dummyFiles[0] : undefined);
+    const [file, setFile] = React.useState<FileSelectItem | undefined>(hasExistingFiles ? dummyFiles[0] : undefined);
     const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
 
     return (
@@ -62,7 +62,7 @@ const SingleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
                     onDownload={dummyFileDownload}
                     maxFiles={1}
                     maxFileSize={1024 * 1024 * 5} // 5 MB
-                    value={file ? [file] : []}
+                    files={file ? [file] : []}
                     error={tooManyFilesSelected ? "Selection was canceled. You can only select one file." : undefined}
                 />
             </CardContent>
@@ -71,7 +71,7 @@ const SingleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
 };
 
 const MultipleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
-    const [files, setFiles] = React.useState<FileSelectFileValue[]>(hasExistingFiles ? dummyFiles : []);
+    const [files, setFiles] = React.useState<FileSelectItem[]>(hasExistingFiles ? dummyFiles : []);
     const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
     const maxNumberOfFiles = 4;
 
@@ -107,7 +107,7 @@ const MultipleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
                     }}
                     onRemove={(fileToRemove) => setFiles(files.filter((file) => file.name !== fileToRemove.name))}
                     onDownload={dummyFileDownload}
-                    value={files}
+                    files={files}
                     maxFiles={maxNumberOfFiles}
                     maxFileSize={1024 * 1024 * 5} // 5 MB
                     error={

--- a/storybook/src/admin/form/file/FileSelect.tsx
+++ b/storybook/src/admin/form/file/FileSelect.tsx
@@ -7,7 +7,7 @@ type StoryProps = {
     hasExistingFiles?: boolean;
 };
 
-const dummyFiles = [
+const dummyFiles: FileSelectFileValue[] = [
     { name: "lorem ipsum.png", size: 3e5 },
     {
         name: "This is a file with a really long name to test truncating in the file list.jpeg",

--- a/storybook/src/admin/form/file/FileSelect.tsx
+++ b/storybook/src/admin/form/file/FileSelect.tsx
@@ -1,0 +1,142 @@
+import { FileSelect, FileSelectFileValue } from "@comet/admin";
+import { Card, CardContent, Grid, Typography } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+type StoryProps = {
+    hasExistingFiles?: boolean;
+};
+
+const dummyFiles = [
+    { name: "lorem ipsum.png", size: 3e5 },
+    {
+        name: "This is a file with a really long name to test truncating in the file list.jpeg",
+        size: 6e6,
+    },
+    {
+        name: "failed.png",
+        error: true,
+    },
+];
+
+const dummyFileDownload = (file: any) => {
+    alert(`Pretend "${file.name}" was just downloaded.`);
+};
+
+const SingleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
+    const [file, setFile] = React.useState<FileSelectFileValue | undefined>(hasExistingFiles ? dummyFiles[0] : undefined);
+    const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
+
+    return (
+        <Card variant="outlined">
+            <CardContent>
+                <Typography variant="h6" gutterBottom>
+                    Single File Select
+                </Typography>
+                <FileSelect
+                    onDrop={(acceptedFiles, rejectedFiles) => {
+                        const tooManyFilesWereDropped = rejectedFiles.some((rejection) =>
+                            rejection.errors.some((error) => error.code === "too-many-files"),
+                        );
+
+                        setTooManyFilesSelected(tooManyFilesWereDropped);
+
+                        if (!tooManyFilesWereDropped) {
+                            if (acceptedFiles.length > 0) {
+                                setFile({
+                                    name: acceptedFiles[0].name,
+                                    size: acceptedFiles[0].size,
+                                });
+                            }
+                            if (rejectedFiles.length > 0) {
+                                setFile({
+                                    name: rejectedFiles[0].file.name,
+                                    error: true,
+                                });
+                            }
+                        }
+                    }}
+                    onRemove={() => {
+                        setFile(undefined);
+                    }}
+                    onDownload={dummyFileDownload}
+                    maxFiles={1}
+                    value={file ? [file] : []}
+                    error={tooManyFilesSelected ? "Selection was canceled. You can only select one file." : undefined}
+                />
+            </CardContent>
+        </Card>
+    );
+};
+
+const MultipleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
+    const [files, setFiles] = React.useState<FileSelectFileValue[]>(hasExistingFiles ? dummyFiles : []);
+    const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
+    const maxNumberOfFiles = 4;
+
+    return (
+        <Card variant="outlined">
+            <CardContent>
+                <Typography variant="h6" gutterBottom>
+                    Multiple File Select
+                </Typography>
+                <FileSelect
+                    onDrop={(acceptedFiles, rejectedFiles) => {
+                        const tooManyFilesWereDropped = rejectedFiles.some((rejection) =>
+                            rejection.errors.some((error) => error.code === "too-many-files"),
+                        );
+
+                        setTooManyFilesSelected(tooManyFilesWereDropped);
+
+                        if (!tooManyFilesWereDropped) {
+                            setFiles((existingFiles) => {
+                                return [
+                                    ...existingFiles,
+                                    ...acceptedFiles.map((file) => ({
+                                        name: file.name,
+                                        size: file.size,
+                                    })),
+                                    ...rejectedFiles.map((file) => ({
+                                        name: file.file.name,
+                                        error: true,
+                                    })),
+                                ];
+                            });
+                        }
+                    }}
+                    onRemove={(fileToRemove) => setFiles(files.filter((file) => file.name !== fileToRemove.name))}
+                    onDownload={dummyFileDownload}
+                    value={files}
+                    maxFiles={maxNumberOfFiles}
+                    maxFileSize={50 * 1024 * 1024} // 50 MB
+                    error={
+                        tooManyFilesSelected
+                            ? `Selection was canceled. You can only select a maximum of ${maxNumberOfFiles} files, please reduce your selection.`
+                            : undefined
+                    }
+                />
+            </CardContent>
+        </Card>
+    );
+};
+
+storiesOf("@comet/admin/form/File", module).add("File Select", () => {
+    return (
+        <div>
+            <Grid container spacing={4}>
+                <Grid item xs={6}>
+                    <SingleFileSelectStory />
+                </Grid>
+                <Grid item xs={6}>
+                    <MultipleFileSelectStory />
+                </Grid>
+                <Grid item xs={6}>
+                    <SingleFileSelectStory hasExistingFiles />
+                </Grid>
+                <Grid item xs={6}>
+                    <MultipleFileSelectStory hasExistingFiles />
+                </Grid>
+            </Grid>
+        </div>
+    );
+});

--- a/storybook/src/admin/form/file/FileSelect.tsx
+++ b/storybook/src/admin/form/file/FileSelect.tsx
@@ -61,6 +61,7 @@ const SingleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
                     }}
                     onDownload={dummyFileDownload}
                     maxFiles={1}
+                    maxFileSize={1024 * 1024 * 5} // 5 MB
                     value={file ? [file] : []}
                     error={tooManyFilesSelected ? "Selection was canceled. You can only select one file." : undefined}
                 />
@@ -108,7 +109,7 @@ const MultipleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
                     onDownload={dummyFileDownload}
                     value={files}
                     maxFiles={maxNumberOfFiles}
-                    maxFileSize={50 * 1024 * 1024} // 50 MB
+                    maxFileSize={1024 * 1024 * 5} // 5 MB
                     error={
                         tooManyFilesSelected
                             ? `Selection was canceled. You can only select a maximum of ${maxNumberOfFiles} files, please reduce your selection.`

--- a/storybook/src/admin/form/file/FileSelectListItem.tsx
+++ b/storybook/src/admin/form/file/FileSelectListItem.tsx
@@ -1,0 +1,93 @@
+import { FileSelectListItem } from "@comet/admin";
+import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
+import { boolean, text } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+storiesOf("@comet/admin/form/File", module)
+    .addDecorator((story) => (
+        <Card sx={{ maxWidth: 440 }}>
+            <CardContent>
+                <Stack spacing={4}>{story()}</Stack>
+            </CardContent>
+        </Card>
+    ))
+    .add("FileSelectListItem", () => {
+        const fileName = text("File Name", "Filename.xyz");
+        const hasFileSize = boolean("Has File Size", true);
+        const canBeDownloaded = boolean("Can Be Downloaded", true);
+        const canBeDeleted = boolean("Can Be Deleted", true);
+
+        const disabled = boolean("Disabled", false);
+        const loading = boolean("Loading", false);
+        const skeleton = boolean("Skeleton", false);
+
+        const hasError = boolean("Has Error", false);
+        const errorMessage = text("Error Message", "");
+        const error = errorMessage ? errorMessage : hasError;
+
+        return (
+            <FileSelectListItem
+                name={fileName}
+                size={hasFileSize ? 1.8 * 1024 * 1024 : undefined}
+                onClickDownload={canBeDownloaded ? () => alert("Download") : undefined}
+                onClickDelete={canBeDeleted ? () => alert("Delete") : undefined}
+                disabled={disabled}
+                loading={loading}
+                skeleton={skeleton}
+                error={error}
+            />
+        );
+    })
+    .add("FileSelectListItem (multiple variants)", () => {
+        return (
+            <>
+                <ExampleWrapper title="File item">
+                    <FileSelectListItem
+                        name="Filename.xyz"
+                        size={1.8 * 1024 * 1024}
+                        onClickDownload={() => alert("Download")}
+                        onClickDelete={() => alert("Delete")}
+                    />
+                </ExampleWrapper>
+                <ExampleWrapper title="Long file name">
+                    <FileSelectListItem
+                        name="This is a really long file name that should cause the text to be truncated and show a tooltip.png"
+                        size={1.8 * 1024 * 1024}
+                        onClickDownload={() => alert("Download")}
+                        onClickDelete={() => alert("Delete")}
+                    />
+                </ExampleWrapper>
+                <ExampleWrapper title="Loading">
+                    <FileSelectListItem name="Filename.xyz" loading />
+                </ExampleWrapper>
+                <ExampleWrapper title="Error (no details)">
+                    <FileSelectListItem name="Filename.xyz" error onClickDelete={() => alert("Delete")} />
+                </ExampleWrapper>
+                <ExampleWrapper title="Error (with details)">
+                    <FileSelectListItem name="Filename.xyz" error="File too large" onClickDelete={() => alert("Delete")} />
+                </ExampleWrapper>
+                <ExampleWrapper title="Disabled">
+                    <FileSelectListItem name="Filename.xyz" size={1.8 * 1024 * 1024} onClickDownload={() => alert("Download")} disabled />
+                </ExampleWrapper>
+                <ExampleWrapper title="Skeleton">
+                    <FileSelectListItem skeleton />
+                </ExampleWrapper>
+            </>
+        );
+    });
+
+type ExampleWrapperProps = React.PropsWithChildren<{
+    title: string;
+}>;
+
+const ExampleWrapper = ({ children, title }: ExampleWrapperProps) => {
+    return (
+        <Box>
+            <Typography gutterBottom variant="body2" fontWeight={700} mb={1}>
+                {title}
+            </Typography>
+            {children}
+        </Box>
+    );
+};

--- a/storybook/src/admin/form/file/FileSelectListItem.tsx
+++ b/storybook/src/admin/form/file/FileSelectListItem.tsx
@@ -1,6 +1,6 @@
-import { FileSelectListItem } from "@comet/admin";
-import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
-import { boolean, text } from "@storybook/addon-knobs";
+import { FileSelectItem, FileSelectListItem } from "@comet/admin";
+import { Card, CardContent, Stack } from "@mui/material";
+import { boolean, select } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
@@ -13,81 +13,31 @@ storiesOf("@comet/admin/form/File", module)
         </Card>
     ))
     .add("FileSelectListItem", () => {
-        const fileName = text("File Name", "Filename.xyz");
-        const hasFileSize = boolean("Has File Size", true);
+        const fileSize = 1.8 * 1024 * 1024; // 1.8 MB
+
+        const fileItems: Record<string, FileSelectItem> = {
+            "Valid File": { name: "Filename.xyz", size: fileSize },
+            "Long File Name": {
+                name: "This is a really long file name that should cause the text to be truncated and show a tooltip.png",
+                size: fileSize,
+            },
+            Loading: { name: "Filename.xyz", loading: true },
+            "Error (no details)": { name: "Filename.xyz", error: true },
+            "Error (with details)": { name: "Filename.xyz", error: "File too large" },
+            Skeleton: { loading: true },
+        };
+
+        const selectedFile = select("File Item", fileItems, fileItems["Valid File"]);
         const canBeDownloaded = boolean("Can Be Downloaded", true);
         const canBeDeleted = boolean("Can Be Deleted", true);
-
         const disabled = boolean("Disabled", false);
-        const loading = boolean("Loading", false);
-        const skeleton = boolean("Skeleton", false);
-
-        const hasError = boolean("Has Error", false);
-        const errorMessage = text("Error Message", "");
-        const error = errorMessage ? errorMessage : hasError;
 
         return (
             <FileSelectListItem
-                name={fileName}
-                size={hasFileSize ? 1.8 * 1024 * 1024 : undefined}
+                file={selectedFile}
                 onClickDownload={canBeDownloaded ? () => alert("Download") : undefined}
                 onClickDelete={canBeDeleted ? () => alert("Delete") : undefined}
                 disabled={disabled}
-                loading={loading}
-                skeleton={skeleton}
-                error={error}
             />
         );
-    })
-    .add("FileSelectListItem (multiple variants)", () => {
-        return (
-            <>
-                <ExampleWrapper title="File item">
-                    <FileSelectListItem
-                        name="Filename.xyz"
-                        size={1.8 * 1024 * 1024}
-                        onClickDownload={() => alert("Download")}
-                        onClickDelete={() => alert("Delete")}
-                    />
-                </ExampleWrapper>
-                <ExampleWrapper title="Long file name">
-                    <FileSelectListItem
-                        name="This is a really long file name that should cause the text to be truncated and show a tooltip.png"
-                        size={1.8 * 1024 * 1024}
-                        onClickDownload={() => alert("Download")}
-                        onClickDelete={() => alert("Delete")}
-                    />
-                </ExampleWrapper>
-                <ExampleWrapper title="Loading">
-                    <FileSelectListItem name="Filename.xyz" loading />
-                </ExampleWrapper>
-                <ExampleWrapper title="Error (no details)">
-                    <FileSelectListItem name="Filename.xyz" error onClickDelete={() => alert("Delete")} />
-                </ExampleWrapper>
-                <ExampleWrapper title="Error (with details)">
-                    <FileSelectListItem name="Filename.xyz" error="File too large" onClickDelete={() => alert("Delete")} />
-                </ExampleWrapper>
-                <ExampleWrapper title="Disabled">
-                    <FileSelectListItem name="Filename.xyz" size={1.8 * 1024 * 1024} onClickDownload={() => alert("Download")} disabled />
-                </ExampleWrapper>
-                <ExampleWrapper title="Skeleton">
-                    <FileSelectListItem skeleton />
-                </ExampleWrapper>
-            </>
-        );
     });
-
-type ExampleWrapperProps = React.PropsWithChildren<{
-    title: string;
-}>;
-
-const ExampleWrapper = ({ children, title }: ExampleWrapperProps) => {
-    return (
-        <Box>
-            <Typography gutterBottom variant="body2" fontWeight={700} mb={1}>
-                {title}
-            </Typography>
-            {children}
-        </Box>
-    );
-};

--- a/storybook/src/docs/components/FileDropzone/FileDropzone.stories.mdx
+++ b/storybook/src/docs/components/FileDropzone/FileDropzone.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Canvas, Story } from "@storybook/addon-docs";
 
 # FileDropzone
 
-A ready to use wrapper around [react-dropzone](https://www.npmjs.com/package/react-dropzone) that manages error and disabled states.
+A wrapper around [react-dropzone](https://www.npmjs.com/package/react-dropzone) that manages error and disabled states.
 
 ## Usage
 

--- a/storybook/src/docs/components/FileDropzone/FileDropzone.stories.mdx
+++ b/storybook/src/docs/components/FileDropzone/FileDropzone.stories.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
+
+<Meta title="Docs/Components/FileDropzone" />
+
+# FileDropzone
+
+A ready to use wrapper around [react-dropzone](https://www.npmjs.com/package/react-dropzone) that manages error and disabled states.
+
+## Usage
+
+-   Use the `onDrop` prop to handle what happens when files are dropped.
+-   Use the `disabled` and `hasError` props to manage the disabled and error states.
+-   Use the `hideDroppableArea` and `hideButton` props to hide the droppable area and button, respectively.
+
+<Canvas>
+    <Story id="stories-components-filedropzone--default" />
+</Canvas>
+
+### Example of disabled and error states
+
+<Canvas>
+    <Story id="stories-components-filedropzone--disabled-and-error-states" />
+</Canvas>

--- a/storybook/src/docs/components/FileDropzone/FileDropzone.stories.tsx
+++ b/storybook/src/docs/components/FileDropzone/FileDropzone.stories.tsx
@@ -1,0 +1,42 @@
+import { FileDropzone } from "@comet/admin";
+import { Card, CardContent, Stack } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+storiesOf("stories/components/FileDropzone", module)
+    .addDecorator((story) => (
+        <Card>
+            <CardContent>
+                <Stack gap={4} direction="row">
+                    {story()}
+                </Stack>
+            </CardContent>
+        </Card>
+    ))
+    .add("Default", () => {
+        return (
+            <FileDropzone
+                onDrop={(acceptedFiles, fileRejections) => {
+                    // Handle what happens with the dropped files
+                }}
+            />
+        );
+    })
+    .add("Disabled and error states", () => {
+        return (
+            <>
+                <FileDropzone
+                    disabled
+                    onDrop={(acceptedFiles, fileRejections) => {
+                        // Handle what happens with the dropped files
+                    }}
+                />
+                <FileDropzone
+                    hasError
+                    onDrop={(acceptedFiles, fileRejections) => {
+                        // Handle what happens with the dropped files
+                    }}
+                />
+            </>
+        );
+    });

--- a/storybook/src/docs/components/FileSelect/FileSelect.stories.mdx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.stories.mdx
@@ -1,0 +1,18 @@
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
+
+<Meta title="Docs/Components/FileSelect" />
+
+# FileSelect
+
+Used to combine `FileDropzone` and `FileSelectListItem` to handle the user's selection of files, displaying those files below, and handling the download and remove actions.
+
+## Usage
+
+-   Use props from [react-dropzone](https://www.npmjs.com/package/react-dropzone), such as `onDrop`, to handle what happens when selecting files.
+-   Use the `value` prop to pass in the list of files that should be shown.
+-   Use the `onDownload` and `onRemove` props to handle what happens when clicking the download and remove buttons.
+-   Limit the amount of files and the size of the individual files with the `maxFiles` and `maxFileSize` props.
+
+<Canvas>
+    <Story id="stories-components-fileselect--fileselect" />
+</Canvas>

--- a/storybook/src/docs/components/FileSelect/FileSelect.stories.mdx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Canvas, Story } from "@storybook/addon-docs";
+import { components } from "@storybook/components";
 
 <Meta title="Docs/Components/FileSelect" />
 
@@ -9,7 +10,7 @@ Used to combine `FileDropzone` and `FileSelectListItem` to handle the user's sel
 ## Usage
 
 -   Use props from [react-dropzone](https://www.npmjs.com/package/react-dropzone), such as `onDrop`, to handle what happens when selecting files.
--   Use the `value` prop to pass in the list of files that should be shown.
+-   Use the `files` prop to pass in the list of files that should be shown.
 -   Use the `onDownload` and `onRemove` props to handle what happens when clicking the download and remove buttons.
 -   Limit the amount of files and the size of the individual files with the `maxFiles` and `maxFileSize` props.
 

--- a/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
@@ -1,0 +1,49 @@
+import { FileSelect, FileSelectFileValue } from "@comet/admin";
+import { Card, CardContent } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+storiesOf("stories/components/FileSelect", module)
+    .addDecorator((story) => (
+        <Card>
+            <CardContent>{story()}</CardContent>
+        </Card>
+    ))
+    .add("FileSelect", () => {
+        const value: FileSelectFileValue[] = [
+            {
+                name: "Filename.xyz",
+                size: 4.3 * 1024 * 1024, // 4.3 MB
+            },
+            {
+                name: "Another file.png",
+                size: 568 * 1024, // 568 KB
+            },
+            {
+                name: "File that is uploading.jpg",
+                loading: true,
+            },
+            {
+                name: "Failed to upload.png",
+                size: 200 * 1024 * 1024, // 200 MB
+                error: "The file is too large",
+            },
+        ];
+
+        return (
+            <FileSelect
+                onDrop={(acceptedFiles, fileRejections) => {
+                    // Handle what happens with the dropped files
+                }}
+                onRemove={(file) => {
+                    // Handle remove
+                }}
+                onDownload={(file) => {
+                    // Handle download
+                }}
+                value={value}
+                maxFileSize={10 * 1024 * 1024} // 10 MB
+                maxFiles={5}
+            />
+        );
+    });

--- a/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
@@ -1,4 +1,4 @@
-import { FileSelect, FileSelectFileValue } from "@comet/admin";
+import { FileSelect, FileSelectItem } from "@comet/admin";
 import { Card, CardContent } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
@@ -10,7 +10,7 @@ storiesOf("stories/components/FileSelect", module)
         </Card>
     ))
     .add("FileSelect", () => {
-        const value: FileSelectFileValue[] = [
+        const value: FileSelectItem[] = [
             {
                 name: "Filename.xyz",
                 size: 4.3 * 1024 * 1024, // 4.3 MB
@@ -41,7 +41,7 @@ storiesOf("stories/components/FileSelect", module)
                 onDownload={(file) => {
                     // Handle download
                 }}
-                value={value}
+                files={value}
                 maxFileSize={10 * 1024 * 1024} // 10 MB
                 maxFiles={5}
             />

--- a/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.mdx
+++ b/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
+
+<Meta title="Docs/Components/FileSelectListItem" />
+
+# FileSelectListItem
+
+Used to display a list of files, including loading, skeleton, and error states and options to download and delete the file.
+
+## Usage
+
+-   Use the `skeleton` prop if you do not have any data for the file.
+-   Use the `loading` prop if the file's data is being fetched or uploaded, but the filename is already available.
+-   Use the `name` and `size` props to display the file name and size.
+-   Use the `onDownload` and `onDelete` props to handle what happens when clicking the download and delete buttons.
+-   Use the `error` prop as a boolean to set the error state or as a string to display an error message.
+
+<Canvas>
+    <Story id="stories-components-fileselectlistitem--fileselectlistitem" />
+</Canvas>

--- a/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.mdx
+++ b/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.mdx
@@ -8,11 +8,12 @@ Used to display a list of files, including loading, skeleton, and error states a
 
 ## Usage
 
--   Use the `skeleton` prop if you do not have any data for the file.
--   Use the `loading` prop if the file's data is being fetched or uploaded, but the filename is already available.
--   Use the `name` and `size` props to display the file name and size.
+-   Pass a `file` prop to display the file.
+    -   The file will be rendered normally if `name` and optionally `size` are provided.
+    -   If the `loading` value is `true` and `name` is provided, the file will be rendered in a loading state.
+    -   If the `loading` value is `true` and no `name` is provided, the file will be rendered as a skeleton.
+    -   The file will be rendered in an error state if the `error` value is `true` or a string with an error message is provided.
 -   Use the `onDownload` and `onDelete` props to handle what happens when clicking the download and delete buttons.
--   Use the `error` prop as a boolean to set the error state or as a string to display an error message.
 
 <Canvas>
     <Story id="stories-components-fileselectlistitem--fileselectlistitem" />

--- a/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.tsx
+++ b/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.tsx
@@ -12,13 +12,19 @@ storiesOf("stories/components/FileSelectListItem", module)
     .add("FileSelectListItem", () => {
         return (
             <>
-                {/* Data (e.g. the name) for this file has not been loaded yet */}
-                <FileSelectListItem skeleton />
+                {/* Data for this file has not been loaded yet */}
+                <FileSelectListItem
+                    file={{
+                        loading: true,
+                    }}
+                />
 
                 {/* All data is available and the file can be downloaded and deleted */}
                 <FileSelectListItem
-                    name="Filename.xyz"
-                    size={4.3 * 1024 * 1024} // 4.3 MB
+                    file={{
+                        name: "Filename.xyz",
+                        size: 4.3 * 1024 * 1024, // 4.3 MB
+                    }}
                     onClickDownload={() => {
                         // Handle download
                     }}
@@ -28,19 +34,31 @@ storiesOf("stories/components/FileSelectListItem", module)
                 />
 
                 {/* The file name is available but the remaining data is still loading or the file is currently being uploaded */}
-                <FileSelectListItem name="File that is uploading.jpg" loading />
+                <FileSelectListItem
+                    file={{
+                        name: "File that is uploading.jpg",
+                        loading: true,
+                    }}
+                />
 
                 {/* Something went wrong, it's not clear what */}
-                <FileSelectListItem name="Unknown error.jpg" error />
+                <FileSelectListItem
+                    file={{
+                        name: "Filename.xyz",
+                        error: true,
+                    }}
+                />
 
                 {/* A specific error ocurred, so the user can see an error message */}
                 <FileSelectListItem
-                    name="Upload failed.png"
-                    size={200 * 1024 * 1024} // 200 MB
+                    file={{
+                        name: "Filename.xyz",
+                        size: 200 * 1024 * 1024, // 200 MB
+                        error: "File too large",
+                    }}
                     onClickDelete={() => {
                         // Handle delete
                     }}
-                    error="File size too large"
                 />
             </>
         );

--- a/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.tsx
+++ b/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.tsx
@@ -1,0 +1,47 @@
+import { FileSelectListItem } from "@comet/admin";
+import { Card, CardContent } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+storiesOf("stories/components/FileSelectListItem", module)
+    .addDecorator((story) => (
+        <Card>
+            <CardContent>{story()}</CardContent>
+        </Card>
+    ))
+    .add("FileSelectListItem", () => {
+        return (
+            <>
+                {/* Data (e.g. the name) for this file has not been loaded yet */}
+                <FileSelectListItem skeleton />
+
+                {/* All data is available and the file can be downloaded and deleted */}
+                <FileSelectListItem
+                    name="Filename.xyz"
+                    size={4.3 * 1024 * 1024} // 4.3 MB
+                    onClickDownload={() => {
+                        // Handle download
+                    }}
+                    onClickDelete={() => {
+                        // Handle delete
+                    }}
+                />
+
+                {/* The file name is available but the remaining data is still loading or the file is currently being uploaded */}
+                <FileSelectListItem name="File that is uploading.jpg" loading />
+
+                {/* Something went wrong, it's not clear what */}
+                <FileSelectListItem name="Unknown error.jpg" error />
+
+                {/* A specific error ocurred, so the user can see an error message */}
+                <FileSelectListItem
+                    name="Upload failed.png"
+                    size={200 * 1024 * 1024} // 200 MB
+                    onClickDelete={() => {
+                        // Handle delete
+                    }}
+                    error="File size too large"
+                />
+            </>
+        );
+    });


### PR DESCRIPTION
`FinalFormFileSelect` explicitly writes the dropzone file into the form values, which makes it difficult to save or retrieve a reference to the file. 

`FileSelect` is a UI-only component that wraps `react-dropzone` and shows a list of selected files. 
For added flexibility, handling the selected files is done independently, e.g., in a `FinalForm` wrapper component. 

The styles have also been updated to reflect some changes in the design and more accurately represent different states, such as `disabled`, `focus`, `hover`, `error`, and `loading`. 

### Adds the `FileDropzone` component

Used to select files using a "Select" button or drag-and-drop.
Basically, it's a wrapper for `react-dropzone` that incorporates styling and manages `error` and `disabled` states.
_Can be used independently of `FileSelect`._ 

### Adds the `FileSelectListItem` component

Used to display a list of files. 
Includes loading/skeleton states and options to download and delete the file. 
_Can be used independently of `FileSelect`._ 

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Add docs
    - [FileSelect](https://deploy-preview-2178--comet-admin.netlify.app/?path=/story/docs-components-fileselect--page)
    - [FileDropzone](https://deploy-preview-2178--comet-admin.netlify.app/?path=/story/docs-components-filedropzone--page)
    - [FileSelectListItem](https://deploy-preview-2178--comet-admin.netlify.app/?path=/story/docs-components-fileselectlistitem--page)
-   [x] Link to the respective task if one exists: COM-800
-   [x] Provide screenshots/screencasts if the change contains visual changes


<details>
    <summary><h3>FileSelect Screenshots</h3></summary>

### No file selected

<img width="437" alt="File select with no files selected" src="https://github.com/vivid-planet/comet/assets/6264317/52312922-7aca-4163-adfd-56e2e97a6360">

### Files selected (with error) 

<img width="437" alt="File select with multiple files selected and one error" src="https://github.com/vivid-planet/comet/assets/6264317/e00f3208-3642-41f8-b1bf-cc2f5c9cb538">

### Max number of files selected

<img width="437" alt="File select with max number of files selected" src="https://github.com/vivid-planet/comet/assets/6264317/ae1d5b9a-c3c1-4ea4-9edb-bc8898bbc9df">
</details>