### PR TITLE
Deprecate `FinalFormFileSelect`

### DIFF
--- a/packages/admin/admin/src/form/FinalFormFileSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormFileSelect.tsx
@@ -12,6 +12,9 @@ import { createComponentSlot } from "../helpers/createComponentSlot";
 import { PrettyBytes } from "../helpers/PrettyBytes";
 import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
+/**
+ * @deprecated use `FileSelect` instead, if necessary by adding a final-form wrapper.
+ */
 export type FinalFormFileSelectClassKey =
     | "root"
     | "dropzone"
@@ -205,6 +208,9 @@ const SelectButton = createComponentSlot(Button)<FinalFormFileSelectClassKey>({
     `,
 );
 
+/**
+ * @deprecated use `FileSelect` instead, if necessary by adding a final-form wrapper.
+ */
 export interface FinalFormFileSelectProps
     extends FieldRenderProps<File | File[], HTMLInputElement>,
         ThemedComponentBaseProps<{
@@ -233,6 +239,9 @@ export interface FinalFormFileSelectProps
     };
 }
 
+/**
+ * @deprecated use `FileSelect` instead, if necessary by adding a final-form wrapper.
+ */
 export function FinalFormFileSelect(inProps: FinalFormFileSelectProps) {
     const {
         slotProps,


### PR DESCRIPTION
The component explicitly writes the dropzone file into the form values, which makes it difficult to save or retrieve a reference to the file.

If there ever is a use-case for this, `FileSelect` (from #2178) can be used with a custom final-form wrapper.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-800