### PR TITLE
Fix styling of `MuiAutocomplete-endAdornment`

### DIFF
--- a/.changeset/silver-cooks-hear.md
+++ b/.changeset/silver-cooks-hear.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": patch
+---
+
+Fix top position of end-adornment in MuiAutocomplete

--- a/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
@@ -17,6 +17,7 @@ export const getMuiAutocomplete: GetMuiComponentTheme<"MuiAutocomplete"> = (comp
             bottom: 0,
             right: spacing(2),
             display: "flex",
+            transform: "none",
         },
         hasPopupIcon: {
             [`&.${autocompleteClasses.root} .${autocompleteClasses.inputRoot}`]: {


### PR DESCRIPTION
Required due to change in MUI: https://github.com/mui/material-ui/pull/41066

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Provide screenshots/screencasts if the change contains visual changes

| Previously | Now |
| ---------- | --- |
| <img width="325" alt="AutoComplete Pre-Fix" src="https://github.com/vivid-planet/comet/assets/6264317/cf82e31f-bbba-4c12-a95e-7961d75c6966"> | <img width="325" alt="AutoComplete Fixed" src="https://github.com/vivid-planet/comet/assets/6264317/d8761193-4b9f-43b2-a531-04d7f821f2ba"> |




