### PR TITLE
Refactor: Replace graphql-type-json with graphql-scalars

### DIFF
--- a/.changeset/small-eggs-learn.md
+++ b/.changeset/small-eggs-learn.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": major
+---
+
+Replace graphql-type-json with graphql-scalars

--- a/.changeset/small-eggs-learn.md
+++ b/.changeset/small-eggs-learn.md
@@ -13,3 +13,4 @@ API Generator: Replace graphql-type-json with graphql-scalars for JSON columns
    ```diff
    - import { GraphQLJSONObject } from "graphql-type-json";
    + import { GraphQLJSONObject } from "graphql-scalars";
+   ```

--- a/.changeset/small-eggs-learn.md
+++ b/.changeset/small-eggs-learn.md
@@ -2,4 +2,14 @@
 "@comet/cms-api": major
 ---
 
-Replace graphql-type-json with graphql-scalars
+API Generator: Replace graphql-type-json with graphql-scalars for JSON columns
+
+**Upgrading**
+
+1. Install graphql-scalars: `npm install graphql-scalars`
+2. Uninstall graphql-type-json: `npm install graphql-type-json`
+3. Update imports:
+
+   ```diff
+   - import { GraphQLJSONObject } from "graphql-type-json";
+   + import { GraphQLJSONObject } from "graphql-scalars";

--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -59,7 +59,6 @@
         "faker": "^5.0.0",
         "file-type": "^16.0.0",
         "graphql": "^15.0.0",
-        "graphql-scalars": "^1.23.0",
         "hasha": "^5.0.0",
         "helmet": "^4.6.0",
         "image-size": "^0.9.0",

--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -59,7 +59,7 @@
         "faker": "^5.0.0",
         "file-type": "^16.0.0",
         "graphql": "^15.0.0",
-        "graphql-type-json": "^0.3.0",
+        "graphql-scalars": "^1.23.0",
         "hasha": "^5.0.0",
         "helmet": "^4.6.0",
         "image-size": "^0.9.0",

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -55,7 +55,7 @@
         "get-image-colors": "^4.0.0",
         "got": "^11.8.0",
         "graphql-parse-resolve-info": "^4.13.0",
-        "graphql-type-json": "^0.3.2",
+        "graphql-scalars": "^1.23.0",
         "hasha": "^5.2.2",
         "jsonwebtoken": "^8.5.1",
         "jszip": "^3.10.1",

--- a/packages/api/cms-api/src/auth/resolver/auth.resolver.ts
+++ b/packages/api/cms-api/src/auth/resolver/auth.resolver.ts
@@ -1,6 +1,6 @@
 import { Inject, Type } from "@nestjs/common";
 import { Args, Context, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 import { IncomingMessage } from "http";
 
 import { SkipBuild } from "../../builds/skip-build.decorator";

--- a/packages/api/cms-api/src/blocks/rootBlocks/root-block-data.scalar.ts
+++ b/packages/api/cms-api/src/blocks/rootBlocks/root-block-data.scalar.ts
@@ -1,6 +1,6 @@
 import { Block } from "@comet/blocks-api";
 import { GraphQLScalarType } from "graphql";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 
 const rootBlockDataScalars = new Map<string, GraphQLScalarType>();
 

--- a/packages/api/cms-api/src/blocks/rootBlocks/root-block-input.scalar.ts
+++ b/packages/api/cms-api/src/blocks/rootBlocks/root-block-input.scalar.ts
@@ -1,6 +1,6 @@
 import { Block } from "@comet/blocks-api";
 import { GraphQLScalarType } from "graphql";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 
 const rootBlockInputScalars = new Map<string, GraphQLScalarType>();
 

--- a/packages/api/cms-api/src/dam/files/entities/file-image.entity.ts
+++ b/packages/api/cms-api/src/dam/files/entities/file-image.entity.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, Embedded, Entity, OneToOne, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, Int, ObjectType } from "@nestjs/graphql";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 import { v4 as uuid } from "uuid";
 
 import { ImageCropArea } from "../../images/entities/image-crop-area.entity";

--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -379,7 +379,7 @@ export async function generateCrudInput(
 import { Transform, Type } from "class-transformer";
 import { IsString, IsNotEmpty, ValidateNested, IsNumber, IsBoolean, IsDate, IsOptional, IsEnum, IsUUID, IsArray, IsInt } from "class-validator";
 import { IsSlug, RootBlockInputScalar, IsNullable, PartialType} from "@comet/cms-api";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 import { BlockInputInterface, isBlockInputInterface } from "@comet/blocks-api";
 ${generateImportsCode(imports)}
 

--- a/packages/api/cms-api/src/redirects/dto/redirect-input.factory.ts
+++ b/packages/api/cms-api/src/redirects/dto/redirect-input.factory.ts
@@ -3,7 +3,7 @@ import { Type } from "@nestjs/common";
 import { Field, InputType } from "@nestjs/graphql";
 import { Transform } from "class-transformer";
 import { IsEnum, IsOptional, ValidateNested, ValidationArguments } from "class-validator";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 
 import { RedirectGenerationType, RedirectSourceTypeValues } from "../redirects.enum";
 import { IsValidRedirectSource } from "../validators/isValidRedirectSource";

--- a/packages/api/cms-api/src/redirects/entities/redirect-entity.factory.ts
+++ b/packages/api/cms-api/src/redirects/entities/redirect-entity.factory.ts
@@ -2,7 +2,7 @@ import { Block, BlockDataInterface, RootBlock, RootBlockEntity } from "@comet/bl
 import { Embedded, Entity, Enum, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Type } from "@nestjs/common";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 import { v4 as uuid } from "uuid";
 
 import { RootBlockType } from "../../blocks/root-block-type";

--- a/packages/api/cms-api/src/user-permissions/dto/current-user.ts
+++ b/packages/api/cms-api/src/user-permissions/dto/current-user.ts
@@ -1,5 +1,5 @@
 import { Field, ObjectType } from "@nestjs/graphql";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 
 import { ContentScope } from "../interfaces/content-scope.interface";
 

--- a/packages/api/cms-api/src/user-permissions/dto/user-content-scopes.input.ts
+++ b/packages/api/cms-api/src/user-permissions/dto/user-content-scopes.input.ts
@@ -1,6 +1,6 @@
 import { Field, InputType } from "@nestjs/graphql";
 import { IsArray, IsObject } from "class-validator";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 
 import { ContentScope } from "../interfaces/content-scope.interface";
 

--- a/packages/api/cms-api/src/user-permissions/dto/user-permission.input.ts
+++ b/packages/api/cms-api/src/user-permissions/dto/user-permission.input.ts
@@ -1,6 +1,6 @@
 import { Field, ID, InputType } from "@nestjs/graphql";
 import { IsArray, IsBoolean, IsDate, IsObject, IsOptional, IsString, IsUUID } from "class-validator";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 
 import { ContentScope } from "../interfaces/content-scope.interface";
 

--- a/packages/api/cms-api/src/user-permissions/entities/user-permission.entity.ts
+++ b/packages/api/cms-api/src/user-permissions/entities/user-permission.entity.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, Entity, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType, registerEnumType } from "@nestjs/graphql";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 import { v4 } from "uuid";
 
 import { ContentScope } from "../interfaces/content-scope.interface";

--- a/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
@@ -1,7 +1,7 @@
 import { EntityRepository } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
-import { GraphQLJSONObject } from "graphql-type-json";
+import { GraphQLJSONObject } from "graphql-scalars";
 
 import { SkipBuild } from "../builds/skip-build.decorator";
 import { RequiredPermission } from "./decorators/required-permission.decorator";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,9 +486,9 @@ importers:
       graphql:
         specifier: ^15.0.0
         version: 15.8.0
-      graphql-type-json:
-        specifier: ^0.3.0
-        version: 0.3.2(graphql@15.8.0)
+      graphql-scalars:
+        specifier: ^1.23.0
+        version: 1.23.0(graphql@15.8.0)
       hasha:
         specifier: ^5.0.0
         version: 5.2.2
@@ -2163,9 +2163,9 @@ importers:
       graphql-parse-resolve-info:
         specifier: ^4.13.0
         version: 4.13.0(graphql@15.8.0)
-      graphql-type-json:
-        specifier: ^0.3.2
-        version: 0.3.2(graphql@15.8.0)
+      graphql-scalars:
+        specifier: ^1.23.0
+        version: 1.23.0(graphql@15.8.0)
       hasha:
         specifier: ^5.2.2
         version: 5.2.2
@@ -3862,7 +3862,7 @@ packages:
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@azure/abort-controller@2.1.2:
@@ -6999,7 +6999,7 @@ packages:
       cssnano-preset-advanced: 5.3.10(postcss@8.4.35)
       postcss: 8.4.35
       postcss-sort-media-queries: 4.4.1(postcss@8.4.35)
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@docusaurus/logger@2.4.1:
@@ -7007,7 +7007,7 @@ packages:
     engines: {node: '>=16.14'}
     dependencies:
       chalk: 4.1.2
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@docusaurus/mdx-loader@2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.2)(react@17.0.2):
@@ -7031,7 +7031,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       remark-emoji: 2.2.0
       stringify-object: 3.3.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       unified: 9.2.2
       unist-util-visit: 2.0.3
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
@@ -7088,7 +7088,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       reading-time: 1.5.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       unist-util-visit: 2.0.3
       utility-types: 3.10.0
       webpack: 5.88.2
@@ -7132,7 +7132,7 @@ packages:
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.5.0
+      tslib: 2.6.3
       utility-types: 3.10.0
       webpack: 5.88.2
     transitivePeerDependencies:
@@ -7168,7 +7168,7 @@ packages:
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.5.0
+      tslib: 2.6.3
       webpack: 5.88.2
     transitivePeerDependencies:
       - '@parcel/css'
@@ -7202,7 +7202,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-json-view: 1.21.3(@types/react@17.0.53)(react-dom@17.0.2)(react@17.0.2)
-      tslib: 2.5.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -7235,7 +7235,7 @@ packages:
       '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.5.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -7266,7 +7266,7 @@ packages:
       '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.5.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -7297,7 +7297,7 @@ packages:
       '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.5.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -7333,7 +7333,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       sitemap: 7.1.1
-      tslib: 2.5.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -7437,7 +7437,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       react-router-dom: 5.3.4(react@17.0.2)
       rtlcss: 3.5.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       utility-types: 3.10.0
     transitivePeerDependencies:
       - '@parcel/css'
@@ -7562,7 +7562,7 @@ packages:
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.5.0
+      tslib: 2.6.3
       utility-types: 3.10.0
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -7591,7 +7591,7 @@ packages:
     engines: {node: '>=16.14'}
     dependencies:
       fs-extra: 10.1.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@docusaurus/types@2.4.1(react-dom@17.0.2)(react@17.0.2):
@@ -7626,7 +7626,7 @@ packages:
         optional: true
     dependencies:
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@docusaurus/utils-validation@2.4.1(@docusaurus/types@2.4.1):
@@ -7637,7 +7637,7 @@ packages:
       '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
       joi: 17.7.0
       js-yaml: 4.1.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -7670,7 +7670,7 @@ packages:
       micromatch: 4.0.5
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
-      tslib: 2.5.0
+      tslib: 2.6.3
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
       webpack: 5.88.2
     transitivePeerDependencies:
@@ -7978,7 +7978,7 @@ packages:
       lodash.get: 4.4.2
       make-error: 1.3.6
       ts-node: 9.1.1(typescript@4.9.4)
-      tslib: 2.5.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -8306,26 +8306,26 @@ packages:
     resolution: {integrity: sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==}
     dependencies:
       '@formatjs/intl-localematcher': 0.2.32
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@formatjs/ecma402-abstract@2.0.0:
     resolution: {integrity: sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==}
     dependencies:
       '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@formatjs/fast-memoize@2.2.0:
     resolution: {integrity: sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@formatjs/icu-messageformat-parser@2.1.14:
     resolution: {integrity: sha512-0KqeVOb72losEhUW+59vhZGGd14s1f35uThfEMVKZHKLEObvJdFTiI3ZQwvTMUCzLEMxnS6mtnYPmG4mTvwd3Q==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.14.3
       '@formatjs/icu-skeleton-parser': 1.3.18
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@formatjs/icu-messageformat-parser@2.7.8:
@@ -8333,45 +8333,45 @@ packages:
     dependencies:
       '@formatjs/ecma402-abstract': 2.0.0
       '@formatjs/icu-skeleton-parser': 1.8.2
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@formatjs/icu-skeleton-parser@1.3.18:
     resolution: {integrity: sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.14.3
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@formatjs/icu-skeleton-parser@1.8.2:
     resolution: {integrity: sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==}
     dependencies:
       '@formatjs/ecma402-abstract': 2.0.0
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@formatjs/intl-displaynames@6.6.8:
     resolution: {integrity: sha512-Lgx6n5KxN16B3Pb05z3NLEBQkGoXnGjkTBNCZI+Cn17YjHJ3fhCeEJJUqRlIZmJdmaXQhjcQVDp6WIiNeRYT5g==}
     dependencies:
       '@formatjs/ecma402-abstract': 2.0.0
       '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@formatjs/intl-listformat@7.5.7:
     resolution: {integrity: sha512-MG2TSChQJQT9f7Rlv+eXwUFiG24mKSzmF144PLb8m8OixyXqn4+YWU+5wZracZGCgVTVmx8viCf7IH3QXoiB2g==}
     dependencies:
       '@formatjs/ecma402-abstract': 2.0.0
       '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@formatjs/intl-localematcher@0.2.32:
     resolution: {integrity: sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@formatjs/intl-localematcher@0.5.4:
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@formatjs/intl@2.10.4(typescript@4.9.4):
     resolution: {integrity: sha512-56483O+HVcL0c7VucAS2tyH020mt9XTozZO67cwtGg0a7KWDukS/FzW3OnvaHmTHDuYsoPIzO+ZHVfU6fT/bJw==}
@@ -8387,7 +8387,7 @@ packages:
       '@formatjs/intl-displaynames': 6.6.8
       '@formatjs/intl-listformat': 7.5.7
       intl-messageformat: 10.5.14
-      tslib: 2.5.0
+      tslib: 2.6.3
       typescript: 4.9.4
 
   /@formatjs/ts-transformer@3.11.5:
@@ -8403,7 +8403,7 @@ packages:
       '@types/node': 17.0.45
       chalk: 4.1.2
       json-stable-stringify: 1.0.2
-      tslib: 2.5.0
+      tslib: 2.6.3
       typescript: 4.9.4
     dev: false
 
@@ -8856,7 +8856,7 @@ packages:
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       dataloader: 2.1.0
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       value-or-promise: 1.0.12
     dev: true
 
@@ -8933,7 +8933,7 @@ packages:
       graphql: 15.8.0
       graphql-ws: 5.11.2(graphql@15.8.0)
       isomorphic-ws: 5.0.0(ws@8.12.0)
-      tslib: 2.5.0
+      tslib: 2.6.3
       ws: 8.12.0
     transitivePeerDependencies:
       - bufferutil
@@ -8952,7 +8952,7 @@ packages:
       extract-files: 11.0.0
       graphql: 15.8.0
       meros: 1.2.1(@types/node@18.15.3)
-      tslib: 2.5.0
+      tslib: 2.6.3
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
@@ -8968,7 +8968,7 @@ packages:
       '@types/ws': 8.5.4
       graphql: 15.8.0
       isomorphic-ws: 5.0.0(ws@8.12.0)
-      tslib: 2.5.0
+      tslib: 2.6.3
       ws: 8.12.0
     transitivePeerDependencies:
       - bufferutil
@@ -8984,7 +8984,7 @@ packages:
       '@graphql-typed-document-node/core': 3.1.1(graphql@15.8.0)
       '@repeaterjs/repeater': 3.0.4
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       value-or-promise: 1.0.12
     dev: true
 
@@ -9103,7 +9103,7 @@ packages:
       '@babel/types': 7.22.11
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -9120,7 +9120,7 @@ packages:
       '@babel/types': 7.22.11
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -9134,7 +9134,7 @@ packages:
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
       resolve-from: 5.0.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-tools/import@6.7.18(graphql@15.8.0):
@@ -9145,7 +9145,7 @@ packages:
       '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       graphql: 15.8.0
       resolve-from: 5.0.0
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@graphql-tools/json-file-loader@6.2.6(graphql@15.8.0):
     resolution: {integrity: sha512-CnfwBSY5926zyb6fkDBHnlTblHnHI4hoBALFYXnrg0Ev4yWU8B04DZl/pBRUc459VNgO2x8/mxGIZj2hPJG1EA==}
@@ -9227,7 +9227,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 8.9.0(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@graphql-tools/merge@8.3.12(graphql@15.8.0):
@@ -9237,7 +9237,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.1.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@graphql-tools/merge@8.3.15(graphql@15.8.0):
     resolution: {integrity: sha512-hYYOlsqkUlL6oOo7zzuk6hIv7xQzy+x21sgK84d5FWaiWYkLYh9As8myuDd9SD5xovWWQ9m/iRhIOVDEMSyEKA==}
@@ -9246,7 +9246,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@graphql-tools/merge@8.3.6(graphql@15.8.0):
     resolution: {integrity: sha512-uUBokxXi89bj08P+iCvQk3Vew4vcfL5ZM6NTylWi8PIpoq4r5nJ625bRuN8h2uubEdRiH8ntN9M4xkd/j7AybQ==}
@@ -9255,7 +9255,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 8.12.0(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-tools/merge@8.4.2(graphql@15.8.0):
@@ -9265,7 +9265,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@graphql-tools/mock@8.7.15(graphql@15.8.0):
     resolution: {integrity: sha512-0zImG5tuObhowqtijlB6TMAIVtCIBsnGGwNW8gnCOa+xZAqfGdUMsSma17tHC2XuI7xhv7A0O8pika9e3APLUg==}
@@ -9276,7 +9276,7 @@ packages:
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       fast-json-stable-stringify: 2.1.0
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@graphql-tools/optimize@1.3.1(graphql@15.8.0):
@@ -9285,7 +9285,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-tools/prisma-loader@7.2.54(@types/node@18.15.3)(graphql@15.8.0):
@@ -9329,7 +9329,7 @@ packages:
       '@ardatan/relay-compiler': 12.0.0(graphql@15.8.0)
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9354,7 +9354,7 @@ packages:
       '@graphql-tools/merge': 8.3.1(graphql@15.8.0)
       '@graphql-tools/utils': 8.9.0(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       value-or-promise: 1.0.11
     dev: false
 
@@ -9366,7 +9366,7 @@ packages:
       '@graphql-tools/merge': 8.3.12(graphql@15.8.0)
       '@graphql-tools/utils': 9.1.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       value-or-promise: 1.0.11
 
   /@graphql-tools/schema@9.0.13(graphql@15.8.0):
@@ -9377,7 +9377,7 @@ packages:
       '@graphql-tools/merge': 8.3.15(graphql@15.8.0)
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       value-or-promise: 1.0.12
 
   /@graphql-tools/schema@9.0.19(graphql@15.8.0):
@@ -9388,7 +9388,7 @@ packages:
       '@graphql-tools/merge': 8.4.2(graphql@15.8.0)
       '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       value-or-promise: 1.0.12
 
   /@graphql-tools/schema@9.0.4(graphql@15.8.0):
@@ -9399,7 +9399,7 @@ packages:
       '@graphql-tools/merge': 8.3.6(graphql@15.8.0)
       '@graphql-tools/utils': 8.12.0(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       value-or-promise: 1.0.11
     dev: true
 
@@ -9478,7 +9478,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-tools/utils@8.13.1(graphql@15.8.0):
@@ -9496,7 +9496,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@graphql-tools/utils@9.1.1(graphql@15.8.0):
@@ -9505,7 +9505,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@graphql-tools/utils@9.1.4(graphql@15.8.0):
     resolution: {integrity: sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==}
@@ -9522,7 +9522,7 @@ packages:
     dependencies:
       '@graphql-typed-document-node/core': 3.1.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@graphql-tools/wrap@7.0.8(graphql@15.8.0):
     resolution: {integrity: sha512-1NDUymworsOlb53Qfh7fonDi2STvqCtbeE68ntKY9K/Ju/be2ZNxrFSbrBHwnxWcN9PjISNnLcAyJ1L5tCUyhg==}
@@ -9546,7 +9546,7 @@ packages:
       '@graphql-tools/schema': 9.0.13(graphql@15.8.0)
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.3
       value-or-promise: 1.0.12
     dev: true
 
@@ -11881,14 +11881,14 @@ packages:
     dependencies:
       asn1js: 3.0.5
       pvtsutils: 1.3.2
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /@peculiar/json-schema@1.1.12:
     resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /@peculiar/webcrypto@1.4.1:
@@ -11898,7 +11898,7 @@ packages:
       '@peculiar/asn1-schema': 2.3.3
       '@peculiar/json-schema': 1.1.12
       pvtsutils: 1.3.2
-      tslib: 2.5.0
+      tslib: 2.6.3
       webcrypto-core: 1.7.5
     dev: true
 
@@ -11932,7 +11932,7 @@ packages:
       open: 8.4.0
       picocolors: 1.0.0
       tiny-glob: 0.2.9
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(@types/webpack@5.28.0)(react-refresh@0.11.0)(webpack@5.88.2):
@@ -13623,7 +13623,7 @@ packages:
       flat-cache: 3.0.4
       micromatch: 4.0.5
       react-docgen-typescript: 2.2.2(typescript@4.9.4)
-      tslib: 2.5.0
+      tslib: 2.6.3
       typescript: 4.9.4
       webpack: 5.88.2
     transitivePeerDependencies:
@@ -14131,7 +14131,7 @@ packages:
   /@swc/helpers@0.5.2:
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /@swc/plugin-emotion@2.5.120:
     resolution: {integrity: sha512-vEA0lJTzY0NUnp+INB5SGYPYGxszOOzEgs3xXg/H34ngDpJ4xftZ3LfvYGxsJD+BgpxwOPh79XSTg1NRiefCTw==}
@@ -15780,7 +15780,7 @@ packages:
     resolution: {integrity: sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   /@wry/equality@0.1.11:
     resolution: {integrity: sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==}
@@ -15792,13 +15792,13 @@ packages:
     resolution: {integrity: sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   /@wry/trie@0.3.2:
     resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   /@xmldom/xmldom@0.7.10:
     resolution: {integrity: sha512-hb9QhOg5MGmpVkFcoZ9XJMe1em5gd0e2eqqjK87O1dwULedXsnY/Zg/Ju6lcohA+t6jVkmKpe7I1etqhvdRdrQ==}
@@ -16630,7 +16630,7 @@ packages:
     dependencies:
       pvtsutils: 1.3.2
       pvutils: 1.1.3
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /assert-plus@1.0.0:
@@ -16657,7 +16657,7 @@ packages:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /astral-regex@2.0.0:
@@ -17706,7 +17706,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -17772,7 +17772,7 @@ packages:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.6.3
       upper-case-first: 2.0.2
 
   /capture-exit@2.0.0:
@@ -18411,7 +18411,7 @@ packages:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.6.3
       upper-case: 2.0.2
 
   /constants-browserify@1.0.0:
@@ -19703,7 +19703,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -21356,7 +21356,7 @@ packages:
     resolution: {integrity: sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==}
     engines: {node: '>= 12'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /file-system-cache@1.1.0:
@@ -22431,6 +22431,16 @@ packages:
       - encoding
     dev: true
 
+  /graphql-scalars@1.23.0(graphql@15.8.0):
+    resolution: {integrity: sha512-YTRNcwitkn8CqYcleKOx9IvedA8JIERn8BRq21nlKgOr4NEcTaWEG0sT+H92eF3ALTFbPgsqfft4cw+MGgv0Gg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.6.3
+    dev: false
+
   /graphql-tag@2.12.6(graphql@15.8.0):
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
     engines: {node: '>=10'}
@@ -22439,14 +22449,6 @@ packages:
     dependencies:
       graphql: 15.8.0
       tslib: 2.4.1
-
-  /graphql-type-json@0.3.2(graphql@15.8.0):
-    resolution: {integrity: sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==}
-    peerDependencies:
-      graphql: '>=0.8.0'
-    dependencies:
-      graphql: 15.8.0
-    dev: false
 
   /graphql-ws@4.9.0(graphql@15.8.0):
     resolution: {integrity: sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==}
@@ -22712,7 +22714,7 @@ packages:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /headers-utils@3.0.2:
     resolution: {integrity: sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==}
@@ -23289,7 +23291,7 @@ packages:
       '@formatjs/ecma402-abstract': 2.0.0
       '@formatjs/fast-memoize': 2.2.0
       '@formatjs/icu-messageformat-parser': 2.7.8
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -23612,7 +23614,7 @@ packages:
   /is-lower-case@2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /is-map@2.0.2:
@@ -23820,7 +23822,7 @@ packages:
   /is-upper-case@2.0.2:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /is-utf8@0.2.1:
@@ -25391,13 +25393,13 @@ packages:
   /lower-case-first@2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /lowercase-keys@1.0.1:
     resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==}
@@ -26277,7 +26279,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   /node-abort-controller@3.0.1:
     resolution: {integrity: sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==}
@@ -26952,7 +26954,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -27116,7 +27118,7 @@ packages:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /path-dirname@1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
@@ -28559,7 +28561,7 @@ packages:
   /pvtsutils@1.3.2:
     resolution: {integrity: sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /pvutils@1.1.3:
@@ -30261,7 +30263,7 @@ packages:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.6.3
       upper-case-first: 2.0.2
 
   /serialize-javascript@4.0.0:
@@ -30572,7 +30574,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /snapdragon-node@2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -30779,7 +30781,7 @@ packages:
   /sponge-case@1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /sprintf-js@1.0.3:
@@ -31379,7 +31381,7 @@ packages:
   /swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /swiper@6.8.4:
@@ -31432,7 +31434,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/utils': 2.3.1
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: false
 
   /synthetic-dom@1.4.0:
@@ -31708,7 +31710,7 @@ packages:
   /title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /tmp-promise@3.0.3:
@@ -31887,7 +31889,7 @@ packages:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   /ts-invariant@0.3.3:
     resolution: {integrity: sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==}
@@ -32104,7 +32106,6 @@ packages:
 
   /tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
-    dev: false
 
   /tsutils@3.21.0(typescript@4.9.4):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -32568,12 +32569,12 @@ packages:
   /upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.3
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -33039,7 +33040,7 @@ packages:
       '@peculiar/json-schema': 1.1.12
       asn1js: 3.0.5
       pvtsutils: 1.3.2
-      tslib: 2.5.0
+      tslib: 2.6.3
     dev: true
 
   /webidl-conversions@3.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,9 +486,6 @@ importers:
       graphql:
         specifier: ^15.0.0
         version: 15.8.0
-      graphql-scalars:
-        specifier: ^1.23.0
-        version: 1.23.0(graphql@15.8.0)
       hasha:
         specifier: ^5.0.0
         version: 5.2.2


### PR DESCRIPTION
This should be non-breaking, as apps have `graphql-type-json` as dependency on their own. After merging this, the starter should also switch to `graphql-scalars`.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
