### PR TITLE
Remove accidentally added text in `FieldSet`

### DIFF
--- a/packages/admin/admin/src/common/FieldSet.tsx
+++ b/packages/admin/admin/src/common/FieldSet.tsx
@@ -87,8 +87,6 @@ export function FieldSet(inProps: React.PropsWithChildren<FieldSetProps>): React
                 <EndAdornment {...slotProps?.endAdornment}>{endAdornment}</EndAdornment>
             </Summary>
             <Children ownerState={ownerState} {...slotProps?.children}>
-                {disablePadding ? "disablePadding" : "not disablePadding"}
-
                 {children}
             </Children>
         </Root>


### PR DESCRIPTION
The conditional `className` was accidentally kept inside the `Children` slot's children when moving it into it's `classesResolver`.