### PR TITLE
Fix label padding on non-deletable `Chip`

### DIFF
--- a/packages/admin/admin-theme/src/componentsTheme/MuiChip.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiChip.tsx
@@ -27,11 +27,12 @@ export const getMuiChip: GetMuiComponentTheme<"MuiChip"> = (component, { palette
             fontSize: 12,
             lineHeight: "16px",
             paddingLeft: 0,
-            paddingRight: "6px",
+            paddingRight: 0,
         },
         deleteIconMedium: {
             margin: 0,
             fontSize: 16,
+            paddingLeft: 6,
         },
         sizeSmall: {
             height: 20,
@@ -46,11 +47,12 @@ export const getMuiChip: GetMuiComponentTheme<"MuiChip"> = (component, { palette
             fontSize: 10,
             lineHeight: "10px",
             paddingLeft: 0,
-            paddingRight: "5px",
+            paddingRight: 0,
         },
         deleteIconSmall: {
             margin: 0,
             fontSize: 12,
+            paddingLeft: 5,
         },
         deleteIconColorPrimary: {
             color: palette.primary.contrastText,

--- a/storybook/src/admin/mui/Chip.tsx
+++ b/storybook/src/admin/mui/Chip.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown } from "@comet/admin-icons";
-import { Card, CardContent, Chip, Grid, Stack, Typography } from "@mui/material";
+import { Box, Card, CardContent, Chip, Grid, Stack, Typography } from "@mui/material";
+import { boolean, select } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
@@ -8,538 +9,317 @@ function Story() {
         <Stack spacing={4}>
             <Card>
                 <CardContent>
-                    <Typography variant="h3" gutterBottom>
+                    <Typography variant="h3" mb={10}>
                         Chips
                     </Typography>
-
+                    <Box mb={10}>
+                        <Typography variant="h4" gutterBottom>
+                            Customizable Chip
+                        </Typography>
+                        <Typography gutterBottom variant="body2">
+                            Use the story knobs to customize the props of the Chip below.
+                        </Typography>
+                        <Chip
+                            label="Customizable Chip"
+                            color={select("Color", ["default", "primary", "secondary", "success", "error", "warning"], "default")}
+                            variant={select("Variant", ["filled", "outlined"], "filled")}
+                            size={select("Size", ["small", "medium"], "medium")}
+                            disabled={boolean("Disabled", false)}
+                            clickable={boolean("Clickable", false)}
+                            icon={boolean("Icon", false) ? <ChevronDown /> : undefined}
+                            onDelete={boolean("Deletable", false) ? () => console.log("Delete") : undefined}
+                        />
+                    </Box>
+                    <Box mb={10}>
+                        <Typography variant="h4" gutterBottom>
+                            Medium size Chips
+                        </Typography>
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip clickable label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
+                        </Grid>
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip variant="outlined" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip variant="outlined" clickable label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip variant="outlined" icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip variant="outlined" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    variant="outlined"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
+                        </Grid>
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip color="primary" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip clickable color="primary" label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="primary" icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="primary" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    color="primary"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
+                        </Grid>
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip color="success" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="success" clickable label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="success" icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="success" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    color="success"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
+                        </Grid>
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip color="error" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="error" clickable label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="error" icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="error" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    color="error"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
+                        </Grid>
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip color="warning" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="warning" clickable label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="warning" icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip color="warning" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    color="warning"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
+                        </Grid>
+                    </Box>
                     <Typography variant="h4" gutterBottom>
-                        Medium
+                        Small size Chips
                     </Typography>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
+                    <Box mb={10}>
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip size="small" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" clickable label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    size="small"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
                         </Grid>
-                        <Grid item>
-                            <Chip
-                                clickable
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip size="small" variant="outlined" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" variant="outlined" clickable label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" variant="outlined" icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" variant="outlined" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    size="small"
+                                    variant="outlined"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
                         </Grid>
-                        <Grid item>
-                            <Chip
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip size="small" color="primary" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" clickable color="primary" label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" icon={<ChevronDown />} clickable color="primary" label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" color="primary" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    size="small"
+                                    color="primary"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
                         </Grid>
-                        <Grid item>
-                            <Chip
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip size="small" color="success" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" color="success" clickable label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" color="success" icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" color="success" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    size="small"
+                                    color="success"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
                         </Grid>
-                    </Grid>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                variant="outlined"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip size="small" color="error" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" color="error" clickable label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" color="error" icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" color="error" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    size="small"
+                                    color="error"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
                         </Grid>
-                        <Grid item>
-                            <Chip
-                                variant="outlined"
-                                clickable
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
+                        <Grid container spacing={2} mb={5}>
+                            <Grid item>
+                                <Chip size="small" color="warning" label="Normal" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" color="warning" clickable label="Clickable" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" color="warning" icon={<ChevronDown />} clickable label="With Icon" />
+                            </Grid>
+                            <Grid item>
+                                <Chip size="small" color="warning" label="Disabled" disabled />
+                            </Grid>
+                            <Grid item>
+                                <Chip
+                                    size="small"
+                                    color="warning"
+                                    label="Deletable"
+                                    onDelete={() => {
+                                        console.log("Delete");
+                                    }}
+                                />
+                            </Grid>
                         </Grid>
-                        <Grid item>
-                            <Chip
-                                variant="outlined"
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                variant="outlined"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                color="primary"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                clickable
-                                color="primary"
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="primary"
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="primary"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                color="success"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="success"
-                                clickable
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="success"
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="success"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                color="error"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="error"
-                                clickable
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="error"
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="error"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                color="warning"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="warning"
-                                clickable
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="warning"
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                color="warning"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
-
-                    <Typography variant="h4" gutterBottom>
-                        Small
-                    </Typography>
-
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                clickable
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                variant="outlined"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                variant="outlined"
-                                clickable
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                variant="outlined"
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                variant="outlined"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="primary"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                clickable
-                                color="primary"
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                icon={<ChevronDown />}
-                                clickable
-                                color="primary"
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="primary"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="success"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="success"
-                                clickable
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="success"
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="success"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="error"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="error"
-                                clickable
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="error"
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="error"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
-                    <Grid container spacing={2} my={5}>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="warning"
-                                label="Normal"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="warning"
-                                clickable
-                                label="Clickable"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="warning"
-                                icon={<ChevronDown />}
-                                clickable
-                                label="With Icon"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Chip
-                                size="small"
-                                color="warning"
-                                label="Disabled"
-                                onDelete={() => {
-                                    console.log("Delete");
-                                }}
-                                disabled
-                            />
-                        </Grid>
-                    </Grid>
+                    </Box>
                 </CardContent>
             </Card>
         </Stack>


### PR DESCRIPTION
The spacing between the label and the delete icon was also included when there was no delete icon, causing the label to appear misaligned.

Also update Chip stories: Now includes non-deletable chips and a Chip that can be customized using storybook knobs.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
    - A changelog is not required, as this issue was added in V7. 
-   [x] Link to the respective task if one exists: COM-800
-   [x] Provide screenshots/screencasts if the change contains visual changes

| Previously | Now |
| --- | --- |
| <img width="148" alt="Chips Previously" src="https://github.com/vivid-planet/comet/assets/6264317/7bcf86c0-94e6-48d9-adf0-da23c7d1c47d"> | <img width="148" alt="Chips Now" src="https://github.com/vivid-planet/comet/assets/6264317/dddb9c59-657b-4f2e-b4cd-834af2065302"> |