### PR TITLE
Demo: Dependent async select

### DIFF
--- a/demo/admin/src/products/ProductForm.gql.ts
+++ b/demo/admin/src/products/ProductForm.gql.ts
@@ -9,12 +9,14 @@ export const productFormFragment = gql`
         additionalTypes
         inStock
         image
-        manufacturer {
-            id
-            name
+        manufacturerCountry: manufacturer {
             addressAsEmbeddable {
                 country
             }
+        }
+        manufacturer {
+            id
+            name
         }
         category {
             id

--- a/demo/admin/src/products/ProductForm.gql.ts
+++ b/demo/admin/src/products/ProductForm.gql.ts
@@ -9,6 +9,13 @@ export const productFormFragment = gql`
         additionalTypes
         inStock
         image
+        manufacturer {
+            id
+            name
+            addressAsEmbeddable {
+                country
+            }
+        }
         category {
             id
             title

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -183,69 +183,65 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                             name="description"
                             label={<FormattedMessage id="product.description" defaultMessage="Description" />}
                         />
-                        <>
-                            <AsyncSelectField
-                                name="manufacturerCountry"
-                                loadOptions={async () => {
-                                    const { data } = await client.query<GQLManufacturerCountriesQuery, GQLManufacturerCountriesQueryVariables>({
-                                        query: gql`
-                                            query ManufacturerCountries {
-                                                manufacturerCountries {
-                                                    nodes {
-                                                        id
-                                                        used
-                                                    }
+                        <AsyncSelectField
+                            name="manufacturerCountry"
+                            loadOptions={async () => {
+                                const { data } = await client.query<GQLManufacturerCountriesQuery, GQLManufacturerCountriesQueryVariables>({
+                                    query: gql`
+                                        query ManufacturerCountries {
+                                            manufacturerCountries {
+                                                nodes {
+                                                    id
+                                                    used
                                                 }
                                             }
-                                        `,
-                                    });
+                                        }
+                                    `,
+                                });
 
-                                    return data.manufacturerCountries.nodes;
-                                }}
-                                getOptionLabel={(option: GQLManufacturerCountriesQuery["manufacturerCountries"]["nodes"][0]) => option.id}
-                                label={<FormattedMessage id="product.manufacturerCountry" defaultMessage="Manufacturer Country" />}
-                                fullWidth
-                            />
-
-                            <AsyncSelectField
-                                name="manufacturer"
-                                loadOptions={async () => {
-                                    const { data } = await client.query<GQLManufacturersQuery, GQLManufacturersQueryVariables>({
-                                        query: gql`
-                                            query Manufacturers($filter: ManufacturerFilter) {
-                                                manufacturers(filter: $filter) {
-                                                    nodes {
-                                                        id
-                                                        name
-                                                    }
+                                return data.manufacturerCountries.nodes;
+                            }}
+                            getOptionLabel={(option) => option.id}
+                            label={<FormattedMessage id="product.manufacturerCountry" defaultMessage="Manufacturer Country" />}
+                            fullWidth
+                        />
+                        <AsyncSelectField
+                            name="manufacturer"
+                            loadOptions={async () => {
+                                const { data } = await client.query<GQLManufacturersQuery, GQLManufacturersQueryVariables>({
+                                    query: gql`
+                                        query Manufacturers($filter: ManufacturerFilter) {
+                                            manufacturers(filter: $filter) {
+                                                nodes {
+                                                    id
+                                                    name
                                                 }
                                             }
-                                        `,
-                                        variables: {
-                                            filter: {
-                                                addressAsEmbeddable_country: {
-                                                    equal: values.manufacturerCountry?.id,
-                                                },
+                                        }
+                                    `,
+                                    variables: {
+                                        filter: {
+                                            addressAsEmbeddable_country: {
+                                                equal: values.manufacturerCountry?.id,
                                             },
                                         },
-                                    });
+                                    },
+                                });
 
-                                    return data.manufacturers.nodes;
-                                }}
-                                getOptionLabel={(option: GQLManufacturersQuery["manufacturers"]["nodes"][0]) => option.name}
-                                label={<FormattedMessage id="product.manufacturer" defaultMessage="Manufacturer" />}
-                                fullWidth
-                                disabled={!values?.manufacturerCountry}
-                            />
-
-                            <OnChangeField name="manufacturerCountry">
-                                {(value, previousValue) => {
-                                    if (value.id !== previousValue.id) {
-                                        form.change("manufacturer", undefined);
-                                    }
-                                }}
-                            </OnChangeField>
-                        </>
+                                return data.manufacturers.nodes;
+                            }}
+                            getOptionLabel={(option: GQLManufacturersQuery["manufacturers"]["nodes"][0]) => option.name}
+                            label={<FormattedMessage id="product.manufacturer" defaultMessage="Manufacturer" />}
+                            fullWidth
+                            disabled={!values?.manufacturerCountry}
+                        />
+                        <OnChangeField name="manufacturerCountry">
+                            {(value, previousValue) => {
+                                if (value.id !== previousValue.id) {
+                                    form.change("manufacturer", undefined);
+                                }
+                            }}
+                        </OnChangeField>
                         <SelectField name="type" label={<FormattedMessage id="product.type" defaultMessage="Type" />} required fullWidth>
                             <MenuItem value="Cap">
                                 <FormattedMessage id="product.type.cap" defaultMessage="Cap" />

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -64,13 +64,9 @@ const rootBlocks = {
     image: DamImageBlock,
 };
 
-type FormValues = Omit<GQLProductFormManualFragment, "image" | "manufacturer"> & {
+type FormValues = Omit<GQLProductFormManualFragment, "image" | "manufacturerCountry"> & {
     image: BlockState<typeof rootBlocks.image>;
-    manufacturerFilter?: { id: string };
-    manufacturer?: {
-        id: string;
-        name: string;
-    };
+    manufacturerCountry?: { id: string };
 };
 
 export function ProductForm({ id }: FormProps): React.ReactElement {
@@ -97,15 +93,9 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
         return {
             ...filteredData,
             image: rootBlocks.image.input2State(filteredData.image),
-            manufacturerFilter: filteredData.manufacturer
+            manufacturerCountry: filteredData.manufacturerCountry
                 ? {
-                      id: filteredData.manufacturer?.addressAsEmbeddable.country,
-                  }
-                : undefined,
-            manufacturer: filteredData.manufacturer
-                ? {
-                      id: filteredData.manufacturer.id,
-                      name: filteredData.manufacturer.name,
+                      id: filteredData.manufacturerCountry?.addressAsEmbeddable.country,
                   }
                 : undefined,
         };
@@ -122,7 +112,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
         },
     });
 
-    const handleSubmit = async ({ manufacturerFilter, ...formValues }: FormValues, form: FormApi<FormValues>, event: FinalFormSubmitEvent) => {
+    const handleSubmit = async ({ manufacturerCountry, ...formValues }: FormValues, form: FormApi<FormValues>, event: FinalFormSubmitEvent) => {
         if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");
         const output = {
             ...formValues,
@@ -195,7 +185,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                         />
                         <>
                             <AsyncSelectField
-                                name="manufacturerFilter"
+                                name="manufacturerCountry"
                                 loadOptions={async () => {
                                     const { data } = await client.query<GQLManufacturerCountriesQuery, GQLManufacturerCountriesQueryVariables>({
                                         query: gql`
@@ -234,7 +224,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                         variables: {
                                             filter: {
                                                 addressAsEmbeddable_country: {
-                                                    equal: values.manufacturerFilter?.id,
+                                                    equal: values.manufacturerCountry?.id,
                                                 },
                                             },
                                         },
@@ -245,10 +235,10 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                 getOptionLabel={(option: GQLManufacturersQuery["manufacturers"]["nodes"][0]) => option.name}
                                 label={<FormattedMessage id="product.manufacturer" defaultMessage="Manufacturer" />}
                                 fullWidth
-                                disabled={!values?.manufacturerFilter}
+                                disabled={!values?.manufacturerCountry}
                             />
 
-                            <OnChangeField name="manufacturerFilter">
+                            <OnChangeField name="manufacturerCountry">
                                 {(value, previousValue) => {
                                     if (!isEqual(value, previousValue)) {
                                         form.change("manufacturer", undefined);

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -1,5 +1,6 @@
-import { useApolloClient, useQuery } from "@apollo/client";
+import { gql, useApolloClient, useQuery } from "@apollo/client";
 import {
+    AsyncSelectField,
     CheckboxField,
     Field,
     filterByFragment,
@@ -8,6 +9,7 @@ import {
     FinalFormSubmitEvent,
     Loading,
     MainContent,
+    OnChangeField,
     SelectField,
     TextAreaField,
     TextField,
@@ -19,6 +21,12 @@ import { BlockState, createFinalFormBlock } from "@comet/blocks-admin";
 import { DamImageBlock, queryUpdatedAt, resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
 import { MenuItem } from "@mui/material";
 import { GQLProductType } from "@src/graphql.generated";
+import {
+    GQLManufacturerCountriesQuery,
+    GQLManufacturerCountriesQueryVariables,
+    GQLManufacturersQuery,
+    GQLManufacturersQueryVariables,
+} from "@src/products/ProductForm.generated";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
 import React from "react";
@@ -56,8 +64,13 @@ const rootBlocks = {
     image: DamImageBlock,
 };
 
-type FormValues = Omit<GQLProductFormManualFragment, "image"> & {
+type FormValues = Omit<GQLProductFormManualFragment, "image" | "manufacturer"> & {
     image: BlockState<typeof rootBlocks.image>;
+    manufacturerFilter?: { id: string };
+    manufacturer?: {
+        id: string;
+        name: string;
+    };
 };
 
 export function ProductForm({ id }: FormProps): React.ReactElement {
@@ -71,17 +84,32 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
         id ? { variables: { id } } : { skip: true },
     );
 
-    const initialValues: Partial<FormValues> = data?.product
-        ? {
-              ...filterByFragment<GQLProductFormManualFragment>(productFormFragment, data.product),
-              image: rootBlocks.image.input2State(data.product.image),
-          }
-        : {
-              image: rootBlocks.image.defaultValues(),
-              inStock: false,
-              additionalTypes: [],
-              tags: [],
-          };
+    const initialValues: Partial<FormValues> = React.useMemo<Partial<FormValues>>(() => {
+        const filteredData = data ? filterByFragment<GQLProductFormManualFragment>(productFormFragment, data.product) : undefined;
+        if (!filteredData) {
+            return {
+                image: rootBlocks.image.defaultValues(),
+                inStock: false,
+                additionalTypes: [],
+                tags: [],
+            };
+        }
+        return {
+            ...filteredData,
+            image: rootBlocks.image.input2State(filteredData.image),
+            manufacturerFilter: filteredData.manufacturer
+                ? {
+                      id: filteredData.manufacturer?.addressAsEmbeddable.country,
+                  }
+                : undefined,
+            manufacturer: filteredData.manufacturer
+                ? {
+                      id: filteredData.manufacturer.id,
+                      name: filteredData.manufacturer.name,
+                  }
+                : undefined,
+        };
+    }, [data]);
 
     const saveConflict = useFormSaveConflict({
         checkConflict: async () => {
@@ -94,7 +122,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
         },
     });
 
-    const handleSubmit = async (formValues: FormValues, form: FormApi<FormValues>, event: FinalFormSubmitEvent) => {
+    const handleSubmit = async ({ manufacturerFilter, ...formValues }: FormValues, form: FormApi<FormValues>, event: FinalFormSubmitEvent) => {
         if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");
         const output = {
             ...formValues,
@@ -105,6 +133,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
             articleNumbers: [],
             discounts: [],
             statistics: { views: 0 },
+            manufacturer: formValues.manufacturer?.id,
         };
         if (mode === "edit") {
             if (!id) throw new Error();
@@ -150,54 +179,119 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
             mode={mode}
             initialValues={initialValues}
             initialValuesEqual={isEqual} //required to compare block data correctly
-            subscription={{}}
+            subscription={{ values: true }} // values required because disable and loadOptions of manufacturer-select depends on values
         >
-            {() => (
-                <>
-                    {saveConflict.dialogs}
-                    <MainContent>
-                        <TextField required fullWidth name="title" label={<FormattedMessage id="product.title" defaultMessage="Title" />} />
-                        <TextField required fullWidth name="slug" label={<FormattedMessage id="product.slug" defaultMessage="Slug" />} />
-                        <TextAreaField
-                            required
-                            fullWidth
-                            name="description"
-                            label={<FormattedMessage id="product.description" defaultMessage="Description" />}
-                        />
-                        <SelectField name="type" label="Type" required fullWidth>
-                            <MenuItem value="Cap">Cap</MenuItem>
-                            <MenuItem value="Shirt">Shirt</MenuItem>
-                            <MenuItem value="Tie">Tie</MenuItem>
-                        </SelectField>
-                        <SelectField name="additionalTypes" label="Additional Type" required fullWidth multiple>
-                            <MenuItem value="Cap">Cap</MenuItem>
-                            <MenuItem value="Shirt">Shirt</MenuItem>
-                            <MenuItem value="Tie">Tie</MenuItem>
-                        </SelectField>
-                        <Field
-                            fullWidth
-                            name="category"
-                            label="Category"
-                            component={FinalFormSelect}
-                            {...categorySelectAsyncProps}
-                            getOptionLabel={(option: GQLProductCategorySelectFragment) => option.title}
-                        />
-                        <Field
-                            fullWidth
-                            name="tags"
-                            label="Tags"
-                            component={FinalFormSelect}
-                            multiple
-                            {...tagsSelectAsyncProps}
-                            getOptionLabel={(option: GQLProductTagsSelectFragment) => option.title}
-                        />
-                        <CheckboxField name="inStock" label={<FormattedMessage id="product.inStock" defaultMessage="In stock" />} fullWidth />
-                        <Field name="image" isEqual={isEqual}>
-                            {createFinalFormBlock(rootBlocks.image)}
-                        </Field>
-                    </MainContent>
-                </>
-            )}
+            {({ values, form }) => {
+                return (
+                    <>
+                        {saveConflict.dialogs}
+                        <MainContent>
+                            <TextField required fullWidth name="title" label={<FormattedMessage id="product.title" defaultMessage="Title" />} />
+                            <TextField required fullWidth name="slug" label={<FormattedMessage id="product.slug" defaultMessage="Slug" />} />
+                            <TextAreaField
+                                required
+                                fullWidth
+                                name="description"
+                                label={<FormattedMessage id="product.description" defaultMessage="Description" />}
+                            />
+                            <>
+                                <AsyncSelectField
+                                    name="manufacturerFilter"
+                                    loadOptions={async () => {
+                                        const { data } = await client.query<GQLManufacturerCountriesQuery, GQLManufacturerCountriesQueryVariables>({
+                                            query: gql`
+                                                query ManufacturerCountries {
+                                                    manufacturerCountries {
+                                                        nodes {
+                                                            id
+                                                            used
+                                                        }
+                                                    }
+                                                }
+                                            `,
+                                        });
+
+                                        return data.manufacturerCountries.nodes;
+                                    }}
+                                    getOptionLabel={(option: GQLManufacturerCountriesQuery["manufacturerCountries"]["nodes"][0]) => option.id}
+                                    label="Manufacturer Country"
+                                    fullWidth
+                                />
+
+                                <AsyncSelectField
+                                    name="manufacturer"
+                                    loadOptions={async () => {
+                                        const { data } = await client.query<GQLManufacturersQuery, GQLManufacturersQueryVariables>({
+                                            query: gql`
+                                                query Manufacturers($filter: ManufacturerFilter) {
+                                                    manufacturers(filter: $filter) {
+                                                        nodes {
+                                                            id
+                                                            name
+                                                        }
+                                                    }
+                                                }
+                                            `,
+                                            variables: {
+                                                filter: {
+                                                    addressAsEmbeddable_country: {
+                                                        equal: values.manufacturerFilter?.id,
+                                                    },
+                                                },
+                                            },
+                                        });
+
+                                        return data.manufacturers.nodes;
+                                    }}
+                                    getOptionLabel={(option: GQLManufacturersQuery["manufacturers"]["nodes"][0]) => option.name}
+                                    label="Manufacturer"
+                                    fullWidth
+                                    disabled={!values?.manufacturerFilter}
+                                />
+
+                                <OnChangeField name="manufacturerFilter">
+                                    {(value, previousValue) => {
+                                        if (!isEqual(value, previousValue)) {
+                                            form.change("manufacturer", undefined);
+                                        }
+                                    }}
+                                </OnChangeField>
+                            </>
+                            <SelectField name="type" label="Type" required fullWidth>
+                                <MenuItem value="Cap">Cap</MenuItem>
+                                <MenuItem value="Shirt">Shirt</MenuItem>
+                                <MenuItem value="Tie">Tie</MenuItem>
+                            </SelectField>
+                            <SelectField name="additionalTypes" label="Additional Type" required fullWidth multiple>
+                                <MenuItem value="Cap">Cap</MenuItem>
+                                <MenuItem value="Shirt">Shirt</MenuItem>
+                                <MenuItem value="Tie">Tie</MenuItem>
+                            </SelectField>
+                            <Field
+                                fullWidth
+                                name="category"
+                                label="Category"
+                                component={FinalFormSelect}
+                                {...categorySelectAsyncProps}
+                                getOptionLabel={(option: GQLProductCategorySelectFragment) => option.title}
+                            />
+                            <Field
+                                fullWidth
+                                name="tags"
+                                label="Tags"
+                                component={FinalFormSelect}
+                                multiple
+                                {...tagsSelectAsyncProps}
+                                getOptionLabel={(option: GQLProductTagsSelectFragment) => option.title}
+                            />
+                            <CheckboxField name="inStock" label={<FormattedMessage id="product.inStock" defaultMessage="In stock" />} fullWidth />
+                            <Field name="image" isEqual={isEqual}>
+                                {createFinalFormBlock(rootBlocks.image)}
+                            </Field>
+                        </MainContent>
+                    </>
+                );
+            }}
         </FinalForm>
     );
 }

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -230,7 +230,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
 
                                 return data.manufacturers.nodes;
                             }}
-                            getOptionLabel={(option: GQLManufacturersQuery["manufacturers"]["nodes"][0]) => option.name}
+                            getOptionLabel={(option) => option.name}
                             label={<FormattedMessage id="product.manufacturer" defaultMessage="Manufacturer" />}
                             fullWidth
                             disabled={!values?.manufacturerCountry}

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -240,7 +240,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
 
                             <OnChangeField name="manufacturerCountry">
                                 {(value, previousValue) => {
-                                    if (!isEqual(value, previousValue)) {
+                                    if (value.id !== previousValue.id) {
                                         form.change("manufacturer", undefined);
                                     }
                                 }}

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -181,117 +181,115 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
             initialValuesEqual={isEqual} //required to compare block data correctly
             subscription={{ values: true }} // values required because disable and loadOptions of manufacturer-select depends on values
         >
-            {({ values, form }) => {
-                return (
-                    <>
-                        {saveConflict.dialogs}
-                        <MainContent>
-                            <TextField required fullWidth name="title" label={<FormattedMessage id="product.title" defaultMessage="Title" />} />
-                            <TextField required fullWidth name="slug" label={<FormattedMessage id="product.slug" defaultMessage="Slug" />} />
-                            <TextAreaField
-                                required
+            {({ values, form }) => (
+                <>
+                    {saveConflict.dialogs}
+                    <MainContent>
+                        <TextField required fullWidth name="title" label={<FormattedMessage id="product.title" defaultMessage="Title" />} />
+                        <TextField required fullWidth name="slug" label={<FormattedMessage id="product.slug" defaultMessage="Slug" />} />
+                        <TextAreaField
+                            required
+                            fullWidth
+                            name="description"
+                            label={<FormattedMessage id="product.description" defaultMessage="Description" />}
+                        />
+                        <>
+                            <AsyncSelectField
+                                name="manufacturerFilter"
+                                loadOptions={async () => {
+                                    const { data } = await client.query<GQLManufacturerCountriesQuery, GQLManufacturerCountriesQueryVariables>({
+                                        query: gql`
+                                            query ManufacturerCountries {
+                                                manufacturerCountries {
+                                                    nodes {
+                                                        id
+                                                        used
+                                                    }
+                                                }
+                                            }
+                                        `,
+                                    });
+
+                                    return data.manufacturerCountries.nodes;
+                                }}
+                                getOptionLabel={(option: GQLManufacturerCountriesQuery["manufacturerCountries"]["nodes"][0]) => option.id}
+                                label="Manufacturer Country"
                                 fullWidth
-                                name="description"
-                                label={<FormattedMessage id="product.description" defaultMessage="Description" />}
                             />
-                            <>
-                                <AsyncSelectField
-                                    name="manufacturerFilter"
-                                    loadOptions={async () => {
-                                        const { data } = await client.query<GQLManufacturerCountriesQuery, GQLManufacturerCountriesQueryVariables>({
-                                            query: gql`
-                                                query ManufacturerCountries {
-                                                    manufacturerCountries {
-                                                        nodes {
-                                                            id
-                                                            used
-                                                        }
+
+                            <AsyncSelectField
+                                name="manufacturer"
+                                loadOptions={async () => {
+                                    const { data } = await client.query<GQLManufacturersQuery, GQLManufacturersQueryVariables>({
+                                        query: gql`
+                                            query Manufacturers($filter: ManufacturerFilter) {
+                                                manufacturers(filter: $filter) {
+                                                    nodes {
+                                                        id
+                                                        name
                                                     }
                                                 }
-                                            `,
-                                        });
-
-                                        return data.manufacturerCountries.nodes;
-                                    }}
-                                    getOptionLabel={(option: GQLManufacturerCountriesQuery["manufacturerCountries"]["nodes"][0]) => option.id}
-                                    label="Manufacturer Country"
-                                    fullWidth
-                                />
-
-                                <AsyncSelectField
-                                    name="manufacturer"
-                                    loadOptions={async () => {
-                                        const { data } = await client.query<GQLManufacturersQuery, GQLManufacturersQueryVariables>({
-                                            query: gql`
-                                                query Manufacturers($filter: ManufacturerFilter) {
-                                                    manufacturers(filter: $filter) {
-                                                        nodes {
-                                                            id
-                                                            name
-                                                        }
-                                                    }
-                                                }
-                                            `,
-                                            variables: {
-                                                filter: {
-                                                    addressAsEmbeddable_country: {
-                                                        equal: values.manufacturerFilter?.id,
-                                                    },
+                                            }
+                                        `,
+                                        variables: {
+                                            filter: {
+                                                addressAsEmbeddable_country: {
+                                                    equal: values.manufacturerFilter?.id,
                                                 },
                                             },
-                                        });
+                                        },
+                                    });
 
-                                        return data.manufacturers.nodes;
-                                    }}
-                                    getOptionLabel={(option: GQLManufacturersQuery["manufacturers"]["nodes"][0]) => option.name}
-                                    label="Manufacturer"
-                                    fullWidth
-                                    disabled={!values?.manufacturerFilter}
-                                />
+                                    return data.manufacturers.nodes;
+                                }}
+                                getOptionLabel={(option: GQLManufacturersQuery["manufacturers"]["nodes"][0]) => option.name}
+                                label="Manufacturer"
+                                fullWidth
+                                disabled={!values?.manufacturerFilter}
+                            />
 
-                                <OnChangeField name="manufacturerFilter">
-                                    {(value, previousValue) => {
-                                        if (!isEqual(value, previousValue)) {
-                                            form.change("manufacturer", undefined);
-                                        }
-                                    }}
-                                </OnChangeField>
-                            </>
-                            <SelectField name="type" label="Type" required fullWidth>
-                                <MenuItem value="Cap">Cap</MenuItem>
-                                <MenuItem value="Shirt">Shirt</MenuItem>
-                                <MenuItem value="Tie">Tie</MenuItem>
-                            </SelectField>
-                            <SelectField name="additionalTypes" label="Additional Type" required fullWidth multiple>
-                                <MenuItem value="Cap">Cap</MenuItem>
-                                <MenuItem value="Shirt">Shirt</MenuItem>
-                                <MenuItem value="Tie">Tie</MenuItem>
-                            </SelectField>
-                            <Field
-                                fullWidth
-                                name="category"
-                                label="Category"
-                                component={FinalFormSelect}
-                                {...categorySelectAsyncProps}
-                                getOptionLabel={(option: GQLProductCategorySelectFragment) => option.title}
-                            />
-                            <Field
-                                fullWidth
-                                name="tags"
-                                label="Tags"
-                                component={FinalFormSelect}
-                                multiple
-                                {...tagsSelectAsyncProps}
-                                getOptionLabel={(option: GQLProductTagsSelectFragment) => option.title}
-                            />
-                            <CheckboxField name="inStock" label={<FormattedMessage id="product.inStock" defaultMessage="In stock" />} fullWidth />
-                            <Field name="image" isEqual={isEqual}>
-                                {createFinalFormBlock(rootBlocks.image)}
-                            </Field>
-                        </MainContent>
-                    </>
-                );
-            }}
+                            <OnChangeField name="manufacturerFilter">
+                                {(value, previousValue) => {
+                                    if (!isEqual(value, previousValue)) {
+                                        form.change("manufacturer", undefined);
+                                    }
+                                }}
+                            </OnChangeField>
+                        </>
+                        <SelectField name="type" label="Type" required fullWidth>
+                            <MenuItem value="Cap">Cap</MenuItem>
+                            <MenuItem value="Shirt">Shirt</MenuItem>
+                            <MenuItem value="Tie">Tie</MenuItem>
+                        </SelectField>
+                        <SelectField name="additionalTypes" label="Additional Type" required fullWidth multiple>
+                            <MenuItem value="Cap">Cap</MenuItem>
+                            <MenuItem value="Shirt">Shirt</MenuItem>
+                            <MenuItem value="Tie">Tie</MenuItem>
+                        </SelectField>
+                        <Field
+                            fullWidth
+                            name="category"
+                            label="Category"
+                            component={FinalFormSelect}
+                            {...categorySelectAsyncProps}
+                            getOptionLabel={(option: GQLProductCategorySelectFragment) => option.title}
+                        />
+                        <Field
+                            fullWidth
+                            name="tags"
+                            label="Tags"
+                            component={FinalFormSelect}
+                            multiple
+                            {...tagsSelectAsyncProps}
+                            getOptionLabel={(option: GQLProductTagsSelectFragment) => option.title}
+                        />
+                        <CheckboxField name="inStock" label={<FormattedMessage id="product.inStock" defaultMessage="In stock" />} fullWidth />
+                        <Field name="image" isEqual={isEqual}>
+                            {createFinalFormBlock(rootBlocks.image)}
+                        </Field>
+                    </MainContent>
+                </>
+            )}
         </FinalForm>
     );
 }

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -213,7 +213,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                     return data.manufacturerCountries.nodes;
                                 }}
                                 getOptionLabel={(option: GQLManufacturerCountriesQuery["manufacturerCountries"]["nodes"][0]) => option.id}
-                                label="Manufacturer Country"
+                                label={<FormattedMessage id="product.manufacturerCountry" defaultMessage="Manufacturer Country" />}
                                 fullWidth
                             />
 
@@ -243,7 +243,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                     return data.manufacturers.nodes;
                                 }}
                                 getOptionLabel={(option: GQLManufacturersQuery["manufacturers"]["nodes"][0]) => option.name}
-                                label="Manufacturer"
+                                label={<FormattedMessage id="product.manufacturer" defaultMessage="Manufacturer" />}
                                 fullWidth
                                 disabled={!values?.manufacturerFilter}
                             />
@@ -256,20 +256,38 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                 }}
                             </OnChangeField>
                         </>
-                        <SelectField name="type" label="Type" required fullWidth>
-                            <MenuItem value="Cap">Cap</MenuItem>
-                            <MenuItem value="Shirt">Shirt</MenuItem>
-                            <MenuItem value="Tie">Tie</MenuItem>
+                        <SelectField name="type" label={<FormattedMessage id="product.type" defaultMessage="Type" />} required fullWidth>
+                            <MenuItem value="Cap">
+                                <FormattedMessage id="product.type.cap" defaultMessage="Cap" />
+                            </MenuItem>
+                            <MenuItem value="Shirt">
+                                <FormattedMessage id="product.type.shirt" defaultMessage="Shirt" />
+                            </MenuItem>
+                            <MenuItem value="Tie">
+                                <FormattedMessage id="product.type.tie" defaultMessage="Tie" />
+                            </MenuItem>
                         </SelectField>
-                        <SelectField name="additionalTypes" label="Additional Type" required fullWidth multiple>
-                            <MenuItem value="Cap">Cap</MenuItem>
-                            <MenuItem value="Shirt">Shirt</MenuItem>
-                            <MenuItem value="Tie">Tie</MenuItem>
+                        <SelectField
+                            name="additionalTypes"
+                            label={<FormattedMessage id="product.additionalTypes" defaultMessage="Additional Types" />}
+                            required
+                            fullWidth
+                            multiple
+                        >
+                            <MenuItem value="Cap">
+                                <FormattedMessage id="product.type.cap" defaultMessage="Cap" />
+                            </MenuItem>
+                            <MenuItem value="Shirt">
+                                <FormattedMessage id="product.type.shirt" defaultMessage="Shirt" />
+                            </MenuItem>
+                            <MenuItem value="Tie">
+                                <FormattedMessage id="product.type.tie" defaultMessage="Tie" />
+                            </MenuItem>
                         </SelectField>
                         <Field
                             fullWidth
                             name="category"
-                            label="Category"
+                            label={<FormattedMessage id="product.category" defaultMessage="Category" />}
                             component={FinalFormSelect}
                             {...categorySelectAsyncProps}
                             getOptionLabel={(option: GQLProductCategorySelectFragment) => option.title}
@@ -277,7 +295,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                         <Field
                             fullWidth
                             name="tags"
-                            label="Tags"
+                            label={<FormattedMessage id="product.tags" defaultMessage="Tags" />}
                             component={FinalFormSelect}
                             multiple
                             {...tagsSelectAsyncProps}


### PR DESCRIPTION
- Extract filter-value into separate form-state object to prevent overwriting when async-select updates its value.
- adding `values` to form-subscription because it's used initializing loadOptions and disabled props of manufacturer async-select
- adding isEqual check to OnChangeField to prevent reset manufacturer async-select after submiting mutation