### PR TITLE
Fix infinite update loop in `useAsyncOptionsProps`

### DIFF
--- a/.changeset/yellow-ligers-explode.md
+++ b/.changeset/yellow-ligers-explode.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix infinite upload loop in `useAsyncOptions`

--- a/.changeset/yellow-ligers-explode.md
+++ b/.changeset/yellow-ligers-explode.md
@@ -2,4 +2,4 @@
 "@comet/admin": patch
 ---
 
-Fix infinite upload loop in `useAsyncOptions`
+Fix infinite update loop in `useAsyncOptions`

--- a/.changeset/yellow-ligers-explode.md
+++ b/.changeset/yellow-ligers-explode.md
@@ -2,4 +2,4 @@
 "@comet/admin": patch
 ---
 
-Fix infinite update loop in `useAsyncOptions`
+Fix infinite update loop in `useAsyncOptionsProps`

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -12,28 +12,19 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     const [open, setOpen] = React.useState(false);
     const [options, setOptions] = React.useState<T[]>([]);
     const loading = open && options.length === 0;
-    React.useEffect(() => {
-        let active = true;
-        if (!open) {
-            return undefined;
-        }
-        setOptions([]);
-        (async () => {
-            const response = await loadOptions();
-            if (active) {
-                setOptions(response);
-            }
-        })();
-        return () => {
-            active = false;
-        };
-    }, [loadOptions, open]);
+
+    const handleOpen = async () => {
+        setOpen(true);
+        setOptions([]); // Reset options to show loading
+        setOptions(await loadOptions());
+    };
+
     return {
         isAsync: true,
         open,
         options,
         loading,
-        onOpen: () => setOpen(true),
+        onOpen: handleOpen,
         onClose: () => setOpen(false),
     };
 }


### PR DESCRIPTION
Caused by `loadOptions` changing for each render. Fixed by loading options in the event handler and not in the effect.