### PR TITLE
Remove peer dependency on `@comet/admin-theme`

### DIFF
--- a/.changeset/brave-carpets-talk.md
+++ b/.changeset/brave-carpets-talk.md
@@ -1,7 +1,0 @@
----
-"@comet/admin": major
----
-
-Add `@comet/admin-theme` as a peer dependency
-
-`@comet/admin` now uses the custom `Typography` variants `list` and `listItem` defined in `@comet/admin-theme`.

--- a/.changeset/cold-humans-pull.md
+++ b/.changeset/cold-humans-pull.md
@@ -1,8 +1,0 @@
----
-"@comet/cms-admin": major
----
-
-Add `@comet/admin-theme` as a peer dependency
-
-`@comet/cms-admin` now uses the custom `Typography` variants `list` and `listItem` defined in `@comet/admin-theme`.
-

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -28,6 +28,7 @@
     },
     "dependencies": {
         "@comet/admin-icons": "workspace:^7.0.0-beta.2",
+        "@comet/admin-theme": "workspace:^7.0.0-beta.2",
         "@mui/lab": "^5.0.0-alpha.76",
         "@mui/private-theming": "^5.0.0",
         "clsx": "^1.1.1",
@@ -48,7 +49,6 @@
         "@babel/cli": "^7.17.6",
         "@babel/core": "^7.20.12",
         "@comet/admin-babel-preset": "workspace:^7.0.0-beta.2",
-        "@comet/admin-theme": "workspace:^7.0.0-beta.2",
         "@comet/eslint-config": "workspace:^7.0.0-beta.2",
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
@@ -97,7 +97,6 @@
     },
     "peerDependencies": {
         "@apollo/client": "^3.7.0",
-        "@comet/admin-theme": "workspace:*",
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
         "@mui/material": "^5.0.0",

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -83,7 +83,6 @@
         "@babel/cli": "^7.17.6",
         "@babel/core": "^7.20.12",
         "@comet/admin-babel-preset": "workspace:^7.0.0-beta.2",
-        "@comet/admin-theme": "workspace:^7.0.0-beta.2",
         "@comet/cli": "workspace:^7.0.0-beta.2",
         "@comet/eslint-config": "workspace:^7.0.0-beta.2",
         "@emotion/react": "^11.5.0",
@@ -144,7 +143,6 @@
     },
     "peerDependencies": {
         "@apollo/client": "^3.7.0",
-        "@comet/admin-theme": "workspace:*",
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
         "@mui/material": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -915,6 +915,9 @@ importers:
       '@comet/admin-icons':
         specifier: workspace:^7.0.0-beta.2
         version: link:../admin-icons
+      '@comet/admin-theme':
+        specifier: workspace:^7.0.0-beta.2
+        version: link:../admin-theme
       '@mui/lab':
         specifier: ^5.0.0-alpha.76
         version: 5.0.0-alpha.117(@emotion/react@11.9.3)(@emotion/styled@11.10.5)(@mui/material@5.11.6)(@types/react@17.0.53)(react-dom@17.0.2)(react@17.0.2)
@@ -970,9 +973,6 @@ importers:
       '@comet/admin-babel-preset':
         specifier: workspace:^7.0.0-beta.2
         version: link:../admin-babel-preset
-      '@comet/admin-theme':
-        specifier: workspace:^7.0.0-beta.2
-        version: link:../admin-theme
       '@comet/eslint-config':
         specifier: workspace:^7.0.0-beta.2
         version: link:../../eslint-config


### PR DESCRIPTION
Having a peer dependency on another Comet package doesn't work correctly with canary or beta releases and causes install errors when trying to upgrade. We don't use peer dependencies for the other packages (e.g., `@comet/admin-icons`) either, but normal dependencies. Package managers should be smart enough to deduplicate anyway.
