### PR TITLE
Remove `<a>` tag from `DamFileDownloadLinkBlock`

### DIFF
--- a/.changeset/brown-geckos-greet.md
+++ b/.changeset/brown-geckos-greet.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": minor
+---
+
+`DamFileDownloadLinkBlock` does not add a-tag

--- a/.changeset/brown-geckos-greet.md
+++ b/.changeset/brown-geckos-greet.md
@@ -1,5 +1,5 @@
 ---
-"@comet/cms-site": minor
+"@comet/cms-site": patch
 ---
 
 `DamFileDownloadLinkBlock` does not add a-tag

--- a/.changeset/brown-geckos-greet.md
+++ b/.changeset/brown-geckos-greet.md
@@ -2,4 +2,6 @@
 "@comet/cms-site": patch
 ---
 
-`DamFileDownloadLinkBlock` does not add a-tag
+Remove `<a>` tag from `DamFileDownloadLinkBlock`
+
+The block incorrectly added the tag which prevents styling it in the application. The tag has been removed to achieve the same behavior as in the other link blocks, e.g. `ExternalLinkBlock`.

--- a/packages/site/cms-site/src/blocks/DamFileDownloadLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/DamFileDownloadLinkBlock.tsx
@@ -5,29 +5,23 @@ import { withPreview } from "../iframebridge/withPreview";
 import { PropsWithData } from "./PropsWithData";
 
 interface Props extends PropsWithData<DamFileDownloadLinkBlockData> {
-    children: React.ReactNode;
+    children: React.ReactElement;
     title?: string;
 }
 
 export const DamFileDownloadLinkBlock = withPreview(
     ({ data: { file, openFileType }, children, title }: Props) => {
-        if (file === undefined) {
-            return <>{children}</>;
+        if (!file) {
+            return children;
         }
 
-        if (openFileType === "Download") {
-            return (
-                <a href={file.fileUrl} title={title}>
-                    {children}
-                </a>
-            );
-        } else {
-            return (
-                <a href={file.fileUrl} target="_blank" rel="noreferrer" title={title}>
-                    {children}
-                </a>
-            );
-        }
+        const childProps = {
+            href: file.fileUrl,
+            title,
+            ...(openFileType !== "Download" && { target: "_blank" }),
+        };
+
+        return React.cloneElement(children, childProps);
     },
     { label: "DamFileDownloadLink" },
 );

--- a/packages/site/cms-site/src/blocks/DamFileDownloadLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/DamFileDownloadLinkBlock.tsx
@@ -18,7 +18,7 @@ export const DamFileDownloadLinkBlock = withPreview(
         const childProps = {
             href: file.fileUrl,
             title,
-            ...(openFileType !== "Download" && { target: "_blank" }),
+            ...(openFileType === "NewTab" && { target: "_blank" }),
         };
 
         return React.cloneElement(children, childProps);


### PR DESCRIPTION
The block incorrectly added the tag which prevents styling it in the application. The tag has been removed to achieve the same behavior as in the other link blocks, e.g. `ExternalLinkBlock`.

--- 

![Screenshot 2024-06-26 at 15 04 08](https://github.com/vivid-planet/comet/assets/42858722/7c7883ff-0a6b-4ad8-8c63-e2b6a52556e1)
