### PR TITLE
Move the ScopeIndicator from the ToolbarBreadcrumbs to the Toolbar

### DIFF
--- a/.changeset/unlucky-hats-exist.md
+++ b/.changeset/unlucky-hats-exist.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": major
+---
+
+Move the `ScopeIndicator` from the `ToolbarBreadcrumbs` to the `Toolbar`

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -7,7 +7,7 @@ import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps
 import { MasterLayoutContext } from "../../mui/MasterLayoutContext";
 import { ToolbarBreadcrumbs } from "./ToolbarBreadcrumbs";
 
-export type ToolbarClassKey = "root" | "topBar" | "bottomBar" | "mainContentContainer" | "breadcrumbs";
+export type ToolbarClassKey = "root" | "topBar" | "bottomBar" | "mainContentContainer" | "breadcrumbs" | "scopeIndicator";
 
 export interface ToolbarProps
     extends ThemedComponentBaseProps<{
@@ -16,6 +16,7 @@ export interface ToolbarProps
         mainContentContainer: "div";
         topBar: "div";
         breadcrumbs: typeof ToolbarBreadcrumbs;
+        scopeIndicator: "div";
     }> {
     elevation?: number;
     children?: React.ReactNode;
@@ -45,9 +46,21 @@ const Root = createComponentSlot(Paper)<ToolbarClassKey, OwnerState>({
 const TopBar = createComponentSlot("div")<ToolbarClassKey>({
     componentName: "Toolbar",
     slotName: "topBar",
-})(css`
-    min-height: 40px;
-`);
+})(
+    ({ theme }) => css`
+        min-height: 40px;
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing(2)};
+        padding-left: ${theme.spacing(2)};
+        padding-right: ${theme.spacing(2)};
+    `,
+);
+
+const ScopeIndicator = createComponentSlot("div")<ToolbarClassKey>({
+    componentName: "Toolbar",
+    slotName: "scopeIndicator",
+})();
 
 const BottomBar = createComponentSlot(MuiToolbar)<ToolbarClassKey>({
     componentName: "Toolbar",
@@ -106,7 +119,8 @@ export const Toolbar = (inProps: ToolbarProps) => {
         <Root elevation={elevation} ownerState={ownerState} {...slotProps?.root} {...restProps}>
             {!hideTopBar && (
                 <TopBar {...slotProps?.topBar}>
-                    <Breadcrumbs scopeIndicator={scopeIndicator} {...slotProps?.breadcrumbs} />
+                    {Boolean(scopeIndicator) && <ScopeIndicator {...slotProps?.scopeIndicator}>{scopeIndicator}</ScopeIndicator>}
+                    <Breadcrumbs {...slotProps?.breadcrumbs} />
                 </TopBar>
             )}
             {children && (

--- a/packages/admin/admin/src/common/toolbar/ToolbarBreadcrumbs.tsx
+++ b/packages/admin/admin/src/common/toolbar/ToolbarBreadcrumbs.tsx
@@ -26,7 +26,6 @@ const __DEBUG__useDebugBreadcrumbData = false;
 
 type ToolbarBreadcrumbsClassKey =
     | "root"
-    | "scopeIndicator"
     | "breadcrumbsList"
     | "mobileBreadcrumbsButton"
     | "currentBreadcrumbsItem"
@@ -42,7 +41,6 @@ type ToolbarBreadcrumbsClassKey =
 interface ToolbarBreadcrumbsProps
     extends ThemedComponentBaseProps<{
         root: "div";
-        scopeIndicator: "div";
         breadcrumbsList: "div";
         mobileBreadcrumbsButton: typeof ButtonBase;
         currentBreadcrumbsItem: typeof Typography;
@@ -55,7 +53,6 @@ interface ToolbarBreadcrumbsProps
         mobileMenuItemText: typeof ListItemText;
         mobileMenuItemNestingIndicator: "div";
     }> {
-    scopeIndicator?: React.ReactNode;
     iconMapping?: {
         itemSeparator?: React.ReactNode;
         openMobileMenu?: React.ReactNode;
@@ -64,7 +61,7 @@ interface ToolbarBreadcrumbsProps
 }
 
 export const ToolbarBreadcrumbs = (inProps: ToolbarBreadcrumbsProps) => {
-    const { scopeIndicator, iconMapping = {}, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarBreadcrumbs" });
+    const { iconMapping = {}, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarBreadcrumbs" });
     const {
         itemSeparator: itemSeparatorIcon = <ChevronRight />,
         openMobileMenu: openMobileMenuIcon = <ChevronDown />,
@@ -92,7 +89,6 @@ export const ToolbarBreadcrumbs = (inProps: ToolbarBreadcrumbsProps) => {
     return (
         <>
             <Root ref={rootRef} {...slotProps?.root} {...restProps}>
-                {Boolean(scopeIndicator) && <ScopeIndicator {...slotProps?.scopeIndicator}>{scopeIndicator}</ScopeIndicator>}
                 <BreadcrumbsList {...slotProps?.breadcrumbsList}>
                     {breadcrumbs.map(({ title, url }, index) => {
                         const isCurrentPage = index === breadcrumbs.length - 1;
@@ -202,15 +198,8 @@ const Root = createComponentSlot("div")<ToolbarBreadcrumbsClassKey>({
         display: flex;
         align-items: center;
         gap: ${theme.spacing(2)};
-        padding-left: ${theme.spacing(2)};
-        padding-right: ${theme.spacing(2)};
     `,
 );
-
-const ScopeIndicator = createComponentSlot("div")<ToolbarBreadcrumbsClassKey>({
-    componentName: "ToolbarBreadcrumbs",
-    slotName: "scopeIndicator",
-})();
 
 const BreadcrumbsList = createComponentSlot("div")<ToolbarBreadcrumbsClassKey>({
     componentName: "ToolbarBreadcrumbs",


### PR DESCRIPTION
This makes more sense because the ScopeIndicator doesn't really have anything to do with the Breadcrumbs. Also, it makes it possible to render a ScopeIndicator without breadcrumbs (outside of a Stack).

It looks the same (see screenshots)

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->


Before:

<img width="1728" alt="Bildschirmfoto 2024-06-27 um 11 04 51" src="https://github.com/vivid-planet/comet/assets/13380047/74278ee2-31d7-44d3-bb63-1f02fa535310">


After:

<img width="1728" alt="Bildschirmfoto 2024-06-27 um 11 06 07" src="https://github.com/vivid-planet/comet/assets/13380047/e80f3346-4310-451d-8899-be7251c04892">


</details>
