### PR TITLE
Fix `@comet/cms-api` block meta generation

### DIFF
--- a/packages/api/blocks-api/block-meta.json
+++ b/packages/api/blocks-api/block-meta.json
@@ -1,22 +1,5 @@
 [
     {
-        "name": "EmailLink",
-        "fields": [
-            {
-                "name": "email",
-                "kind": "String",
-                "nullable": true
-            }
-        ],
-        "inputFields": [
-            {
-                "name": "email",
-                "kind": "String",
-                "nullable": true
-            }
-        ]
-    },
-    {
         "name": "ExternalLink",
         "fields": [
             {
@@ -39,23 +22,6 @@
             {
                 "name": "openInNewWindow",
                 "kind": "Boolean",
-                "nullable": false
-            }
-        ]
-    },
-    {
-        "name": "PhoneLink",
-        "fields": [
-            {
-                "name": "phone",
-                "kind": "String",
-                "nullable": false
-            }
-        ],
-        "inputFields": [
-            {
-                "name": "phone",
-                "kind": "String",
                 "nullable": false
             }
         ]

--- a/packages/api/cms-api/generate-block-meta.ts
+++ b/packages/api/cms-api/generate-block-meta.ts
@@ -1,7 +1,7 @@
-import { createRichTextBlock, createTextLinkBlock, EmailLinkBlock, ExternalLinkBlock, getBlocksMeta, PhoneLinkBlock } from "@comet/blocks-api";
+import { createRichTextBlock, createTextLinkBlock, ExternalLinkBlock, getBlocksMeta } from "@comet/blocks-api";
 import { promises as fs } from "fs";
 
-import { createLinkBlock, createSeoBlock, createTextImageBlock, InternalLinkBlock } from "./src";
+import { createLinkBlock, createSeoBlock, createTextImageBlock, EmailLinkBlock, InternalLinkBlock, PhoneLinkBlock } from "./src";
 
 async function generateBlockMeta(): Promise<void> {
     console.info("Generating block-meta.json...");


### PR DESCRIPTION
The files were moved from `@comet/blocks-api` to `@comet/cms-api`, but the import was not updated resulting, in a TS error when generating the block meta.

---

![Screenshot 2024-06-27 at 13 45 48](https://github.com/vivid-planet/comet/assets/42858722/1fb4c30b-aafd-4522-a8de-fa954d5fc664)
