### PR TITLE
Lint generated schema files in API packages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,6 +61,13 @@ jobs:
 
             - run: pnpm install --frozen-lockfile
 
+            - name: Generate schema files
+              run: |
+                  pnpm --filter '@comet/blocks-api' run generate-block-meta
+                  pnpm --filter '@comet/cms-api' run generate-block-meta
+                  pnpm --filter '@comet/cms-api' run generate-schema
+                  git diff --exit-code HEAD --
+
             - name: Copy schema files
               run: pnpm run copy-schema-files
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,13 +61,6 @@ jobs:
 
             - run: pnpm install --frozen-lockfile
 
-            - name: Generate schema files
-              run: |
-                  pnpm --filter '@comet/blocks-api' run generate-block-meta
-                  pnpm --filter '@comet/cms-api' run generate-block-meta
-                  pnpm --filter '@comet/cms-api' run generate-schema
-                  git diff --exit-code HEAD --
-
             - name: Copy schema files
               run: pnpm run copy-schema-files
 
@@ -80,3 +73,8 @@ jobs:
                   pnpm run lint
                   # check for duplicate ids of formatted messages
                   pnpm run intl:extract
+                  # check if schema files are up to date
+                  pnpm --filter '@comet/blocks-api' run generate-block-meta
+                  pnpm --filter '@comet/cms-api' run generate-block-meta
+                  pnpm --filter '@comet/cms-api' run generate-schema
+                  git diff --exit-code HEAD --

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -441,14 +441,14 @@
             {
                 "name": "phone",
                 "kind": "String",
-                "nullable": false
+                "nullable": true
             }
         ],
         "inputFields": [
             {
                 "name": "phone",
                 "kind": "String",
-                "nullable": false
+                "nullable": true
             }
         ]
     },


### PR DESCRIPTION
The GraphQL schema and block meta generation in API packages repeatedly didn't work due to missing and/or broken imports. To prevent this, we generate the files in the lint workflow, where an error during generation should be more visible. This furthermore allows as to verify that the files are up-to-date (similar to the API Generator lint).