### PR TITLE
Adapt demo vite dev server host option

### DIFF
--- a/demo/admin/vite.config.mts
+++ b/demo/admin/vite.config.mts
@@ -47,7 +47,7 @@ export default defineConfig(({ mode }) => {
             }),
         ],
         server: {
-            host: "0.0.0.0",
+            host: true,
             port: Number(process.env.ADMIN_PORT),
         },
         define: {


### PR DESCRIPTION
Change vite server host option from `host: "0.0.0.0"` to `host: true`.
This fixes the local development for me.
`admin-codegen` and `admin-block-codegen` kept waiting for `admin` microservice to start.

https://vitejs.dev/config/server-options.html#server-host