### PR TITLE
Add permission configuration

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -2,28 +2,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
-type CurrentUserPermission {
-  permission: String!
-  contentScopes: [JSONObject!]!
-}
-
-"""
-The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
-
-type CurrentUser {
-  id: String!
-  name: String!
-  email: String!
-  language: String!
-  permissions: [CurrentUserPermission!]!
-}
-
 type UserPermission {
   id: ID!
   source: UserPermissionSource!
   permission: String!
+  configuration: JSONObject
   validFrom: DateTime
   validTo: DateTime
   reason: String
@@ -39,9 +22,28 @@ enum UserPermissionSource {
 }
 
 """
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+"""
 A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
 """
 scalar DateTime
+
+type CurrentUserPermission {
+  permission: String!
+  configuration: JSONObject
+  contentScopes: [JSONObject!]!
+}
+
+type CurrentUser {
+  id: String!
+  name: String!
+  email: String!
+  language: String!
+  permissions: [CurrentUserPermission!]!
+}
 
 type Dependency {
   rootId: String!
@@ -187,6 +189,11 @@ type User {
 type PaginatedUserList {
   nodes: [User!]!
   totalCount: Int!
+}
+
+type Permission {
+  permission: String!
+  configuration: JSONObject
 }
 
 type Link implements DocumentInterface {
@@ -605,7 +612,7 @@ type Query {
   userPermissionsUsers(offset: Int! = 0, limit: Int! = 25, search: String, filter: UserFilter, sort: [UserSort!]): PaginatedUserList!
   userPermissionsPermissionList(userId: String!): [UserPermission!]!
   userPermissionsPermission(id: ID!, userId: String): UserPermission!
-  userPermissionsAvailablePermissions: [String!]!
+  userPermissionsAvailablePermissions: [Permission!]!
   userPermissionsContentScopes(userId: String!, skipManual: Boolean): [JSONObject!]!
   userPermissionsAvailableContentScopes: [JSONObject!]!
   buildTemplates: [BuildTemplate!]!
@@ -937,8 +944,6 @@ type Mutation {
   updateDamFolder(id: ID!, input: UpdateDamFolderInput!): DamFolder!
   moveDamFolders(folderIds: [ID!]!, targetFolderId: ID, scope: DamScopeInput!): [DamFolder!]!
   deleteDamFolder(id: ID!): Boolean!
-  generateImageTitle(fileId: String!): String!
-  generateAltText(fileId: String!): String!
   createNews(scope: NewsContentScopeInput!, input: NewsInput!): News!
   updateNews(id: ID!, input: NewsUpdateInput!, lastUpdatedAt: DateTime): News!
   deleteNews(id: ID!): Boolean!
@@ -964,6 +969,7 @@ type Mutation {
 
 input UserPermissionInput {
   permission: String!
+  configuration: JSONObject
   validFrom: DateTime
   validTo: DateTime
   reason: String

--- a/demo/api/src/auth/access-control.service.ts
+++ b/demo/api/src/auth/access-control.service.ts
@@ -7,7 +7,17 @@ export class AccessControlService extends AbstractAccessControlService {
         if (user.isAdmin) {
             return UserPermissions.allPermissions;
         } else {
-            return [{ permission: "products" }, { permission: "news", contentScopes: [{ domain: "secondary", language: "en" }] }];
+            return [
+                { permission: "products" },
+                {
+                    permission: ["news", "news.update"],
+                    contentScopes: [{ domain: "secondary", language: "en" }],
+                },
+                {
+                    permission: { permission: "news", configuration: { delete: true } },
+                    contentScopes: [{ domain: "secondary", language: "en" }],
+                },
+            ];
         }
     }
     getContentScopesForUser(user: User): ContentScopesForUser {

--- a/demo/api/src/footer/generated/footer.resolver.ts
+++ b/demo/api/src/footer/generated/footer.resolver.ts
@@ -11,7 +11,7 @@ import { FooterInput } from "./dto/footer.input";
 import { FootersService } from "./footers.service";
 
 @Resolver(() => Footer)
-@RequiredPermission(["pageTree"])
+@RequiredPermission(["pageTree.read"])
 export class FooterResolver {
     constructor(
         private readonly entityManager: EntityManager,
@@ -30,6 +30,7 @@ export class FooterResolver {
     }
 
     @Mutation(() => Footer)
+    @RequiredPermission(["pageTree.update"])
     async saveFooter(
         @Args("scope", { type: () => FooterContentScope }) scope: FooterContentScope,
         @Args("input", { type: () => FooterInput }) input: FooterInput,

--- a/demo/api/src/news/generated/news.resolver.ts
+++ b/demo/api/src/news/generated/news.resolver.ts
@@ -15,7 +15,7 @@ import { PaginatedNews } from "./dto/paginated-news";
 import { NewsService } from "./news.service";
 
 @Resolver(() => News)
-@RequiredPermission(["news"])
+@RequiredPermission(["news.read"])
 export class NewsResolver {
     constructor(
         private readonly entityManager: EntityManager,
@@ -64,6 +64,7 @@ export class NewsResolver {
     }
 
     @Mutation(() => News)
+    @RequiredPermission(["news.create"])
     async createNews(
         @Args("scope", { type: () => NewsContentScope }) scope: NewsContentScope,
         @Args("input", { type: () => NewsInput }) input: NewsInput,
@@ -85,6 +86,7 @@ export class NewsResolver {
 
     @Mutation(() => News)
     @AffectedEntity(News)
+    @RequiredPermission(["news.update"])
     async updateNews(
         @Args("id", { type: () => ID }) id: string,
         @Args("input", { type: () => NewsUpdateInput }) input: NewsUpdateInput,
@@ -114,6 +116,7 @@ export class NewsResolver {
 
     @Mutation(() => Boolean)
     @AffectedEntity(News)
+    @RequiredPermission(["news.delete"])
     async deleteNews(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
         const news = await this.repository.findOneOrFail(id);
         this.entityManager.remove(news);
@@ -123,6 +126,7 @@ export class NewsResolver {
 
     @Mutation(() => News)
     @AffectedEntity(News)
+    @RequiredPermission(["news.update"])
     async updateNewsVisibility(
         @Args("id", { type: () => ID }) id: string,
         @Args("visible", { type: () => Boolean }) visible: boolean,

--- a/demo/api/src/products/generated/product-category.resolver.ts
+++ b/demo/api/src/products/generated/product-category.resolver.ts
@@ -15,7 +15,7 @@ import { ProductCategoryInput, ProductCategoryUpdateInput } from "./dto/product-
 import { ProductCategoriesService } from "./product-categories.service";
 
 @Resolver(() => ProductCategory)
-@RequiredPermission(["products"], { skipScopeCheck: true })
+@RequiredPermission(["products.read"], { skipScopeCheck: true })
 export class ProductCategoryResolver {
     constructor(
         private readonly entityManager: EntityManager,
@@ -67,6 +67,7 @@ export class ProductCategoryResolver {
     }
 
     @Mutation(() => ProductCategory)
+    @RequiredPermission(["products.create"], { skipScopeCheck: true })
     async createProductCategory(@Args("input", { type: () => ProductCategoryInput }) input: ProductCategoryInput): Promise<ProductCategory> {
         const { products: productsInput, ...assignInput } = input;
         const productCategory = this.repository.create({
@@ -87,6 +88,7 @@ export class ProductCategoryResolver {
 
     @Mutation(() => ProductCategory)
     @AffectedEntity(ProductCategory)
+    @RequiredPermission(["products.update"], { skipScopeCheck: true })
     async updateProductCategory(
         @Args("id", { type: () => ID }) id: string,
         @Args("input", { type: () => ProductCategoryUpdateInput }) input: ProductCategoryUpdateInput,
@@ -116,6 +118,7 @@ export class ProductCategoryResolver {
 
     @Mutation(() => Boolean)
     @AffectedEntity(ProductCategory)
+    @RequiredPermission(["products.delete"], { skipScopeCheck: true })
     async deleteProductCategory(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
         const productCategory = await this.repository.findOneOrFail(id);
         this.entityManager.remove(productCategory);

--- a/demo/api/src/products/generated/product-tag.resolver.ts
+++ b/demo/api/src/products/generated/product-tag.resolver.ts
@@ -16,7 +16,7 @@ import { ProductTagsArgs } from "./dto/product-tags.args";
 import { ProductTagsService } from "./product-tags.service";
 
 @Resolver(() => ProductTag)
-@RequiredPermission(["products"], { skipScopeCheck: true })
+@RequiredPermission(["products.read"], { skipScopeCheck: true })
 export class ProductTagResolver {
     constructor(
         private readonly entityManager: EntityManager,
@@ -65,6 +65,7 @@ export class ProductTagResolver {
     }
 
     @Mutation(() => ProductTag)
+    @RequiredPermission(["products.create"], { skipScopeCheck: true })
     async createProductTag(@Args("input", { type: () => ProductTagInput }) input: ProductTagInput): Promise<ProductTag> {
         const { productsWithStatus: productsWithStatusInput, products: productsInput, ...assignInput } = input;
         const productTag = this.repository.create({
@@ -99,6 +100,7 @@ export class ProductTagResolver {
 
     @Mutation(() => ProductTag)
     @AffectedEntity(ProductTag)
+    @RequiredPermission(["products.update"], { skipScopeCheck: true })
     async updateProductTag(
         @Args("id", { type: () => ID }) id: string,
         @Args("input", { type: () => ProductTagUpdateInput }) input: ProductTagUpdateInput,
@@ -142,6 +144,7 @@ export class ProductTagResolver {
 
     @Mutation(() => Boolean)
     @AffectedEntity(ProductTag)
+    @RequiredPermission(["products.delete"], { skipScopeCheck: true })
     async deleteProductTag(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
         const productTag = await this.repository.findOneOrFail(id);
         this.entityManager.remove(productTag);

--- a/demo/api/src/products/generated/product-to-tag.resolver.ts
+++ b/demo/api/src/products/generated/product-to-tag.resolver.ts
@@ -9,7 +9,7 @@ import { ProductTag } from "../entities/product-tag.entity";
 import { ProductToTag } from "../entities/product-to-tag.entity";
 
 @Resolver(() => ProductToTag)
-@RequiredPermission(["products"], { skipScopeCheck: true })
+@RequiredPermission(["products.read"], { skipScopeCheck: true })
 export class ProductToTagResolver {
     @ResolveField(() => Product)
     async product(@Parent() productToTag: ProductToTag): Promise<Product> {

--- a/demo/api/src/products/generated/product-variant.resolver.ts
+++ b/demo/api/src/products/generated/product-variant.resolver.ts
@@ -8,7 +8,7 @@ import { Product } from "../entities/product.entity";
 import { ProductVariant } from "../entities/product-variant.entity";
 
 @Resolver(() => ProductVariant)
-@RequiredPermission(["products"], { skipScopeCheck: true })
+@RequiredPermission(["products.read"], { skipScopeCheck: true })
 export class ProductVariantResolver {
     @ResolveField(() => Product)
     async product(@Parent() productVariant: ProductVariant): Promise<Product> {

--- a/demo/api/src/products/generated/product.resolver.ts
+++ b/demo/api/src/products/generated/product.resolver.ts
@@ -19,7 +19,7 @@ import { ProductsArgs } from "./dto/products.args";
 import { ProductsService } from "./products.service";
 
 @Resolver(() => Product)
-@RequiredPermission(["products"], { skipScopeCheck: true })
+@RequiredPermission(["products.read"], { skipScopeCheck: true })
 export class ProductResolver {
     constructor(
         private readonly entityManager: EntityManager,
@@ -84,6 +84,7 @@ export class ProductResolver {
     }
 
     @Mutation(() => Product)
+    @RequiredPermission(["products.create"], { skipScopeCheck: true })
     async createProduct(@Args("input", { type: () => ProductInput }) input: ProductInput): Promise<Product> {
         const {
             variants: variantsInput,
@@ -151,6 +152,7 @@ export class ProductResolver {
 
     @Mutation(() => Product)
     @AffectedEntity(Product)
+    @RequiredPermission(["products.update"], { skipScopeCheck: true })
     async updateProduct(
         @Args("id", { type: () => ID }) id: string,
         @Args("input", { type: () => ProductUpdateInput }) input: ProductUpdateInput,
@@ -230,6 +232,7 @@ export class ProductResolver {
 
     @Mutation(() => Boolean)
     @AffectedEntity(Product)
+    @RequiredPermission(["products.delete"], { skipScopeCheck: true })
     async deleteProduct(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
         const product = await this.repository.findOneOrFail(id);
         this.entityManager.remove(product);
@@ -239,6 +242,7 @@ export class ProductResolver {
 
     @Mutation(() => Product)
     @AffectedEntity(Product)
+    @RequiredPermission(["products.update"], { skipScopeCheck: true })
     async updateProductVisibility(
         @Args("id", { type: () => ID }) id: string,
         @Args("visible", { type: () => Boolean }) visible: boolean,

--- a/packages/admin/cms-admin/src/userPermissions/UserPermissionsPage.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/UserPermissionsPage.tsx
@@ -5,15 +5,23 @@ import { FormattedMessage } from "react-intl";
 import { UserPage } from "./user/UserPage";
 import { UserGrid } from "./UserGrid";
 
-export const UserPermissionsPage = (): React.ReactElement => (
-    <Stack topLevelTitle={<FormattedMessage id="comet.userPermissions.title" defaultMessage="User Management" />}>
-        <StackSwitch>
-            <StackPage name="table">
-                <MainContent fullHeight>
-                    <UserGrid />
-                </MainContent>
-            </StackPage>
-            <StackPage name="edit">{(userId) => <UserPage userId={userId} />}</StackPage>
-        </StackSwitch>
-    </Stack>
+export interface UserPermissionsPageProps {
+    configurationSlots?: { [key: string]: () => JSX.Element };
+}
+
+export const UserPermissionsSettings = React.createContext<UserPermissionsPageProps>({});
+
+export const UserPermissionsPage = (props: UserPermissionsPageProps): React.ReactElement => (
+    <UserPermissionsSettings.Provider value={props}>
+        <Stack topLevelTitle={<FormattedMessage id="comet.userPermissions.title" defaultMessage="User Management" />}>
+            <StackSwitch>
+                <StackPage name="table">
+                    <MainContent fullHeight>
+                        <UserGrid />
+                    </MainContent>
+                </StackPage>
+                <StackPage name="edit">{(userId) => <UserPage userId={userId} />}</StackPage>
+            </StackSwitch>
+        </Stack>
+    </UserPermissionsSettings.Provider>
 );

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/PermissionDialog.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/PermissionDialog.tsx
@@ -1,10 +1,12 @@
 import { gql, useApolloClient, useQuery } from "@apollo/client";
-import { CancelButton, Field, FinalForm, FinalFormInput, FinalFormSelect, FormSection, Loading, SaveButton } from "@comet/admin";
+import { CancelButton, Field, FinalForm, FinalFormCheckbox, FinalFormInput, FinalFormSelect, FormSection, Loading, SaveButton } from "@comet/admin";
 import { FinalFormDatePicker } from "@comet/admin-date-time";
-import { Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import { Dialog, DialogActions, DialogContent, DialogTitle, InputBaseProps, styled } from "@mui/material";
 import React from "react";
+import { FieldRenderProps, Form } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
+import { UserPermissionsSettings } from "../../UserPermissionsPage";
 import { camelCaseToHumanReadable } from "../../utils/camelCaseToHumanReadable";
 import {
     GQLAvailablePermissionsQuery,
@@ -19,12 +21,56 @@ import {
     namedOperations,
 } from "./PermissionDialog.generated";
 
+const CheckboxConfiguration = ({ configuration }: { configuration: Record<string, boolean> }) => {
+    return (
+        <>
+            {Object.keys(configuration).map((key) => (
+                <Field key={key} name={key} component={FinalFormCheckbox} type="checkbox" label={camelCaseToHumanReadable(key)} />
+            ))}
+        </>
+    );
+};
+
+type ConfigurationProps = InputBaseProps &
+    FieldRenderProps<JSON, HTMLInputElement | HTMLTextAreaElement> & {
+        configurationComponent: () => React.ReactNode;
+    };
+const Configuration = ({ configurationComponent, input, disabled }: ConfigurationProps) => {
+    const ConfigurationComponent = ({ values }: { values: JSON }) => {
+        React.useEffect(() => {
+            if (input.value !== values) {
+                input.onChange(values);
+            }
+        }, [values]);
+        return configurationComponent();
+    };
+    return (
+        <FormSection title={<FormattedMessage id="comet.userPermissions.configuration" defaultMessage="Configuration" />}>
+            <Fieldset disabled={disabled}>
+                <Form
+                    onSubmit={() => {
+                        /* */
+                    }}
+                    initialValues={input.value}
+                    render={ConfigurationComponent}
+                />
+            </Fieldset>
+        </FormSection>
+    );
+};
+
+// TODO Find better way to disable all children
+const Fieldset = styled("fieldset")`
+    border: none;
+`;
+
 interface FormProps {
     userId: string;
     permissionId: string | "add";
     handleDialogClose: () => void;
 }
 export const PermissionDialog: React.FC<FormProps> = ({ userId, permissionId, handleDialogClose }) => {
+    const settings = React.useContext(UserPermissionsSettings);
     const client = useApolloClient();
     const submit = async (submitData: GQLUserPermissionDialogFragment) => {
         const { source, __typename, ...data } = submitData; // Remove source and __typename from data
@@ -66,6 +112,7 @@ export const PermissionDialog: React.FC<FormProps> = ({ userId, permissionId, ha
             }
             fragment UserPermissionDialog on UserPermission {
                 permission
+                configuration
                 source
                 validFrom
                 validTo
@@ -85,7 +132,10 @@ export const PermissionDialog: React.FC<FormProps> = ({ userId, permissionId, ha
     >(
         gql`
             query AvailablePermissions {
-                availablePermissions: userPermissionsAvailablePermissions
+                availablePermissions: userPermissionsAvailablePermissions {
+                    permission
+                    configuration
+                }
             }
         `,
     );
@@ -117,75 +167,98 @@ export const PermissionDialog: React.FC<FormProps> = ({ userId, permissionId, ha
                 onSubmit={submit}
                 onAfterSubmit={() => null}
                 initialValues={initialValues}
-                render={({ values }) => (
-                    <>
-                        <DialogTitle>
-                            <FormattedMessage id="comet.userPermissions.showPermission" defaultMessage="Show permission" />
-                        </DialogTitle>
-                        <DialogContent>
-                            <Field
-                                required
-                                fullWidth
-                                name="permission"
-                                component={FinalFormSelect}
-                                options={availablePermissionsData.availablePermissions}
-                                getOptionLabel={(permission: string) => camelCaseToHumanReadable(permission)}
-                                disabled={disabled}
-                                label={<FormattedMessage id="comet.userPermissions.permission" defaultMessage="Permission" />}
-                            />
-                            <Field
-                                name="validFrom"
-                                label={<FormattedMessage id="comet.userPermissions.validFrom" defaultMessage="Valid from" />}
-                                fullWidth
-                                component={FinalFormDatePicker}
-                                disabled={disabled}
-                                clearable={true}
-                                formatDateOptions={{ month: "short", day: "numeric", year: "numeric" }}
-                            />
-                            <Field
-                                name="validTo"
-                                label={<FormattedMessage id="comet.userPermissions.validTo" defaultMessage="Valid to" />}
-                                fullWidth
-                                component={FinalFormDatePicker}
-                                disabled={disabled}
-                                clearable={true}
-                                formatDateOptions={{ month: "short", day: "numeric", year: "numeric" }}
-                            />
-                            <FormSection title={<FormattedMessage id="comet.userPermissions.documentation" defaultMessage="Documentation" />}>
+                render={({ values }) => {
+                    const configuration = availablePermissionsData.availablePermissions.find(
+                        (p) => p.permission === values.permission,
+                    )?.configuration;
+                    let configurationComponent;
+                    if (configuration) {
+                        if (settings.configurationSlots && settings.configurationSlots[values.permission]) {
+                            configurationComponent = settings.configurationSlots[values.permission];
+                        } else {
+                            configurationComponent = () => <CheckboxConfiguration configuration={configuration} />;
+                            if (!values.configuration) values.configuration = configuration; // By default enable all sub-permissions
+                        }
+                    }
+                    return (
+                        <>
+                            <DialogTitle>
+                                <FormattedMessage id="comet.userPermissions.showPermission" defaultMessage="Show permission" />
+                            </DialogTitle>
+                            <DialogContent>
                                 <Field
+                                    required
                                     fullWidth
-                                    name="reason"
-                                    component={FinalFormInput}
+                                    name="permission"
+                                    component={FinalFormSelect}
+                                    options={availablePermissionsData.availablePermissions.map((p) => p.permission)}
+                                    getOptionLabel={(permission: string) => camelCaseToHumanReadable(permission)}
                                     disabled={disabled}
-                                    label={<FormattedMessage id="comet.userPermissions.reason" defaultMessage="Reason" />}
-                                    disableContentTranslation
+                                    label={<FormattedMessage id="comet.userPermissions.permission" defaultMessage="Permission" />}
+                                />
+                                {configurationComponent && (
+                                    <Field
+                                        name="configuration"
+                                        type="hidden"
+                                        component={Configuration}
+                                        disabled={disabled}
+                                        configurationComponent={configurationComponent}
+                                    />
+                                )}
+                                <Field
+                                    name="validFrom"
+                                    label={<FormattedMessage id="comet.userPermissions.validFrom" defaultMessage="Valid from" />}
+                                    fullWidth
+                                    component={FinalFormDatePicker}
+                                    disabled={disabled}
+                                    clearable={true}
+                                    formatDateOptions={{ month: "short", day: "numeric", year: "numeric" }}
                                 />
                                 <Field
+                                    name="validTo"
+                                    label={<FormattedMessage id="comet.userPermissions.validTo" defaultMessage="Valid to" />}
                                     fullWidth
-                                    name="requestedBy"
-                                    component={FinalFormInput}
+                                    component={FinalFormDatePicker}
                                     disabled={disabled}
-                                    label={<FormattedMessage id="comet.userPermissions.requestedBy" defaultMessage="Requested by" />}
-                                    disableContentTranslation
+                                    clearable={true}
+                                    formatDateOptions={{ month: "short", day: "numeric", year: "numeric" }}
                                 />
-                                <Field
-                                    fullWidth
-                                    name="approvedBy"
-                                    component={FinalFormInput}
-                                    disabled={disabled}
-                                    label={<FormattedMessage id="comet.userPermissions.approvedBy" defaultMessage="Approved by" />}
-                                    disableContentTranslation
-                                />
-                            </FormSection>
-                        </DialogContent>
-                        <DialogActions>
-                            <CancelButton onClick={handleDialogClose}>
-                                <FormattedMessage id="comet.userPermissions.close" defaultMessage="Close" />
-                            </CancelButton>
-                            {!disabled && <SaveButton type="submit" />}
-                        </DialogActions>
-                    </>
-                )}
+                                <FormSection title={<FormattedMessage id="comet.userPermissions.documentation" defaultMessage="Documentation" />}>
+                                    <Field
+                                        fullWidth
+                                        name="reason"
+                                        component={FinalFormInput}
+                                        disabled={disabled}
+                                        label={<FormattedMessage id="comet.userPermissions.reason" defaultMessage="Reason" />}
+                                        disableContentTranslation
+                                    />
+                                    <Field
+                                        fullWidth
+                                        name="requestedBy"
+                                        component={FinalFormInput}
+                                        disabled={disabled}
+                                        label={<FormattedMessage id="comet.userPermissions.requestedBy" defaultMessage="Requested by" />}
+                                        disableContentTranslation
+                                    />
+                                    <Field
+                                        fullWidth
+                                        name="approvedBy"
+                                        component={FinalFormInput}
+                                        disabled={disabled}
+                                        label={<FormattedMessage id="comet.userPermissions.approvedBy" defaultMessage="Approved by" />}
+                                        disableContentTranslation
+                                    />
+                                </FormSection>
+                            </DialogContent>
+                            <DialogActions>
+                                <CancelButton onClick={handleDialogClose}>
+                                    <FormattedMessage id="comet.userPermissions.close" defaultMessage="Close" />
+                                </CancelButton>
+                                {!disabled && <SaveButton type="submit" />}
+                            </DialogActions>
+                        </>
+                    );
+                }}
             />
         </Dialog>
     );

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -1,25 +1,8 @@
-type CurrentUserPermission {
-  permission: String!
-  contentScopes: [JSONObject!]!
-}
-
-"""
-The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
-
-type CurrentUser {
-  id: String!
-  name: String!
-  email: String!
-  language: String!
-  permissions: [CurrentUserPermission!]!
-}
-
 type UserPermission {
   id: ID!
   source: UserPermissionSource!
   permission: String!
+  configuration: JSONObject
   validFrom: DateTime
   validTo: DateTime
   reason: String
@@ -35,9 +18,28 @@ enum UserPermissionSource {
 }
 
 """
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+"""
 A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
 """
 scalar DateTime
+
+type CurrentUserPermission {
+  permission: String!
+  configuration: JSONObject
+  contentScopes: [JSONObject!]!
+}
+
+type CurrentUser {
+  id: String!
+  name: String!
+  email: String!
+  language: String!
+  permissions: [CurrentUserPermission!]!
+}
 
 type Dependency {
   rootId: String!
@@ -183,6 +185,11 @@ type User {
 type PaginatedUserList {
   nodes: [User!]!
   totalCount: Int!
+}
+
+type Permission {
+  permission: String!
+  configuration: JSONObject
 }
 
 type PageTreeNode {
@@ -363,7 +370,7 @@ type Query {
   userPermissionsUsers(offset: Int! = 0, limit: Int! = 25, search: String, filter: UserFilter, sort: [UserSort!]): PaginatedUserList!
   userPermissionsPermissionList(userId: String!): [UserPermission!]!
   userPermissionsPermission(id: ID!, userId: String): UserPermission!
-  userPermissionsAvailablePermissions: [String!]!
+  userPermissionsAvailablePermissions: [Permission!]!
   userPermissionsContentScopes(userId: String!, skipManual: Boolean): [JSONObject!]!
   userPermissionsAvailableContentScopes: [JSONObject!]!
 }
@@ -624,6 +631,7 @@ input PageTreeNodeCreateInput {
 
 input UserPermissionInput {
   permission: String!
+  configuration: JSONObject
   validFrom: DateTime
   validTo: DateTime
   reason: String

--- a/packages/api/cms-api/src/generator/generate-crud-single.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-single.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 
 import { CrudSingleGeneratorOptions, hasFieldFeature } from "./crud-generator.decorator";
 import { generateCrudInput } from "./generate-crud-input";
+import { createRequiredPermissionDecorator } from "./utils/create-required-permission-decorator";
 import { GeneratedFile } from "./utils/write-generated-files";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -57,7 +58,7 @@ export async function generateCrudSingle(generatorOptions: CrudSingleGeneratorOp
     import { Paginated${classNamePlural} } from "./dto/paginated-${fileNamePlural}";
 
     @Resolver(() => ${metadata.className})
-    @RequiredPermission(${JSON.stringify(generatorOptions.requiredPermission)}${!scopeProp ? `, { skipScopeCheck: true }` : ""})
+    ${createRequiredPermissionDecorator(generatorOptions.requiredPermission, "read", !scopeProp)}
     export class ${classNameSingular}Resolver {
         constructor(
             private readonly entityManager: EntityManager,
@@ -78,6 +79,7 @@ export async function generateCrudSingle(generatorOptions: CrudSingleGeneratorOp
         }
     
         @Mutation(() => ${metadata.className})
+        ${createRequiredPermissionDecorator(generatorOptions.requiredPermission, "update", !scopeProp)}
         async save${classNameSingular}(
             ${scopeProp ? `@Args("scope", { type: () => ${scopeProp.type} }) scope: ${scopeProp.type},` : ""}
             @Args("input", { type: () => ${classNameSingular}Input }) input: ${classNameSingular}Input,

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -7,6 +7,7 @@ import { CrudGeneratorOptions, hasFieldFeature } from "./crud-generator.decorato
 import { generateCrudInput } from "./generate-crud-input";
 import { buildNameVariants, classNameToInstanceName } from "./utils/build-name-variants";
 import { integerTypes } from "./utils/constants";
+import { createRequiredPermissionDecorator } from "./utils/create-required-permission-decorator";
 import { generateImportsCode, Imports } from "./utils/generate-imports-code";
 import { findEnumImportPath, findEnumName } from "./utils/ts-morph-helper";
 import { GeneratedFile } from "./utils/write-generated-files";
@@ -591,7 +592,7 @@ function generateNestedEntityResolver({ generatorOptions, metadata }: { generato
     ${generateImportsCode(imports)}
 
     @Resolver(() => ${metadata.className})
-    @RequiredPermission(${JSON.stringify(generatorOptions.requiredPermission)}${skipScopeCheck ? `, { skipScopeCheck: true }` : ""})
+    ${createRequiredPermissionDecorator(generatorOptions.requiredPermission, "read", skipScopeCheck)}
     export class ${classNameSingular}Resolver {
         ${code}
     }
@@ -760,7 +761,7 @@ function generateResolver({ generatorOptions, metadata }: { generatorOptions: Cr
     ${generateImportsCode(imports)}
 
     @Resolver(() => ${metadata.className})
-    @RequiredPermission(${JSON.stringify(generatorOptions.requiredPermission)}${skipScopeCheck ? `, { skipScopeCheck: true }` : ""})
+    ${createRequiredPermissionDecorator(generatorOptions.requiredPermission, "read", skipScopeCheck)}
     export class ${classNameSingular}Resolver {
         constructor(
             private readonly entityManager: EntityManager,
@@ -858,6 +859,7 @@ function generateResolver({ generatorOptions, metadata }: { generatorOptions: Cr
                 ? `
 
         @Mutation(() => ${metadata.className})
+        ${createRequiredPermissionDecorator(generatorOptions.requiredPermission, "create", skipScopeCheck)}
         async create${classNameSingular}(
             ${scopeProp ? `@Args("scope", { type: () => ${scopeProp.type} }) scope: ${scopeProp.type},` : ""}
             @Args("input", { type: () => ${classNameSingular}Input }) input: ${classNameSingular}Input
@@ -878,6 +880,7 @@ function generateResolver({ generatorOptions, metadata }: { generatorOptions: Cr
                 ? `
         @Mutation(() => ${metadata.className})
         @AffectedEntity(${metadata.className})
+        ${createRequiredPermissionDecorator(generatorOptions.requiredPermission, "update", skipScopeCheck)}
         async update${classNameSingular}(
             ${
                 integerTypes.includes(metadata.properties.id.type)
@@ -910,6 +913,7 @@ function generateResolver({ generatorOptions, metadata }: { generatorOptions: Cr
                 ? `
         @Mutation(() => Boolean)
         @AffectedEntity(${metadata.className})
+        ${createRequiredPermissionDecorator(generatorOptions.requiredPermission, "delete", skipScopeCheck)}
         async delete${metadata.className}(${
                       integerTypes.includes(metadata.properties.id.type)
                           ? `@Args("id", { type: () => ID }, { transform: (value) => parseInt(value) }) id: number`
@@ -929,6 +933,7 @@ function generateResolver({ generatorOptions, metadata }: { generatorOptions: Cr
                 ? `
         @Mutation(() => ${metadata.className})
         @AffectedEntity(${metadata.className})
+        ${createRequiredPermissionDecorator(generatorOptions.requiredPermission, "update", skipScopeCheck)}
         async update${classNameSingular}Visibility(
             @Args("id", { type: () => ID }) id: string,
             @Args("visible", { type: () => Boolean }) visible: boolean,

--- a/packages/api/cms-api/src/generator/utils/create-required-permission-decorator.ts
+++ b/packages/api/cms-api/src/generator/utils/create-required-permission-decorator.ts
@@ -1,0 +1,12 @@
+export function createRequiredPermissionDecorator(
+    requiredPermissions: string | string[] | undefined,
+    subPermission: string,
+    skipScopeCheck: boolean,
+): string {
+    if (!requiredPermissions) return "";
+    let permissions = Array.isArray(requiredPermissions) ? requiredPermissions : [requiredPermissions];
+    if (subPermission) {
+        permissions = permissions.map((permission) => `${permission}.${subPermission}`);
+    }
+    return `@RequiredPermission(${JSON.stringify(permissions)}${skipScopeCheck ? `, { skipScopeCheck: true }` : ""})`;
+}

--- a/packages/api/cms-api/src/mikro-orm/migrations/Migration20240205110518.ts
+++ b/packages/api/cms-api/src/mikro-orm/migrations/Migration20240205110518.ts
@@ -1,0 +1,11 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240205110518 extends Migration {
+    async up(): Promise<void> {
+        this.addSql('alter table "CometUserPermission" add configuration jsonb default null;');
+    }
+
+    async down(): Promise<void> {
+        this.addSql('alter table "CometUserPermission" drop configuration;');
+    }
+}

--- a/packages/api/cms-api/src/mikro-orm/mikro-orm.module.ts
+++ b/packages/api/cms-api/src/mikro-orm/mikro-orm.module.ts
@@ -23,6 +23,7 @@ import { Migration20231206123505 } from "./migrations/Migration20231206123505";
 import { Migration20231215103630 } from "./migrations/Migration20231215103630";
 import { Migration20231218092313 } from "./migrations/Migration20231218092313";
 import { Migration20231222090009 } from "./migrations/Migration20231222090009";
+import { Migration20240205110518 } from "./migrations/Migration20240205110518";
 
 export const PG_UNIQUE_CONSTRAINT_VIOLATION = "23505";
 
@@ -83,6 +84,7 @@ export function createOrmConfig({ migrations, ...defaults }: MikroOrmNestjsOptio
                 { name: "Migration20231222090009", class: Migration20231222090009 },
                 { name: "Migration20231204140305", class: Migration20231204140305 },
                 { name: "Migration20231218092313", class: Migration20231218092313 },
+                { name: "Migration20240205110518", class: Migration20240205110518 },
                 ...(migrations?.migrationsList || []),
             ].sort((migrationA, migrationB) => {
                 if (migrationA.name < migrationB.name) {

--- a/packages/api/cms-api/src/user-permissions/access-control.service.ts
+++ b/packages/api/cms-api/src/user-permissions/access-control.service.ts
@@ -1,16 +1,30 @@
 import { Injectable } from "@nestjs/common";
 
 import { CurrentUser } from "./dto/current-user";
+import { Permission } from "./dto/permission";
 import { ContentScope } from "./interfaces/content-scope.interface";
+import { UserPermissionsService } from "./user-permissions.service";
 import { AccessControlServiceInterface } from "./user-permissions.types";
 
 @Injectable()
 export abstract class AbstractAccessControlService implements AccessControlServiceInterface {
-    private checkContentScope(userContentScopes: ContentScope[], contentScope: ContentScope): boolean {
-        return userContentScopes.some((cs) => Object.entries(contentScope).every(([scope, value]) => cs[scope] === value));
-    }
-    isAllowed(user: CurrentUser, permission: string, contentScope?: ContentScope): boolean {
+    isAllowed(user: CurrentUser, permission: string | Permission, contentScope?: ContentScope): boolean {
         if (!user.permissions) return false;
-        return user.permissions.some((p) => p.permission === permission && (!contentScope || this.checkContentScope(p.contentScopes, contentScope)));
+
+        const { permission: requiredPermission, configuration: requiredConfiguration } = UserPermissionsService.parsePermission(permission);
+
+        return user.permissions.some((p) => {
+            if (p.permission !== requiredPermission) return false;
+
+            if (requiredConfiguration) {
+                if (!p.configuration) return false;
+                for (const key of Object.keys(requiredConfiguration)) {
+                    if (requiredConfiguration[key] !== p.configuration[key]) return false;
+                }
+            }
+
+            if (!contentScope) return true;
+            return p.contentScopes.some((cs) => Object.entries(contentScope).every(([scope, value]) => cs[scope] === value));
+        });
     }
 }

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
@@ -79,8 +79,8 @@ describe("UserPermissionsGuard", () => {
     it("allows user with exact permission", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: true },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: true, disablePermissionCheck: false },
             },
         });
         expect(
@@ -95,8 +95,8 @@ describe("UserPermissionsGuard", () => {
     it("allows user with at least one permission", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: true },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: true, disablePermissionCheck: false },
             },
         });
         expect(
@@ -114,8 +114,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user with a wrong permission", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: true },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: true, disablePermissionCheck: false },
             },
         });
         expect(
@@ -130,8 +130,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user with only a partial permission", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: true },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: true, disablePermissionCheck: false },
             },
         });
         expect(
@@ -146,8 +146,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user with empty permission", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: true },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: true, disablePermissionCheck: false },
             },
         });
         expect(
@@ -162,8 +162,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user without permissions", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: true },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: true, disablePermissionCheck: false },
             },
         });
         expect(
@@ -178,8 +178,8 @@ describe("UserPermissionsGuard", () => {
     it("allows user with at least one of the required permissions", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1", "p2"], // One of the permissions is required
-                options: { skipScopeCheck: true },
+                requiredPermission: [{ permission: "p1" }, { permission: "p2" }], // One of the permissions is required
+                options: { skipScopeCheck: true, disablePermissionCheck: false },
             },
         });
         expect(
@@ -194,8 +194,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user without one the the required permissions", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1", "p2"], // One of the permissions is required
-                options: { skipScopeCheck: true },
+                requiredPermission: [{ permission: "p1" }, { permission: "p2" }], // One of the permissions is required
+                options: { skipScopeCheck: true, disablePermissionCheck: false },
             },
         });
         expect(
@@ -210,8 +210,8 @@ describe("UserPermissionsGuard", () => {
     it("allows user with scope", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
         });
         expect(
@@ -227,8 +227,8 @@ describe("UserPermissionsGuard", () => {
     it("allows user with scope when submitted scope is partial", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
         });
         expect(
@@ -244,8 +244,8 @@ describe("UserPermissionsGuard", () => {
     it("allows user with scope when submitted scope is empty", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
         });
         expect(
@@ -261,8 +261,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user with wrong scope", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
         });
         expect(
@@ -278,8 +278,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user with a partial scope", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
         });
         expect(
@@ -295,8 +295,8 @@ describe("UserPermissionsGuard", () => {
     it("allows user by affected entity", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
             affectedEntities: [{ entity: TestEntity, options: { idArg: "id" } }],
         });
@@ -317,8 +317,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user with wrong scope by affected entity", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
             affectedEntities: [{ entity: TestEntity, options: { idArg: "id" } }],
         });
@@ -339,8 +339,8 @@ describe("UserPermissionsGuard", () => {
     it("allows user by multiple affected entities", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
             affectedEntities: [{ entity: TestEntity, options: { idArg: "id" } }],
         });
@@ -361,8 +361,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user without all requried scopes by multiple affected entities", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
             affectedEntities: [{ entity: TestEntity, options: { idArg: "id" } }],
         });
@@ -383,8 +383,8 @@ describe("UserPermissionsGuard", () => {
     it("allows user by scoped entity", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
             affectedEntities: [{ entity: TestEntity, options: { idArg: "id" } }],
             scopedEntity: (_entity) => ({ a: "a" }),
@@ -403,8 +403,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user with wrong scope by scoped entity", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
             affectedEntities: [{ entity: TestEntity, options: { idArg: "id" } }],
             scopedEntity: (_entity) => ({ a: "a" }),
@@ -423,8 +423,8 @@ describe("UserPermissionsGuard", () => {
     it("allows user by multiple scopes from one scoped entity", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
             affectedEntities: [{ entity: TestEntity, options: { idArg: "id" } }],
             scopedEntity: (_entity) => [{ a: "a" }, { a: "b" }], // One of the scopes is required
@@ -443,8 +443,8 @@ describe("UserPermissionsGuard", () => {
     it("denies user with wrong scope by multiple scopes from one scoped entity", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
             affectedEntities: [{ entity: TestEntity, options: { idArg: "id" } }],
             scopedEntity: (_entity) => [{ a: "a" }, { a: "b" }], // One of the scopes is required
@@ -475,7 +475,7 @@ describe("UserPermissionsGuard", () => {
         mockAnnotations({
             requiredPermission: {
                 requiredPermission: [],
-                options: { skipScopeCheck: true },
+                options: { skipScopeCheck: true, disablePermissionCheck: false },
             },
         });
         expect(async () =>
@@ -490,8 +490,8 @@ describe("UserPermissionsGuard", () => {
     it("fails when Content Scope cannot be acquired", async () => {
         mockAnnotations({
             requiredPermission: {
-                requiredPermission: ["p1"],
-                options: { skipScopeCheck: false },
+                requiredPermission: [{ permission: "p1" }],
+                options: { skipScopeCheck: false, disablePermissionCheck: false },
             },
         });
         expect(async () =>

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
@@ -3,7 +3,7 @@ import { Reflector } from "@nestjs/core";
 import { GqlContextType, GqlExecutionContext } from "@nestjs/graphql";
 
 import { ContentScopeService } from "../content-scope.service";
-import { DisablePermissionCheck, RequiredPermissionMetadata } from "../decorators/required-permission.decorator";
+import { RequiredPermissionMetadata } from "../decorators/required-permission.decorator";
 import { CurrentUser } from "../dto/current-user";
 import { ACCESS_CONTROL_SERVICE } from "../user-permissions.constants";
 import { AccessControlServiceInterface, SystemUser } from "../user-permissions.types";
@@ -31,10 +31,10 @@ export class UserPermissionsGuard implements CanActivate {
         const requiredPermission = this.getDecorator<RequiredPermissionMetadata>(context, "requiredPermission");
         if (!requiredPermission && this.isResolvingGraphQLField(context)) return true;
         if (!requiredPermission) throw new Error(`RequiredPermission decorator is missing in ${location}`);
+        if (requiredPermission.options.disablePermissionCheck) return true;
         const requiredPermissions = requiredPermission.requiredPermission;
-        if (requiredPermissions.includes(DisablePermissionCheck)) return true;
         if (requiredPermissions.length === 0) throw new Error(`RequiredPermission decorator has empty permissions in ${location}`);
-        if (this.isResolvingGraphQLField(context) || requiredPermission.options?.skipScopeCheck) {
+        if (this.isResolvingGraphQLField(context) || requiredPermission.options.skipScopeCheck) {
             // At least one permission is required
             return requiredPermissions.some((permission) => this.accessControlService.isAllowed(user, permission));
         } else {

--- a/packages/api/cms-api/src/user-permissions/dto/current-user.ts
+++ b/packages/api/cms-api/src/user-permissions/dto/current-user.ts
@@ -7,6 +7,8 @@ import { ContentScope } from "../interfaces/content-scope.interface";
 export class CurrentUserPermission {
     @Field()
     permission: string;
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    configuration?: Record<string, unknown>;
     @Field(() => [GraphQLJSONObject])
     contentScopes: ContentScope[];
 }

--- a/packages/api/cms-api/src/user-permissions/dto/permission.ts
+++ b/packages/api/cms-api/src/user-permissions/dto/permission.ts
@@ -1,0 +1,10 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { GraphQLJSONObject } from "graphql-type-json";
+
+@ObjectType()
+export class Permission {
+    @Field()
+    permission: string;
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    configuration?: Record<string, unknown>;
+}

--- a/packages/api/cms-api/src/user-permissions/dto/user-permission.input.ts
+++ b/packages/api/cms-api/src/user-permissions/dto/user-permission.input.ts
@@ -26,6 +26,11 @@ export class UserPermissionInput {
     @IsString()
     permission: string;
 
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @IsObject()
+    @IsOptional()
+    configuration?: JSON;
+
     @Field(() => Date, { nullable: true })
     @IsDate()
     @IsOptional()

--- a/packages/api/cms-api/src/user-permissions/entities/user-permission.entity.ts
+++ b/packages/api/cms-api/src/user-permissions/entities/user-permission.entity.ts
@@ -4,6 +4,7 @@ import { GraphQLJSONObject } from "graphql-type-json";
 import { v4 } from "uuid";
 
 import { ContentScope } from "../interfaces/content-scope.interface";
+import { PermissionConfiguration } from "../user-permissions.types";
 
 export enum UserPermissionSource {
     MANUAL = "MANUAL",
@@ -29,6 +30,10 @@ export class UserPermission extends BaseEntity<UserPermission, "id"> {
     @Field()
     @Property({ columnType: "text" })
     permission: string;
+
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @Property({ type: "json", nullable: true })
+    configuration?: PermissionConfiguration;
 
     @Field(() => Date, { nullable: true })
     @Property({ columnType: "date", nullable: true })

--- a/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
@@ -5,6 +5,7 @@ import { IsString } from "class-validator";
 
 import { SkipBuild } from "../builds/skip-build.decorator";
 import { RequiredPermission } from "./decorators/required-permission.decorator";
+import { Permission } from "./dto/permission";
 import { UserPermissionInput, UserPermissionOverrideContentScopesInput } from "./dto/user-permission.input";
 import { UserPermission, UserPermissionSource } from "./entities/user-permission.entity";
 import { UserPermissionsService } from "./user-permissions.service";
@@ -51,8 +52,8 @@ export class UserPermissionResolver {
         return permission;
     }
 
-    @Query(() => [String])
-    async userPermissionsAvailablePermissions(): Promise<string[]> {
+    @Query(() => [Permission])
+    async userPermissionsAvailablePermissions(): Promise<Permission[]> {
         return this.service.getAvailablePermissions();
     }
 

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -3,6 +3,7 @@ import { JwtPayload } from "jsonwebtoken";
 
 import { CurrentUser } from "./dto/current-user";
 import { FindUsersArgs } from "./dto/paginated-user-list";
+import { Permission } from "./dto/permission";
 import { UserPermission } from "./entities/user-permission.entity";
 import { ContentScope } from "./interfaces/content-scope.interface";
 import { User } from "./interfaces/user";
@@ -17,7 +18,7 @@ export type Users = [User[], number];
 export type SystemUser = true;
 
 type PermissionForUser = {
-    permission: string;
+    permission: string | string[] | Permission;
     contentScopes?: ContentScope[];
 } & Pick<UserPermission, "validFrom" | "validTo" | "reason" | "requestedBy" | "approvedBy">;
 export type PermissionsForUser = PermissionForUser[] | UserPermissions.allPermissions;
@@ -25,10 +26,12 @@ export type PermissionsForUser = PermissionForUser[] | UserPermissions.allPermis
 export type ContentScopesForUser = ContentScope[] | UserPermissions.allContentScopes;
 
 export interface AccessControlServiceInterface {
-    isAllowed(user: CurrentUser | SystemUser, permission: string, contentScope?: ContentScope): boolean;
+    isAllowed(user: CurrentUser | SystemUser, permission: string | Permission, contentScope?: ContentScope): boolean;
     getPermissionsForUser?: (user: User) => Promise<PermissionsForUser> | PermissionsForUser;
     getContentScopesForUser?: (user: User) => Promise<ContentScopesForUser> | ContentScopesForUser;
 }
+
+export type PermissionConfiguration = Record<string, unknown>;
 
 export interface UserPermissionsUserServiceInterface {
     getUser: (id: string) => Promise<User> | User;


### PR DESCRIPTION
Combines https://github.com/vivid-planet/comet/pull/1743 with https://github.com/vivid-planet/comet/pull/1662

By default the generator generates dot-separated permissions, which will be sufficient for most webs. This does not require additional configuration by the developer. However, the internal structure and the admin-panel allows injecting components to store a more sophisticated configurations.

Cases where it might be necessary:
- Content-based restriction without having to alter the ContentScopes
  - because the configuration is only needed for one permission and doesn't touch the rest of the application) or
  - the selection requires a rather complex widget
- User-scoped data which is needed for one permission (e.g. a username which is needed to access an external API)

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [ ] Changeset
-   [ ] Write tests
-   [ ] Add example of PermissionConfiguration component to demo
-   [x] Link to the respective task if one exists: COM-666
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Default Configuration created by Generator</summary>
    <img width="661" alt="image" src="https://github.com/vivid-planet/comet/assets/1013756/3984fa30-5fa3-41e9-8ee5-5a0b35fbbc8f">
</details>
