### PR TITLE
Fix schema of demo-api

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -937,8 +937,6 @@ type Mutation {
   updateDamFolder(id: ID!, input: UpdateDamFolderInput!): DamFolder!
   moveDamFolders(folderIds: [ID!]!, targetFolderId: ID, scope: DamScopeInput!): [DamFolder!]!
   deleteDamFolder(id: ID!): Boolean!
-  generateImageTitle(fileId: String!): String!
-  generateAltText(fileId: String!): String!
   createNews(scope: NewsContentScopeInput!, input: NewsInput!): News!
   updateNews(id: ID!, input: NewsUpdateInput!, lastUpdatedAt: DateTime): News!
   deleteNews(id: ID!): Boolean!


### PR DESCRIPTION
Since there are no API-Keys for content generation set the ContentGenerationModule is not added in app.module.ts: https://github.com/vivid-planet/comet/blob/main/demo/api/src/app.module.ts#L159