### PR TITLE
Demo: Conditional fields, wrapped in object

### DIFF
--- a/demo/admin/src/products/ManufacturerForm.tsx
+++ b/demo/admin/src/products/ManufacturerForm.tsx
@@ -192,7 +192,7 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
             mode={mode}
             initialValues={initialValues}
             initialValuesEqual={isEqual} //required to compare block data correctly
-            subscription={{ values: true }}
+            subscription={{}}
         >
             {({ values }) => (
                 <>
@@ -242,7 +242,7 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
                                 {(props) => (
                                     <FormControlLabel
                                         label={
-                                            values?.useAlternativeAddress ? (
+                                            props.input.checked ? (
                                                 <FormattedMessage id="manufacturer.address.useAlternativeAddress.yes" defaultMessage="Yes" />
                                             ) : (
                                                 <FormattedMessage id="manufacturer.address.useAlternativeAddress.no" defaultMessage="No" />

--- a/demo/admin/src/products/ManufacturerForm.tsx
+++ b/demo/admin/src/products/ManufacturerForm.tsx
@@ -194,7 +194,7 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
             initialValuesEqual={isEqual} //required to compare block data correctly
             subscription={{}}
         >
-            {({ values }) => (
+            {() => (
                 <>
                     {saveConflict.dialogs}
                     <MainContent>

--- a/demo/admin/src/products/ManufacturerForm.tsx
+++ b/demo/admin/src/products/ManufacturerForm.tsx
@@ -252,52 +252,61 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
                                     />
                                 )}
                             </Field>
-                            {values?.useAlternativeAddress && (
-                                <>
-                                    <TextField
-                                        required
-                                        fullWidth
-                                        name="address.alternativeAddress.street"
-                                        label={
-                                            <FormattedMessage
-                                                id="manufacturer.address.alternativeAddress.street"
-                                                defaultMessage="Alt-Address Street"
+                            <Field name="useAlternativeAddress" subscription={{ value: true }}>
+                                {({ input: { value } }) =>
+                                    value ? (
+                                        <>
+                                            <TextField
+                                                required
+                                                fullWidth
+                                                name="address.alternativeAddress.street"
+                                                label={
+                                                    <FormattedMessage
+                                                        id="manufacturer.address.alternativeAddress.street"
+                                                        defaultMessage="Alt-Address Street"
+                                                    />
+                                                }
                                             />
-                                        }
-                                    />
-                                    <Field
-                                        fullWidth
-                                        name="address.alternativeAddress.streetNumber"
-                                        component={FinalFormInput}
-                                        type="number"
-                                        label={
-                                            <FormattedMessage
-                                                id="manufacturer.address.alternativeAddress.streetNumber"
-                                                defaultMessage="Alt-Address Street Number"
+                                            <Field
+                                                fullWidth
+                                                name="address.alternativeAddress.streetNumber"
+                                                component={FinalFormInput}
+                                                type="number"
+                                                label={
+                                                    <FormattedMessage
+                                                        id="manufacturer.address.alternativeAddress.streetNumber"
+                                                        defaultMessage="Alt-Address Street Number"
+                                                    />
+                                                }
                                             />
-                                        }
-                                    />
-                                    <Field
-                                        required
-                                        fullWidth
-                                        name="address.alternativeAddress.zip"
-                                        component={FinalFormInput}
-                                        type="number"
-                                        label={<FormattedMessage id="manufacturer.address.alternativeAddress.zip" defaultMessage="Alt-Address Zip" />}
-                                    />
-                                    <TextField
-                                        required
-                                        fullWidth
-                                        name="address.alternativeAddress.country"
-                                        label={
-                                            <FormattedMessage
-                                                id="manufacturer.address.alternativeAddress.country"
-                                                defaultMessage="Alt-Address Country"
+                                            <Field
+                                                required
+                                                fullWidth
+                                                name="address.alternativeAddress.zip"
+                                                component={FinalFormInput}
+                                                type="number"
+                                                label={
+                                                    <FormattedMessage
+                                                        id="manufacturer.address.alternativeAddress.zip"
+                                                        defaultMessage="Alt-Address Zip"
+                                                    />
+                                                }
                                             />
-                                        }
-                                    />
-                                </>
-                            )}
+                                            <TextField
+                                                required
+                                                fullWidth
+                                                name="address.alternativeAddress.country"
+                                                label={
+                                                    <FormattedMessage
+                                                        id="manufacturer.address.alternativeAddress.country"
+                                                        defaultMessage="Alt-Address Country"
+                                                    />
+                                                }
+                                            />
+                                        </>
+                                    ) : null
+                                }
+                            </Field>
                         </FieldSet>
                         <FieldSet
                             collapsible={false}

--- a/demo/admin/src/products/ManufacturerForm.tsx
+++ b/demo/admin/src/products/ManufacturerForm.tsx
@@ -9,6 +9,7 @@ import {
     FinalFormSwitch,
     Loading,
     MainContent,
+    messages,
     TextField,
     useFormApiRef,
     useStackSwitchApi,
@@ -241,14 +242,8 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
                             >
                                 {(props) => (
                                     <FormControlLabel
-                                        label={
-                                            props.input.checked ? (
-                                                <FormattedMessage id="manufacturer.address.useAlternativeAddress.yes" defaultMessage="Yes" />
-                                            ) : (
-                                                <FormattedMessage id="manufacturer.address.useAlternativeAddress.no" defaultMessage="No" />
-                                            )
-                                        }
                                         control={<FinalFormSwitch {...props} />}
+                                        label={props.input.checked ? <FormattedMessage {...messages.yes} /> : <FormattedMessage {...messages.no} />}
                                     />
                                 )}
                             </Field>

--- a/demo/admin/src/products/ManufacturerForm.tsx
+++ b/demo/admin/src/products/ManufacturerForm.tsx
@@ -6,6 +6,7 @@ import {
     FinalForm,
     FinalFormInput,
     FinalFormSubmitEvent,
+    FinalFormSwitch,
     Loading,
     MainContent,
     TextField,
@@ -13,6 +14,7 @@ import {
     useStackSwitchApi,
 } from "@comet/admin";
 import { queryUpdatedAt, resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
+import { Divider, FormControlLabel } from "@mui/material";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
 import React from "react";
@@ -30,6 +32,7 @@ import {
 } from "./ManufacturerForm.gql.generated";
 
 type FormValues = Omit<GQLManufacturerFormDetailsFragment, "address" | "addressAsEmbeddable"> & {
+    useAlternativeAddress: boolean;
     address:
         | (Omit<NonNullable<GQLManufacturerFormDetailsFragment["address"]>, "streetNumber" | "zip" | "alternativeAddress"> & {
               streetNumber: string | null;
@@ -77,6 +80,7 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
         if (!filteredData) return {};
         return {
             ...filteredData,
+            useAlternativeAddress: !!filteredData.address?.alternativeAddress,
             address: filteredData.address
                 ? {
                       ...filteredData.address,
@@ -119,7 +123,7 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
         },
     });
 
-    const handleSubmit = async (formValues: FormValues, form: FormApi<FormValues>, event: FinalFormSubmitEvent) => {
+    const handleSubmit = async ({ useAlternativeAddress, ...formValues }: FormValues, form: FormApi<FormValues>, event: FinalFormSubmitEvent) => {
         if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");
         const output = {
             ...formValues,
@@ -128,15 +132,16 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
                       ...formValues.address,
                       streetNumber: formValues.address?.streetNumber ? parseInt(formValues.address.streetNumber) : null,
                       zip: parseInt(formValues.address.zip),
-                      alternativeAddress: formValues.address?.alternativeAddress
-                          ? {
-                                ...formValues.address.alternativeAddress,
-                                streetNumber: formValues.address?.alternativeAddress.streetNumber
-                                    ? parseInt(formValues.address.alternativeAddress.streetNumber)
-                                    : null,
-                                zip: parseInt(formValues.address.alternativeAddress.zip),
-                            }
-                          : undefined,
+                      alternativeAddress:
+                          useAlternativeAddress && formValues.address?.alternativeAddress
+                              ? {
+                                    ...formValues.address.alternativeAddress,
+                                    streetNumber: formValues.address?.alternativeAddress.streetNumber
+                                        ? parseInt(formValues.address.alternativeAddress.streetNumber)
+                                        : null,
+                                    zip: parseInt(formValues.address.alternativeAddress.zip),
+                                }
+                              : undefined,
                   }
                 : undefined,
             addressAsEmbeddable: {
@@ -187,9 +192,9 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
             mode={mode}
             initialValues={initialValues}
             initialValuesEqual={isEqual} //required to compare block data correctly
-            subscription={{}}
+            subscription={{ values: true }}
         >
-            {() => (
+            {({ values }) => (
                 <>
                     {saveConflict.dialogs}
                     <MainContent>
@@ -227,54 +232,72 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
                                 name="address.country"
                                 label={<FormattedMessage id="manufacturer.address.country" defaultMessage="Address Country" />}
                             />
-                            <FieldSet
-                                collapsible={true}
-                                initiallyExpanded={false}
-                                title={<FormattedMessage id="manufacturer.address.alternativeAddress" defaultMessage="Alt-Address" />}
-                                supportText={
-                                    <FormattedMessage
-                                        id="manufacturer.address.alternativeAddress.supportText"
-                                        defaultMessage="An alt-address to be used"
-                                    />
-                                }
+                            <Divider sx={{ marginBottom: 5 }} />
+                            <Field
+                                fullWidth
+                                name="useAlternativeAddress"
+                                type="checkbox"
+                                label={<FormattedMessage id="manufacturer.address.useAlternativeAddress" defaultMessage="Use alternative address" />}
                             >
-                                <TextField
-                                    required
-                                    fullWidth
-                                    name="address.alternativeAddress.street"
-                                    label={
-                                        <FormattedMessage id="manufacturer.address.alternativeAddress.street" defaultMessage="Alt-Address Street" />
-                                    }
-                                />
-                                <Field
-                                    fullWidth
-                                    name="address.alternativeAddress.streetNumber"
-                                    component={FinalFormInput}
-                                    type="number"
-                                    label={
-                                        <FormattedMessage
-                                            id="manufacturer.address.alternativeAddress.streetNumber"
-                                            defaultMessage="Alt-Address Street Number"
-                                        />
-                                    }
-                                />
-                                <Field
-                                    required
-                                    fullWidth
-                                    name="address.alternativeAddress.zip"
-                                    component={FinalFormInput}
-                                    type="number"
-                                    label={<FormattedMessage id="manufacturer.address.alternativeAddress.zip" defaultMessage="Alt-Address Zip" />}
-                                />
-                                <TextField
-                                    required
-                                    fullWidth
-                                    name="address.alternativeAddress.country"
-                                    label={
-                                        <FormattedMessage id="manufacturer.address.alternativeAddress.country" defaultMessage="Alt-Address Country" />
-                                    }
-                                />
-                            </FieldSet>
+                                {(props) => (
+                                    <FormControlLabel
+                                        label={
+                                            values?.useAlternativeAddress ? (
+                                                <FormattedMessage id="manufacturer.address.useAlternativeAddress.yes" defaultMessage="Yes" />
+                                            ) : (
+                                                <FormattedMessage id="manufacturer.address.useAlternativeAddress.no" defaultMessage="No" />
+                                            )
+                                        }
+                                        control={<FinalFormSwitch {...props} />}
+                                    />
+                                )}
+                            </Field>
+                            {values?.useAlternativeAddress && (
+                                <>
+                                    <TextField
+                                        required
+                                        fullWidth
+                                        name="address.alternativeAddress.street"
+                                        label={
+                                            <FormattedMessage
+                                                id="manufacturer.address.alternativeAddress.street"
+                                                defaultMessage="Alt-Address Street"
+                                            />
+                                        }
+                                    />
+                                    <Field
+                                        fullWidth
+                                        name="address.alternativeAddress.streetNumber"
+                                        component={FinalFormInput}
+                                        type="number"
+                                        label={
+                                            <FormattedMessage
+                                                id="manufacturer.address.alternativeAddress.streetNumber"
+                                                defaultMessage="Alt-Address Street Number"
+                                            />
+                                        }
+                                    />
+                                    <Field
+                                        required
+                                        fullWidth
+                                        name="address.alternativeAddress.zip"
+                                        component={FinalFormInput}
+                                        type="number"
+                                        label={<FormattedMessage id="manufacturer.address.alternativeAddress.zip" defaultMessage="Alt-Address Zip" />}
+                                    />
+                                    <TextField
+                                        required
+                                        fullWidth
+                                        name="address.alternativeAddress.country"
+                                        label={
+                                            <FormattedMessage
+                                                id="manufacturer.address.alternativeAddress.country"
+                                                defaultMessage="Alt-Address Country"
+                                            />
+                                        }
+                                    />
+                                </>
+                            )}
                         </FieldSet>
                         <FieldSet
                             collapsible={false}

--- a/demo/api/src/products/entities/manufacturer.entity.ts
+++ b/demo/api/src/products/entities/manufacturer.entity.ts
@@ -32,9 +32,9 @@ export class AlternativeAddress {
 @ObjectType()
 @InputType("AddressInput")
 export class Address extends AlternativeAddress {
+    @IsNullable()
     @Property({ type: "json", nullable: true })
     @Field(() => AlternativeAddress, { nullable: true })
-    @IsObject()
     alternativeAddress?: AlternativeAddress = undefined;
 }
 

--- a/demo/api/src/products/entities/manufacturer.entity.ts
+++ b/demo/api/src/products/entities/manufacturer.entity.ts
@@ -1,4 +1,4 @@
-import { CrudGenerator, IsNullable } from "@comet/cms-api";
+import { CrudGenerator, IsNullable, IsUndefinable } from "@comet/cms-api";
 import { BaseEntity, Embeddable, Embedded, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, InputType, ObjectType } from "@nestjs/graphql";
 import { IsNumber, IsObject, IsString } from "class-validator";
@@ -35,6 +35,8 @@ export class Address extends AlternativeAddress {
     @IsNullable()
     @Property({ type: "json", nullable: true })
     @Field(() => AlternativeAddress, { nullable: true })
+    @IsObject()
+    @IsUndefinable()
     alternativeAddress?: AlternativeAddress = undefined;
 }
 


### PR DESCRIPTION
- using switch/toggle to hide/show conditional form fields with divider to separate to other fields
- all conditional fields are stored grouped in a single object
- initial state depends on existence of object
- disabling should keep values until saved
- conditional required fields should only be validated if enabled/visible

open
- should we add a demo for not-nested conditional fields?
- should we add a demo with form saving switch-state?
- label is above switch but should be to the left


https://github.com/vivid-planet/comet/assets/1324250/a8b432e6-2df9-472f-adb4-9fd2df8593cd

