### PR TITLE
Harmonize video blocks options

### DIFF
--- a/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
@@ -1,5 +1,5 @@
 import { gql, useApolloClient } from "@apollo/client";
-import { Field, FieldContainer, FinalFormSwitch } from "@comet/admin";
+import { Field, FieldContainer } from "@comet/admin";
 import { Delete, MoreVertical, OpenNewTab, Video } from "@comet/admin-icons";
 import {
     AdminComponentButton,
@@ -23,6 +23,7 @@ import { DamPathLazy } from "../form/file/DamPathLazy";
 import { FileField } from "../form/file/FileField";
 import { CmsBlockContext } from "./CmsBlockContextProvider";
 import { GQLVideoBlockDamFileQuery, GQLVideoBlockDamFileQueryVariables } from "./DamVideoBlock.generated";
+import { VideoOptionsFields } from "./helpers/VideoOptionsFields";
 
 type State = DamVideoBlockData;
 
@@ -128,21 +129,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
 
         return (
             <Box padding={isInPaper ? 3 : 0} pb={0}>
-                <BlocksFinalForm
-                    onSubmit={(values) => {
-                        updateState((prevState) => {
-                            // case: autoplay = false and showControls = false is not allowed
-                            if (!values.autoplay && prevState.autoplay) {
-                                return { ...prevState, ...values, showControls: true };
-                            }
-                            if (!values.showControls && prevState.showControls) {
-                                return { ...prevState, ...values, autoplay: true };
-                            }
-                            return { ...prevState, ...values };
-                        });
-                    }}
-                    initialValues={state}
-                >
+                <BlocksFinalForm onSubmit={updateState} initialValues={state}>
                     {state.damFile ? (
                         <FieldContainer fullWidth>
                             <AdminComponentPaper disablePadding>
@@ -203,24 +190,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                     ) : (
                         <Field name="damFile" component={FileField} fullWidth allowedMimetypes={["video/mp4"]} />
                     )}
-                    <Field
-                        type="checkbox"
-                        name="autoplay"
-                        label={<FormattedMessage id="comet.blocks.video.autoplay" defaultMessage="Autoplay" />}
-                        component={FinalFormSwitch}
-                    />
-                    <Field
-                        type="checkbox"
-                        name="loop"
-                        label={<FormattedMessage id="comet.blocks.video.loop" defaultMessage="Loop" />}
-                        component={FinalFormSwitch}
-                    />
-                    <Field
-                        type="checkbox"
-                        name="showControls"
-                        label={<FormattedMessage id="comet.blocks.video.showControls" defaultMessage="Show controls" />}
-                        component={FinalFormSwitch}
-                    />
+                    <VideoOptionsFields />
                 </BlocksFinalForm>
             </Box>
         );

--- a/packages/admin/cms-admin/src/blocks/helpers/VideoOptionsFields.tsx
+++ b/packages/admin/cms-admin/src/blocks/helpers/VideoOptionsFields.tsx
@@ -1,0 +1,52 @@
+import { Field, FinalFormSwitch, OnChangeField } from "@comet/admin";
+import { FormControlLabel } from "@mui/material";
+import * as React from "react";
+import { useForm } from "react-final-form";
+import { FormattedMessage } from "react-intl";
+
+export const VideoOptionsFields = () => {
+    const form = useForm();
+    return (
+        <>
+            <Field name="autoplay" type="checkbox">
+                {(props) => (
+                    <FormControlLabel
+                        label={<FormattedMessage id="comet.blocks.video.autoplay" defaultMessage="Autoplay" />}
+                        control={<FinalFormSwitch {...props} />}
+                    />
+                )}
+            </Field>
+            <Field name="loop" type="checkbox">
+                {(props) => (
+                    <FormControlLabel
+                        label={<FormattedMessage id="comet.blocks.video.loop" defaultMessage="Loop" />}
+                        control={<FinalFormSwitch {...props} />}
+                    />
+                )}
+            </Field>
+            <Field name="showControls" type="checkbox">
+                {(props) => (
+                    <FormControlLabel
+                        label={<FormattedMessage id="comet.blocks.video.showControls" defaultMessage="Show controls" />}
+                        control={<FinalFormSwitch {...props} />}
+                    />
+                )}
+            </Field>
+            {/* case: autoplay = false and showControls = false is not allowed */}
+            <OnChangeField name="autoplay">
+                {(value, previousValue) => {
+                    if (!value && previousValue) {
+                        form.change("showControls", true);
+                    }
+                }}
+            </OnChangeField>
+            <OnChangeField name="showControls">
+                {(value, previousValue) => {
+                    if (!value && previousValue) {
+                        form.change("autoplay", true);
+                    }
+                }}
+            </OnChangeField>
+        </>
+    );
+};


### PR DESCRIPTION
Outsource video options fields to use in DamVideoBlock, YouTubeVideoBlock (when moved to cms-admin from blocks-admin) and VimeoVideoBlock (PR open)

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
<img width="453" alt="Screenshot 2024-07-01 at 14 54 03" src="https://github.com/vivid-planet/comet/assets/42858722/8277c699-1352-44ab-88d5-e8349d9149de">
</details>
