### PR TITLE
CMS-Admin: Make `upload` part of public API

### DIFF
--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -71,6 +71,7 @@ export { createDocumentRootBlocksMethods } from "./documents/createDocumentRootB
 export type { DocumentInterface, DocumentType } from "./documents/types";
 export { ChooseFileDialog } from "./form/file/chooseFile/ChooseFileDialog";
 export { FileField } from "./form/file/FileField";
+export { upload } from "./form/file/upload";
 export { FinalFormToggleButtonGroup } from "./form/FinalFormToggleButtonGroup";
 export { queryUpdatedAt } from "./form/queryUpdatedAt";
 export { serializeInitialValues } from "./form/serializeInitialValues";


### PR DESCRIPTION
Use-Case: I'm not using the DAM Page, but FinalFormFileSelect (which currently does not upload the files).

Current work-around: copy the file

Possible downside: breaking changes to `upload` may require a new Comet major version 