### PR TITLE
Temporarily disable Storybook version update check

### DIFF
--- a/storybook/package.json
+++ b/storybook/package.json
@@ -7,7 +7,7 @@
     ],
     "scripts": {
         "build-storybook": "build-storybook",
-        "storybook": "start-storybook -p 26638",
+        "storybook": "start-storybook -p 26638 --no-version-updates",
         "lint": "run-p lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0 src/ package.json",
         "lint:tsc": "tsc --noEmit"


### PR DESCRIPTION
Currently causes an error in node-fetch when fetching the latest version. Disabling the check resolves the issue.
