### PR TITLE
Fix default values for `YouTubeVideoBlock`

### DIFF
--- a/packages/admin/blocks-admin/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/YouTubeVideoBlock.tsx
@@ -37,7 +37,7 @@ export const YouTubeVideoBlock: BlockInterface<YouTubeVideoBlockData, State, You
 
     displayName: <FormattedMessage id="comet.blocks.youTubeVideo" defaultMessage="Video (YouTube)" />,
 
-    defaultValues: () => ({ youtubeIdentifier: "", autoplay: false, showControls: false, loop: false, aspectRatio: "16X9" }),
+    defaultValues: () => ({ youtubeIdentifier: "", autoplay: false, showControls: false, loop: false }),
 
     category: BlockCategory.Media,
 


### PR DESCRIPTION
The aspect ratio was removed in #2235, but forgotten to remove in the default values as well. This lead to an validation error when saving a new block with its default values.