### PR TITLE
YouTubeVideoBlock: Remove default value for identifier

### DIFF
--- a/.changeset/tiny-mangos-tease.md
+++ b/.changeset/tiny-mangos-tease.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Fix a validation error for default values in `YouTubeVideoBlock`

--- a/packages/admin/blocks-admin/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/YouTubeVideoBlock.tsx
@@ -37,7 +37,7 @@ export const YouTubeVideoBlock: BlockInterface<YouTubeVideoBlockData, State, You
 
     displayName: <FormattedMessage id="comet.blocks.youTubeVideo" defaultMessage="Video (YouTube)" />,
 
-    defaultValues: () => ({ youtubeIdentifier: "", autoplay: false, showControls: false, loop: false, aspectRatio: "16X9" }),
+    defaultValues: () => ({ autoplay: false, showControls: false, loop: false, aspectRatio: "16X9" }),
 
     category: BlockCategory.Media,
 


### PR DESCRIPTION
Otherwise a newly added block prevents saving the page.