### PR TITLE
Bump `pnpm/action-setup` version to v4

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,8 +24,6 @@ jobs:
             - uses: actions/checkout@v3
 
             - uses: pnpm/action-setup@v4
-              with:
-                  version: 8.2.0
 
             - name: Use Node.js 18.x
               uses: actions/setup-node@v3

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -26,8 +26,6 @@ jobs:
                   path: "demo/admin/lang/comet-lang"
 
             - uses: pnpm/action-setup@v4
-              with:
-                  version: 8.2.0
 
             - name: Use Node.js 18.x
               uses: actions/setup-node@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,8 +49,6 @@ jobs:
                   test -f demo/site/lang/comet-demo-lang/site/de.json || echo "{}" > demo/site/lang/comet-demo-lang/site/de.json
 
             - uses: pnpm/action-setup@v4
-              with:
-                  version: 8.2.0
 
             - name: Use Node.js 18.x
               uses: actions/setup-node@v3

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -17,8 +17,6 @@ jobs:
               uses: actions/checkout@v3
 
             - uses: pnpm/action-setup@v4
-              with:
-                  version: 8.2.0
 
             - name: Use Node.js 18.x
               uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
               uses: actions/checkout@v3
 
             - uses: pnpm/action-setup@v4
-              with:
-                  version: 8.2.0
 
             - name: Use Node.js 18.x
               uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
                   git config user.email github-actions@github.com
 
             - uses: pnpm/action-setup@v4
-              with:
-                  version: 8.2.0
 
             - name: Use Node.js 18.x
               uses: actions/setup-node@v3


### PR DESCRIPTION
Due to pipeline failing with pnpm/action-setup we bump the version to v4 to fix

https://github.com/pnpm/pnpm/issues/6424