### PR TITLE
Fix validation of YouTubeVideoBlock

### DIFF
--- a/.changeset/small-apricots-yawn.md
+++ b/.changeset/small-apricots-yawn.md
@@ -1,0 +1,11 @@
+---
+"@comet/blocks-api": patch
+---
+
+Fix validation of `YouTubeVideoBlock`
+
+Previously, the validation of the `YouTubeVideoBlock` differed between admin and API.
+The admin allowed YouTube URLs and YouTube video IDs.
+The API only allowed URLs but blocked video IDs.
+
+Now, the API validation also accepts URLs and video IDs.

--- a/packages/api/blocks-api/src/blocks/validator/is-valid-youtube-identifier.ts
+++ b/packages/api/blocks-api/src/blocks/validator/is-valid-youtube-identifier.ts
@@ -1,0 +1,36 @@
+import { Injectable } from "@nestjs/common";
+import { isString, registerDecorator, ValidatorConstraint, ValidatorConstraintInterface } from "class-validator";
+
+export const IsValidYoutubeIdentifier = () => {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    return (object: Object, propertyName: string): void => {
+        registerDecorator({
+            target: object.constructor,
+            propertyName,
+            validator: IsValidYoutubeIdentifierConstraint,
+        });
+    };
+};
+
+const EXPECTED_YT_ID_LENGTH = 11;
+
+@ValidatorConstraint({ name: "IsValidYoutubeIdentifier" })
+@Injectable()
+export class IsValidYoutubeIdentifierConstraint implements ValidatorConstraintInterface {
+    validate(value: unknown): boolean {
+        if (!isString(value)) {
+            return false;
+        }
+
+        // copy of blocks-admin/src/blocks/YouTubeVideoBlock.tsx
+        // regex from https://stackoverflow.com/a/51870158
+        const regExp =
+            /(https?:\/\/)?(((m|www)\.)?(youtube(-nocookie)?|youtube.googleapis)\.com.*(v\/|v=|vi=|vi\/|e\/|embed\/|user\/.*\/u\/\d+\/)|youtu\.be\/)([_0-9a-zA-Z-]+)/;
+        const match = value.match(regExp);
+        return value.length === EXPECTED_YT_ID_LENGTH || (!!match && match[8].length == EXPECTED_YT_ID_LENGTH);
+    }
+
+    defaultMessage(): string {
+        return "Invalid YouTube identifier";
+    }
+}

--- a/packages/api/blocks-api/src/blocks/youtube-video.block.ts
+++ b/packages/api/blocks-api/src/blocks/youtube-video.block.ts
@@ -1,7 +1,8 @@
-import { IsBoolean, IsEnum, IsOptional, IsString, Matches } from "class-validator";
+import { IsBoolean, IsEnum, IsOptional, IsString } from "class-validator";
 
 import { BlockData, BlockDataInterface, BlockInput, createBlock, inputToData } from "./block";
 import { BlockField } from "./decorators/field";
+import { IsValidYoutubeIdentifier } from "./validator/is-valid-youtube-identifier";
 
 enum AspectRatio {
     "16X9" = "16X9",
@@ -29,10 +30,7 @@ class YouTubeVideoBlockInput extends BlockInput {
     @IsOptional()
     @IsString()
     @BlockField({ nullable: true })
-    // regex from https://stackoverflow.com/a/51870158
-    @Matches(
-        /(https?:\/\/)?(((m|www)\.)?(youtube(-nocookie)?|youtube.googleapis)\.com.*(v\/|v=|vi=|vi\/|e\/|embed\/|user\/.*\/u\/\d+\/)|youtu\.be\/)([_0-9a-zA-Z-]+)/,
-    )
+    @IsValidYoutubeIdentifier()
     youtubeIdentifier?: string;
 
     @IsEnum(AspectRatio)


### PR DESCRIPTION
Previously, the validation of the `YouTubeVideoBlock` differed between admin and API.
The admin allowed YouTube URLs and YouTube video IDs.
The API only allowed URLs but blocked video IDs.

Now, the API validation also accepts URLs and video IDs.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-898

