### PR TITLE
Demo: Fix next build issue with dynamic-code-evaluation and cache-manager usage in middleware

### DIFF
--- a/demo/site/src/middleware.ts
+++ b/demo/site/src/middleware.ts
@@ -48,5 +48,12 @@ export const config = {
         "/((?!api|_next/static|_next/image|favicon.ico|favicon.svg|favicon.png|manifest.json).*)",
     ],
     // TODO find a better solution for this (https://nextjs.org/docs/messages/edge-dynamic-code-evaluation)
-    unstable_allowDynamic: ["/node_modules/graphql/**"],
+    unstable_allowDynamic: [
+        "/node_modules/graphql/**",
+        /*
+         * cache-manager uses lodash.clonedeep which uses dynamic code evaluation.
+         * See https://github.com/lodash/lodash/issues/5525.
+         */
+        "**/node_modules/.pnpm/**/lodash.clonedeep/**",
+    ],
 };


### PR DESCRIPTION
fix similar as in https://github.com/vivid-planet/comet-starter/blame/next/site/src/middleware.ts#L53 but adapted so it works with pnpm

(the line above `/node_modules/graphql/**` might also not work with pnpm, seems it is not required and could be removed)