### PR TITLE
Fix Prettier peer dependency

### DIFF
--- a/.changeset/selfish-ears-push.md
+++ b/.changeset/selfish-ears-push.md
@@ -1,0 +1,7 @@
+---
+"@comet/eslint-config": patch
+---
+
+Fix Prettier peer dependency
+
+The dependency range was incorrectly set to `>= 2`. Change to `^2.0.0` since Prettier v3 isn't supported at the moment.

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,7 +32,7 @@
     },
     "peerDependencies": {
         "eslint": ">= 8",
-        "prettier": ">= 2"
+        "prettier": "^2.0.0"
     },
     "peerDependenciesMeta": {
         "next": {


### PR DESCRIPTION
The dependency range was incorrectly set to `>= 2`. Change to `^2.0.0` since Prettier v3 isn't supported at the moment.

---

We should upgrade to Prettier v3 in the future. However, this is a breaking change because we need to upgrade eslint-plugin-prettier as well, which only allows Prettier `>= 3` .