### PR TITLE
Fix the duplicate filename check in `FilesService#updateByEntity`

### DIFF
--- a/.changeset/eighty-carpets-deliver.md
+++ b/.changeset/eighty-carpets-deliver.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix the duplicate filename check in `FilesService#updateByEntity`
+
+Previously, we checked the existing file name (`entity.name`) for the check instead of the new name (`input.name`). This never resulted in an error.

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -251,10 +251,11 @@ export class FilesService {
             entity.image.cropArea = image.cropArea;
         }
 
-        const entityWithSameName = await this.findOneByFilenameAndFolder({ filename: entity.name, folderId }, entity.scope);
-
-        if (entityWithSameName !== null && entityWithSameName.id !== entity.id) {
-            throw new Error(`Entity with name '${entity.name}' already exists in ${folder ? `folder '${folder.name}'` : "root folder"}`);
+        if (input.name) {
+            const entityWithSameName = await this.findOneByFilenameAndFolder({ filename: input.name, folderId }, entity.scope);
+            if (entityWithSameName !== null && entityWithSameName.id !== entity.id) {
+                throw new Error(`Entity with name '${input.name}' already exists in ${folder ? `folder '${folder.name}'` : "root folder"}`);
+            }
         }
 
         const file = Object.assign(entity, {


### PR DESCRIPTION
Previously, we checked the existing file name (`entity.name`) for the check instead of the new name (`input.name`). This never resulted in an error.