### PR TITLE
Remove next/link legacy behavior

### DIFF
--- a/.changeset/thirty-countries-refuse.md
+++ b/.changeset/thirty-countries-refuse.md
@@ -1,0 +1,13 @@
+---
+"@comet/cms-site": major
+---
+
+Remove `next/link` legacy behavior
+
+Previously, Next required the `Link` component to have a child `<a>` tag. To style this tag correctly in the application, none of the library link blocks (`DamFileDownloadLinkBlock`, `ExternalLinkBlock`, `EmailLinkBlock`, `InternalLinkBlock`, and `PhoneLinkBlock`) rendered the tag, but cloned the children with the correct props instead.
+
+However, since Next v13 the `Link` component no longer requires a child `<a>` tag. Consequently, we don't need to render the tag for the `InternalLinkBlock` (which uses `Link` internally) anymore. In order to style all link blocks correctly, we now render an `<a>` tag for all other link blocks.
+
+**Upgrade**
+
+To upgrade, either remove all `<a>` tags from your link block usages, or add the `legacyBehavior` prop to all library link blocks.

--- a/.changeset/thirty-countries-refuse.md
+++ b/.changeset/thirty-countries-refuse.md
@@ -2,7 +2,7 @@
 "@comet/cms-site": major
 ---
 
-Remove `next/link` legacy behavior
+Remove `next/link` legacy behavior as default behavior
 
 Previously, Next required the `Link` component to have a child `<a>` tag. To style this tag correctly in the application, none of the library link blocks (`DamFileDownloadLinkBlock`, `ExternalLinkBlock`, `EmailLinkBlock`, `InternalLinkBlock`, and `PhoneLinkBlock`) rendered the tag, but cloned the children with the correct props instead.
 

--- a/demo/site/next-env.d.ts
+++ b/demo/site/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/demo/site/src/blocks/InternalLinkBlock.tsx
+++ b/demo/site/src/blocks/InternalLinkBlock.tsx
@@ -7,11 +7,17 @@ import * as React from "react";
 interface InternalLinkBlockProps extends PropsWithData<InternalLinkBlockData> {
     children: React.ReactNode;
     title?: string;
+    className?: string;
 }
 
-export function InternalLinkBlock({ data: { targetPage, targetPageAnchor }, children, title }: InternalLinkBlockProps): React.ReactElement {
+export function InternalLinkBlock({
+    data: { targetPage, targetPageAnchor },
+    children,
+    title,
+    className,
+}: InternalLinkBlockProps): React.ReactElement {
     if (!targetPage) {
-        return <>{children}</>;
+        return <span className={className}>{children}</span>;
     }
 
     let href = targetPageAnchor !== undefined ? `${targetPage.path}#${targetPageAnchor}` : targetPage.path;
@@ -23,7 +29,7 @@ export function InternalLinkBlock({ data: { targetPage, targetPageAnchor }, chil
     }
 
     return (
-        <Link href={href} passHref title={title} legacyBehavior>
+        <Link href={href} title={title} className={className}>
             {children}
         </Link>
     );

--- a/demo/site/src/blocks/LinkBlock.tsx
+++ b/demo/site/src/blocks/LinkBlock.tsx
@@ -16,33 +16,33 @@ import * as React from "react";
 import { InternalLinkBlock } from "./InternalLinkBlock";
 
 const supportedBlocks: SupportedBlocks = {
-    internal: ({ children, title, ...props }) => (
-        <InternalLinkBlock data={props} title={title}>
+    internal: ({ children, title, className, ...props }) => (
+        <InternalLinkBlock data={props} title={title} className={className}>
             {children}
         </InternalLinkBlock>
     ),
-    external: ({ children, title, ...props }) => (
-        <ExternalLinkBlock data={props} title={title}>
+    external: ({ children, title, className, ...props }) => (
+        <ExternalLinkBlock data={props} title={title} className={className}>
             {children}
         </ExternalLinkBlock>
     ),
-    news: ({ children, title, ...props }) => (
-        <NewsLinkBlock data={props} title={title}>
+    news: ({ children, title, className, ...props }) => (
+        <NewsLinkBlock data={props} title={title} className={className}>
             {children}
         </NewsLinkBlock>
     ),
-    damFileDownload: ({ children, title, ...props }) => (
-        <DamFileDownloadLinkBlock data={props} title={title}>
+    damFileDownload: ({ children, title, className, ...props }) => (
+        <DamFileDownloadLinkBlock data={props} title={title} className={className}>
             {children}
         </DamFileDownloadLinkBlock>
     ),
-    email: ({ children, title, ...props }) => (
-        <EmailLinkBlock data={props} title={title}>
+    email: ({ children, title, className, ...props }) => (
+        <EmailLinkBlock data={props} title={title} className={className}>
             {children}
         </EmailLinkBlock>
     ),
-    phone: ({ children, title, ...props }) => (
-        <PhoneLinkBlock data={props} title={title}>
+    phone: ({ children, title, className, ...props }) => (
+        <PhoneLinkBlock data={props} title={title} className={className}>
             {children}
         </PhoneLinkBlock>
     ),
@@ -50,12 +50,13 @@ const supportedBlocks: SupportedBlocks = {
 
 interface LinkBlockProps extends PropsWithData<LinkBlockData> {
     children: React.ReactNode;
+    className?: string;
 }
 
 export const LinkBlock = withPreview(
-    ({ data, children }: LinkBlockProps) => {
+    ({ data, children, className }: LinkBlockProps) => {
         return (
-            <OneOfBlock data={data} supportedBlocks={supportedBlocks}>
+            <OneOfBlock data={data} supportedBlocks={supportedBlocks} className={className}>
                 {children}
             </OneOfBlock>
         );

--- a/demo/site/src/blocks/RichTextBlock.tsx
+++ b/demo/site/src/blocks/RichTextBlock.tsx
@@ -9,7 +9,7 @@ import { LinkBlock } from "./LinkBlock";
 
 const GreenCustomHeader: React.FC<{ children: React.ReactNode }> = ({ children }) => <h3 style={{ color: "green" }}>{children}</h3>;
 
-export const DefaultStyleLink = styled.a`
+const DefaultStyleLink = styled(LinkBlock)`
     color: ${({ theme }) => theme.colors.primary};
 `;
 
@@ -64,9 +64,9 @@ const defaultRenderers: Renderers = {
         // key is the entity key value from raw
         LINK: (children, data, { key }) => {
             return (
-                <LinkBlock key={key} data={data as LinkBlockData}>
-                    <DefaultStyleLink>{children}</DefaultStyleLink>
-                </LinkBlock>
+                <DefaultStyleLink key={key} data={data as LinkBlockData}>
+                    {children}
+                </DefaultStyleLink>
             );
         },
     },

--- a/demo/site/src/blocks/TextLinkBlock.tsx
+++ b/demo/site/src/blocks/TextLinkBlock.tsx
@@ -2,16 +2,21 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { DemoTextLinkBlockData } from "@src/blocks.generated";
 import * as React from "react";
+import styled from "styled-components";
 
 import { LinkBlock } from "./LinkBlock";
 
 export const TextLinkBlock = withPreview(
     ({ data: { link, text } }: PropsWithData<DemoTextLinkBlockData>) => {
-        return (
-            <LinkBlock data={link}>
-                <a>{text}</a>
-            </LinkBlock>
-        );
+        return <Link data={link}>{text}</Link>;
     },
     { label: "Link" },
 );
+
+const Link = styled(LinkBlock)`
+    color: ${({ theme }) => theme.colors.black};
+
+    &:hover {
+        color: ${({ theme }) => theme.colors.primary};
+    }
+`;

--- a/demo/site/src/header/Header.tsx
+++ b/demo/site/src/header/Header.tsx
@@ -16,12 +16,12 @@ function Header({ header }: Props): JSX.Element {
                 <TopLevelNavigation>
                     {header.items.map((item) => (
                         <TopLevelLinkContainer key={item.id}>
-                            <PageLink page={item.node}>{(active) => <Link $active={active}>{item.node.name}</Link>}</PageLink>
+                            <Link page={item.node}>{item.node.name}</Link>
                             {item.node.childNodes.length > 0 && (
                                 <SubLevelNavigation>
                                     {item.node.childNodes.map((node) => (
                                         <li key={node.id}>
-                                            <PageLink page={node}>{(active) => <Link $active={active}>{node.name}</Link>}</PageLink>
+                                            <Link page={node}>{node.name}</Link>
                                         </li>
                                     ))}
                                 </SubLevelNavigation>
@@ -66,13 +66,17 @@ const TopLevelLinkContainer = styled.li`
     }
 `;
 
-const Link = styled.a<{ $active: boolean }>`
+const Link = styled(PageLink)`
     text-decoration: none;
     padding: 5px 10px;
-    color: ${({ $active, theme }) => ($active ? theme.colors.primary : theme.colors.black)};
+    color: ${({ theme }) => theme.colors.black};
 
     &:hover {
         text-decoration: underline;
+    }
+
+    &.active {
+        color: ${({ theme }) => theme.colors.primary};
     }
 `;
 

--- a/demo/site/src/header/Header.tsx
+++ b/demo/site/src/header/Header.tsx
@@ -16,12 +16,16 @@ function Header({ header }: Props): JSX.Element {
                 <TopLevelNavigation>
                     {header.items.map((item) => (
                         <TopLevelLinkContainer key={item.id}>
-                            <Link page={item.node}>{item.node.name}</Link>
+                            <Link page={item.node} activeClassName="active">
+                                {item.node.name}
+                            </Link>
                             {item.node.childNodes.length > 0 && (
                                 <SubLevelNavigation>
                                     {item.node.childNodes.map((node) => (
                                         <li key={node.id}>
-                                            <Link page={node}>{node.name}</Link>
+                                            <Link page={node} activeClassName="active">
+                                                {node.name}
+                                            </Link>
                                         </li>
                                     ))}
                                 </SubLevelNavigation>

--- a/demo/site/src/header/PageLink.tsx
+++ b/demo/site/src/header/PageLink.tsx
@@ -10,24 +10,25 @@ import { GQLPageLinkFragment } from "./PageLink.fragment.generated";
 
 interface Props {
     page: GQLPageLinkFragment;
-    children: ((active: boolean) => React.ReactNode) | React.ReactNode;
+    children: React.ReactNode;
+    className?: string;
 }
 
-function PageLink({ page, children }: Props): JSX.Element | null {
+function PageLink({ page, children, className }: Props): JSX.Element | null {
     const pathname = usePathname();
-    const active = pathname === page.path;
+    const active = (pathname.substring(3) || "/") === page.path; // Remove language prefix
 
     if (page.documentType === "Link") {
         if (page.document === null || page.document.__typename !== "Link") {
             return null;
         }
 
-        // TODO how to use language prefix in InternalLinkBlock?
-        return <LinkBlock data={page.document.content}>{typeof children === "function" ? children(active) : children}</LinkBlock>;
+        // Links to other targets can never be active
+        return <LinkBlock data={page.document.content}>{children}</LinkBlock>;
     } else if (page.documentType === "Page") {
         return (
-            <Link href={`/${page.scope.language}${page.path}`} passHref legacyBehavior>
-                {typeof children === "function" ? children(active) : children}
+            <Link href={`/${page.scope.language}${page.path}`} className={active ? `active ${className}` : className}>
+                {children}
             </Link>
         );
     } else if (page.documentType === "PredefinedPage") {
@@ -38,8 +39,11 @@ function PageLink({ page, children }: Props): JSX.Element | null {
         const type = (page.document as GQLPredefinedPage).type;
 
         return (
-            <Link href={type && predefinedPagePaths[type] ? `/${page.scope.language}${predefinedPagePaths[type]}` : ""} passHref legacyBehavior>
-                {typeof children === "function" ? children(active) : children}
+            <Link
+                href={type && predefinedPagePaths[type] ? `/${page.scope.language}${predefinedPagePaths[type]}` : ""}
+                className={active ? `active ${className}` : className}
+            >
+                {children}
             </Link>
         );
     } else {

--- a/demo/site/src/header/PageLink.tsx
+++ b/demo/site/src/header/PageLink.tsx
@@ -12,11 +12,18 @@ interface Props {
     page: GQLPageLinkFragment;
     children: React.ReactNode;
     className?: string;
+    activeClassName?: string;
 }
 
-function PageLink({ page, children, className }: Props): JSX.Element | null {
+function PageLink({ page, children, className: passedClassName, activeClassName }: Props): JSX.Element | null {
     const pathname = usePathname();
     const active = (pathname.substring(3) || "/") === page.path; // Remove language prefix
+
+    let className = passedClassName;
+
+    if (active) {
+        className = className ? `${className} ${activeClassName}` : activeClassName;
+    }
 
     if (page.documentType === "Link") {
         if (page.document === null || page.document.__typename !== "Link") {
@@ -27,7 +34,7 @@ function PageLink({ page, children, className }: Props): JSX.Element | null {
         return <LinkBlock data={page.document.content}>{children}</LinkBlock>;
     } else if (page.documentType === "Page") {
         return (
-            <Link href={`/${page.scope.language}${page.path}`} className={active ? `active ${className}` : className}>
+            <Link href={`/${page.scope.language}${page.path}`} className={className}>
                 {children}
             </Link>
         );
@@ -39,10 +46,7 @@ function PageLink({ page, children, className }: Props): JSX.Element | null {
         const type = (page.document as GQLPredefinedPage).type;
 
         return (
-            <Link
-                href={type && predefinedPagePaths[type] ? `/${page.scope.language}${predefinedPagePaths[type]}` : ""}
-                className={active ? `active ${className}` : className}
-            >
+            <Link href={type && predefinedPagePaths[type] ? `/${page.scope.language}${predefinedPagePaths[type]}` : ""} className={className}>
                 {children}
             </Link>
         );

--- a/demo/site/src/header/PageLink.tsx
+++ b/demo/site/src/header/PageLink.tsx
@@ -30,8 +30,11 @@ function PageLink({ page, children, className: passedClassName, activeClassName 
             return null;
         }
 
-        // Links to other targets can never be active
-        return <LinkBlock data={page.document.content}>{children}</LinkBlock>;
+        return (
+            <LinkBlock data={page.document.content} className={className}>
+                {children}
+            </LinkBlock>
+        );
     } else if (page.documentType === "Page") {
         return (
             <Link href={`/${page.scope.language}${page.path}`} className={className}>

--- a/demo/site/src/news/blocks/NewsLinkBlock.tsx
+++ b/demo/site/src/news/blocks/NewsLinkBlock.tsx
@@ -3,15 +3,15 @@ import { NewsLinkBlockData } from "@src/blocks.generated";
 import Link from "next/link";
 import * as React from "react";
 
-type Props = PropsWithData<NewsLinkBlockData> & { title?: string };
+type Props = PropsWithData<NewsLinkBlockData> & { title?: string; className?: string };
 
-function NewsLinkBlock({ data: { id }, children, title }: React.PropsWithChildren<Props>): JSX.Element | null {
+function NewsLinkBlock({ data: { id }, children, title, className }: React.PropsWithChildren<Props>): JSX.Element | null {
     if (id === undefined) {
-        return null;
+        return <span className={className}>{children}</span>;
     }
 
     return (
-        <Link href={{ pathname: "/news/[id]", query: { id } }} title={title}>
+        <Link href={`/news/${id}`} title={title} className={className}>
             {children}
         </Link>
     );

--- a/demo/site/src/topNavigation/TopNavigation.tsx
+++ b/demo/site/src/topNavigation/TopNavigation.tsx
@@ -13,12 +13,16 @@ export function TopNavigation({ data }: Props): JSX.Element {
         <TopLevelNavigation>
             {data.map((item) => (
                 <TopLevelLinkContainer key={item.id}>
-                    <Link page={item}>{item.name}</Link>
+                    <Link page={item} activeClassName="active">
+                        {item.name}
+                    </Link>
                     {item.childNodes.length > 0 && (
                         <SubLevelNavigation>
                             {item.childNodes.map((node) => (
                                 <li key={node.id}>
-                                    <Link page={node}>{node.name}</Link>
+                                    <Link page={node} activeClassName="active">
+                                        {node.name}
+                                    </Link>
                                 </li>
                             ))}
                         </SubLevelNavigation>

--- a/demo/site/src/topNavigation/TopNavigation.tsx
+++ b/demo/site/src/topNavigation/TopNavigation.tsx
@@ -13,12 +13,12 @@ export function TopNavigation({ data }: Props): JSX.Element {
         <TopLevelNavigation>
             {data.map((item) => (
                 <TopLevelLinkContainer key={item.id}>
-                    <PageLink page={item}>{(active) => <Link $active={active}>{item.name}</Link>}</PageLink>
+                    <Link page={item}>{item.name}</Link>
                     {item.childNodes.length > 0 && (
                         <SubLevelNavigation>
                             {item.childNodes.map((node) => (
                                 <li key={node.id}>
-                                    <PageLink page={node}>{(active) => <Link $active={active}>{node.name}</Link>}</PageLink>
+                                    <Link page={node}>{node.name}</Link>
                                 </li>
                             ))}
                         </SubLevelNavigation>
@@ -59,13 +59,17 @@ const TopLevelLinkContainer = styled.li`
     }
 `;
 
-const Link = styled.a<{ $active: boolean }>`
+const Link = styled(PageLink)`
     text-decoration: none;
     padding: 5px 10px;
-    color: ${({ $active, theme }) => ($active ? theme.colors.white : theme.colors.n200)};
+    color: ${({ theme }) => theme.colors.n200};
     font-size: 12px;
 
     &:hover {
         text-decoration: underline;
+    }
+
+    &.active {
+        color: ${({ theme }) => theme.colors.white};
     }
 `;

--- a/docs/docs/migration/migration-from-v6-to-v7.md
+++ b/docs/docs/migration/migration-from-v6-to-v7.md
@@ -831,6 +831,53 @@ The `InternalLinkBlock` provided by `@comet/cms-site` is deprecated.
 Instead, implement your own `InternalLinkBlock`.
 This is needed for more flexibility, e.g., support for internationalized routing.
 
+### Add `legacyBevavior` to all link block usages
+
+Previously, Next required the `Link` component to have a child `<a>` tag. To style this tag correctly in the application, none of the library link blocks rendered the tag, but cloned the children with the correct props instead. However, since Next v13 the `Link` component no longer requires a child `<a>` tag. Consequently, we don't need to render the tag for the `InternalLinkBlock` (which uses `Link` internally) anymore. In order to style all link blocks correctly, we now render an `<a>` tag for all other link blocks.
+
+To migrate, add the `legacyBehavior` to all library link block usages. For example:
+
+```diff title=LinkBlock.tsx
+const supportedBlocks: SupportedBlocks = {
+    internal: ({ children, title, ...props }) => (
+        <InternalLinkBlock
+            data={props}
+            title={title}
++           legacyBehavior
+        >
+            {children}
+        </InternalLinkBlock>
+    ),
+    external: ({ children, title, ...props }) => (
+        <ExternalLinkBlock
+            data={props}
+            title={title}
++           legacyBehavior
+        >
+            {children}
+        </ExternalLinkBlock>
+    ),
+    /* Other link blocks */
+};
+
+export const LinkBlock = withPreview(
+    ({ data, children }: LinkBlockProps) => {
+        return (
+            <OneOfBlock data={data} supportedBlocks={supportedBlocks}>
+                {children}
+            </OneOfBlock>
+        );
+    },
+    { label: "Link" },
+);
+```
+
+:::info
+
+New projects shouldn't use the legacy behavior. Instead, add support to pass the `className` prop through to the `LinkBlock` an its child blocks. See [this PR](https://github.com/vivid-planet/comet/pull/2271) for an example.
+
+:::
+
 ### Add `aspectRatio` to `PixelImageBlock` and `Image`
 
 Previously, there was a default aspect ratio of `16x9`.

--- a/docs/docs/migration/migration-from-v6-to-v7.md
+++ b/docs/docs/migration/migration-from-v6-to-v7.md
@@ -833,9 +833,8 @@ This is needed for more flexibility, e.g., support for internationalized routing
 
 ### Add `legacyBevavior` to all link block usages
 
-Previously, Next required the `Link` component to have a child `<a>` tag. To style this tag correctly in the application, none of the library link blocks rendered the tag, but cloned the children with the correct props instead. However, since Next v13 the `Link` component no longer requires a child `<a>` tag. Consequently, we don't need to render the tag for the `InternalLinkBlock` (which uses `Link` internally) anymore. In order to style all link blocks correctly, we now render an `<a>` tag for all other link blocks.
-
-To migrate, add the `legacyBehavior` to all library link block usages. For example:
+All link blocks in `@comet/cms-site` now render a child `<a>` tag by default to align with the new behavior of the Next `Link` component, which is used by `InternalLinkBlock`.
+For existing projects, add the `legacyBehavior` prop to all library link block usages to use the old behavior, where the `<a>` tag is defined in the application. For example:
 
 ```diff title=LinkBlock.tsx
 const supportedBlocks: SupportedBlocks = {

--- a/packages/site/cms-site/src/blocks/DamFileDownloadLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/DamFileDownloadLinkBlock.tsx
@@ -9,16 +9,28 @@ interface Props extends PropsWithData<DamFileDownloadLinkBlockData> {
     children: React.ReactElement;
     title?: string;
     className?: string;
+    legacyBehavior?: boolean;
 }
 
 export const DamFileDownloadLinkBlock = withPreview(
-    ({ data: { file, openFileType }, children, title, className }: Props) => {
+    ({ data: { file, openFileType }, children, title, className, legacyBehavior }: Props) => {
         if (!file) {
+            if (legacyBehavior) {
+                return children;
+            }
+
             return <span className={className}>{children}</span>;
         }
 
+        const href = file.fileUrl;
+        const target = openFileType === "NewTab" ? "_blank" : undefined;
+
+        if (legacyBehavior) {
+            return React.cloneElement(children, { href, target, title });
+        }
+
         return (
-            <a href={file.fileUrl} target={openFileType === "NewTab" ? "_blank" : undefined} title={title} className={className}>
+            <a href={href} target={target} title={title} className={className}>
                 {children}
             </a>
         );

--- a/packages/site/cms-site/src/blocks/DamFileDownloadLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/DamFileDownloadLinkBlock.tsx
@@ -8,21 +8,20 @@ import { PropsWithData } from "./PropsWithData";
 interface Props extends PropsWithData<DamFileDownloadLinkBlockData> {
     children: React.ReactElement;
     title?: string;
+    className?: string;
 }
 
 export const DamFileDownloadLinkBlock = withPreview(
-    ({ data: { file, openFileType }, children, title }: Props) => {
+    ({ data: { file, openFileType }, children, title, className }: Props) => {
         if (!file) {
-            return children;
+            return <span className={className}>{children}</span>;
         }
 
-        const childProps = {
-            href: file.fileUrl,
-            title,
-            ...(openFileType === "NewTab" && { target: "_blank" }),
-        };
-
-        return React.cloneElement(children, childProps);
+        return (
+            <a href={file.fileUrl} target={openFileType === "NewTab" ? "_blank" : undefined} title={title} className={className}>
+                {children}
+            </a>
+        );
     },
     { label: "DamFileDownloadLink" },
 );

--- a/packages/site/cms-site/src/blocks/EmailLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/EmailLinkBlock.tsx
@@ -6,17 +6,17 @@ import { PropsWithData } from "./PropsWithData";
 interface EmailLinkBlockProps extends PropsWithData<EmailLinkBlockData> {
     children: React.ReactElement;
     title?: string;
+    className?: string;
 }
 
-export const EmailLinkBlock = ({ data: { email }, children, title }: EmailLinkBlockProps) => {
+export const EmailLinkBlock = ({ data: { email }, children, title, className }: EmailLinkBlockProps) => {
     if (!email) {
-        return children;
+        return <span className={className}>{children}</span>;
     }
 
-    const childProps = {
-        href: `mailto:${email}`,
-        title,
-    };
-
-    return React.cloneElement(children, childProps);
+    return (
+        <a href={`mailto:${email}`} title={title} className={className}>
+            {children}
+        </a>
+    );
 };

--- a/packages/site/cms-site/src/blocks/EmailLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/EmailLinkBlock.tsx
@@ -7,15 +7,26 @@ interface EmailLinkBlockProps extends PropsWithData<EmailLinkBlockData> {
     children: React.ReactElement;
     title?: string;
     className?: string;
+    legacyBehavior?: boolean;
 }
 
-export const EmailLinkBlock = ({ data: { email }, children, title, className }: EmailLinkBlockProps) => {
+export const EmailLinkBlock = ({ data: { email }, children, title, className, legacyBehavior }: EmailLinkBlockProps) => {
     if (!email) {
+        if (legacyBehavior) {
+            return children;
+        }
+
         return <span className={className}>{children}</span>;
     }
 
+    const href = `mailto:${email}`;
+
+    if (legacyBehavior) {
+        return React.cloneElement(children, { href, title });
+    }
+
     return (
-        <a href={`mailto:${email}`} title={title} className={className}>
+        <a href={href} title={title} className={className}>
             {children}
         </a>
     );

--- a/packages/site/cms-site/src/blocks/ExternalLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/ExternalLinkBlock.tsx
@@ -11,9 +11,16 @@ interface ExternalLinkBlockProps extends PropsWithData<ExternalLinkBlockData> {
     children: React.ReactElement;
     title?: string;
     className?: string;
+    legacyBehavior?: boolean;
 }
 
-export function ExternalLinkBlock({ data: { targetUrl, openInNewWindow }, children, title, className }: ExternalLinkBlockProps): React.ReactElement {
+export function ExternalLinkBlock({
+    data: { targetUrl, openInNewWindow },
+    children,
+    title,
+    className,
+    legacyBehavior,
+}: ExternalLinkBlockProps): React.ReactElement {
     const preview = usePreview();
 
     if (preview.previewType === "SitePreview" || preview.previewType === "BlockPreview") {
@@ -28,6 +35,10 @@ export function ExternalLinkBlock({ data: { targetUrl, openInNewWindow }, childr
             }
         };
 
+        if (legacyBehavior) {
+            return React.cloneElement(children, { href: "#", onClick, title });
+        }
+
         return (
             <a href="#" onClick={onClick} title={title} className={className}>
                 {children}
@@ -35,11 +46,22 @@ export function ExternalLinkBlock({ data: { targetUrl, openInNewWindow }, childr
         );
     } else {
         if (!targetUrl) {
+            if (legacyBehavior) {
+                return children;
+            }
+
             return <span className={className}>{children}</span>;
         }
 
+        const href = targetUrl;
+        const target = openInNewWindow ? "_blank" : undefined;
+
+        if (legacyBehavior) {
+            return React.cloneElement(children, { href, target, title });
+        }
+
         return (
-            <a href={targetUrl ? targetUrl : "#"} target={openInNewWindow ? "_blank" : undefined} title={title} className={className}>
+            <a href={href} target={target} title={title} className={className}>
                 {children}
             </a>
         );

--- a/packages/site/cms-site/src/blocks/ExternalLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/ExternalLinkBlock.tsx
@@ -10,9 +10,10 @@ import { PropsWithData } from "./PropsWithData";
 interface ExternalLinkBlockProps extends PropsWithData<ExternalLinkBlockData> {
     children: React.ReactElement;
     title?: string;
+    className?: string;
 }
 
-export function ExternalLinkBlock({ data: { targetUrl, openInNewWindow }, children, title }: ExternalLinkBlockProps): React.ReactElement {
+export function ExternalLinkBlock({ data: { targetUrl, openInNewWindow }, children, title, className }: ExternalLinkBlockProps): React.ReactElement {
     const preview = usePreview();
 
     if (preview.previewType === "SitePreview" || preview.previewType === "BlockPreview") {
@@ -27,18 +28,20 @@ export function ExternalLinkBlock({ data: { targetUrl, openInNewWindow }, childr
             }
         };
 
-        return React.cloneElement(children, { href: "#", onClick, title });
+        return (
+            <a href="#" onClick={onClick} title={title} className={className}>
+                {children}
+            </a>
+        );
     } else {
         if (!targetUrl) {
-            return children;
+            return <span className={className}>{children}</span>;
         }
 
-        const childProps = {
-            href: targetUrl ? targetUrl : "#",
-            target: openInNewWindow ? "_blank" : undefined,
-            title,
-        };
-
-        return React.cloneElement(children, childProps);
+        return (
+            <a href={targetUrl ? targetUrl : "#"} target={openInNewWindow ? "_blank" : undefined} title={title} className={className}>
+                {children}
+            </a>
+        );
     }
 }

--- a/packages/site/cms-site/src/blocks/InternalLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/InternalLinkBlock.tsx
@@ -8,23 +8,24 @@ import { PropsWithData } from "./PropsWithData";
 interface InternalLinkBlockProps extends PropsWithData<InternalLinkBlockData> {
     children: React.ReactNode;
     title?: string;
+    className?: string;
 }
 
 /**
  * @deprecated There should be a copy of this component in the application for flexibility (e.g. multi language support)
  */
-export function InternalLinkBlock({ data: { targetPage, targetPageAnchor }, children, title }: InternalLinkBlockProps): React.ReactElement {
+export function InternalLinkBlock({
+    data: { targetPage, targetPageAnchor },
+    children,
+    title,
+    className,
+}: InternalLinkBlockProps): React.ReactElement {
     if (!targetPage) {
-        return <>{children}</>;
+        return <span className={className}>{children}</span>;
     }
 
     return (
-        <Link
-            href={targetPageAnchor !== undefined ? `${targetPage.path}#${targetPageAnchor}` : targetPage.path}
-            passHref
-            title={title}
-            legacyBehavior
-        >
+        <Link href={targetPageAnchor !== undefined ? `${targetPage.path}#${targetPageAnchor}` : targetPage.path} title={title} className={className}>
             {children}
         </Link>
     );

--- a/packages/site/cms-site/src/blocks/InternalLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/InternalLinkBlock.tsx
@@ -9,6 +9,7 @@ interface InternalLinkBlockProps extends PropsWithData<InternalLinkBlockData> {
     children: React.ReactNode;
     title?: string;
     className?: string;
+    legacyBehavior?: boolean;
 }
 
 /**
@@ -19,13 +20,28 @@ export function InternalLinkBlock({
     children,
     title,
     className,
+    legacyBehavior,
 }: InternalLinkBlockProps): React.ReactElement {
     if (!targetPage) {
+        if (legacyBehavior) {
+            return <>{children}</>;
+        }
+
         return <span className={className}>{children}</span>;
     }
 
+    const href = targetPageAnchor !== undefined ? `${targetPage.path}#${targetPageAnchor}` : targetPage.path;
+
+    if (legacyBehavior) {
+        return (
+            <Link href={href} title={title} passHref legacyBehavior>
+                {children}
+            </Link>
+        );
+    }
+
     return (
-        <Link href={targetPageAnchor !== undefined ? `${targetPage.path}#${targetPageAnchor}` : targetPage.path} title={title} className={className}>
+        <Link href={href} title={title} className={className}>
             {children}
         </Link>
     );

--- a/packages/site/cms-site/src/blocks/PhoneLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/PhoneLinkBlock.tsx
@@ -7,15 +7,26 @@ interface PhoneLinkBlockProps extends PropsWithData<PhoneLinkBlockData> {
     children: React.ReactElement;
     title?: string;
     className?: string;
+    legacyBehavior?: boolean;
 }
 
-export const PhoneLinkBlock = ({ data: { phone }, children, title, className }: PhoneLinkBlockProps) => {
+export const PhoneLinkBlock = ({ data: { phone }, children, title, className, legacyBehavior }: PhoneLinkBlockProps) => {
     if (!phone) {
+        if (legacyBehavior) {
+            return children;
+        }
+
         return <span className={className}>{children}</span>;
     }
 
+    const href = `tel:${phone}`;
+
+    if (legacyBehavior) {
+        return React.cloneElement(children, { href, title });
+    }
+
     return (
-        <a href={`tel:${phone}`} title={title} className={className}>
+        <a href={href} title={title} className={className}>
             {children}
         </a>
     );

--- a/packages/site/cms-site/src/blocks/PhoneLinkBlock.tsx
+++ b/packages/site/cms-site/src/blocks/PhoneLinkBlock.tsx
@@ -6,17 +6,17 @@ import { PropsWithData } from "./PropsWithData";
 interface PhoneLinkBlockProps extends PropsWithData<PhoneLinkBlockData> {
     children: React.ReactElement;
     title?: string;
+    className?: string;
 }
 
-export const PhoneLinkBlock = ({ data: { phone }, children, title }: PhoneLinkBlockProps) => {
+export const PhoneLinkBlock = ({ data: { phone }, children, title, className }: PhoneLinkBlockProps) => {
     if (!phone) {
-        return children;
+        return <span className={className}>{children}</span>;
     }
 
-    const childProps = {
-        href: `tel:${phone}`,
-        title,
-    };
-
-    return React.cloneElement(children, childProps);
+    return (
+        <a href={`tel:${phone}`} title={title} className={className}>
+            {children}
+        </a>
+    );
 };

--- a/packages/site/cms-site/src/blocks/factories/OneOfBlock.tsx
+++ b/packages/site/cms-site/src/blocks/factories/OneOfBlock.tsx
@@ -12,9 +12,10 @@ interface Props {
     };
     supportedBlocks: SupportedBlocks;
     children?: React.ReactNode;
+    className?: string;
 }
 
-export const OneOfBlock: React.FC<Props> = ({ data: { block, ...additionalProps }, supportedBlocks, children }) => {
+export const OneOfBlock: React.FC<Props> = ({ data: { block, ...additionalProps }, supportedBlocks, children, className }) => {
     if (!block) {
         return null;
     }
@@ -33,5 +34,5 @@ export const OneOfBlock: React.FC<Props> = ({ data: { block, ...additionalProps 
         return null;
     }
 
-    return <>{blockFunction({ ...block.props, ...additionalProps, children })}</>;
+    return <>{blockFunction({ ...block.props, ...additionalProps, children, className })}</>;
 };


### PR DESCRIPTION
This PR only demonstrates the necessary code changes. I will add a migration guide and changesets once we decide we want to change that now.

Changes necessary in projects:

Either: 
- All custom link blocks need to render a HTML tag (a or span) that accepts a className
- All link stylings need to be change to style the link block, not the a-tag in the link block
- className needs to be prop drilled in LinkBlock

This will require lots of work in the projects I suppose. The [Next codemod ](https://nextjs.org/docs/app/building-your-application/upgrading/codemods#remove-a-tags-from-link-components) will not be of much help here.

Or: Add `legacyBehavior` prop to link block usages.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-803