### PR TITLE
ManyToOneIntFilter

### DIFF
--- a/packages/api/cms-api/src/common/filter/many-to-one-int.filter.ts
+++ b/packages/api/cms-api/src/common/filter/many-to-one-int.filter.ts
@@ -1,0 +1,21 @@
+import { Field, InputType, Int } from "@nestjs/graphql";
+import { IsArray, IsInt, IsOptional } from "class-validator";
+
+@InputType()
+export class ManyToOneIntFilter {
+    @Field(() => [Int], { nullable: true })
+    @IsOptional()
+    @IsArray()
+    @IsInt()
+    isAnyOf?: number[];
+
+    @Field(() => Int, { nullable: true })
+    @IsOptional()
+    @IsInt()
+    equal?: number;
+
+    @Field(() => Int, { nullable: true })
+    @IsOptional()
+    @IsInt()
+    notEqual?: number;
+}

--- a/packages/api/cms-api/src/common/filter/mikro-orm.ts
+++ b/packages/api/cms-api/src/common/filter/mikro-orm.ts
@@ -1,4 +1,5 @@
 import { FilterQuery, ObjectQuery } from "@mikro-orm/core";
+import { ManyToOneIntFilter } from "src/common/filter/many-to-one-int.filter";
 
 import { BooleanFilter } from "./boolean.filter";
 import { DateFilter } from "./date.filter";
@@ -86,6 +87,16 @@ export function filterToMikroOrmQuery(
             ret.$eq = filterProperty.equal;
         }
     } else if (filterProperty instanceof ManyToOneFilter) {
+        if (filterProperty.equal !== undefined) {
+            ret.$eq = filterProperty.equal;
+        }
+        if (filterProperty.notEqual !== undefined) {
+            ret.$ne = filterProperty.notEqual;
+        }
+        if (filterProperty.isAnyOf !== undefined) {
+            ret.$in = filterProperty.isAnyOf;
+        }
+    } else if (filterProperty instanceof ManyToOneIntFilter) {
         if (filterProperty.equal !== undefined) {
             ret.$eq = filterProperty.equal;
         }

--- a/packages/api/cms-api/src/common/filter/mikro-orm.ts
+++ b/packages/api/cms-api/src/common/filter/mikro-orm.ts
@@ -1,10 +1,10 @@
 import { FilterQuery, ObjectQuery } from "@mikro-orm/core";
-import { ManyToOneIntFilter } from "src/common/filter/many-to-one-int.filter";
 
 import { BooleanFilter } from "./boolean.filter";
 import { DateFilter } from "./date.filter";
 import { EnumFilterInterface, isEnumFilter } from "./enum.filter.factory";
 import { ManyToOneFilter } from "./many-to-one.filter";
+import { ManyToOneIntFilter } from "./many-to-one-int.filter";
 import { NumberFilter } from "./number.filter";
 import { StringFilter } from "./string.filter";
 

--- a/packages/api/cms-api/src/generator/generate-crud-many-to-one.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-many-to-one.spec.ts
@@ -1,0 +1,61 @@
+import { BaseEntity, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Ref } from "@mikro-orm/core";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { v4 as uuid } from "uuid";
+
+import { generateCrud } from "./generate-crud";
+import { lintGeneratedFiles, parseSource } from "./utils/test-helper";
+
+@Entity()
+export class Company extends BaseEntity<Company, "id"> {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @OneToMany(() => Measure, (measure) => measure.company)
+    measures = new Collection<Measure>(this);
+}
+
+@Entity()
+export class Measure extends BaseEntity<Company, "id"> {
+    @PrimaryKey({ columnType: "int", type: "int" })
+    id: number;
+
+    @ManyToOne(() => Company, { onDelete: "cascade", ref: true })
+    company: Ref<Company>;
+}
+
+describe("GenerateCrud", () => {
+    describe("test m:1 filter with int id", () => {
+        it("should be a valid generated ts file", async () => {
+            LazyMetadataStorage.load();
+            const orm = await MikroORM.init({
+                type: "postgresql",
+                dbName: "test-db",
+                entities: [Company, Measure],
+            });
+
+            const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("Measure"));
+            const lintedOut = await lintGeneratedFiles(out);
+
+            const file = lintedOut.find((file) => file.name === "dto/measure.filter.ts");
+            if (!file) throw new Error("File not found");
+
+            const source = parseSource(file.content);
+
+            const classes = source.getClasses();
+            expect(classes.length).toBe(1);
+
+            const cls = classes[0];
+            expect(cls.getName()).toBe("MeasureFilter");
+            const structure = cls.getStructure();
+
+            expect(structure.properties?.length).toBe(4);
+
+            if (!structure.properties || !structure.properties[0]) throw new Error("property not found");
+            const filterProp = structure.properties[1];
+            expect(filterProp.name).toBe("company");
+            expect(filterProp.type).toBe("ManyToOneIntFilter");
+
+            orm.close();
+        });
+    });
+});

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -127,7 +127,7 @@ function generateFilterDto({ generatorOptions, metadata }: { generatorOptions: C
         }
     });
 
-    const filterOut = `import { StringFilter, NumberFilter, BooleanFilter, DateFilter, ManyToOneFilter, ManyToOneFilter, createEnumFilter } from "@comet/cms-api";
+    const filterOut = `import { StringFilter, NumberFilter, BooleanFilter, DateFilter, ManyToOneFilter, ManyToOneIntFilter, createEnumFilter } from "@comet/cms-api";
     import { Field, InputType } from "@nestjs/graphql";
     import { Type } from "class-transformer";
     import { IsNumber, IsOptional, IsString, ValidateNested } from "class-validator";

--- a/packages/api/cms-api/src/generator/generate-crud.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.ts
@@ -127,7 +127,7 @@ function generateFilterDto({ generatorOptions, metadata }: { generatorOptions: C
         }
     });
 
-    const filterOut = `import { StringFilter, NumberFilter, BooleanFilter, DateFilter, ManyToOneFilter, createEnumFilter } from "@comet/cms-api";
+    const filterOut = `import { StringFilter, NumberFilter, BooleanFilter, DateFilter, ManyToOneFilter, ManyToOneFilter, createEnumFilter } from "@comet/cms-api";
     import { Field, InputType } from "@nestjs/graphql";
     import { Type } from "class-transformer";
     import { IsNumber, IsOptional, IsString, ValidateNested } from "class-validator";
@@ -174,6 +174,13 @@ function generateFilterDto({ generatorOptions, metadata }: { generatorOptions: C
                     @IsOptional()
                     @Type(() => DateFilter)
                     ${prop.name}?: DateFilter;
+                    `;
+                } else if (prop.reference === "m:1" && integerTypes.includes(metadata.properties.id.type)) {
+                    return `@Field(() => ManyToOneIntFilter, { nullable: true })
+                    @ValidateNested()
+                    @IsOptional()
+                    @Type(() => ManyToOneIntFilter)
+                    ${prop.name}?: ManyToOneIntFilter;
                     `;
                 } else if (prop.reference === "m:1") {
                     return `@Field(() => ManyToOneFilter, { nullable: true })

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -51,6 +51,7 @@ export { BooleanFilter } from "./common/filter/boolean.filter";
 export { DateFilter } from "./common/filter/date.filter";
 export { createEnumFilter } from "./common/filter/enum.filter.factory";
 export { ManyToOneFilter } from "./common/filter/many-to-one.filter";
+export { ManyToOneIntFilter } from "./common/filter/many-to-one-int.filter";
 export { filtersToMikroOrmQuery, searchToMikroOrmQuery } from "./common/filter/mikro-orm";
 export { NumberFilter } from "./common/filter/number.filter";
 export { StringFilter } from "./common/filter/string.filter";


### PR DESCRIPTION
Add a new filter type, ManyToOneIntFilter. The ManyToOneIntFilter functions identically to the existing ManyToOneFilter but uses integer IDs instead of UUIDs. This enhancement allows for filtering based on integer IDs, which can be more suitable for certain use cases.

---
"@comet/cms-api": minor
---

Introduced ManyToOneIntFilter for filtering based on integer IDs, providing functionality similar to ManyToOneFilter but using int IDs instead of UUIDs.


---

COM-931