### PR TITLE
Fix Stack Breadcrumbs on reload

### DIFF
--- a/packages/admin/admin/src/stack/Stack.tsx
+++ b/packages/admin/admin/src/stack/Stack.tsx
@@ -74,7 +74,7 @@ export function Stack(props: StackProps) {
     const location = useLocation();
 
     const getVisibleBreadcrumbs = React.useCallback(() => {
-        return breadcrumbs.map((i) => {
+        return sortByParentId(breadcrumbs).map((i) => {
             return { ...i, url: i.locationUrl ?? i.url };
         });
     }, [breadcrumbs]);
@@ -94,7 +94,7 @@ export function Stack(props: StackProps) {
 
     const addBreadcrumb = React.useCallback((id: string, parentId: string, url: string, title: React.ReactNode) => {
         setBreadcrumbs((old) => {
-            return sortByParentId([
+            return [
                 ...old,
                 {
                     id,
@@ -102,27 +102,23 @@ export function Stack(props: StackProps) {
                     url,
                     title,
                 },
-            ]);
+            ];
         });
     }, []);
 
     const updateBreadcrumb = React.useCallback((id: string, parentId: string, url: string, title: React.ReactNode) => {
         setBreadcrumbs((old) => {
-            return sortByParentId(
-                old.map((crumb) => {
-                    return crumb.id === id ? { ...crumb, parentId, url, title } : crumb;
-                }),
-            );
+            return old.map((crumb) => {
+                return crumb.id === id ? { ...crumb, parentId, url, title } : crumb;
+            });
         });
     }, []);
 
     const removeBreadcrumb = React.useCallback((id: string) => {
         setBreadcrumbs((old) => {
-            return sortByParentId(
-                old.filter((crumb) => {
-                    return crumb.id !== id;
-                }),
-            );
+            return old.filter((crumb) => {
+                return crumb.id !== id;
+            });
         });
     }, []);
 
@@ -148,7 +144,9 @@ export function Stack(props: StackProps) {
     React.useEffect(() => {
         // execute on location change, set locationUrl for the last breadcrumb to the current location
         setBreadcrumbs((old) => {
-            return [...old.slice(0, -1), { ...old[old.length - 1], locationUrl: location.pathname + location.search }];
+            const sorted = sortByParentId(old);
+            sorted[sorted.length - 1].locationUrl = location.pathname + location.search; // modify object in place
+            return [...old]; // clone (with modified object) to new array to trigger a state update
         });
     }, [location]);
 


### PR DESCRIPTION
This reverts commit 12e9825e1f37db600511fb87e91f6ec9428b304d.

When adding breadcrumbs items incrementally (eg. by opening detail page) the sorting worked correctly.

But when adding multiple after a reload (where multiple breadcrumbs render) the inner breadcrumb is added before the outer, resulting in an dangling parentId which causes sortByParentId to drop this breadcrumb. This was caused by an code "improvement" that I simply reverted now.

COM-919