### PR TITLE
Remove section about relative DAM URLs from migration guide

### DIFF
--- a/docs/docs/migration/migration-from-v6-to-v7.md
+++ b/docs/docs/migration/migration-from-v6-to-v7.md
@@ -849,43 +849,6 @@ Example:
  />
 ```
 
-### Make relative DAM URLs work
-
-This requires the following change (depending on which router you use):
-
-#### Pages Router
-
-```diff
-// next.config.js
-
-const nextConfig = {
-    rewrites: async () => {
-        if (process.env.NEXT_PUBLIC_SITE_IS_PREVIEW === "true") return [];
-        var rewrites = await require("./preBuild/build/preBuild/src/createRewrites").createRewrites();
--       return rewrites;
-+       return [
-+           ...rewrites,
-+           {
-+               source: "/dam/:path*",
-+               destination: process.env.API_URL + "/dam/:path*",
-+           },
-+       ];
-    },
-    // ...
-```
-
-#### App Router
-
-```diff
-// middleware.ts
-
-export async function middleware(request: NextRequest) {
-+   if (request.nextUrl.pathname.startsWith("/dam/")) {
-+       return NextResponse.rewrite(new URL(`${process.env.API_URL_INTERNAL}${request.nextUrl.pathname}`));
-+   }
-    // ...
-```
-
 ### Switch to Next.js Preview Mode
 
 #### Requires following changes to site:


### PR DESCRIPTION
Adding this when migrating to v7 would result in a diminished SEO ranking due to broken links. One could add permanent redirects to prevent this, but I doubt that our developers will think about this.