### PR TITLE
Adjust h6 typography usages

### DIFF
--- a/demo/admin/src/common/ComponentDemo.tsx
+++ b/demo/admin/src/common/ComponentDemo.tsx
@@ -118,7 +118,7 @@ export function ComponentDemo(): React.ReactElement {
 
                         <AdminComponentSectionGroup title="Grouped Section Headline">
                             <AdminComponentSection>
-                                <Typography variant="h6">Label</Typography>
+                                <Typography variant="subtitle1">Label</Typography>
                             </AdminComponentSection>
 
                             <AdminComponentSection>

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogTitle.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogTitle.ts
@@ -3,14 +3,14 @@ import { GetMuiComponentTheme } from "./getComponentsTheme";
 
 export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (component, { palette, typography }) => ({
     ...component,
+    defaultProps: {
+        variant: "subtitle1",
+    },
     styleOverrides: mergeOverrideStyles<"MuiDialogTitle">(component?.styleOverrides, {
         root: {
             backgroundColor: palette.grey["A200"],
             color: "#ffffff",
             padding: 20,
-            fontSize: 14,
-            lineHeight: "20px",
-            fontWeight: typography.fontWeightBold,
         },
     }),
 });

--- a/packages/admin/admin/src/translator/BaseTranslationDialog.tsx
+++ b/packages/admin/admin/src/translator/BaseTranslationDialog.tsx
@@ -26,12 +26,12 @@ export const BaseTranslationDialog = <T,>(props: TranslationDialogBaseProps<T>) 
             <DialogContent>
                 <Grid container columnSpacing={4} rowSpacing={2} columns={2} alignItems="center">
                     <Grid item xs={1}>
-                        <Typography variant="h6">
+                        <Typography variant="subtitle2">
                             <FormattedMessage id="comet.translator.original" defaultMessage="Original" />
                         </Typography>
                     </Grid>
                     <Grid item xs={1}>
-                        <Typography variant="h6">
+                        <Typography variant="subtitle2">
                             <FormattedMessage id="comet.translator.translation" defaultMessage="Translation" />
                         </Typography>
                     </Grid>

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentSection.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentSection.tsx
@@ -16,7 +16,7 @@ export function AdminComponentSection({ children, title, disableBottomMargin }: 
         return (
             <Root disableBottomMargin={disableBottomMargin}>
                 <HiddenInSubroute>
-                    <Title variant="h6">{title}</Title>
+                    <Title variant="subtitle1">{title}</Title>
                 </HiddenInSubroute>
                 {children}
             </Root>

--- a/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/ColumnsLayoutPreview.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/ColumnsLayoutPreview.tsx
@@ -35,5 +35,5 @@ const RootContent = styled(ColumnsLayoutPreviewSpacing)`
 `;
 
 export function ColumnsLayoutPreviewContent({ width }: ItemProps): React.ReactElement<ItemProps> {
-    return <RootContent width={width}>{width > 3 ? <Typography variant="h6">{width}</Typography> : null}</RootContent>;
+    return <RootContent width={width}>{width > 3 ? <Typography variant="subtitle1">{width}</Typography> : null}</RootContent>;
 }

--- a/packages/admin/cms-admin/src/dam/DataGrid/breadcrumbs/FolderBreadcrumbs.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/breadcrumbs/FolderBreadcrumbs.tsx
@@ -96,7 +96,7 @@ const FolderBreadcrumb = ({ id, url }: FolderBreadcrumbProps): React.ReactElemen
     return (
         <FolderBreadcrumbWrapper>
             <Link color="inherit" underline="none" key={id} to={url} component={RouterLink}>
-                <Typography component="span" variant="h6">
+                <Typography component="span" variant="subtitle1">
                     {id === null ? <FormattedMessage id="comet.pages.dam.assetManager" defaultMessage="Asset Manager" /> : data?.damFolder.name}
                 </Typography>
             </Link>

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/FileUploadErrorDialog.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/FileUploadErrorDialog.tsx
@@ -57,7 +57,7 @@ export const FileUploadErrorDialog = ({ open = false, onClose, validationErrors 
                 <FormattedMessage id="comet.pages.dam.uploadErrors" defaultMessage="Upload errors" />
             </DialogTitle>
             <DialogContent>
-                <Typography style={{ paddingBottom: "16px" }} variant="h6">
+                <Typography style={{ paddingBottom: "16px" }} variant="subtitle1">
                     <FormattedMessage id="comet.pages.dam.followingFilesCouldNotBeUploaded" defaultMessage="Following files could not be uploaded:" />
                 </Typography>
                 <Table>
@@ -76,7 +76,7 @@ export const FileUploadErrorDialog = ({ open = false, onClose, validationErrors 
                             return (
                                 <TableRow key={errorsOfFile[0].file.path ?? errorsOfFile[0].file.name}>
                                     <TableCell>
-                                        <Typography variant="h6">{errorsOfFile[0].file.name}</Typography>
+                                        <Typography variant="subtitle1">{errorsOfFile[0].file.name}</Typography>
                                         <Path variant="body2">{errorsOfFile[0].file.path}</Path>
                                     </TableCell>
                                     <TableCell>

--- a/packages/admin/cms-admin/src/pages/pageTree/PageDeleteDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageDeleteDialog.tsx
@@ -56,7 +56,7 @@ export const PageDeleteDialog: React.FC<PageDeleteDialogProps> = (props) => {
                         <WarningIconWrapper>
                             <WarningIcon color="inherit" fontSize="large" />
                         </WarningIconWrapper>
-                        <Typography variant="h6">
+                        <Typography variant="subtitle1">
                             {dialogInformation?.hasSubpages ? (
                                 <FormattedMessage
                                     id="comet.pages.pages.page.deleteDialog.contentIncludingSubpages"

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/PermissionGrid.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/PermissionGrid.tsx
@@ -52,7 +52,7 @@ export const PermissionGrid: React.FC<{
             flex: 1,
             pinnable: false,
             headerName: intl.formatMessage({ id: "comet.userPermissions.permission", defaultMessage: "Permission" }),
-            renderCell: ({ row }) => <Typography variant="h6">{camelCaseToHumanReadable(row.permission)}</Typography>,
+            renderCell: ({ row }) => <Typography variant="subtitle2">{camelCaseToHumanReadable(row.permission)}</Typography>,
         },
         {
             field: "source",


### PR DESCRIPTION
For components that have a screendesign, I used the value defined in Figma. 

For the rest, I chose subtitle1 because subtitle1 in v7 is

```ts
subtitle1: {
    fontFamily,
    fontSize: 16,
    lineHeight: "20px",
    fontWeight: 600,
    fontVariationSettings: "'wdth' 85",
},
```

and h6 in v6 was

```ts
    h6: {
        fontFamily,
        fontSize: 16,
        lineHeight: "20px",
        fontWeight: fontWeights.fontWeightBold,
    },
```

so it looks very similar and doesn't unintentionally change the look

---

COM-935
