### PR TITLE
Set `fullWidth` automatically for horizontal fields

### DIFF
--- a/.changeset/strange-coins-hug.md
+++ b/.changeset/strange-coins-hug.md
@@ -1,0 +1,10 @@
+---
+"@comet/admin": minor
+---
+
+Automatically set `fullWidth` for `FieldContainer` with `variant="horizontal"`
+
+Horizontal fields are automatically responsive:
+If they are less than 600px wide, the layout automatically changes to vertical.
+For this to work correctly, the fields must be `fullWidth`.
+Therefore, `fullWidth` is now `true` by default for horizontal fields.

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -197,7 +197,7 @@ const HelperText = createComponentSlot(FormHelperText)<FieldContainerClassKey>({
 export const FieldContainer = (inProps: React.PropsWithChildren<FieldContainerProps>) => {
     const {
         variant = "vertical",
-        fullWidth,
+        fullWidth: passedFullWidth,
         label,
         error,
         disabled,
@@ -210,6 +210,7 @@ export const FieldContainer = (inProps: React.PropsWithChildren<FieldContainerPr
         slotProps,
         ...restProps
     } = useThemeProps({ props: inProps, name: "CometAdminFormFieldContainer" });
+    const fullWidth = passedFullWidth ?? variant === "horizontal";
 
     const hasError = !!error;
     const hasWarning = !hasError && !!warning;


### PR DESCRIPTION
## Problem

`variant="horizontal"` doesn't work correctly anymore without `fullWidth`. The reason is that we added the feature that a vertical layout is forced automatically if the field is less than 600px wide: 

https://github.com/vivid-planet/comet/blob/eb5ff99f1392025ee8cdfa06b64c6f1d5596589e/packages/admin/admin/src/form/FieldContainer.tsx#L219

If a field doesn't have fullWidth, it will never be >= 600px.

## Solution

Automatically enable fullWidth for horizontal fields

### Alternative solutions

1. Leave it like this and horizontal fields only work correctly with fullWidth manually set
2. Only calculate forceVertical if fullWidth is set



---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
- COM-940
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Previously:

<img width="784" alt="Bildschirmfoto 2024-07-17 um 09 39 20" src="https://github.com/user-attachments/assets/f49d8c5b-c4c0-46fa-93ff-5df4424c7d67">


Now:

<img width="780" alt="Bildschirmfoto 2024-07-17 um 09 38 53" src="https://github.com/user-attachments/assets/74f223ee-60f9-47d7-b175-14e0a98c2658">


</details>
