### PR TITLE
Add `fill` prop to `YouTubeVideoBlock` and `DamVideoBlock`

### DIFF
--- a/.changeset/ninety-countries-chew.md
+++ b/.changeset/ninety-countries-chew.md
@@ -2,4 +2,4 @@
 "@comet/cms-site": patch
 ---
 
-Add optional `fill` prop to `YouTubeVideo` and `DamVideo` block to support same behaviour as `PixelImage` block. 
+Add optional `fill` prop to `YouTubeVideoBlock` and `DamVideoBlock` to support same behavior as in `PixelImageBlock` 

--- a/.changeset/ninety-countries-chew.md
+++ b/.changeset/ninety-countries-chew.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": patch
+---
+
+Add optional `fill` prop to `YouTubeVideo` and `DamVideo` block to support same behaviour as `PixelImage` block. 

--- a/.changeset/ninety-countries-chew.md
+++ b/.changeset/ninety-countries-chew.md
@@ -1,5 +1,5 @@
 ---
-"@comet/cms-site": patch
+"@comet/cms-site": minor
 ---
 
 Add optional `fill` prop to `YouTubeVideoBlock` and `DamVideoBlock` to support same behavior as in `PixelImageBlock` 

--- a/demo/site/src/blocks/FullWidthImageBlock.tsx
+++ b/demo/site/src/blocks/FullWidthImageBlock.tsx
@@ -11,7 +11,7 @@ export const FullWidthImageBlock = withPreview(
     ({ data: { image, content } }: PropsWithData<FullWidthImageBlockData>) => {
         return (
             <Root>
-                <DamImageBlock data={image} layout="responsive" sizes="100vw" aspectRatio="16x9" />
+                <DamImageBlock data={image} sizes="100vw" aspectRatio="16x9" />
                 <OptionalBlock
                     block={(props) => (
                         <Content>

--- a/demo/site/src/blocks/MediaBlock.tsx
+++ b/demo/site/src/blocks/MediaBlock.tsx
@@ -4,15 +4,15 @@ import { MediaBlockData } from "@src/blocks.generated";
 
 import { DamImageBlock } from "./DamImageBlock";
 
-const supportedBlocks: SupportedBlocks = {
-    image: (props) => <DamImageBlock data={props} aspectRatio="inherit" />,
-    damVideo: (props) => <DamVideoBlock data={props} />,
-    youTubeVideo: (props) => <YouTubeVideoBlock data={props} />,
-};
+const getSupportedBlocks = (fill?: boolean): SupportedBlocks => ({
+    image: (props) => <DamImageBlock data={props} aspectRatio="inherit" fill={fill} />,
+    damVideo: (props) => <DamVideoBlock data={props} fill={fill} />,
+    youTubeVideo: (props) => <YouTubeVideoBlock data={props} fill={fill} />,
+});
 
 export const MediaBlock = withPreview(
-    ({ data }: PropsWithData<MediaBlockData>) => {
-        return <OneOfBlock data={data} supportedBlocks={supportedBlocks} />;
+    ({ data, fill }: PropsWithData<MediaBlockData> & { fill?: boolean }) => {
+        return <OneOfBlock data={data} supportedBlocks={getSupportedBlocks(fill)} />;
     },
     { label: "Media" },
 );

--- a/packages/site/cms-site/src/blocks/DamVideoBlock.tsx
+++ b/packages/site/cms-site/src/blocks/DamVideoBlock.tsx
@@ -12,6 +12,7 @@ interface DamVideoBlockProps extends PropsWithData<DamVideoBlockData> {
     aspectRatio?: string;
     previewImageSizes?: string;
     renderPreviewImage?: (props: VideoPreviewImageProps) => React.ReactElement;
+    fill?: boolean;
 }
 
 export const DamVideoBlock = withPreview(
@@ -20,6 +21,7 @@ export const DamVideoBlock = withPreview(
         aspectRatio = "16x9",
         previewImageSizes,
         renderPreviewImage,
+        fill,
     }: DamVideoBlockProps) => {
         if (damFile === undefined) {
             return <PreviewSkeleton type="media" hasContent={false} />;
@@ -32,13 +34,20 @@ export const DamVideoBlock = withPreview(
             <>
                 {hasPreviewImage && showPreviewImage ? (
                     renderPreviewImage ? (
-                        renderPreviewImage({ onPlay: () => setShowPreviewImage(false), image: previewImage, aspectRatio, sizes: previewImageSizes })
+                        renderPreviewImage({
+                            onPlay: () => setShowPreviewImage(false),
+                            image: previewImage,
+                            aspectRatio,
+                            sizes: previewImageSizes,
+                            fill: fill,
+                        })
                     ) : (
                         <VideoPreviewImage
                             onPlay={() => setShowPreviewImage(false)}
                             image={previewImage}
                             aspectRatio={aspectRatio}
                             sizes={previewImageSizes}
+                            fill={fill}
                         />
                     )
                 ) : (
@@ -49,6 +58,7 @@ export const DamVideoBlock = withPreview(
                         playsInline
                         muted={autoplay}
                         $aspectRatio={aspectRatio.replace("x", " / ")}
+                        $fill={fill}
                     >
                         <source src={damFile.fileUrl} type={damFile.mimetype} />
                     </Video>
@@ -59,12 +69,16 @@ export const DamVideoBlock = withPreview(
     { label: "Video" },
 );
 
-const Video = styled.video<{ $aspectRatio: string }>`
+const Video = styled.video<{ $aspectRatio: string; $fill?: boolean }>`
     width: 100%;
     object-fit: cover;
 
-    ${({ $aspectRatio }) =>
-        css`
-            aspect-ratio: ${$aspectRatio};
-        `}
+    ${({ $aspectRatio, $fill }) =>
+        $fill
+            ? css`
+                  height: 100%;
+              `
+            : css`
+                  aspect-ratio: ${$aspectRatio};
+              `}
 `;

--- a/packages/site/cms-site/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/site/cms-site/src/blocks/YouTubeVideoBlock.tsx
@@ -24,6 +24,7 @@ interface YouTubeVideoBlockProps extends PropsWithData<YouTubeVideoBlockData> {
     aspectRatio?: string;
     previewImageSizes?: string;
     renderPreviewImage?: (props: VideoPreviewImageProps) => React.ReactElement;
+    fill?: boolean;
 }
 
 export const YouTubeVideoBlock = withPreview(
@@ -32,6 +33,7 @@ export const YouTubeVideoBlock = withPreview(
         aspectRatio = "16x9",
         previewImageSizes,
         renderPreviewImage,
+        fill,
     }: YouTubeVideoBlockProps) => {
         const [showPreviewImage, setShowPreviewImage] = React.useState(true);
         const hasPreviewImage = !!(previewImage && previewImage.damFile);
@@ -62,17 +64,24 @@ export const YouTubeVideoBlock = withPreview(
             <>
                 {hasPreviewImage && showPreviewImage ? (
                     renderPreviewImage ? (
-                        renderPreviewImage({ onPlay: () => setShowPreviewImage(false), image: previewImage, aspectRatio, sizes: previewImageSizes })
+                        renderPreviewImage({
+                            onPlay: () => setShowPreviewImage(false),
+                            image: previewImage,
+                            aspectRatio,
+                            sizes: previewImageSizes,
+                            fill: fill,
+                        })
                     ) : (
                         <VideoPreviewImage
                             onPlay={() => setShowPreviewImage(false)}
                             image={previewImage}
                             aspectRatio={aspectRatio}
                             sizes={previewImageSizes}
+                            fill={fill}
                         />
                     )
                 ) : (
-                    <VideoContainer $aspectRatio={aspectRatio.replace("x", "/")}>
+                    <VideoContainer $aspectRatio={aspectRatio.replace("x", "/")} $fill={fill}>
                         <YouTubeContainer src={youtubeUrl.toString()} allow="autoplay" />
                     </VideoContainer>
                 )}
@@ -82,14 +91,19 @@ export const YouTubeVideoBlock = withPreview(
     { label: "Video" },
 );
 
-const VideoContainer = styled.div<{ $aspectRatio: string }>`
+const VideoContainer = styled.div<{ $aspectRatio: string; $fill?: boolean }>`
     overflow: hidden;
     position: relative;
 
-    ${({ $aspectRatio }) =>
-        css`
-            aspect-ratio: ${$aspectRatio};
-        `}
+    ${({ $aspectRatio, $fill }) =>
+        $fill
+            ? css`
+                  width: 100%;
+                  height: 100%;
+              `
+            : css`
+                  aspect-ratio: ${$aspectRatio};
+              `}
 `;
 
 const YouTubeContainer = styled.iframe`

--- a/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
+++ b/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { PixelImageBlockData } from "../../blocks.generated";
 import { PixelImageBlock } from "../PixelImageBlock";
@@ -9,12 +9,13 @@ export interface VideoPreviewImageProps {
     image: PixelImageBlockData;
     aspectRatio: string;
     sizes?: string;
+    fill?: boolean;
 }
 
-export const VideoPreviewImage = ({ onPlay, image, aspectRatio, sizes = "100vw" }: VideoPreviewImageProps) => {
+export const VideoPreviewImage = ({ onPlay, image, aspectRatio, sizes = "100vw", fill }: VideoPreviewImageProps) => {
     return (
-        <Root>
-            <PixelImageBlock data={image} aspectRatio={aspectRatio} sizes={sizes} />
+        <Root $fill={fill}>
+            <PixelImageBlock data={image} aspectRatio={aspectRatio} sizes={sizes} fill={fill} />
             <IconWrapper onClick={onPlay}>
                 <PlayIcon />
             </IconWrapper>
@@ -22,9 +23,15 @@ export const VideoPreviewImage = ({ onPlay, image, aspectRatio, sizes = "100vw" 
     );
 };
 
-const Root = styled.div`
+const Root = styled.div<{ $fill?: boolean }>`
     position: relative;
     width: 100%;
+
+    ${({ $fill }) =>
+        $fill &&
+        css`
+            height: 100%;
+        `}
 `;
 
 const IconWrapper = styled.button`


### PR DESCRIPTION
Use case: The aspect ratio of a video should be ignored and the block should adapt to its parent container instead (e.g., inside a full height stage). The behavior is the same as in the `PixelImageBlock`.