### PR TITLE
Allow options with empty id to clear the form value ...

### DIFF
--- a/.changeset/dirty-knives-remain.md
+++ b/.changeset/dirty-knives-remain.md
@@ -1,0 +1,39 @@
+---
+"@comet/admin": patch
+---
+
+Allow options with empty id to clear the form value when using `FinalFormSelect`/`SelectField` with the `options` prop and `FinalFormAsyncSelect`/`AsyncSelectField`
+
+Previously, selecting "No Value" from the example below would set the form value to the option object itself.
+Now, the form value is set to `undefined` when an option is selected with an id of an empty string.
+
+```tsx
+const options = [
+    { id: "", title: "No Value" },
+    { id: "chocolate", title: "Chocolate" },
+];
+// ...
+<Field name="select" label="Select">
+    {(props) => (
+        <FinalFormSelect
+            {...props}
+            options={options}
+            getOptionLabel={(option) => option.title}
+            getOptionSelected={(option, value) => option.title === value.title}
+        />
+    )}
+</Field>
+```
+
+This behavior is now consistent with `FinalFormSelect` when rendering the options as children.
+
+```tsx
+<Field name="select" label="Select">
+    {(props) => (
+        <FinalFormSelect {...props}>
+            <MenuItem value="">No Value</MenuItem>
+            <MenuItem value="chocolate">Chocolate</MenuItem>
+        </FinalFormSelect>
+    )}
+</Field>
+```

--- a/.changeset/dirty-knives-remain.md
+++ b/.changeset/dirty-knives-remain.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin": patch
+"@comet/admin": major
 ---
 
 Allow options with empty id to clear the form value when using `FinalFormSelect`/`SelectField` with the `options` prop and `FinalFormAsyncSelect`/`AsyncSelectField`

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -28,7 +28,7 @@ export const FinalFormSelect = <T,>({
     },
     getOptionValue = (option: T) => {
         if (typeof option === "object" && option !== null) {
-            if ((option as any).id) return String((option as any).id);
+            if ((option as any).id || (option as any).id === "") return String((option as any).id);
             if ((option as any).value) return String((option as any).value);
             return JSON.stringify(option);
         } else {
@@ -85,11 +85,18 @@ export const FinalFormSelect = <T,>({
             }
             onChange={(event) => {
                 const value = event.target.value;
-                onChange(
-                    Array.isArray(value)
-                        ? value.map((v) => options.find((i) => getOptionValue(i) == v))
-                        : options.find((i) => getOptionValue(i) == value),
-                );
+
+                if (Array.isArray(value)) {
+                    onChange(value.map((v) => options.find((i) => getOptionValue(i) == v)));
+                } else {
+                    const selectedOption = options.find((i) => getOptionValue(i) == value);
+
+                    if (selectedOption && getOptionValue(selectedOption) === "") {
+                        onChange(undefined);
+                    } else {
+                        onChange(selectedOption);
+                    }
+                }
             }}
             value={Array.isArray(value) ? value.map((i) => getOptionValue(i)) : getOptionValue(value)}
         >

--- a/storybook/src/admin/form/SelectsWithEmptyValue.tsx
+++ b/storybook/src/admin/form/SelectsWithEmptyValue.tsx
@@ -1,0 +1,75 @@
+import { AsyncSelectField, Field, FinalFormSelect, SelectField } from "@comet/admin";
+import { Box, Button, MenuItem, Stack, Typography } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { Form } from "react-final-form";
+
+interface OptionWithId {
+    id: string;
+    title: string;
+}
+
+const optionsWithId: OptionWithId[] = [
+    { id: "", title: "No Value" },
+    { id: "chocolate", title: "Chocolate" },
+    { id: "strawberry", title: "Strawberry" },
+    { id: "vanilla", title: "Vanilla" },
+];
+
+storiesOf("@comet/admin/form", module).add("Selects with empty values", () => {
+    return (
+        <Form
+            mode="edit"
+            onSubmit={(values) => {
+                alert(JSON.stringify(values, null, 4));
+            }}
+            initialValues={{}}
+            render={({ handleSubmit, values }) => (
+                <form onSubmit={handleSubmit}>
+                    <Stack direction="row" spacing={8}>
+                        <Stack spacing={8} width={400}>
+                            <Box>
+                                <Typography variant="h4" gutterBottom>
+                                    Selects using options object with id
+                                </Typography>
+                                <AsyncSelectField
+                                    fullWidth
+                                    name="asyncSelectFieldId"
+                                    label="AsyncSelectField (ID)"
+                                    loadOptions={async () => {
+                                        return optionsWithId;
+                                    }}
+                                    getOptionLabel={(option: OptionWithId) => option.title}
+                                />
+                                <SelectField name="selectFieldId" label="SelectField (ID)" fullWidth>
+                                    {optionsWithId.map((option: OptionWithId) => (
+                                        <MenuItem key={option.id} value={option.id}>
+                                            {option.title}
+                                        </MenuItem>
+                                    ))}
+                                </SelectField>
+                                <Field name="finalFormSelectId" label="FinalFormSelect (ID)" fullWidth>
+                                    {(props) => (
+                                        <FinalFormSelect
+                                            {...props}
+                                            options={optionsWithId}
+                                            getOptionLabel={(option: OptionWithId) => option.title}
+                                            getOptionSelected={(option: OptionWithId, value: OptionWithId) => option.title === value.title}
+                                            fullWidth
+                                        />
+                                    )}
+                                </Field>
+                            </Box>
+                            <Button color="primary" variant="contained" type="submit">
+                                Submit
+                            </Button>
+                        </Stack>
+                        <Box component="pre" sx={{ width: 300 }}>
+                            {JSON.stringify({ values }, null, 2)}
+                        </Box>
+                    </Stack>
+                </form>
+            )}
+        />
+    );
+});


### PR DESCRIPTION
... when using `FinalFormSelect`/`SelectField` with the `options` prop and `FinalFormAsyncSelect`/`AsyncSelectField`.

Previously, selecting "No Value" from the example below would set the form value to the option object itself.
Now, the form value is set to `undefined` when an option is selected with an id of an empty string.

```tsx
const options = [
    { id: "", title: "No Value" },
    { id: "chocolate", title: "Chocolate" },
];
// ...
<Field name="select" label="Select">
    {(props) => (
        <FinalFormSelect
            {...props}
            options={options}
            getOptionLabel={(option) => option.title}
            getOptionSelected={(option, value) => option.title === value.title}
        />
    )}
</Field>
```

This behavior is now consistent with `FinalFormSelect` when rendering the options as children.

```tsx
<Field name="select" label="Select">
    {(props) => (
        <FinalFormSelect {...props}>
            <MenuItem value="">No Value</MenuItem>
            <MenuItem value="chocolate">Chocolate</MenuItem>
        </FinalFormSelect>
    )}
</Field>
```

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-942
-   [x] Provide screenshots/screencasts if the change contains visual changes

### Example

Previously the `AsyncSelectField` and `FinalFormSelect` would write the options object into the form values, when selecting "No Value". 

https://github.com/user-attachments/assets/b46ffa1b-7f89-4732-9b91-5b664167a611

Now the value is set to `undefined`, causing the value to be removed from the form values. 

https://github.com/user-attachments/assets/52426bb5-9dfa-4915-847f-347d79a9c372

