### PR TITLE
Spread public site config

### DIFF
--- a/packages/cli/src/commands/site-configs.ts
+++ b/packages/cli/src/commands/site-configs.ts
@@ -27,8 +27,8 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
         const replacerFunctions: Record<string, (siteConfigs: BaseSiteConfig[]) => unknown> = {
             private: (siteConfigs: BaseSiteConfig[]): ExtractPrivateSiteConfig<BaseSiteConfig>[] =>
                 siteConfigs.map((siteConfig) =>
-                    (({ public: publicVars, ...rest }) => ({
-                        ...rest,
+                    ((siteConfig) => ({
+                        ...siteConfig,
                         url: getUrlFromDomain(siteConfig.domains.preliminary ?? siteConfig.domains.main),
                     }))(siteConfig),
                 ),

--- a/packages/cli/src/commands/site-configs.ts
+++ b/packages/cli/src/commands/site-configs.ts
@@ -27,18 +27,19 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
         const replacerFunctions: Record<string, (siteConfigs: BaseSiteConfig[]) => unknown> = {
             private: (siteConfigs: BaseSiteConfig[]): ExtractPrivateSiteConfig<BaseSiteConfig>[] =>
                 siteConfigs.map((siteConfig) =>
-                    ((siteConfig) => ({
-                        ...siteConfig,
+                    (({ public: publicVars, ...rest }) => ({
+                        ...publicVars,
+                        ...rest,
                         url: getUrlFromDomain(siteConfig.domains.preliminary ?? siteConfig.domains.main),
                     }))(siteConfig),
                 ),
             public: (siteConfigs: BaseSiteConfig[]): ExtractPublicSiteConfig<BaseSiteConfig>[] =>
                 siteConfigs.map((siteConfig) => ({
+                    ...siteConfig.public,
                     name: siteConfig.name,
                     contentScope: siteConfig.contentScope,
                     domains: siteConfig.domains,
                     preloginEnabled: siteConfig.preloginEnabled || false,
-                    public: siteConfig.public,
                     url: getUrlFromDomain(siteConfig.domains.preliminary ?? siteConfig.domains.main),
                 })),
         };


### PR DESCRIPTION
Spread public site config options into the site config (instead of leaving them in `public`)

---

Also: Add public values also to the private config.

Reason: You might need public values in the private config (e.g., here https://github.com/vivid-planet/comet-starter/blob/a7ec7377ba5278a05e1ee7f45f4ee5926e95bf6b/api/src/app.module.ts#L82). There is no reason why the public values shouldn't be available in the private config. 