### PR TITLE
Remove contentScope from `BaseSiteConfig`

### DIFF
--- a/packages/cli/src/commands/site-configs.ts
+++ b/packages/cli/src/commands/site-configs.ts
@@ -35,7 +35,6 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
             public: (siteConfigs: BaseSiteConfig[]): ExtractPublicSiteConfig<BaseSiteConfig>[] =>
                 siteConfigs.map((siteConfig) => ({
                     name: siteConfig.name,
-                    contentScope: siteConfig.contentScope,
                     domains: siteConfig.domains,
                     preloginEnabled: siteConfig.preloginEnabled || false,
                     public: siteConfig.public,

--- a/packages/cli/src/site-configs.types.ts
+++ b/packages/cli/src/site-configs.types.ts
@@ -1,6 +1,5 @@
 export type BaseSiteConfig = {
     name: string;
-    contentScope: Record<string, unknown>;
     domains: {
         main: string;
         preliminary?: string;
@@ -13,6 +12,6 @@ export type BaseSiteConfig = {
 export type ExtractPrivateSiteConfig<S extends BaseSiteConfig> = S & {
     url: string;
 };
-export type ExtractPublicSiteConfig<S extends BaseSiteConfig> = Pick<S, "name" | "contentScope" | "domains" | "preloginEnabled" | "public"> & {
+export type ExtractPublicSiteConfig<S extends BaseSiteConfig> = Pick<S, "name" | "domains" | "preloginEnabled" | "public"> & {
     url: string;
 };

--- a/site-configs.ts
+++ b/site-configs.ts
@@ -4,42 +4,50 @@ import { SiteConfig } from "./site-configs.types";
 export default (): SiteConfig[] => [
     {
         name: 'Comet Site "Main/DE"',
-        contentScope: {
-            domain: "main",
-            language: "de",
-        },
         domains: {
             main: "localhost:3000",
         },
+        public: {
+            contentScope: {
+                domain: "main",
+                language: "de",
+            },
+        }
     },
     {
         name: 'Comet Site "Main/EN"',
-        contentScope: {
-            domain: "main",
-            language: "en",
-        },
         domains: {
             main: "en.localhost:3000",
         },
+        public: {
+            contentScope: {
+                domain: "main",
+                language: "en",
+            },
+        }
     },
     {
         name: 'Comet Site "Secondary/DE"',
-        contentScope: {
-            domain: "secondary",
-            language: "de",
-        },
         domains: {
             main: "secondary-de.localhost:3000",
         },
+        public: {
+            contentScope: {
+                domain: "secondary",
+                language: "de",
+            },
+        }
     },
     {
         name: 'Comet Site "Secondary/EN"',
-        contentScope: {
-            domain: "secondary",
-            language: "en",
-        },
         domains: {
             main: "secondary-en.localhost:3000",
         },
+        public: {
+            contentScope: {
+                domain: "secondary",
+                language: "en",
+            },
+        }
     },
 ];

--- a/site-configs.types.ts
+++ b/site-configs.types.ts
@@ -1,11 +1,19 @@
 import type { BaseSiteConfig, ExtractPrivateSiteConfig, ExtractPublicSiteConfig } from "@comet/cli";
 
-export type SiteConfig = BaseSiteConfig & {
-    contentScope: {
-        domain: string;
-        language: string;
+interface ContentScope {
+    domain: string;
+    language: string;
+}
+
+export type SiteConfig = BaseSiteConfig;
+
+export type PrivateSiteConfig = ExtractPrivateSiteConfig<SiteConfig> & {
+    public: {
+        contentScope: ContentScope;
     };
 };
-
-export type PrivateSiteConfig = ExtractPrivateSiteConfig<SiteConfig>;
-export type PublicSiteConfig = ExtractPublicSiteConfig<SiteConfig>;
+export type PublicSiteConfig = ExtractPublicSiteConfig<SiteConfig> & {
+    public: {
+        contentScope: ContentScope;
+    };
+};


### PR DESCRIPTION
Remove `contentScope` from `BaseSiteConfig`

Instead, `contentScope` should be added via `public`. This offers more flexibility in the projects, e.g., sharing one site config for multiple scopes as done in https://github.com/vivid-planet/comet-starter/pull/283/files