### PR TITLE
Prevent unintended width: 100% on nested InputBase (using old styling method)

### DIFF
--- a/.changeset/weak-knives-doubt.md
+++ b/.changeset/weak-knives-doubt.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": patch
+---
+
+Prevent unintended `width: 100%` on nested `InputBase` components inside `FieldContainer` and `Field` components
+
+`FieldContainer` (and therefore `Field`) needs to set the with of the `InputBase` it wraps to 100%.
+This also caused deeply nested `InputBase` components, e.g., inside a `Dialog`, to get this `width` and break the styling of these components, as they are not intended to be styled by `FieldContainer`.

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -44,9 +44,6 @@ const styles = (theme: Theme) => {
                     marginRight: theme.spacing(4),
                 },
             },
-            "& [class*='MuiInputBase-root']": {
-                width: "100%",
-            },
         },
         vertical: {},
         horizontal: {
@@ -81,7 +78,11 @@ const styles = (theme: Theme) => {
             },
         },
         label: {},
-        inputContainer: {},
+        inputContainer: {
+            "& > [class*='MuiInputBase-root']": {
+                width: "100%",
+            },
+        },
         hasError: {
             "& $label:not([class*='Mui-focused'])": {
                 color: theme.palette.error.main,


### PR DESCRIPTION
This is the same fix as in https://github.com/vivid-planet/comet/pull/2288. 
The previous PR was done using the new styling method for V7 while this is the fix for the old styling method in V6. 

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-922
-   [x] Provide screenshots/screencasts if the change contains visual changes

### Example of `DataGrid`, in `Dialog`, in `Field`

Previously the width of the input for "Rows per page" was so large, it caused horizontal scrolling on the DataGrids paging element. 

| Previously | Now |
| --- | --- |
| <img width="512" alt="previously" src="https://github.com/user-attachments/assets/f425e968-55a8-4420-800c-9ca02b7ed88b"> | <img width="512" alt="now" src="https://github.com/user-attachments/assets/993d417f-e702-433e-910f-fd193b3464c3"> |

