### PR TITLE
`FileSelect` styling adjustments

### DIFF
--- a/packages/admin/admin/src/form/file/FileDropzone.tsx
+++ b/packages/admin/admin/src/form/file/FileDropzone.tsx
@@ -156,7 +156,7 @@ const Dropzone = createComponentSlot("div")<FileDropzoneClassKey, OwnerState>({
         align-self: stretch;
         border-radius: 4px;
         border: 1px dashed ${theme.palette.grey[200]};
-        background-color: transparent;
+        background-color: white;
         transition: background-color 200ms, border-color 200ms;
         cursor: pointer;
 

--- a/packages/admin/admin/src/form/file/FileSelectListItem.tsx
+++ b/packages/admin/admin/src/form/file/FileSelectListItem.tsx
@@ -87,7 +87,7 @@ export const FileSelectListItem = (inProps: FileSelectListItemProps) => {
     } = iconMapping;
 
     if ("loading" in file && !file.name) {
-        return <Skeleton variant="rounded" height={35} animation="wave" width="100%" sx={{ borderRadius: 2 }} {...slotProps?.skeleton} />;
+        return <Skeleton variant="rounded" animation="wave" {...slotProps?.skeleton} />;
     }
 
     const ownerState: OwnerState = {
@@ -164,6 +164,7 @@ const Root = createComponentSlot("div")<FileSelectListItemClassKey, OwnerState>(
         background-color: ${theme.palette.grey[50]};
         transition: background-color 200ms;
         width: 100%;
+        border: 1px solid ${theme.palette.grey[100]};
         box-sizing: border-box;
 
         &:hover {
@@ -190,13 +191,19 @@ const Root = createComponentSlot("div")<FileSelectListItemClassKey, OwnerState>(
         `}
     `,
 );
-
 const Skeleton = createComponentSlot(MuiSkeleton)<FileSelectListItemClassKey>({
     componentName: "FileSelectListItem",
     slotName: "skeleton",
-})(css`
-    ${commonItemSpacingStyles};
-`);
+})(
+    ({ theme }) => css`
+        width: 100%;
+        height: 36px;
+        border: 1px solid ${theme.palette.grey[100]};
+        border-radius: 4px;
+        box-sizing: border-box;
+        ${commonItemSpacingStyles};
+    `,
+);
 
 const Content = createComponentSlot("div")<FileSelectListItemClassKey>({
     componentName: "FileSelectListItem",
@@ -237,9 +244,9 @@ const FileName = createComponentSlot(Typography)<FileSelectListItemClassKey, Own
         overflow: hidden;
         white-space: nowrap;
         flex-grow: 1;
-        line-height: 19px;
-        padding-top: 8px;
-        padding-bottom: 8px;
+        line-height: 16px;
+        padding-top: 9px;
+        padding-bottom: 9px;
 
         ${ownerState.hasErrorWithoutDetails &&
         css`
@@ -248,7 +255,8 @@ const FileName = createComponentSlot(Typography)<FileSelectListItemClassKey, Own
 
         ${ownerState.hasErrorWithDetails &&
         css`
-            padding-bottom: 1px;
+            padding-top: 7px;
+            padding-bottom: 4px;
         `}
 
         ${ownerState.disabled &&
@@ -296,7 +304,8 @@ const ErrorDetails = createComponentSlot("div")<FileSelectListItemClassKey>({
         align-items: center;
         gap: ${theme.spacing(1)};
         color: ${theme.palette.error.main};
-        padding-bottom: 8px;
+        padding-bottom: 7px;
+        font-size: 12px;
         line-height: 0;
     `,
 );

--- a/storybook/src/admin/form/file/FileSelect.tsx
+++ b/storybook/src/admin/form/file/FileSelect.tsx
@@ -1,5 +1,6 @@
 import { FileSelect, FileSelectItem } from "@comet/admin";
-import { Card, CardContent, Grid, Typography } from "@mui/material";
+import { Box, Grid, Typography } from "@mui/material";
+import { boolean } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
@@ -26,98 +27,96 @@ const dummyFileDownload = (file: any) => {
 const SingleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
     const [file, setFile] = React.useState<FileSelectItem | undefined>(hasExistingFiles ? dummyFiles[0] : undefined);
     const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
+    const noBackground = boolean("No Background", false);
 
     return (
-        <Card variant="outlined">
-            <CardContent>
-                <Typography variant="h6" gutterBottom>
-                    Single File Select
-                </Typography>
-                <FileSelect
-                    onDrop={(acceptedFiles, rejectedFiles) => {
-                        const tooManyFilesWereDropped = rejectedFiles.some((rejection) =>
-                            rejection.errors.some((error) => error.code === "too-many-files"),
-                        );
+        <Box padding={4} sx={{ backgroundColor: noBackground ? "transparent" : "white" }}>
+            <Typography variant="h6" gutterBottom>
+                Single File Select
+            </Typography>
+            <FileSelect
+                onDrop={(acceptedFiles, rejectedFiles) => {
+                    const tooManyFilesWereDropped = rejectedFiles.some((rejection) =>
+                        rejection.errors.some((error) => error.code === "too-many-files"),
+                    );
 
-                        setTooManyFilesSelected(tooManyFilesWereDropped);
+                    setTooManyFilesSelected(tooManyFilesWereDropped);
 
-                        if (!tooManyFilesWereDropped) {
-                            if (acceptedFiles.length > 0) {
-                                setFile({
-                                    name: acceptedFiles[0].name,
-                                    size: acceptedFiles[0].size,
-                                });
-                            }
-                            if (rejectedFiles.length > 0) {
-                                setFile({
-                                    name: rejectedFiles[0].file.name,
-                                    error: true,
-                                });
-                            }
+                    if (!tooManyFilesWereDropped) {
+                        if (acceptedFiles.length > 0) {
+                            setFile({
+                                name: acceptedFiles[0].name,
+                                size: acceptedFiles[0].size,
+                            });
                         }
-                    }}
-                    onRemove={() => {
-                        setFile(undefined);
-                    }}
-                    onDownload={dummyFileDownload}
-                    maxFiles={1}
-                    maxFileSize={1024 * 1024 * 5} // 5 MB
-                    files={file ? [file] : []}
-                    error={tooManyFilesSelected ? "Selection was canceled. You can only select one file." : undefined}
-                />
-            </CardContent>
-        </Card>
+                        if (rejectedFiles.length > 0) {
+                            setFile({
+                                name: rejectedFiles[0].file.name,
+                                error: true,
+                            });
+                        }
+                    }
+                }}
+                onRemove={() => {
+                    setFile(undefined);
+                }}
+                onDownload={dummyFileDownload}
+                maxFiles={1}
+                maxFileSize={1024 * 1024 * 5} // 5 MB
+                files={file ? [file] : []}
+                error={tooManyFilesSelected ? "Selection was canceled. You can only select one file." : undefined}
+            />
+        </Box>
     );
 };
 
 const MultipleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
     const [files, setFiles] = React.useState<FileSelectItem[]>(hasExistingFiles ? dummyFiles : []);
     const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
+    const noBackground = boolean("No Background", false);
     const maxNumberOfFiles = 4;
 
     return (
-        <Card variant="outlined">
-            <CardContent>
-                <Typography variant="h6" gutterBottom>
-                    Multiple File Select
-                </Typography>
-                <FileSelect
-                    onDrop={(acceptedFiles, rejectedFiles) => {
-                        const tooManyFilesWereDropped = rejectedFiles.some((rejection) =>
-                            rejection.errors.some((error) => error.code === "too-many-files"),
-                        );
+        <Box padding={4} sx={{ backgroundColor: noBackground ? "transparent" : "white" }}>
+            <Typography variant="h6" gutterBottom>
+                Multiple File Select
+            </Typography>
+            <FileSelect
+                onDrop={(acceptedFiles, rejectedFiles) => {
+                    const tooManyFilesWereDropped = rejectedFiles.some((rejection) =>
+                        rejection.errors.some((error) => error.code === "too-many-files"),
+                    );
 
-                        setTooManyFilesSelected(tooManyFilesWereDropped);
+                    setTooManyFilesSelected(tooManyFilesWereDropped);
 
-                        if (!tooManyFilesWereDropped) {
-                            setFiles((existingFiles) => {
-                                return [
-                                    ...existingFiles,
-                                    ...acceptedFiles.map((file) => ({
-                                        name: file.name,
-                                        size: file.size,
-                                    })),
-                                    ...rejectedFiles.map((file) => ({
-                                        name: file.file.name,
-                                        error: true,
-                                    })),
-                                ];
-                            });
-                        }
-                    }}
-                    onRemove={(fileToRemove) => setFiles(files.filter((file) => file.name !== fileToRemove.name))}
-                    onDownload={dummyFileDownload}
-                    files={files}
-                    maxFiles={maxNumberOfFiles}
-                    maxFileSize={1024 * 1024 * 5} // 5 MB
-                    error={
-                        tooManyFilesSelected
-                            ? `Selection was canceled. You can only select a maximum of ${maxNumberOfFiles} files, please reduce your selection.`
-                            : undefined
+                    if (!tooManyFilesWereDropped) {
+                        setFiles((existingFiles) => {
+                            return [
+                                ...existingFiles,
+                                ...acceptedFiles.map((file) => ({
+                                    name: file.name,
+                                    size: file.size,
+                                })),
+                                ...rejectedFiles.map((file) => ({
+                                    name: file.file.name,
+                                    error: true,
+                                })),
+                            ];
+                        });
                     }
-                />
-            </CardContent>
-        </Card>
+                }}
+                onRemove={(fileToRemove) => setFiles(files.filter((file) => file.name !== fileToRemove.name))}
+                onDownload={dummyFileDownload}
+                files={files}
+                maxFiles={maxNumberOfFiles}
+                maxFileSize={1024 * 1024 * 5} // 5 MB
+                error={
+                    tooManyFilesSelected
+                        ? `Selection was canceled. You can only select a maximum of ${maxNumberOfFiles} files, please reduce your selection.`
+                        : undefined
+                }
+            />
+        </Box>
     );
 };
 


### PR DESCRIPTION
Implement updated design to also support usage on content without white a background.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-875
-   [x] Provide screenshots/screencasts if the change contains visual changes


| Previously | Now |
| --- | --- |
| <img width="882" alt="previously white background" src="https://github.com/user-attachments/assets/89d71504-1f3b-4791-862e-dee38c5e0eab"> | <img width="882" alt="now white background" src="https://github.com/user-attachments/assets/8c94038a-c361-4f3d-9233-15405a416e2f"> |
| <img width="882" alt="previously gray background" src="https://github.com/user-attachments/assets/a06c7685-8080-4ab5-96bc-c4372771ce6e"> | <img width="882" alt="now gray background" src="https://github.com/user-attachments/assets/ac492496-55ed-492c-af84-ac833bb4bc94"> |






