### PR TITLE
Automatically determine the basePath in sitePreviewRoute

### DIFF
--- a/packages/site/cms-site/src/sitePreview/SitePreviewUtils.ts
+++ b/packages/site/cms-site/src/sitePreview/SitePreviewUtils.ts
@@ -26,7 +26,7 @@ function getPreviewScopeSigningKey() {
     return process.env.SITE_PREVIEW_SECRET || "secret";
 }
 
-export async function sitePreviewRoute(request: NextRequest, graphQLFetch: GraphQLFetch, options?: { apiRoutePostfix?: string }) {
+export async function sitePreviewRoute(request: NextRequest, graphQLFetch: GraphQLFetch, options?: { apiRouteSuffix?: string }) {
     const previewScopeSigningKey = getPreviewScopeSigningKey();
     const params = request.nextUrl.searchParams;
     const settingsParam = params.get("settings");
@@ -65,8 +65,8 @@ export async function sitePreviewRoute(request: NextRequest, graphQLFetch: Graph
 
     draftMode().enable();
 
-    const apiRoutePostfix = options?.apiRoutePostfix ?? "/api/site-preview";
-    const basePath = request.nextUrl.pathname.split(apiRoutePostfix)[0];
+    const apiRouteSuffix = options?.apiRouteSuffix ?? "/api/site-preview";
+    const basePath = request.nextUrl.pathname.split(apiRouteSuffix)[0];
 
     return redirect(path.join(basePath, params.get("path") ?? "") || "/");
 }

--- a/packages/site/cms-site/src/sitePreview/SitePreviewUtils.ts
+++ b/packages/site/cms-site/src/sitePreview/SitePreviewUtils.ts
@@ -66,7 +66,7 @@ export async function sitePreviewRoute(request: NextRequest, graphQLFetch: Graph
     draftMode().enable();
 
     const apiRouteSuffix = options?.apiRouteSuffix ?? "/api/site-preview";
-    const basePath = request.nextUrl.pathname.split(apiRouteSuffix)[0];
+    const basePath = request.nextUrl.pathname.replace(apiRouteSuffix, "");
 
     return redirect(path.join(basePath, params.get("path") ?? "") || "/");
 }

--- a/packages/site/cms-site/src/sitePreview/SitePreviewUtils.ts
+++ b/packages/site/cms-site/src/sitePreview/SitePreviewUtils.ts
@@ -4,6 +4,7 @@ import { jwtVerify, SignJWT } from "jose";
 import { cookies, draftMode } from "next/headers";
 import { redirect } from "next/navigation";
 import { type NextRequest } from "next/server";
+import path from "path";
 
 import { GraphQLFetch } from "../graphQLFetch/graphQLFetch";
 
@@ -25,7 +26,7 @@ function getPreviewScopeSigningKey() {
     return process.env.SITE_PREVIEW_SECRET || "secret";
 }
 
-export async function sitePreviewRoute(request: NextRequest, graphQLFetch: GraphQLFetch) {
+export async function sitePreviewRoute(request: NextRequest, graphQLFetch: GraphQLFetch, options?: { apiRoutePostfix?: string }) {
     const previewScopeSigningKey = getPreviewScopeSigningKey();
     const params = request.nextUrl.searchParams;
     const settingsParam = params.get("settings");
@@ -64,7 +65,10 @@ export async function sitePreviewRoute(request: NextRequest, graphQLFetch: Graph
 
     draftMode().enable();
 
-    return redirect(params.get("path") || "/");
+    const apiRoutePostfix = options?.apiRoutePostfix ?? "/api/site-preview";
+    const basePath = request.nextUrl.pathname.split(apiRoutePostfix)[0];
+
+    return redirect(path.join(basePath, params.get("path") ?? "") || "/");
 }
 
 /**


### PR DESCRIPTION
If your URL contains, for example, a language prefix, it is automatically prepended to the redirect URL in sitePreviewRoute. 

See https://github.com/vivid-planet/comet-starter/pull/283/commits/21e9ad6e4a7f97000b3305b7fec54af8c7af639b for an example

apiRoutePostfix can be overridden for the unlikely case that the site-preview route is not under `/api/site-preview`