### PR TITLE
Fix DamFile Extension Migration

### DIFF
--- a/packages/api/cms-api/src/mikro-orm/migrations/Migration20240702123233.ts
+++ b/packages/api/cms-api/src/mikro-orm/migrations/Migration20240702123233.ts
@@ -41,15 +41,17 @@ export class Migration20240702123233 extends Migration {
             })
             .join(" OR ");
 
-        this.addSql(`
-          WITH mimetype_extension_map AS (
-              SELECT jsonb_build_object(${sqlMimetypeToSingleExtensionMap}) AS map
-          )
-    
-          UPDATE "DamFile"
-          SET "name" = CONCAT("name", '.', mimetype_extension_map.map ->> "DamFile".mimetype)
-          FROM mimetype_extension_map
-          WHERE ${sqlCaseClauses};
-        `);
+        if (sqlCaseClauses.length > 0) {
+            this.addSql(`
+              WITH mimetype_extension_map AS (
+                  SELECT jsonb_build_object(${sqlMimetypeToSingleExtensionMap}) AS map
+              )
+        
+              UPDATE "DamFile"
+              SET "name" = CONCAT("name", '.', mimetype_extension_map.map ->> "DamFile".mimetype)
+              FROM mimetype_extension_map
+              WHERE ${sqlCaseClauses};
+            `);
+        }
     }
 }


### PR DESCRIPTION
Only execute SQL if sqlCaseClauses.length > 0. Otherwise the migration fails for a database with no DamFiles