### PR TITLE
Fix error dialog to show GraphQL errors again

### DIFF
--- a/.changeset/fifty-toes-wink.md
+++ b/.changeset/fifty-toes-wink.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": patch
+---
+
+Fix error dialog to show GraphQL errors again
+
+Previously, GraphQL errors without an http status code didn't trigger an error dialog anymore.

--- a/packages/admin/admin/src/error/errordialog/createErrorDialogApolloLink.tsx
+++ b/packages/admin/admin/src/error/errordialog/createErrorDialogApolloLink.tsx
@@ -23,7 +23,7 @@ export const createErrorDialogApolloLink = () => {
             error = graphQLErrors.map(({ message }) => message);
             if (graphQLErrors.some((e) => e.message === "UNAUTHENTICATED")) {
                 errorType = "unauthenticated"; // Error is triggered by Comet Guard
-            } else if (graphQLErrors.some((e) => e.extensions.response.statusCode === StatusCodes.UNAUTHORIZED)) {
+            } else if (graphQLErrors.some((e) => e.extensions.response?.statusCode === StatusCodes.UNAUTHORIZED)) {
                 errorType = "unauthorized"; // Error is triggered by UnauthorizedException
             } else {
                 errorType = "graphql";


### PR DESCRIPTION
`extensions.response.statusCode` is not set for GraphQL errors:

<img width="692" alt="Bildschirmfoto 2024-07-18 um 13 13 05" src="https://github.com/user-attachments/assets/54628aa7-3857-481c-a99f-d82cbca70fce">


That caused an error in the ErrorDialog and consequently the error dialog wasn't shown anymore for GraphQL errors. Now it works again:

<img width="1920" alt="Bildschirmfoto 2024-07-18 um 13 18 53" src="https://github.com/user-attachments/assets/fa40bf5b-29d3-42b6-af49-e0d158969f49">
