### PR TITLE
Admin Generator (Future): Refactor generateFields

### DIFF
--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -1,0 +1,64 @@
+import { IntrospectionQuery } from "graphql";
+
+import { FormConfig, GeneratorReturn, isFormFieldConfig, isFormLayoutConfig } from "../generator";
+import { Imports } from "../utils/generateImportsCode";
+import { generateFormField } from "./generateFormField";
+import { generateFormLayout } from "./generateFormLayout";
+
+export type GenerateFieldsReturn = GeneratorReturn & {
+    imports: Imports;
+    hooksCode: string;
+    formFragmentFields: string[];
+    formValueToGqlInputCode: string;
+};
+
+export function generateFields({
+    gqlIntrospection,
+    baseOutputFilename,
+    fields,
+    formConfig,
+}: {
+    gqlIntrospection: IntrospectionQuery;
+    baseOutputFilename: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fields: FormConfig<any>["fields"];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    formConfig: FormConfig<any>;
+}): GenerateFieldsReturn {
+    const gqlDocuments: Record<string, string> = {};
+    let hooksCode = "";
+    let formValueToGqlInputCode = "";
+    const formFragmentFields: string[] = [];
+    const imports: Imports = [];
+
+    const code = fields
+        .map((field) => {
+            let generated: GenerateFieldsReturn;
+            if (isFormFieldConfig(field)) {
+                generated = generateFormField({ gqlIntrospection, baseOutputFilename, config: field, formConfig });
+            } else if (isFormLayoutConfig(field)) {
+                generated = generateFormLayout({ gqlIntrospection, baseOutputFilename, config: field, formConfig });
+            } else {
+                throw new Error("Not supported config");
+            }
+
+            for (const name in generated.gqlDocuments) {
+                gqlDocuments[name] = generated.gqlDocuments[name];
+            }
+            imports.push(...generated.imports);
+            hooksCode += generated.hooksCode;
+            formValueToGqlInputCode += generated.formValueToGqlInputCode;
+            formFragmentFields.push(...generated.formFragmentFields);
+            return generated.code;
+        })
+        .join("\n");
+
+    return {
+        code,
+        hooksCode,
+        formValueToGqlInputCode,
+        formFragmentFields,
+        gqlDocuments,
+        imports,
+    };
+}

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -1,17 +1,24 @@
 import { IntrospectionEnumType, IntrospectionNamedTypeRef, IntrospectionObjectType, IntrospectionQuery } from "graphql";
 
-import { FormConfig, FormFieldConfig, GeneratorReturn } from "./generator";
-import { camelCaseToHumanReadable } from "./utils/camelCaseToHumanReadable";
-import { Imports } from "./utils/generateImportsCode";
-import { isFieldOptional } from "./utils/isFieldOptional";
+import { FormConfig, FormFieldConfig } from "../generator";
+import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
+import { Imports } from "../utils/generateImportsCode";
+import { isFieldOptional } from "../utils/isFieldOptional";
+import { GenerateFieldsReturn } from "./generateFields";
 
-export function generateFormField(
-    { gqlIntrospection, baseOutputFilename }: { gqlIntrospection: IntrospectionQuery; baseOutputFilename: string },
+export function generateFormField({
+    gqlIntrospection,
+    baseOutputFilename,
+    config,
+    formConfig,
+}: {
+    gqlIntrospection: IntrospectionQuery;
+    baseOutputFilename: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    config: FormFieldConfig<any>,
+    config: FormFieldConfig<any>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    formConfig: FormConfig<any>,
-): GeneratorReturn & { imports: Imports; hooksCode: string; formFragmentField: string; formValueToGqlInputCode: string } {
+    formConfig: FormConfig<any>;
+}): GenerateFieldsReturn {
     const gqlType = formConfig.gqlType;
     const instanceGqlType = gqlType[0].toLowerCase() + gqlType.substring(1);
 
@@ -242,7 +249,7 @@ export function generateFormField(
         code,
         hooksCode,
         formValueToGqlInputCode,
-        formFragmentField,
+        formFragmentFields: [formFragmentField],
         gqlDocuments,
         imports,
     };


### PR DESCRIPTION
to simplify nesting fields, required for fieldSet

implementing central function generating both types of config (layout + field), use it with generate fieldset. use same function-signature for generat field, generate form-layout and form-fields to allow recursive calls.

next steps
- try/start implement dependent async-select
- try/start implement conditional fields