### PR TITLE
Ignore build folder in prettier

### DIFF
--- a/demo/admin/.prettierignore
+++ b/demo/admin/.prettierignore
@@ -3,3 +3,4 @@ lang-compiled/
 lang/
 schema.json
 src/fragmentTypes.json
+build/


### PR DESCRIPTION
Otherwise prettier fails locally:

<img width="540" alt="Bildschirmfoto 2024-07-22 um 10 35 50" src="https://github.com/user-attachments/assets/bdddbcc3-d61e-4dd4-a6fd-c1f9cdaf7dbb">
