### PR TITLE
Fix `DocumentInterface.updateMutation` type

### DIFF
--- a/.changeset/itchy-pandas-rush.md
+++ b/.changeset/itchy-pandas-rush.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix `DocumentInterface.updateMutation` type
+
+The type for the `input` variable needs to be `DocumentOutput`, not `DocumentInput`.

--- a/packages/admin/cms-admin/src/documents/types.ts
+++ b/packages/admin/cms-admin/src/documents/types.ts
@@ -39,7 +39,7 @@ export interface DocumentInterface<
     displayName: React.ReactNode;
     getQuery?: TypedDocumentNode<GQLPageQuery, GQLPageQueryVariables>; // TODO better typing (see createUsePage.tsx)
     editComponent?: React.ComponentType<{ id: string; category: string }>;
-    updateMutation?: TypedDocumentNode<GQLUpdatePageMutation, GQLUpdatePageMutationVariables<DocumentInput>>;
+    updateMutation?: TypedDocumentNode<GQLUpdatePageMutation, GQLUpdatePageMutationVariables<DocumentOutput>>;
     inputToOutput?: (input: DocumentInput) => DocumentOutput;
     menuIcon: (props: SvgIconProps<"svg">) => JSX.Element | null;
     hideInMenuIcon?: (props: SvgIconProps<"svg">) => JSX.Element | null;


### PR DESCRIPTION
The type for the `input` variable needs to be `DocumentOutput`, not `DocumentInput`.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)