### PR TITLE
API Generator: Change default value for input field if property has no initializer

### DIFF
--- a/.changeset/forty-ways-matter.md
+++ b/.changeset/forty-ways-matter.md
@@ -2,44 +2,44 @@
 "@comet/cms-api": minor
 ---
 
-API Generator: Change default value for property of `InputType` if property has no initializer in entity
+API Generator: Change default value for input field if property has no initializer
 
-Previously, the following property for an entity
+Previously, the following property of an entity
 
 ```ts
-    @Property({ type: types.date, nullable: true })
-    @Field({ nullable: true })
-    availableSince?: Date;
+@Property({ type: types.date, nullable: true })
+@Field({ nullable: true })
+availableSince?: Date;
 ```
 
 resulted in the following input being generated:
 
 ```ts
-    @IsNullable()
-    @IsDate()
-    @Field({ nullable: true })
-    availableSince?: Date;
+@IsNullable()
+@IsDate()
+@Field({ nullable: true })
+availableSince?: Date;
 ```
 
 This was problematic for two reasons:
 
-1.  You would receive a misleading error message if you tried to create an entity without providing a value for the property. For example:
+1.  The error message would be misleading when trying to create an entity without providing a value for the property. For example, a valid GraphQL mutation
 
-```graphql
-mutation CreateProduct {
-    createProduct(input: { title: "A", slug: "A", description: "FOO" }) {
-        id
-        availableSince
+    ```graphql
+    mutation CreateProduct {
+        createProduct(input: { title: "A", slug: "A", description: "FOO" }) {
+            id
+            availableSince
+        }
     }
-}
-```
+    ```
 
-resulted in the following error
+    would result in the following error:
 
-```
-"isDate": "availableSince must be a Date instance"
-```
+    ```
+    "isDate": "availableSince must be a Date instance"
+    ```
 
-2. Relying on the initializer as the default value is not obvious and appears somewhat magical.
+2.  Relying on the initializer as the default value is not obvious and appears somewhat magical.
 
-To address this, we now use null as the default value for nullable properties if no initializer is provided. If an initializer is provided, it is used as the default value.
+To address this, we now use `null` as the default value for nullable properties if no initializer is provided. If an initializer is provided, it is used as the default value.

--- a/.changeset/forty-ways-matter.md
+++ b/.changeset/forty-ways-matter.md
@@ -1,0 +1,45 @@
+---
+"@comet/cms-api": minor
+---
+
+API Generator: Change default value for property of `InputType` if property has no initializer in entity
+
+Previously, the following property for an entity
+
+```ts
+    @Property({ type: types.date, nullable: true })
+    @Field({ nullable: true })
+    availableSince?: Date;
+```
+
+resulted in the following input being generated:
+
+```ts
+    @IsNullable()
+    @IsDate()
+    @Field({ nullable: true })
+    availableSince?: Date;
+```
+
+This was problematic for two reasons:
+
+1.  You would receive a misleading error message if you tried to create an entity without providing a value for the property. For example:
+
+```graphql
+mutation CreateProduct {
+    createProduct(input: { title: "A", slug: "A", description: "FOO" }) {
+        id
+        availableSince
+    }
+}
+```
+
+resulted in the following error
+
+```
+"isDate": "availableSince must be a Date instance"
+```
+
+2. Relying on the initializer as the default value is not obvious and appears somewhat magical.
+
+To address this, we now use null as the default value for nullable properties if no initializer is provided. If an initializer is provided, it is used as the default value.

--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -80,7 +80,8 @@ export async function generateCrudInput(
             continue;
         } else if (prop.enum) {
             const initializer = morphTsProperty(prop.name, metadata).getInitializer()?.getText();
-            const defaultValue = prop.nullable && (initializer == "undefined" || initializer == "null") ? "null" : initializer;
+            const defaultValue =
+                prop.nullable && (initializer == "undefined" || initializer == "null" || initializer === undefined) ? "null" : initializer;
             const fieldOptions = tsCodeRecordToString({ nullable: prop.nullable ? "true" : undefined, defaultValue });
             const enumName = findEnumName(prop.name, metadata);
             const importPath = findEnumImportPath(enumName, `${generatorOptions.targetDirectory}/dto`, metadata);
@@ -103,7 +104,8 @@ export async function generateCrudInput(
             type = `${enumName}[]`;
         } else if (prop.type === "string" || prop.type === "text") {
             const initializer = morphTsProperty(prop.name, metadata).getInitializer()?.getText();
-            const defaultValue = prop.nullable && (initializer == "undefined" || initializer == "null") ? "null" : initializer;
+            const defaultValue =
+                prop.nullable && (initializer == "undefined" || initializer == "null" || initializer === undefined) ? "null" : initializer;
             const fieldOptions = tsCodeRecordToString({ nullable: prop.nullable ? "true" : undefined, defaultValue });
             decorators.push("@IsString()");
             if (prop.name.startsWith("scope_")) {
@@ -116,7 +118,8 @@ export async function generateCrudInput(
             type = "string";
         } else if (prop.type === "DecimalType" || prop.type == "BigIntType" || prop.type === "number") {
             const initializer = morphTsProperty(prop.name, metadata).getInitializer()?.getText();
-            const defaultValue = prop.nullable && (initializer == "undefined" || initializer == "null") ? "null" : initializer;
+            const defaultValue =
+                prop.nullable && (initializer == "undefined" || initializer == "null" || initializer === undefined) ? "null" : initializer;
             const fieldOptions = tsCodeRecordToString({ nullable: prop.nullable ? "true" : undefined, defaultValue });
             if (integerTypes.includes(prop.columnTypes[0])) {
                 decorators.push("@IsInt()");
@@ -128,14 +131,16 @@ export async function generateCrudInput(
             type = "number";
         } else if (prop.type === "DateType" || prop.type === "Date") {
             const initializer = morphTsProperty(prop.name, metadata).getInitializer()?.getText();
-            const defaultValue = prop.nullable && (initializer == "undefined" || initializer == "null") ? "null" : initializer;
+            const defaultValue =
+                prop.nullable && (initializer == "undefined" || initializer == "null" || initializer === undefined) ? "null" : initializer;
             const fieldOptions = tsCodeRecordToString({ nullable: prop.nullable ? "true" : undefined, defaultValue });
             decorators.push("@IsDate()");
             decorators.push(`@Field(${fieldOptions})`);
             type = "Date";
         } else if (prop.type === "BooleanType" || prop.type === "boolean") {
             const initializer = morphTsProperty(prop.name, metadata).getInitializer()?.getText();
-            const defaultValue = prop.nullable && (initializer == "undefined" || initializer == "null") ? "null" : initializer;
+            const defaultValue =
+                prop.nullable && (initializer == "undefined" || initializer == "null" || initializer === undefined) ? "null" : initializer;
             const fieldOptions = tsCodeRecordToString({ nullable: prop.nullable ? "true" : undefined, defaultValue });
             decorators.push("@IsBoolean()");
             decorators.push(`@Field(${fieldOptions})`);
@@ -153,7 +158,7 @@ export async function generateCrudInput(
             type = "BlockInputInterface";
         } else if (prop.reference == "m:1") {
             const initializer = morphTsProperty(prop.name, metadata).getInitializer()?.getText();
-            const defaultValueNull = prop.nullable && (initializer == "undefined" || initializer == "null");
+            const defaultValueNull = prop.nullable && (initializer == "undefined" || initializer == "null" || initializer === undefined);
             const fieldOptions = tsCodeRecordToString({
                 nullable: prop.nullable ? "true" : undefined,
                 defaultValue: defaultValueNull ? "null" : undefined,
@@ -290,7 +295,11 @@ export async function generateCrudInput(
             if (tsType.isArray()) {
                 const initializer = tsProp.getInitializer()?.getText();
                 const defaultValue =
-                    prop.nullable && (initializer == "undefined" || initializer == "null") ? "null" : initializer == "[]" ? "[]" : undefined;
+                    prop.nullable && (initializer == "undefined" || initializer == "null" || initializer === undefined)
+                        ? "null"
+                        : initializer == "[]"
+                        ? "[]"
+                        : undefined;
                 const fieldOptions = tsCodeRecordToString({
                     nullable: prop.nullable ? "true" : undefined,
                     defaultValue: defaultValue,
@@ -330,7 +339,7 @@ export async function generateCrudInput(
             }
         } else if (prop.type == "uuid") {
             const initializer = morphTsProperty(prop.name, metadata).getInitializer()?.getText();
-            const defaultValueNull = prop.nullable && (initializer == "undefined" || initializer == "null");
+            const defaultValueNull = prop.nullable && (initializer == "undefined" || initializer == "null" || initializer === undefined);
             const fieldOptions = tsCodeRecordToString({
                 nullable: prop.nullable ? "true" : undefined,
                 defaultValue: defaultValueNull ? "null" : undefined,


### PR DESCRIPTION
Previously, the following property of an entity

```ts
@Property({ type: types.date, nullable: true })
@Field({ nullable: true })
availableSince?: Date;
```

resulted in the following input being generated:

```ts
@IsNullable()
@IsDate()
@Field({ nullable: true })
availableSince?: Date;
```

This was problematic for two reasons:

1.  The error message would be misleading when trying to create an entity without providing a value for the property. For example, a valid GraphQL mutation

    ```graphql
    mutation CreateProduct {
        createProduct(input: { title: "A", slug: "A", description: "FOO" }) {
            id
            availableSince
        }
    }
    ```

    would result in the following error:

    ```
    "isDate": "availableSince must be a Date instance"
    ```

2.  Relying on the initializer as the default value is not obvious and appears somewhat magical.

To address this, we now use `null` as the default value for nullable properties if no initializer is provided. If an initializer is provided, it is used as the default value.

---

While working on a different feature for the API generator, I noticed this strange behaviour, that you need to provide an initializer for the input to be valid as it must contain a default value.

With https://github.com/vivid-planet/comet/pull/1820 this was bypassed for demo.

Is this something we want to support? I think we should, but I'm not sure if it is that easy if it was bypassed in demo... 

This line must be modified:
`const defaultValue = prop.nullable && (initializer == "undefined" || initializer == "null") ? "null" : initializer;`
