### PR TITLE
Remove `azureAiTranslate` query from Demo schema.gql

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -655,7 +655,6 @@ type Query {
   productCategories(offset: Int! = 0, limit: Int! = 25, search: String, filter: ProductCategoryFilter, sort: [ProductCategorySort!]): PaginatedProductCategories!
   productTag(id: ID!): ProductTag!
   productTags(offset: Int! = 0, limit: Int! = 25, search: String, filter: ProductTagFilter, sort: [ProductTagSort!]): PaginatedProductTags!
-  azureAiTranslate(input: AzureAiTranslationInput!): String!
 }
 
 input UserFilter {
@@ -901,11 +900,6 @@ enum ProductTagSortField {
   title
   createdAt
   updatedAt
-}
-
-input AzureAiTranslationInput {
-  text: String!
-  targetLanguage: String!
 }
 
 type Mutation {


### PR DESCRIPTION
Developers don't have the necessary environment variables in the .env.local file by default.