### PR TITLE
Remove index signature from `ContentScope` interface

### DIFF
--- a/.changeset/good-keys-pretend.md
+++ b/.changeset/good-keys-pretend.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Remove index signature from `ContentScope` interface
+
+This allows using scope DTOs without index signature in `@ScopedEntity()`.

--- a/packages/api/cms-api/src/user-permissions/access-control.service.ts
+++ b/packages/api/cms-api/src/user-permissions/access-control.service.ts
@@ -7,7 +7,9 @@ import { AccessControlServiceInterface } from "./user-permissions.types";
 @Injectable()
 export abstract class AbstractAccessControlService implements AccessControlServiceInterface {
     private checkContentScope(userContentScopes: ContentScope[], contentScope: ContentScope): boolean {
-        return userContentScopes.some((cs) => Object.entries(contentScope).every(([scope, value]) => cs[scope] === value));
+        return userContentScopes.some((cs) =>
+            Object.entries(contentScope).every(([scope, value]) => (cs as Record<string, unknown>)[scope] === value),
+        );
     }
     isAllowed(user: CurrentUser, permission: string, contentScope?: ContentScope): boolean {
         if (!user.permissions) return false;

--- a/packages/api/cms-api/src/user-permissions/interfaces/content-scope.interface.ts
+++ b/packages/api/cms-api/src/user-permissions/interfaces/content-scope.interface.ts
@@ -1,3 +1,2 @@
-export interface ContentScope {
-    [key: string]: string;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContentScope {}


### PR DESCRIPTION
This allows using scope DTOs without index signature in `@ScopedEntity()`.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
