### PR TITLE
Change behaviour of `FileSelect` regarding `multiple` and `maxFiles` props

### DIFF
--- a/.changeset/rotten-pots-itch.md
+++ b/.changeset/rotten-pots-itch.md
@@ -54,6 +54,3 @@ Use `slotProps.dropzone.hideButton` instead.
 +    }}
  />
 ```
-
-The `multiple` prop has been removed and is no longer necessary.
-The multi-file behavior is now always active unless the `maxFiles` prop is set to 1.

--- a/packages/admin/admin/src/form/FinalFormFileSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormFileSelect.tsx
@@ -14,9 +14,9 @@ export interface FinalFormFileSelectProps
 export function FinalFormFileSelect(inProps: FinalFormFileSelectProps) {
     const {
         disabled,
-        maxSize,
         maxFiles,
-        input: { onChange, value: fieldValue },
+        maxSize,
+        input: { onChange, value: fieldValue, multiple },
         meta,
         ...restProps
     } = useThemeProps({
@@ -26,7 +26,7 @@ export function FinalFormFileSelect(inProps: FinalFormFileSelectProps) {
 
     const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
     const [rejectedFiles, setRejectedFiles] = React.useState<ErrorFileSelectItem[]>([]);
-    const singleFile = maxFiles === 1;
+    const singleFile = (!multiple && typeof maxFiles === "undefined") || maxFiles === 1;
 
     const onDrop = React.useCallback<NonNullable<DropzoneOptions["onDrop"]>>(
         (acceptedFiles, fileRejections) => {
@@ -92,6 +92,7 @@ export function FinalFormFileSelect(inProps: FinalFormFileSelectProps) {
                 setRejectedFiles(rejectedFiles.filter((file) => file.name !== fileToRemove.name));
             }}
             disabled={disabled}
+            multiple={multiple}
             maxFiles={maxFiles}
             maxFileSize={maxSize}
             error={

--- a/packages/admin/admin/src/form/file/FileSelect.tsx
+++ b/packages/admin/admin/src/form/file/FileSelect.tsx
@@ -43,6 +43,7 @@ export type FileSelectProps<AdditionalValidFileValues = Record<string, unknown>>
     accept?: Accept;
     maxFileSize?: number;
     maxFiles?: number;
+    multiple?: boolean;
     error?: React.ReactNode;
     iconMapping?: {
         error?: React.ReactNode;
@@ -55,7 +56,8 @@ export const FileSelect = <AdditionalValidFileValues = Record<string, unknown>,>
         disabled,
         accept,
         maxFileSize,
-        maxFiles,
+        maxFiles: passedMaxFiles,
+        multiple: passedMultiple,
         iconMapping = {},
         onDrop,
         onRemove,
@@ -70,7 +72,9 @@ export const FileSelect = <AdditionalValidFileValues = Record<string, unknown>,>
 
     const { error: errorIcon = <ErrorIcon color="error" /> } = iconMapping;
 
-    const multiple = typeof maxFiles === "undefined" || maxFiles > 1;
+    const multiple = passedMultiple || (typeof passedMaxFiles !== "undefined" && passedMaxFiles > 1);
+    const maxFiles = typeof passedMaxFiles === "undefined" ? (multiple ? undefined : 1) : passedMaxFiles;
+
     const numberOfValidFiles = files?.filter((file) => !("error" in file)).length ?? 0;
     const maxAmountOfFilesSelected = typeof maxFiles !== "undefined" && multiple && numberOfValidFiles >= maxFiles;
     const maxNumberOfFilesToBeAdded = maxFiles ? maxFiles - numberOfValidFiles : undefined;

--- a/storybook/src/admin/form/FinalFormFileSelect.tsx
+++ b/storybook/src/admin/form/FinalFormFileSelect.tsx
@@ -24,13 +24,7 @@ function Story() {
                             <Grid item xs={6}>
                                 <Card variant="outlined">
                                     <CardContent>
-                                        <Field
-                                            name="singleFile"
-                                            label="File select (default)"
-                                            component={FinalFormFileSelect}
-                                            maxFiles={1}
-                                            fullWidth
-                                        />
+                                        <Field name="singleFile" label="Single file select" component={FinalFormFileSelect} fullWidth />
                                     </CardContent>
                                 </Card>
                             </Grid>
@@ -39,16 +33,11 @@ function Story() {
                                     <CardContent>
                                         <Field
                                             name="multipleFiles"
-                                            label="File select (dropzone only, multiple, max file size 5 MB), max 5 files"
+                                            label="Multi file select (max file size 5 MB)"
                                             component={FinalFormFileSelect}
-                                            maxSize={50 * 1024 * 1024}
-                                            maxFiles={5}
+                                            maxSize={5 * 1024 * 1024} // 5 MB
+                                            multiple
                                             fullWidth
-                                            slotProps={{
-                                                dropzone: {
-                                                    hideButton: true,
-                                                },
-                                            }}
                                         />
                                     </CardContent>
                                 </Card>
@@ -57,16 +46,12 @@ function Story() {
                                 <Card variant="outlined">
                                     <CardContent>
                                         <Field
-                                            name="multipleImages"
-                                            label="File select (button only, accept only images)"
+                                            name="fiveImages"
+                                            label="Select up to 5 images"
                                             component={FinalFormFileSelect}
                                             accept={{ "image/*": [] }}
+                                            maxFiles={5}
                                             fullWidth
-                                            slotProps={{
-                                                dropzone: {
-                                                    hideDroppableArea: true,
-                                                },
-                                            }}
                                         />
                                     </CardContent>
                                 </Card>
@@ -74,7 +59,7 @@ function Story() {
                             <Grid item xs={6}>
                                 <Card variant="outlined">
                                     <CardContent>
-                                        <Field name="disabled" label="File select (disabled)" component={FinalFormFileSelect} disabled fullWidth />
+                                        <Field name="disabled" label="Disabled file select" component={FinalFormFileSelect} disabled fullWidth />
                                     </CardContent>
                                 </Card>
                             </Grid>

--- a/storybook/src/admin/form/file/FileSelect.tsx
+++ b/storybook/src/admin/form/file/FileSelect.tsx
@@ -61,7 +61,6 @@ const SingleFileSelectStory = ({ hasExistingFiles }: StoryProps) => {
                     setFile(undefined);
                 }}
                 onDownload={dummyFileDownload}
-                maxFiles={1}
                 maxFileSize={1024 * 1024 * 5} // 5 MB
                 files={file ? [file] : []}
                 error={tooManyFilesSelected ? "Selection was canceled. You can only select one file." : undefined}


### PR DESCRIPTION
Add back the `multiple` prop and be a single-file select by default. Only allow selecting multiple files when either the `multiple` prop is set or when the `maxFiles` prop is set and has a value of more than `1`.

Also simplify stories slightly for more common use cases.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-879
