### PR TITLE
Add custom error message for invalid file type

### DIFF
--- a/packages/admin/cms-admin/src/form/file/FinalFormFileUpload.tsx
+++ b/packages/admin/cms-admin/src/form/file/FinalFormFileUpload.tsx
@@ -61,6 +61,12 @@ export const FinalFormFileUpload = <MaxFiles extends number | undefined>({ input
                         failedFile.error = <FormattedMessage id="comet.finalFormFileUpload.fileTooLarge" defaultMessage="File is too large." />;
                     }
 
+                    if (rejection.errors.some((error) => error.code === "file-invalid-type")) {
+                        failedFile.error = (
+                            <FormattedMessage id="comet.finalFormFileUpload.fileInvalidType" defaultMessage="File type is not allowed." />
+                        );
+                    }
+
                     setFailedUploads((existing) => [...existing, failedFile]);
                 });
 


### PR DESCRIPTION
Same as in `FinalFormFileSelect`:
https://github.com/vivid-planet/comet/blob/2ab9abd04b815df94685ea83b6fefa940aa2e601/packages/admin/admin/src/form/FinalFormFileSelect.tsx#L44-L48

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [ ] Merge PR dependency https://github.com/vivid-planet/comet/pull/2151
-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-858
-   [x] Provide screenshots/screencasts if the change contains visual changes

| Previously | Now |
| --- | --- |
| <img width="488" alt="Invalid file type previously" src="https://github.com/user-attachments/assets/63037811-4f63-470a-94d7-b13eb570f7d1"> | <img width="488" alt="Invalid file type now" src="https://github.com/user-attachments/assets/cfd4de74-79ab-4c93-8ab0-e25cfea3588c"> |