### PR TITLE
Secure file uploads upload endpoint by default

### DIFF
--- a/.changeset/odd-countries-drive.md
+++ b/.changeset/odd-countries-drive.md
@@ -1,0 +1,18 @@
+---
+"@comet/cms-api": major
+---
+
+Secure file uploads upload endpoint by default
+
+The `/file-uploads/upload` endpoint now requires the `fileUploads` permission by default.
+
+Use the `upload.public` option to make the endpoint public:
+
+```diff
+FileUploadsModule.register({
+    /* ... */,
++   upload: {
++       public: true,
++   },
+}),
+```

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -140,6 +140,9 @@ export class AppModule {
                     maxFileSize: config.fileUploads.maxFileSize,
                     directory: `${config.blob.storageDirectoryPrefix}-file-uploads`,
                     acceptedMimeTypes: ["application/pdf", "application/x-zip-compressed", "application/zip"],
+                    upload: {
+                        public: true,
+                    },
                 }),
                 ...(config.contentGeneration
                     ? [

--- a/docs/docs/migration/migration-from-v6-to-v7.md
+++ b/docs/docs/migration/migration-from-v6-to-v7.md
@@ -378,6 +378,20 @@ This requires the following changes:
 -   Change all usages of the `PublicUploadsService` to `FileUploadsService`.
 -   In the site or the Admin change the upload URL from `/public-upload/files/upload` to `/files-uploads/upload`.
 
+### Make file uploads upload endpoint public
+
+The `/file-uploads/upload` endpoint now requires the `fileUploads` permission by default.
+If necessary (e.g., a file upload in the site), make the endpoint public:
+
+```diff
+FileUploadsModule.register({
+    /* ... */,
++   upload: {
++       public: true,
++   },
+}),
+```
+
 ### Remove usages of `download` or `FileUploadService`
 
 Use `createFileUploadInputFromUrl` instead:

--- a/packages/api/cms-api/src/file-uploads/file-uploads.config.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.config.ts
@@ -2,4 +2,7 @@ export interface FileUploadsConfig {
     directory: string;
     maxFileSize: number;
     acceptedMimeTypes: string[];
+    upload?: {
+        public: boolean;
+    };
 }

--- a/packages/api/cms-api/src/file-uploads/file-uploads.controller.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.controller.ts
@@ -1,31 +1,45 @@
 import { EntityManager } from "@mikro-orm/postgresql";
-import { Controller, Post, UploadedFile, UseInterceptors } from "@nestjs/common";
+import { Controller, Post, Type, UploadedFile, UseInterceptors } from "@nestjs/common";
 import rimraf from "rimraf";
 
 import { DisableCometGuards } from "../auth/decorators/disable-comet-guards.decorator";
 import { FileUploadInput } from "../dam/files/dto/file-upload.input";
+import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { FileUpload } from "./entities/file-upload.entity";
 import { FileUploadsService } from "./file-uploads.service";
 import { FileUploadsFileInterceptor } from "./file-uploads-file.interceptor";
 
-@Controller("file-uploads")
-export class FileUploadsController {
-    constructor(private readonly fileUploadsService: FileUploadsService, private readonly entityManager: EntityManager) {}
+export function createFileUploadsController(options: { public: boolean }): Type<unknown> {
+    @Controller("file-uploads")
+    class BaseFileUploadsController {
+        constructor(private readonly fileUploadsService: FileUploadsService, private readonly entityManager: EntityManager) {}
 
-    @Post("upload")
-    @UseInterceptors(FileUploadsFileInterceptor("file"))
-    @DisableCometGuards()
-    async upload(@UploadedFile() file: FileUploadInput): Promise<FileUpload> {
-        const fileUpload = await this.fileUploadsService.upload(file);
+        @Post("upload")
+        @UseInterceptors(FileUploadsFileInterceptor("file"))
+        async upload(@UploadedFile() file: FileUploadInput): Promise<FileUpload> {
+            const fileUpload = await this.fileUploadsService.upload(file);
 
-        await this.entityManager.flush();
+            await this.entityManager.flush();
 
-        rimraf(file.path, (error) => {
-            if (error) {
-                console.error("An error occurred when removing the file: ", error);
-            }
-        });
+            rimraf(file.path, (error) => {
+                if (error) {
+                    console.error("An error occurred when removing the file: ", error);
+                }
+            });
 
-        return fileUpload;
+            return fileUpload;
+        }
     }
+
+    if (options.public) {
+        @DisableCometGuards()
+        class PublicFileUploadsController extends BaseFileUploadsController {}
+
+        return PublicFileUploadsController;
+    }
+
+    @RequiredPermission("fileUploads", { skipScopeCheck: true })
+    class PrivateFileUploadsController extends BaseFileUploadsController {}
+
+    return PrivateFileUploadsController;
 }

--- a/packages/api/cms-api/src/file-uploads/file-uploads.module.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.module.ts
@@ -6,7 +6,7 @@ import { FileValidationService } from "../dam/files/file-validation.service";
 import { FileUpload } from "./entities/file-upload.entity";
 import { FileUploadsConfig } from "./file-uploads.config";
 import { FILE_UPLOADS_CONFIG, FILE_UPLOADS_FILE_VALIDATION_SERVICE } from "./file-uploads.constants";
-import { FileUploadsController } from "./file-uploads.controller";
+import { createFileUploadsController } from "./file-uploads.controller";
 import { FileUploadsService } from "./file-uploads.service";
 
 @Global()
@@ -29,7 +29,7 @@ export class FileUploadsModule {
             module: FileUploadsModule,
             imports: [MikroOrmModule.forFeature([FileUpload]), BlobStorageModule],
             providers: [fileUploadsConfigProvider, FileUploadsService, fileUploadsFileValidatorProvider],
-            controllers: [FileUploadsController],
+            controllers: [createFileUploadsController(options.upload ?? { public: false })],
             exports: [FileUploadsService],
         };
     }


### PR DESCRIPTION
The `/file-uploads/upload` endpoint now requires the `fileUploads` permission by default. It can be made public by using the `upload.public` option:

```diff
FileUploadsModule.register({
    /* ... */,
+   upload: {
+       public: true,
+   },
}),
```

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

Depends on #2336.

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)