### PR TITLE
Allow rendering `FileSelectListItem` as a card with a preview using the `filePreview` prop

### DIFF
--- a/packages/admin/admin/src/form/file/FileSelectListItem.tsx
+++ b/packages/admin/admin/src/form/file/FileSelectListItem.tsx
@@ -100,7 +100,7 @@ export const FileSelectListItem = (inProps: FileSelectListItemProps) => {
         filePreviewError: filePreviewErrorIcon = <FileNotMenu fontSize="inherit" color="inherit" />,
     } = iconMapping;
 
-    const getFilePreviewContent = React.useCallback(() => {
+    const getFilePreviewContent = () => {
         if ("loading" in file) {
             return filePreviewLoadingIcon;
         }
@@ -114,7 +114,7 @@ export const FileSelectListItem = (inProps: FileSelectListItemProps) => {
         }
 
         return filePreviewGenericFileIcon;
-    }, [file, filePreview, filePreviewGenericFileIcon, filePreviewLoadingIcon, filePreviewErrorIcon]);
+    };
 
     const ownerState: OwnerState = {
         hasFilePreview: Boolean(filePreview),

--- a/storybook/src/admin/form/file/FileSelectListItem.tsx
+++ b/storybook/src/admin/form/file/FileSelectListItem.tsx
@@ -5,15 +5,8 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 
 storiesOf("@comet/admin/form/File", module)
-    // .addDecorator((story) => (
-    //     <Card sx={{ maxWidth: 440 }}>
-    //         <CardContent>
-    //             <Stack spacing={4}>{story()}</Stack>
-    //         </CardContent>
-    //     </Card>
-    // ))
     .addDecorator((story) => (
-        <Card sx={{ maxWidth: 282 }}>
+        <Card sx={{ maxWidth: 300 }}>
             <CardContent>
                 <Stack spacing={4}>{story()}</Stack>
             </CardContent>

--- a/storybook/src/admin/form/file/FileSelectListItem.tsx
+++ b/storybook/src/admin/form/file/FileSelectListItem.tsx
@@ -5,8 +5,15 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 
 storiesOf("@comet/admin/form/File", module)
+    // .addDecorator((story) => (
+    //     <Card sx={{ maxWidth: 440 }}>
+    //         <CardContent>
+    //             <Stack spacing={4}>{story()}</Stack>
+    //         </CardContent>
+    //     </Card>
+    // ))
     .addDecorator((story) => (
-        <Card sx={{ maxWidth: 440 }}>
+        <Card sx={{ maxWidth: 282 }}>
             <CardContent>
                 <Stack spacing={4}>{story()}</Stack>
             </CardContent>
@@ -27,9 +34,16 @@ storiesOf("@comet/admin/form/File", module)
             Skeleton: { loading: true },
         };
 
+        const filePreviewOptions = {
+            None: undefined,
+            "Generic Preview": true,
+            "Image Preview": "https://picsum.photos/756/756",
+        };
+
         const downloadMethods = ["No download", "Download function", "Download URL"];
 
         const selectedFile = select("File Item", fileItems, fileItems["Valid File"]);
+        const showFilePreview = select("File Preview", filePreviewOptions, filePreviewOptions.None);
         const downloadMethod = select("Can be downloaded", downloadMethods, downloadMethods[0]);
         const canBeDeleted = boolean("Can Be Deleted", true);
         const disabled = boolean("Disabled", false);
@@ -40,6 +54,7 @@ storiesOf("@comet/admin/form/File", module)
                 onClickDownload={downloadMethod === "Download function" ? () => alert("Downloading file") : undefined}
                 downloadUrl={downloadMethod === "Download URL" ? "https://example.com" : undefined}
                 onClickDelete={canBeDeleted ? () => alert("Delete") : undefined}
+                filePreview={showFilePreview}
                 disabled={disabled}
             />
         );

--- a/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.mdx
+++ b/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.mdx
@@ -14,7 +14,14 @@ Used to display a list of files, including loading, skeleton, and error states a
     -   If the `loading` value is `true` and no `name` is provided, the file will be rendered as a skeleton.
     -   The file will be rendered in an error state if the `error` value is `true` or a string with an error message is provided.
 -   Use the `downloadUrl`, `onClickDownload` and `onClickDelete` props to handle what happens when clicking the download and delete buttons.
+-   Set the `filePreview` prop to `true` or pass in a image url to display the item as a card with a preview.
 
 <Canvas>
     <Story id="stories-components-fileselectlistitem--fileselectlistitem" />
+</Canvas>
+
+### File preview card
+
+<Canvas>
+    <Story id="stories-components-fileselectlistitem--preview" />
 </Canvas>

--- a/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.tsx
+++ b/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.tsx
@@ -1,5 +1,5 @@
 import { FileSelectListItem } from "@comet/admin";
-import { Card, CardContent } from "@mui/material";
+import { Box, Card, CardContent } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
@@ -61,5 +61,68 @@ storiesOf("stories/components/FileSelectListItem", module)
                     }}
                 />
             </>
+        );
+    })
+    .add("Preview", () => {
+        return (
+            <Box display="grid" gridTemplateColumns="repeat(3, 1fr)" gap={2}>
+                <FileSelectListItem
+                    file={{
+                        loading: true,
+                    }}
+                    filePreview
+                />
+                <FileSelectListItem
+                    file={{
+                        name: "Filename.zip",
+                        size: 4.3 * 1024 * 1024, // 4.3 MB
+                    }}
+                    onClickDownload={() => {
+                        // Handle download
+                    }}
+                    onClickDelete={() => {
+                        // Handle delete
+                    }}
+                    filePreview
+                />
+                <FileSelectListItem
+                    file={{
+                        name: "Filename.jpg",
+                        size: 4.3 * 1024 * 1024, // 4.3 MB
+                    }}
+                    onClickDownload={() => {
+                        // Handle download
+                    }}
+                    onClickDelete={() => {
+                        // Handle delete
+                    }}
+                    filePreview="https://picsum.photos/528/528"
+                />
+                <FileSelectListItem
+                    file={{
+                        name: "File that is uploading.jpg",
+                        loading: true,
+                    }}
+                    filePreview
+                />
+                <FileSelectListItem
+                    file={{
+                        name: "Filename.xyz",
+                        error: true,
+                    }}
+                    filePreview
+                />
+                <FileSelectListItem
+                    file={{
+                        name: "Filename.xyz",
+                        size: 200 * 1024 * 1024, // 200 MB
+                        error: "File too large",
+                    }}
+                    onClickDelete={() => {
+                        // Handle delete
+                    }}
+                    filePreview
+                />
+            </Box>
         );
     });


### PR DESCRIPTION
---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
    - ⚠️ Not needed, as long as this is merged before the V7 release. 
-   [x] Link to the respective task if one exists: COM-802
-   [x] Provide screenshots/screencasts if the change contains visual changes

<img width="916" alt="image" src="https://github.com/user-attachments/assets/26afbb06-21f2-4b68-8718-ccbab9120d15">

