### PR TITLE
Add support for grid/card layout of items in `FileSelect` and `FinalFormFileSelect`

### DIFF
--- a/packages/admin/admin/src/form/file/FileSelect.tsx
+++ b/packages/admin/admin/src/form/file/FileSelect.tsx
@@ -15,7 +15,8 @@ import { getFilesInfoText } from "./getFilesInfoText";
 
 export type FileSelectClassKey =
     | "root"
-    | "showFilesAsPreviewGrid"
+    | "listLayout"
+    | "gridLayout"
     | "maxFilesReachedInfo"
     | "dropzone"
     | "fileList"
@@ -23,6 +24,8 @@ export type FileSelectClassKey =
     | "error"
     | "errorMessage"
     | "filesInfoText";
+
+type Layout = "list" | "grid";
 
 type ThemeProps = ThemedComponentBaseProps<{
     root: "div";
@@ -36,7 +39,7 @@ type ThemeProps = ThemedComponentBaseProps<{
 }>;
 
 type OwnerState = {
-    showFilesAsPreviewGrid: boolean;
+    layout: Layout;
 };
 
 export type FileSelectProps<AdditionalValidFileValues = Record<string, unknown>> = {
@@ -52,7 +55,7 @@ export type FileSelectProps<AdditionalValidFileValues = Record<string, unknown>>
     maxFiles?: number;
     multiple?: boolean;
     error?: React.ReactNode;
-    showFilesAsPreviewGrid?: boolean;
+    layout?: Layout;
     iconMapping?: {
         error?: React.ReactNode;
     };
@@ -74,7 +77,7 @@ export const FileSelect = <AdditionalValidFileValues = Record<string, unknown>,>
         getDownloadUrl,
         files,
         error,
-        showFilesAsPreviewGrid,
+        layout = "list",
         ...restProps
     } = useThemeProps({
         props: inProps,
@@ -94,7 +97,7 @@ export const FileSelect = <AdditionalValidFileValues = Record<string, unknown>,>
     const showFileList = files.length > 0 || readOnly;
 
     const ownerState: OwnerState = {
-        showFilesAsPreviewGrid: Boolean(showFilesAsPreviewGrid),
+        layout,
     };
 
     return (
@@ -146,7 +149,7 @@ export const FileSelect = <AdditionalValidFileValues = Record<string, unknown>,>
                                         }
                                         downloadUrl={isValidFile && getDownloadUrl ? getDownloadUrl(file) : undefined}
                                         onClickDelete={readOnly || !onRemove ? undefined : () => onRemove(file)}
-                                        filePreview={showFilesAsPreviewGrid}
+                                        filePreview={layout === "grid"}
                                         {...slotProps?.fileListItem}
                                     />
                                 );
@@ -181,7 +184,7 @@ export const FileSelect = <AdditionalValidFileValues = Record<string, unknown>,>
 const Root = createComponentSlot("div")<FileSelectClassKey, OwnerState>({
     componentName: "FileSelect",
     slotName: "root",
-    classesResolver: ({ showFilesAsPreviewGrid }) => [showFilesAsPreviewGrid && "showFilesAsPreviewGrid"],
+    classesResolver: ({ layout }) => [layout === "list" && "listLayout", layout === "grid" && "gridLayout"],
 })(css`
     display: flex;
     flex-direction: column;
@@ -201,7 +204,7 @@ const FileList = createComponentSlot("div")<FileSelectClassKey, OwnerState>({
     ({ theme, ownerState }) => css`
         width: 100%;
 
-        ${ownerState.showFilesAsPreviewGrid &&
+        ${ownerState.layout === "grid" &&
         css`
             display: grid;
             gap: ${theme.spacing(2)};

--- a/storybook/src/admin/form/FinalFormFileSelect.tsx
+++ b/storybook/src/admin/form/FinalFormFileSelect.tsx
@@ -1,5 +1,5 @@
 import { Field, FinalFormFileSelect } from "@comet/admin";
-import { Card, CardContent, Grid } from "@mui/material";
+import { Box, Card, CardContent, Grid, Typography } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 import { Form } from "react-final-form";
@@ -13,7 +13,7 @@ type FormValues = {
 
 function Story() {
     return (
-        <div style={{ width: 800 }}>
+        <Box maxWidth={1600}>
             <Form<FormValues>
                 onSubmit={(values) => {
                     //
@@ -63,12 +63,66 @@ function Story() {
                                     </CardContent>
                                 </Card>
                             </Grid>
+                            <Grid item xs={12}>
+                                <Card variant="outlined">
+                                    <CardContent>
+                                        <Typography variant="h4" sx={{ mb: 4 }}>
+                                            Vertical form layout
+                                        </Typography>
+                                        <Field
+                                            name="vertical"
+                                            label="File Select"
+                                            component={FinalFormFileSelect}
+                                            multiple
+                                            fullWidth
+                                            helperText="Selected files will also be shown in the read-only field below."
+                                        />
+                                        <Field
+                                            name="vertical"
+                                            label="File Select - ReadOnly Grid"
+                                            component={FinalFormFileSelect}
+                                            showFilesAsPreviewGrid
+                                            readOnly
+                                            multiple
+                                            fullWidth
+                                        />
+                                    </CardContent>
+                                </Card>
+                            </Grid>
+                            <Grid item xs={12}>
+                                <Card variant="outlined">
+                                    <CardContent>
+                                        <Typography variant="h4" sx={{ mb: 4 }}>
+                                            Horizontal form layout
+                                        </Typography>
+                                        <Field
+                                            name="horizontal"
+                                            label="File Select"
+                                            component={FinalFormFileSelect}
+                                            multiple
+                                            fullWidth
+                                            variant="horizontal"
+                                            helperText="Selected files will also be shown in the read-only field below."
+                                        />
+                                        <Field
+                                            variant="horizontal"
+                                            name="horizontal"
+                                            label="File Select - ReadOnly Grid"
+                                            component={FinalFormFileSelect}
+                                            showFilesAsPreviewGrid
+                                            readOnly
+                                            multiple
+                                            fullWidth
+                                        />
+                                    </CardContent>
+                                </Card>
+                            </Grid>
                         </Grid>
                         <pre>{JSON.stringify(values, null, 2)}</pre>
                     </form>
                 )}
             />
-        </div>
+        </Box>
     );
 }
 

--- a/storybook/src/admin/form/FinalFormFileSelect.tsx
+++ b/storybook/src/admin/form/FinalFormFileSelect.tsx
@@ -81,7 +81,7 @@ function Story() {
                                             name="vertical"
                                             label="File Select - ReadOnly Grid"
                                             component={FinalFormFileSelect}
-                                            showFilesAsPreviewGrid
+                                            layout="grid"
                                             readOnly
                                             multiple
                                             fullWidth
@@ -109,7 +109,7 @@ function Story() {
                                             name="horizontal"
                                             label="File Select - ReadOnly Grid"
                                             component={FinalFormFileSelect}
-                                            showFilesAsPreviewGrid
+                                            layout="grid"
                                             readOnly
                                             multiple
                                             fullWidth

--- a/storybook/src/admin/form/file/FileSelect.tsx
+++ b/storybook/src/admin/form/file/FileSelect.tsx
@@ -4,9 +4,11 @@ import { boolean, select } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
+const getLayout = () => select("Layout", { List: "list", Grid: "grid" }, "list");
+
 storiesOf("@comet/admin/form/File", module)
     .addDecorator((story) => (
-        <Card sx={{ maxWidth: 440 }}>
+        <Card sx={{ maxWidth: getLayout() === "grid" ? 960 : 440 }}>
             <CardContent>
                 <Stack spacing={4}>{story()}</Stack>
             </CardContent>
@@ -79,6 +81,7 @@ storiesOf("@comet/admin/form/File", module)
                 onDownload={() => {
                     console.log("Downloading file");
                 }}
+                layout={getLayout()}
                 files={filesMapping[filesSelection]}
                 disabled={disabled}
                 readOnly={readOnly}

--- a/storybook/src/docs/components/FileSelect/FileSelect.stories.mdx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.stories.mdx
@@ -12,6 +12,7 @@ Used to combine `FileDropzone` and `FileSelectListItem` to handle the user's sel
 -   Use props from [react-dropzone](https://www.npmjs.com/package/react-dropzone), such as `onDrop`, to handle what happens when selecting files.
 -   Use the `files` prop to pass in the list of files that should be shown.
 -   Use the `getDownloadUrl`, `onDownload` and `onRemove` props to handle what happens when clicking the download and remove buttons.
+-   Set the `showFilesAsPreviewGrid` prop to `true` to display the files as a grid of cards with a file preview.
 -   Limit the amount of files and the size of the individual files with the `maxFiles` and `maxFileSize` props.
 
 <Canvas>
@@ -22,4 +23,10 @@ Used to combine `FileDropzone` and `FileSelectListItem` to handle the user's sel
 
 <Canvas>
     <Story id="stories-components-fileselect--readonly-fileselect" />
+</Canvas>
+
+### ReadOnly FileSelect (Grid with preview)
+
+<Canvas>
+    <Story id="stories-components-fileselect--grid-with-preview" />
 </Canvas>

--- a/storybook/src/docs/components/FileSelect/FileSelect.stories.mdx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.stories.mdx
@@ -12,7 +12,7 @@ Used to combine `FileDropzone` and `FileSelectListItem` to handle the user's sel
 -   Use props from [react-dropzone](https://www.npmjs.com/package/react-dropzone), such as `onDrop`, to handle what happens when selecting files.
 -   Use the `files` prop to pass in the list of files that should be shown.
 -   Use the `getDownloadUrl`, `onDownload` and `onRemove` props to handle what happens when clicking the download and remove buttons.
--   Set the `showFilesAsPreviewGrid` prop to `true` to display the files as a grid of cards with a file preview.
+-   Set the `layout` prop to `grid` to display the files as a grid of cards with a file preview.
 -   Limit the amount of files and the size of the individual files with the `maxFiles` and `maxFileSize` props.
 
 <Canvas>

--- a/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
@@ -68,4 +68,43 @@ storiesOf("stories/components/FileSelect", module)
                 readOnly
             />
         );
+    })
+    .add("Grid with preview", () => {
+        const value: FileSelectItem[] = [
+            {
+                name: "Filename.xyz",
+                size: 4.3 * 1024 * 1024, // 4.3 MB
+            },
+            {
+                name: "Another file.png",
+                size: 568 * 1024, // 568 KB
+            },
+            {
+                name: "And another file.png",
+                size: 5.6 * 1024 * 1024, // 5.6 MB
+            },
+            {
+                name: "Yet another file.pdf",
+                size: 8.2 * 1024 * 1024, // 8.2 MB
+            },
+            {
+                name: "And again another file.jpg",
+                size: 3.4 * 1024 * 1024, // 3.4 MB
+            },
+            {
+                name: "One last file.png",
+                size: 1.2 * 1024 * 1024, // 1.2 MB
+            },
+        ];
+
+        return (
+            <FileSelect
+                onDownload={(file) => {
+                    // Handle download
+                }}
+                files={value}
+                readOnly
+                showFilesAsPreviewGrid
+            />
+        );
     });

--- a/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
@@ -104,7 +104,7 @@ storiesOf("stories/components/FileSelect", module)
                 }}
                 files={value}
                 readOnly
-                showFilesAsPreviewGrid
+                layout="grid"
             />
         );
     });


### PR DESCRIPTION
---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Merge dependent PR https://github.com/vivid-planet/comet/pull/2341
-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
    - ⚠️ Not needed, as long as this is merged before the V7 release.
-   [x] Link to the respective task if one exists: COM-802
-   [x] Provide screenshots/screencasts if the change contains visual changes

<img width="770" alt="FinalFormFileSelect with grid-card view" src="https://github.com/user-attachments/assets/8201d2f9-c9f5-4b0a-a6f6-25fe581bb1b3">

