### PR TITLE
Sort contentScope keys to make equality check easier

### DIFF
--- a/.changeset/quick-oranges-punch.md
+++ b/.changeset/quick-oranges-punch.md
@@ -1,0 +1,10 @@
+---
+"@comet/cms-api": patch
+---
+
+Sort the keys in content scopes returned by `UserPermissionsService` alphabetically
+
+This fixes issues when comparing content scopes after converting them to strings via `JSON.stringify()`.
+
+This specifically fixes a bug on the UserPermissionsPage:
+When the `availableContentScopes` passed to the `UserPermissionsModule` weren't sorted alphabetically, the allowed scopes wouldn't be displayed correctly in the UI.

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -21,6 +21,7 @@ import {
     UserPermissionsOptions,
     UserPermissionsUserServiceInterface,
 } from "./user-permissions.types";
+import { sortContentScopeKeysAlphabetically } from "./utils/sort-content-scope-keys-alphabetically";
 
 @Injectable()
 export class UserPermissionsService {
@@ -38,7 +39,7 @@ export class UserPermissionsService {
             if (typeof this.options.availableContentScopes === "function") {
                 return this.options.availableContentScopes();
             }
-            return this.options.availableContentScopes;
+            return this.options.availableContentScopes.map((cs) => sortContentScopeKeysAlphabetically(cs));
         }
         return [];
     }
@@ -142,7 +143,7 @@ export class UserPermissionsService {
             }
         }
 
-        return contentScopes;
+        return contentScopes.map((cs) => sortContentScopeKeysAlphabetically(cs));
     }
 
     normalizeContentScopes(contentScopes: ContentScope[], availableContentScopes: ContentScope[]): ContentScope[] {

--- a/packages/api/cms-api/src/user-permissions/utils/sort-content-scope-keys-alphabetically.ts
+++ b/packages/api/cms-api/src/user-permissions/utils/sort-content-scope-keys-alphabetically.ts
@@ -1,0 +1,10 @@
+import { ContentScope } from "../interfaces/content-scope.interface";
+
+export function sortContentScopeKeysAlphabetically(obj: ContentScope): ContentScope {
+    return Object.keys(obj)
+        .sort()
+        .reduce<ContentScope>((acc, key) => {
+            acc[key as keyof ContentScope] = obj[key as keyof ContentScope];
+            return acc;
+        }, {});
+}


### PR DESCRIPTION
## Problem

In the admin on the UserPermissionsPage, the content scopes are compared using string comparison after JSON.stringify(). 

This fails if the `availableContentScopes` passed to the `UserPermissionsModule` aren't sorted alphabetically. It appears that the assigned content scopes retrieved from the database are always sorted alphabetically. This results in an API result like this:

<img width="598" alt="Bildschirmfoto 2024-07-26 um 12 08 03" src="https://github.com/user-attachments/assets/a20e8200-fdd9-4e0b-9e36-9d01b6b3ba84">

(Note that availableContentScopes has language first and userContentScopes has domain first)

This causes the equality check to fail and the UserPage to break:

<img width="1920" alt="Bildschirmfoto 2024-07-26 um 12 07 45" src="https://github.com/user-attachments/assets/03d15fb1-ba9a-4ec8-873d-459aa62de1aa">

(no checkmarks are shown, although the user has two scopes)

## Solution

I sort the keys of all content scopes when retrieving them via the UserPermissionsService. This resolves the issue.

---

Other potential solutions could be sorting the keys in the admin before JSON.stringify or transforming the string back to an object and doing a deep equality check.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
