### PR TITLE
RFC: GraphQL Query ID handling

### DIFF
--- a/demo/admin/codegen.ts
+++ b/demo/admin/codegen.ts
@@ -26,7 +26,7 @@ const config: CodegenConfig = {
                 },
                 enumsAsTypes: true,
                 namingConvention: "keep",
-                scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), { DateTime: "string" }),
+                scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), { DateTime: "string", UUID: "string" }),
                 typesPrefix: "GQL",
             },
         },

--- a/demo/admin/src/products/ProductForm.gql.ts
+++ b/demo/admin/src/products/ProductForm.gql.ts
@@ -30,8 +30,8 @@ export const productFormFragment = gql`
 `;
 
 export const productQuery = gql`
-    query Product($id: ID!) {
-        product(id: $id) {
+    query Product($id: UUID!) {
+        productById2(id: $id) {
             id
             updatedAt
             ...ProductFormManual

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -759,6 +759,8 @@ type Query {
   kubernetesJob(name: String!): KubernetesJob!
   kubernetesJobLogs(name: String!): String!
   product(id: ID!): Product!
+  productById1(id: ID!): Product!
+  productById2(id: UUID!): Product!
   productBySlug(slug: String!): Product
   products(offset: Int! = 0, limit: Int! = 25, status: [ProductStatus!]! = [Published, Unpublished], search: String, filter: ProductFilter, sort: [ProductSort!]): PaginatedProducts!
   productCategory(id: ID!): ProductCategory!
@@ -932,6 +934,11 @@ enum NewsSortField {
   createdAt
   updatedAt
 }
+
+"""
+A field whose value is a generic Universally Unique Identifier: https://en.wikipedia.org/wiki/Universally_unique_identifier.
+"""
+scalar UUID
 
 input ProductFilter {
   title: StringFilter

--- a/demo/api/src/products/generated/product.resolver.ts
+++ b/demo/api/src/products/generated/product.resolver.ts
@@ -12,8 +12,10 @@ import {
 import { FindOptions, Reference } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
+import { ParseUUIDPipe } from "@nestjs/common";
 import { Args, ID, Info, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { GraphQLResolveInfo } from "graphql";
+import { GraphQLUUID } from "graphql-scalars";
 
 import { Manufacturer } from "../entities/manufacturer.entity";
 import { Product } from "../entities/product.entity";
@@ -45,6 +47,26 @@ export class ProductResolver {
     @Query(() => Product)
     @AffectedEntity(Product)
     async product(@Args("id", { type: () => ID }) id: string): Promise<Product> {
+        const product = await this.repository.findOneOrFail(id);
+        return product;
+    }
+
+    @Query(() => Product)
+    @AffectedEntity(Product)
+    async productById1(
+        @Args("id", { type: () => ID }, ParseUUIDPipe)
+        id: string,
+    ): Promise<Product> {
+        const product = await this.repository.findOneOrFail(id);
+        return product;
+    }
+
+    @Query(() => Product)
+    @AffectedEntity(Product)
+    async productById2(
+        @Args("id", { type: () => GraphQLUUID })
+        id: string,
+    ): Promise<Product> {
         const product = await this.repository.findOneOrFail(id);
         return product;
     }


### PR DESCRIPTION
Currently our "Entity By Id" Queries look like this:
```ts
    @Query(() => Product)
    @AffectedEntity(Product)
    async product(@Args("id", { type: () => ID }) id: string): Promise<Product> {
        const product = await this.repository.findOneOrFail(id);
        return product;
    }
```

If you submit a malformed id:
```graphql
query Product0 {
  product(id: "ec9f2ed2-7e8f-491a-9137-651eb338ed6fx") {
    id
  }
}
``` 

you get an error from the DB
```
      "message": "select \"p0\".* from \"Product\" as \"p0\" where \"p0\".\"id\" = 'ec9f2ed2-7e8f-491a-9137-651eb338ed6fx' limit 1 - invalid input syntax for type uuid: \"ec9f2ed2-7e8f-491a-9137-651eb338ed6fx\"",
```

This error can be caught earlier. Our security team also noted that this exposes implementation details to a potential attacker. But this could be resolved in another way.

As we now have the [UUID type from graphql-scalars](https://the-guild.dev/graphql/scalars/docs/scalars/uuid), we can simply use it to prevent this error. A malformed ID would now result into `GRAPHQL_VALIDATION_FAILED`. A previous attempt to mitigate this error by using an ArgsType with class-validator was declined due to the need of an extra class.

For the sake of completeness, an additional method to mitigate this issue by using Pipes is also shown. I would not use that, as we don't use Pipes currently and I think it would be better to use GraphQL for that.