### PR TITLE
Fix private/public site config types

### DIFF
--- a/packages/cli/src/site-configs.types.ts
+++ b/packages/cli/src/site-configs.types.ts
@@ -9,9 +9,9 @@ export type BaseSiteConfig = {
     preloginEnabled?: boolean;
     public?: Record<string, unknown>;
 };
-export type ExtractPrivateSiteConfig<S extends BaseSiteConfig> = S & {
+export type ExtractPrivateSiteConfig<S extends BaseSiteConfig> = Omit<S, "public"> & {
     url: string;
-};
-export type ExtractPublicSiteConfig<S extends BaseSiteConfig> = Pick<S, "name" | "domains" | "preloginEnabled" | "public"> & {
+} & S["public"];
+export type ExtractPublicSiteConfig<S extends BaseSiteConfig> = Pick<S, "name" | "domains" | "preloginEnabled"> & {
     url: string;
-};
+} & S["public"];

--- a/packages/cli/src/site-configs.types.ts
+++ b/packages/cli/src/site-configs.types.ts
@@ -9,9 +9,11 @@ export type BaseSiteConfig = {
     preloginEnabled?: boolean;
     public?: Record<string, unknown>;
 };
-export type ExtractPrivateSiteConfig<S extends BaseSiteConfig> = Omit<S, "public"> & {
-    url: string;
-} & S["public"];
-export type ExtractPublicSiteConfig<S extends BaseSiteConfig> = Pick<S, "name" | "domains" | "preloginEnabled"> & {
-    url: string;
-} & S["public"];
+export type ExtractPrivateSiteConfig<S extends BaseSiteConfig> = S["public"] &
+    Omit<S, "public"> & {
+        url: string;
+    };
+export type ExtractPublicSiteConfig<S extends BaseSiteConfig> = S["public"] &
+    Pick<S, "name" | "domains" | "preloginEnabled"> & {
+        url: string;
+    };


### PR DESCRIPTION
In #2297 the public site config was spread into the site config. However, the types for extracting the public and private site config weren't adapted accordingly.