### PR TITLE
Fix minimum visible blocks tooltip showing even though minVisibleBlocks is not defined

### DIFF
--- a/.changeset/cold-bags-walk.md
+++ b/.changeset/cold-bags-walk.md
@@ -2,4 +2,4 @@
 "@comet/blocks-admin": patch
 ---
 
-createListBlock: Don't show the minimum required blocks tooltip when the option isn't used
+createListBlock: Don't show the minimum visible blocks tooltip when the option isn't used

--- a/.changeset/cold-bags-walk.md
+++ b/.changeset/cold-bags-walk.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": patch
+---
+
+This fixes a bug where a tooltip for the minimum amount of required blocks of a `LinkBlock` was shown even if the option was not defined in the options.

--- a/.changeset/cold-bags-walk.md
+++ b/.changeset/cold-bags-walk.md
@@ -2,4 +2,4 @@
 "@comet/blocks-admin": patch
 ---
 
-This fixes a bug where a tooltip for the minimum amount of required blocks of a `LinkBlock` was shown even if the option was not defined in the options.
+createListBlock: Don't show the minimum required blocks tooltip when the option isn't used

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -325,7 +325,8 @@ export function createListBlock<T extends BlockInterface, AdditionalItemFields e
 
                                                         const showMaxBlocksAllowedMessage = isMaxVisibleBlocksReached && !data.visible;
                                                         const showMinBlocksRequiredMessage =
-                                                            !isMinVisibleBlocksMet || (minVisibleBlocks === totalVisibleBlocks && data.visible);
+                                                            (!!minVisibleBlocks && !isMinVisibleBlocksMet) ||
+                                                            (minVisibleBlocks === totalVisibleBlocks && data.visible);
 
                                                         return (
                                                             <HoverPreviewComponent key={data.key} componentSlug={`${data.key}/edit`}>


### PR DESCRIPTION
---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-857
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

### `minVisibleBlocks === undefined`
https://github.com/user-attachments/assets/4876a7a9-d5bc-4c28-8236-c19e470c6ecf

### `minVisibleBlocks === 1`

https://github.com/user-attachments/assets/d65e5047-072c-4602-978a-2f72d42b1e07



</details>
