### PR TITLE
Admin Generator (Future): Add `initialSortProp` option in `GridConfig`

### DIFF
--- a/.changeset/tame-candles-switch.md
+++ b/.changeset/tame-candles-switch.md
@@ -2,6 +2,6 @@
 "@comet/cms-admin": minor
 ---
 
-Admin Generator: Add `initialSortProp` option in `GridConfig`
+Admin Generator (Future): Add support for passing an initial sort to grids
 
-Setting `initialSortProp` allows to pass an initial sort to the generated Grid.
+Setting the `initialSortProp` option allows to pass an initial sort to the generated Grid.

--- a/.changeset/tame-candles-switch.md
+++ b/.changeset/tame-candles-switch.md
@@ -4,4 +4,4 @@
 
 Admin Generator (Future): Add support for passing an initial sort to grids
 
-Setting the `initialSortProp` option allows to pass an initial sort to the generated Grid.
+Setting the `initialSortProp` option allows to pass an initial sort to the generated grid.

--- a/.changeset/tame-candles-switch.md
+++ b/.changeset/tame-candles-switch.md
@@ -1,7 +1,0 @@
----
-"@comet/cms-admin": minor
----
-
-Admin Generator (Future): Add support for passing an initial sort to grids
-
-Setting the `initialSortProp` option allows to pass an initial sort to the generated grid.

--- a/.changeset/tame-candles-switch.md
+++ b/.changeset/tame-candles-switch.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": minor
+---
+
+Admin Generator: `initialSort` option in `GridConfig` is added
+
+Setting an `initialSort` for a generated Grid is now possible.

--- a/.changeset/tame-candles-switch.md
+++ b/.changeset/tame-candles-switch.md
@@ -2,6 +2,6 @@
 "@comet/cms-admin": minor
 ---
 
-Admin Generator: `initialSort` option in `GridConfig` is added
+Admin Generator: Add `initialSortProp` option in `GridConfig`
 
-Setting an `initialSort` for a generated Grid is now possible.
+Setting `initialSortProp` allows to pass an initial sort to the generated Grid.

--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -8,10 +8,7 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
     filterProp: true,
     toolbarActionProp: true,
     rowActionProp: true,
-    initialSort: [
-        { field: "inStock", sort: "desc" },
-        { field: "price", sort: "asc" },
-    ],
+    initialSortProp: true,
     columns: [
         { type: "boolean", name: "inStock", headerName: "In stock", width: 90 },
         { type: "text", name: "title", headerName: "Titel", minWidth: 200, maxWidth: 250 },

--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -8,6 +8,10 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
     filterProp: true,
     toolbarActionProp: true,
     rowActionProp: true,
+    initialSort: [
+        { field: "inStock", sort: "desc" },
+        { field: "price", sort: "asc" },
+    ],
     columns: [
         { type: "boolean", name: "inStock", headerName: "In stock", width: 90 },
         { type: "text", name: "title", headerName: "Titel", minWidth: 200, maxWidth: 250 },

--- a/demo/admin/src/products/future/ProductsPage.tsx
+++ b/demo/admin/src/products/future/ProductsPage.tsx
@@ -45,6 +45,10 @@ export function ProductsPage(): React.ReactElement {
                     <StackToolbar scopeIndicator={<ContentScopeIndicator global />} />
                     <MainContent fullHeight>
                         <ProductsGrid
+                            initialSort={[
+                                { field: "inStock", sort: "desc" },
+                                { field: "price", sort: "asc" },
+                            ]}
                             toolbarAction={
                                 <Button
                                     startIcon={<AddIcon />}

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -17,7 +17,7 @@ import {
     usePersistentColumnState,
 } from "@comet/admin";
 import { DamImageBlock } from "@comet/cms-admin";
-import { DataGridPro, GridRenderCellParams, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
+import { DataGridPro, GridRenderCellParams, GridSortDirection, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import { GQLProductFilter } from "@src/graphql.generated";
 import * as React from "react";
 import { useIntl } from "react-intl";
@@ -91,20 +91,13 @@ type Props = {
     toolbarAction?: React.ReactNode;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     rowAction?: (params: GridRenderCellParams<any, GQLProductsGridFutureFragment, any>) => React.ReactNode;
+    initialSort?: Array<{ field: string; sort: GridSortDirection }>;
 };
 
-export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React.ReactElement {
+export function ProductsGrid({ filter, toolbarAction, rowAction, initialSort }: Props): React.ReactElement {
     const client = useApolloClient();
     const intl = useIntl();
-    const dataGridProps = {
-        ...useDataGridRemote({
-            initialSort: [
-                { field: "inStock", sort: "desc" },
-                { field: "price", sort: "asc" },
-            ],
-        }),
-        ...usePersistentColumnState("ProductsGrid"),
-    };
+    const dataGridProps = { ...useDataGridRemote({ initialSort: initialSort }), ...usePersistentColumnState("ProductsGrid") };
 
     const columns: GridColDef<GQLProductsGridFutureFragment>[] = [
         { field: "inStock", headerName: intl.formatMessage({ id: "product.inStock", defaultMessage: "In stock" }), type: "boolean", width: 90 },

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -96,7 +96,15 @@ type Props = {
 export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React.ReactElement {
     const client = useApolloClient();
     const intl = useIntl();
-    const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };
+    const dataGridProps = {
+        ...useDataGridRemote({
+            initialSort: [
+                { field: "inStock", sort: "desc" },
+                { field: "price", sort: "asc" },
+            ],
+        }),
+        ...usePersistentColumnState("ProductsGrid"),
+    };
 
     const columns: GridColDef<GQLProductsGridFutureFragment>[] = [
         { field: "inStock", headerName: intl.formatMessage({ id: "product.inStock", defaultMessage: "In stock" }), type: "boolean", width: 90 },

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -97,7 +97,7 @@ type Props = {
 export function ProductsGrid({ filter, toolbarAction, rowAction, initialSort }: Props): React.ReactElement {
     const client = useApolloClient();
     const intl = useIntl();
-    const dataGridProps = { ...useDataGridRemote({ initialSort: initialSort }), ...usePersistentColumnState("ProductsGrid") };
+    const dataGridProps = { ...useDataGridRemote({ initialSort }), ...usePersistentColumnState("ProductsGrid") };
 
     const columns: GridColDef<GQLProductsGridFutureFragment>[] = [
         { field: "inStock", headerName: intl.formatMessage({ id: "product.inStock", defaultMessage: "In stock" }), type: "boolean", width: 90 },

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -469,7 +469,15 @@ export function generateGrid(
     export function ${gqlTypePlural}Grid(${gridPropsParamsCode}): React.ReactElement {
         ${allowCopyPaste || allowDeleting ? "const client = useApolloClient();" : ""}
         const intl = useIntl();
-        const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("${gqlTypePlural}Grid") };
+        const dataGridProps = { ...useDataGridRemote(${
+            config.initialSort
+                ? `{ initialSort: [${config.initialSort
+                      .map((item) => {
+                          return `{field: "${item.field}", sort: "${item.sort}"}`;
+                      })
+                      .join(",\n")} ] }`
+                : ""
+        }), ...usePersistentColumnState("${gqlTypePlural}Grid") };
         ${hasScope ? `const { scope } = useContentScope();` : ""}
 
         const columns: GridColDef<GQL${fragmentName}Fragment>[] = [

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -57,7 +57,6 @@ function generateGridPropsCode(props: Prop[]): { gridPropsTypeCode: string; grid
         }
         return acc;
     }, []);
-    //TODO where my prop? all done?
     return {
         gridPropsTypeCode: `type Props = {
             ${uniqueProps

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -478,7 +478,7 @@ export function generateGrid(
         ${allowCopyPaste || allowDeleting ? "const client = useApolloClient();" : ""}
         const intl = useIntl();
           const dataGridProps = { ...useDataGridRemote(${
-              config.initialSortProp ? `{ initialSort: initialSort }` : ""
+              config.initialSortProp ? `{ initialSort }` : ""
           }), ...usePersistentColumnState("${gqlTypePlural}Grid") };
         ${hasScope ? `const { scope } = useContentScope();` : ""}
 

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -57,6 +57,7 @@ function generateGridPropsCode(props: Prop[]): { gridPropsTypeCode: string; grid
         }
         return acc;
     }, []);
+    //TODO where my prop? all done?
     return {
         gridPropsTypeCode: `type Props = {
             ${uniqueProps
@@ -318,6 +319,14 @@ export function generateGrid(
         });
     }
 
+    if (config.initialSortProp) {
+        props.push({
+            name: "initialSort",
+            type: `Array<{ field: string; sort: GridSortDirection }>`,
+            optional: true,
+        });
+    }
+
     const { gridPropsTypeCode, gridPropsParamsCode } = generateGridPropsCode(props);
 
     const code = `import { gql, useApolloClient, useQuery } from "@apollo/client";
@@ -340,7 +349,7 @@ export function generateGrid(
     import { Add as AddIcon, Edit } from "@comet/admin-icons";
     import { BlockPreviewContent } from "@comet/blocks-admin";
     import { Alert, Button, Box, IconButton } from "@mui/material";
-    import { DataGridPro, GridRenderCellParams, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
+    import { DataGridPro, GridRenderCellParams, GridSortDirection, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
     import { useContentScope } from "@src/common/ContentScopeProvider";
     import {
         GQL${gqlTypePlural}GridQuery,
@@ -469,15 +478,9 @@ export function generateGrid(
     export function ${gqlTypePlural}Grid(${gridPropsParamsCode}): React.ReactElement {
         ${allowCopyPaste || allowDeleting ? "const client = useApolloClient();" : ""}
         const intl = useIntl();
-        const dataGridProps = { ...useDataGridRemote(${
-            config.initialSort
-                ? `{ initialSort: [${config.initialSort
-                      .map((item) => {
-                          return `{field: "${item.field}", sort: "${item.sort}"}`;
-                      })
-                      .join(",\n")} ] }`
-                : ""
-        }), ...usePersistentColumnState("${gqlTypePlural}Grid") };
+          const dataGridProps = { ...useDataGridRemote(${
+              config.initialSortProp ? `{ initialSort: initialSort }` : ""
+          }), ...usePersistentColumnState("${gqlTypePlural}Grid") };
         ${hasScope ? `const { scope } = useContentScope();` : ""}
 
         const columns: GridColDef<GQL${fragmentName}Fragment>[] = [

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -1,6 +1,7 @@
 import { GridColDef } from "@comet/admin";
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 import { loadSchema } from "@graphql-tools/load";
+import { GridSortDirection } from "@mui/x-data-grid";
 import { glob } from "glob";
 import { introspectionFromSchema } from "graphql";
 import { basename, dirname } from "path";
@@ -66,6 +67,7 @@ export type GridColumnConfig<T> = (
     | { type: "staticSelect"; values?: string[] }
     | { type: "block"; block: ImportReference }
 ) & { name: UsableFields<T> } & DataGridSettings;
+
 export type GridConfig<T extends { __typename?: string }> = {
     type: "grid";
     gqlType: T["__typename"];
@@ -81,6 +83,7 @@ export type GridConfig<T extends { __typename?: string }> = {
     toolbar?: boolean;
     toolbarActionProp?: boolean;
     rowActionProp?: boolean;
+    initialSort?: Array<{ field: string; sort: GridSortDirection }>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -1,7 +1,6 @@
 import { GridColDef } from "@comet/admin";
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 import { loadSchema } from "@graphql-tools/load";
-import { GridSortDirection } from "@mui/x-data-grid";
 import { glob } from "glob";
 import { introspectionFromSchema } from "graphql";
 import { basename, dirname } from "path";
@@ -83,7 +82,7 @@ export type GridConfig<T extends { __typename?: string }> = {
     toolbar?: boolean;
     toolbarActionProp?: boolean;
     rowActionProp?: boolean;
-    initialSort?: Array<{ field: string; sort: GridSortDirection }>;
+    initialSortProp?: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
`initialSortProp` is added to `GridConfig`. 

Setting `initialSortProp` allows passing an initial sort prop to the generated grid.

Use case example: Being able to reuse the same generated grid for similar views, with different initial sorts.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: SVK-273
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
The initalSort in this example is:  column "In stock" DESC, column "Price" ASC

<img width="1558" alt="Screenshot 2024-07-31 at 10 54 27" src="https://github.com/user-attachments/assets/a691272a-60d1-4249-bcef-a03ed559b162">

</details>
