### PR TITLE
Fix alignment of input in horizontal variant when there is no label

### DIFF
--- a/.changeset/spotty-vans-wave.md
+++ b/.changeset/spotty-vans-wave.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix the alignment of the input inside `FieldContainer` and `Field` when there is no label with `variant="horizontal"`

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -239,7 +239,7 @@ export const FieldContainer = (inProps: React.PropsWithChildren<FieldContainerPr
     return (
         <Root ownerState={ownerState} fullWidth={fullWidth} disabled={disabled} required={required} ref={ref} {...slotProps?.root} {...restProps}>
             <>
-                {label && (
+                {(label || (variant === "horizontal" && !forceVertical)) && (
                     <Label ownerState={ownerState} disabled={disabled} {...slotProps?.label}>
                         {label}
                     </Label>


### PR DESCRIPTION
---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-982
-   [x] Provide screenshots/screencasts if the change contains visual changes

| Previously | Now |
| --- | --- |
| <img width="929" alt="Checkboxes Previously" src="https://github.com/user-attachments/assets/b98a018a-150d-4fb6-a8b8-f3b0b79b439d"> | <img width="929" alt="Checkboxes Now" src="https://github.com/user-attachments/assets/5d21fe03-8cb8-459c-9c2f-8b26e1dd1615"> |