### PR TITLE
Adjust alignment and spacing of label, input, and child fields of `FieldContainer` and `Field`

### DIFF
--- a/.changeset/clean-doors-shave.md
+++ b/.changeset/clean-doors-shave.md
@@ -1,0 +1,6 @@
+---
+"@comet/admin-theme": minor
+"@comet/admin": minor
+---
+
+Adjust the alignment and spacing of the label, the input, and child fields inside `FieldContainer` and `Field`

--- a/packages/admin/admin-theme/src/componentsTheme/MuiFormControlLabel.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiFormControlLabel.ts
@@ -8,6 +8,12 @@ export const getMuiFormControlLabel: GetMuiComponentTheme<"MuiFormControlLabel">
             marginLeft: -9,
             marginTop: -7,
             marginBottom: -7,
+
+            ".CometAdminFormFieldContainer-horizontal &": {
+                marginTop: 0,
+                marginBottom: 0,
+                minHeight: 40,
+            },
         },
     }),
 });

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -85,7 +85,6 @@ const Root = createComponentSlot(FormControl)<FieldContainerClassKey, OwnerState
         css`
             display: flex;
             flex-direction: row;
-            align-items: center;
             max-width: 944px;
             gap: ${theme.spacing(4)};
         `}
@@ -130,6 +129,7 @@ const Label = createComponentSlot(FormLabel)<FieldContainerClassKey, OwnerState>
             flex-shrink: 0;
             flex-grow: 0;
             margin-bottom: 0;
+            margin-top: ${theme.spacing(2)};
         `}
 
         ${ownerState.disabled &&
@@ -163,6 +163,16 @@ const InputContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
         !ownerState.forceVertical &&
         css`
             flex-grow: 1;
+        `}
+
+        ${ownerState.variant === "horizontal" &&
+        !ownerState.forceVertical &&
+        css`
+            min-height: 40px;
+
+            > .CometAdminFormFieldContainer-root {
+                margin-bottom: 0;
+            }
         `}
 
         & > [class*="${inputBaseClasses.root}"] {


### PR DESCRIPTION
Previously, the label and input of fields were centered vertically. 
Now, the label is positioned from the top, and each input has a minimum height of 40px. 

Additionally, the spacing of child fields was adjusted to make sure elements with less height, such as radios and checkboxes, would still be centered vertically with the label and would still be aligned with their siblings and inputs of other fields. 

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-982
-   [x] Provide screenshots/screencasts if the change contains visual changes

| Previously | Now |
| --- | --- |
| <img width="812" alt="Text inputs previously" src="https://github.com/user-attachments/assets/15f5d1bb-0e6a-4d52-9373-f87789ac73bf"> | <img width="812" alt="Text inputs now" src="https://github.com/user-attachments/assets/7252c355-b066-4f6b-8088-b8b45a8494ac"> |
| <img width="812" alt="child fields previously" src="https://github.com/user-attachments/assets/7985fed3-066a-41ea-9288-663a513718e6"> | <img width="812" alt="child fields now" src="https://github.com/user-attachments/assets/e05c2e83-e70b-488f-ac6d-22490a4f5f69"> |