### PR TITLE
Add dev story for synchronized RTEs

### DIFF
--- a/storybook/src/admin-rte/SynchronizedEditors.tsx
+++ b/storybook/src/admin-rte/SynchronizedEditors.tsx
@@ -1,0 +1,55 @@
+import { IRteRef, makeRteApi, Rte } from "@comet/admin-rte";
+import { Grid, Typography } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import { EditorState } from "draft-js";
+import * as React from "react";
+
+import { PrintEditorState, useAutoFocus } from "./helper";
+
+const [useRteApi] = makeRteApi();
+
+function Story() {
+    const { editorState, setEditorState } = useRteApi();
+    const [activeEditor, setActiveEditor] = React.useState<"left" | "right">("left");
+
+    // focus the editor to see the cursor immediately
+    const leftEditorRef = React.useRef<IRteRef>();
+    useAutoFocus(leftEditorRef);
+
+    return (
+        <Grid container spacing={4}>
+            <Grid item xs={6}>
+                <Typography variant="h4" gutterBottom>
+                    Left Editor
+                </Typography>
+                <Rte
+                    // Use EditorState.createWithContent(editorState.getCurrentContent()) to update state without losing focus in the active editor
+                    value={activeEditor === "left" ? editorState : EditorState.createWithContent(editorState.getCurrentContent())}
+                    onChange={(value) => {
+                        setEditorState(value);
+                        setActiveEditor("left");
+                    }}
+                    ref={leftEditorRef}
+                />
+            </Grid>
+            <Grid item xs={6}>
+                <Typography variant="h4" gutterBottom>
+                    Right Editor
+                </Typography>
+                <Rte
+                    // Use EditorState.createWithContent(editorState.getCurrentContent()) to update state without losing focus in the active editor
+                    value={activeEditor === "right" ? editorState : EditorState.createWithContent(editorState.getCurrentContent())}
+                    onChange={(value) => {
+                        setEditorState(value);
+                        setActiveEditor("right");
+                    }}
+                />
+            </Grid>
+            <Grid item xs={12}>
+                <PrintEditorState editorState={editorState} />
+            </Grid>
+        </Grid>
+    );
+}
+
+storiesOf("@comet/admin-rte", module).add("Synchronized RTEs", () => <Story />);


### PR DESCRIPTION
Demonstrates how to change an editor state from "the outside". The important part is creating a new editor state using `EditorState.createWithContent` when the editor isn't in focus.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: [COM-739](https://vivid-planet.atlassian.net/browse/COM-739)
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    


https://github.com/user-attachments/assets/7e9b6bf9-da5c-49e4-ad02-69f35902dae1



</details>


[COM-739]: https://vivid-planet.atlassian.net/browse/COM-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ