### PR TITLE
Make the separator of `FinalFormRangeInput` overridable and change the default to the string "to"

### DIFF
--- a/.changeset/witty-moons-sit.md
+++ b/.changeset/witty-moons-sit.md
@@ -1,0 +1,11 @@
+---
+"@comet/admin": minor
+---
+
+Make the separator of `FinalFormRangeInput` overridable using the `separator` prop and change the default to the string "to"
+
+Example to restore the previous separator:
+
+```tsx
+<Field name="numberRange" label="Range Input" component={FinalFormRangeInput} min={0} max={100} separator="-" />
+```

--- a/packages/admin/admin/src/form/FinalFormRangeInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormRangeInput.tsx
@@ -2,6 +2,7 @@ import { FormControl, InputBase, Slider, SliderProps } from "@mui/material";
 import { ComponentsOverrides, css, Theme, useThemeProps } from "@mui/material/styles";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
+import { FormattedMessage } from "react-intl";
 
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
@@ -62,6 +63,7 @@ export interface FinalFormRangeInputProps
     max: number;
     startAdornment?: React.ReactNode;
     endAdornment?: React.ReactNode;
+    separator?: React.ReactNode;
     sliderProps?: Omit<SliderProps, "min" | "max">;
 }
 
@@ -69,9 +71,10 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
     const {
         min,
         max,
-        sliderProps,
         startAdornment,
         endAdornment,
+        separator = <FormattedMessage id="comet.rangeInput.separator" defaultMessage="to" />,
+        sliderProps,
         input: { name, onChange, value: fieldValue },
         slotProps,
         ...restProps
@@ -124,7 +127,7 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
                         />
                     </FormControl>
                 </InputFieldContainer>
-                <InputFieldsSeparatorContainer {...slotProps?.inputFieldsSeparatorContainer}>-</InputFieldsSeparatorContainer>
+                <InputFieldsSeparatorContainer {...slotProps?.inputFieldsSeparatorContainer}>{separator}</InputFieldsSeparatorContainer>
                 <InputFieldContainer {...slotProps?.inputFieldContainer}>
                     <FormControl fullWidth>
                         <InputBase


### PR DESCRIPTION
---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-998
-   [x] Provide screenshots/screencasts if the change contains visual changes

| Previously | Now |
| --- | --- |
| <img width="453" alt="Screenshot 2024-08-02 at 10 58 26" src="https://github.com/user-attachments/assets/6f5eb7f5-02cf-440c-8d5c-1aae2d395e9d"> | <img width="453" alt="Screenshot 2024-08-02 at 10 58 18" src="https://github.com/user-attachments/assets/c29cdb4c-ccc1-4d0a-93ba-6c15981697f9"> |