### PR TITLE
Admin Generator (Future): Implement omiting field value from mutation by setting `virtual: true`

### DIFF
--- a/.changeset/odd-keys-join.md
+++ b/.changeset/odd-keys-join.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": minor
+---
+
+Admin Generator: Add `virtual` prop to field-config to omit field value from mutation
+
+Setting `virtual: true` generates to form-code to omit the value from gql-mutation input. A field used to filter asyncSelect can use this prop to prevent the generated code submitting the filter-value.

--- a/.changeset/odd-keys-join.md
+++ b/.changeset/odd-keys-join.md
@@ -1,7 +1,0 @@
----
-"@comet/cms-admin": minor
----
-
-Admin Generator: Add `virtual` prop to field-config to omit field value from mutation
-
-Setting `virtual: true` generates to form-code to omit the value from gql-mutation input. A field used to filter asyncSelect can use this prop to prevent the generated code submitting the filter-value.

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -308,7 +308,14 @@ export function generateForm(
                 : ""
         }
 
-        const handleSubmit = async (formValues: FormValues, form: FormApi<FormValues>${addMode ? `, event: FinalFormSubmitEvent` : ""}) => {
+        const handleSubmit = async (${
+            formValuesConfig.filter((config) => !!config.destructFromFormValues).length
+                ? `{ ${formValuesConfig
+                      .filter((config) => !!config.destructFromFormValues)
+                      .map((config) => config.destructFromFormValues)
+                      .join(", ")}, ...formValues }`
+                : `formValues`
+        }: FormValues, form: FormApi<FormValues>${addMode ? `, event: FinalFormSubmitEvent` : ""}) => {
             ${editMode ? `if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");` : ""}
             const output = {
                 ...formValues,

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -12,6 +12,7 @@ export type GenerateFieldsReturn = GeneratorReturn & {
     formValueToGqlInputCode: string;
     formValuesConfig: {
         omitFromFragmentType?: string;
+        destructFromFormValues?: string; // equals omitting from formValues copied directly to mutation-input
         typeCode?: string;
         initializationCode?: string;
         defaultInitializationCode?: string;

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -24,7 +24,7 @@ export type FormFieldConfig<T> = (
     | { type: "staticSelect"; values?: string[] }
     | { type: "asyncSelect"; rootQuery: string; labelField?: string }
     | { type: "block"; block: ImportReference }
-) & { name: keyof T; label?: string; required?: boolean; validate?: ImportReference; helperText?: string; readOnly?: boolean };
+) & { name: keyof T; label?: string; required?: boolean; virtual?: boolean; validate?: ImportReference; helperText?: string; readOnly?: boolean };
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export function isFormFieldConfig<T>(arg: any): arg is FormFieldConfig<T> {
     return !isFormLayoutConfig(arg);


### PR DESCRIPTION
This is required to use fields as filter for async selects, because in many cases the value of the filter field doesn't need to be saved (e.g., if selecting some attribute of the filtered entity to limit options in the select).