### PR TITLE
Fix behavior of `FinalFormRangeInput` when `min`/`max` values are inverted

### DIFF
--- a/.changeset/nervous-seahorses-tell.md
+++ b/.changeset/nervous-seahorses-tell.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": patch
+---
+
+Fix the behavior of `FinalFormRangeInput` when the `min` and `max` values are inverted
+
+Previously, e.g., when the `min` value was changed to something greater than the `max` value, the `min` value would be set to the same as the max value.
+Now, the `min` and `max` values are swapped.

--- a/packages/admin/admin/src/form/FinalFormRangeInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormRangeInput.tsx
@@ -89,6 +89,19 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
         setInternalMaxInput(fieldValue.max);
     }, [fieldValue]);
 
+    const updateMinMaxValues = () => {
+        const internalMinValue = typeof internalMinInput === "undefined" ? min : internalMinInput;
+        const internalMaxValue = typeof internalMaxInput === "undefined" ? max : internalMaxInput;
+
+        const minValue = Math.min(internalMinValue, internalMaxValue);
+        const maxValue = Math.max(internalMinValue, internalMaxValue);
+
+        onChange({
+            min: Math.max(minValue, min),
+            max: Math.min(maxValue, max),
+        });
+    };
+
     return (
         <Root {...slotProps?.root} {...restProps}>
             <InputsWrapper {...slotProps?.inputsWrapper}>
@@ -105,16 +118,12 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
                             endAdornment={endAdornment}
                             onBlur={() => {
                                 if (internalMinInput !== undefined) {
-                                    const minFieldValue = Math.min(internalMinInput ? internalMinInput : min, fieldValue.max ? fieldValue.max : max);
-                                    onChange({
-                                        min: minFieldValue < min ? min : minFieldValue,
-                                        max: internalMaxInput === undefined ? max : internalMaxInput,
-                                    });
+                                    updateMinMaxValues();
                                 } else {
                                     onChange(undefined);
                                 }
                             }}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                            onChange={(e) => {
                                 if (e.target.value === "") {
                                     setInternalMinInput(undefined);
                                 } else {
@@ -138,16 +147,12 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
                             endAdornment={endAdornment ? endAdornment : ""}
                             onBlur={() => {
                                 if (internalMaxInput !== undefined) {
-                                    const maxFieldValue = Math.max(fieldValue.min ? fieldValue.min : min, internalMaxInput ? internalMaxInput : max);
-                                    onChange({
-                                        min: internalMinInput === undefined ? min : internalMinInput,
-                                        max: maxFieldValue > max ? max : maxFieldValue,
-                                    });
+                                    updateMinMaxValues();
                                 } else {
                                     onChange(undefined);
                                 }
                             }}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                            onChange={(e) => {
                                 if (e.target.value === "") {
                                     setInternalMaxInput(undefined);
                                 } else {


### PR DESCRIPTION
Previously, e.g., when the `min` value was changed to something greater than the `max` value, the `min` value would be set to the same as the max value. Now, the `min` and `max` values are swapped.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-998