### PR TITLE
Admin Generator (Future): Add custom query features to asyncSelect

### DIFF
--- a/.changeset/modern-hairs-glow.md
+++ b/.changeset/modern-hairs-glow.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": minor
+---
+
+Admin Generator: Add filter support for asyncSelect
+
+Setting `filterField` for asyncSelect-field will change the generated code to add the value of the referenced field (by name) to filter-var of the graphql-query.

--- a/.changeset/odd-keys-join.md
+++ b/.changeset/odd-keys-join.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": minor
+---
+
+Admin Generator: Add `virtual` prop to field-config to omit field value from mutation
+
+Setting `virtual: true` generates to form-code to omit the value from gql-mutation input. A field used to filter asyncSelect can use this prop to prevent the generated code submitting the filter-value.

--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -35,6 +35,15 @@ export const ProductForm: FormConfig<GQLProduct> = {
             collapsible: true,
             initiallyExpanded: false,
             fields: [
+                {
+                    type: "asyncSelect",
+                    name: "manufacturer",
+                    rootQuery: "manufacturers",
+                    filterField: {
+                        name: "type",
+                        filterMapping: `addressAsEmbeddable_country: { equal: {value} }`,
+                    },
+                },
                 { type: "boolean", name: "inStock" },
                 { type: "date", name: "availableSince" },
                 { type: "block", name: "image", label: "Image", block: { name: "DamImageBlock", import: "@comet/cms-admin" } },

--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -37,10 +37,20 @@ export const ProductForm: FormConfig<GQLProduct> = {
             fields: [
                 {
                     type: "asyncSelect",
+                    virtual: true,
+                    name: "manufacturerCountry",
+                    gqlFieldName: "manufacturer",
+                    initQueryIdPath: "addressAsEmbeddable.country",
+                    initQueryLabelPath: "addressAsEmbeddable.country",
+                    rootQuery: "manufacturerCountries",
+                    labelField: "label",
+                },
+                {
+                    type: "asyncSelect",
                     name: "manufacturer",
                     rootQuery: "manufacturers",
                     filterField: {
-                        name: "type",
+                        name: "manufacturerCountry",
                         gqlVarType: "filter",
                         gqlVarName: "addressAsEmbeddable_country",
                     },

--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -41,7 +41,8 @@ export const ProductForm: FormConfig<GQLProduct> = {
                     rootQuery: "manufacturers",
                     filterField: {
                         name: "type",
-                        filterMapping: `addressAsEmbeddable_country: { equal: {value} }`,
+                        gqlVarType: "filter",
+                        gqlVarName: "addressAsEmbeddable_country",
                     },
                 },
                 { type: "boolean", name: "inStock" },

--- a/demo/admin/src/products/future/generated/ProductForm.gql.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.gql.tsx
@@ -13,6 +13,10 @@ export const productFormFragment = gql`
             id
             title
         }
+        manufacturer {
+            id
+            name
+        }
         inStock
         availableSince
         image

--- a/demo/admin/src/products/future/generated/ProductForm.gql.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.gql.tsx
@@ -13,6 +13,14 @@ export const productFormFragment = gql`
             id
             title
         }
+        manufacturerCountry: manufacturer {
+            id: addressAsEmbeddable {
+                country
+            }
+            label: addressAsEmbeddable {
+                country
+            }
+        }
         manufacturer {
             id
             name

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -12,6 +12,7 @@ import {
     FinalFormSubmitEvent,
     Loading,
     MainContent,
+    OnChangeField,
     TextAreaField,
     TextField,
     useFormApiRef,
@@ -29,7 +30,12 @@ import { FormSpy } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
 import { validateTitle } from "../validateTitle";
-import { GQLProductCategoriesSelectQuery, GQLProductCategoriesSelectQueryVariables } from "./ProductForm.generated";
+import {
+    GQLManufacturersSelectQuery,
+    GQLManufacturersSelectQueryVariables,
+    GQLProductCategoriesSelectQuery,
+    GQLProductCategoriesSelectQueryVariables,
+} from "./ProductForm.generated";
 import { createProductMutation, productFormFragment, productQuery, updateProductMutation } from "./ProductForm.gql";
 import {
     GQLCreateProductMutation,
@@ -96,6 +102,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
         const output = {
             ...formValues,
             category: formValues.category?.id,
+            manufacturer: formValues.manufacturer?.id,
             image: rootBlocks.image.state2Output(formValues.image),
         };
         if (mode === "edit") {
@@ -134,9 +141,9 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
             mode={mode}
             initialValues={initialValues}
             initialValuesEqual={isEqual} //required to compare block data correctly
-            subscription={{}}
+            subscription={{ values: true }}
         >
-            {() => (
+            {({ values, form }) => (
                 <>
                     {saveConflict.dialogs}
                     <MainContent>
@@ -242,6 +249,37 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                         </FieldSet>
 
                         <FieldSet collapsible title={<FormattedMessage id="product.additionalData.title" defaultMessage="Additional Data" />}>
+                            <AsyncSelectField
+                                variant="horizontal"
+                                fullWidth
+                                name="manufacturer"
+                                label={<FormattedMessage id="product.manufacturer" defaultMessage="Manufacturer" />}
+                                loadOptions={async () => {
+                                    const { data } = await client.query<GQLManufacturersSelectQuery, GQLManufacturersSelectQueryVariables>({
+                                        query: gql`
+                                            query ManufacturersSelect($filter: ManufacturerFilter) {
+                                                manufacturers(filter: $filter) {
+                                                    nodes {
+                                                        id
+                                                        name
+                                                    }
+                                                }
+                                            }
+                                        `,
+                                        variables: { filter: { addressAsEmbeddable_country: { equal: values.type } } },
+                                    });
+                                    return data.manufacturers.nodes;
+                                }}
+                                getOptionLabel={(option) => option.name}
+                                disabled={!values?.type}
+                            />
+                            <OnChangeField name="type">
+                                {(value, previousValue) => {
+                                    if (value.id !== previousValue.id) {
+                                        form.change("manufacturer", undefined);
+                                    }
+                                }}
+                            </OnChangeField>
                             <Field name="inStock" label="" type="checkbox" variant="horizontal" fullWidth>
                                 {(props) => (
                                     <FormControlLabel

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -451,6 +451,7 @@ type Manufacturer {
 
 type ManufacturerCountry {
   id: String!
+  label: String!
   used: Float!
 }
 

--- a/demo/api/src/products/entities/manufacturer-country.entity.ts
+++ b/demo/api/src/products/entities/manufacturer-country.entity.ts
@@ -4,7 +4,8 @@ import { Field, ObjectType } from "@nestjs/graphql";
 
 @ObjectType()
 @Entity({
-    expression: 'SELECT "addressAsEmbeddable_country" AS id, COUNT(*) AS used FROM "Manufacturer" GROUP BY "addressAsEmbeddable_country"',
+    expression:
+        'SELECT "addressAsEmbeddable_country" AS id, "addressAsEmbeddable_country" AS label, COUNT(*) AS used FROM "Manufacturer" GROUP BY "addressAsEmbeddable_country"',
 })
 // view-entity can't be saved or updated so disable create, update and delete
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/`, create: false, update: false, delete: false })
@@ -13,6 +14,11 @@ export class ManufacturerCountry {
     @Property()
     @CrudField({ sort: false }) // sort for "group by"-views currently not supported
     id: string;
+
+    @Field()
+    @Property()
+    @CrudField({ sort: false }) // sort for "group by"-views currently not supported
+    label: string;
 
     @Field()
     @Property()

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -311,7 +311,14 @@ export function generateForm(
                 : ""
         }
     
-        const handleSubmit = async (formValues: FormValues, form: FormApi<FormValues>${addMode ? `, event: FinalFormSubmitEvent` : ""}) => {
+        const handleSubmit = async (${
+            formValuesConfig.filter((config) => !!config.destructFromFormValues).length
+                ? `{ ${formValuesConfig
+                      .filter((config) => !!config.destructFromFormValues)
+                      .map((config) => config.destructFromFormValues)
+                      .join(", ")}, ...formValues }`
+                : `formValues`
+        }: FormValues, form: FormApi<FormValues>${addMode ? `, event: FinalFormSubmitEvent` : ""}) => {
             ${editMode ? `if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");` : ""}
             const output = {
                 ...formValues,

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -194,11 +194,8 @@ export function generateForm(
         });
     }
 
-    const finalFormSubscription = [...(generatedFields.finalFormConfig?.subscription?.values ? ["values"] : [])];
-    const finalFormRenderProps = [
-        ...(generatedFields.finalFormConfig?.renderProps?.values ? ["values"] : []),
-        ...(generatedFields.finalFormConfig?.renderProps?.form ? ["form"] : []),
-    ];
+    const finalFormSubscription = Object.keys(generatedFields.finalFormConfig?.subscription ?? {});
+    const finalFormRenderProps = Object.keys(generatedFields.finalFormConfig?.renderProps ?? {});
 
     const code = `import { useApolloClient, useQuery, gql } from "@apollo/client";
     import {

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -194,6 +194,12 @@ export function generateForm(
         });
     }
 
+    const finalFormSubscription = [...(generatedFields.finalFormConfig?.subscription?.values ? ["values"] : [])];
+    const finalFormRenderProps = [
+        ...(generatedFields.finalFormConfig?.renderProps?.values ? ["values"] : []),
+        ...(generatedFields.finalFormConfig?.renderProps?.form ? ["form"] : []),
+    ];
+
     const code = `import { useApolloClient, useQuery, gql } from "@apollo/client";
     import {
         AsyncSelectField,
@@ -382,9 +388,9 @@ export function generateForm(
                 mode=${mode == "all" ? `{mode}` : editMode ? `"edit"` : `"add"`}
                 initialValues={initialValues}
                 initialValuesEqual={isEqual} //required to compare block data correctly
-                subscription={{}}
+                subscription={{ ${finalFormSubscription.length ? finalFormSubscription.map((field) => `${field}: true`).join(", ") : ``} }}
             >
-                {() => (
+                {(${finalFormRenderProps.length ? `{${finalFormRenderProps.join(", ")}}` : ``}) => (
                     ${editMode ? `<>` : ``}
                         ${editMode ? `{saveConflict.dialogs}` : ``}
                         <MainContent>

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -17,8 +17,8 @@ export type GenerateFieldsReturn = GeneratorReturn & {
         defaultInitializationCode?: string;
     }[];
     finalFormConfig?: {
-        subscription?: { values: boolean };
-        renderProps?: { values?: boolean; form?: boolean };
+        subscription?: { values?: true };
+        renderProps?: { values?: true; form?: true };
     };
 };
 
@@ -49,7 +49,7 @@ export function generateFields({
     const formFragmentFields: string[] = [];
     const imports: Imports = [];
     const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
-    const finalFormConfig = { subscription: { values: false }, renderProps: { values: false, form: false } };
+    const finalFormConfig = { subscription: {}, renderProps: {} };
 
     const code = fields
         .map((field) => {
@@ -71,9 +71,8 @@ export function generateFields({
             formFragmentFields.push(...generated.formFragmentFields);
             formValuesConfig.push(...generated.formValuesConfig);
 
-            finalFormConfig.subscription.values = finalFormConfig.subscription.values || !!generated.finalFormConfig?.subscription?.values;
-            finalFormConfig.renderProps.values = finalFormConfig.renderProps.values || !!generated.finalFormConfig?.renderProps?.values;
-            finalFormConfig.renderProps.form = finalFormConfig.renderProps.form || !!generated.finalFormConfig?.renderProps?.form;
+            finalFormConfig.subscription = { ...finalFormConfig.subscription, ...generated.finalFormConfig?.subscription };
+            finalFormConfig.renderProps = { ...finalFormConfig.renderProps, ...generated.finalFormConfig?.renderProps };
 
             return generated.code;
         })

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -22,6 +22,14 @@ export type GenerateFieldsReturn = GeneratorReturn & {
     };
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function findFieldByName(name: string, fields: FormConfig<any>["fields"]): FormConfig<any>["fields"][0] | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return fields.reduce<FormConfig<any>["fields"][0] | undefined>((acc, field) => {
+        return acc ? acc : field.name === name ? field : isFormLayoutConfig(field) ? findFieldByName(name, field.fields) : undefined;
+    }, undefined);
+}
+
 export function generateFields({
     gqlIntrospection,
     baseOutputFilename,

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -16,6 +16,10 @@ export type GenerateFieldsReturn = GeneratorReturn & {
         initializationCode?: string;
         defaultInitializationCode?: string;
     }[];
+    finalFormConfig?: {
+        subscription?: { values: boolean };
+        renderProps?: { values?: boolean; form?: boolean };
+    };
 };
 
 export function generateFields({
@@ -37,6 +41,7 @@ export function generateFields({
     const formFragmentFields: string[] = [];
     const imports: Imports = [];
     const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
+    const finalFormConfig = { subscription: { values: false }, renderProps: { values: false, form: false } };
 
     const code = fields
         .map((field) => {
@@ -57,6 +62,11 @@ export function generateFields({
             formValueToGqlInputCode += generated.formValueToGqlInputCode;
             formFragmentFields.push(...generated.formFragmentFields);
             formValuesConfig.push(...generated.formValuesConfig);
+
+            finalFormConfig.subscription.values = finalFormConfig.subscription.values || !!generated.finalFormConfig?.subscription?.values;
+            finalFormConfig.renderProps.values = finalFormConfig.renderProps.values || !!generated.finalFormConfig?.renderProps?.values;
+            finalFormConfig.renderProps.form = finalFormConfig.renderProps.form || !!generated.finalFormConfig?.renderProps?.form;
+
             return generated.code;
         })
         .join("\n");
@@ -69,5 +79,6 @@ export function generateFields({
         gqlDocuments,
         imports,
         formValuesConfig,
+        finalFormConfig,
     };
 }

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -12,6 +12,7 @@ export type GenerateFieldsReturn = GeneratorReturn & {
     formValueToGqlInputCode: string;
     formValuesConfig: {
         omitFromFragmentType?: string;
+        destructFromFormValues?: string; // equals omitting from formValues copied directly to mutation-input
         typeCode?: string;
         initializationCode?: string;
         defaultInitializationCode?: string;

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -44,7 +44,10 @@ export function generateFormField({
     const readOnlyPropsWithLock = `${readOnlyProps} ${endAdornmentWithLockIconProp}`;
 
     const imports: Imports = [];
-    let formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
+    const defaultFormValuesConfig: GenerateFieldsReturn["formValuesConfig"][0] = {
+        destructFromFormValues: config.virtual ? name : undefined,
+    };
+    let formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [defaultFormValuesConfig];
 
     const gqlDocuments: Record<string, string> = {};
     const hooksCode = "";
@@ -109,7 +112,7 @@ export function generateFormField({
         if (isFieldOptional({ config, gqlIntrospection: gqlIntrospection, gqlType: gqlType })) {
             assignment = `formValues.${name} ? ${assignment} : null`;
         }
-        formValueToGqlInputCode = `${name}: ${assignment},`;
+        formValueToGqlInputCode = !config.virtual ? `${name}: ${assignment},` : ``;
 
         let initializationAssignment = `String(data.${instanceGqlType}.${name})`;
         if (!required) {
@@ -117,9 +120,12 @@ export function generateFormField({
         }
         formValuesConfig = [
             {
-                omitFromFragmentType: name,
-                typeCode: `${name}${!required ? `?` : ``}: string;`,
-                initializationCode: `${name}: ${initializationAssignment}`,
+                ...defaultFormValuesConfig,
+                ...{
+                    omitFromFragmentType: name,
+                    typeCode: `${name}${!required ? `?` : ``}: string;`,
+                    initializationCode: `${name}: ${initializationAssignment}`,
+                },
             },
         ];
     } else if (config.type == "boolean") {
@@ -140,7 +146,10 @@ export function generateFormField({
         </Field>`;
         formValuesConfig = [
             {
-                defaultInitializationCode: `${name}: false`,
+                ...defaultFormValuesConfig,
+                ...{
+                    defaultInitializationCode: `${name}: false`,
+                },
             },
         ];
     } else if (config.type == "date") {
@@ -164,19 +173,25 @@ export function generateFormField({
             />`;
         formValuesConfig = [
             {
-                initializationCode: `${name}: data.${instanceGqlType}.${name} ? new Date(data.${instanceGqlType}.${name}) : undefined`,
+                ...defaultFormValuesConfig,
+                ...{
+                    initializationCode: `${name}: data.${instanceGqlType}.${name} ? new Date(data.${instanceGqlType}.${name}) : undefined`,
+                },
             },
         ];
     } else if (config.type == "block") {
         code = `<Field name="${name}" isEqual={isEqual}>
             {createFinalFormBlock(rootBlocks.${String(config.name)})}
         </Field>`;
-        formValueToGqlInputCode = `${name}: rootBlocks.${name}.state2Output(formValues.${name}),`;
+        formValueToGqlInputCode = !config.virtual ? `${name}: rootBlocks.${name}.state2Output(formValues.${name}),` : ``;
         formValuesConfig = [
             {
-                typeCode: `${name}: BlockState<typeof rootBlocks.${name}>;`,
-                initializationCode: `${name}: rootBlocks.${name}.input2State(data.${instanceGqlType}.${name})`,
-                defaultInitializationCode: `${name}: rootBlocks.${name}.defaultValues()`,
+                ...defaultFormValuesConfig,
+                ...{
+                    typeCode: `${name}: BlockState<typeof rootBlocks.${name}>;`,
+                    initializationCode: `${name}: rootBlocks.${name}.input2State(data.${instanceGqlType}.${name})`,
+                    defaultInitializationCode: `${name}: rootBlocks.${name}.defaultValues()`,
+                },
             },
         ];
     } else if (config.type == "staticSelect") {
@@ -257,7 +272,7 @@ export function generateFormField({
             finalFormConfig = { subscription: { values: true }, renderProps: { values: true, form: true } };
         }
 
-        formValueToGqlInputCode = `${name}: formValues.${name}?.id,`;
+        formValueToGqlInputCode = !config.virtual ? `${name}: formValues.${name}?.id,` : ``;
         imports.push({
             name: `GQL${queryName}Query`,
             importPath: `./${baseOutputFilename}.generated`,

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -47,6 +47,7 @@ export function generateFormField({
 
     const gqlDocuments: Record<string, string> = {};
     const hooksCode = "";
+    let finalFormConfig: GenerateFieldsReturn["finalFormConfig"];
 
     let validateCode = "";
     if (config.validate) {
@@ -288,5 +289,6 @@ export function generateFormField({
         gqlDocuments,
         imports,
         formValuesConfig,
+        finalFormConfig,
     };
 }

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -287,11 +287,18 @@ export function generateFormField({
                                 }
                             }
                         }\`${
-                            filterField && rootQueryFilterType
-                                ? `, variables: { filter: { ${config.filterField?.filterMapping.replace(
-                                      /{value}/,
-                                      `values.${filterField.type === "asyncSelect" ? `${String(filterField.name)}?.id` : String(filterField.name)}`,
-                                  )} } }`
+                            filterField && rootQueryFilterType && config.filterField
+                                ? `, variables: { ${(config.filterField?.gqlVarType === "filter"
+                                      ? `filter: { gqlVarName: { equal: valuesVar } }`
+                                      : `gqlVarName: valuesVar`
+                                  )
+                                      .replace(`gqlVarName`, config.filterField.gqlVarName)
+                                      .replace(
+                                          `valuesVar`,
+                                          `values.${
+                                              filterField.type === "asyncSelect" ? `${String(filterField.name)}?.id` : String(filterField.name)
+                                          }`,
+                                      )} }`
                                 : ``
                         }
                     });

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
@@ -27,7 +27,7 @@ export function generateFormLayout({
     const gqlDocuments: Record<string, string> = {};
     const imports: Imports = [];
     const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
-    const finalFormConfig = { subscription: { values: false }, renderProps: { values: false, form: false } };
+    const finalFormConfig = { subscription: {}, renderProps: {} };
 
     if (config.type === "fieldSet") {
         const generatedFields = generateFields({ gqlIntrospection, baseOutputFilename, fields: config.fields, formConfig });
@@ -40,9 +40,8 @@ export function generateFormLayout({
         imports.push(...generatedFields.imports);
         formValuesConfig.push(...generatedFields.formValuesConfig);
 
-        finalFormConfig.subscription.values = finalFormConfig.subscription.values || !!generatedFields.finalFormConfig?.subscription?.values;
-        finalFormConfig.renderProps.values = finalFormConfig.renderProps.values || !!generatedFields.finalFormConfig?.renderProps?.values;
-        finalFormConfig.renderProps.form = finalFormConfig.renderProps.form || !!generatedFields.finalFormConfig?.renderProps?.form;
+        finalFormConfig.subscription = { ...finalFormConfig.subscription, ...generatedFields.finalFormConfig?.subscription };
+        finalFormConfig.renderProps = { ...finalFormConfig.renderProps, ...generatedFields.finalFormConfig?.renderProps };
 
         imports.push({ name: "FieldSet", importPath: "@comet/admin" });
         const supportPlaceholder = config.supportText?.includes("{");

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
@@ -27,6 +27,7 @@ export function generateFormLayout({
     const gqlDocuments: Record<string, string> = {};
     const imports: Imports = [];
     const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
+    const finalFormConfig = { subscription: { values: false }, renderProps: { values: false, form: false } };
 
     if (config.type === "fieldSet") {
         const generatedFields = generateFields({ gqlIntrospection, baseOutputFilename, fields: config.fields, formConfig });
@@ -38,6 +39,10 @@ export function generateFormLayout({
         }
         imports.push(...generatedFields.imports);
         formValuesConfig.push(...generatedFields.formValuesConfig);
+
+        finalFormConfig.subscription.values = finalFormConfig.subscription.values || !!generatedFields.finalFormConfig?.subscription?.values;
+        finalFormConfig.renderProps.values = finalFormConfig.renderProps.values || !!generatedFields.finalFormConfig?.renderProps?.values;
+        finalFormConfig.renderProps.form = finalFormConfig.renderProps.form || !!generatedFields.finalFormConfig?.renderProps?.form;
 
         imports.push({ name: "FieldSet", importPath: "@comet/admin" });
         const supportPlaceholder = config.supportText?.includes("{");
@@ -76,5 +81,6 @@ export function generateFormLayout({
         gqlDocuments,
         imports,
         formValuesConfig,
+        finalFormConfig,
     };
 }

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -15,6 +15,7 @@ import { getPropsForFilterProp } from "./generateGrid/getPropsForFilterProp";
 import { GeneratorReturn, GridConfig } from "./generator";
 import { camelCaseToHumanReadable } from "./utils/camelCaseToHumanReadable";
 import { findMutationType } from "./utils/findMutationType";
+import { findQueryTypeOrThrow } from "./utils/findQueryType";
 import { findRootBlocks } from "./utils/findRootBlocks";
 import { generateImportsCode, Imports } from "./utils/generateImportsCode";
 
@@ -25,20 +26,6 @@ function tsCodeRecordToString(object: TsCodeRecordToStringObject) {
         .filter(([key, value]) => value !== undefined)
         .map(([key, value]) => `${key}: ${value},`)
         .join("\n")}}`;
-}
-
-function findQueryType(queryName: string, schema: IntrospectionQuery) {
-    const queryType = schema.__schema.types.find((type) => type.name === schema.__schema.queryType.name) as IntrospectionObjectType | undefined;
-    if (!queryType) throw new Error("Can't find Query type in gql schema");
-    const ret = queryType.fields.find((field) => field.name === queryName);
-    if (!ret) throw new Error(`Can't find query ${queryName} in gql schema`);
-    return ret;
-}
-
-function findQueryTypeOrThrow(queryName: string, schema: IntrospectionQuery) {
-    const ret = findQueryType(queryName, schema);
-    if (!ret) throw new Error(`Can't find query ${queryName} in gql schema`);
-    return ret;
 }
 
 export type Prop = { type: string; optional: boolean; name: string };

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -26,8 +26,10 @@ export type FormFieldConfig<T> = (
           type: "asyncSelect";
           name: string; // not "keyof T" because it can fetch anything to filter another asyncSelect
           gqlFieldName?: keyof T;
+          initQueryIdPath?: string; // if gqlField-object does not have an id-field, or it's required to use any other field, e.g. asyncSelect is used for filtering; dot-separated
+          initQueryLabelPath?: string; // if label is not on first level of gqlField-object; dot-separated
           rootQuery: string;
-          labelField?: string;
+          labelField?: string; // should be the field used as option-label of the rootQuery
           filterField?: { name: string; gqlVarName: string; gqlVarType: "rootProp" | "filter" };
       }
     | { type: "block"; name: keyof T; block: ImportReference }

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -22,7 +22,12 @@ export type FormFieldConfig<T> = (
     | { type: "date" }
     // TODO | { type: "dateTime" }
     | { type: "staticSelect"; values?: string[] }
-    | { type: "asyncSelect"; rootQuery: string; labelField?: string }
+    | {
+          type: "asyncSelect";
+          rootQuery: string;
+          labelField?: string;
+          filterField?: { name: string; filterMapping: string };
+      }
     | { type: "block"; block: ImportReference }
 ) & { name: keyof T; label?: string; required?: boolean; validate?: ImportReference; helperText?: string; readOnly?: boolean };
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -16,20 +16,23 @@ type ImportReference = {
 };
 
 export type FormFieldConfig<T> = (
-    | { type: "text"; multiline?: boolean }
-    | { type: "number" }
-    | { type: "boolean" }
-    | { type: "date" }
+    | { type: "text"; name: keyof T; multiline?: boolean }
+    | { type: "number"; name: keyof T }
+    | { type: "boolean"; name: keyof T }
+    | { type: "date"; name: keyof T }
     // TODO | { type: "dateTime" }
-    | { type: "staticSelect"; values?: string[] }
+    | { type: "staticSelect"; name: keyof T; values?: string[] }
     | {
           type: "asyncSelect";
+          name: string; // not "keyof T" because it can fetch anything to filter another asyncSelect
+          gqlFieldName?: keyof T;
           rootQuery: string;
           labelField?: string;
           filterField?: { name: string; gqlVarName: string; gqlVarType: "rootProp" | "filter" };
       }
-    | { type: "block"; block: ImportReference }
-) & { name: keyof T; label?: string; required?: boolean; virtual?: boolean; validate?: ImportReference; helperText?: string; readOnly?: boolean };
+    | { type: "block"; name: keyof T; block: ImportReference }
+) & { label?: string; required?: boolean; virtual?: boolean; validate?: ImportReference; helperText?: string; readOnly?: boolean };
+
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export function isFormFieldConfig<T>(arg: any): arg is FormFieldConfig<T> {
     return !isFormLayoutConfig(arg);

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -26,7 +26,7 @@ export type FormFieldConfig<T> = (
           type: "asyncSelect";
           rootQuery: string;
           labelField?: string;
-          filterField?: { name: string; filterMapping: string };
+          filterField?: { name: string; gqlVarName: string; gqlVarType: "rootProp" | "filter" };
       }
     | { type: "block"; block: ImportReference }
 ) & { name: keyof T; label?: string; required?: boolean; validate?: ImportReference; helperText?: string; readOnly?: boolean };

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -29,7 +29,7 @@ export type FormFieldConfig<T> = (
           filterField?: { name: string; gqlVarName: string; gqlVarType: "rootProp" | "filter" };
       }
     | { type: "block"; block: ImportReference }
-) & { name: keyof T; label?: string; required?: boolean; validate?: ImportReference; helperText?: string; readOnly?: boolean };
+) & { name: keyof T; label?: string; required?: boolean; virtual?: boolean; validate?: ImportReference; helperText?: string; readOnly?: boolean };
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export function isFormFieldConfig<T>(arg: any): arg is FormFieldConfig<T> {
     return !isFormLayoutConfig(arg);

--- a/packages/admin/cms-admin/src/generator/future/utils/findQueryType.ts
+++ b/packages/admin/cms-admin/src/generator/future/utils/findQueryType.ts
@@ -1,0 +1,15 @@
+import { IntrospectionObjectType, IntrospectionQuery } from "graphql";
+
+export function findQueryType(queryName: string, schema: IntrospectionQuery) {
+    const queryType = schema.__schema.types.find((type) => type.name === schema.__schema.queryType.name) as IntrospectionObjectType | undefined;
+    if (!queryType) throw new Error("Can't find Query type in gql schema");
+    const ret = queryType.fields.find((field) => field.name === queryName);
+    if (!ret) throw new Error(`Can't find query ${queryName} in gql schema`);
+    return ret;
+}
+
+export function findQueryTypeOrThrow(queryName: string, schema: IntrospectionQuery) {
+    const ret = findQueryType(queryName, schema);
+    if (!ret) throw new Error(`Can't find query ${queryName} in gql schema`);
+    return ret;
+}

--- a/packages/admin/cms-admin/src/generator/future/utils/isFieldOptional.ts
+++ b/packages/admin/cms-admin/src/generator/future/utils/isFieldOptional.ts
@@ -4,11 +4,13 @@ import { FormFieldConfig } from "../generator";
 
 export const isFieldOptional = ({
     config,
+    gqlFieldName,
     gqlIntrospection,
     gqlType,
 }: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     config: FormFieldConfig<any>;
+    gqlFieldName: string;
     gqlIntrospection: IntrospectionQuery;
     gqlType: string;
 }): boolean => {
@@ -23,7 +25,7 @@ export const isFieldOptional = ({
     const schemaEntity = gqlIntrospection.__schema.types.find((type) => type.kind === "OBJECT" && type.name === gqlType);
     if (!schemaEntity) throw new Error(`didn't find entity ${gqlType} in schema types`);
     if (schemaEntity.kind !== "OBJECT") throw new Error(`kind of ${gqlType} is not object, but should be.`); // this should not happen
-    const fieldDef = schemaEntity.fields.find((field) => field.name === String(config.name));
-    if (!fieldDef) throw new Error(`didn't find field ${String(config.name)} of ${gqlType} in introspected gql-schema.`);
+    const fieldDef = schemaEntity.fields.find((field) => field.name === gqlFieldName);
+    if (!fieldDef) throw new Error(`didn't find field ${gqlFieldName} of ${gqlType} in introspected gql-schema.`);
     return fieldDef.type.kind !== "NON_NULL";
 };


### PR DESCRIPTION
To use an asyncSelect as filter for another asyncSelect it's often required to initially fetch the same nested entity with different attributes and map them to id and label.

e.g.

```
vehicle {
    vin
    brand: model { // => init-source for filter-field
        id: brand { id }
        name: brand { name }
    }
    model { // init-source for filtered-field
        id
        name
        [ brand { id name } ] // brand is nested this way
    }
}

brands { // query providing options for filter-field 
    id
    name
}

models(brand: $brand) { // query providing options for filtered-field
    id
    name
}
```

it also works if for some reason it's not nested and foreign-key is on entity-root. For now it's not possible to map id/label for the query providing options. It's required to implement a query suited as asyncSelect-options query. (needs id and field used as label)
```
vehicle {
    vin
    brand: model { // => init-source for filter-field
        id: brandId
        name: brandId
    }
    model { // init-source for filtered-field
        id
        name
        [ brandId ] // only id in schema
    }
}

brands { // query providing options for filter-field 
    id
    name
}

models(brand: $brand) { // query providing options for filtered-field
    id
    name
}
```