### PR TITLE
Fix false positives in `resolveHasSaveConflict` check

### DIFF
--- a/.changeset/pink-glasses-build.md
+++ b/.changeset/pink-glasses-build.md
@@ -1,5 +1,8 @@
 ---
-"@comet/cms-admin": minor
+"@comet/cms-admin": patch
 ---
 
-Round Update Date to full seconds in resolveHasSaveConflict Check
+Fix false positives in `resolveHasSaveConflict` check
+
+The check occasionally failed due to rounding errors.
+This is fixed by rounding to full seconds before checking.

--- a/.changeset/pink-glasses-build.md
+++ b/.changeset/pink-glasses-build.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Round Update Date to full seconds in resolveHasSaveConflict Check

--- a/packages/admin/cms-admin/src/pages/resolveHasSaveConflict.tsx
+++ b/packages/admin/cms-admin/src/pages/resolveHasSaveConflict.tsx
@@ -1,9 +1,16 @@
-import { isAfter, parseISO } from "date-fns";
+import { addSeconds, isAfter, parseISO, startOfSecond } from "date-fns";
 
 export function resolveHasSaveConflict(referenceDateAsString?: string, newDateAsString?: string): boolean {
     if (referenceDateAsString != null && newDateAsString != null) {
-        const referenceDate = parseISO(referenceDateAsString);
-        const newDate = parseISO(newDateAsString);
+        const referenceDate =
+            parseISO(referenceDateAsString).getMilliseconds() < 500
+                ? startOfSecond(parseISO(referenceDateAsString))
+                : startOfSecond(addSeconds(parseISO(referenceDateAsString), 1));
+        const newDate =
+            parseISO(newDateAsString).getMilliseconds() < 500
+                ? startOfSecond(parseISO(newDateAsString))
+                : startOfSecond(addSeconds(parseISO(newDateAsString), 1));
+
         return isAfter(newDate, referenceDate);
     }
     return false;


### PR DESCRIPTION
The check occasionally failed due to rounding errors.
This is fixed by rounding to full seconds before checking.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-939
-   [x] Provide screenshots/screencasts if the change contains visual changes


