### PR TITLE
Add Storybook and Docs to dev-pm config

### DIFF
--- a/dev-pm.config.js
+++ b/dev-pm.config.js
@@ -245,5 +245,13 @@ module.exports = {
             group: ["demo-site-pages", "demo"],
             waitOn: ["tcp:$API_PORT"],
         },
+        {
+            name: "docs",
+            script: "pnpm --filter comet-docs start",
+        },
+        {
+            name: "storybook",
+            script: "pnpm --filter comet-storybook run storybook",
+        },
     ],
 };

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
         "lint:root": "$npm_execpath prettier --check './!(demo|docs|packages|storybook)/**/*.{js,json,md,yml,yaml}'",
         "lint:eslint": "pnpm recursive run lint:eslint",
         "lint:tsc": "pnpm recursive run lint:tsc",
-        "storybook": "pnpm --filter comet-storybook run storybook",
-        "docs": "pnpm --filter ./docs run start",
+        "storybook": "dev-pm start storybook",
+        "docs": "dev-pm start docs",
         "test": "pnpm recursive run test",
         "version": "$npm_execpath changeset version && pnpm install --lockfile-only",
         "publish": "pnpm run build:packages && $npm_execpath changeset publish"


### PR DESCRIPTION
With this all our development processes are managed by dev-pm. This allows to have logs for Storybook and a package in the same terminal window, for instance `npx dev-pm logs storybook comet-admin`. One downside of this approach is that the logs for Storybook and Docs aren't followed automatically anymore.