### PR TITLE
Admin-Generator: add option to export query, e.g. used for refetchQueries

### DIFF
--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -366,7 +366,7 @@ export function generateGrid(
         }
     \`;
 
-    const ${instanceGqlTypePlural}Query = gql\`
+    ${config.exportQuery ? `export ` : ``}const ${instanceGqlTypePlural}Query = gql\`
         query ${gqlTypePlural}Grid(${[
         ...gqlArgs.filter((gqlArg) => gqlArg.queryOrMutationName === gridQueryType.name).map((gqlArg) => `$${gqlArg.name}: ${gqlArg.type}!`),
         ...[`$offset: Int!`, `$limit: Int!`],

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -71,6 +71,7 @@ export type GridConfig<T extends { __typename?: string }> = {
     gqlType: T["__typename"];
     fragmentName?: string;
     query?: string;
+    exportQuery?: boolean; // to refetch from outside
     columns: GridColumnConfig<T>[];
     add?: boolean;
     edit?: boolean;


### PR DESCRIPTION
Enable refetch grid-contents from outside of the grid, required e.g. if rows where added/removed. The easiest way is to use apolloClient.refetchQueries referencing the now exportable query