### PR TITLE
Improve variable naming and typing for `muiGridFilterToGql`

### DIFF
--- a/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
+++ b/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
@@ -46,7 +46,7 @@ type GqlFilter = {
     or?: GqlFilter[] | null;
 };
 
-function convertValueByType(value: string, type?: string) {
+function convertValueByType(value: any, type?: string) {
     if (type === "number") {
         return parseFloat(value);
     } else if (type === "boolean") {

--- a/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
+++ b/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
@@ -61,14 +61,14 @@ function convertValueByType(value: string, type?: string) {
 export function muiGridFilterToGql(columns: GridColDef[], filterModel?: GridFilterModel): { filter: GqlFilter; search?: string } {
     if (!filterModel) return { filter: {} };
     const filterItems = filterModel.items
-        .filter((value) => value.value !== undefined)
-        .map((value) => {
-            if (!value.operatorValue) throw new Error("operaturValue not set");
-            const gqlOperator = muiGridOperatorValueToGqlOperator[value.operatorValue] || value.operatorValue;
-            const column = columns.find((i) => i.field == value.columnField);
-            const convertedValue = convertValueByType(value.value, column?.type);
+        .filter((filterItem) => filterItem.value !== undefined)
+        .map((filterItem) => {
+            if (!filterItem.operatorValue) throw new Error("operaturValue not set");
+            const gqlOperator = muiGridOperatorValueToGqlOperator[filterItem.operatorValue] || filterItem.operatorValue;
+            const column = columns.find((i) => i.field == filterItem.columnField);
+            const convertedValue = convertValueByType(filterItem.value, column?.type);
             return {
-                [value.columnField]: {
+                [filterItem.columnField]: {
                     [gqlOperator]: convertedValue,
                 } as GqlStringFilter | GqlNumberFilter,
             };


### PR DESCRIPTION
Small improvements for `muiGridFilterToGql`
- Change name `value` to `filterItem` because value is actually a field inside of this variable
- Vhange type for `value`-param of `convertValueByType`-function to `any` because it's only called with a field with type `any`. This should actually be detected by TypeScript, but I don't know why not.

---

**Note**
- it was not required to add ts-ignore to use `any` as param-type.
- this change should not need a changelog because it's only internal