### PR TITLE
Override `padding-right` of `MuiTablePagination` to fix DataGrid pagination select styling

### DIFF
--- a/.changeset/long-dolls-shake.md
+++ b/.changeset/long-dolls-shake.md
@@ -2,7 +2,4 @@
 "@comet/admin-theme": patch
 ---
 
-Override `padding-right` of `MuiTablePagination`
-
-This fixes the styling of the pagination select in `DataGrid`s.
-Previously, the text and icon stuck together.
+Fix spacing between page number and chevron icon in the pagination select of `DataGrid`

--- a/.changeset/long-dolls-shake.md
+++ b/.changeset/long-dolls-shake.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin-theme": patch
+---
+
+Override `padding-right` of `MuiTablePagination`
+
+This fixes the styling of the pagination select in `DataGrid`s.
+Previously, the text and icon stuck together.

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTablePagination.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTablePagination.ts
@@ -1,0 +1,15 @@
+import { inputBaseClasses, tablePaginationClasses } from "@mui/material";
+
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiTablePagination: GetMuiComponentTheme<"MuiTablePagination"> = (component, { palette }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiTablePagination">(component?.styleOverrides, {
+        select: {
+            [`&.${inputBaseClasses.input}.${tablePaginationClasses.select}`]: {
+                paddingRight: 32,
+            },
+        },
+    }),
+});

--- a/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
@@ -42,6 +42,7 @@ import { getMuiSvgIcon } from "./MuiSvgIcon";
 import { getMuiSwitch } from "./MuiSwitch";
 import { getMuiTab } from "./MuiTab";
 import { getMuiTableCell } from "./MuiTableCell";
+import { getMuiTablePagination } from "./MuiTablePagination";
 import { getMuiTableRow } from "./MuiTableRow";
 import { getMuiTabs } from "./MuiTabs";
 import { getMuiToggleButton } from "./MuiToggleButton";
@@ -108,4 +109,5 @@ export const getComponentsTheme = (components: Components, themeData: ThemeData)
     MuiToggleButtonGroup: getMuiToggleButtonGroup(components.MuiToggleButtonGroup, themeData),
     MuiTooltip: getMuiTooltip(components.MuiTooltip, themeData),
     MuiTypography: getMuiTypography(components.MuiTypography, themeData),
+    MuiTablePagination: getMuiTablePagination(components.MuiTablePagination, themeData),
 });


### PR DESCRIPTION
Override `padding-right` of `MuiTablePagination`

This fixes the styling of the pagination select in `DataGrid`s.
Previously, the text and icon stuck together.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-1004
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Previously:

<img width="1728" alt="Bildschirmfoto 2024-08-08 um 09 17 47" src="https://github.com/user-attachments/assets/cb854563-a5b4-4c86-9d4c-db966692f8fb">


Now:

<img width="1728" alt="Bildschirmfoto 2024-08-08 um 09 17 33" src="https://github.com/user-attachments/assets/b8c84d58-461a-40dc-975b-3613330cd2f5">


</details>
