### PR TITLE
Add `RadioGroupField` component to make it easier to create radio group fields in forms

### DIFF
--- a/.changeset/sharp-mails-film.md
+++ b/.changeset/sharp-mails-film.md
@@ -2,7 +2,7 @@
 "@comet/admin": minor
 ---
 
-Add `RadioGroupField` component to make it easier to create radio fields in final forms
+Add `RadioGroupField` component to make it easier to create radio group fields in forms
 
 You can now do:
 

--- a/.changeset/sharp-mails-film.md
+++ b/.changeset/sharp-mails-film.md
@@ -1,0 +1,38 @@
+---
+"@comet/admin": minor
+---
+
+Add `RadioGroupField` component to make it easier to create radio fields in final forms
+
+You can now do:
+
+```tsx
+<RadioGroupField
+    label="Radio"
+    name="radio"
+    fullWidth
+    options={[
+        {
+            label: "Option One",
+            value: "option-one",
+        },
+        {
+            label: "Option Two",
+            value: "option-two",
+        },
+    ]}
+/>
+```
+
+instead of:
+
+```tsx
+<FieldContainer label="Radio" fullWidth>
+    <Field name="radio" type="radio" value="option-one">
+        {(props) => <FormControlLabel label="Option One" control={<FinalFormRadio {...props} />} />}
+    </Field>
+    <Field name="radio" type="radio" value="option-two">
+        {(props) => <FormControlLabel label="Option Two" control={<FinalFormRadio {...props} />} />}
+    </Field>
+</FieldContainer>
+```

--- a/packages/admin/admin/src/form/fields/RadioGroupField.tsx
+++ b/packages/admin/admin/src/form/fields/RadioGroupField.tsx
@@ -1,0 +1,29 @@
+import { FormControlLabel, RadioGroup } from "@mui/material";
+import MuiRadio from "@mui/material/Radio";
+import React from "react";
+
+import { Field, FieldProps } from "../../form/Field";
+
+type RadioGroupFieldOption<Value extends string> = {
+    label: React.ReactNode;
+    value: Value;
+};
+
+export type RadioGroupFieldProps<Value extends string> = FieldProps<Value, HTMLInputElement> & {
+    options: RadioGroupFieldOption<Value>[];
+    layout?: "row" | "column";
+};
+
+export const RadioGroupField = <Value extends string>({ options, layout = "row", ...restProps }: RadioGroupFieldProps<Value>) => {
+    return (
+        <Field<Value> {...restProps}>
+            {({ input: { checked, value, onBlur, onFocus, ...restInput } }) => (
+                <RadioGroup {...restInput} row={layout === "row"}>
+                    {options.map(({ value, label }) => (
+                        <FormControlLabel key={value} label={label} value={value} control={<MuiRadio />} />
+                    ))}
+                </RadioGroup>
+            )}
+        </Field>
+    );
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -83,6 +83,7 @@ export { AsyncSelectField, AsyncSelectFieldProps } from "./form/fields/AsyncSele
 export { AutocompleteField, AutocompleteFieldProps } from "./form/fields/AutocompleteField";
 export { CheckboxField, CheckboxFieldProps } from "./form/fields/CheckboxField";
 export { NumberField, NumberFieldProps } from "./form/fields/NumberField";
+export { RadioGroupField, RadioGroupFieldProps } from "./form/fields/RadioGroupField";
 export { SearchField, SearchFieldProps } from "./form/fields/SearchField";
 export { SelectField, SelectFieldProps } from "./form/fields/SelectField";
 export { SwitchField, SwitchFieldProps } from "./form/fields/SwitchField";

--- a/storybook/src/admin/form/AllFieldComponents.tsx
+++ b/storybook/src/admin/form/AllFieldComponents.tsx
@@ -6,9 +6,9 @@ import {
     Field,
     FieldContainer,
     FieldSet,
-    FinalFormRadio,
     FinalFormRangeInput,
     NumberField,
+    RadioGroupField,
     SearchField,
     SelectField,
     SwitchField,
@@ -17,7 +17,7 @@ import {
 } from "@comet/admin";
 import { ColorField } from "@comet/admin-color-picker";
 import { DateField, DateRangeField, DateTimeField, TimeField, TimeRangeField } from "@comet/admin-date-time";
-import { Box, Button, FormControlLabel, Link, MenuItem } from "@mui/material";
+import { Box, Button, Link, MenuItem } from "@mui/material";
 import { select } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
@@ -95,6 +95,7 @@ function Story() {
                                 fullWidth
                             />
                         </FieldSet>
+
                         <FieldSet title="Field-Components with Field-Container">
                             <CheckboxField name="singleCheckbox" fieldLabel="Single Checkbox" variant={fieldVariant} fullWidth />
                             <CheckboxField
@@ -121,34 +122,78 @@ function Story() {
                                 <CheckboxField name="checkboxList" label="Checkbox five" value="checkbox-five" />
                             </FieldContainer>
                             <SwitchField name="switch" label={values.switch ? "On" : "Off"} fieldLabel="Switch" variant={fieldVariant} />
-                            <FieldContainer label="Radio" variant={fieldVariant} fullWidth>
-                                <Field name="radio" type="radio" value="option-one">
-                                    {(props) => <FormControlLabel label="Option One" control={<FinalFormRadio {...props} />} />}
-                                </Field>
-                                <Field name="radio" type="radio" value="option-two">
-                                    {(props) => <FormControlLabel label="Option Two" control={<FinalFormRadio {...props} />} />}
-                                </Field>
-                            </FieldContainer>
-                            <FieldContainer label="Radio (many options)" variant={fieldVariant} fullWidth>
-                                <Field name="radioManyOptions" type="radio" value="option-one">
-                                    {(props) => <FormControlLabel label="Option One" control={<FinalFormRadio {...props} />} />}
-                                </Field>
-                                <Field name="radioManyOptions" type="radio" value="option-two">
-                                    {(props) => <FormControlLabel label="Option Two" control={<FinalFormRadio {...props} />} />}
-                                </Field>
-                                <Field name="radioManyOptions" type="radio" value="option-three">
-                                    {(props) => <FormControlLabel label="Option Three" control={<FinalFormRadio {...props} />} />}
-                                </Field>
-                                <Field name="radioManyOptions" type="radio" value="option-four">
-                                    {(props) => <FormControlLabel label="Option Four" control={<FinalFormRadio {...props} />} />}
-                                </Field>
-                                <Field name="radioManyOptions" type="radio" value="option-five">
-                                    {(props) => <FormControlLabel label="Option Five" control={<FinalFormRadio {...props} />} />}
-                                </Field>
-                                <Field name="radioManyOptions" type="radio" value="option-six">
-                                    {(props) => <FormControlLabel label="Option Six" control={<FinalFormRadio {...props} />} />}
-                                </Field>
-                            </FieldContainer>
+                        </FieldSet>
+                        <FieldSet title="Radio Groups">
+                            <RadioGroupField
+                                label="Required"
+                                name="radio"
+                                variant={fieldVariant}
+                                fullWidth
+                                required
+                                options={[
+                                    {
+                                        label: "Option One",
+                                        value: "option-one",
+                                    },
+                                    {
+                                        label: "Option Two",
+                                        value: "option-two",
+                                    },
+                                ]}
+                            />
+                            <RadioGroupField
+                                label="Many Options"
+                                name="radioGroupManyOptions"
+                                variant={fieldVariant}
+                                fullWidth
+                                options={[
+                                    {
+                                        label: "Option One",
+                                        value: "option-one",
+                                    },
+                                    {
+                                        label: "Option Two",
+                                        value: "option-two",
+                                    },
+                                    {
+                                        label: "Option Three",
+                                        value: "option-three",
+                                    },
+                                    {
+                                        label: "Option Four",
+                                        value: "option-four",
+                                    },
+                                    {
+                                        label: "Option Five",
+                                        value: "option-five",
+                                    },
+                                    {
+                                        label: "Option Six",
+                                        value: "option-six",
+                                    },
+                                ]}
+                            />
+                            <RadioGroupField
+                                label="Column Layout"
+                                name="radioGroupFullWidthOptions"
+                                variant={fieldVariant}
+                                layout="column"
+                                fullWidth
+                                options={[
+                                    {
+                                        label: "Option One",
+                                        value: "option-one",
+                                    },
+                                    {
+                                        label: "Option Two",
+                                        value: "option-two",
+                                    },
+                                    {
+                                        label: "Option Three",
+                                        value: "option-three",
+                                    },
+                                ]}
+                            />
                         </FieldSet>
                         <FieldSet title="Number Range">
                             <Field


### PR DESCRIPTION
You can now do:

```tsx
<RadioGroupField
    label="Radio"
    name="radio"
    fullWidth
    options={[
        {
            label: "Option One",
            value: "option-one",
        },
        {
            label: "Option Two",
            value: "option-two",
        },
    ]}
/>
```

instead of:

```tsx
<FieldContainer label="Radio" fullWidth>
    <Field name="radio" type="radio" value="option-one">
        {(props) => <FormControlLabel label="Option One" control={<FinalFormRadio {...props} />} />}
    </Field>
    <Field name="radio" type="radio" value="option-two">
        {(props) => <FormControlLabel label="Option Two" control={<FinalFormRadio {...props} />} />}
    </Field>
</FieldContainer>
```

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-995
