### PR TITLE
Change text color of FilePreview action buttons to white

### DIFF
--- a/.changeset/good-cameras-bathe.md
+++ b/.changeset/good-cameras-bathe.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Change text color of `FilePreview` action buttons to white
+
+Previously, the text was invisible because it was black on a black background.

--- a/packages/admin/cms-admin/src/dam/FileForm/FilePreview.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/FilePreview.tsx
@@ -32,7 +32,7 @@ const ActionsContainer = styled("div")`
 `;
 
 const ActionButton = styled(Button)`
-    color: ${({ theme }) => theme.palette.primary.contrastText};
+    color: white;
 `;
 
 const FileWrapper = styled(Paper)`


### PR DESCRIPTION
Previously, the text was invisible because it was black on a black background.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Previously:

<img width="1728" alt="Bildschirmfoto 2024-08-08 um 15 50 22" src="https://github.com/user-attachments/assets/9b427e6b-9b97-40d8-99b9-3ea8e39eed3e">


Now:

<img width="1728" alt="Bildschirmfoto 2024-08-08 um 15 48 15" src="https://github.com/user-attachments/assets/677946e7-94e0-450f-a360-4a55507ac7bf">



</details>
