### PR TITLE
Add `CheckboxListField` component

### DIFF
--- a/.changeset/odd-trees-carry.md
+++ b/.changeset/odd-trees-carry.md
@@ -2,14 +2,14 @@
 "@comet/admin": minor
 ---
 
-Add `CheckboxGroupField` component to make it easier to create checkbox group fields in forms
+Add `CheckboxListField` component to make it easier to create checkbox lists in forms
 
 You can now do:
 
 ```tsx
-<CheckboxGroupField
-    label="Checkbox Group"
-    name="checkboxGroup"
+<CheckboxListField
+    label="Checkbox List"
+    name="checkboxList"
     fullWidth
     options={[
         {
@@ -27,7 +27,7 @@ You can now do:
 instead of:
 
 ```tsx
-<FieldContainer label="Checkbox Group" fullWidth>
+<FieldContainer label="Checkbox List" fullWidth>
     <CheckboxField name="checkboxList" label="Checkbox one" value="checkbox-one" />
     <CheckboxField name="checkboxList" label="Checkbox two" value="checkbox-two" />
 </FieldContainer>

--- a/.changeset/odd-trees-carry.md
+++ b/.changeset/odd-trees-carry.md
@@ -1,0 +1,34 @@
+---
+"@comet/admin": minor
+---
+
+Add `CheckboxGroupField` component to make it easier to create checkbox group fields in forms
+
+You can now do:
+
+```tsx
+<CheckboxGroupField
+    label="Checkbox Group"
+    name="checkboxGroup"
+    fullWidth
+    options={[
+        {
+            label: "Option One",
+            value: "option-one",
+        },
+        {
+            label: "Option Two",
+            value: "option-two",
+        },
+    ]}
+/>
+```
+
+instead of:
+
+```tsx
+<FieldContainer label="Checkbox Group" fullWidth>
+    <CheckboxField name="checkboxList" label="Checkbox one" value="checkbox-one" />
+    <CheckboxField name="checkboxList" label="Checkbox two" value="checkbox-two" />
+</FieldContainer>
+```

--- a/packages/admin/admin/src/form/fields/CheckboxGroupField.tsx
+++ b/packages/admin/admin/src/form/fields/CheckboxGroupField.tsx
@@ -1,0 +1,43 @@
+import { Checkbox, FormControlLabel, FormGroup } from "@mui/material";
+import React from "react";
+
+import { Field, FieldProps } from "../Field";
+
+type CheckboxGroupFieldOption<Value extends string> = {
+    label: React.ReactNode;
+    value: Value;
+};
+
+export type CheckboxGroupFieldProps<Value extends string> = FieldProps<[Value], HTMLInputElement> & {
+    options: CheckboxGroupFieldOption<Value>[];
+    layout?: "row" | "column";
+};
+
+export const CheckboxGroupField = <Value extends string>({ options, layout = "row", required, ...restProps }: CheckboxGroupFieldProps<Value>) => {
+    return (
+        <Field<[Value]> required={required} {...restProps}>
+            {({ input: { value, onBlur, onFocus, onChange, name, ...restInput } }) => (
+                <FormGroup row={layout === "row"} {...restInput}>
+                    {options.map((option) => (
+                        <FormControlLabel
+                            key={option.value}
+                            label={option.label}
+                            value={option.value}
+                            name={name}
+                            onChange={(_, checked) => {
+                                if (checked) {
+                                    onChange([...value, option.value]);
+                                } else if (value.length > 1) {
+                                    onChange(value.filter((v) => v !== option.value));
+                                } else {
+                                    onChange(undefined);
+                                }
+                            }}
+                            control={<Checkbox required={required} />}
+                        />
+                    ))}
+                </FormGroup>
+            )}
+        </Field>
+    );
+};

--- a/packages/admin/admin/src/form/fields/CheckboxListField.tsx
+++ b/packages/admin/admin/src/form/fields/CheckboxListField.tsx
@@ -3,17 +3,17 @@ import React from "react";
 
 import { Field, FieldProps } from "../Field";
 
-type CheckboxGroupFieldOption<Value extends string> = {
+type CheckboxListFieldOption<Value extends string> = {
     label: React.ReactNode;
     value: Value;
 };
 
-export type CheckboxGroupFieldProps<Value extends string> = FieldProps<[Value], HTMLInputElement> & {
-    options: CheckboxGroupFieldOption<Value>[];
+export type CheckboxListFieldProps<Value extends string> = FieldProps<[Value], HTMLInputElement> & {
+    options: CheckboxListFieldOption<Value>[];
     layout?: "row" | "column";
 };
 
-export const CheckboxGroupField = <Value extends string>({ options, layout = "row", required, ...restProps }: CheckboxGroupFieldProps<Value>) => {
+export const CheckboxListField = <Value extends string>({ options, layout = "row", required, ...restProps }: CheckboxListFieldProps<Value>) => {
     return (
         <Field<[Value]> required={required} {...restProps}>
             {({ input: { value, onBlur, onFocus, onChange, name, ...restInput } }) => (

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -82,7 +82,7 @@ export { AsyncAutocompleteField, AsyncAutocompleteFieldProps } from "./form/fiel
 export { AsyncSelectField, AsyncSelectFieldProps } from "./form/fields/AsyncSelectField";
 export { AutocompleteField, AutocompleteFieldProps } from "./form/fields/AutocompleteField";
 export { CheckboxField, CheckboxFieldProps } from "./form/fields/CheckboxField";
-export { CheckboxGroupField, CheckboxGroupFieldProps } from "./form/fields/CheckboxGroupField";
+export { CheckboxListField, CheckboxListFieldProps } from "./form/fields/CheckboxListField";
 export { NumberField, NumberFieldProps } from "./form/fields/NumberField";
 export { RadioGroupField, RadioGroupFieldProps } from "./form/fields/RadioGroupField";
 export { SearchField, SearchFieldProps } from "./form/fields/SearchField";

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -82,6 +82,7 @@ export { AsyncAutocompleteField, AsyncAutocompleteFieldProps } from "./form/fiel
 export { AsyncSelectField, AsyncSelectFieldProps } from "./form/fields/AsyncSelectField";
 export { AutocompleteField, AutocompleteFieldProps } from "./form/fields/AutocompleteField";
 export { CheckboxField, CheckboxFieldProps } from "./form/fields/CheckboxField";
+export { CheckboxGroupField, CheckboxGroupFieldProps } from "./form/fields/CheckboxGroupField";
 export { NumberField, NumberFieldProps } from "./form/fields/NumberField";
 export { RadioGroupField, RadioGroupFieldProps } from "./form/fields/RadioGroupField";
 export { SearchField, SearchFieldProps } from "./form/fields/SearchField";

--- a/storybook/src/admin/form/AllFieldComponents.tsx
+++ b/storybook/src/admin/form/AllFieldComponents.tsx
@@ -3,10 +3,11 @@ import {
     AsyncSelectField,
     AutocompleteField,
     CheckboxField,
+    CheckboxGroupField,
     Field,
-    FieldContainer,
     FieldSet,
     FinalFormRangeInput,
+    FormSection,
     NumberField,
     RadioGroupField,
     SearchField,
@@ -94,34 +95,105 @@ function Story() {
                                 variant={fieldVariant}
                                 fullWidth
                             />
-                        </FieldSet>
-
-                        <FieldSet title="Field-Components with Field-Container">
-                            <CheckboxField name="singleCheckbox" fieldLabel="Single Checkbox" variant={fieldVariant} fullWidth />
-                            <CheckboxField
-                                name="checkboxWithAdditionalLabel"
-                                fieldLabel="Checkbox with additional label"
-                                label={
-                                    <>
-                                        This label has a{" "}
-                                        <Link href="https://www.comet-dxp.com" target="_blank">
-                                            link
-                                        </Link>{" "}
-                                        inside of it.
-                                    </>
-                                }
-                                variant={fieldVariant}
-                                fullWidth
-                            />
-                            <CheckboxField name="checkboxWithoutFieldLabel" label="Checkbox without a field label" variant={fieldVariant} fullWidth />
-                            <FieldContainer label="Checkbox list" variant={fieldVariant} fullWidth>
-                                <CheckboxField name="checkboxList" label="Checkbox one" value="checkbox-one" />
-                                <CheckboxField name="checkboxList" label="Checkbox two" value="checkbox-two" />
-                                <CheckboxField name="checkboxList" label="Checkbox three" value="checkbox-three" />
-                                <CheckboxField name="checkboxList" label="Checkbox four" value="checkbox-four" />
-                                <CheckboxField name="checkboxList" label="Checkbox five" value="checkbox-five" />
-                            </FieldContainer>
                             <SwitchField name="switch" label={values.switch ? "On" : "Off"} fieldLabel="Switch" variant={fieldVariant} />
+                        </FieldSet>
+                        <FieldSet title="Checkboxes">
+                            <FormSection title="Individual Checkboxes">
+                                <CheckboxField name="requiredCheckbox" fieldLabel="Required Checkbox" variant={fieldVariant} required fullWidth />
+                                <CheckboxField
+                                    name="checkboxWithAdditionalLabel"
+                                    fieldLabel="Checkbox with additional label"
+                                    label={
+                                        <>
+                                            This label has a{" "}
+                                            <Link href="https://www.comet-dxp.com" target="_blank">
+                                                link
+                                            </Link>{" "}
+                                            inside of it.
+                                        </>
+                                    }
+                                    variant={fieldVariant}
+                                    fullWidth
+                                />
+                                <CheckboxField
+                                    name="checkboxWithoutFieldLabel"
+                                    label="Checkbox without a field label"
+                                    variant={fieldVariant}
+                                    fullWidth
+                                />
+                            </FormSection>
+                            <FormSection title="Checkbox Groups">
+                                <CheckboxGroupField
+                                    label="Required"
+                                    name="requiredCheckboxGroup"
+                                    variant={fieldVariant}
+                                    fullWidth
+                                    required
+                                    options={[
+                                        {
+                                            label: "Option One",
+                                            value: "option-one",
+                                        },
+                                        {
+                                            label: "Option Two",
+                                            value: "option-two",
+                                        },
+                                    ]}
+                                />
+                                <CheckboxGroupField
+                                    label="Many Options"
+                                    name="checkboxGroupManyOptions"
+                                    variant={fieldVariant}
+                                    fullWidth
+                                    options={[
+                                        {
+                                            label: "Option One",
+                                            value: "option-one",
+                                        },
+                                        {
+                                            label: "Option Two",
+                                            value: "option-two",
+                                        },
+                                        {
+                                            label: "Option Three",
+                                            value: "option-three",
+                                        },
+                                        {
+                                            label: "Option Four",
+                                            value: "option-four",
+                                        },
+                                        {
+                                            label: "Option Five",
+                                            value: "option-five",
+                                        },
+                                        {
+                                            label: "Option Six",
+                                            value: "option-six",
+                                        },
+                                    ]}
+                                />
+                                <CheckboxGroupField
+                                    label="Column Layout"
+                                    name="checkboxGroupColumnLayout"
+                                    variant={fieldVariant}
+                                    layout="column"
+                                    fullWidth
+                                    options={[
+                                        {
+                                            label: "Option One",
+                                            value: "option-one",
+                                        },
+                                        {
+                                            label: "Option Two",
+                                            value: "option-two",
+                                        },
+                                        {
+                                            label: "Option Three",
+                                            value: "option-three",
+                                        },
+                                    ]}
+                                />
+                            </FormSection>
                         </FieldSet>
                         <FieldSet title="Radio Groups">
                             <RadioGroupField
@@ -175,7 +247,7 @@ function Story() {
                             />
                             <RadioGroupField
                                 label="Column Layout"
-                                name="radioGroupFullWidthOptions"
+                                name="radioGroupColumnLayout"
                                 variant={fieldVariant}
                                 layout="column"
                                 fullWidth

--- a/storybook/src/admin/form/AllFieldComponents.tsx
+++ b/storybook/src/admin/form/AllFieldComponents.tsx
@@ -3,7 +3,7 @@ import {
     AsyncSelectField,
     AutocompleteField,
     CheckboxField,
-    CheckboxGroupField,
+    CheckboxListField,
     Field,
     FieldSet,
     FinalFormRangeInput,
@@ -122,10 +122,10 @@ function Story() {
                                     fullWidth
                                 />
                             </FormSection>
-                            <FormSection title="Checkbox Groups">
-                                <CheckboxGroupField
+                            <FormSection title="Checkbox Lists">
+                                <CheckboxListField
                                     label="Required"
-                                    name="requiredCheckboxGroup"
+                                    name="requiredCheckboxList"
                                     variant={fieldVariant}
                                     fullWidth
                                     required
@@ -140,9 +140,9 @@ function Story() {
                                         },
                                     ]}
                                 />
-                                <CheckboxGroupField
+                                <CheckboxListField
                                     label="Many Options"
-                                    name="checkboxGroupManyOptions"
+                                    name="checkboxListManyOptions"
                                     variant={fieldVariant}
                                     fullWidth
                                     options={[
@@ -172,9 +172,9 @@ function Story() {
                                         },
                                     ]}
                                 />
-                                <CheckboxGroupField
+                                <CheckboxListField
                                     label="Column Layout"
-                                    name="checkboxGroupColumnLayout"
+                                    name="checkboxListColumnLayout"
                                     variant={fieldVariant}
                                     layout="column"
                                     fullWidth


### PR DESCRIPTION
To make it easier to create checkbox lists in forms and be more consistent with the method of creating radio groups.

This also enables the correct required behavior and error states, which was not possible out of the box with the previous method of creating lists of checkboxes. 

You can now do:

```tsx
<CheckboxListField
    label="Checkbox List"
    name="checkboxList"
    fullWidth
    options={[
        {
            label: "Option One",
            value: "option-one",
        },
        {
            label: "Option Two",
            value: "option-two",
        },
    ]}
/>
```

instead of:

```tsx
<FieldContainer label="Checkbox List" fullWidth>
    <CheckboxField name="checkboxList" label="Checkbox one" value="checkbox-one" />
    <CheckboxField name="checkboxList" label="Checkbox two" value="checkbox-two" />
</FieldContainer>
```


---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-995