### PR TITLE
Fix the content scope indicator on the `EditFile` page if DAM scoping is disabled

### DIFF
--- a/.changeset/good-brooms-walk.md
+++ b/.changeset/good-brooms-walk.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix the content scope indicator on the `EditFile` page if DAM scoping is disabled

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -113,7 +113,7 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
                 </StackPage>
                 <StackPage name="edit" title={intl.formatMessage({ id: "comet.pages.dam.edit", defaultMessage: "Edit" })}>
                     {(selectedId: string) => {
-                        return <EditFile id={selectedId} />;
+                        return <EditFile id={selectedId} contentScopeIndicator={props.contentScopeIndicator} />;
                     }}
                 </StackPage>
                 <StackPage name="folder" title={data?.damFolder.name}>

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -22,13 +22,11 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { Link as RouterLink } from "react-router-dom";
 import ReactSplit from "react-split";
 
-import { ContentScopeIndicator } from "../../contentScope/ContentScopeIndicator";
 import { useContentScope } from "../../contentScope/Provider";
 import { useDependenciesConfig } from "../../dependencies/DependenciesConfig";
 import { DependencyList } from "../../dependencies/DependencyList";
 import { GQLFocalPoint, GQLImageCropAreaInput, GQLLicenseInput } from "../../graphql.generated";
 import { useDamConfig } from "../config/useDamConfig";
-import { useDamScope } from "../config/useDamScope";
 import { LicenseValidityTags } from "../DataGrid/tags/LicenseValidityTags";
 import Duplicates from "./Duplicates";
 import { damFileDependentsQuery, damFileDetailQuery, updateDamFileMutation } from "./EditFile.gql";
@@ -59,6 +57,7 @@ export interface EditFileFormValues extends EditImageFormValues {
 
 interface EditFormProps {
     id: string;
+    contentScopeIndicator?: React.ReactNode;
 }
 
 const useInitialValues = (id: string) => {
@@ -70,7 +69,7 @@ const useInitialValues = (id: string) => {
     return { loading, data, error };
 };
 
-const EditFile = ({ id }: EditFormProps): React.ReactElement => {
+const EditFile = ({ id, contentScopeIndicator }: EditFormProps): React.ReactElement => {
     const { match: scopeMatch } = useContentScope();
     const initialValues = useInitialValues(id);
     const file = initialValues.data?.damFile;
@@ -99,7 +98,7 @@ const EditFile = ({ id }: EditFormProps): React.ReactElement => {
         );
     }
 
-    return <EditFileInner file={file} id={id} />;
+    return <EditFileInner file={file} id={id} contentScopeIndicator={contentScopeIndicator} />;
 };
 
 export type DamFileDetails = GQLDamFileDetailFragment;
@@ -107,13 +106,13 @@ export type DamFileDetails = GQLDamFileDetailFragment;
 interface EditFileInnerProps {
     file: DamFileDetails;
     id: string;
+    contentScopeIndicator?: React.ReactNode;
 }
 
-const EditFileInner = ({ file, id }: EditFileInnerProps) => {
+const EditFileInner = ({ file, id, contentScopeIndicator }: EditFileInnerProps) => {
     const dependencyMap = useDependenciesConfig();
     const intl = useIntl();
     const damConfig = useDamConfig();
-    const scope = useDamScope();
     const apolloClient = useApolloClient();
 
     const onSubmit = React.useCallback(
@@ -188,7 +187,7 @@ const EditFileInner = ({ file, id }: EditFileInnerProps) => {
         >
             {() => (
                 <>
-                    <Toolbar scopeIndicator={<ContentScopeIndicator scope={scope} />}>
+                    <Toolbar scopeIndicator={contentScopeIndicator}>
                         <ToolbarBackButton />
                         <ToolbarTitleItem>{file.name}</ToolbarTitleItem>
                         {damConfig.enableLicenseFeature &&


### PR DESCRIPTION
Previously, EditFile showed an empty scope indicator if the DAM was scoped globally:

<img width="1728" alt="Bildschirmfoto 2024-08-08 um 16 00 39" src="https://github.com/user-attachments/assets/44c507bb-80c1-4273-b638-c2b4475b9c54">


---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [ ] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [ ] Link to the respective task if one exists: <!-- For instance, COM-123 -->
-   [ ] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->
</details>
