### PR TITLE
Fix visible icon button color in `ListBlock` and `ColumnsBlock`

### DIFF
--- a/.changeset/thirty-melons-speak.md
+++ b/.changeset/thirty-melons-speak.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Fix color for visible icon button in `ListBlock` and `ColumnsBlock`

--- a/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
@@ -335,7 +335,7 @@ export function createColumnsBlock<T extends BlockInterface>({
                                                                         visibilityButton={
                                                                             <IconButton onClick={() => toggleVisible(column.key)} size="small">
                                                                                 {column.visible ? (
-                                                                                    <Visible color="secondary" />
+                                                                                    <Visible color="success" />
                                                                                 ) : (
                                                                                     <Invisible color="action" />
                                                                                 )}

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -375,7 +375,7 @@ export function createListBlock<T extends BlockInterface, AdditionalItemFields e
                                                                                     disabled={!canToggleVisibility}
                                                                                 >
                                                                                     {data.visible ? (
-                                                                                        <Visible color="secondary" />
+                                                                                        <Visible color="success" />
                                                                                     ) : (
                                                                                         <Invisible color="action" />
                                                                                     )}


### PR DESCRIPTION
"secondary" color was changed in #1999  