### PR TITLE
Admin Generator (Future): Render the value's label as defined in the grid config of `staticSelect`

### DIFF
--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -124,6 +124,15 @@ export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React
                 { value: "Shirt", label: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }) },
                 { value: "Tie", label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }) },
             ],
+            renderCell: ({ row }) => {
+                const valueOptions = [
+                    { value: "Cap", label: intl.formatMessage({ id: "product.type.cap", defaultMessage: "great Cap" }) },
+                    { value: "Shirt", label: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }) },
+                    { value: "Tie", label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }) },
+                ];
+                const selectedOption = valueOptions.find(({ value }) => value === row.type);
+                return selectedOption ? selectedOption.label : row.type;
+            },
             flex: 1,
             maxWidth: 150,
             minWidth: 150,

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -124,14 +124,16 @@ export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React
                 { value: "Shirt", label: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }) },
                 { value: "Tie", label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }) },
             ],
-            renderCell: ({ row }) => {
-                const valueOptions = [
-                    { value: "Cap", label: intl.formatMessage({ id: "product.type.cap", defaultMessage: "great Cap" }) },
-                    { value: "Shirt", label: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }) },
-                    { value: "Tie", label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }) },
-                ];
-                const selectedOption = valueOptions.find(({ value }) => value === row.type);
-                return selectedOption ? selectedOption.label : row.type;
+            renderCell: ({ row, colDef }) => {
+                if (colDef.valueOptions && Array.isArray(colDef.valueOptions)) {
+                    const selectedOption = colDef.valueOptions.find((option) => typeof option === "object" && option.value === row.type);
+
+                    if (selectedOption && typeof selectedOption === "object") {
+                        return selectedOption.label;
+                    }
+                }
+
+                return row.type;
             },
             flex: 1,
             maxWidth: 150,

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -275,11 +275,18 @@ export function generateGrid(
                 })
                 .join(" ")}]`;
 
+            renderCell = `({ row }) => {
+                const valueOptions = ${valueOptions};
+                const selectedOption = valueOptions.find(({ value }) => value === row.${name});
+                return selectedOption ? selectedOption.label : row.${name};
+            }`;
+
             return {
                 name,
                 type,
                 gridType: "singleSelect" as const,
                 valueOptions,
+                renderCell,
                 width: column.width,
                 minWidth: column.minWidth,
                 maxWidth: column.maxWidth,

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -274,11 +274,16 @@ export function generateGrid(
                     return `{value: ${JSON.stringify(i.value)}, label: ${label}}, `;
                 })
                 .join(" ")}]`;
+            renderCell = `({ row, colDef }) => {
+                if (colDef.valueOptions && Array.isArray(colDef.valueOptions)) {
+                    const selectedOption = colDef.valueOptions.find((option) => typeof option === "object" && option.value === row.${name});
 
-            renderCell = `({ row }) => {
-                const valueOptions = ${valueOptions};
-                const selectedOption = valueOptions.find(({ value }) => value === row.${name});
-                return selectedOption ? selectedOption.label : row.${name};
+                    if (selectedOption && typeof selectedOption === "object") {
+                        return selectedOption.label;
+                    }
+                }
+
+                return row.${name};
             }`;
 
             return {


### PR DESCRIPTION
Automatically rendering the label from `valueOptions` is not supported by DataGrid V5.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: SVK-334