### PR TITLE
Fix Jaeger tracing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
             - ${JAEGER_OLTP_PORT}:4318 #OLTP over HTTP
         environment:
             COLLECTOR_OTLP_ENABLED: "true"
+            COLLECTOR_OTLP_HTTP_HOST_PORT: 0.0.0.0:4318
 
 networks:
     postgres:


### PR DESCRIPTION
Due to a recent change in the OpenTelemetry Collector, Jaeger didn't accept OpenTelemetry data anymore. Until this change is reverted upstream, we explicitly pass the the host IP to Jaeger as a workaround. See https://github.com/jaegertracing/jaeger/issues/5737 for more information.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

See https://github.com/vivid-planet/comet-starter/pull/311.