### PR TITLE
OneOfBlock: Remove label for the type field

### DIFF
--- a/.changeset/modern-waves-leave.md
+++ b/.changeset/modern-waves-leave.md
@@ -2,4 +2,6 @@
 "@comet/blocks-admin": minor
 ---
 
-Remove the label of the OneOfBlock
+OneOfBlock: Remove label for the type field
+
+The label was unnecessary and occasionally caused UI problems when having two labels next each other.

--- a/.changeset/modern-waves-leave.md
+++ b/.changeset/modern-waves-leave.md
@@ -2,9 +2,4 @@
 "@comet/blocks-admin": minor
 ---
 
-Makes it possible to change or hide the label of a OneOfBlock
-
-Introduced two new properties:
-
--   _labelText_ is used to change the Text of the label
--   _hideLabel_ hides the label
+Remove the label of the OneOfBlock

--- a/.changeset/modern-waves-leave.md
+++ b/.changeset/modern-waves-leave.md
@@ -1,0 +1,10 @@
+---
+"@comet/blocks-admin": minor
+---
+
+Makes it possible to change or hide the label of a OneOfBlock
+
+Introduced two new properties:
+
+-   _labelText_ is used to change the Text of the label
+-   _hideLabel_ hides the label

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -61,8 +61,6 @@ type BlockType = string;
 export interface CreateOneOfBlockOptions<T extends boolean> {
     name: string;
     displayName?: React.ReactNode;
-    labelText?: React.ReactNode;
-    hideLabel?: boolean;
     supportedBlocks: Record<BlockType, BlockInterface>;
     category?: BlockCategory | CustomBlockCategory;
     variant?: "select" | "radio" | "toggle";
@@ -73,8 +71,6 @@ export const createOneOfBlock = <T extends boolean = boolean>({
     supportedBlocks,
     name,
     displayName = "Switch",
-    labelText,
-    hideLabel = false,
     category = BlockCategory.Other,
     variant = "select",
     allowEmpty: passedAllowEmpty,
@@ -354,7 +350,6 @@ export const createOneOfBlock = <T extends boolean = boolean>({
 
             const activeBlock = getActiveBlock(state);
             const selectedBlockType = activeBlock.block ? activeBlock.state.type : "none";
-            const label = labelText ? labelText : <FormattedMessage id="comet.blocks.oneOf.blockType" defaultMessage="Type" />;
 
             return (
                 <SelectPreviewComponent>
@@ -371,7 +366,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
                                 {variant === "select" && (
                                     <>
                                         <Box padding={isInPaper ? 3 : 0}>
-                                            <Field name="blockType" fullWidth label={hideLabel ? null : label}>
+                                            <Field name="blockType" fullWidth>
                                                 {(props) => (
                                                     <FinalFormSelect {...props} fullWidth>
                                                         {options.map((option) => (
@@ -389,7 +384,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
                                 {variant === "radio" && (
                                     <>
                                         <Box display="flex" flexDirection="column" padding={3}>
-                                            <FieldContainer label={hideLabel ? null : label}>
+                                            <FieldContainer>
                                                 {options.map((option) => (
                                                     <Field key={option.value} name="blockType" type="radio" value={option.value} fullWidth>
                                                         {(props) => <FormControlLabel label={option.label} control={<FinalFormRadio {...props} />} />}
@@ -403,7 +398,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
                                 {variant === "toggle" && (
                                     <>
                                         <Box padding={isInPaper ? 3 : 0}>
-                                            <Field name="blockType" fullWidth label={hideLabel ? null : label}>
+                                            <Field name="blockType" fullWidth>
                                                 {({ input: { value, onChange } }) => (
                                                     <ToggleButtonGroup
                                                         value={value}

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -61,6 +61,8 @@ type BlockType = string;
 export interface CreateOneOfBlockOptions<T extends boolean> {
     name: string;
     displayName?: React.ReactNode;
+    labelText?: React.ReactNode;
+    hideLabel?: boolean;
     supportedBlocks: Record<BlockType, BlockInterface>;
     category?: BlockCategory | CustomBlockCategory;
     variant?: "select" | "radio" | "toggle";
@@ -71,6 +73,8 @@ export const createOneOfBlock = <T extends boolean = boolean>({
     supportedBlocks,
     name,
     displayName = "Switch",
+    labelText,
+    hideLabel = false,
     category = BlockCategory.Other,
     variant = "select",
     allowEmpty: passedAllowEmpty,
@@ -350,6 +354,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
 
             const activeBlock = getActiveBlock(state);
             const selectedBlockType = activeBlock.block ? activeBlock.state.type : "none";
+            const label = labelText ? labelText : <FormattedMessage id="comet.blocks.oneOf.blockType" defaultMessage="Type" />;
 
             return (
                 <SelectPreviewComponent>
@@ -366,11 +371,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
                                 {variant === "select" && (
                                     <>
                                         <Box padding={isInPaper ? 3 : 0}>
-                                            <Field
-                                                name="blockType"
-                                                fullWidth
-                                                label={<FormattedMessage id="comet.blocks.oneOf.blockType" defaultMessage="Type" />}
-                                            >
+                                            <Field name="blockType" fullWidth label={hideLabel ? null : label}>
                                                 {(props) => (
                                                     <FinalFormSelect {...props} fullWidth>
                                                         {options.map((option) => (
@@ -388,7 +389,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
                                 {variant === "radio" && (
                                     <>
                                         <Box display="flex" flexDirection="column" padding={3}>
-                                            <FieldContainer label={<FormattedMessage id="comet.blocks.oneOf.blockType" defaultMessage="Type" />}>
+                                            <FieldContainer label={hideLabel ? null : label}>
                                                 {options.map((option) => (
                                                     <Field key={option.value} name="blockType" type="radio" value={option.value} fullWidth>
                                                         {(props) => <FormControlLabel label={option.label} control={<FinalFormRadio {...props} />} />}
@@ -402,11 +403,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
                                 {variant === "toggle" && (
                                     <>
                                         <Box padding={isInPaper ? 3 : 0}>
-                                            <Field
-                                                name="blockType"
-                                                fullWidth
-                                                label={<FormattedMessage id="comet.blocks.oneOf.blockType" defaultMessage="Type" />}
-                                            >
+                                            <Field name="blockType" fullWidth label={hideLabel ? null : label}>
                                                 {({ input: { value, onChange } }) => (
                                                     <ToggleButtonGroup
                                                         value={value}


### PR DESCRIPTION
The label was unnecessary and occasionally caused UI problems when having two labels next each other.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-863
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
Hidden label:

![image](https://github.com/user-attachments/assets/7fe549ee-2730-4513-978b-e41ef4e86af8)

</details>
