### PR TITLE
Sort contentScope keys to make equality check easier (v6)

### DIFF
--- a/.changeset/quick-oranges-punch.md
+++ b/.changeset/quick-oranges-punch.md
@@ -1,0 +1,10 @@
+---
+"@comet/cms-api": patch
+---
+
+Sort the keys in content scopes returned by `UserPermissionsService` alphabetically
+
+This fixes issues when comparing content scopes after converting them to strings via `JSON.stringify()`.
+
+This specifically fixes a bug on the UserPermissionsPage:
+When the `availableContentScopes` passed to the `UserPermissionsModule` weren't sorted alphabetically, the allowed scopes wouldn't be displayed correctly in the UI.

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -21,6 +21,7 @@ import {
     UserPermissionsOptions,
     UserPermissionsUserServiceInterface,
 } from "./user-permissions.types";
+import { sortContentScopeKeysAlphabetically } from "./utils/sort-content-scope-keys-alphabetically";
 
 @Injectable()
 export class UserPermissionsService {
@@ -38,7 +39,7 @@ export class UserPermissionsService {
             if (typeof this.options.availableContentScopes === "function") {
                 return this.options.availableContentScopes();
             }
-            return this.options.availableContentScopes;
+            return this.options.availableContentScopes.map((cs) => sortContentScopeKeysAlphabetically(cs));
         }
         return [];
     }
@@ -142,7 +143,7 @@ export class UserPermissionsService {
             }
         }
 
-        return contentScopes;
+        return contentScopes.map((cs) => sortContentScopeKeysAlphabetically(cs));
     }
 
     normalizeContentScopes(contentScopes: ContentScope[], availableContentScopes: ContentScope[]): ContentScope[] {

--- a/packages/api/cms-api/src/user-permissions/utils/sort-content-scope-keys-alphabetically.ts
+++ b/packages/api/cms-api/src/user-permissions/utils/sort-content-scope-keys-alphabetically.ts
@@ -1,0 +1,10 @@
+import { ContentScope } from "../interfaces/content-scope.interface";
+
+export function sortContentScopeKeysAlphabetically(obj: ContentScope): ContentScope {
+    return Object.keys(obj)
+        .sort()
+        .reduce<ContentScope>((acc, key) => {
+            acc[key as keyof ContentScope] = obj[key as keyof ContentScope];
+            return acc;
+        }, {});
+}


### PR DESCRIPTION
Backport of https://github.com/vivid-planet/comet/pull/2345