### PR TITLE
Support Icons in OneOfBlock Tabs

### DIFF
--- a/.changeset/fluffy-points-think.md
+++ b/.changeset/fluffy-points-think.md
@@ -1,0 +1,11 @@
+---
+"@comet/blocks-admin": minor
+---
+
+Add Support for Icons in OneOfBlock tabs
+
+Usage:
+
+-   Add tabLabels to `createOneOfBlock` props
+    -   `tabLabels: { image: <Image />, damVideo: <Video />, youTubeVideo: <YouTube /> }`
+    -   the keys in the tabLabels need to be the same as the `supportedBlocks`

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -62,6 +62,7 @@ export interface CreateOneOfBlockOptions<T extends boolean> {
     name: string;
     displayName?: React.ReactNode;
     supportedBlocks: Record<BlockType, BlockInterface>;
+    tabLabels?: Record<BlockType, React.ReactNode>;
     category?: BlockCategory | CustomBlockCategory;
     variant?: "select" | "radio" | "toggle";
     allowEmpty?: T;
@@ -69,6 +70,7 @@ export interface CreateOneOfBlockOptions<T extends boolean> {
 
 export const createOneOfBlock = <T extends boolean = boolean>({
     supportedBlocks,
+    tabLabels,
     name,
     displayName = "Switch",
     category = BlockCategory.Other,
@@ -116,7 +118,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
     Object.entries(supportedBlocks).forEach(([blockType, block]) => {
         options.push({
             value: blockType,
-            label: block.displayName,
+            label: tabLabels && tabLabels[blockType] ? tabLabels[blockType] : block.displayName,
         });
     });
 


### PR DESCRIPTION
---
Add support for Icons and other ReactNodes for OneOfBlock Tab Labels

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [ ] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [ ] Link to the respective task if one exists: COM-862
-   [ ] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    
![image](https://github.com/user-attachments/assets/5c0979ee-129e-48bb-8d0c-959ce9a5c508)

</details>
