### PR TITLE
Change concurrency group in v6 to `release-v6`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         name: Release
         runs-on: ubuntu-latest
         concurrency:
-            group: release
+            group: release-v6
             cancel-in-progress: true
         steps:
             - name: Checkout Repo


### PR DESCRIPTION
This should prevent v6 release pipelines from canceling release pipelines on main (or the other way round)