### PR TITLE
add `maxVisibleBlocks` prop to `createBlocksBlock`

### DIFF
--- a/.changeset/lemon-bulldogs-collect.md
+++ b/.changeset/lemon-bulldogs-collect.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": minor
+---
+
+feature: add `maxVisibleBlocks` prop to `createBlocksBlock`


### PR DESCRIPTION
feature: add `maxVisibleBlocks` prop to `createBlocksBlock`

We decided to use a BlocksBlock for a list of StageBlocks for the stages. For that use case we need to add a maximum number of visible blocks.
