### PR TITLE
Export a type for all icon names: `IconName`

### DIFF
--- a/.changeset/mean-insects-join.md
+++ b/.changeset/mean-insects-join.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-icons": minor
+---
+
+Export a type for all icon names: `IconName`

--- a/packages/admin/admin-icons/generate-icons.ts
+++ b/packages/admin/admin-icons/generate-icons.ts
@@ -58,6 +58,7 @@ const main = async () => {
     );
     bar.stop();
 
+    await writeGeneratedTypesFile(icons);
     await writeIndexFile(icons);
 };
 
@@ -110,6 +111,13 @@ const writeComponent = async (icon: Icon, svgString: string) => {
     if (icon.componentName != null && component != null) {
         writeFileSync(`src/generated/${icon.componentName}.tsx`, component);
     }
+};
+
+const writeGeneratedTypesFile = async (icons: Icon[]) => {
+    writeFileSync(
+        `src/generated/GeneratedIconName.ts`,
+        `export type GeneratedIconName = ${icons.map((icon) => `"${icon.componentName}"`).join(" | ")};`,
+    );
 };
 
 const writeIndexFile = async (icons: Icon[]) => {

--- a/packages/admin/admin-icons/src/index.ts
+++ b/packages/admin/admin-icons/src/index.ts
@@ -1,3 +1,5 @@
+import { GeneratedIconName } from "./generated/GeneratedIconName";
+
 export { default as BallTriangle } from "./BallTriangle";
 export { default as CheckboxChecked } from "./CheckboxChecked";
 export { default as CheckboxUnchecked } from "./CheckboxUnchecked";
@@ -8,3 +10,15 @@ export { default as MovePage } from "./MovePage";
 export { default as RadioChecked } from "./RadioChecked";
 export { default as RadioUnchecked } from "./RadioUnchecked";
 export { default as ThreeDotSaving } from "./ThreeDotSaving";
+
+export type IconName =
+    | GeneratedIconName
+    | "BallTriangle"
+    | "CheckboxChecked"
+    | "CheckboxUnchecked"
+    | "CometColor"
+    | "Html"
+    | "MovePage"
+    | "RadioChecked"
+    | "RadioUnchecked"
+    | "ThreeDotSaving";


### PR DESCRIPTION
This is helpful, e.g., for typing the icons that can be set in the grid column config of the future admin generator. 

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: SVK-270