### PR TITLE
Add missing database migrations for Comet modules

### DIFF
--- a/demo/api/src/db/migrations/Migration20240814090355.ts
+++ b/demo/api/src/db/migrations/Migration20240814090355.ts
@@ -1,0 +1,31 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240814090355 extends Migration {
+    async up(): Promise<void> {
+        this.addSql('alter table "News" drop constraint if exists "News_category_check";');
+        this.addSql('alter table "News" drop constraint if exists "News_status_check";');
+
+        this.addSql('alter table "Product" drop constraint if exists "Product_status_check";');
+
+        this.addSql('alter table "Product" drop constraint "Product_statistics_foreign";');
+
+        this.addSql('alter table "News" alter column "category" type text using ("category"::text);');
+        this.addSql("alter table \"News\" add constraint \"News_category_check\" check (\"category\" in ('Events', 'Company', 'Awards'));");
+        this.addSql('alter table "News" alter column "category" set default \'Awards\';');
+        this.addSql('alter table "News" alter column "status" type text using ("status"::text);');
+        this.addSql('alter table "News" add constraint "News_status_check" check ("status" in (\'Active\', \'Deleted\'));');
+        this.addSql('alter table "News" alter column "status" set default \'Active\';');
+
+        this.addSql('alter table "Product" alter column "description" type varchar(255) using ("description"::varchar(255));');
+        this.addSql('alter table "Product" alter column "createdAt" type timestamptz(0) using ("createdAt"::timestamptz(0));');
+        this.addSql('alter table "Product" alter column "updatedAt" type timestamptz(0) using ("updatedAt"::timestamptz(0));');
+        this.addSql('alter table "Product" alter column "inStock" type boolean using ("inStock"::boolean);');
+        this.addSql('alter table "Product" alter column "inStock" set default true;');
+        this.addSql('alter table "Product" alter column "status" type text using ("status"::text);');
+        this.addSql("alter table \"Product\" add constraint \"Product_status_check\" check (\"status\" in ('Published', 'Unpublished', 'Deleted'));");
+        this.addSql('alter table "Product" alter column "status" set default \'Unpublished\';');
+        this.addSql(
+            'alter table "Product" add constraint "Product_statistics_foreign" foreign key ("statistics") references "ProductStatistics" ("id") on update cascade on delete set null;',
+        );
+    }
+}

--- a/packages/api/cms-api/src/mikro-orm/migrations/Migration20240814090503.ts
+++ b/packages/api/cms-api/src/mikro-orm/migrations/Migration20240814090503.ts
@@ -1,0 +1,13 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240814090503 extends Migration {
+    async up(): Promise<void> {
+        this.addSql('alter table "DamFolder" alter column "archived" type boolean using ("archived"::boolean);');
+        this.addSql('alter table "DamFolder" alter column "archived" set default false;');
+        this.addSql('alter table "DamFolder" alter column "isInboxFromOtherScope" type boolean using ("isInboxFromOtherScope"::boolean);');
+        this.addSql('alter table "DamFolder" alter column "isInboxFromOtherScope" set default false;');
+
+        this.addSql('alter table "DamFile" alter column "archived" type boolean using ("archived"::boolean);');
+        this.addSql('alter table "DamFile" alter column "archived" set default false;');
+    }
+}

--- a/packages/api/cms-api/src/mikro-orm/migrations/Migration20240814090541.ts
+++ b/packages/api/cms-api/src/mikro-orm/migrations/Migration20240814090541.ts
@@ -1,0 +1,8 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240814090541 extends Migration {
+    async up(): Promise<void> {
+        this.addSql('drop index "PublicUpload_contentHash_index";');
+        this.addSql('create index "CometFileUpload_contentHash_index" on "CometFileUpload" ("contentHash");');
+    }
+}

--- a/packages/api/cms-api/src/mikro-orm/migrations/Migration20240814090653.ts
+++ b/packages/api/cms-api/src/mikro-orm/migrations/Migration20240814090653.ts
@@ -1,0 +1,8 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240814090653 extends Migration {
+    async up(): Promise<void> {
+        this.addSql('alter table "PageTreeNode" alter column "hideInMenu" type boolean using ("hideInMenu"::boolean);');
+        this.addSql('alter table "PageTreeNode" alter column "hideInMenu" set default false;');
+    }
+}

--- a/packages/api/cms-api/src/mikro-orm/mikro-orm.module.ts
+++ b/packages/api/cms-api/src/mikro-orm/mikro-orm.module.ts
@@ -25,6 +25,9 @@ import { Migration20231218092313 } from "./migrations/Migration20231218092313";
 import { Migration20231222090009 } from "./migrations/Migration20231222090009";
 import { Migration20240702123233 } from "./migrations/Migration20240702123233";
 import { Migration20240725071750 } from "./migrations/Migration20240725071750";
+import { Migration20240814090503 } from "./migrations/Migration20240814090503";
+import { Migration20240814090541 } from "./migrations/Migration20240814090541";
+import { Migration20240814090653 } from "./migrations/Migration20240814090653";
 
 export const PG_UNIQUE_CONSTRAINT_VIOLATION = "23505";
 
@@ -87,6 +90,9 @@ export function createOrmConfig({ migrations, ...defaults }: MikroOrmNestjsOptio
                 { name: "Migration20231218092313", class: Migration20231218092313 },
                 { name: "Migration20240702123233", class: Migration20240702123233 },
                 { name: "Migration20240725071750", class: Migration20240725071750 },
+                { name: "Migration20240814090503", class: Migration20240814090503 },
+                { name: "Migration20240814090541", class: Migration20240814090541 },
+                { name: "Migration20240814090653", class: Migration20240814090653 },
                 ...(migrations?.migrationsList || []),
             ].sort((migrationA, migrationB) => {
                 if (migrationA.name < migrationB.name) {


### PR DESCRIPTION
We repeatedly encountered statements affecting package-internal tables when creating a new database migration in projects. These migrations were either forgotten or come as a result of updating to newer MikroORM versions. To fix this, we now add the migrations to the `@comet/cms-api` package, which results in the statements not showing up any longer in newly created migrations.

However, MikroORM still generates a migration with the following three statements:

```ts
this.addSql('alter table "DamFolder" alter column "mpath" type uuid array using ("mpath"::uuid array);');
this.addSql('alter table "DamFile" alter column "contentHash" type character(32) using ("contentHash"::character(32));');
this.addSql('alter table "CometFileUpload" alter column "contentHash" type character(32) using ("contentHash"::character(32));');
```

These statements will still be generated every time, even after running the same migration multiple times. This is probably related to MikroORMs schema diffing approach, so we can't fix that for now.

Note: I intentionally split the migrations based on module boundaries, as we plan to support running only the module-related migrations in the future.