### PR TITLE
Admin Generator (Future): Add missing filter for `FormValues` type

### DIFF
--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -237,7 +237,7 @@ export function generateForm(
                   .join(" | ")}>`
             : `GQL${fragmentName}Fragment`
     } ${
-        formValuesConfig.length > 0
+        formValuesConfig.filter((config) => !!config.typeCode).length > 0
             ? `& {
                 ${formValuesConfig
                     .filter((config) => !!config.typeCode)


### PR DESCRIPTION
The `.filter` call was not added for length-detection, so an empty type was generated.