### PR TITLE
Reduce `uploadsMaxFileSize` to 10MB

### DIFF
--- a/demo/api/src/comet-config.json
+++ b/demo/api/src/comet-config.json
@@ -7,7 +7,7 @@
         "quality": 80
     },
     "dam": {
-        "uploadsMaxFileSize": 500,
+        "uploadsMaxFileSize": 10,
         "allowedImageSizes": [320, 420, 768, 1024, 1200, 2048],
         "allowedImageAspectRatios": ["16x9", "4x3", "3x2", "3x1", "2x1", "1x1", "1x2", "1x3", "2x3", "3x4", "9x16", "1200x630"]
     }


### PR DESCRIPTION
Currently, the max file size is 500 MB. However, the main use case for the DAM ist uploading images for websites. For performance reasons, images on a website should ideally be less than 1MB. 

Some CMS users don't really think about file sizes. Recently, someone uploaded a 72 MB image that couldn't be displayed on the website because the ImgProxy couldn't handle it.

---

So I think we should reduce the max file size to a more reasonable number. I now used 10MB because 

- we also optimize the images through the ImgProxy reducing the file size
- I suppose this will also cover most cases of bigger files someone might want to offer as a download
 
The limit can be increased on demand anyway.

