### PR TITLE
`Demo`: remove barrel react imports

### DIFF
--- a/demo/admin/.eslintrc.json
+++ b/demo/admin/.eslintrc.json
@@ -2,6 +2,18 @@
     "extends": "@comet/eslint-config/react",
     "ignorePatterns": ["schema.json", "src/fragmentTypes.json", "dist/**", "src/**/*.generated.ts"],
     "rules": {
-        "@calm/react-intl/missing-formatted-message": "off"
+        "@calm/react-intl/missing-formatted-message": "off",
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -27,7 +27,7 @@ import { ImportFromUnsplash } from "@src/dam/ImportFromUnsplash";
 import { pageTreeCategories } from "@src/pageTree/pageTreeCategories";
 import { theme } from "@src/theme";
 import { HTML5toTouch } from "rdndmb-html5-to-touch";
-import * as React from "react";
+import { Component, Fragment } from "react";
 import { DndProvider } from "react-dnd-multi-backend";
 import * as ReactDOM from "react-dom";
 import { FormattedMessage, IntlProvider } from "react-intl";
@@ -54,7 +54,7 @@ const config = createConfig();
 const apolloClient = createApolloClient(config.apiUrl);
 const apiClient = createHttpClient(config.apiUrl);
 
-class App extends React.Component {
+class App extends Component {
     public static render(baseEl: Element): void {
         ReactDOM.render(<App />, baseEl);
     }
@@ -111,7 +111,7 @@ class App extends React.Component {
                                                             pageTreeDocumentTypes={pageTreeDocumentTypes}
                                                             additionalPageTreeNodeFragment={additionalPageTreeNodeFieldsFragment}
                                                         >
-                                                            <React.Fragment>
+                                                            <Fragment>
                                                                 <GlobalStyle />
                                                                 <ContentScopeProvider>
                                                                     {({ match }) => (
@@ -141,7 +141,7 @@ class App extends React.Component {
                                                                         </Switch>
                                                                     )}
                                                                 </ContentScopeProvider>
-                                                            </React.Fragment>
+                                                            </Fragment>
                                                         </CmsBlockContextProvider>
                                                     </SnackbarProvider>
                                                 </DndProvider>

--- a/demo/admin/src/common/ComponentDemo.tsx
+++ b/demo/admin/src/common/ComponentDemo.tsx
@@ -43,7 +43,7 @@ import {
 } from "@comet/blocks-admin";
 import { DamImageBlock, FinalFormToggleButtonGroup, PixelImageBlock } from "@comet/cms-admin";
 import { Box, FormControlLabel, Grid, MenuItem, Typography } from "@mui/material";
-import * as React from "react";
+import { ReactNode, useState } from "react";
 
 import { RichTextBlock } from "./blocks/RichTextBlock";
 
@@ -76,12 +76,12 @@ const ColumnsBlock = createColumnsBlock({
 });
 
 interface CustomSelectItemProps {
-    icon: React.ReactNode;
-    primary: React.ReactNode;
-    secondary: React.ReactNode;
+    icon: ReactNode;
+    primary: ReactNode;
+    secondary: ReactNode;
 }
 
-function CustomSelectItem({ icon, primary, secondary }: CustomSelectItemProps): React.ReactElement {
+function CustomSelectItem({ icon, primary, secondary }: CustomSelectItemProps) {
     return (
         <Grid container spacing={4} alignItems="center">
             <Grid item>
@@ -99,13 +99,13 @@ function CustomSelectItem({ icon, primary, secondary }: CustomSelectItemProps): 
     );
 }
 
-export function ComponentDemo(): React.ReactElement {
-    const [optionalBlockState, setOptionalBlockState] = React.useState(OptionalRichTextBlock.defaultValues());
-    const [pixelImageBlockState, setPixelImageBlockState] = React.useState(PixelImageBlock.defaultValues());
-    const [listBlockState, setListBlockState] = React.useState(ListBlock.defaultValues());
-    const [blocksBlockState, setBlocksBlockState] = React.useState(BlocksBlock.defaultValues());
-    const [columnsBlockState, setColumnsBlockState] = React.useState(ColumnsBlock.defaultValues());
-    const [imageBlockState, setImageBlockState] = React.useState(DamImageBlock.defaultValues());
+export function ComponentDemo() {
+    const [optionalBlockState, setOptionalBlockState] = useState(OptionalRichTextBlock.defaultValues());
+    const [pixelImageBlockState, setPixelImageBlockState] = useState(PixelImageBlock.defaultValues());
+    const [listBlockState, setListBlockState] = useState(ListBlock.defaultValues());
+    const [blocksBlockState, setBlocksBlockState] = useState(BlocksBlock.defaultValues());
+    const [columnsBlockState, setColumnsBlockState] = useState(ColumnsBlock.defaultValues());
+    const [imageBlockState, setImageBlockState] = useState(DamImageBlock.defaultValues());
 
     return (
         <Stack topLevelTitle="Component demo">

--- a/demo/admin/src/common/ContentScopeProvider.tsx
+++ b/demo/admin/src/common/ContentScopeProvider.tsx
@@ -10,7 +10,6 @@ import {
     useSitesConfig,
 } from "@comet/cms-admin";
 import { SitesConfig } from "@src/config";
-import React from "react";
 
 type Domain = "main" | "secondary" | string;
 type Language = "en" | string;
@@ -30,7 +29,7 @@ export function useContentScopeConfig(p: ContentScopeConfigProps): void {
     return useContentScopeConfigLibrary(p);
 }
 
-const ContentScopeProvider: React.FC<Pick<ContentScopeProviderProps, "children">> = ({ children }) => {
+const ContentScopeProvider = ({ children }: Pick<ContentScopeProviderProps, "children">) => {
     const sitesConfig = useSitesConfig<SitesConfig>();
     const user = useCurrentUser();
 

--- a/demo/admin/src/common/EditPageNode.tsx
+++ b/demo/admin/src/common/EditPageNode.tsx
@@ -2,7 +2,6 @@ import { gql } from "@apollo/client";
 import { SelectField } from "@comet/admin";
 import { createEditPageNode } from "@comet/cms-admin";
 import { Box, Divider, MenuItem } from "@mui/material";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 export type { GQLPageTreeNodeAdditionalFieldsFragment } from "./EditPageNode.generated"; //re-export

--- a/demo/admin/src/common/MasterHeader.tsx
+++ b/demo/admin/src/common/MasterHeader.tsx
@@ -1,7 +1,6 @@
 import { BuildEntry, ContentScopeControls, Header, UserHeaderItem } from "@comet/cms-admin";
-import * as React from "react";
 
-const MasterHeader: React.FC = () => {
+const MasterHeader = () => {
     return (
         <Header>
             <ContentScopeControls />

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -32,7 +32,6 @@ import { ProductsPage } from "@src/products/generated/ProductsPage";
 import { ManufacturersPage as ManufacturersHandmadePage } from "@src/products/ManufacturersPage";
 import ProductsHandmadePage from "@src/products/ProductsPage";
 import ProductTagsPage from "@src/products/tags/ProductTagsPage";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 import { Redirect, RouteComponentProps } from "react-router-dom";
 

--- a/demo/admin/src/common/blocks/LinkListBlock.tsx
+++ b/demo/admin/src/common/blocks/LinkListBlock.tsx
@@ -2,7 +2,6 @@ import { createListBlock } from "@comet/blocks-admin";
 import { userGroupAdditionalItemFields } from "@src/userGroups/userGroupAdditionalItemFields";
 import { UserGroupChip } from "@src/userGroups/UserGroupChip";
 import { UserGroupContextMenuItem } from "@src/userGroups/UserGroupContextMenuItem";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { TextLinkBlock } from "./TextLinkBlock";

--- a/demo/admin/src/common/blocks/SpaceBlock.tsx
+++ b/demo/admin/src/common/blocks/SpaceBlock.tsx
@@ -1,8 +1,8 @@
 import { createSpaceBlock } from "@comet/blocks-admin";
-import * as React from "react";
+import { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
-const options: { value: string; label: React.ReactNode }[] = [
+const options: { value: string; label: ReactNode }[] = [
     { value: "d150", label: <FormattedMessage id="spacing.d150" defaultMessage="Dynamic 150" /> },
     { value: "d200", label: <FormattedMessage id="spacing.d200" defaultMessage="Dynamic 200" /> },
     { value: "d250", label: <FormattedMessage id="spacing.d250" defaultMessage="Dynamic 250" /> },

--- a/demo/admin/src/common/blocks/customBlockCategories.tsx
+++ b/demo/admin/src/common/blocks/customBlockCategories.tsx
@@ -1,5 +1,4 @@
 import { BlockCategory } from "@comet/blocks-admin";
-import React from "react";
 import { FormattedMessage } from "react-intl";
 
 const customBlockCategory = {

--- a/demo/admin/src/dam/ImportFromUnsplash.tsx
+++ b/demo/admin/src/dam/ImportFromUnsplash.tsx
@@ -2,17 +2,17 @@ import { CancelButton, messages, SaveButton } from "@comet/admin";
 import { useCurrentDamFolder, useDamAcceptedMimeTypes, useDamFileUpload } from "@comet/cms-admin";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { getRandomUnsplashImage, UnsplashImage } from "./getRandomUnsplashImage";
 import UnsplashIcon from "./UnsplashIcon";
 
-export const ImportFromUnsplash: React.FC = () => {
+export const ImportFromUnsplash = () => {
     const { allAcceptedMimeTypes } = useDamAcceptedMimeTypes();
     const { folderId } = useCurrentDamFolder();
-    const [isOpen, setIsOpen] = React.useState(false);
-    const [unsplashImage, setUnsplashImage] = React.useState<UnsplashImage>();
+    const [isOpen, setIsOpen] = useState(false);
+    const [unsplashImage, setUnsplashImage] = useState<UnsplashImage>();
 
     const { uploadFiles } = useDamFileUpload({
         acceptedMimetypes: allAcceptedMimeTypes,

--- a/demo/admin/src/dam/UnsplashIcon.tsx
+++ b/demo/admin/src/dam/UnsplashIcon.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from "@mui/material";
-import * as React from "react";
 
 export default function UnsplashIcon(props: SvgIconProps): JSX.Element {
     return (

--- a/demo/admin/src/dashboard/Dashboard.tsx
+++ b/demo/admin/src/dashboard/Dashboard.tsx
@@ -1,14 +1,13 @@
 import { MainContent, Stack, Toolbar } from "@comet/admin";
 import { ContentScopeIndicator, DashboardHeader, LatestBuildsDashboardWidget, useUserPermissionCheck } from "@comet/cms-admin";
 import { Grid } from "@mui/material";
-import * as React from "react";
 import { useIntl } from "react-intl";
 
 import backgroundImage1x from "./dashboard-image@1x.jpg";
 import backgroundImage2x from "./dashboard-image@2x.jpg";
 import { LatestContentUpdates } from "./LatestContentUpdates";
 
-const Dashboard: React.FC = () => {
+const Dashboard = () => {
     const intl = useIntl();
     const isAllowed = useUserPermissionCheck();
     return (

--- a/demo/admin/src/dashboard/LatestContentUpdates.tsx
+++ b/demo/admin/src/dashboard/LatestContentUpdates.tsx
@@ -3,7 +3,6 @@ import { LatestContentUpdatesDashboardWidget } from "@comet/cms-admin";
 import { useContentScope } from "@src/common/ContentScopeProvider";
 import { GQLLatestContentUpdatesQueryVariables } from "@src/dashboard/LatestContentUpdates.generated";
 import { categoryToUrlParam } from "@src/pageTree/pageTreeCategories";
-import React from "react";
 
 import { GQLLatestContentUpdatesQuery } from "./LatestContentUpdates.generated";
 

--- a/demo/admin/src/links/EditLink.tsx
+++ b/demo/admin/src/links/EditLink.tsx
@@ -16,7 +16,6 @@ import { AdminComponentRoot } from "@comet/blocks-admin";
 import { ContentScopeIndicator, createUsePage, PageName } from "@comet/cms-admin";
 import { IconButton } from "@mui/material";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
-import * as React from "react";
 import { useIntl } from "react-intl";
 
 import { GQLEditLinkQuery, GQLEditLinkQueryVariables, GQLUpdateLinkMutation, GQLUpdateLinkMutationVariables } from "./EditLink.generated";
@@ -62,7 +61,7 @@ interface Props {
     id: string;
 }
 
-export const EditLink: React.FC<Props> = ({ id }) => {
+export const EditLink = ({ id }: Props) => {
     const intl = useIntl();
     const stackApi = useStackApi();
 

--- a/demo/admin/src/links/Link.tsx
+++ b/demo/admin/src/links/Link.tsx
@@ -9,7 +9,6 @@ import { GQLLink, GQLLinkInput } from "@src/graphql.generated";
 import { EditLink } from "@src/links/EditLink";
 import { categoryToUrlParam } from "@src/pageTree/pageTreeCategories";
 import gql from "graphql-tag";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 const rootBlocks = {

--- a/demo/admin/src/news/blocks/NewsDetailBlock.tsx
+++ b/demo/admin/src/news/blocks/NewsDetailBlock.tsx
@@ -1,7 +1,6 @@
 import { Field, FinalFormInput } from "@comet/admin";
 import { BlockInterface, BlocksFinalForm, createBlockSkeleton } from "@comet/blocks-admin";
 import { NewsDetailBlockData, NewsDetailBlockInput } from "@src/blocks.generated";
-import * as React from "react";
 
 type State = NewsDetailBlockData;
 

--- a/demo/admin/src/news/blocks/NewsLinkBlock.tsx
+++ b/demo/admin/src/news/blocks/NewsLinkBlock.tsx
@@ -1,7 +1,6 @@
 import { TextField } from "@comet/admin";
 import { BlockInterface, BlocksFinalForm, createBlockSkeleton, LinkBlockInterface } from "@comet/blocks-admin";
 import { NewsLinkBlockData, NewsLinkBlockInput } from "@src/blocks.generated";
-import * as React from "react";
 
 type State = NewsLinkBlockData;
 

--- a/demo/admin/src/news/dependencies/NewsDependency.tsx
+++ b/demo/admin/src/news/dependencies/NewsDependency.tsx
@@ -1,6 +1,5 @@
 import { createDependencyMethods, DamImageBlock, DependencyInterface } from "@comet/cms-admin";
 import { NewsContentBlock } from "@src/news/blocks/NewsContentBlock";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 export const NewsDependency: DependencyInterface = {

--- a/demo/admin/src/news/generated/NewsForm.tsx
+++ b/demo/admin/src/news/generated/NewsForm.tsx
@@ -29,7 +29,7 @@ import { IconButton, MenuItem } from "@mui/material";
 import { useContentScope } from "@src/common/ContentScopeProvider";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
-import React from "react";
+import { useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { NewsContentBlock } from "../blocks/NewsContentBlock";
@@ -58,7 +58,7 @@ interface FormProps {
     id?: string;
 }
 
-export function NewsForm({ id }: FormProps): React.ReactElement {
+export function NewsForm({ id }: FormProps) {
     const stackApi = useStackApi();
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
@@ -71,7 +71,7 @@ export function NewsForm({ id }: FormProps): React.ReactElement {
         id ? { variables: { id } } : { skip: true },
     );
 
-    const initialValues = React.useMemo<Partial<FormValues>>(
+    const initialValues = useMemo<Partial<FormValues>>(
         () =>
             data?.news
                 ? {

--- a/demo/admin/src/news/generated/NewsGrid.tsx
+++ b/demo/admin/src/news/generated/NewsGrid.tsx
@@ -23,7 +23,6 @@ import { DamImageBlock } from "@comet/cms-admin";
 import { Button, IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import { useContentScope } from "@src/common/ContentScopeProvider";
-import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { NewsContentBlock } from "../blocks/NewsContentBlock";
@@ -97,7 +96,7 @@ function NewsGridToolbar() {
     );
 }
 
-export function NewsGrid(): React.ReactElement {
+export function NewsGrid() {
     const client = useApolloClient();
     const intl = useIntl();
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("NewsGrid") };

--- a/demo/admin/src/news/generated/NewsPage.tsx
+++ b/demo/admin/src/news/generated/NewsPage.tsx
@@ -3,13 +3,12 @@
 
 import { Stack, StackPage, StackSwitch, StackToolbar } from "@comet/admin";
 import { ContentScopeIndicator } from "@comet/cms-admin";
-import * as React from "react";
 import { useIntl } from "react-intl";
 
 import { NewsForm } from "./NewsForm";
 import { NewsGrid } from "./NewsGrid";
 
-export function NewsPage(): React.ReactElement {
+export function NewsPage() {
     const intl = useIntl();
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "news.news", defaultMessage: "News" })}>

--- a/demo/admin/src/pageTree/pageTreeCategories.tsx
+++ b/demo/admin/src/pageTree/pageTreeCategories.tsx
@@ -1,7 +1,6 @@
 import { AllCategories } from "@comet/cms-admin";
 import { GQLPageTreeNodeCategory } from "@src/graphql.generated";
 import { kebabCase, pascalCase } from "change-case";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 export const pageTreeCategories: AllCategories = [

--- a/demo/admin/src/pages/EditPage.tsx
+++ b/demo/admin/src/pages/EditPage.tsx
@@ -18,7 +18,6 @@ import { Button, IconButton } from "@mui/material";
 import { SeoBlock } from "@src/common/blocks/SeoBlock";
 import { useContentScope } from "@src/common/ContentScopeProvider";
 import { GQLPageTreeNodeCategory } from "@src/graphql.generated";
-import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useRouteMatch } from "react-router";
 
@@ -87,7 +86,7 @@ const usePage = createUsePage({
     `,
 });
 
-export const EditPage: React.FC<Props> = ({ id, category }) => {
+export const EditPage = ({ id, category }: Props) => {
     const intl = useIntl();
     const { pageState, rootBlocksApi, hasChanges, loading, dialogs, pageSaveButton, handleSavePage } = usePage({
         pageId: id,

--- a/demo/admin/src/pages/Page.tsx
+++ b/demo/admin/src/pages/Page.tsx
@@ -8,7 +8,6 @@ import { GQLPageTreeNodeAdditionalFieldsFragment } from "@src/common/EditPageNod
 import { GQLPage, GQLPageInput } from "@src/graphql.generated";
 import { categoryToUrlParam } from "@src/pageTree/pageTreeCategories";
 import gql from "graphql-tag";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { EditPage } from "./EditPage";

--- a/demo/admin/src/pages/PageContentBlock.tsx
+++ b/demo/admin/src/pages/PageContentBlock.tsx
@@ -9,7 +9,6 @@ import { NewsDetailBlock } from "@src/news/blocks/NewsDetailBlock";
 import { userGroupAdditionalItemFields } from "@src/userGroups/userGroupAdditionalItemFields";
 import { UserGroupChip } from "@src/userGroups/UserGroupChip";
 import { UserGroupContextMenuItem } from "@src/userGroups/UserGroupContextMenuItem";
-import * as React from "react";
 
 import { ColumnsBlock } from "./blocks/ColumnsBlock";
 import { FullWidthImageBlock } from "./blocks/FullWidthImageBlock";

--- a/demo/admin/src/pages/blocks/ColumnsBlock.tsx
+++ b/demo/admin/src/pages/blocks/ColumnsBlock.tsx
@@ -9,7 +9,6 @@ import {
 import { DamImageBlock } from "@comet/cms-admin";
 import { HeadlineBlock } from "@src/common/blocks/HeadlineBlock";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 const ColumnsContentBlock = createBlocksBlock({

--- a/demo/admin/src/pages/blocks/FullWidthImageBlock.tsx
+++ b/demo/admin/src/pages/blocks/FullWidthImageBlock.tsx
@@ -3,7 +3,6 @@ import { createCompositeBlock, createOptionalBlock } from "@comet/blocks-admin";
 import { DamImageBlock } from "@comet/cms-admin";
 import { customBlockCategory } from "@src/common/blocks/customBlockCategories";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 const FullWidthImageContentBlock = createOptionalBlock(RichTextBlock, {

--- a/demo/admin/src/pages/blocks/MediaBlock.tsx
+++ b/demo/admin/src/pages/blocks/MediaBlock.tsx
@@ -1,6 +1,5 @@
 import { BlockCategory, createOneOfBlock } from "@comet/blocks-admin";
 import { DamImageBlock, DamVideoBlock, YouTubeVideoBlock } from "@comet/cms-admin";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 export const MediaBlock = createOneOfBlock({

--- a/demo/admin/src/pages/blocks/TeaserBlock.tsx
+++ b/demo/admin/src/pages/blocks/TeaserBlock.tsx
@@ -2,7 +2,6 @@ import { BlockCategory, createCompositeBlock } from "@comet/blocks-admin";
 import { DamImageBlock } from "@comet/cms-admin";
 import { HeadlineBlock } from "@src/common/blocks/HeadlineBlock";
 import { LinkListBlock } from "@src/common/blocks/LinkListBlock";
-import React from "react";
 import { FormattedMessage } from "react-intl";
 
 const TeaserBlock = createCompositeBlock(

--- a/demo/admin/src/pages/blocks/VideoBlock.tsx
+++ b/demo/admin/src/pages/blocks/VideoBlock.tsx
@@ -1,6 +1,5 @@
 import { BlockCategory, createOneOfBlock } from "@comet/blocks-admin";
 import { DamVideoBlock, YouTubeVideoBlock } from "@comet/cms-admin";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 export const VideoBlock = createOneOfBlock({

--- a/demo/admin/src/pages/mainMenu/MainMenu.tsx
+++ b/demo/admin/src/pages/mainMenu/MainMenu.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import { Loading, Selected, Stack, StackPage, StackSwitch } from "@comet/admin";
-import * as React from "react";
 import { useIntl } from "react-intl";
 
 import EditMainMenuItem, { editMainMenuItemFragment, GQLEditMainMenuItemFragment } from "./components/EditMainMenuItem";
@@ -16,7 +15,7 @@ const MAIN_MENU_ITEM_QUERY = gql`
     ${editMainMenuItemFragment}
 `;
 
-const MainMenu: React.FunctionComponent = () => {
+const MainMenu = () => {
     const intl = useIntl();
 
     return (

--- a/demo/admin/src/pages/mainMenu/components/EditMainMenuItem.tsx
+++ b/demo/admin/src/pages/mainMenu/components/EditMainMenuItem.tsx
@@ -17,7 +17,7 @@ import { Button } from "@mui/material";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import { useContentScope } from "@src/common/ContentScopeProvider";
 import isEqual from "lodash.isequal";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useRouteMatch } from "react-router-dom";
 
@@ -55,27 +55,27 @@ interface EditMainMenuItemProps {
 type RichTextBlockState = BlockState<typeof RichTextBlock>;
 type RichTextBlockOutput = BlockOutputApi<typeof RichTextBlock>;
 
-const EditMainMenuItem: React.FunctionComponent<EditMainMenuItemProps> = ({ item }) => {
+const EditMainMenuItem = ({ item }: EditMainMenuItemProps) => {
     const previewApi = useBlockPreview();
     const match = useRouteMatch();
     const [updateMainMenuItem, { loading: saving, error: saveError }] = useMutation<
         GQLUpdateMainMenuItemMutation,
         GQLUpdateMainMenuItemMutationVariables
     >(updateMainMenuItemMutation);
-    const [referenceContent, setReferenceContent] = React.useState<RichTextBlockOutput | null>(null);
-    const [hasChanges, setHasChanges] = React.useState(false);
-    const [content, setContent] = React.useState<RichTextBlockState | null>(null);
+    const [referenceContent, setReferenceContent] = useState<RichTextBlockOutput | null>(null);
+    const [hasChanges, setHasChanges] = useState(false);
+    const [content, setContent] = useState<RichTextBlockState | null>(null);
     const { match: contentScopeMatch, scope } = useContentScope();
     const siteConfig = useSiteConfig({ scope });
     const intl = useIntl();
     const blockContext = useCmsBlockContext();
 
-    React.useEffect(() => {
+    useEffect(() => {
         setContent(item.content ? RichTextBlock.input2State(item.content) : null);
         setReferenceContent(item.content ? RichTextBlock.state2Output(RichTextBlock.input2State(item.content)) : null);
     }, [item]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         const equal = isEqual(referenceContent, content ? RichTextBlock.state2Output(content) : null);
         setHasChanges(!equal);
     }, [content, referenceContent]);

--- a/demo/admin/src/pages/mainMenu/components/MainMenuItems.tsx
+++ b/demo/admin/src/pages/mainMenu/components/MainMenuItems.tsx
@@ -4,7 +4,6 @@ import { Edit } from "@comet/admin-icons";
 import { ContentScopeIndicator } from "@comet/cms-admin";
 import { IconButton } from "@mui/material";
 import { useContentScope } from "@src/common/ContentScopeProvider";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { GQLMainMenuQuery, GQLMainMenuQueryVariables } from "./MainMenuItems.generated";
@@ -24,7 +23,7 @@ const mainMenuQuery = gql`
     }
 `;
 
-const MainMenuItems: React.FunctionComponent = () => {
+const MainMenuItems = () => {
     const { scope } = useContentScope();
 
     const { tableData, api, loading, error } = useTableQuery<GQLMainMenuQuery, GQLMainMenuQueryVariables>()(mainMenuQuery, {

--- a/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
+++ b/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
@@ -3,7 +3,6 @@ import { FinalForm, FinalFormSaveButton, Loading, MainContent, SelectField, Tool
 import { ArrowLeft } from "@comet/admin-icons";
 import { PageName } from "@comet/cms-admin";
 import { IconButton, MenuItem } from "@mui/material";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import {
@@ -48,7 +47,7 @@ interface Props {
     id: string;
 }
 
-export const EditPredefinedPage: React.FC<Props> = ({ id }) => {
+export const EditPredefinedPage = ({ id }: Props) => {
     const stackApi = useStackApi();
 
     const { data, loading } = useQuery<GQLPredefinedPageQuery, GQLPredefinedPageQueryVariables>(getQuery, {

--- a/demo/admin/src/predefinedPage/PredefinedPage.tsx
+++ b/demo/admin/src/predefinedPage/PredefinedPage.tsx
@@ -4,7 +4,6 @@ import { DocumentInterface } from "@comet/cms-admin";
 import { GQLPredefinedPage, GQLPredefinedPageInput } from "@src/graphql.generated";
 import { EditPredefinedPage } from "@src/predefinedPage/EditPredefinedPage";
 import gql from "graphql-tag";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { GQLPredefinedPageInfoTagQuery, GQLPredefinedPageInfoTagQueryVariables } from "./PredefinedPage.generated";

--- a/demo/admin/src/products/ManufacturerForm.tsx
+++ b/demo/admin/src/products/ManufacturerForm.tsx
@@ -18,7 +18,7 @@ import { queryUpdatedAt, resolveHasSaveConflict, useFormSaveConflict } from "@co
 import { Divider, FormControlLabel } from "@mui/material";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
-import React from "react";
+import { useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { createManufacturerMutation, manufacturerFormFragment, manufacturerQuery, updateManufacturerMutation } from "./ManufacturerForm.gql";
@@ -65,7 +65,7 @@ interface FormProps {
     id?: string;
 }
 
-export function ManufacturerForm({ id }: FormProps): React.ReactElement {
+export function ManufacturerForm({ id }: FormProps) {
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
     const formApiRef = useFormApiRef<FormValues>();
@@ -76,7 +76,7 @@ export function ManufacturerForm({ id }: FormProps): React.ReactElement {
         id ? { variables: { id } } : { skip: true },
     );
 
-    const initialValues = React.useMemo<Partial<FormValues>>(() => {
+    const initialValues = useMemo<Partial<FormValues>>(() => {
         const filteredData = data ? filterByFragment<GQLManufacturerFormDetailsFragment>(manufacturerFormFragment, data.manufacturer) : undefined;
         if (!filteredData) return {};
         return {

--- a/demo/admin/src/products/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/ManufacturersGrid.tsx
@@ -28,7 +28,6 @@ import {
     GQLManufacturersListQueryVariables,
 } from "@src/products/ManufacturersGrid.generated";
 import gql from "graphql-tag";
-import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 function ManufacturersGridToolbar() {

--- a/demo/admin/src/products/ManufacturersPage.tsx
+++ b/demo/admin/src/products/ManufacturersPage.tsx
@@ -13,7 +13,6 @@ import {
 import { ContentScopeIndicator } from "@comet/cms-admin";
 import { ManufacturerForm } from "@src/products/ManufacturerForm";
 import { ManufacturersGrid } from "@src/products/ManufacturersGrid";
-import * as React from "react";
 import { useIntl } from "react-intl";
 
 const FormToolbar = () => (
@@ -27,7 +26,7 @@ const FormToolbar = () => (
     </StackToolbar>
 );
 
-export function ManufacturersPage(): React.ReactElement {
+export function ManufacturersPage() {
     const intl = useIntl();
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "products.manufacturers", defaultMessage: "Manufacturers" })}>

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -34,7 +34,7 @@ import {
 } from "@src/products/ProductForm.generated";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
-import React from "react";
+import { useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 
 import {
@@ -73,7 +73,7 @@ type FormValues = Omit<ProductFormManualFragment, "image" | "manufacturerCountry
     manufacturerCountry?: { id: string };
 };
 
-export function ProductForm({ id }: FormProps): React.ReactElement {
+export function ProductForm({ id }: FormProps) {
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
     const formApiRef = useFormApiRef<FormValues>();
@@ -84,7 +84,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
         id ? { variables: { id } } : { skip: true },
     );
 
-    const initialValues: Partial<FormValues> = React.useMemo<Partial<FormValues>>(() => {
+    const initialValues: Partial<FormValues> = useMemo<Partial<FormValues>>(() => {
         const filteredData = data ? filterByFragment<ProductFormManualFragment>(productFormFragment, data.product) : undefined;
         if (!filteredData) {
             return {

--- a/demo/admin/src/products/ProductPriceForm.tsx
+++ b/demo/admin/src/products/ProductPriceForm.tsx
@@ -4,7 +4,6 @@ import { queryUpdatedAt, resolveHasSaveConflict, useFormSaveConflict } from "@co
 import { CircularProgress } from "@mui/material";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
-import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { productPriceFormFragment, productPriceFormQuery, updateProductPriceFormMutation } from "./ProductPriceForm.gql";
@@ -24,7 +23,7 @@ type FormValues = Omit<GQLProductPriceFormFragment, "price"> & {
     price?: string;
 };
 
-export function ProductPriceForm({ id }: FormProps): React.ReactElement {
+export function ProductPriceForm({ id }: FormProps) {
     const client = useApolloClient();
     const formApiRef = useFormApiRef<FormValues>();
 

--- a/demo/admin/src/products/ProductVariantForm.tsx
+++ b/demo/admin/src/products/ProductVariantForm.tsx
@@ -14,7 +14,6 @@ import { BlockState, createFinalFormBlock } from "@comet/blocks-admin";
 import { DamImageBlock, queryUpdatedAt, resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
-import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import {
@@ -46,7 +45,7 @@ type FormValues = Omit<GQLProductVariantFormFragment, "image"> & {
     image: BlockState<typeof rootBlocks.image>;
 };
 
-export function ProductVariantForm({ id, productId }: FormProps): React.ReactElement {
+export function ProductVariantForm({ id, productId }: FormProps) {
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
     const formApiRef = useFormApiRef<FormValues>();

--- a/demo/admin/src/products/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/ProductVariantsGrid.tsx
@@ -17,7 +17,6 @@ import { Add as AddIcon, Edit } from "@comet/admin-icons";
 import { Box, Button, IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import gql from "graphql-tag";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import {

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -23,7 +23,6 @@ import { DamImageBlock } from "@comet/cms-admin";
 import { Button, IconButton, useTheme } from "@mui/material";
 import { DataGridPro, GridFilterInputSingleSelect, GridFilterInputValue, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import gql from "graphql-tag";
-import * as React from "react";
 import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
 
 import {

--- a/demo/admin/src/products/ProductsGridPreviewAction.tsx
+++ b/demo/admin/src/products/ProductsGridPreviewAction.tsx
@@ -2,7 +2,7 @@ import { Tooltip } from "@comet/admin";
 import { View } from "@comet/admin-icons";
 import { Dialog, DialogContent, DialogTitle, IconButton, Typography } from "@mui/material";
 import { GQLProductsListManualFragment } from "@src/products/ProductsGrid.generated";
-import React from "react";
+import { useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 type Props = {
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export const ProductsGridPreviewAction = ({ product }: Props) => {
-    const [showDetails, setShowDetails] = React.useState(false);
+    const [showDetails, setShowDetails] = useState(false);
     return (
         <>
             <Tooltip title="View Details">

--- a/demo/admin/src/products/ProductsPage.tsx
+++ b/demo/admin/src/products/ProductsPage.tsx
@@ -14,7 +14,6 @@ import {
     ToolbarFillSpace,
 } from "@comet/admin";
 import { ContentScopeIndicator } from "@comet/cms-admin";
-import React from "react";
 import { useIntl } from "react-intl";
 
 import { ProductForm } from "./ProductForm";
@@ -34,7 +33,7 @@ const FormToolbar = () => (
     </StackToolbar>
 );
 
-const ProductsPage: React.FC = () => {
+const ProductsPage = () => {
     const intl = useIntl();
 
     return (

--- a/demo/admin/src/products/categories/ProductCategoriesPage.tsx
+++ b/demo/admin/src/products/categories/ProductCategoriesPage.tsx
@@ -12,7 +12,6 @@ import {
     ToolbarFillSpace,
 } from "@comet/admin";
 import { ContentScopeIndicator } from "@comet/cms-admin";
-import React from "react";
 import { useIntl } from "react-intl";
 
 import ProductCategoriesTable from "./ProductCategoriesTable";
@@ -29,7 +28,7 @@ const FormToolbar = () => (
     </StackToolbar>
 );
 
-const ProductCategoriesPage: React.FC = () => {
+const ProductCategoriesPage = () => {
     const intl = useIntl();
 
     return (

--- a/demo/admin/src/products/categories/ProductCategoriesTable.tsx
+++ b/demo/admin/src/products/categories/ProductCategoriesTable.tsx
@@ -19,7 +19,6 @@ import { Add as AddIcon, Edit } from "@comet/admin-icons";
 import { Button, IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import gql from "graphql-tag";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import {

--- a/demo/admin/src/products/categories/ProductCategoryForm.tsx
+++ b/demo/admin/src/products/categories/ProductCategoryForm.tsx
@@ -3,7 +3,6 @@ import { filterByFragment, FinalForm, FinalFormSubmitEvent, MainContent, TextFie
 import { resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
 import { CircularProgress } from "@mui/material";
 import { FormApi } from "final-form";
-import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import {
@@ -31,7 +30,7 @@ interface FormProps {
 
 type FormState = GQLProductCategoryFormFragment;
 
-function ProductCategoryForm({ id }: FormProps): React.ReactElement {
+function ProductCategoryForm({ id }: FormProps) {
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
     const formApiRef = useFormApiRef<FormState>();

--- a/demo/admin/src/products/future/CreateCapProductPage.tsx
+++ b/demo/admin/src/products/future/CreateCapProductPage.tsx
@@ -10,10 +10,9 @@ import {
 } from "@comet/admin";
 import { ContentScopeIndicator } from "@comet/cms-admin";
 import { CreateCapProductForm } from "@src/products/future/generated/CreateCapProductForm";
-import * as React from "react";
 import { useIntl } from "react-intl";
 
-export function CreateCapProductPage(): React.ReactElement {
+export function CreateCapProductPage() {
     const intl = useIntl();
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "products.createCapProduct", defaultMessage: "Create Cap Product" })}>

--- a/demo/admin/src/products/future/ManufacturersPage.tsx
+++ b/demo/admin/src/products/future/ManufacturersPage.tsx
@@ -1,10 +1,9 @@
 import { MainContent, Stack, StackPage, StackSwitch, StackToolbar } from "@comet/admin";
 import { ContentScopeIndicator } from "@comet/cms-admin";
 import { ManufacturersGrid } from "@src/products/future/generated/ManufacturersGrid";
-import * as React from "react";
 import { useIntl } from "react-intl";
 
-export function ManufacturersPage(): React.ReactElement {
+export function ManufacturersPage() {
     const intl = useIntl();
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "manufacturers.manufacturers", defaultMessage: "Manufacturers" })}>

--- a/demo/admin/src/products/future/ProductsPage.tsx
+++ b/demo/admin/src/products/future/ProductsPage.tsx
@@ -18,7 +18,6 @@ import { Add as AddIcon, Edit } from "@comet/admin-icons";
 import { ContentScopeIndicator } from "@comet/cms-admin";
 import { Button, IconButton } from "@mui/material";
 import { ProductVariantsGrid } from "@src/products/future/generated/ProductVariantsGrid";
-import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { ProductForm } from "./generated/ProductForm";
@@ -36,7 +35,7 @@ const FormToolbar = () => (
     </StackToolbar>
 );
 
-export function ProductsPage(): React.ReactElement {
+export function ProductsPage() {
     const intl = useIntl();
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "products.products", defaultMessage: "Products" })}>

--- a/demo/admin/src/products/future/ProductsWithLowPricePage.tsx
+++ b/demo/admin/src/products/future/ProductsWithLowPricePage.tsx
@@ -1,9 +1,8 @@
 import { MainContent } from "@comet/admin";
-import * as React from "react";
 
 import { ProductsGrid } from "./generated/ProductsGrid";
 
-export function ProductsWithLowPricePage(): React.ReactElement {
+export function ProductsWithLowPricePage() {
     // This grid needs no add or edit-button
     return (
         <MainContent fullHeight>

--- a/demo/admin/src/products/future/generated/CreateCapProductForm.tsx
+++ b/demo/admin/src/products/future/generated/CreateCapProductForm.tsx
@@ -20,7 +20,6 @@ import { FormControlLabel } from "@mui/material";
 import { GQLProductType } from "@src/graphql.generated";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
-import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { validateTitle } from "../validateTitle";
@@ -44,7 +43,7 @@ interface FormProps {
     type: GQLProductType;
 }
 
-export function CreateCapProductForm({ type }: FormProps): React.ReactElement {
+export function CreateCapProductForm({ type }: FormProps) {
     const client = useApolloClient();
 
     const formApiRef = useFormApiRef<FormValues>();

--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -20,7 +20,6 @@ import {
 import { Add as AddIcon, Edit } from "@comet/admin-icons";
 import { Button, IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
-import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import {
@@ -101,7 +100,7 @@ function ManufacturersGridToolbar() {
     );
 }
 
-export function ManufacturersGrid(): React.ReactElement {
+export function ManufacturersGrid() {
     const client = useApolloClient();
     const intl = useIntl();
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ManufacturersGrid") };

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -24,7 +24,7 @@ import { DamImageBlock, queryUpdatedAt, resolveHasSaveConflict, useFormSaveConfl
 import { FormControlLabel, InputAdornment, MenuItem } from "@mui/material";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
-import React from "react";
+import { useMemo } from "react";
 import { FormSpy } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
@@ -53,7 +53,7 @@ interface FormProps {
     id?: string;
 }
 
-export function ProductForm({ id }: FormProps): React.ReactElement {
+export function ProductForm({ id }: FormProps) {
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
     const formApiRef = useFormApiRef<FormValues>();
@@ -64,7 +64,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
         id ? { variables: { id } } : { skip: true },
     );
 
-    const initialValues = React.useMemo<Partial<FormValues>>(
+    const initialValues = useMemo<Partial<FormValues>>(
         () =>
             data?.product
                 ? {

--- a/demo/admin/src/products/future/generated/ProductPriceForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductPriceForm.tsx
@@ -5,7 +5,7 @@ import { Field, filterByFragment, FinalForm, FinalFormInput, Loading, MainConten
 import { queryUpdatedAt, resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
-import React from "react";
+import { useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { productFormFragment, productQuery, updateProductMutation } from "./ProductPriceForm.gql";
@@ -25,14 +25,14 @@ interface FormProps {
     id: string;
 }
 
-export function ProductPriceForm({ id }: FormProps): React.ReactElement {
+export function ProductPriceForm({ id }: FormProps) {
     const client = useApolloClient();
 
     const formApiRef = useFormApiRef<FormValues>();
 
     const { data, error, loading, refetch } = useQuery<GQLProductQuery, GQLProductQueryVariables>(productQuery, { variables: { id } });
 
-    const initialValues = React.useMemo<Partial<FormValues>>(
+    const initialValues = useMemo<Partial<FormValues>>(
         () =>
             data?.product
                 ? {

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -21,7 +21,6 @@ import { Add as AddIcon, Edit } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { Button, IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
-import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import {
@@ -98,7 +97,7 @@ type Props = {
     product: string;
 };
 
-export function ProductVariantsGrid({ product }: Props): React.ReactElement {
+export function ProductVariantsGrid({ product }: Props) {
     const client = useApolloClient();
     const intl = useIntl();
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductVariantsGrid") };

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -19,7 +19,7 @@ import {
 import { DamImageBlock } from "@comet/cms-admin";
 import { DataGridPro, GridRenderCellParams, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import { GQLProductFilter } from "@src/graphql.generated";
-import * as React from "react";
+import { ReactNode } from "react";
 import { useIntl } from "react-intl";
 
 import {
@@ -71,7 +71,7 @@ const createProductMutation = gql`
     }
 `;
 
-function ProductsGridToolbar({ toolbarAction }: { toolbarAction?: React.ReactNode }) {
+function ProductsGridToolbar({ toolbarAction }: { toolbarAction?: ReactNode }) {
     return (
         <DataGridToolbar>
             <ToolbarItem>
@@ -88,12 +88,12 @@ function ProductsGridToolbar({ toolbarAction }: { toolbarAction?: React.ReactNod
 
 type Props = {
     filter?: GQLProductFilter;
-    toolbarAction?: React.ReactNode;
+    toolbarAction?: ReactNode;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rowAction?: (params: GridRenderCellParams<any, GQLProductsGridFutureFragment, any>) => React.ReactNode;
+    rowAction?: (params: GridRenderCellParams<any, GQLProductsGridFutureFragment, any>) => ReactNode;
 };
 
-export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React.ReactElement {
+export function ProductsGrid({ filter, toolbarAction, rowAction }: Props) {
     const client = useApolloClient();
     const intl = useIntl();
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };

--- a/demo/admin/src/products/future/validateTitle.tsx
+++ b/demo/admin/src/products/future/validateTitle.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { FormattedMessage } from "react-intl";
 
 export function validateTitle(value: string) {

--- a/demo/admin/src/products/generated/ProductForm.tsx
+++ b/demo/admin/src/products/generated/ProductForm.tsx
@@ -30,7 +30,7 @@ import { ContentScopeIndicator, DamImageBlock, queryUpdatedAt, resolveHasSaveCon
 import { FormControlLabel, IconButton, MenuItem } from "@mui/material";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
-import React from "react";
+import { useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { createProductMutation, productFormFragment, productFormQuery, updateProductMutation } from "./ProductForm.gql";
@@ -57,7 +57,7 @@ interface FormProps {
     id?: string;
 }
 
-export function ProductForm({ id }: FormProps): React.ReactElement {
+export function ProductForm({ id }: FormProps) {
     const stackApi = useStackApi();
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
@@ -69,7 +69,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
         id ? { variables: { id } } : { skip: true },
     );
 
-    const initialValues = React.useMemo<Partial<FormValues>>(
+    const initialValues = useMemo<Partial<FormValues>>(
         () =>
             data?.product
                 ? {

--- a/demo/admin/src/products/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/generated/ProductsGrid.tsx
@@ -22,7 +22,6 @@ import { BlockPreviewContent } from "@comet/blocks-admin";
 import { DamImageBlock } from "@comet/cms-admin";
 import { Button, IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
-import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import {
@@ -99,7 +98,7 @@ function ProductsGridToolbar() {
     );
 }
 
-export function ProductsGrid(): React.ReactElement {
+export function ProductsGrid() {
     const client = useApolloClient();
     const intl = useIntl();
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };

--- a/demo/admin/src/products/generated/ProductsPage.tsx
+++ b/demo/admin/src/products/generated/ProductsPage.tsx
@@ -3,13 +3,12 @@
 
 import { Stack, StackPage, StackSwitch, StackToolbar } from "@comet/admin";
 import { ContentScopeIndicator } from "@comet/cms-admin";
-import * as React from "react";
 import { useIntl } from "react-intl";
 
 import { ProductForm } from "./ProductForm";
 import { ProductsGrid } from "./ProductsGrid";
 
-export function ProductsPage(): React.ReactElement {
+export function ProductsPage() {
     const intl = useIntl();
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "products.products", defaultMessage: "Products" })}>

--- a/demo/admin/src/products/tags/ProductTagForm.tsx
+++ b/demo/admin/src/products/tags/ProductTagForm.tsx
@@ -3,7 +3,6 @@ import { filterByFragment, FinalForm, FinalFormSubmitEvent, MainContent, TextFie
 import { resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
 import { CircularProgress } from "@mui/material";
 import { FormApi } from "final-form";
-import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import {
@@ -31,7 +30,7 @@ interface FormProps {
 
 type FormState = GQLProductTagFormFragment;
 
-function ProductTagForm({ id }: FormProps): React.ReactElement {
+function ProductTagForm({ id }: FormProps) {
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
     const formApiRef = useFormApiRef<FormState>();

--- a/demo/admin/src/products/tags/ProductTagTable.tsx
+++ b/demo/admin/src/products/tags/ProductTagTable.tsx
@@ -19,7 +19,6 @@ import { Add as AddIcon, Edit } from "@comet/admin-icons";
 import { Box, Button, IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import gql from "graphql-tag";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import {

--- a/demo/admin/src/products/tags/ProductTagsPage.tsx
+++ b/demo/admin/src/products/tags/ProductTagsPage.tsx
@@ -12,13 +12,12 @@ import {
     ToolbarFillSpace,
 } from "@comet/admin";
 import { ContentScopeIndicator } from "@comet/cms-admin";
-import React from "react";
 import { useIntl } from "react-intl";
 
 import ProductTagForm from "./ProductTagForm";
 import ProductTagsTable from "./ProductTagTable";
 
-const ProductTagsPage: React.FC = () => {
+const ProductTagsPage = () => {
     const intl = useIntl();
 
     return (

--- a/demo/admin/src/userGroups/UserGroupChip.tsx
+++ b/demo/admin/src/userGroups/UserGroupChip.tsx
@@ -1,6 +1,5 @@
 import { Box, Chip } from "@mui/material";
 import { GQLUserGroup } from "@src/graphql.generated";
-import * as React from "react";
 
 import { userGroupOptions } from "./userGroupOptions";
 

--- a/demo/admin/src/userGroups/UserGroupContextMenuItem.tsx
+++ b/demo/admin/src/userGroups/UserGroupContextMenuItem.tsx
@@ -2,7 +2,7 @@ import { messages, SelectField } from "@comet/admin";
 import { Account } from "@comet/admin-icons";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, ListItemIcon, MenuItem } from "@mui/material";
 import { GQLUserGroup } from "@src/graphql.generated";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
@@ -24,7 +24,7 @@ interface Props {
 }
 
 function UserGroupContextMenuItem({ item, onChange, onMenuClose }: Props): JSX.Element {
-    const [dialogOpen, setDialogOpen] = React.useState(false);
+    const [dialogOpen, setDialogOpen] = useState(false);
 
     interface FormValues {
         userGroup: GQLUserGroup;

--- a/demo/admin/src/userGroups/userGroupOptions.tsx
+++ b/demo/admin/src/userGroups/userGroupOptions.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 const userGroupOptions = [

--- a/demo/site-pages/.eslintrc.json
+++ b/demo/site-pages/.eslintrc.json
@@ -2,6 +2,18 @@
     "extends": "@comet/eslint-config/nextjs",
     "ignorePatterns": ["**/**/*.generated.ts", "dist/**"],
     "rules": {
-        "@calm/react-intl/missing-formatted-message": "off"
+        "@calm/react-intl/missing-formatted-message": "off",
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/demo/site-pages/src/blocks/AnchorBlock.tsx
+++ b/demo/site-pages/src/blocks/AnchorBlock.tsx
@@ -1,6 +1,5 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { AnchorBlockData } from "@src/blocks.generated";
-import * as React from "react";
 
 const AnchorBlock = withPreview(
     ({ data: { name } }: PropsWithData<AnchorBlockData>) => {

--- a/demo/site-pages/src/blocks/ColorThemeContext.tsx
+++ b/demo/site-pages/src/blocks/ColorThemeContext.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
+import { createContext, PropsWithChildren, useContext } from "react";
 
 export type ColorTheme = "Default" | "GreyN1" | "GreyN2" | "GreyN3" | "DarkBlue";
 
-const ColorThemeContext = React.createContext<ColorTheme>("Default");
+const ColorThemeContext = createContext<ColorTheme>("Default");
 
-export function ColorThemeProvider({ children, colorTheme }: React.PropsWithChildren<{ colorTheme: ColorTheme }>): React.ReactElement {
+export function ColorThemeProvider({ children, colorTheme }: PropsWithChildren<{ colorTheme: ColorTheme }>) {
     return <ColorThemeContext.Provider value={colorTheme}>{children}</ColorThemeContext.Provider>;
 }
 
 export function useColorTheme(): ColorTheme {
-    return React.useContext(ColorThemeContext);
+    return useContext(ColorThemeContext);
 }

--- a/demo/site-pages/src/blocks/ColumnsBlock.tsx
+++ b/demo/site-pages/src/blocks/ColumnsBlock.tsx
@@ -1,6 +1,5 @@
 import { BlocksBlock, PropsWithData, SupportedBlocks, withPreview } from "@comet/cms-site";
 import { ColumnsBlockData, ColumnsContentBlockData } from "@src/blocks.generated";
-import * as React from "react";
 import styled from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";

--- a/demo/site-pages/src/blocks/DamImageBlock.tsx
+++ b/demo/site-pages/src/blocks/DamImageBlock.tsx
@@ -2,7 +2,6 @@ import { PixelImageBlock, PreviewSkeleton, PropsWithData, SvgImageBlock, withPre
 import { DamImageBlockData, PixelImageBlockData, SvgImageBlockData } from "@src/blocks.generated";
 import { NextImageBottomPaddingFix } from "@src/components/common/NextImageBottomPaddingFix";
 import { ImageProps } from "next/image";
-import * as React from "react";
 
 type Props = PropsWithData<DamImageBlockData> &
     Omit<ImageProps, "src" | "width" | "height" | "alt"> & {

--- a/demo/site-pages/src/blocks/FullWidthImageBlock.tsx
+++ b/demo/site-pages/src/blocks/FullWidthImageBlock.tsx
@@ -1,6 +1,5 @@
 import { OptionalBlock, PropsWithData, withPreview } from "@comet/cms-site";
 import { FullWidthImageBlockData } from "@src/blocks.generated";
-import * as React from "react";
 import styled from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";

--- a/demo/site-pages/src/blocks/HeadlineBlock.tsx
+++ b/demo/site-pages/src/blocks/HeadlineBlock.tsx
@@ -1,11 +1,11 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { HeadlineBlockData } from "@src/blocks.generated";
-import * as React from "react";
+import { ElementType } from "react";
 import { Renderers } from "redraft";
 
 import RichTextBlock from "./RichTextBlock";
 
-const headlineTags: { [key: string]: React.ElementType } = {
+const headlineTags: { [key: string]: ElementType } = {
     "header-one": "h1",
     "header-two": "h2",
     "header-three": "h3",

--- a/demo/site-pages/src/blocks/LinkBlock.tsx
+++ b/demo/site-pages/src/blocks/LinkBlock.tsx
@@ -9,7 +9,7 @@ import {
 } from "@comet/cms-site";
 import { LinkBlockData } from "@src/blocks.generated";
 import { NewsLinkBlock } from "@src/news/blocks/NewsLinkBlock";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 const supportedBlocks: SupportedBlocks = {
     internal: ({ children, title, ...props }) => (
@@ -34,12 +34,8 @@ const supportedBlocks: SupportedBlocks = {
     ),
 };
 
-interface LinkBlockProps extends PropsWithData<LinkBlockData> {
-    children: React.ReactNode;
-}
-
 export const LinkBlock = withPreview(
-    ({ data, children }: LinkBlockProps) => {
+    ({ data, children }: PropsWithChildren<PropsWithData<LinkBlockData>>) => {
         return (
             <OneOfBlock data={data} supportedBlocks={supportedBlocks}>
                 {children}

--- a/demo/site-pages/src/blocks/LinkListBlock.tsx
+++ b/demo/site-pages/src/blocks/LinkListBlock.tsx
@@ -1,6 +1,5 @@
 import { ListBlock, PropsWithData, withPreview } from "@comet/cms-site";
 import { LinkListBlockData } from "@src/blocks.generated";
-import * as React from "react";
 
 import { TextLinkBlock } from "./TextLinkBlock";
 

--- a/demo/site-pages/src/blocks/MediaBlock.tsx
+++ b/demo/site-pages/src/blocks/MediaBlock.tsx
@@ -1,6 +1,5 @@
 import { DamVideoBlock, OneOfBlock, PropsWithData, SupportedBlocks, withPreview } from "@comet/cms-site";
 import { MediaBlockData } from "@src/blocks.generated";
-import * as React from "react";
 
 import { DamImageBlock } from "./DamImageBlock";
 

--- a/demo/site-pages/src/blocks/PageContentBlock.tsx
+++ b/demo/site-pages/src/blocks/PageContentBlock.tsx
@@ -1,7 +1,6 @@
 import { BlocksBlock, DamVideoBlock, PropsWithData, SupportedBlocks, YouTubeVideoBlock } from "@comet/cms-site";
 import { PageContentBlockData } from "@src/blocks.generated";
 import { TeaserBlock } from "@src/documents/pages/blocks/TeaserBlock";
-import * as React from "react";
 
 import { AnchorBlock } from "./AnchorBlock";
 import { ColumnsBlock } from "./ColumnsBlock";
@@ -32,6 +31,6 @@ const supportedBlocks: SupportedBlocks = {
     teaser: (props) => <TeaserBlock data={props} />,
 };
 
-export const PageContentBlock: React.FC<PropsWithData<PageContentBlockData>> = ({ data }) => {
+export const PageContentBlock = ({ data }: PropsWithData<PageContentBlockData>) => {
     return <BlocksBlock data={data} supportedBlocks={supportedBlocks} />;
 };

--- a/demo/site-pages/src/blocks/RichTextBlock.tsx
+++ b/demo/site-pages/src/blocks/RichTextBlock.tsx
@@ -1,12 +1,12 @@
 import { hasRichTextBlockContent, PreviewSkeleton, PropsWithData, withPreview } from "@comet/cms-site";
 import { LinkBlockData, RichTextBlockData } from "@src/blocks.generated";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 import redraft, { Renderers } from "redraft";
 import styled from "styled-components";
 
 import { LinkBlock } from "./LinkBlock";
 
-const GreenCustomHeader: React.FC<{ children: React.ReactNode }> = ({ children }) => <h3 style={{ color: "green" }}>{children}</h3>;
+const GreenCustomHeader = ({ children }: PropsWithChildren) => <h3 style={{ color: "green" }}>{children}</h3>;
 
 export const DefaultStyleLink = styled.a`
     color: ${({ theme }) => theme.colors.primary};
@@ -75,7 +75,7 @@ interface RichTextBlockProps extends PropsWithData<RichTextBlockData> {
     renderers?: Renderers;
 }
 
-const RichTextBlock: React.FC<RichTextBlockProps> = ({ data, renderers = defaultRenderers }) => {
+const RichTextBlock = ({ data, renderers = defaultRenderers }: RichTextBlockProps) => {
     const rendered = redraft(data.draftContent, renderers);
 
     return (

--- a/demo/site-pages/src/blocks/SpaceBlock.tsx
+++ b/demo/site-pages/src/blocks/SpaceBlock.tsx
@@ -1,6 +1,5 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { DemoSpaceBlockData } from "@src/blocks.generated";
-import * as React from "react";
 
 const SpaceMapping: Record<string, number> = {
     d150: 10,
@@ -15,7 +14,7 @@ const SpaceMapping: Record<string, number> = {
     d600: 300,
 };
 
-const SpaceBlock: React.FC<PropsWithData<DemoSpaceBlockData>> = ({ data: { spacing } }) => {
+const SpaceBlock = ({ data: { spacing } }: PropsWithData<DemoSpaceBlockData>) => {
     return <div style={{ height: `${SpaceMapping[spacing]}px` }} />;
 };
 

--- a/demo/site-pages/src/blocks/TextImageBlock.tsx
+++ b/demo/site-pages/src/blocks/TextImageBlock.tsx
@@ -1,6 +1,5 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { TextImageBlockData } from "@src/blocks.generated";
-import * as React from "react";
 import styled from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";

--- a/demo/site-pages/src/blocks/TextLinkBlock.tsx
+++ b/demo/site-pages/src/blocks/TextLinkBlock.tsx
@@ -1,6 +1,5 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { DemoTextLinkBlockData } from "@src/blocks.generated";
-import * as React from "react";
 
 import { LinkBlock } from "./LinkBlock";
 

--- a/demo/site-pages/src/components/Breadcrumbs.tsx
+++ b/demo/site-pages/src/components/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import { GridRoot } from "@src/components/common/GridRoot";
 import { gql } from "graphql-request";
 import Link from "next/link";
-import * as React from "react";
+import { Fragment } from "react";
 
 import { GQLBreadcrumbsFragment } from "./Breadcrumbs.generated";
 import * as sc from "./Breadcrumbs.sc";
@@ -17,18 +17,18 @@ export const breadcrumbsFragment = gql`
     }
 `;
 
-const Breadcrumbs: React.FunctionComponent<GQLBreadcrumbsFragment> = ({ name, path, parentNodes }) => {
+const Breadcrumbs = ({ name, path, parentNodes }: GQLBreadcrumbsFragment) => {
     return (
         <GridRoot>
             {parentNodes.length > 0 && (
                 <sc.Container>
                     {parentNodes.map((parentNode) => (
-                        <React.Fragment key={parentNode.path}>
+                        <Fragment key={parentNode.path}>
                             <Link href={parentNode.path} passHref>
                                 <sc.Link> {parentNode.name}</sc.Link>
                             </Link>
                             <sc.Divider />
-                        </React.Fragment>
+                        </Fragment>
                     ))}
                     <Link href={path} passHref>
                         <sc.Link> {name}</sc.Link>

--- a/demo/site-pages/src/header/Header.tsx
+++ b/demo/site-pages/src/header/Header.tsx
@@ -1,5 +1,4 @@
 import { gql } from "graphql-request";
-import * as React from "react";
 import styled from "styled-components";
 
 import { GQLHeaderFragment } from "./Header.generated";

--- a/demo/site-pages/src/header/PageLink.tsx
+++ b/demo/site-pages/src/header/PageLink.tsx
@@ -4,7 +4,7 @@ import { predefinedPagePaths } from "@src/predefinedPages/predefinedPagePaths";
 import { gql } from "graphql-request";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import * as React from "react";
+import { ReactNode } from "react";
 
 import { GQLPageLinkFragment } from "./PageLink.generated";
 
@@ -26,7 +26,7 @@ const pageLinkFragment = gql`
 
 interface Props {
     page: GQLPageLinkFragment;
-    children: ((active: boolean) => React.ReactNode) | React.ReactNode;
+    children: ((active: boolean) => ReactNode) | ReactNode;
 }
 
 function PageLink({ page, children }: Props): JSX.Element | null {

--- a/demo/site-pages/src/news/blocks/NewsLinkBlock.tsx
+++ b/demo/site-pages/src/news/blocks/NewsLinkBlock.tsx
@@ -1,11 +1,11 @@
 import { PropsWithData } from "@comet/cms-site";
 import { NewsLinkBlockData } from "@src/blocks.generated";
 import Link from "next/link";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 type Props = PropsWithData<NewsLinkBlockData> & { title?: string };
 
-function NewsLinkBlock({ data: { id }, children, title }: React.PropsWithChildren<Props>): JSX.Element | null {
+function NewsLinkBlock({ data: { id }, children, title }: PropsWithChildren<Props>): JSX.Element | null {
     if (id === undefined) {
         return null;
     }

--- a/demo/site-pages/src/pageTypes/Page.tsx
+++ b/demo/site-pages/src/pageTypes/Page.tsx
@@ -6,7 +6,6 @@ import { Header, headerFragment } from "@src/header/Header";
 import { topMenuPageTreeNodeFragment, TopNavigation } from "@src/topNavigation/TopNavigation";
 import { gql, GraphQLClient } from "graphql-request";
 import Head from "next/head";
-import * as React from "react";
 
 import { GQLPageQuery } from "./Page.generated";
 

--- a/demo/site-pages/src/pages/404.tsx
+++ b/demo/site-pages/src/pages/404.tsx
@@ -1,9 +1,6 @@
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
-interface NotFound404Props {
-    children: React.ReactNode;
-}
-export default function NotFound404({ children }: NotFound404Props): JSX.Element {
+export default function NotFound404({ children }: PropsWithChildren) {
     return (
         <>
             <h1>404 - Page Not Found</h1>

--- a/demo/site-pages/src/pages/[[...path]].tsx
+++ b/demo/site-pages/src/pages/[[...path]].tsx
@@ -7,7 +7,6 @@ import createGraphQLClient from "@src/util/createGraphQLClient";
 import { gql } from "graphql-request";
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
 import { ParsedUrlQuery } from "querystring";
-import * as React from "react";
 
 import { GQLPagesQuery, GQLPagesQueryVariables, GQLPageTypeQuery, GQLPageTypeQueryVariables } from "./[[...path]].generated";
 

--- a/demo/site-pages/src/pages/_app.tsx
+++ b/demo/site-pages/src/pages/_app.tsx
@@ -4,7 +4,6 @@ import { AppProps, NextWebVitalsMetric } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import Script from "next/script";
-import * as React from "react";
 import { IntlProvider } from "react-intl";
 import { createGlobalStyle, ThemeProvider } from "styled-components";
 

--- a/demo/site-pages/src/pages/_document.tsx
+++ b/demo/site-pages/src/pages/_document.tsx
@@ -1,5 +1,4 @@
 import Document, { DocumentContext, DocumentInitialProps, Head, Html, Main, NextScript } from "next/document";
-import * as React from "react";
 import { ServerStyleSheet } from "styled-components";
 
 export default class MyDocument extends Document {

--- a/demo/site-pages/src/pages/block-preview/main-menu.tsx
+++ b/demo/site-pages/src/pages/block-preview/main-menu.tsx
@@ -1,8 +1,7 @@
 import { BlockPreviewProvider, IFrameBridgeProvider, useIFrameBridge } from "@comet/cms-site";
 import RichTextBlock from "@src/blocks/RichTextBlock";
-import * as React from "react";
 
-const PreviewMainMenu: React.FunctionComponent = () => {
+const PreviewMainMenu = () => {
     const iFrameBridge = useIFrameBridge();
 
     return <div>{iFrameBridge.block && <RichTextBlock data={iFrameBridge.block} />}</div>;

--- a/demo/site-pages/src/pages/block-preview/page.tsx
+++ b/demo/site-pages/src/pages/block-preview/page.tsx
@@ -1,11 +1,11 @@
 import { BlockPreviewProvider, IFrameBridgeProvider, useIFrameBridge } from "@comet/cms-site";
 import { PageContentBlock } from "@src/blocks/PageContentBlock";
-import * as React from "react";
 
-const PreviewPage: React.FunctionComponent = () => {
+const PreviewPage = () => {
     const iFrameBridge = useIFrameBridge();
     return <div>{iFrameBridge.block && <PageContentBlock data={iFrameBridge.block} />}</div>;
 };
+
 const IFrameBridgePreviewPage = (): JSX.Element => {
     return (
         <IFrameBridgeProvider>

--- a/demo/site/.eslintrc.json
+++ b/demo/site/.eslintrc.json
@@ -2,6 +2,18 @@
     "extends": "@comet/eslint-config/nextjs",
     "ignorePatterns": ["**/**/*.generated.ts", "dist/**"],
     "rules": {
-        "@calm/react-intl/missing-formatted-message": "off"
+        "@calm/react-intl/missing-formatted-message": "off",
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/demo/site/src/app/[lang]/IntlProvider.tsx
+++ b/demo/site/src/app/[lang]/IntlProvider.tsx
@@ -1,10 +1,11 @@
 "use client";
-import * as React from "react";
+
+import { ComponentProps, PropsWithChildren } from "react";
 import { IntlProvider as LibraryIntlProvider } from "react-intl";
 
-type Messages = React.ComponentProps<typeof LibraryIntlProvider>["messages"];
+type Messages = ComponentProps<typeof LibraryIntlProvider>["messages"];
 
-export function IntlProvider({ children, locale, messages }: { children: React.ReactNode; locale: string; messages: Messages }) {
+export function IntlProvider({ children, locale, messages }: PropsWithChildren<{ locale: string; messages: Messages }>) {
     return (
         <LibraryIntlProvider locale={locale} defaultLocale={locale} messages={messages}>
             {children}

--- a/demo/site/src/app/[lang]/layout.tsx
+++ b/demo/site/src/app/[lang]/layout.tsx
@@ -1,4 +1,5 @@
 import { readFile } from "fs/promises";
+import { PropsWithChildren } from "react";
 
 import { IntlProvider } from "./IntlProvider";
 
@@ -11,7 +12,7 @@ async function loadMessages(lang: string) {
     return messages;
 }
 
-export default async function Page({ children, params }: { children: React.ReactNode; params: { lang: string } }) {
+export default async function Page({ children, params }: PropsWithChildren<{ params: { lang: string } }>) {
     const messages = await loadMessages(params.lang);
     return (
         <IntlProvider locale={params.lang} messages={messages}>

--- a/demo/site/src/app/block-preview/main-menu/page.tsx
+++ b/demo/site/src/app/block-preview/main-menu/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 import { BlockPreviewProvider, IFrameBridgeProvider, useIFrameBridge } from "@comet/cms-site";
 import RichTextBlock from "@src/blocks/RichTextBlock";
-import * as React from "react";
 
-const PreviewMainMenu: React.FunctionComponent = () => {
+const PreviewMainMenu = () => {
     const iFrameBridge = useIFrameBridge();
 
     return <div>{iFrameBridge.block && <RichTextBlock data={iFrameBridge.block} />}</div>;

--- a/demo/site/src/app/block-preview/page/page.tsx
+++ b/demo/site/src/app/block-preview/page/page.tsx
@@ -4,15 +4,15 @@ import { PageContentBlockData } from "@src/blocks.generated";
 import { PageContentBlock } from "@src/blocks/PageContentBlock";
 import { recursivelyLoadBlockData } from "@src/recursivelyLoadBlockData";
 import { graphQLApiUrl } from "@src/util/graphQLClient";
-import * as React from "react";
+import { useEffect, useState } from "react";
 
-const PreviewPage: React.FunctionComponent = () => {
+const PreviewPage = () => {
     const iFrameBridge = useIFrameBridge();
 
     const { fetch, graphQLFetch } = useBlockPreviewFetch(graphQLApiUrl);
 
-    const [blockData, setBlockData] = React.useState<PageContentBlockData>();
-    React.useEffect(() => {
+    const [blockData, setBlockData] = useState<PageContentBlockData>();
+    useEffect(() => {
         async function load() {
             if (!iFrameBridge.block) {
                 setBlockData(undefined);

--- a/demo/site/src/app/layout.tsx
+++ b/demo/site/src/app/layout.tsx
@@ -3,6 +3,7 @@ import StyledComponentsRegistry from "@src/util/StyledComponentsRegistry";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { draftMode } from "next/headers";
+import { PropsWithChildren } from "react";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -10,11 +11,7 @@ export const metadata: Metadata = {
     title: "Comet Demo Site",
 };
 
-export default function RootLayout({
-    children,
-}: Readonly<{
-    children: React.ReactNode;
-}>) {
+export default function RootLayout({ children }: Readonly<PropsWithChildren>) {
     return (
         <html>
             <body className={inter.className}>

--- a/demo/site/src/blocks/AnchorBlock.tsx
+++ b/demo/site/src/blocks/AnchorBlock.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { AnchorBlockData } from "@src/blocks.generated";
-import * as React from "react";
 
 const AnchorBlock = withPreview(
     ({ data: { name } }: PropsWithData<AnchorBlockData>) => {

--- a/demo/site/src/blocks/ColumnsBlock.tsx
+++ b/demo/site/src/blocks/ColumnsBlock.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { BlocksBlock, PropsWithData, SupportedBlocks, withPreview } from "@comet/cms-site";
 import { ColumnsBlockData, ColumnsContentBlockData } from "@src/blocks.generated";
-import * as React from "react";
 import styled from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";

--- a/demo/site/src/blocks/DamImageBlock.tsx
+++ b/demo/site/src/blocks/DamImageBlock.tsx
@@ -2,7 +2,6 @@
 import { PixelImageBlock, PreviewSkeleton, PropsWithData, SvgImageBlock, withPreview } from "@comet/cms-site";
 import { DamImageBlockData, PixelImageBlockData, SvgImageBlockData } from "@src/blocks.generated";
 import { ImageProps } from "next/image";
-import * as React from "react";
 
 type Props = PropsWithData<DamImageBlockData> & Omit<ImageProps, "src" | "width" | "height" | "alt"> & { aspectRatio: string | "inherit" };
 

--- a/demo/site/src/blocks/FullWidthImageBlock.tsx
+++ b/demo/site/src/blocks/FullWidthImageBlock.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { OptionalBlock, PropsWithData, withPreview } from "@comet/cms-site";
 import { FullWidthImageBlockData } from "@src/blocks.generated";
-import * as React from "react";
 import styled from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";

--- a/demo/site/src/blocks/HeadlineBlock.tsx
+++ b/demo/site/src/blocks/HeadlineBlock.tsx
@@ -1,12 +1,12 @@
 "use client";
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { HeadlineBlockData } from "@src/blocks.generated";
-import * as React from "react";
+import { ElementType } from "react";
 import { Renderers } from "redraft";
 
 import RichTextBlock from "./RichTextBlock";
 
-const headlineTags: { [key: string]: React.ElementType } = {
+const headlineTags: { [key: string]: ElementType } = {
     "header-one": "h1",
     "header-two": "h2",
     "header-three": "h3",

--- a/demo/site/src/blocks/InternalLinkBlock.tsx
+++ b/demo/site/src/blocks/InternalLinkBlock.tsx
@@ -2,20 +2,14 @@
 import { PropsWithData } from "@comet/cms-site";
 import { InternalLinkBlockData } from "@src/blocks.generated";
 import Link from "next/link";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
-interface InternalLinkBlockProps extends PropsWithData<InternalLinkBlockData> {
-    children: React.ReactNode;
+interface InternalLinkBlockProps extends PropsWithChildren<PropsWithData<InternalLinkBlockData>> {
     title?: string;
     className?: string;
 }
 
-export function InternalLinkBlock({
-    data: { targetPage, targetPageAnchor },
-    children,
-    title,
-    className,
-}: InternalLinkBlockProps): React.ReactElement {
+export function InternalLinkBlock({ data: { targetPage, targetPageAnchor }, children, title, className }: InternalLinkBlockProps) {
     if (!targetPage) {
         return <span className={className}>{children}</span>;
     }

--- a/demo/site/src/blocks/LinkBlock.tsx
+++ b/demo/site/src/blocks/LinkBlock.tsx
@@ -11,7 +11,7 @@ import {
 } from "@comet/cms-site";
 import { LinkBlockData } from "@src/blocks.generated";
 import { NewsLinkBlock } from "@src/news/blocks/NewsLinkBlock";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 import { InternalLinkBlock } from "./InternalLinkBlock";
 
@@ -48,8 +48,7 @@ const supportedBlocks: SupportedBlocks = {
     ),
 };
 
-interface LinkBlockProps extends PropsWithData<LinkBlockData> {
-    children: React.ReactNode;
+interface LinkBlockProps extends PropsWithChildren<PropsWithData<LinkBlockData>> {
     className?: string;
 }
 

--- a/demo/site/src/blocks/LinkListBlock.tsx
+++ b/demo/site/src/blocks/LinkListBlock.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { ListBlock, PropsWithData, withPreview } from "@comet/cms-site";
 import { LinkListBlockData } from "@src/blocks.generated";
-import * as React from "react";
 
 import { TextLinkBlock } from "./TextLinkBlock";
 

--- a/demo/site/src/blocks/PageContentBlock.tsx
+++ b/demo/site/src/blocks/PageContentBlock.tsx
@@ -3,7 +3,6 @@ import { BlocksBlock, DamVideoBlock, PropsWithData, SupportedBlocks, YouTubeVide
 import { PageContentBlockData } from "@src/blocks.generated";
 import { TeaserBlock } from "@src/documents/pages/blocks/TeaserBlock";
 import { NewsDetailBlock } from "@src/news/blocks/NewsDetailBlock";
-import * as React from "react";
 
 import { AnchorBlock } from "./AnchorBlock";
 import { ColumnsBlock } from "./ColumnsBlock";
@@ -35,6 +34,6 @@ const supportedBlocks: SupportedBlocks = {
     newsDetail: (props) => <NewsDetailBlock data={props} />,
 };
 
-export const PageContentBlock: React.FC<PropsWithData<PageContentBlockData>> = ({ data }) => {
+export const PageContentBlock = ({ data }: PropsWithData<PageContentBlockData>) => {
     return <BlocksBlock data={data} supportedBlocks={supportedBlocks} />;
 };

--- a/demo/site/src/blocks/RichTextBlock.tsx
+++ b/demo/site/src/blocks/RichTextBlock.tsx
@@ -1,13 +1,13 @@
 "use client";
 import { hasRichTextBlockContent, PreviewSkeleton, PropsWithData, withPreview } from "@comet/cms-site";
 import { LinkBlockData, RichTextBlockData } from "@src/blocks.generated";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 import redraft, { Renderers } from "redraft";
 import styled from "styled-components";
 
 import { LinkBlock } from "./LinkBlock";
 
-const GreenCustomHeader: React.FC<{ children: React.ReactNode }> = ({ children }) => <h3 style={{ color: "green" }}>{children}</h3>;
+const GreenCustomHeader = ({ children }: PropsWithChildren) => <h3 style={{ color: "green" }}>{children}</h3>;
 
 const DefaultStyleLink = styled(LinkBlock)`
     color: ${({ theme }) => theme.colors.primary};
@@ -76,7 +76,7 @@ interface RichTextBlockProps extends PropsWithData<RichTextBlockData> {
     renderers?: Renderers;
 }
 
-const RichTextBlock: React.FC<RichTextBlockProps> = ({ data, renderers = defaultRenderers }) => {
+const RichTextBlock = ({ data, renderers = defaultRenderers }: RichTextBlockProps) => {
     const rendered = redraft(data.draftContent, renderers);
 
     return (

--- a/demo/site/src/blocks/SpaceBlock.tsx
+++ b/demo/site/src/blocks/SpaceBlock.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { DemoSpaceBlockData } from "@src/blocks.generated";
-import * as React from "react";
 
 const SpaceMapping: Record<string, number> = {
     d150: 10,
@@ -16,7 +15,7 @@ const SpaceMapping: Record<string, number> = {
     d600: 300,
 };
 
-const SpaceBlock: React.FC<PropsWithData<DemoSpaceBlockData>> = ({ data: { spacing } }) => {
+const SpaceBlock = ({ data: { spacing } }: PropsWithData<DemoSpaceBlockData>) => {
     return <div style={{ height: `${SpaceMapping[spacing]}px` }} />;
 };
 

--- a/demo/site/src/blocks/TextImageBlock.tsx
+++ b/demo/site/src/blocks/TextImageBlock.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { TextImageBlockData } from "@src/blocks.generated";
-import * as React from "react";
 import styled from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";

--- a/demo/site/src/blocks/TextLinkBlock.tsx
+++ b/demo/site/src/blocks/TextLinkBlock.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { DemoTextLinkBlockData } from "@src/blocks.generated";
-import * as React from "react";
 import styled from "styled-components";
 
 import { LinkBlock } from "./LinkBlock";

--- a/demo/site/src/components/Breadcrumbs.tsx
+++ b/demo/site/src/components/Breadcrumbs.tsx
@@ -1,23 +1,23 @@
 "use client";
 import { GridRoot } from "@src/components/common/GridRoot";
 import Link from "next/link";
-import * as React from "react";
+import { Fragment } from "react";
 
 import { GQLBreadcrumbsFragment } from "./Breadcrumbs.fragment.generated";
 import * as sc from "./Breadcrumbs.sc";
 
-const Breadcrumbs: React.FunctionComponent<GQLBreadcrumbsFragment> = ({ name, path, parentNodes }) => {
+const Breadcrumbs = ({ name, path, parentNodes }: GQLBreadcrumbsFragment) => {
     return (
         <GridRoot>
             {parentNodes.length > 0 && (
                 <sc.Container>
                     {parentNodes.map((parentNode) => (
-                        <React.Fragment key={parentNode.path}>
+                        <Fragment key={parentNode.path}>
                             <Link href={parentNode.path} passHref>
                                 <sc.Link> {parentNode.name}</sc.Link>
                             </Link>
                             <sc.Divider />
-                        </React.Fragment>
+                        </Fragment>
                     ))}
                     <Link href={path} passHref>
                         <sc.Link> {name}</sc.Link>

--- a/demo/site/src/documentTypes/Page.tsx
+++ b/demo/site/src/documentTypes/Page.tsx
@@ -11,7 +11,6 @@ import { topMenuPageTreeNodeFragment } from "@src/topNavigation/TopNavigation.fr
 import { createGraphQLFetch } from "@src/util/graphQLClient";
 import type { Metadata, ResolvingMetadata } from "next";
 import { notFound } from "next/navigation";
-import * as React from "react";
 
 import { GQLPageQuery, GQLPageQueryVariables } from "./Page.generated";
 

--- a/demo/site/src/header/Header.tsx
+++ b/demo/site/src/header/Header.tsx
@@ -1,5 +1,5 @@
 "use client";
-import * as React from "react";
+
 import styled from "styled-components";
 
 import { GQLHeaderFragment } from "./Header.fragment.generated";

--- a/demo/site/src/header/PageLink.tsx
+++ b/demo/site/src/header/PageLink.tsx
@@ -4,13 +4,12 @@ import { GQLPredefinedPage } from "@src/graphql.generated";
 import { predefinedPagePaths } from "@src/predefinedPages/predefinedPagePaths";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 import { GQLPageLinkFragment } from "./PageLink.fragment.generated";
 
-interface Props {
+interface Props extends PropsWithChildren {
     page: GQLPageLinkFragment;
-    children: React.ReactNode;
     className?: string;
     activeClassName?: string;
 }

--- a/demo/site/src/news/blocks/NewsContentBlock.tsx
+++ b/demo/site/src/news/blocks/NewsContentBlock.tsx
@@ -4,7 +4,6 @@ import { DamImageBlock } from "@src/blocks/DamImageBlock";
 import { HeadlineBlock } from "@src/blocks/HeadlineBlock";
 import RichTextBlock from "@src/blocks/RichTextBlock";
 import { TextImageBlock } from "@src/blocks/TextImageBlock";
-import * as React from "react";
 
 const supportedBlocks: SupportedBlocks = {
     headline: (props) => <HeadlineBlock data={props} />,
@@ -13,6 +12,6 @@ const supportedBlocks: SupportedBlocks = {
     textImage: (props) => <TextImageBlock data={props} />,
 };
 
-export const NewsContentBlock: React.FC<PropsWithData<NewsContentBlockData>> = ({ data }) => {
+export const NewsContentBlock = ({ data }: PropsWithData<NewsContentBlockData>) => {
     return <BlocksBlock data={data} supportedBlocks={supportedBlocks} />;
 };

--- a/demo/site/src/news/blocks/NewsDetailBlock.tsx
+++ b/demo/site/src/news/blocks/NewsDetailBlock.tsx
@@ -1,13 +1,11 @@
 "use client";
 import { PropsWithData } from "@comet/cms-site";
 import { NewsLinkBlockData } from "@src/blocks.generated";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 import { LoadedData } from "./NewsDetailBlock.loader";
 
-function NewsDetailBlock({
-    data: { id, loaded },
-}: React.PropsWithChildren<PropsWithData<NewsLinkBlockData & { loaded: LoadedData }>>): JSX.Element | null {
+function NewsDetailBlock({ data: { id, loaded } }: PropsWithChildren<PropsWithData<NewsLinkBlockData & { loaded: LoadedData }>>): JSX.Element | null {
     if (id === undefined) {
         return null;
     }

--- a/demo/site/src/news/blocks/NewsLinkBlock.tsx
+++ b/demo/site/src/news/blocks/NewsLinkBlock.tsx
@@ -1,11 +1,11 @@
 import { PropsWithData } from "@comet/cms-site";
 import { NewsLinkBlockData } from "@src/blocks.generated";
 import Link from "next/link";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 type Props = PropsWithData<NewsLinkBlockData> & { title?: string; className?: string };
 
-function NewsLinkBlock({ data: { news }, children, title, className }: React.PropsWithChildren<Props>): JSX.Element | null {
+function NewsLinkBlock({ data: { news }, children, title, className }: PropsWithChildren<Props>): JSX.Element | null {
     if (news === undefined) {
         return <span className={className}>{children}</span>;
     }

--- a/demo/site/src/util/StyledComponentsRegistry.tsx
+++ b/demo/site/src/util/StyledComponentsRegistry.tsx
@@ -1,10 +1,10 @@
 "use client";
 import theme from "@src/theme";
 import { useServerInsertedHTML } from "next/navigation";
-import React, { useState } from "react";
+import { PropsWithChildren, useState } from "react";
 import { ServerStyleSheet, StyleSheetManager, ThemeProvider } from "styled-components";
 
-export default function StyledComponentsRegistry({ children }: { children: React.ReactNode }) {
+export default function StyledComponentsRegistry({ children }: PropsWithChildren) {
     // Only create stylesheet once with lazy initial state
     // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
     const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());


### PR DESCRIPTION
Use named imports instead of barrel importing React. Doing so will result in less code and better readability. The new [React docs](https://react.dev/) also use named imports and never import React itself.

We temporarily add the eslint rules in the packages. The restrict-import rule will be added in the v8 (next) branch in the `eslint-config` package, then they will be removed again in the packages.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [ ] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-1026
