### PR TITLE
Remove unnecessary padding of DataGrid rows

### DIFF
--- a/.changeset/breezy-eels-kneel.md
+++ b/.changeset/breezy-eels-kneel.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": patch
+---
+
+Remove unnecessary padding of DataGrid rows

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -68,12 +68,6 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
                 outline: "none",
             },
         },
-        columnHeadersInner: {
-            padding: spacing(0, 2),
-        },
-        row: {
-            padding: spacing(0, 2),
-        },
         cell: {
             borderTop: `1px solid ${palette.grey[100]}`,
 


### PR DESCRIPTION
Previously, all DataGrids had a strange padding on the left side (see screenshots).

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-935
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

### Previously:

<img width="708" alt="Bildschirmfoto 2024-08-16 um 13 37 28" src="https://github.com/user-attachments/assets/b1bb9a96-4335-45fa-aecf-82639495920b">

<img width="1728" alt="Bildschirmfoto 2024-08-16 um 13 37 21" src="https://github.com/user-attachments/assets/f66251d4-2380-4bb7-ba3f-4d9096425ed6">


### Now:

<img width="707" alt="Bildschirmfoto 2024-08-16 um 13 37 50" src="https://github.com/user-attachments/assets/02cda84c-9b70-4e21-bc03-679fae9134cb">

<img width="1728" alt="Bildschirmfoto 2024-08-16 um 13 36 34" src="https://github.com/user-attachments/assets/50d850c5-afe8-4a17-bfc2-dda00cd46426">



</details>
