### PR TITLE
adapt `admin-generator` to generate files without barrel react imports

### DIFF
--- a/.changeset/curvy-planes-wonder.md
+++ b/.changeset/curvy-planes-wonder.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Adapt generator to generate files without barrel react imports

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -218,7 +218,7 @@ export function generateForm(
     import { FormControlLabel, IconButton, MenuItem, InputAdornment } from "@mui/material";
     import { FormApi } from "final-form";
     import isEqual from "lodash.isequal";
-    import React from "react";
+    import { useMemo } from "react";
     import { FormattedMessage } from "react-intl";
     ${generateImportsCode(imports)}
     ${
@@ -249,7 +249,7 @@ export function generateForm(
 
     ${formPropsTypeCode}
 
-    export function ${exportName}(${formPropsParamsCode}): React.ReactElement {
+    export function ${exportName}(${formPropsParamsCode}) {
         const client = useApolloClient();
         ${mode == "all" ? `const mode = id ? "edit" : "add";` : ""}
         const formApiRef = useFormApiRef<FormValues>();
@@ -268,7 +268,7 @@ export function generateForm(
 
         ${
             editMode
-                ? `const initialValues = React.useMemo<Partial<FormValues>>(() => data?.${instanceGqlType}
+                ? `const initialValues = useMemo<Partial<FormValues>>(() => data?.${instanceGqlType}
         ? {
             ...filterByFragment<GQL${fragmentName}Fragment>(${instanceGqlType}FormFragment, data.${instanceGqlType}),
             ${formValuesConfig

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -168,7 +168,7 @@ export function generateGrid(
 
     const forwardToolbarAction = allowAdding && toolbar && config.toolbarActionProp;
     if (forwardToolbarAction) {
-        props.push({ name: "toolbarAction", type: "React.ReactNode", optional: true });
+        props.push({ name: "toolbarAction", type: "ReactNode", optional: true });
     }
 
     const sortArg = gridQueryType.args.find((arg) => arg.name === "sort");
@@ -321,7 +321,7 @@ export function generateGrid(
     if (forwardRowAction) {
         props.push({
             name: "rowAction",
-            type: `(params: GridRenderCellParams<any, GQL${fragmentName}Fragment, any>) => React.ReactNode`,
+            type: `(params: GridRenderCellParams<any, GQL${fragmentName}Fragment, any>) => ReactNode`,
             optional: true,
         });
     }
@@ -359,7 +359,7 @@ export function generateGrid(
         GQLDelete${gqlType}Mutation,
         GQLDelete${gqlType}MutationVariables
     } from "./${baseOutputFilename}.generated";
-    import * as React from "react";
+    import { ReactNode } from "react";
     import { FormattedMessage, useIntl } from "react-intl";
     ${generateImportsCode(imports)}
 
@@ -437,7 +437,7 @@ export function generateGrid(
 
     ${
         toolbar
-            ? `function ${gqlTypePlural}GridToolbar(${forwardToolbarAction ? `{ toolbarAction }: { toolbarAction?: React.ReactNode }` : ``}) {
+            ? `function ${gqlTypePlural}GridToolbar(${forwardToolbarAction ? `{ toolbarAction }: { toolbarAction?: ReactNode }` : ``}) {
         return (
             <DataGridToolbar>
                 ${
@@ -474,7 +474,7 @@ export function generateGrid(
 
     ${gridPropsTypeCode}
 
-    export function ${gqlTypePlural}Grid(${gridPropsParamsCode}): React.ReactElement {
+    export function ${gqlTypePlural}Grid(${gridPropsParamsCode}) {
         ${allowCopyPaste || allowDeleting ? "const client = useApolloClient();" : ""}
         const intl = useIntl();
         const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("${gqlTypePlural}Grid") };

--- a/packages/admin/cms-admin/src/generator/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/generateForm.ts
@@ -141,7 +141,7 @@ export async function writeCrudForm(generatorConfig: CrudGeneratorConfig, schema
     import { IconButton, FormControlLabel, MenuItem } from "@mui/material";
     import { FormApi } from "final-form";
     import isEqual from "lodash.isequal";
-    import React from "react";
+    import { useMemo } from "react";
     import { FormattedMessage } from "react-intl";
     import { useContentScope } from "@src/common/ContentScopeProvider";
     import { create${entityName}Mutation, ${instanceEntityName}CheckForChangesQuery, ${instanceEntityName}FormFragment, ${instanceEntityName}FormQuery, update${entityName}Mutation } from "./${entityName}Form.gql";
@@ -187,7 +187,7 @@ export async function writeCrudForm(generatorConfig: CrudGeneratorConfig, schema
         id?: string;
     }
 
-    export function ${entityName}Form({ id }: FormProps): React.ReactElement {
+    export function ${entityName}Form({ id }: FormProps) {
         const stackApi = useStackApi();
         const client = useApolloClient();
         const mode = id ? "edit" : "add";
@@ -199,7 +199,7 @@ export async function writeCrudForm(generatorConfig: CrudGeneratorConfig, schema
             id ? { variables: { id } } : { skip: true },
         );
     
-        const initialValues = React.useMemo<Partial<FormValues>>(() => data?.${instanceEntityName}
+        const initialValues = useMemo<Partial<FormValues>>(() => data?.${instanceEntityName}
             ? {
                   ...filterByFragment<GQL${entityName}FormFragment>(${instanceEntityName}FormFragment, data.${instanceEntityName}),
                   ${numberFields.map((field) => `${field.name}: String(data.${instanceEntityName}.${field.name}),`).join("\n")}

--- a/packages/admin/cms-admin/src/generator/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/generateGrid.ts
@@ -235,7 +235,6 @@ export async function writeCrudGrid(
         GQLDelete${entityName}Mutation,
         GQLDelete${entityName}MutationVariables 
     } from "./${classNamePlural}Grid.generated";
-    import * as React from "react";
     import { FormattedMessage, useIntl } from "react-intl";
     ${Object.entries(rootBlocks)
         .map(([rootBlockKey, rootBlock]) => `import { ${rootBlock.name} } from "${rootBlock.import}";`)
@@ -317,7 +316,7 @@ export async function writeCrudGrid(
         );
     }
     
-    export function ${classNamePlural}Grid(): React.ReactElement {
+    export function ${classNamePlural}Grid() {
         const client = useApolloClient();
         const intl = useIntl();
         const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("${classNamePlural}Grid") };

--- a/packages/admin/cms-admin/src/generator/generatePage.ts
+++ b/packages/admin/cms-admin/src/generator/generatePage.ts
@@ -19,12 +19,11 @@ export async function writeCrudPage({ entityName, target: targetDirectory }: Cru
     const out = `
         import { Stack, StackPage, StackSwitch, StackToolbar } from "@comet/admin";
         import { ContentScopeIndicator } from "@comet/cms-admin";
-        import * as React from "react";
         import { useIntl } from "react-intl";
         import { ${entityName}Form } from "./${entityName}Form";
         import { ${classNamePlural}Grid } from "./${classNamePlural}Grid";
 
-        export function ${classNamePlural}Page(): React.ReactElement {
+        export function ${classNamePlural}Page() {
             const intl = useIntl();
             return (
                 <Stack topLevelTitle={intl.formatMessage({ id: "${instanceNamePlural}.${instanceNamePlural}", defaultMessage: "${camelCaseToHumanReadable(


### PR DESCRIPTION
Use named imports instead of barrel importing React. Doing so will result in less code and better readability. The new [React docs](https://react.dev/) also use named imports and never import React itself.


---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-1026
