### PR TITLE
`blocks-admin`: remove barrel react imports

### DIFF
--- a/packages/admin/blocks-admin/.eslintrc.json
+++ b/packages/admin/blocks-admin/.eslintrc.json
@@ -2,6 +2,18 @@
     "extends": "@comet/eslint-config/react",
     "ignorePatterns": ["src/*.generated.ts", "lib/**"],
     "rules": {
-        "@comet/no-other-module-relative-import": "off"
+        "@comet/no-other-module-relative-import": "off",
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/packages/admin/blocks-admin/src/blocks/SpaceBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/SpaceBlock.tsx
@@ -1,5 +1,4 @@
 import { Field, FinalFormInput } from "@comet/admin";
-import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { SpaceBlockData, SpaceBlockInput } from "../blocks.generated";

--- a/packages/admin/blocks-admin/src/blocks/common/AddBlockDrawer.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AddBlockDrawer.tsx
@@ -16,7 +16,7 @@ import {
     Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { ChangeEventHandler, isValidElement, KeyboardEventHandler, ReactElement, ReactNode, useMemo, useState } from "react";
 import { FormattedMessage, MessageDescriptor, useIntl } from "react-intl";
 
 import { BlockCategory, blockCategoryLabels, BlockInterface, CustomBlockCategory } from "../types";
@@ -25,7 +25,7 @@ type BlockType = string;
 
 interface Category {
     id: string;
-    label: React.ReactNode;
+    label: ReactNode;
     blocks: Array<[BlockType, BlockInterface]>;
 }
 
@@ -36,12 +36,12 @@ interface Props {
     onAddNewBlock: (type: string, addAndEdit: boolean) => void;
 }
 
-export function AddBlockDrawer({ open, onClose, blocks, onAddNewBlock }: Props): React.ReactElement {
+export function AddBlockDrawer({ open, onClose, blocks, onAddNewBlock }: Props) {
     const intl = useIntl();
-    const [searchValue, setSearchValue] = React.useState("");
+    const [searchValue, setSearchValue] = useState("");
     const [addAndEdit, setAddAndEdit] = useStoredState<boolean>("addAndEdit", true);
 
-    const categories = React.useMemo(() => {
+    const categories = useMemo(() => {
         const categories: Category[] = [];
         const categoriesOrder = Object.keys(BlockCategory);
 
@@ -61,7 +61,7 @@ export function AddBlockDrawer({ open, onClose, blocks, onAddNewBlock }: Props):
             }
 
             let id: string;
-            let label: React.ReactNode;
+            let label: ReactNode;
 
             if (isCustomBlockCategory(block.category)) {
                 if (block.category.id in BlockCategory) {
@@ -115,11 +115,11 @@ export function AddBlockDrawer({ open, onClose, blocks, onAddNewBlock }: Props):
         onClose();
     };
 
-    const handleSearchFieldChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    const handleSearchFieldChange: ChangeEventHandler<HTMLInputElement> = (event) => {
         setSearchValue(event.target.value);
     };
 
-    const handleSearchFieldKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
+    const handleSearchFieldKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
         const hasSearchResults = categories.length > 0 && categories[0].blocks.length > 0;
 
         if (event.key === "Enter" && hasSearchResults) {
@@ -129,7 +129,7 @@ export function AddBlockDrawer({ open, onClose, blocks, onAddNewBlock }: Props):
         }
     };
 
-    const handleAddAndEditChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    const handleAddAndEditChange: ChangeEventHandler<HTMLInputElement> = (event) => {
         setAddAndEdit(event.target.checked);
     };
 
@@ -199,8 +199,8 @@ function isCustomBlockCategory(category: BlockCategory | CustomBlockCategory): c
     return typeof category === "object";
 }
 
-function isFormattedMessage(node: React.ReactNode): node is React.ReactElement<MessageDescriptor> {
-    return React.isValidElement(node) && node.type === FormattedMessage;
+function isFormattedMessage(node: ReactNode): node is ReactElement<MessageDescriptor> {
+    return isValidElement(node) && node.type === FormattedMessage;
 }
 
 const Content = styled(DialogContent)`

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentButton.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentButton.tsx
@@ -1,18 +1,17 @@
 import { Button } from "@mui/material";
-import * as React from "react";
+import { MouseEventHandler, PropsWithChildren, ReactNode } from "react";
 
 import { AdminComponentPaper } from "./AdminComponentPaper";
 
 interface Props {
     variant?: "primary" | "default";
     size?: "medium" | "large";
-    startIcon?: React.ReactNode;
-    children?: React.ReactNode;
-    onClick?: React.MouseEventHandler;
+    startIcon?: ReactNode;
+    onClick?: MouseEventHandler;
     disabled?: boolean;
 }
 
-export function AdminComponentButton({ variant, size, ...buttonProps }: Props): React.ReactElement {
+export const AdminComponentButton = ({ variant, size, ...buttonProps }: PropsWithChildren<Props>) => {
     return (
         <AdminComponentPaper disablePadding>
             <Button
@@ -27,4 +26,4 @@ export function AdminComponentButton({ variant, size, ...buttonProps }: Props): 
             />
         </AdminComponentPaper>
     );
-}
+};

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentNestedButton.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentNestedButton.tsx
@@ -1,20 +1,20 @@
 import { Edit, Warning } from "@comet/admin-icons";
 import { Button, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { MouseEventHandler, ReactNode } from "react";
 
 import { usePromise } from "../../common/usePromise";
 import { AdminComponentPaper } from "./AdminComponentPaper";
 
 interface Props {
-    displayName: React.ReactNode;
-    preview: React.ReactNode;
+    displayName: ReactNode;
+    preview: ReactNode;
     count?: number;
-    onClick?: React.MouseEventHandler<HTMLElement>;
+    onClick?: MouseEventHandler<HTMLElement>;
     isValid?: () => Promise<boolean> | boolean;
 }
 
-export function AdminComponentNestedButton({ displayName, preview, count, onClick, isValid: isValidFn }: Props): React.ReactElement {
+export const AdminComponentNestedButton = ({ displayName, preview, count, onClick, isValid: isValidFn }: Props) => {
     const isValid = usePromise(isValidFn, { initialValue: true });
 
     return (
@@ -33,7 +33,7 @@ export function AdminComponentNestedButton({ displayName, preview, count, onClic
             </Button>
         </AdminComponentPaper>
     );
-}
+};
 
 const TextContainer = styled("span")`
     min-width: 0;

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentPaper.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentPaper.tsx
@@ -1,19 +1,18 @@
 import { Box, Paper } from "@mui/material";
-import * as React from "react";
+import { createContext, PropsWithChildren, useContext } from "react";
 
-const AdminComponentPaperContext = React.createContext<boolean>(false);
+const AdminComponentPaperContext = createContext<boolean>(false);
 
 export function useAdminComponentPaper(): boolean {
-    return React.useContext(AdminComponentPaperContext);
+    return useContext(AdminComponentPaperContext);
 }
 
 interface Props {
-    children?: React.ReactNode;
     disablePadding?: boolean;
 }
 
-export function AdminComponentPaper({ children, disablePadding }: Props): React.ReactElement {
-    const hasBackground = React.useContext(AdminComponentPaperContext);
+export const AdminComponentPaper = ({ children, disablePadding }: PropsWithChildren<Props>) => {
+    const hasBackground = useContext(AdminComponentPaperContext);
 
     if (hasBackground) {
         return <Box padding={disablePadding ? 0 : 3}>{children}</Box>;
@@ -26,4 +25,4 @@ export function AdminComponentPaper({ children, disablePadding }: Props): React.
             </AdminComponentPaperContext.Provider>
         );
     }
-}
+};

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
@@ -1,14 +1,13 @@
 import { Stack, StackBreadcrumbs } from "@comet/admin";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { PropsWithChildren, ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 interface Props {
-    children: React.ReactNode;
-    title?: React.ReactNode;
+    title?: ReactNode;
 }
 
-function AdminComponentRoot(props: Props): React.ReactElement {
+const AdminComponentRoot = (props: PropsWithChildren<Props>) => {
     const { children, title = <FormattedMessage id="comet.blocks" defaultMessage="Blocks" /> } = props;
 
     return (
@@ -27,7 +26,7 @@ function AdminComponentRoot(props: Props): React.ReactElement {
             <ChildrenContainer>{children}</ChildrenContainer>
         </Stack>
     );
-}
+};
 
 export { AdminComponentRoot };
 

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentSection.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentSection.tsx
@@ -1,17 +1,16 @@
 import { css, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { PropsWithChildren, ReactNode } from "react";
 
 import { HiddenInSubroute } from "./HiddenInSubroute";
 
 interface Props {
-    children: React.ReactNode;
-    title?: React.ReactNode;
+    title?: ReactNode;
     variant?: "normal" | "dense";
     disableBottomMargin?: boolean;
 }
 
-export function AdminComponentSection({ children, title, disableBottomMargin }: Props): React.ReactElement {
+export const AdminComponentSection = ({ children, title, disableBottomMargin }: PropsWithChildren<Props>) => {
     if (title) {
         return (
             <Root disableBottomMargin={disableBottomMargin}>
@@ -24,7 +23,7 @@ export function AdminComponentSection({ children, title, disableBottomMargin }: 
     }
 
     return <Root disableBottomMargin={disableBottomMargin}>{children}</Root>;
-}
+};
 
 const Root = styled("div", { shouldForwardProp: (prop) => prop !== "disableBottomMargin" })<Pick<Props, "variant" | "disableBottomMargin">>`
     ${({ disableBottomMargin, variant, theme }) =>

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentSectionGroup.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentSectionGroup.tsx
@@ -1,15 +1,14 @@
 import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { PropsWithChildren, ReactNode } from "react";
 
 import { HiddenInSubroute } from "./HiddenInSubroute";
 
 interface Props {
-    children: React.ReactNode;
-    title?: React.ReactNode;
+    title?: ReactNode;
 }
 
-export function AdminComponentSectionGroup({ children, title }: Props): React.ReactElement {
+export const AdminComponentSectionGroup = ({ children, title }: PropsWithChildren<Props>) => {
     return (
         <Root>
             {title && (
@@ -22,7 +21,7 @@ export function AdminComponentSectionGroup({ children, title }: Props): React.Re
             {children}
         </Root>
     );
-}
+};
 
 const Root = styled("div")`
     &:not(:last-child) {

--- a/packages/admin/blocks-admin/src/blocks/common/AdminTabLabel.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminTabLabel.tsx
@@ -1,11 +1,11 @@
 import { Warning } from "@comet/admin-icons";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { ReactNode } from "react";
 
 import { usePromise } from "../../common/usePromise";
 
 export interface AdminTabLabelProps {
-    children: React.ReactNode;
+    children?: ReactNode;
     isValid?: () => Promise<boolean> | boolean;
 }
 

--- a/packages/admin/blocks-admin/src/blocks/common/AdminTabs.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminTabs.tsx
@@ -1,7 +1,6 @@
 import { RouteWithErrorBoundary } from "@comet/admin";
 import { Tab as MuiTab, TabProps, Tabs as MuiTabs } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
 import { Switch, useRouteMatch } from "react-router";
 import { Link, LinkProps } from "react-router-dom";
 

--- a/packages/admin/blocks-admin/src/blocks/common/AdminTabsTabContent.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminTabsTabContent.tsx
@@ -1,15 +1,14 @@
 import { Box } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 import { useScrollRestoration } from "../../common/useScrollRestoration";
 
 interface TabContentProps {
-    children: React.ReactNode;
     selectedTab?: string;
 }
 
-export function TabContent({ children, selectedTab }: TabContentProps): React.ReactElement {
+export const TabContent = ({ children, selectedTab }: PropsWithChildren<TabContentProps>) => {
     const scrollRestoration = useScrollRestoration<HTMLDivElement>(`adminTabsTabContent-${selectedTab}`);
     return (
         <Root {...scrollRestoration}>
@@ -18,7 +17,7 @@ export function TabContent({ children, selectedTab }: TabContentProps): React.Re
             </Box>
         </Root>
     );
-}
+};
 
 const Root = styled("div")`
     overflow-y: auto;

--- a/packages/admin/blocks-admin/src/blocks/common/HiddenInSubroute.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/HiddenInSubroute.tsx
@@ -1,11 +1,7 @@
-import * as React from "react";
+import { ReactNode } from "react";
 import { Route, useRouteMatch } from "react-router";
 
-interface Props {
-    children: React.ReactNode;
-}
-
-export function HiddenInSubroute({ children }: Props): React.ReactElement {
+export const HiddenInSubroute = ({ children }: { children?: ReactNode }) => {
     const match = useRouteMatch();
 
     return (
@@ -13,4 +9,4 @@ export function HiddenInSubroute({ children }: Props): React.ReactElement {
             {children}
         </Route>
     );
-}
+};

--- a/packages/admin/blocks-admin/src/blocks/common/OneImageWithTextPreview.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/OneImageWithTextPreview.tsx
@@ -1,6 +1,6 @@
 import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { ReactNode } from "react";
 
 import { isPreviewContentImageRule, isPreviewContentTextRule, PreviewContent, PreviewImage } from "../types";
 
@@ -29,7 +29,7 @@ export function OneImageWithTextPreview({ content }: { content: PreviewContent[]
     }
 }
 
-function TextAndImage({ text, image }: { text: React.ReactNode; image: PreviewImage }): JSX.Element {
+function TextAndImage({ text, image }: { text: ReactNode; image: PreviewImage }): JSX.Element {
     return (
         <div style={{ display: "flex" }}>
             <div>
@@ -48,7 +48,7 @@ const ImageTag = styled("img")`
     margin-right: 12px;
 `;
 
-function Text({ text }: { text: React.ReactNode }): JSX.Element {
+function Text({ text }: { text: ReactNode }): JSX.Element {
     return <>{text}</>;
 }
 

--- a/packages/admin/blocks-admin/src/blocks/common/blockRow/BlockPreviewContent.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/blockRow/BlockPreviewContent.tsx
@@ -1,5 +1,5 @@
 import { Typography } from "@mui/material";
-import * as React from "react";
+import { ReactNode } from "react";
 
 import { useBlockContext } from "../../../context/useBlockContext";
 import { BlockInterface, isPreviewContentImageRule, isPreviewContentTextRule } from "../../types";
@@ -7,7 +7,7 @@ import * as sc from "./BlockPreviewContent.sc";
 import { StackedImages } from "./image/StackedImages";
 
 interface BlockPreviewContentProps {
-    title?: React.ReactNode;
+    title?: ReactNode;
     block: BlockInterface;
     state?: unknown;
     input?: unknown;

--- a/packages/admin/blocks-admin/src/blocks/common/blockRow/BlockRow.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/blockRow/BlockRow.tsx
@@ -1,7 +1,7 @@
 import { messages } from "@comet/admin";
 import { Copy, Delete, Drag, MoreVertical, Paste, Warning } from "@comet/admin-icons";
 import { Checkbox, Divider, IconButton, ListItemIcon, Menu, MenuItem } from "@mui/material";
-import * as React from "react";
+import { ChangeEvent, MouseEventHandler, ReactNode, useRef, useState } from "react";
 import { DropTargetMonitor, useDrag, useDrop, XYCoord } from "react-dnd";
 import { FormattedMessage } from "react-intl";
 
@@ -15,13 +15,13 @@ const ItemTypes = {
 };
 
 interface BlockRowProps {
-    renderPreviewContent: () => React.ReactNode;
+    renderPreviewContent: () => ReactNode;
     onContentClick?: () => void;
     onDeleteClick?: () => void;
     id: string;
     index: number;
     moveBlock: (dragIndex: number, hoverIndex: number) => void;
-    visibilityButton: React.ReactNode;
+    visibilityButton: ReactNode;
     onAddNewBlock: (beforeIndex: number) => void;
     onCopyClick?: () => void;
     onPasteClick?: () => void;
@@ -30,8 +30,8 @@ interface BlockRowProps {
     isValidFn: () => boolean | Promise<boolean>;
     slideIn: boolean;
     hideBottomInsertBetweenButton?: boolean;
-    additionalMenuItems?: (onMenuClose: () => void) => React.ReactNode;
-    additionalContent?: React.ReactNode;
+    additionalMenuItems?: (onMenuClose: () => void) => ReactNode;
+    additionalContent?: ReactNode;
 }
 
 interface IDragItem {
@@ -42,7 +42,7 @@ interface IDragItem {
 
 export function BlockRow(props: BlockRowProps): JSX.Element {
     const { index, onAddNewBlock, slideIn } = props;
-    const ref = React.useRef<HTMLDivElement>(null);
+    const ref = useRef<HTMLDivElement>(null);
     const [, drop] = useDrop({
         accept: ItemTypes.BLOCK,
         hover(item: IDragItem, monitor: DropTargetMonitor) {
@@ -94,7 +94,7 @@ export function BlockRow(props: BlockRowProps): JSX.Element {
         },
     });
 
-    const [hover, setHover] = React.useState(false);
+    const [hover, setHover] = useState(false);
     const [{ isDragging }, drag] = useDrag({
         type: ItemTypes.BLOCK,
         item: { type: ItemTypes.BLOCK, id: props.id, index: props.index }, // type in item should not be needed anymore since react-dnd 14
@@ -105,9 +105,9 @@ export function BlockRow(props: BlockRowProps): JSX.Element {
     const opacity = isDragging ? 0 : 1;
     drag(drop(ref));
 
-    const [menuAnchorEl, setMenuAnchorEl] = React.useState<HTMLElement>();
+    const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement>();
 
-    const handleMoreClick: React.MouseEventHandler<HTMLElement> = (event) => {
+    const handleMoreClick: MouseEventHandler<HTMLElement> = (event) => {
         setMenuAnchorEl(event.currentTarget);
     };
 
@@ -162,7 +162,7 @@ export function BlockRow(props: BlockRowProps): JSX.Element {
                         {hover || props.selected ? (
                             <Checkbox
                                 checked={props.selected}
-                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                onChange={(event: ChangeEvent<HTMLInputElement>) => {
                                     props.onSelectedClick?.(event.target.checked);
                                 }}
                             />

--- a/packages/admin/blocks-admin/src/blocks/common/blockRow/InsertInBetweenAction.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/blockRow/InsertInBetweenAction.tsx
@@ -1,14 +1,14 @@
-import React from "react";
+import { ReactNode } from "react";
 
 import * as sc from "./InsertInBetweenAction.sc";
 
 interface Props {
-    top?: React.ReactNode;
-    bottom?: React.ReactNode;
+    top?: ReactNode;
+    bottom?: ReactNode;
 }
 
 // Layout component, a button can be on top, on bottom or on both of the tree-row
-export default function InsertInBetweenAction({ top, bottom }: Props): React.ReactElement {
+export default function InsertInBetweenAction({ top, bottom }: Props) {
     return (
         <sc.Root>
             <sc.TopSpot>{top}</sc.TopSpot>

--- a/packages/admin/blocks-admin/src/blocks/common/blockRow/InsertInBetweenActionButton.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/blockRow/InsertInBetweenActionButton.tsx
@@ -1,7 +1,6 @@
 import { AddNoCircle } from "@comet/admin-icons";
 import { ButtonBase } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import React from "react";
 
 const IconWrapper = styled("div")`
     && {
@@ -37,7 +36,7 @@ interface Props {
 }
 
 // renders one ore two insert-buttons
-export default function InsertInBetweenActionButton({ onClick }: Props): React.ReactElement {
+export default function InsertInBetweenActionButton({ onClick }: Props) {
     return (
         <Root onClick={onClick}>
             <IconWrapper>

--- a/packages/admin/blocks-admin/src/blocks/common/blockRow/image/StackedImages.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/blockRow/image/StackedImages.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { PreviewContentImage } from "../../../types";
 import * as sc from "./StackedImages.sc";
 

--- a/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/ColumnsIcon.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/ColumnsIcon.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from "@mui/material";
-import * as React from "react";
 
 interface ColumnsIconProps extends SvgIconProps {
     columns: number;

--- a/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/ColumnsLayoutPreview.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/ColumnsLayoutPreview.tsx
@@ -1,17 +1,17 @@
 import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { Children, ReactElement } from "react";
 
 interface ContainerProps {
-    children: React.ReactElement<ItemProps>[];
+    children: ReactElement<ItemProps>[];
 }
 
 interface ItemProps {
     width: number;
 }
 
-export function ColumnsLayoutPreview({ children }: ContainerProps): React.ReactElement {
-    const columns = React.Children.map(children, (child) => `${child.props.width}fr`).join(" ");
+export function ColumnsLayoutPreview({ children }: ContainerProps) {
+    const columns = Children.map(children, (child) => `${child.props.width}fr`).join(" ");
     return <Root columns={columns}>{children}</Root>;
 }
 
@@ -34,6 +34,6 @@ const RootContent = styled(ColumnsLayoutPreviewSpacing)`
     align-items: center;
 `;
 
-export function ColumnsLayoutPreviewContent({ width }: ItemProps): React.ReactElement<ItemProps> {
+export function ColumnsLayoutPreviewContent({ width }: ItemProps): ReactElement<ItemProps> {
     return <RootContent width={width}>{width > 3 ? <Typography variant="subtitle1">{width}</Typography> : null}</RootContent>;
 }

--- a/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/FinalFormColumnsSelect.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/FinalFormColumnsSelect.tsx
@@ -1,5 +1,4 @@
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
-import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 import { ColumnsIcon } from "./ColumnsIcon";
@@ -8,7 +7,7 @@ interface Props extends FieldRenderProps<number> {
     columns: number[];
 }
 
-export function FinalFormColumnsSelect({ input: { value, onChange }, columns }: Props): React.ReactElement {
+export function FinalFormColumnsSelect({ input: { value, onChange }, columns }: Props) {
     return (
         <ToggleButtonGroup
             value={value}

--- a/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/FinalFormLayoutSelect.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/FinalFormLayoutSelect.tsx
@@ -8,14 +8,14 @@ import {
     Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { ReactNode, useMemo } from "react";
 import { FieldRenderProps } from "react-final-form";
 
 import { ColumnsBlockLayout } from "../createColumnsBlock";
 
 interface Section {
     name?: string;
-    label?: React.ReactNode;
+    label?: ReactNode;
     layouts: ColumnsBlockLayout[];
 }
 
@@ -24,7 +24,7 @@ interface Props extends FieldRenderProps<ColumnsBlockLayout> {
 }
 
 export function FinalFormLayoutSelect({ input: { value, onChange }, layouts }: Props) {
-    const sections = React.useMemo(() => {
+    const sections = useMemo(() => {
         const sections: Section[] = [];
 
         layouts.forEach((layout) => {

--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
@@ -11,7 +11,7 @@ import {
 import { Add, Copy, Delete, Invisible, Paste, Visible } from "@comet/admin-icons";
 import { Box, Checkbox, FormControlLabel, IconButton, Tooltip, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { ChangeEvent, FunctionComponent, ReactNode, useCallback, useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { v4 as uuid } from "uuid";
 
@@ -90,18 +90,18 @@ interface BlocksBlockAdditionalItemField<Value = unknown> {
 
 interface CreateBlocksBlockOptions<AdditionalItemFields extends Record<string, unknown>> {
     name: string;
-    displayName?: React.ReactNode;
+    displayName?: ReactNode;
     supportedBlocks: Record<BlockType, BlockInterface>;
     maxVisibleBlocks?: number;
     additionalItemFields?: {
         [Key in keyof AdditionalItemFields]: BlocksBlockAdditionalItemField<AdditionalItemFields[Key]>;
     };
-    AdditionalItemContextMenuItems?: React.FunctionComponent<{
+    AdditionalItemContextMenuItems?: FunctionComponent<{
         item: BlocksBlockItem<BlockInterface, AdditionalItemFields>;
         onChange: (item: BlocksBlockItem<BlockInterface, AdditionalItemFields>) => void;
         onMenuClose: () => void;
     }>;
-    AdditionalItemContent?: React.FunctionComponent<{ item: BlocksBlockItem<BlockInterface, AdditionalItemFields> }>;
+    AdditionalItemContent?: FunctionComponent<{ item: BlocksBlockItem<BlockInterface, AdditionalItemFields> }>;
 }
 
 export function createBlocksBlock<AdditionalItemFields extends Record<string, unknown> = DefaultAdditionalItemFields>({
@@ -294,7 +294,7 @@ export function createBlocksBlock<AdditionalItemFields extends Record<string, un
         definesOwnPadding: true,
 
         AdminComponent: ({ state, updateState }) => {
-            const toggleVisible = React.useCallback(
+            const toggleVisible = useCallback(
                 (blockKey: string) => {
                     updateState((prevState) => ({
                         ...prevState,
@@ -304,15 +304,15 @@ export function createBlocksBlock<AdditionalItemFields extends Record<string, un
                 [updateState],
             );
 
-            const [showAddBlockDrawer, setShowAddBlockDrawer] = React.useState(false);
-            const [beforeIndex, setBeforeIndex] = React.useState<number>();
-            const [cannotPasteBlockError, setCannotPasteBlockError] = React.useState<React.ReactNode>();
+            const [showAddBlockDrawer, setShowAddBlockDrawer] = useState(false);
+            const [beforeIndex, setBeforeIndex] = useState<number>();
+            const [cannotPasteBlockError, setCannotPasteBlockError] = useState<ReactNode>();
 
             const snackbarApi = useSnackbarApi();
 
             const totalVisibleBlocks = state.blocks.filter((block) => block.visible).length;
 
-            React.useEffect(() => {
+            useEffect(() => {
                 if (state.blocks.some((block) => block.slideIn)) {
                     const timeoutHandle = window.setTimeout(() => {
                         updateState((prevState) => ({ ...prevState, blocks: prevState.blocks.map((block) => ({ ...block, slideIn: false })) }));
@@ -324,7 +324,7 @@ export function createBlocksBlock<AdditionalItemFields extends Record<string, un
                 }
             }, [state.blocks, updateState]);
 
-            const handleUndoClick = React.useCallback(
+            const handleUndoClick = useCallback(
                 (removedBlocks: RemovedBlocksBlockItem<BlockInterface, AdditionalItemFields>[] | undefined) => {
                     if (!removedBlocks) {
                         return;
@@ -345,7 +345,7 @@ export function createBlocksBlock<AdditionalItemFields extends Record<string, un
                 [updateState],
             );
 
-            const deleteBlocks = React.useCallback(
+            const deleteBlocks = useCallback(
                 (blockKeys: string[]) => {
                     updateState((prevState) => {
                         const blocksToRemove = prevState.blocks
@@ -439,7 +439,7 @@ export function createBlocksBlock<AdditionalItemFields extends Record<string, un
                 return key;
             };
 
-            const createUpdateSubBlocksFn = React.useCallback(
+            const createUpdateSubBlocksFn = useCallback(
                 (blockKey: string) => {
                     const updateSubBlocksFn: DispatchSetStateAction<unknown> = (setStateAction) => {
                         updateState((prevState) => ({
@@ -509,7 +509,7 @@ export function createBlocksBlock<AdditionalItemFields extends Record<string, un
                 setBeforeIndex(undefined);
             };
 
-            const handleToggleSelectAll = (event: React.ChangeEvent<HTMLInputElement>) => {
+            const handleToggleSelectAll = (event: ChangeEvent<HTMLInputElement>) => {
                 const selected = event.target.checked;
                 updateState((prevState) => {
                     return {

--- a/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
@@ -2,7 +2,7 @@ import { Field, StackPage, StackPageTitle, StackSwitch, StackSwitchApiContext } 
 import { Add, Copy, Delete, Invisible, Paste, Visible } from "@comet/admin-icons";
 import { Checkbox, Divider, FormControlLabel, IconButton, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { ReactNode } from "react";
 import { FormattedMessage, IntlShape, useIntl } from "react-intl";
 import { v4 as uuid } from "uuid";
 
@@ -27,13 +27,13 @@ import { createUseAdminComponent as createUseListBlockAdminComponent } from "./l
 export interface ColumnsBlockLayout {
     name: string;
     columns: number;
-    label: React.ReactNode;
-    preview: React.ReactNode;
+    label: ReactNode;
+    preview: ReactNode;
     section?:
         | string
         | {
               name: string;
-              label?: React.ReactNode;
+              label?: ReactNode;
           };
 }
 
@@ -53,7 +53,7 @@ interface ColumnsBlockState<T extends BlockInterface> {
 
 interface CreateColumnsBlockOptions<T extends BlockInterface> {
     name: string;
-    displayName: React.ReactNode;
+    displayName: ReactNode;
     category?: BlockCategory | CustomBlockCategory;
     contentBlock: T;
     layouts: ColumnsBlockLayout[];

--- a/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx
@@ -1,6 +1,6 @@
 import { StackPage, StackSwitch, StackSwitchApiContext, SubRoute, useSubRoutePrefix } from "@comet/admin";
 import { Divider } from "@mui/material";
-import * as React from "react";
+import { Fragment, ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { HoverPreviewComponent } from "../../iframebridge/HoverPreviewComponent";
@@ -17,7 +17,7 @@ import { isBlockInterface } from "../helpers/isBlockInterface";
 import { BlockCategory, BlockInputApi, BlockInterface, BlockOutputApi, BlockState, CustomBlockCategory } from "../types";
 
 interface BlockConfiguration {
-    title?: React.ReactNode;
+    title?: ReactNode;
     nested?: boolean;
     block: BlockInterface | BlockInterfaceWithOptions;
     hiddenInSubroute?: boolean;
@@ -27,7 +27,7 @@ interface BlockConfiguration {
 
 interface GroupConfiguration {
     blocks: Record<string, BlockConfiguration>;
-    title?: React.ReactNode;
+    title?: ReactNode;
     paper?: boolean;
 }
 
@@ -37,7 +37,7 @@ interface NormalizedBlockConfiguration extends BlockConfiguration {
 
 interface CreateCompositeBlockOptionsBase {
     name: string;
-    displayName: React.ReactNode;
+    displayName: ReactNode;
     /**
      * @deprecated Use override instead to adapt the factored block
      */
@@ -173,7 +173,7 @@ export const createCompositeBlock = <Options extends CreateCompositeBlockOptions
                 const sectionVariant = group.paper ? "dense" : "normal";
                 const showDivider = divider && (isInPaper || group.paper);
 
-                let children: React.ReactNode;
+                let children: ReactNode;
 
                 if (nested) {
                     children = (
@@ -205,7 +205,7 @@ export const createCompositeBlock = <Options extends CreateCompositeBlockOptions
                     );
                 }
 
-                const Container = nested || hiddenInSubroute ? HiddenInSubroute : React.Fragment;
+                const Container = nested || hiddenInSubroute ? HiddenInSubroute : Fragment;
 
                 if (paper) {
                     return (
@@ -242,14 +242,14 @@ export const createCompositeBlock = <Options extends CreateCompositeBlockOptions
                             {Object.entries(groups).map(([groupKey, group]) => {
                                 const { title, paper, blocks } = group;
                                 const children = Object.keys(blocks).map((blockKey) => (
-                                    <React.Fragment key={blockKey}>{renderBlock(blockKey, group)}</React.Fragment>
+                                    <Fragment key={blockKey}>{renderBlock(blockKey, group)}</Fragment>
                                 ));
 
                                 const hiddenInSubroute = Object.values(blocks).every(
                                     (blockConfig) => blockConfig.hiddenInSubroute || blockConfig.nested,
                                 );
 
-                                const Container = hiddenInSubroute ? HiddenInSubroute : React.Fragment;
+                                const Container = hiddenInSubroute ? HiddenInSubroute : Fragment;
 
                                 if (paper) {
                                     const definesOwnPadding = Object.values(blocks).every((blockConfig) => {

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -2,7 +2,7 @@ import { StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
 import { Add, Copy, Delete, Invisible, Paste, Visible } from "@comet/admin-icons";
 import { Box, Checkbox, FormControlLabel, IconButton, Tooltip, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 import { v4 as uuid } from "uuid";
 
@@ -67,9 +67,9 @@ export interface ListBlockAdditionalItemField<Value = unknown> {
 
 interface CreateListBlockOptions<T extends BlockInterface, AdditionalItemFields extends Record<string, unknown>> {
     name: string;
-    displayName?: React.ReactNode;
-    itemName?: React.ReactNode;
-    itemsName?: React.ReactNode;
+    displayName?: ReactNode;
+    itemName?: ReactNode;
+    itemsName?: ReactNode;
     block: T;
     minVisibleBlocks?: number;
     maxVisibleBlocks?: number;
@@ -77,12 +77,12 @@ interface CreateListBlockOptions<T extends BlockInterface, AdditionalItemFields 
     additionalItemFields?: {
         [Key in keyof AdditionalItemFields]: ListBlockAdditionalItemField<AdditionalItemFields[Key]>;
     };
-    AdditionalItemContextMenuItems?: React.FunctionComponent<{
+    AdditionalItemContextMenuItems?: FunctionComponent<{
         item: ListBlockItem<T, AdditionalItemFields>;
         onChange: (item: ListBlockItem<T, AdditionalItemFields>) => void;
         onMenuClose: () => void;
     }>;
-    AdditionalItemContent?: React.FunctionComponent<{ item: ListBlockItem<T, AdditionalItemFields> }>;
+    AdditionalItemContent?: FunctionComponent<{ item: ListBlockItem<T, AdditionalItemFields> }>;
 }
 
 export function createListBlock<T extends BlockInterface, AdditionalItemFields extends Record<string, unknown> = DefaultAdditionalItemFields>({

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -2,7 +2,7 @@ import { Field, FieldContainer, FinalFormRadio, FinalFormSelect } from "@comet/a
 import { Box, Divider, FormControlLabel, MenuItem, ToggleButton as MuiToggleButton, ToggleButtonGroup as MuiToggleButtonGroup } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import isEqual from "lodash.isequal";
-import * as React from "react";
+import { ReactNode, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { BlocksFinalForm } from "../../form/BlocksFinalForm";
@@ -60,7 +60,7 @@ export type OneOfBlockOutput<Config extends boolean> = {
 type BlockType = string;
 export interface CreateOneOfBlockOptions<T extends boolean> {
     name: string;
-    displayName?: React.ReactNode;
+    displayName?: ReactNode;
     supportedBlocks: Record<BlockType, BlockInterface>;
     category?: BlockCategory | CustomBlockCategory;
     variant?: "select" | "radio" | "toggle";
@@ -109,7 +109,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
         };
     }
 
-    const options: Array<{ value: string; label: React.ReactNode }> = allowEmpty
+    const options: Array<{ value: string; label: ReactNode }> = allowEmpty
         ? [{ value: "none", label: <FormattedMessage id="comet.blocks.oneOfBlock.empty" defaultMessage="None" /> }]
         : [];
 
@@ -275,7 +275,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
         AdminComponent: ({ state, updateState }) => {
             const isInPaper = useAdminComponentPaper();
 
-            const handleBlockSelect = React.useCallback(
+            const handleBlockSelect = useCallback(
                 (blockType: string) => {
                     updateState((prevState) => {
                         let newState: OneOfBlockState = prevState;
@@ -332,7 +332,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
                 [updateState],
             );
 
-            const createUpdateSubBlocksFn = React.useCallback(
+            const createUpdateSubBlocksFn = useCallback(
                 (blockType: string) => {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     const updateSubBlocksFn: DispatchSetStateAction<any> = (setStateAction) => {

--- a/packages/admin/blocks-admin/src/blocks/factories/createOptionalBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOptionalBlock.tsx
@@ -1,6 +1,6 @@
 import { Box, Divider } from "@mui/material";
 import isEqual from "lodash.isequal";
-import * as React from "react";
+import { ReactNode } from "react";
 import { Route, useRouteMatch } from "react-router";
 
 import { Collapsible } from "../../common/Collapsible";
@@ -30,7 +30,7 @@ export interface OptionalBlockOutput<DecoratedBlock extends BlockInterface> {
 
 export function createOptionalBlock<T extends BlockInterface>(
     decoratedBlock: T,
-    options?: { title?: React.ReactNode; name?: string },
+    options?: { title?: ReactNode; name?: string },
 ): BlockInterface<OptionalBlockDecoratorFragment<T>, OptionalBlockState<T>, OptionalBlockOutput<T>> {
     const OptionalBlock: BlockInterface<OptionalBlockDecoratorFragment<T>, OptionalBlockState<T>, OptionalBlockOutput<T>> = {
         ...createBlockSkeleton(),

--- a/packages/admin/blocks-admin/src/blocks/factories/listBlock/createUseAdminComponent.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/listBlock/createUseAdminComponent.tsx
@@ -1,5 +1,5 @@
 import { UndoSnackbar, useSnackbarApi } from "@comet/admin";
-import * as React from "react";
+import { ChangeEvent, ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { v4 as uuid } from "uuid";
 
@@ -18,7 +18,7 @@ interface CreateListBlockUseAdminComponentOptions<T extends BlockInterface> {
 type ListBlockUseAdminComponentProps<T extends BlockInterface> = BlockAdminComponentProps<ListBlockState<T>>;
 
 interface ListBlockUseAdminComponentApi<T extends BlockInterface> {
-    cannotPasteBlockErrorDialog: React.ReactNode;
+    cannotPasteBlockErrorDialog: ReactNode;
     toggleVisible: (blockKey: string) => void;
     deleteBlocks: (blockKeys: string[]) => void;
     deleteAllSelectedBlocks: () => void;
@@ -27,7 +27,7 @@ interface ListBlockUseAdminComponentApi<T extends BlockInterface> {
     totalVisibleBlocks: number;
     updateClipboardContent: (content: ClipboardContent) => Promise<void>;
     pasteBlock: (insertAt: number) => Promise<void>;
-    handleToggleSelectAll: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    handleToggleSelectAll: (event: ChangeEvent<HTMLInputElement>) => void;
     selectBlock: (currentBlock: ListBlockItem<T>, select: boolean) => void;
     copySelectedBlocks: () => void;
     selectedCount: number;
@@ -42,9 +42,9 @@ export function createUseAdminComponent<T extends BlockInterface>({
     additionalItemFields = {},
 }: CreateListBlockUseAdminComponentOptions<T>): (props: ListBlockUseAdminComponentProps<T>) => ListBlockUseAdminComponentApi<T> {
     const useListBlockAdminComponent: (props: ListBlockUseAdminComponentProps<T>) => ListBlockUseAdminComponentApi<T> = ({ state, updateState }) => {
-        const [cannotPasteBlockError, setCannotPasteBlockError] = React.useState<React.ReactNode>();
+        const [cannotPasteBlockError, setCannotPasteBlockError] = useState<ReactNode>();
 
-        React.useEffect(() => {
+        useEffect(() => {
             if (state.blocks.some((block) => block.slideIn)) {
                 const timeoutHandle = window.setTimeout(() => {
                     updateState((prevState) => ({ ...prevState, blocks: prevState.blocks.map((block) => ({ ...block, slideIn: false })) }));
@@ -56,7 +56,7 @@ export function createUseAdminComponent<T extends BlockInterface>({
             }
         }, [state.blocks, updateState]);
 
-        const toggleVisible = React.useCallback(
+        const toggleVisible = useCallback(
             (blockKey: string) => {
                 updateState((prevState) => ({
                     ...prevState,
@@ -67,7 +67,7 @@ export function createUseAdminComponent<T extends BlockInterface>({
         );
 
         const snackbarApi = useSnackbarApi();
-        const handleUndoClick = React.useCallback(
+        const handleUndoClick = useCallback(
             (removedBlocks: RemovedListBlockItem<T>[] | undefined) => {
                 if (!removedBlocks) {
                     return;
@@ -86,7 +86,7 @@ export function createUseAdminComponent<T extends BlockInterface>({
             [updateState],
         );
 
-        const deleteBlocks = React.useCallback(
+        const deleteBlocks = useCallback(
             (blockKeys: string[]) => {
                 updateState((prevState) => {
                     const blocksToRemove = prevState.blocks
@@ -159,7 +159,7 @@ export function createUseAdminComponent<T extends BlockInterface>({
             return key;
         };
 
-        const createUpdateSubBlocksFn = React.useCallback(
+        const createUpdateSubBlocksFn = useCallback(
             (blockKey: string) => {
                 const updateSubBlocksFn: DispatchSetStateAction<BlockState<T>> = (setStateAction) => {
                     updateState((prevState) => ({
@@ -178,7 +178,7 @@ export function createUseAdminComponent<T extends BlockInterface>({
 
         const { updateClipboardContent, getClipboardContent } = useBlockClipboard({ supports: block });
 
-        const cannotPasteBlockErrorDialog = React.useMemo(
+        const cannotPasteBlockErrorDialog = useMemo(
             () =>
                 cannotPasteBlockError !== undefined && (
                     <CannotPasteBlockDialog open onClose={() => setCannotPasteBlockError(undefined)} error={cannotPasteBlockError} />
@@ -220,7 +220,7 @@ export function createUseAdminComponent<T extends BlockInterface>({
             });
         };
 
-        const handleToggleSelectAll = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const handleToggleSelectAll = (event: ChangeEvent<HTMLInputElement>) => {
             const selected = event.target.checked;
 
             updateState((prevState) => {

--- a/packages/admin/blocks-admin/src/blocks/factories/spaceBlock/createSpaceBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/spaceBlock/createSpaceBlock.tsx
@@ -1,6 +1,6 @@
 import { SelectField } from "@comet/admin";
 import { MenuItem } from "@mui/material";
-import * as React from "react";
+import { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { BlocksFinalForm } from "../../../form/BlocksFinalForm";
@@ -11,7 +11,7 @@ import { BlockCategory, BlockInterface } from "../../types";
 export interface SpaceBlockFactoryOptions<T> {
     name?: string;
     defaultValue: T;
-    options: { value: T; label: React.ReactNode }[];
+    options: { value: T; label: ReactNode }[];
 }
 
 export const createSpaceBlock = <T extends string | number>({

--- a/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/composeBlocks.spec.tsx
+++ b/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/composeBlocks.spec.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { SpaceBlock } from "../../SpaceBlock";
 import { BlockInputApi, BlockState } from "../../types";
 import { resolveNewState } from "../../utils";

--- a/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/composeBlocks.tsx
+++ b/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/composeBlocks.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as React from "react";
 
 import { BlockPreviewContent } from "../../common/blockRow/BlockPreviewContent";
 import { BlockContext, BlockDependency, BlockInterface, BlockMethods, DispatchSetStateAction, PreviewContent, SetStateAction } from "../../types";

--- a/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/types.ts
+++ b/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/types.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { ReactNode } from "react";
+
 import { AnonymousBlockInterface, BlockInputApi, BlockInterface, BlockOutputApi, BlockState, DispatchSetStateAction } from "../../types";
 import { Flatten, KeysMatching } from "./utility-types";
 
@@ -68,12 +70,12 @@ type AdminComponentPropsMapByCompositeBlocks<C extends CompositeBlocks> = {
 
 export type AdminComponentsMap<C extends CompositeBlocksConfig> = AdminComponentsMapByCompositeBlocks<ExtractCompositeBlocks<C>>;
 type AdminComponentsMapByCompositeBlocks<C extends CompositeBlocks> = {
-    [K in keyof C]: React.ReactNode;
+    [K in keyof C]: ReactNode;
 };
 
 export type PreviewMap<C extends CompositeBlocksConfig> = PreviewMapByCompositeBlocks<ExtractCompositeBlocks<C>>;
 type PreviewMapByCompositeBlocks<C extends CompositeBlocks> = {
-    [K in keyof C]: React.ReactNode;
+    [K in keyof C]: ReactNode;
 };
 
 export type ChildBlockCountMap<C extends CompositeBlocksConfig> = ChildBlockCountMapByCompositeBlocks<ExtractCompositeBlocks<C>>;

--- a/packages/admin/blocks-admin/src/blocks/helpers/createBlockSkeleton.tsx
+++ b/packages/admin/blocks-admin/src/blocks/helpers/createBlockSkeleton.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { BlockCategory, BlockInterface, RootBlockInterface } from "../types";

--- a/packages/admin/blocks-admin/src/blocks/helpers/createCompositeBlockSelectField.tsx
+++ b/packages/admin/blocks-admin/src/blocks/helpers/createCompositeBlockSelectField.tsx
@@ -1,13 +1,13 @@
 import { SelectField, SelectFieldProps } from "@comet/admin";
 import { MenuItem } from "@mui/material";
-import * as React from "react";
+import { ReactNode } from "react";
 
 import { BlocksFinalForm } from "../../form/BlocksFinalForm";
 import { createCompositeSetting } from "./composeBlocks/createCompositeSetting";
 
 interface Options<T extends string | number> {
     defaultValue: T;
-    options: Array<{ value: T; label: React.ReactNode }>;
+    options: Array<{ value: T; label: ReactNode }>;
     fieldProps?: Partial<SelectFieldProps<T>>;
 }
 

--- a/packages/admin/blocks-admin/src/blocks/helpers/createCompositeBlockTextField.tsx
+++ b/packages/admin/blocks-admin/src/blocks/helpers/createCompositeBlockTextField.tsx
@@ -1,5 +1,4 @@
 import { TextField, TextFieldProps } from "@comet/admin";
-import * as React from "react";
 
 import { BlocksFinalForm } from "../../form/BlocksFinalForm";
 import { createCompositeSetting } from "./composeBlocks/createCompositeSetting";

--- a/packages/admin/blocks-admin/src/blocks/types.tsx
+++ b/packages/admin/blocks-admin/src/blocks/types.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { ComponentType, ReactElement, ReactNode } from "react";
 import { FormattedMessage, MessageDescriptor } from "react-intl";
 
 export type SetStateFn<S> = (prevState: S) => S;
@@ -25,15 +25,15 @@ export interface BlockAdminComponentProps<S = any> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type BlockAdminComponent<S = any> = React.ComponentType<BlockAdminComponentProps<S>>;
-export type BindBlockAdminComponent<T extends BlockAdminComponent> = T extends React.ComponentType<infer BlockAdminComponentProps>
-    ? React.ComponentType<Partial<BlockAdminComponentProps>>
+export type BlockAdminComponent<S = any> = ComponentType<BlockAdminComponentProps<S>>;
+export type BindBlockAdminComponent<T extends BlockAdminComponent> = T extends ComponentType<infer BlockAdminComponentProps>
+    ? ComponentType<Partial<BlockAdminComponentProps>>
     : never;
 
 export interface AdminComponentPart {
     key: string;
-    label: React.ReactNode;
-    content: React.ReactNode;
+    label: ReactNode;
+    content: ReactNode;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -50,7 +50,7 @@ export function isPreviewContentTextRule(content: PreviewContent): content is Pr
     return content.type === "text";
 }
 
-export type PreviewContentText = { type: "text"; content: React.ReactNode };
+export type PreviewContentText = { type: "text"; content: ReactNode };
 
 export function isPreviewContentImageRule(content: PreviewContent): content is PreviewContentImage {
     return content.type === "image";
@@ -80,7 +80,7 @@ export interface BlockMethods<
     isValid: (state: State) => Promise<boolean> | boolean;
     childBlockCount?: (state: State) => number;
     previewContent: (state: State, context?: BlockContext) => PreviewContent[];
-    dynamicDisplayName?: (state: State) => React.ReactNode;
+    dynamicDisplayName?: (state: State) => ReactNode;
     anchors?: (state: State) => string[];
     dependencies?: (state: State) => BlockDependency[];
     replaceDependenciesInOutput: (output: OutputApi, replacements: ReplaceDependencyObject[]) => OutputApi;
@@ -111,7 +111,7 @@ export interface BlockInterface<
     PreviewState extends PreviewStateInterface = InputApi & PreviewStateInterface,
 > extends AnonymousBlockInterface<InputApi, State, OutputApi, PreviewState> {
     name: string;
-    displayName: React.ReactNode;
+    displayName: ReactNode;
     category: BlockCategory | CustomBlockCategory;
 }
 
@@ -152,7 +152,7 @@ export enum BlockCategory {
     Other = "Other",
 }
 
-export type CustomBlockCategory = { id: string; label: string | React.ReactElement<MessageDescriptor>; insertBefore?: BlockCategory };
+export type CustomBlockCategory = { id: string; label: string | ReactElement<MessageDescriptor>; insertBefore?: BlockCategory };
 
 export const blockCategoryLabels = {
     [BlockCategory.TextAndContent]: <FormattedMessage id="comet.blocks.category.textAndContent" defaultMessage="Text & Content" />,

--- a/packages/admin/blocks-admin/src/clipboard/CannotPasteBlockDialog.tsx
+++ b/packages/admin/blocks-admin/src/clipboard/CannotPasteBlockDialog.tsx
@@ -1,15 +1,15 @@
 import { messages } from "@comet/admin";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
-import * as React from "react";
+import { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 interface Props {
     open: boolean;
     onClose: () => void;
-    error: React.ReactNode;
+    error: ReactNode;
 }
 
-function CannotPasteBlockDialog({ open, onClose, error }: Props): React.ReactElement {
+const CannotPasteBlockDialog = ({ open, onClose, error }: Props) => {
     return (
         <Dialog open={open} onClose={onClose}>
             <DialogTitle>
@@ -23,6 +23,6 @@ function CannotPasteBlockDialog({ open, onClose, error }: Props): React.ReactEle
             </DialogActions>
         </Dialog>
     );
-}
+};
 
 export { CannotPasteBlockDialog };

--- a/packages/admin/blocks-admin/src/clipboard/useBlockClipboard.tsx
+++ b/packages/admin/blocks-admin/src/clipboard/useBlockClipboard.tsx
@@ -1,5 +1,5 @@
 import { readClipboardText, writeClipboardText } from "@comet/admin";
-import * as React from "react";
+import { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { BlockInterface, BlockOutputApi, BlockState } from "../blocks/types";
@@ -23,7 +23,7 @@ interface TransformedClipboardBlock {
 
 type TransformedClipboardContent = TransformedClipboardBlock[];
 
-type GetClipboardContentResponse = { canPaste: true; content: ClipboardContent } | { canPaste: false; error: React.ReactNode };
+type GetClipboardContentResponse = { canPaste: true; content: ClipboardContent } | { canPaste: false; error: ReactNode };
 
 interface BlockClipboardApi {
     updateClipboardContent: (content: ClipboardContent) => Promise<void>;

--- a/packages/admin/blocks-admin/src/common/Collapsible.tsx
+++ b/packages/admin/blocks-admin/src/common/Collapsible.tsx
@@ -1,13 +1,13 @@
 import { Button, Collapse } from "@mui/material";
-import React, { FunctionComponent } from "react";
+import { PropsWithChildren, ReactNode } from "react";
 
 interface CollapsibleProps {
     open: boolean;
-    header: React.ReactNode;
+    header: ReactNode;
     onChange: (open: boolean) => void;
 }
 
-export const Collapsible: FunctionComponent<CollapsibleProps> = ({ header, children, open, onChange }) => {
+export const Collapsible = ({ header, children, open, onChange }: PropsWithChildren<CollapsibleProps>) => {
     return (
         <>
             <Button

--- a/packages/admin/blocks-admin/src/common/CollapsibleSwitchButtonHeader.tsx
+++ b/packages/admin/blocks-admin/src/common/CollapsibleSwitchButtonHeader.tsx
@@ -1,13 +1,13 @@
 import { Switch, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import React, { FunctionComponent } from "react";
+import { ReactNode } from "react";
 
 interface CollapsibleSwitchButtonHeaderProps {
     checked: boolean;
-    title?: React.ReactNode;
+    title?: ReactNode;
 }
 
-export const CollapsibleSwitchButtonHeader: FunctionComponent<CollapsibleSwitchButtonHeaderProps> = ({ checked, title }) => {
+export const CollapsibleSwitchButtonHeader = ({ checked, title }: CollapsibleSwitchButtonHeaderProps) => {
     return (
         <Root>
             <Typography>{title}</Typography>

--- a/packages/admin/blocks-admin/src/common/usePromise.ts
+++ b/packages/admin/blocks-admin/src/common/usePromise.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useEffect, useState } from "react";
 
 interface UsePromiseOptions<S> {
     initialValue: S;
@@ -8,13 +8,13 @@ export function usePromise(): undefined; // For convinience, the caller doesnt n
 export function usePromise<S>(fn: undefined | (() => Promise<S> | S)): S | undefined; // Without initial value the return maybe undefined (until the first promise is resolved)
 export function usePromise<S>(fn: undefined | (() => Promise<S> | S), options: UsePromiseOptions<S>): S; // Initial values are given, return is never undefined
 export function usePromise<S>(fn?: undefined | (() => Promise<S> | S), options?: UsePromiseOptions<S>): S | undefined {
-    const [state, setState] = React.useState(() => {
+    const [state, setState] = useState(() => {
         if (options) {
             return options.initialValue;
         }
         return undefined;
     });
-    React.useEffect(() => {
+    useEffect(() => {
         // @TODO: add throtteling- or debouncing-options to avoid evaluating the promise on every render
         const evaluateFn = async () => {
             if (fn) {

--- a/packages/admin/blocks-admin/src/common/useScrollRestoration.ts
+++ b/packages/admin/blocks-admin/src/common/useScrollRestoration.ts
@@ -1,8 +1,8 @@
-import * as React from "react";
+import { MutableRefObject, useCallback, useLayoutEffect, useRef } from "react";
 import { useLocation } from "react-router";
 
 interface UseScrollRestorationProps<Element> {
-    ref: React.MutableRefObject<Element | null>;
+    ref: MutableRefObject<Element | null>;
     onScroll: () => void;
 }
 
@@ -10,17 +10,17 @@ export function useScrollRestoration<Element extends HTMLElement>(identifier: st
     const location = useLocation();
     const identifierForRoute = `${location.pathname}-${identifier}`;
 
-    const ref = React.useRef<Element>(null);
+    const ref = useRef<Element>(null);
 
-    const scrollPositionsRef = React.useRef<Record<string, number | undefined>>({});
+    const scrollPositionsRef = useRef<Record<string, number | undefined>>({});
 
-    React.useLayoutEffect((): void => {
+    useLayoutEffect((): void => {
         if (ref.current) {
             ref.current.scrollTo(0, scrollPositionsRef.current[identifierForRoute] ?? 0);
         }
     }, [identifierForRoute]);
 
-    const onScroll = React.useCallback(() => {
+    const onScroll = useCallback(() => {
         if (ref.current) {
             scrollPositionsRef.current[identifierForRoute] = ref.current.scrollTop;
         }

--- a/packages/admin/blocks-admin/src/context/BlockContext.tsx
+++ b/packages/admin/blocks-admin/src/context/BlockContext.tsx
@@ -1,3 +1,3 @@
-import * as React from "react";
+import { createContext } from "react";
 
-export const BlockContext = React.createContext<unknown>(undefined);
+export const BlockContext = createContext<unknown>(undefined);

--- a/packages/admin/blocks-admin/src/context/BlockContextProvider.tsx
+++ b/packages/admin/blocks-admin/src/context/BlockContextProvider.tsx
@@ -1,12 +1,11 @@
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 import { BlockContext } from "./BlockContext";
 
 interface Props {
     value: unknown;
-    children: React.ReactNode;
 }
 
-export function BlockContextProvider({ value, children }: Props): React.ReactElement {
+export const BlockContextProvider = ({ value, children }: PropsWithChildren<Props>) => {
     return <BlockContext.Provider value={value}>{children}</BlockContext.Provider>;
-}
+};

--- a/packages/admin/blocks-admin/src/context/useBlockContext.ts
+++ b/packages/admin/blocks-admin/src/context/useBlockContext.ts
@@ -1,7 +1,7 @@
-import * as React from "react";
+import { useContext } from "react";
 
 import { BlockContext } from "./BlockContext";
 
-export function useBlockContext(): unknown {
-    return React.useContext(BlockContext);
+export function useBlockContext() {
+    return useContext(BlockContext);
 }

--- a/packages/admin/blocks-admin/src/form/AutosaveFinalForm.tsx
+++ b/packages/admin/blocks-admin/src/form/AutosaveFinalForm.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AnyObject, Form, FormProps, FormSpy } from "react-final-form";
 
 function AutosaveSpy() {

--- a/packages/admin/blocks-admin/src/form/BlockFieldContainer.tsx
+++ b/packages/admin/blocks-admin/src/form/BlockFieldContainer.tsx
@@ -1,7 +1,5 @@
 import { FieldContainer, FieldContainerProps } from "@comet/admin";
-import * as React from "react";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function BlockFieldContainer(props: FieldContainerProps): React.ReactElement {
+export const BlockFieldContainer = (props: FieldContainerProps) => {
     return <FieldContainer {...props} />;
-}
+};

--- a/packages/admin/blocks-admin/src/form/BlocksFinalForm.tsx
+++ b/packages/admin/blocks-admin/src/form/BlocksFinalForm.tsx
@@ -1,5 +1,4 @@
 import { FinalFormContextProvider, FinalFormContextProviderProps } from "@comet/admin";
-import * as React from "react";
 import { AnyObject, Form, FormProps, FormSpy } from "react-final-form";
 
 interface AutoSaveSpyProps<FormValues> {

--- a/packages/admin/blocks-admin/src/form/createFinalFormBlock.tsx
+++ b/packages/admin/blocks-admin/src/form/createFinalFormBlock.tsx
@@ -1,11 +1,10 @@
-import React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 import { BlockInterface } from "../blocks/types";
 import { resolveNewState } from "../blocks/utils";
 
 const createFinalFormBlock = (block: BlockInterface) => {
-    return ({ input: { value, onChange } }: FieldRenderProps<unknown>): React.ReactElement => (
+    return ({ input: { value, onChange } }: FieldRenderProps<unknown>) => (
         <block.AdminComponent state={value} updateState={(setStateAction) => onChange(resolveNewState({ prevState: value, setStateAction }))} />
     );
 };

--- a/packages/admin/blocks-admin/src/iframebridge/HoverPreviewComponent.tsx
+++ b/packages/admin/blocks-admin/src/iframebridge/HoverPreviewComponent.tsx
@@ -1,22 +1,23 @@
-import * as React from "react";
+import { PropsWithChildren, useEffect, useRef } from "react";
 import { useRouteMatch } from "react-router";
 import scrollIntoView from "scroll-into-view-if-needed";
 
 import * as sc from "./HoverPreviewComponent.sc";
 import { useIFrameBridge } from "./useIFrameBridge";
 
-interface IHoverPreviewComponentProps {
+interface HoverPreviewComponentProps {
     componentSlug: string;
 }
-export const HoverPreviewComponent: React.FunctionComponent<IHoverPreviewComponentProps> = ({ children, componentSlug }) => {
+
+export const HoverPreviewComponent = ({ children, componentSlug }: PropsWithChildren<HoverPreviewComponentProps>) => {
     const match = useRouteMatch();
     const iFrameBridge = useIFrameBridge();
-    const rootEl = React.useRef<HTMLDivElement | null>(null);
+    const rootEl = useRef<HTMLDivElement | null>(null);
 
     const componentRoute = componentSlug.startsWith("#") ? `${match.url}${componentSlug}` : `${match.url}/${componentSlug}`;
 
     const isHovered = iFrameBridge.hoveredSiteRoute?.includes(componentRoute) ?? false;
-    React.useEffect(() => {
+    useEffect(() => {
         const timeout = setTimeout(() => {
             if (isHovered) {
                 if (rootEl.current) {

--- a/packages/admin/blocks-admin/src/iframebridge/IFrameBridge.tsx
+++ b/packages/admin/blocks-admin/src/iframebridge/IFrameBridge.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { createContext, createRef, PropsWithChildren, Ref, useCallback, useEffect, useRef, useState } from "react";
 import { Route, useHistory } from "react-router";
 
 import {
@@ -14,7 +14,7 @@ import {
 } from "./IFrameMessage";
 
 export interface IFrameBridgeContext {
-    iFrameRef: React.Ref<HTMLIFrameElement>;
+    iFrameRef: Ref<HTMLIFrameElement>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sendBlockState: (blockState: any) => void; // TODO: only PageBlock is supported currently
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -26,8 +26,8 @@ export interface IFrameBridgeContext {
     sendHoverComponent: (adminRoute: string | null) => void;
 }
 
-export const IFrameBridgeContext = React.createContext<IFrameBridgeContext>({
-    iFrameRef: React.createRef(),
+export const IFrameBridgeContext = createContext<IFrameBridgeContext>({
+    iFrameRef: createRef(),
     sendBlockState: () => {
         // empty
     },
@@ -50,14 +50,14 @@ export const IFrameBridgeContext = React.createContext<IFrameBridgeContext>({
 interface IFrameBridgeProviderProps {
     onReceiveMessage?: (message: IFrameMessage) => void;
 }
-export const IFrameBridgeProvider: React.FunctionComponent<IFrameBridgeProviderProps> = ({ children, onReceiveMessage }) => {
-    const iFrameRef = React.useRef<HTMLIFrameElement>(null);
-    const [iFrameReady, setIFrameReady] = React.useState(false);
+export const IFrameBridgeProvider = ({ children, onReceiveMessage }: PropsWithChildren<IFrameBridgeProviderProps>) => {
+    const iFrameRef = useRef<HTMLIFrameElement>(null);
+    const [iFrameReady, setIFrameReady] = useState(false);
 
-    const [hoveredSiteRoute, setHoveredSiteRoute] = React.useState<string | null>(null);
+    const [hoveredSiteRoute, setHoveredSiteRoute] = useState<string | null>(null);
 
     const history = useHistory();
-    const sendMessage = React.useCallback(
+    const sendMessage = useCallback(
         (message: AdminMessage) => {
             if (!iFrameReady) {
                 throw Error("iFrame not ready");
@@ -69,7 +69,7 @@ export const IFrameBridgeProvider: React.FunctionComponent<IFrameBridgeProviderP
         },
         [iFrameReady],
     );
-    const _onReceiveMessage = React.useCallback(
+    const _onReceiveMessage = useCallback(
         (message: IFrameMessage) => {
             onReceiveMessage?.(message);
             switch (message.cometType) {
@@ -87,7 +87,7 @@ export const IFrameBridgeProvider: React.FunctionComponent<IFrameBridgeProviderP
         [history, onReceiveMessage],
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
             try {
                 const message = JSON.parse(event.data);
@@ -108,7 +108,7 @@ export const IFrameBridgeProvider: React.FunctionComponent<IFrameBridgeProviderP
         };
     }, [_onReceiveMessage]);
 
-    const sendSelectComponent = React.useCallback(
+    const sendSelectComponent = useCallback(
         (adminRoute: string) => {
             const message: IAdminSelectComponentMessage = { cometType: AdminMessageType.SelectComponent, data: { adminRoute } };
             sendMessage(message);

--- a/packages/admin/blocks-admin/src/iframebridge/SelectPreviewComponent.tsx
+++ b/packages/admin/blocks-admin/src/iframebridge/SelectPreviewComponent.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
+import { ReactNode, useEffect } from "react";
 import { useLocation } from "react-router";
 
 import { useIFrameBridge } from "./useIFrameBridge";
 
-export const SelectPreviewComponent: React.FunctionComponent = ({ children }) => {
+export const SelectPreviewComponent = ({ children }: { children?: ReactNode }) => {
     const location = useLocation();
     const iFrameBridge = useIFrameBridge();
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (iFrameBridge.iFrameReady) {
             iFrameBridge.sendSelectComponent(`${location.pathname}${location.hash}`);
         }

--- a/packages/admin/blocks-admin/src/iframebridge/useIFrameBridge.ts
+++ b/packages/admin/blocks-admin/src/iframebridge/useIFrameBridge.ts
@@ -1,7 +1,7 @@
-import * as React from "react";
+import { useContext } from "react";
 
 import { IFrameBridgeContext } from "./IFrameBridge";
 
 export function useIFrameBridge(): IFrameBridgeContext {
-    return React.useContext(IFrameBridgeContext);
+    return useContext(IFrameBridgeContext);
 }

--- a/packages/admin/tsconfig.base.json
+++ b/packages/admin/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.core.json",
     "compilerOptions": {
-        "jsx": "react",
+        "jsx": "react-jsx",
         "lib": ["DOM", "ES2015", "ES2016", "ES2017", "ES2018", "ES2019", "ESNext.AsyncIterable"],
         "noImplicitAny": true,
         "sourceMap": true,


### PR DESCRIPTION
Use named imports instead of barrel importing React. Doing so will result in less code and better readability. The new [React docs](https://react.dev/) also use named imports and never import React itself.

To avoid conflicts, we temporarily add the eslint rules in the packages on main. The restrict-import rule will be added in the v8 (next) branch in the eslint-config package, then they will be removed there again.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-1026
