### PR TITLE
Fix key as `adminRoute` is not necessarily unique

### DIFF
--- a/.changeset/twenty-mirrors-taste.md
+++ b/.changeset/twenty-mirrors-taste.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": patch
+---
+
+Fix a bug where a block's hover-overlay element in the admin preview might persist after the underlying element is moved or resized

--- a/packages/site/cms-site/src/iframebridge/PreviewOverlay.tsx
+++ b/packages/site/cms-site/src/iframebridge/PreviewOverlay.tsx
@@ -22,14 +22,14 @@ export const PreviewOverlay = () => {
 
     return (
         <OverlayRoot style={{ height: bottomMostElementPosition }}>
-            {iFrameBridge.previewElementsData.map((element) => {
+            {iFrameBridge.previewElementsData.map((element, index) => {
                 const isSelected = element.adminRoute === iFrameBridge.selectedAdminRoute;
 
                 if (isSelected && lastSelectedElementPath !== element.adminRoute) {
                     lastSelectedElementPath = element.adminRoute;
                 }
 
-                return <PreviewOverlayElement key={element.adminRoute} element={element} />;
+                return <PreviewOverlayElement key={index} element={element} />;
             })}
         </OverlayRoot>
     );


### PR DESCRIPTION
Fixes a bug where a block's hover-overlay element in the admin preview might persist after the underlying element is moved or resized. 


---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-1019
-   [x] Provide screenshots/screencasts if the change contains visual changes

Previously, when resizing the preview a lot, blocks with a certain structure could cause the preview to look like this:

<img width="814" alt="Admin preview" src="https://github.com/user-attachments/assets/afc9ce31-5a1b-44e0-8237-d429af646c74">