### PR TITLE
Demo: Implement custom grid filter

### DIFF
--- a/demo/admin/src/products/ManufacturerFilter.tsx
+++ b/demo/admin/src/products/ManufacturerFilter.tsx
@@ -50,7 +50,7 @@ function ManufacturerFilter({ item, applyValue }: GridFilterInputValueProps) {
             }}
             onChange={(event, value, reason) => {
                 // value can't be "{ id: value.id, name: value.name }" because value is sent to api
-                applyValue({ id: item.id, operatorValue: "equals", value: value.id, columnField: "manufacturer" });
+                applyValue({ id: item.id, operatorValue: "equals", value: value ? value.id : undefined, columnField: "manufacturer" });
             }}
             renderInput={(params) => (
                 <TextField

--- a/demo/admin/src/products/ManufacturerFilter.tsx
+++ b/demo/admin/src/products/ManufacturerFilter.tsx
@@ -4,6 +4,7 @@ import Autocomplete from "@mui/material/Autocomplete";
 import { GridFilterInputValueProps, GridFilterOperator } from "@mui/x-data-grid-pro";
 import * as React from "react";
 import { useIntl } from "react-intl";
+import { useDebounce } from "use-debounce";
 
 import { GQLManufacturersFilterQuery, GQLManufacturersFilterQueryVariables } from "./ManufacturerFilter.generated";
 
@@ -23,12 +24,13 @@ const manufacturersQuery = gql`
 function ManufacturerFilter({ item, applyValue }: GridFilterInputValueProps) {
     const intl = useIntl();
     const [search, setSearch] = React.useState<string | undefined>(undefined);
+    const [debouncedSearch] = useDebounce(search, 500);
 
     const { data } = useQuery<GQLManufacturersFilterQuery, GQLManufacturersFilterQueryVariables>(manufacturersQuery, {
         variables: {
             offset: 0,
             limit: 10,
-            search: search,
+            search: debouncedSearch,
         },
     });
 

--- a/demo/admin/src/products/ManufacturerFilter.tsx
+++ b/demo/admin/src/products/ManufacturerFilter.tsx
@@ -22,11 +22,13 @@ const manufacturersQuery = gql`
 // Source: https://mui.com/x/react-data-grid/filtering/customization/#multiple-values-operator
 function ManufacturerFilter({ item, applyValue }: GridFilterInputValueProps) {
     const intl = useIntl();
+    const [search, setSearch] = React.useState<string | undefined>(undefined);
 
     const { data } = useQuery<GQLManufacturersFilterQuery, GQLManufacturersFilterQueryVariables>(manufacturersQuery, {
         variables: {
             offset: 0,
             limit: 10,
+            search: search,
         },
     });
 
@@ -37,6 +39,7 @@ function ManufacturerFilter({ item, applyValue }: GridFilterInputValueProps) {
             options={data?.manufacturers.nodes ?? []}
             autoHighlight
             value={item.value}
+            filterOptions={(x) => x} // disable local filtering
             isOptionEqualToValue={(option, value) => {
                 // does only highlight the selected value in options-list but does not trigger getOptionLabel-Call
                 return option.id == value;
@@ -53,6 +56,10 @@ function ManufacturerFilter({ item, applyValue }: GridFilterInputValueProps) {
                 <TextField
                     {...params}
                     placeholder={intl.formatMessage({ id: "manufacturer-filter.placeholder", defaultMessage: "Choose a manufacturer" })}
+                    value={search}
+                    onChange={(event) => {
+                        setSearch(event.target.value);
+                    }}
                     inputProps={{
                         ...params.inputProps,
                         autoComplete: "new-password", // disable autocomplete and autofill

--- a/demo/admin/src/products/ManufacturerFilter.tsx
+++ b/demo/admin/src/products/ManufacturerFilter.tsx
@@ -1,6 +1,6 @@
 import { gql, useQuery } from "@apollo/client";
+import { InputBase } from "@mui/material";
 import Autocomplete from "@mui/material/Autocomplete";
-import TextField from "@mui/material/TextField";
 import { GridFilterInputValueProps, GridFilterOperator } from "@mui/x-data-grid-pro";
 import * as React from "react";
 import { useIntl } from "react-intl";
@@ -53,7 +53,7 @@ function ManufacturerFilter({ item, applyValue }: GridFilterInputValueProps) {
                 applyValue({ id: item.id, operatorValue: "equals", value: value ? value.id : undefined, columnField: "manufacturer" });
             }}
             renderInput={(params) => (
-                <TextField
+                <InputBase
                     {...params}
                     placeholder={intl.formatMessage({ id: "manufacturer-filter.placeholder", defaultMessage: "Choose a manufacturer" })}
                     value={search ? search : null}

--- a/demo/admin/src/products/ManufacturerFilter.tsx
+++ b/demo/admin/src/products/ManufacturerFilter.tsx
@@ -1,0 +1,80 @@
+import { gql, useQuery } from "@apollo/client";
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
+import { GridFilterInputValueProps, GridFilterOperator } from "@mui/x-data-grid-pro";
+import { GQLManufacturersFilterQuery, GQLManufacturersFilterQueryVariables } from "@src/products/ManufacturerFilter.generated";
+import * as React from "react";
+import { useIntl } from "react-intl";
+
+const manufacturerFilterFragment = gql`
+    fragment ManufacturersFilter on Manufacturer {
+        id
+        name
+    }
+`;
+
+const manufacturersQuery = gql`
+    query ManufacturersFilter($offset: Int!, $limit: Int!, $search: String) {
+        manufacturers(offset: $offset, limit: $limit, search: $search) {
+            nodes {
+                ...ManufacturersFilter
+            }
+            totalCount
+        }
+    }
+    ${manufacturerFilterFragment}
+`;
+
+// Source: https://mui.com/x/react-data-grid/filtering/customization/#multiple-values-operator
+function ManufacturerFilter(props: GridFilterInputValueProps) {
+    const { item, applyValue } = props;
+    const intl = useIntl();
+
+    const { data } = useQuery<GQLManufacturersFilterQuery, GQLManufacturersFilterQueryVariables>(manufacturersQuery, {
+        variables: {
+            offset: 0,
+            limit: 10,
+        },
+    });
+
+    // source https://mui.com/material-ui/react-autocomplete/
+    return (
+        <Autocomplete
+            id="manufacturer-select"
+            size="small"
+            options={data?.manufacturers.nodes ?? []}
+            autoHighlight
+            value={item.value}
+            isOptionEqualToValue={(option, value) => {
+                // does only highlight the selected value in options-list but does not trigger getOptionLabel-Call
+                return option.id == value;
+            }}
+            getOptionLabel={(option) => {
+                // option.name is not set if loaded from filters-model, small delay replacing id with name because of loading
+                return option.name ?? data?.manufacturers.nodes.find((item) => item.id === option)?.name ?? option;
+            }}
+            onChange={(event, value, reason) => {
+                // value can't be "{ id: value.id, name: value.name }" because value is sent to api
+                applyValue({ id: item.id, operatorValue: "equals", value: value.id, columnField: "manufacturer" });
+            }}
+            renderInput={(params) => (
+                <TextField
+                    {...params}
+                    placeholder={intl.formatMessage({ id: "manufacturer-filter.placeholder", defaultMessage: "Choose a manufacturer" })}
+                    inputProps={{
+                        ...params.inputProps,
+                        autoComplete: "new-password", // disable autocomplete and autofill
+                    }}
+                />
+            )}
+        />
+    );
+}
+
+export const ManufacturerFilterOperator: GridFilterOperator = {
+    value: "equals",
+    getApplyFilterFn: (filterItem) => {
+        throw new Error("not implemented, we filter server side");
+    },
+    InputComponent: ManufacturerFilter,
+};

--- a/demo/admin/src/products/ManufacturerFilter.tsx
+++ b/demo/admin/src/products/ManufacturerFilter.tsx
@@ -55,14 +55,12 @@ function ManufacturerFilter({ item, applyValue }: GridFilterInputValueProps) {
             renderInput={(params) => (
                 <InputBase
                     {...params}
+                    {...params.InputProps}
+                    autoComplete="off"
                     placeholder={intl.formatMessage({ id: "manufacturer-filter.placeholder", defaultMessage: "Choose a manufacturer" })}
                     value={search ? search : null}
                     onChange={(event) => {
                         setSearch(event.target.value);
-                    }}
-                    inputProps={{
-                        ...params.inputProps,
-                        autoComplete: "new-password", // disable autocomplete and autofill
                     }}
                 />
             )}

--- a/demo/admin/src/products/ManufacturerFilter.tsx
+++ b/demo/admin/src/products/ManufacturerFilter.tsx
@@ -2,32 +2,25 @@ import { gql, useQuery } from "@apollo/client";
 import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
 import { GridFilterInputValueProps, GridFilterOperator } from "@mui/x-data-grid-pro";
-import { GQLManufacturersFilterQuery, GQLManufacturersFilterQueryVariables } from "@src/products/ManufacturerFilter.generated";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
-const manufacturerFilterFragment = gql`
-    fragment ManufacturersFilter on Manufacturer {
-        id
-        name
-    }
-`;
+import { GQLManufacturersFilterQuery, GQLManufacturersFilterQueryVariables } from "./ManufacturerFilter.generated";
 
 const manufacturersQuery = gql`
     query ManufacturersFilter($offset: Int!, $limit: Int!, $search: String) {
         manufacturers(offset: $offset, limit: $limit, search: $search) {
             nodes {
-                ...ManufacturersFilter
+                id
+                name
             }
             totalCount
         }
     }
-    ${manufacturerFilterFragment}
 `;
 
 // Source: https://mui.com/x/react-data-grid/filtering/customization/#multiple-values-operator
-function ManufacturerFilter(props: GridFilterInputValueProps) {
-    const { item, applyValue } = props;
+function ManufacturerFilter({ item, applyValue }: GridFilterInputValueProps) {
     const intl = useIntl();
 
     const { data } = useQuery<GQLManufacturersFilterQuery, GQLManufacturersFilterQueryVariables>(manufacturersQuery, {
@@ -40,7 +33,6 @@ function ManufacturerFilter(props: GridFilterInputValueProps) {
     // source https://mui.com/material-ui/react-autocomplete/
     return (
         <Autocomplete
-            id="manufacturer-select"
             size="small"
             options={data?.manufacturers.nodes ?? []}
             autoHighlight

--- a/demo/admin/src/products/ManufacturerFilter.tsx
+++ b/demo/admin/src/products/ManufacturerFilter.tsx
@@ -38,7 +38,7 @@ function ManufacturerFilter({ item, applyValue }: GridFilterInputValueProps) {
             size="small"
             options={data?.manufacturers.nodes ?? []}
             autoHighlight
-            value={item.value}
+            value={item.value ? item.value : null}
             filterOptions={(x) => x} // disable local filtering
             isOptionEqualToValue={(option, value) => {
                 // does only highlight the selected value in options-list but does not trigger getOptionLabel-Call
@@ -56,7 +56,7 @@ function ManufacturerFilter({ item, applyValue }: GridFilterInputValueProps) {
                 <TextField
                     {...params}
                     placeholder={intl.formatMessage({ id: "manufacturer-filter.placeholder", defaultMessage: "Choose a manufacturer" })}
-                    value={search}
+                    value={search ? search : null}
                     onChange={(event) => {
                         setSearch(event.target.value);
                     }}

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -213,12 +213,11 @@ export function ProductsGrid() {
         },
         {
             field: "manufacturer",
-            headerName: intl.formatMessage({ id: "products.manufacturer", defaultMessage: "Manufacturer" }), // shown in filter-column-list and find-column-list
+            headerName: intl.formatMessage({ id: "products.manufacturer", defaultMessage: "Manufacturer" }),
             sortable: false,
             valueGetter: ({ value }) => value?.name,
             filterOperators: [ManufacturerFilterOperator],
         },
-        // action column
         {
             field: "action",
             headerName: "",

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -22,11 +22,11 @@ import { Add as AddIcon, Edit, StateFilled } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { Button, IconButton, useTheme } from "@mui/material";
 import { DataGridPro, GridFilterInputSingleSelect, GridFilterInputValue, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
-import { ManufacturerFilterOperator } from "@src/products/ManufacturerFilter";
 import gql from "graphql-tag";
 import * as React from "react";
 import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
 
+import { ManufacturerFilterOperator } from "./ManufacturerFilter";
 import {
     GQLCreateProductMutation,
     GQLCreateProductMutationVariables,
@@ -211,11 +211,11 @@ export function ProductsGrid() {
                 );
             },
         },
-        //stub column(s) to show needed filters, still shown in find-column-list
         {
             field: "manufacturer",
             headerName: intl.formatMessage({ id: "products.manufacturer", defaultMessage: "Manufacturer" }), // shown in filter-column-list and find-column-list
             sortable: false,
+            valueGetter: ({ value }) => (value ? value.name : "-"),
             filterOperators: [ManufacturerFilterOperator],
         },
         // action column
@@ -296,7 +296,6 @@ export function ProductsGrid() {
                 components={{
                     Toolbar: ProductsGridToolbar,
                 }}
-                columnVisibilityModel={{ manufacturer: false }}
             />
         </MainContent>
     );
@@ -328,6 +327,9 @@ const productsFragment = gql`
         }
         variants {
             id
+        }
+        manufacturer {
+            name
         }
         articleNumbers
         discounts {

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -22,6 +22,7 @@ import { Add as AddIcon, Edit, StateFilled } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { Button, IconButton, useTheme } from "@mui/material";
 import { DataGridPro, GridFilterInputSingleSelect, GridFilterInputValue, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
+import { ManufacturerFilterOperator } from "@src/products/ManufacturerFilter";
 import gql from "graphql-tag";
 import * as React from "react";
 import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
@@ -210,6 +211,14 @@ export function ProductsGrid() {
                 );
             },
         },
+        //stub column(s) to show needed filters, still shown in find-column-list
+        {
+            field: "manufacturer",
+            headerName: intl.formatMessage({ id: "products.manufacturer", defaultMessage: "Manufacturer" }), // shown in filter-column-list and find-column-list
+            sortable: false,
+            filterOperators: [ManufacturerFilterOperator],
+        },
+        // action column
         {
             field: "action",
             headerName: "",
@@ -287,6 +296,7 @@ export function ProductsGrid() {
                 components={{
                     Toolbar: ProductsGridToolbar,
                 }}
+                columnVisibilityModel={{ manufacturer: false }}
             />
         </MainContent>
     );

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -215,7 +215,7 @@ export function ProductsGrid() {
             field: "manufacturer",
             headerName: intl.formatMessage({ id: "products.manufacturer", defaultMessage: "Manufacturer" }), // shown in filter-column-list and find-column-list
             sortable: false,
-            valueGetter: ({ value }) => (value ? value.name : "-"),
+            valueGetter: ({ value }) => value?.name,
             filterOperators: [ManufacturerFilterOperator],
         },
         // action column


### PR DESCRIPTION
## Requirement
Add a custom filter to MUI DataGrid for advanced filters, e.g., `OneToMany` or `ManyToOne` filters. This demo also serves as template for support in the Admin Generator.

### Example

<details>
    <summary>Screenshots/screencasts</summary>

https://github.com/user-attachments/assets/cf63e4af-de38-4a97-9e84-30ed8f2dc0c1
</details>

## Solution
Use mui-data-grid custom-filter feature. This needs a associated column-config (Does not necessary relate to any data, but it's header-label is used in the left select-field of the filter-popup. Drawback: this column is still shown in find-column-list even if hidden by `columnVisibilityModel` .) and a custom InputComponent (=`ManufacturerFilter` in ManufacturerFilter.tsx)

## Open issues
- [ ] pseudo-column is shown in find-column-list, find a way to hide it.