### PR TITLE
Pass currentUser to UserService

### DIFF
--- a/.changeset/smooth-houses-marry.md
+++ b/.changeset/smooth-houses-marry.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Pass `currentUser`-object to `UserService`
+
+When the UserService is used for the resolver in the Administration-Panel this change allows filtering the listed user based on the currently logged-in user.

--- a/demo/api/src/auth/access-control.service.ts
+++ b/demo/api/src/auth/access-control.service.ts
@@ -7,7 +7,11 @@ export class AccessControlService extends AbstractAccessControlService {
         if (user.isAdmin) {
             return UserPermissions.allPermissions;
         } else {
-            return [{ permission: "products" }, { permission: "news", contentScopes: [{ domain: "secondary", language: "en" }] }];
+            return [
+                { permission: "products" },
+                { permission: "news", contentScopes: [{ domain: "secondary", language: "en" }] },
+                { permission: "userPermissions" },
+            ];
         }
     }
     getContentScopesForUser(user: User): ContentScopesForUser {

--- a/demo/api/src/auth/user.service.ts
+++ b/demo/api/src/auth/user.service.ts
@@ -1,18 +1,24 @@
 import { FindUsersArgs, User, UserPermissionsUserServiceInterface, Users } from "@comet/cms-api";
-import { Injectable } from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 
 import { staticUsers } from "./static-users";
 
 @Injectable()
 export class UserService implements UserPermissionsUserServiceInterface {
-    getUser(id: string): User {
+    getUser(id: string, currentUser?: User): User {
         const index = parseInt(id) - 1;
-        if (staticUsers[index]) return staticUsers[index];
+        if (staticUsers[index]) {
+            if (currentUser && !currentUser.isAdmin && staticUsers[index].isAdmin) throw new UnauthorizedException("Not allowed");
+            return staticUsers[index];
+        }
         throw new Error("User not found");
     }
-    findUsers(args: FindUsersArgs): Users {
+    findUsers(args: FindUsersArgs, currentUser: User): Users {
         const search = args.search?.toLowerCase();
-        const users = staticUsers.filter((user) => !search || user.name.toLowerCase().includes(search) || user.email.toLowerCase().includes(search));
+        let users = staticUsers.filter((user) => !search || user.name.toLowerCase().includes(search) || user.email.toLowerCase().includes(search));
+        if (!currentUser.isAdmin) {
+            users = users.filter((u) => !u.isAdmin);
+        }
         return [users, users.length];
     }
 }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -9,7 +9,6 @@ import getUuid from "uuid-by-string";
 
 import { DisablePermissionCheck, RequiredPermissionMetadata } from "./decorators/required-permission.decorator";
 import { CurrentUser } from "./dto/current-user";
-import { FindUsersArgs } from "./dto/paginated-user-list";
 import { UserContentScopes } from "./entities/user-content-scopes.entity";
 import { UserPermission, UserPermissionSource } from "./entities/user-permission.entity";
 import { ContentScope } from "./interfaces/content-scope.interface";
@@ -74,11 +73,6 @@ export class UserPermissionsService {
     async getUser(id: string): Promise<User> {
         if (!this.userService) throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
         return this.userService.getUser(id);
-    }
-
-    async findUsers(args: FindUsersArgs): Promise<[User[], number]> {
-        if (!this.userService) throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
-        return this.userService.findUsers(args);
     }
 
     async checkContentScopes(contentScopes: ContentScope[]): Promise<void> {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -31,8 +31,8 @@ export interface AccessControlServiceInterface {
 }
 
 export interface UserPermissionsUserServiceInterface {
-    getUser: (id: string) => Promise<User> | User;
-    findUsers: (args: FindUsersArgs) => Promise<Users> | Users;
+    getUser: (id: string, currentUser?: User) => Promise<User> | User;
+    findUsers: (args: FindUsersArgs, currentUser: User) => Promise<Users> | Users;
     createUserFromIdToken?: (idToken: JwtPayload) => Promise<User> | User;
 }
 

--- a/packages/api/cms-api/src/user-permissions/user.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user.resolver.ts
@@ -1,10 +1,14 @@
+import { Inject, Optional } from "@nestjs/common";
 import { Args, ObjectType, Query, Resolver } from "@nestjs/graphql";
 
+import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
 import { PaginatedResponseFactory } from "../common/pagination/paginated-response.factory";
 import { RequiredPermission } from "./decorators/required-permission.decorator";
+import { CurrentUser } from "./dto/current-user";
 import { FindUsersArgs } from "./dto/paginated-user-list";
 import { User } from "./dto/user";
-import { UserPermissionsService } from "./user-permissions.service";
+import { USER_PERMISSIONS_USER_SERVICE } from "./user-permissions.constants";
+import { UserPermissionsUserServiceInterface } from "./user-permissions.types";
 
 @ObjectType()
 class PaginatedUserList extends PaginatedResponseFactory.create(User) {}
@@ -12,16 +16,21 @@ class PaginatedUserList extends PaginatedResponseFactory.create(User) {}
 @Resolver(() => User)
 @RequiredPermission(["userPermissions"], { skipScopeCheck: true })
 export class UserResolver {
-    constructor(private readonly userService: UserPermissionsService) {}
+    constructor(@Inject(USER_PERMISSIONS_USER_SERVICE) @Optional() private readonly userService: UserPermissionsUserServiceInterface | undefined) {}
+
+    private getUserService(): UserPermissionsUserServiceInterface {
+        if (!this.userService) throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
+        return this.userService;
+    }
 
     @Query(() => User)
-    async userPermissionsUserById(@Args("id", { type: () => String }) id: string): Promise<User> {
-        return this.userService.getUser(id);
+    async userPermissionsUserById(@Args("id", { type: () => String }) id: string, @GetCurrentUser() currentUser: CurrentUser): Promise<User> {
+        return this.getUserService().getUser(id, currentUser);
     }
 
     @Query(() => PaginatedUserList)
-    async userPermissionsUsers(@Args() args: FindUsersArgs): Promise<PaginatedUserList> {
-        const [users, totalCount] = await this.userService.findUsers(args);
+    async userPermissionsUsers(@Args() args: FindUsersArgs, @GetCurrentUser() currentUser: CurrentUser): Promise<PaginatedUserList> {
+        const [users, totalCount] = await this.getUserService().findUsers(args, currentUser);
         return new PaginatedUserList(users, totalCount, args);
     }
 }


### PR DESCRIPTION
Use-Case: Non-Admin users should see the Administration-Panel but not all available users. This is accomplished in the UserService, which is part of the application. On the other hand the available permissions and Content scopes should also be restricted, therfore a separate PR will be made.

Useful info:
- UserPermissionsService.findUsers is not needed anymore
- UserService.getUser and UserService.findUsers get a second parameter (this is backwards-compatible) when called in the context of the Administration-Panel
- The demo makes use of this (when switching to the Non-Admin-User the Admin-Users are not shown in the Administration-Panel)

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [X] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)