### PR TITLE
Add support for the `options` prop to `SelectField`, similar to `FinalFormSelect`

### DIFF
--- a/.changeset/large-guests-suffer.md
+++ b/.changeset/large-guests-suffer.md
@@ -1,0 +1,28 @@
+---
+"@comet/admin": minor
+---
+
+Add support for the `options` prop to `SelectField`, similar to `FinalFormSelect`
+
+```tsx
+type Option {
+    value: string;
+    label: string;
+}
+
+const options: Option[] = [
+    { value: "chocolate", label: "Chocolate" },
+    { value: "strawberry", label: "Strawberry" },
+];
+
+// ...
+
+<SelectField
+    name="select"
+    label="Select a flavor"
+    fullWidth
+    options={options}
+    getOptionLabel={(option: Option) => option.label}
+    getOptionSelected={(option: Option, value: Option) => option.value === value.value}
+/>
+```

--- a/packages/admin/admin/src/form/fields/SelectField.tsx
+++ b/packages/admin/admin/src/form/fields/SelectField.tsx
@@ -11,18 +11,31 @@ type SelectFieldPropsToExtendFromWithoutChildren<Value extends string | number> 
 };
 
 export interface SelectFieldProps<Value extends string | number> extends SelectFieldPropsToExtendFromWithoutChildren<Value> {
-    children: ReturnType<Required<SelectFieldPropsToExtendFrom<Value>>["children"]>;
+    children?: ReturnType<Required<SelectFieldPropsToExtendFrom<Value>>["children"]>;
     componentsProps?: {
         finalFormSelect?: FinalFormSelectProps<Value>;
     };
 }
 
-export function SelectField<Value extends string | number>({ componentsProps = {}, children, ...restProps }: SelectFieldProps<Value>) {
+export function SelectField<Value extends string | number>({
+    componentsProps = {},
+    children,
+    options,
+    getOptionLabel,
+    getOptionSelected,
+    ...restProps
+}: SelectFieldProps<Value>) {
     const { finalFormSelect: finalFormSelectProps } = componentsProps;
     return (
         <Field {...restProps}>
             {(props) => (
-                <FinalFormSelect<Value> {...props} {...finalFormSelectProps}>
+                <FinalFormSelect<Value>
+                    options={options}
+                    getOptionLabel={getOptionLabel}
+                    getOptionSelected={getOptionSelected}
+                    {...props}
+                    {...finalFormSelectProps}
+                >
                     {children}
                 </FinalFormSelect>
             )}

--- a/storybook/src/admin/form/Select.tsx
+++ b/storybook/src/admin/form/Select.tsx
@@ -1,4 +1,4 @@
-import { Field, FinalFormSelect } from "@comet/admin";
+import { Field, FinalFormSelect, SelectField } from "@comet/admin";
 import { Account } from "@comet/admin-icons";
 import { Card, CardContent, InputAdornment, MenuItem } from "@mui/material";
 import { storiesOf } from "@storybook/react";
@@ -49,17 +49,14 @@ function Story() {
                                         )}
                                     </Field>
 
-                                    <Field name="flavorOptions" label="Flavor with Options as prop" fullWidth>
-                                        {(props) => (
-                                            <FinalFormSelect
-                                                {...props}
-                                                options={options}
-                                                getOptionLabel={(option: Option) => option.label}
-                                                getOptionSelected={(option: Option, value: Option) => option.value === value.value}
-                                                fullWidth
-                                            />
-                                        )}
-                                    </Field>
+                                    <SelectField
+                                        name="flavorOptions"
+                                        label="Flavor with Options as prop"
+                                        fullWidth
+                                        options={options}
+                                        getOptionLabel={(option: Option) => option.label}
+                                        getOptionSelected={(option: Option, value: Option) => option.value === value.value}
+                                    />
 
                                     <Field name="flavorRequired" label="Required Flavor" fullWidth>
                                         {(props) => (


### PR DESCRIPTION
```tsx
type Option {
    value: string;
    label: string;
}

const options: Option[] = [
    { value: "chocolate", label: "Chocolate" },
    { value: "strawberry", label: "Strawberry" },
];

// ...

<SelectField
    name="select"
    label="Select a flavor"
    fullWidth
    options={options}
    getOptionLabel={(option: Option) => option.label}
    getOptionSelected={(option: Option, value: Option) => option.value === value.value}
/>
```

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
