### PR TITLE
Allow pinning DataGrid columns using the column config

### DIFF
--- a/.changeset/cold-hats-return.md
+++ b/.changeset/cold-hats-return.md
@@ -1,0 +1,19 @@
+---
+"@comet/admin": minor
+---
+
+Allow pinning DataGrid columns using the column config when using `DataGridPro` or `DataGridPremium` with the `usePersistentColumnState` hook
+
+```tsx
+const columns: GridColDef[] = [
+    {
+        field: "title",
+        pinned: "left",
+    },
+    // ... other columns
+    {
+        field: "actions",
+        pinned: "right",
+    },
+];
+```

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -216,6 +216,7 @@ export function ProductsGrid() {
             sortable: false,
             filterable: false,
             width: 106,
+            pinned: "right",
             renderCell: (params) => {
                 return (
                     <>

--- a/packages/admin/admin/src/dataGrid/GridColDef.ts
+++ b/packages/admin/admin/src/dataGrid/GridColDef.ts
@@ -4,6 +4,8 @@ import {
     GridValidRowModel,
 } from "@mui/x-data-grid";
 
+import { GridPinnedColumns } from "./usePersistentColumnState";
+
 export interface GridColDef<R extends GridValidRowModel = any, V = any, F = V> extends MuiGridColDef<R, V, F> {
     /**
      * Media query to define when the column is visible.
@@ -14,4 +16,8 @@ export interface GridColDef<R extends GridValidRowModel = any, V = any, F = V> e
      * Requires DataGridPro or DataGridPremium.
      */
     sortBy?: string | string[];
+    /**
+     * Requires DataGridPro or DataGridPremium.
+     */
+    pinned?: keyof GridPinnedColumns;
 }


### PR DESCRIPTION
When using `DataGridPro` or `DataGridPremium` with the `usePersistentColumnState` hook.

```tsx
const columns: GridColDef[] = [
    {
        field: "title",
        pinned: "left",
    },
    // ... other columns
    {
        field: "actions",
        pinned: "right",
    },
];
```

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-1031
-   [x] Provide screenshots/screencasts if the change contains visual changes

<img width="861" alt="Screenshot 2024-08-21 at 14 11 08" src="https://github.com/user-attachments/assets/f292eb41-8529-4f93-b9a4-ec43435d8456">
