### PR TITLE
Fix bug in `DamVideoBlock` that caused the block to crash if no video file was selected

### DIFF
--- a/.changeset/fair-trains-turn.md
+++ b/.changeset/fair-trains-turn.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix bug in `DamVideoBlock` that caused the block to crash if no video file was selected
+
+The block used to crash if no video was selected because the `DamVideoBlockTransformerService` returned an empty object.
+This left the `previewImage` state in the admin `undefined` causing `state2Output` to fail.

--- a/packages/api/cms-api/src/dam/blocks/video/dam-video-block-transformer.service.ts
+++ b/packages/api/cms-api/src/dam/blocks/video/dam-video-block-transformer.service.ts
@@ -1,4 +1,4 @@
-import { BlockContext, BlockTransformerServiceInterface } from "@comet/blocks-api";
+import { BlockContext, BlockTransformerServiceInterface, TraversableTransformResponse } from "@comet/blocks-api";
 import { Injectable } from "@nestjs/common";
 
 import { FilesService } from "../../files/files.service";
@@ -28,18 +28,21 @@ export class DamVideoBlockTransformerService implements BlockTransformerServiceI
     constructor(private readonly filesService: FilesService) {}
 
     async transformToPlain(block: DamVideoBlockData, { previewDamUrls, relativeDamUrls }: BlockContext) {
+        const ret: TraversableTransformResponse = {
+            autoplay: block.autoplay,
+            loop: block.loop,
+            showControls: block.showControls,
+            previewImage: block.previewImage,
+        };
+
         if (!block.damFileId) {
-            return {};
+            return ret;
         }
 
         const file = await this.filesService.findOneById(block.damFileId);
 
-        if (!file) {
-            return {};
-        }
-
-        return {
-            damFile: {
+        if (file) {
+            ret.damFile = {
                 id: file.id,
                 name: file.name,
                 size: file.size,
@@ -50,11 +53,9 @@ export class DamVideoBlockTransformerService implements BlockTransformerServiceI
                 archived: file.archived,
                 scope: file.scope,
                 fileUrl: await this.filesService.createFileUrl(file, { previewDamUrls, relativeDamUrls }),
-            },
-            autoplay: block.autoplay,
-            loop: block.loop,
-            showControls: block.showControls,
-            previewImage: block.previewImage,
-        };
+            };
+        }
+
+        return ret;
     }
 }


### PR DESCRIPTION
The block used to crash if no video was selected because the `DamVideoBlockTransformerService` returned an empty object.
This left the `previewImage` state in the admin `undefined` causing `state2Output` to fail.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-1041
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Previously:


https://github.com/user-attachments/assets/1ecb480b-394b-485e-9215-76201aaddedf



Now:


https://github.com/user-attachments/assets/fd0b9a22-2735-4c5a-bbab-7962ea3746cd



</details>
