### PR TITLE
Fix `useAsyncOptionsPropsSelect` Select story

### DIFF
--- a/storybook/src/docs/hooks/useAsyncOptionsProps/useAsyncOptionsPropsSelect.stories.tsx
+++ b/storybook/src/docs/hooks/useAsyncOptionsProps/useAsyncOptionsPropsSelect.stories.tsx
@@ -3,14 +3,15 @@ import { storiesOf } from "@storybook/react";
 import * as React from "react";
 import { Form } from "react-final-form";
 
-interface Option {
-    value: string;
-    label: string;
-}
+storiesOf("stories/hooks/useAsyncOptionsPropsSelect", module).add("Select", () => {
+    interface Option {
+        value: string;
+        label: string;
+    }
+    const initialValues = React.useMemo(() => {
+        return { selectAsync: { value: "strawberry", label: "Strawberry" } };
+    }, []);
 
-const initialValues = { selectAsync: { value: "strawberry", label: "Strawberry" } };
-
-function Story() {
     const selectAsyncProps = useAsyncOptionsProps<Option>(async () => {
         return new Promise((resolve) =>
             setTimeout(() => {
@@ -41,6 +42,4 @@ function Story() {
             </Form>
         </div>
     );
-}
-
-storiesOf("stories/hooks/useAsyncOptionsPropsSelect", module).add("Select", Story);
+});

--- a/storybook/src/docs/hooks/useAsyncOptionsProps/useAsyncOptionsPropsSelect.stories.tsx
+++ b/storybook/src/docs/hooks/useAsyncOptionsProps/useAsyncOptionsPropsSelect.stories.tsx
@@ -23,7 +23,7 @@ storiesOf("stories/hooks/useAsyncOptionsPropsSelect", module).add("Select", () =
 
     return (
         <div style={{ minHeight: "50px" }}>
-            <Form onSubmit={() => {}} initialValues={{ selectAsync: { value: "strawberry", label: "Strawberry" } }}>
+            <Form onSubmit={() => {}} keepDirtyOnReinitialize initialValues={{ selectAsync: { value: "strawberry", label: "Strawberry" } }}>
                 {() => (
                     <Field
                         name="selectAsync"
@@ -31,6 +31,8 @@ storiesOf("stories/hooks/useAsyncOptionsPropsSelect", module).add("Select", () =
                         {...selectAsyncProps}
                         getOptionLabel={(option: Option) => option.label}
                         getOptionSelected={(option: Option, value: Option) => {
+                            console.log({ option, value });
+
                             return option.value === value.value;
                         }}
                         style={{ width: "300px" }}

--- a/storybook/src/docs/hooks/useAsyncOptionsProps/useAsyncOptionsPropsSelect.stories.tsx
+++ b/storybook/src/docs/hooks/useAsyncOptionsProps/useAsyncOptionsPropsSelect.stories.tsx
@@ -3,12 +3,14 @@ import { storiesOf } from "@storybook/react";
 import * as React from "react";
 import { Form } from "react-final-form";
 
-storiesOf("stories/hooks/useAsyncOptionsPropsSelect", module).add("Select", () => {
-    interface Option {
-        value: string;
-        label: string;
-    }
+interface Option {
+    value: string;
+    label: string;
+}
 
+const initialValues = { selectAsync: { value: "strawberry", label: "Strawberry" } };
+
+function Story() {
     const selectAsyncProps = useAsyncOptionsProps<Option>(async () => {
         return new Promise((resolve) =>
             setTimeout(() => {
@@ -23,7 +25,7 @@ storiesOf("stories/hooks/useAsyncOptionsPropsSelect", module).add("Select", () =
 
     return (
         <div style={{ minHeight: "50px" }}>
-            <Form onSubmit={() => {}} keepDirtyOnReinitialize initialValues={{ selectAsync: { value: "strawberry", label: "Strawberry" } }}>
+            <Form onSubmit={() => {}} initialValues={initialValues}>
                 {() => (
                     <Field
                         name="selectAsync"
@@ -31,8 +33,6 @@ storiesOf("stories/hooks/useAsyncOptionsPropsSelect", module).add("Select", () =
                         {...selectAsyncProps}
                         getOptionLabel={(option: Option) => option.label}
                         getOptionSelected={(option: Option, value: Option) => {
-                            console.log({ option, value });
-
                             return option.value === value.value;
                         }}
                         style={{ width: "300px" }}
@@ -41,4 +41,6 @@ storiesOf("stories/hooks/useAsyncOptionsPropsSelect", module).add("Select", () =
             </Form>
         </div>
     );
-});
+}
+
+storiesOf("stories/hooks/useAsyncOptionsPropsSelect", module).add("Select", Story);


### PR DESCRIPTION
Fix a bug inside useAsyncOptionsPropsSelect that caused selected options to be overwritten by the initialValues on each render by memoizing the initialValues variable.

---
<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-970
-   [x] Provide screenshots/screencasts if the change contains visual changes
