### PR TITLE
Admin Generator (Future): Form - Add optionalRender field option

### DIFF
--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -32,7 +32,7 @@ export const ProductForm: FormConfig<GQLProduct> = {
             name: "additionalData",
             fields: [
                 { type: "boolean", name: "inStock" },
-                { type: "date", name: "availableSince" },
+                { type: "date", name: "availableSince", optionalRender: true },
                 { type: "block", name: "image", label: "Image", block: { name: "DamImageBlock", import: "@comet/cms-admin" } },
                 { type: "fileUpload", name: "priceList", label: "Price List", maxFileSize: 1024 * 1024 * 4 },
                 { type: "fileUpload", name: "datasheets", label: "Datasheets", multiple: true, maxFileSize: 1024 * 1024 * 4 },

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -63,9 +63,10 @@ type FormValues = ProductFormDetailsFragment & {
 
 interface FormProps {
     id?: string;
+    showAvailableSince?: boolean;
 }
 
-export function ProductForm({ id }: FormProps): React.ReactElement {
+export function ProductForm({ id, showAvailableSince }: FormProps): React.ReactElement {
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
     const formApiRef = useFormApiRef<FormValues>();
@@ -264,14 +265,15 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                     />
                                 )}
                             </Field>
-
-                            <Field
-                                variant="horizontal"
-                                fullWidth
-                                name="availableSince"
-                                component={FinalFormDatePicker}
-                                label={<FormattedMessage id="product.availableSince" defaultMessage="Available Since" />}
-                            />
+                            {showAvailableSince && (
+                                <Field
+                                    variant="horizontal"
+                                    fullWidth
+                                    name="availableSince"
+                                    component={FinalFormDatePicker}
+                                    label={<FormattedMessage id="product.availableSince" defaultMessage="Available Since" />}
+                                />
+                            )}
                             <Field name="image" isEqual={isEqual}>
                                 {createFinalFormBlock(rootBlocks.image)}
                             </Field>

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -73,8 +73,6 @@ export function generateForm(
         }
     }
 
-    const { formPropsTypeCode, formPropsParamsCode } = generateFormPropsCode(props);
-
     const rootBlockFields = formFields
         .filter((field) => field.type == "block")
         .map((field) => {
@@ -106,10 +104,13 @@ export function generateForm(
         gqlDocuments[name] = generatedFields.gqlDocuments[name];
     }
     imports.push(...generatedFields.imports);
+    props.push(...generatedFields.props);
     hooksCode += generatedFields.hooksCode;
     formValueToGqlInputCode += generatedFields.formValueToGqlInputCode;
     formFragmentFields.push(...generatedFields.formFragmentFields);
     formValuesConfig.push(...generatedFields.formValuesConfig);
+
+    const { formPropsTypeCode, formPropsParamsCode } = generateFormPropsCode(props);
 
     const fragmentName = config.fragmentName ?? `${gqlType}Form`;
     gqlDocuments[`${instanceGqlType}FormFragment`] = `

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -1,5 +1,6 @@
 import { IntrospectionQuery } from "graphql";
 
+import { Prop } from "../generateForm";
 import { FormConfig, GeneratorReturn, isFormFieldConfig, isFormLayoutConfig } from "../generator";
 import { Imports } from "../utils/generateImportsCode";
 import { generateFormField } from "./generateFormField";
@@ -10,6 +11,7 @@ export type GenerateFieldsReturn = GeneratorReturn & {
     hooksCode: string;
     formFragmentFields: string[];
     formValueToGqlInputCode: string;
+    props: Prop[];
     formValuesConfig: {
         omitFromFragmentType?: string;
         destructFromFormValues?: string; // equals omitting from formValues copied directly to mutation-input
@@ -37,6 +39,7 @@ export function generateFields({
     let formValueToGqlInputCode = "";
     const formFragmentFields: string[] = [];
     const imports: Imports = [];
+    const props: Prop[] = [];
     const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
 
     const code = fields
@@ -54,6 +57,7 @@ export function generateFields({
                 gqlDocuments[name] = generated.gqlDocuments[name];
             }
             imports.push(...generated.imports);
+            props.push(...generated.props);
             hooksCode += generated.hooksCode;
             formValueToGqlInputCode += generated.formValueToGqlInputCode;
             formFragmentFields.push(...generated.formFragmentFields);
@@ -64,6 +68,7 @@ export function generateFields({
 
     return {
         code,
+        props,
         hooksCode,
         formValueToGqlInputCode,
         formFragmentFields,

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -320,7 +320,8 @@ export function generateFormField({
         throw new Error(`Unsupported type`);
     }
     return {
-        code,
+        code: config.optionalRender ? `{ show${name[0].toUpperCase() + name.substring(1)} && ${code} }` : code,
+        props: config.optionalRender ? [{ name: `show${name[0].toUpperCase() + name.substring(1)}`, type: `boolean`, optional: true }] : [],
         hooksCode,
         formValueToGqlInputCode,
         formFragmentFields: [formFragmentField],

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
@@ -1,5 +1,6 @@
 import { IntrospectionQuery } from "graphql";
 
+import { Prop } from "../generateForm";
 import { FormConfig, FormLayoutConfig } from "../generator";
 import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
 import { Imports } from "../utils/generateImportsCode";
@@ -27,6 +28,7 @@ export function generateFormLayout({
     const formFragmentFields: string[] = [];
     const gqlDocuments: Record<string, string> = {};
     const imports: Imports = [];
+    const props: Prop[] = [];
     const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
 
     if (config.type === "fieldSet") {
@@ -40,6 +42,7 @@ export function generateFormLayout({
             gqlDocuments[name] = generatedFields.gqlDocuments[name];
         }
         imports.push(...generatedFields.imports);
+        props.push(...generatedFields.props);
         formValuesConfig.push(...generatedFields.formValuesConfig);
 
         imports.push({ name: "FieldSet", importPath: "@comet/admin" });
@@ -73,6 +76,7 @@ export function generateFormLayout({
     }
     return {
         code,
+        props,
         hooksCode,
         formValueToGqlInputCode,
         formFragmentFields,

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -37,7 +37,16 @@ export type FormFieldConfig<T> = (
     | { type: "block"; block: ImportReference }
     | SingleFileFormFieldConfig
     | MultiFileFormFieldConfig
-) & { name: keyof T; label?: string; required?: boolean; virtual?: boolean; validate?: ImportReference; helperText?: string; readOnly?: boolean };
+) & {
+    name: keyof T;
+    label?: string;
+    required?: boolean;
+    optionalRender?: boolean;
+    virtual?: boolean;
+    validate?: ImportReference;
+    helperText?: string;
+    readOnly?: boolean;
+};
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export function isFormFieldConfig<T>(arg: any): arg is FormFieldConfig<T> {
     return !isFormLayoutConfig(arg);


### PR DESCRIPTION
## Requirement
A form has several (currently 3) checkboxes depending on enabled features. It would require to generate 8 different forms to support any combination. This is to much. So it should be possible to show/hide specific fields.

## Solution
Add option to allow show/hide fields from outside of the grid.