### PR TITLE
`admin-color-picker`: remove barrel react imports

### DIFF
--- a/packages/admin/admin-color-picker/.eslintrc.json
+++ b/packages/admin/admin-color-picker/.eslintrc.json
@@ -2,6 +2,7 @@
     "extends": "@comet/eslint-config/react",
     "ignorePatterns": ["src/*.generated.ts", "lib/**"],
     "rules": {
-        "@comet/no-other-module-relative-import": "off"
+        "@comet/no-other-module-relative-import": "off",
+        "react/react-in-jsx-scope": "off"
     }
 }

--- a/packages/admin/admin-color-picker/src/ColorField.tsx
+++ b/packages/admin/admin-color-picker/src/ColorField.tsx
@@ -1,10 +1,9 @@
 import { Field, FieldProps } from "@comet/admin";
-import * as React from "react";
 
 import { FinalFormColorPicker } from "./FinalFormColorPicker";
 
 export type ColorFieldProps = FieldProps<string, HTMLInputElement>;
 
-export const ColorField = ({ ...restProps }: ColorFieldProps): React.ReactElement => {
+export const ColorField = ({ ...restProps }: ColorFieldProps) => {
     return <Field component={FinalFormColorPicker} {...restProps} />;
 };

--- a/packages/admin/admin-color-picker/src/ColorPicker.tsx
+++ b/packages/admin/admin-color-picker/src/ColorPicker.tsx
@@ -2,7 +2,7 @@ import { ClearInputAdornment, InputWithPopperComponents, InputWithPopperProps } 
 import { Close } from "@comet/admin-icons";
 import { ComponentsOverrides, InputBaseProps, Typography } from "@mui/material";
 import { Theme, useThemeProps } from "@mui/material/styles";
-import * as React from "react";
+import { ChangeEvent, ComponentType, FocusEvent, HTMLAttributes, ReactNode, useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import tinycolor from "tinycolor2";
 import { useDebouncedCallback } from "use-debounce";
@@ -29,13 +29,13 @@ import {
     SlotProps,
 } from "./ColorPicker.slots";
 
-export interface ColorPickerColorPreviewProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "color">, PreviewIndicatorColorProps {}
-export interface ColorPickerNoColorPreviewProps extends React.HTMLAttributes<HTMLDivElement>, PreviewIndicatorEmptyOrInvalidProps {}
+export interface ColorPickerColorPreviewProps extends Omit<HTMLAttributes<HTMLDivElement>, "color">, PreviewIndicatorColorProps {}
+export interface ColorPickerNoColorPreviewProps extends HTMLAttributes<HTMLDivElement>, PreviewIndicatorEmptyOrInvalidProps {}
 
 export interface ColorPickerPropsComponents extends InputWithPopperComponents {
-    ColorPickerColorPreview?: React.ComponentType<ColorPickerColorPreviewProps>;
-    ColorPickerInvalidPreview?: React.ComponentType<ColorPickerNoColorPreviewProps>;
-    ColorPickerEmptyPreview?: React.ComponentType<ColorPickerNoColorPreviewProps>;
+    ColorPickerColorPreview?: ComponentType<ColorPickerColorPreviewProps>;
+    ColorPickerInvalidPreview?: ComponentType<ColorPickerNoColorPreviewProps>;
+    ColorPickerEmptyPreview?: ComponentType<ColorPickerNoColorPreviewProps>;
 }
 
 const DefaultColorPreviewIndicator = ({ type, color }: ColorPickerColorPreviewProps) => {
@@ -59,8 +59,8 @@ export interface ColorPickerProps extends Omit<InputWithPopperProps, "children" 
     endAdornment?: InputBaseProps["endAdornment"];
     invalidIndicatorCharacter?: string;
     required?: boolean;
-    titleText?: React.ReactNode;
-    clearButtonText?: React.ReactNode;
+    titleText?: ReactNode;
+    clearButtonText?: ReactNode;
     components?: ColorPickerPropsComponents;
     slotProps?: SlotProps;
 }
@@ -92,10 +92,10 @@ export const ColorPicker = (inProps: ColorPickerProps) => {
         ...inputWithPopperComponents
     } = components;
 
-    const [displayValue, setDisplayValue] = React.useState<string>(value ?? "");
+    const [displayValue, setDisplayValue] = useState<string>(value ?? "");
     const previewColor = displayValue ? tinycolor(displayValue) : null;
 
-    React.useEffect(() => {
+    useEffect(() => {
         setDisplayValue(value ?? "");
     }, [value, setDisplayValue]);
 
@@ -160,10 +160,10 @@ export const ColorPicker = (inProps: ColorPickerProps) => {
                 )
             }
             value={displayValue}
-            onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+            onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
                 setDisplayValue(e.currentTarget.value);
             }}
-            onBlur={(e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+            onBlur={(e: FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
                 onBlur && onBlur(e);
                 onChangeColor(displayValue);
             }}

--- a/packages/admin/admin-color-picker/src/FinalFormColorPicker.tsx
+++ b/packages/admin/admin-color-picker/src/FinalFormColorPicker.tsx
@@ -1,10 +1,9 @@
-import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 import { ColorPicker, ColorPickerProps } from "./ColorPicker";
 
 export type FinalFormColorPickerProps = ColorPickerProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
 
-export const FinalFormColorPicker = ({ meta, input, ...restProps }: FinalFormColorPickerProps): React.ReactElement => {
+export const FinalFormColorPicker = ({ meta, input, ...restProps }: FinalFormColorPickerProps) => {
     return <ColorPicker {...input} {...restProps} />;
 };

--- a/packages/admin/tsconfig.base.json
+++ b/packages/admin/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.core.json",
     "compilerOptions": {
-        "jsx": "react",
+        "jsx": "react-jsx",
         "lib": ["DOM", "ES2015", "ES2016", "ES2017", "ES2018", "ES2019", "ESNext.AsyncIterable"],
         "noImplicitAny": true,
         "sourceMap": true,


### PR DESCRIPTION
Use named imports instead of barrel importing React. Doing so will result in less code and better readability. The new [React docs](https://react.dev/) also use named imports and never import React itself.

To avoid conflicts, we temporarily add the eslint rules in the packages on main. The restrict-import rule will be added in the v8 (next) branch in the eslint-config package, then they will be removed there again.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-1026
