### PR TITLE
`admin-date-time`: remove barrel react imports

### DIFF
--- a/packages/admin/admin-date-time/.eslintrc.json
+++ b/packages/admin/admin-date-time/.eslintrc.json
@@ -2,6 +2,7 @@
     "extends": "@comet/eslint-config/react",
     "ignorePatterns": ["src/*.generated.ts", "lib/**"],
     "rules": {
-        "@comet/no-other-module-relative-import": "off"
+        "@comet/no-other-module-relative-import": "off",
+        "react/react-in-jsx-scope": "off"
     }
 }

--- a/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
+++ b/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
@@ -2,7 +2,7 @@ import { createComponentSlot, ThemedComponentBaseProps } from "@comet/admin";
 import { ArrowLeft, ArrowRight, ChevronDown } from "@comet/admin-icons";
 import { Box, Button, buttonClasses, ComponentsOverrides, IconButton, Menu, menuClasses, MenuItem } from "@mui/material";
 import { css, Theme, useThemeProps } from "@mui/material/styles";
-import * as React from "react";
+import { useRef, useState } from "react";
 import { useIntl } from "react-intl";
 
 export interface DatePickerNavigationProps
@@ -26,11 +26,11 @@ export const DatePickerNavigation = (inProps: DatePickerNavigationProps) => {
     });
     const intl = useIntl();
 
-    const [showMonthSelect, setShowMonthSelect] = React.useState<boolean>(false);
-    const [showYearSelect, setShowYearSelect] = React.useState<boolean>(false);
+    const [showMonthSelect, setShowMonthSelect] = useState<boolean>(false);
+    const [showYearSelect, setShowYearSelect] = useState<boolean>(false);
 
-    const monthSelectRef = React.useRef<HTMLButtonElement>(null);
-    const yearSelectRef = React.useRef<HTMLButtonElement>(null);
+    const monthSelectRef = useRef<HTMLButtonElement>(null);
+    const yearSelectRef = useRef<HTMLButtonElement>(null);
 
     return (
         <Root {...slotProps?.root} {...restProps}>

--- a/packages/admin/admin-date-time/src/datePicker/DateField.tsx
+++ b/packages/admin/admin-date-time/src/datePicker/DateField.tsx
@@ -1,10 +1,9 @@
 import { Field, FieldProps } from "@comet/admin";
-import * as React from "react";
 
 import { FinalFormDatePicker } from "./FinalFormDatePicker";
 
 export type DateFieldProps = FieldProps<Date, HTMLInputElement>;
 
-export const DateField = ({ ...restProps }: DateFieldProps): React.ReactElement => {
+export const DateField = ({ ...restProps }: DateFieldProps) => {
     return <Field component={FinalFormDatePicker} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/datePicker/DatePicker.tsx
+++ b/packages/admin/admin-date-time/src/datePicker/DatePicker.tsx
@@ -5,7 +5,6 @@ import { ClearInputAdornment, InputWithPopperProps } from "@comet/admin";
 import { Calendar as CalendarIcon } from "@comet/admin-icons";
 import { ComponentsOverrides } from "@mui/material";
 import { Theme, useThemeProps } from "@mui/material/styles";
-import * as React from "react";
 import { FormatDateOptions, useIntl } from "react-intl";
 
 import { DatePickerNavigation } from "../DatePickerNavigation";

--- a/packages/admin/admin-date-time/src/datePicker/FinalFormDatePicker.tsx
+++ b/packages/admin/admin-date-time/src/datePicker/FinalFormDatePicker.tsx
@@ -1,10 +1,9 @@
-import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 import { DatePicker, DatePickerProps } from "./DatePicker";
 
 export type FinalFormDatePickerProps = DatePickerProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
 
-export const FinalFormDatePicker = ({ meta, input, ...restProps }: FinalFormDatePickerProps): React.ReactElement => {
+export const FinalFormDatePicker = ({ meta, input, ...restProps }: FinalFormDatePickerProps) => {
     return <DatePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/dateRangePicker/DateRangeField.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/DateRangeField.tsx
@@ -1,11 +1,10 @@
 import { Field, FieldProps } from "@comet/admin";
-import * as React from "react";
 
 import { DateRange } from "./DateRangePicker";
 import { FinalFormDateRangePicker } from "./FinalFormDateRangePicker";
 
 export type DateRangeFieldProps = FieldProps<DateRange, HTMLInputElement>;
 
-export const DateRangeField = ({ ...restProps }: DateRangeFieldProps): React.ReactElement => {
+export const DateRangeField = ({ ...restProps }: DateRangeFieldProps) => {
     return <Field component={FinalFormDateRangePicker} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.tsx
@@ -5,7 +5,6 @@ import { ClearInputAdornment, InputWithPopperProps } from "@comet/admin";
 import { Calendar } from "@comet/admin-icons";
 import { ComponentsOverrides } from "@mui/material";
 import { Theme, useThemeProps } from "@mui/material/styles";
-import * as React from "react";
 import { Range } from "react-date-range";
 import { FormatDateOptions, useIntl } from "react-intl";
 

--- a/packages/admin/admin-date-time/src/dateRangePicker/FinalFormDateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/FinalFormDateRangePicker.tsx
@@ -1,10 +1,9 @@
-import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 import { DateRange, DateRangePicker, DateRangePickerProps } from "./DateRangePicker";
 
 export type FinalFormDateRangePickerProps = DateRangePickerProps & FieldRenderProps<DateRange, HTMLInputElement | HTMLTextAreaElement>;
 
-export const FinalFormDateRangePicker = ({ meta, input, ...restProps }: FinalFormDateRangePickerProps): React.ReactElement => {
+export const FinalFormDateRangePicker = ({ meta, input, ...restProps }: FinalFormDateRangePickerProps) => {
     return <DateRangePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimeField.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimeField.tsx
@@ -1,10 +1,9 @@
 import { Field, FieldProps } from "@comet/admin";
-import * as React from "react";
 
 import { FinalFormDateTimePicker } from "./FinalFormDateTimePicker";
 
 export type DateTimeFieldProps = FieldProps<Date, HTMLInputElement>;
 
-export const DateTimeField = ({ ...restProps }: DateTimeFieldProps): React.ReactElement => {
+export const DateTimeField = ({ ...restProps }: DateTimeFieldProps) => {
     return <Field component={FinalFormDateTimePicker} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
@@ -1,7 +1,7 @@
 import { createComponentSlot, ThemedComponentBaseProps } from "@comet/admin";
 import { ComponentsOverrides, FormControl } from "@mui/material";
 import { css, Theme, useThemeProps } from "@mui/material/styles";
-import * as React from "react";
+import { useRef } from "react";
 import { useIntl } from "react-intl";
 
 import { DatePicker as DatePickerBase } from "../datePicker/DatePicker";
@@ -65,8 +65,8 @@ export const DateTimePicker = (inProps: DateTimePickerProps) => {
         name: "CometAdminDateTimePicker",
     });
     const intl = useIntl();
-    const datePickerRef = React.useRef<HTMLElement>(null);
-    const timePickerRef = React.useRef<HTMLElement>(null);
+    const datePickerRef = useRef<HTMLElement>(null);
+    const timePickerRef = useRef<HTMLElement>(null);
 
     const onChangeDate = (newDate?: string) => {
         if (newDate === undefined) {

--- a/packages/admin/admin-date-time/src/dateTimePicker/FinalFormDateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/FinalFormDateTimePicker.tsx
@@ -1,10 +1,9 @@
-import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 import { DateTimePicker, DateTimePickerProps } from "./DateTimePicker";
 
 export type FinalFormDateTimePickerProps = DateTimePickerProps & FieldRenderProps<Date, HTMLInputElement | HTMLTextAreaElement>;
 
-export const FinalFormDateTimePicker = ({ meta, input, ...restProps }: FinalFormDateTimePickerProps): React.ReactElement => {
+export const FinalFormDateTimePicker = ({ meta, input, ...restProps }: FinalFormDateTimePickerProps) => {
     return <DateTimePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/timePicker/FinalFormTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/FinalFormTimePicker.tsx
@@ -1,10 +1,9 @@
-import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 import { TimePicker, TimePickerProps } from "./TimePicker";
 
 export type FinalFormTimePickerProps = TimePickerProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
 
-export const FinalFormTimePicker = ({ meta, input, ...restProps }: FinalFormTimePickerProps): React.ReactElement => {
+export const FinalFormTimePicker = ({ meta, input, ...restProps }: FinalFormTimePickerProps) => {
     return <TimePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/timePicker/TimeField.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/TimeField.tsx
@@ -1,10 +1,9 @@
 import { Field, FieldProps } from "@comet/admin";
-import * as React from "react";
 
 import { FinalFormTimePicker } from "./FinalFormTimePicker";
 
 export type TimeFieldProps = FieldProps<string, HTMLInputElement>;
 
-export const TimeField = ({ ...restProps }: TimeFieldProps): React.ReactElement => {
+export const TimeField = ({ ...restProps }: TimeFieldProps) => {
     return <Field component={FinalFormTimePicker} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/timePicker/TimePicker.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/TimePicker.tsx
@@ -10,7 +10,7 @@ import { Time } from "@comet/admin-icons";
 import { ComponentsOverrides, InputAdornment, ListItemText, MenuItem, MenuList } from "@mui/material";
 import { css, Theme, useThemeProps } from "@mui/material/styles";
 import { format } from "date-fns";
-import * as React from "react";
+import { useRef } from "react";
 import { FormatDateOptions, FormattedTime, useIntl } from "react-intl";
 
 import { getClosestDateToDate, getDateFromTimeValue, getDateRangeListByMinuteStep } from "../utils/timePickerHelpers";
@@ -74,7 +74,7 @@ export const TimePicker = (inProps: TimePickerProps) => {
         ...inputWithPopperProps
     } = useThemeProps({ props: inProps, name: "CometAdminTimePicker" });
     const intl = useIntl();
-    const focusedItemRef = React.useRef<HTMLLIElement>(null);
+    const focusedItemRef = useRef<HTMLLIElement>(null);
 
     const dateValue: Date | null = value ? getDateFromTimeValue(value) : null;
     const timeOptions = getDateRangeListByMinuteStep(min, max, minuteStep);

--- a/packages/admin/admin-date-time/src/timeRangePicker/FinalFormTimeRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/timeRangePicker/FinalFormTimeRangePicker.tsx
@@ -1,10 +1,9 @@
-import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 import { TimeRange, TimeRangePicker, TimeRangePickerProps } from "./TimeRangePicker";
 
 export type FinalFormTimeRangePickerProps = TimeRangePickerProps & FieldRenderProps<TimeRange, HTMLInputElement | HTMLTextAreaElement>;
 
-export const FinalFormTimeRangePicker = ({ meta, input, ...restProps }: FinalFormTimeRangePickerProps): React.ReactElement => {
+export const FinalFormTimeRangePicker = ({ meta, input, ...restProps }: FinalFormTimeRangePickerProps) => {
     return <TimeRangePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/timeRangePicker/TimeRangeField.tsx
+++ b/packages/admin/admin-date-time/src/timeRangePicker/TimeRangeField.tsx
@@ -1,11 +1,10 @@
 import { Field, FieldProps } from "@comet/admin";
-import * as React from "react";
 
 import { FinalFormTimeRangePicker } from "./FinalFormTimeRangePicker";
 import { TimeRange } from "./TimeRangePicker";
 
 export type TimeRangeFieldProps = FieldProps<TimeRange, HTMLInputElement>;
 
-export const TimeRangeField = ({ ...restProps }: TimeRangeFieldProps): React.ReactElement => {
+export const TimeRangeField = ({ ...restProps }: TimeRangeFieldProps) => {
     return <Field component={FinalFormTimeRangePicker} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/timeRangePicker/TimeRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/timeRangePicker/TimeRangePicker.tsx
@@ -1,7 +1,7 @@
 import { createComponentSlot, ThemedComponentBaseProps } from "@comet/admin";
 import { ComponentsOverrides, FormControl, Theme, Typography } from "@mui/material";
 import { css, useThemeProps } from "@mui/material/styles";
-import * as React from "react";
+import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { FormatDateOptions, FormattedMessage, useIntl } from "react-intl";
 
 import { TimePicker as TimePickerBase } from "../timePicker/TimePicker";
@@ -78,7 +78,7 @@ export interface TimeRangePickerProps
     min?: string;
     max?: string;
     required?: boolean;
-    separatorText?: React.ReactNode;
+    separatorText?: ReactNode;
 }
 
 type IndividualTimeValue = string | undefined;
@@ -96,16 +96,16 @@ export const TimeRangePicker = (inProps: TimeRangePickerProps) => {
     } = useThemeProps({ props: inProps, name: "CometAdminTimeRangePicker" });
     const intl = useIntl();
 
-    const [startTime, setStartTime] = React.useState<IndividualTimeValue>(value?.start);
-    const [endTime, setEndTime] = React.useState<IndividualTimeValue>(value?.end);
+    const [startTime, setStartTime] = useState<IndividualTimeValue>(value?.start);
+    const [endTime, setEndTime] = useState<IndividualTimeValue>(value?.end);
 
-    const [startPickerIsOpen, setStartPickerIsOpen] = React.useState<boolean>(false);
-    const [endPickerIsOpen, setEndPickerIsOpen] = React.useState<boolean>(false);
+    const [startPickerIsOpen, setStartPickerIsOpen] = useState<boolean>(false);
+    const [endPickerIsOpen, setEndPickerIsOpen] = useState<boolean>(false);
 
-    const startPickerRef = React.useRef<HTMLElement>(null);
-    const endPickerRef = React.useRef<HTMLElement>(null);
+    const startPickerRef = useRef<HTMLElement>(null);
+    const endPickerRef = useRef<HTMLElement>(null);
 
-    const onChangeTimeValue = React.useCallback(
+    const onChangeTimeValue = useCallback(
         (newTimeValue: IndividualTimeValue, type: "start" | "end") => {
             if (newTimeValue === undefined) {
                 onChange?.(undefined);
@@ -133,7 +133,7 @@ export const TimeRangePicker = (inProps: TimeRangePickerProps) => {
     );
 
     // Setting both values the same when closing the pickers and one value is undefined needs to be handled inside `useEffect`, as `setStartTime`/`setEndTime` might not be complete when calling `onClosePopper`.
-    React.useEffect(() => {
+    useEffect(() => {
         if (!startPickerIsOpen && !endPickerIsOpen) {
             if (startTime !== undefined && endTime === undefined) {
                 onChangeTimeValue(startTime, "end");

--- a/packages/admin/admin-date-time/src/utils/DateFnsLocaleProvider.tsx
+++ b/packages/admin/admin-date-time/src/utils/DateFnsLocaleProvider.tsx
@@ -1,10 +1,10 @@
 import { Locale } from "date-fns";
-import * as React from "react";
+import { createContext, useContext } from "react";
 
-export const DateFnsLocaleContext = React.createContext<Locale | undefined>(undefined);
+export const DateFnsLocaleContext = createContext<Locale | undefined>(undefined);
 
 export const DateFnsLocaleProvider = DateFnsLocaleContext.Provider;
 
 export function useDateFnsLocale() {
-    return React.useContext(DateFnsLocaleContext);
+    return useContext(DateFnsLocaleContext);
 }

--- a/packages/admin/tsconfig.base.json
+++ b/packages/admin/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.core.json",
     "compilerOptions": {
-        "jsx": "react",
+        "jsx": "react-jsx",
         "lib": ["DOM", "ES2015", "ES2016", "ES2017", "ES2018", "ES2019", "ESNext.AsyncIterable"],
         "noImplicitAny": true,
         "sourceMap": true,


### PR DESCRIPTION
Use named imports instead of barrel importing React. Doing so will result in less code and better readability. The new [React docs](https://react.dev/) also use named imports and never import React itself.

To avoid conflicts, we temporarily add the eslint rules in the packages on main. The restrict-import rule will be added in the v8 (next) branch in the eslint-config package, then they will be removed there again.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-1026
