### PR TITLE
`admin-react-select`: remove barrel react imports

### DIFF
--- a/packages/admin/admin-react-select/.eslintrc.json
+++ b/packages/admin/admin-react-select/.eslintrc.json
@@ -2,6 +2,7 @@
     "extends": "@comet/eslint-config/react",
     "ignorePatterns": ["src/*.generated.ts", "lib/**"],
     "rules": {
-        "@comet/no-other-module-relative-import": "off"
+        "@comet/no-other-module-relative-import": "off",
+        "react/react-in-jsx-scope": "off"
     }
 }

--- a/packages/admin/admin-react-select/src/FinalFormReactSelect.tsx
+++ b/packages/admin/admin-react-select/src/FinalFormReactSelect.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 import { FieldRenderProps } from "react-final-form";
 import { OptionTypeBase } from "react-select";
 import { Props as ReactSelectAsyncProps } from "react-select/async";
@@ -13,7 +13,7 @@ import {
 } from "./ReactSelect";
 
 // tslint:disable:max-classes-per-file
-export class FinalFormReactSelect<OptionType extends OptionTypeBase> extends React.Component<
+export class FinalFormReactSelect<OptionType extends OptionTypeBase> extends Component<
     FieldRenderProps<OptionType | null, HTMLElement> & ReactSelectProps<OptionType>
 > {
     public render() {
@@ -21,7 +21,7 @@ export class FinalFormReactSelect<OptionType extends OptionTypeBase> extends Rea
         return <Select<OptionType> {...input} {...rest} />;
     }
 }
-export class FinalFormReactSelectAsync<OptionType extends OptionTypeBase, IsMulti extends boolean> extends React.Component<
+export class FinalFormReactSelectAsync<OptionType extends OptionTypeBase, IsMulti extends boolean> extends Component<
     FieldRenderProps<OptionType | null, HTMLElement> & ReactSelectAsyncProps<OptionType, IsMulti>
 > {
     public render() {
@@ -30,7 +30,7 @@ export class FinalFormReactSelectAsync<OptionType extends OptionTypeBase, IsMult
         return <Async<OptionType, boolean> {...input} {...rest} />;
     }
 }
-export class FinalFormReactSelectCreatable<OptionType extends OptionTypeBase, IsMulti extends boolean> extends React.Component<
+export class FinalFormReactSelectCreatable<OptionType extends OptionTypeBase, IsMulti extends boolean> extends Component<
     FieldRenderProps<OptionType | null, HTMLElement> & ReactSelectCreatableProps<OptionType, IsMulti>
 > {
     public render() {
@@ -39,7 +39,7 @@ export class FinalFormReactSelectCreatable<OptionType extends OptionTypeBase, Is
         return <Creatable<OptionType, boolean> {...input} {...rest} />;
     }
 }
-export class FinalFormReactSelectAsyncCreatable<OptionType extends OptionTypeBase, IsMulti extends boolean> extends React.Component<
+export class FinalFormReactSelectAsyncCreatable<OptionType extends OptionTypeBase, IsMulti extends boolean> extends Component<
     FieldRenderProps<OptionType | null, HTMLElement> & ReactSelectCreatableProps<OptionType, false> & ReactSelectAsyncProps<OptionType, IsMulti>
 > {
     public render() {

--- a/packages/admin/admin-react-select/src/FinalFormReactSelectStaticOptions.tsx
+++ b/packages/admin/admin-react-select/src/FinalFormReactSelectStaticOptions.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 import { FieldInputProps, FieldRenderProps } from "react-final-form";
 import { Props as ReactSelectProps } from "react-select/base";
 import { OptionsType } from "react-select/src/types";
@@ -13,7 +13,7 @@ interface IOptionType {
 interface IProps extends FieldRenderProps<string, HTMLElement>, ReactSelectProps<IOptionType> {
     options: OptionsType<IOptionType>;
 }
-export class FinalFormReactSelectStaticOptions extends React.Component<IProps> {
+export class FinalFormReactSelectStaticOptions extends Component<IProps> {
     public render() {
         const { input, meta, ...rest } = this.props;
 

--- a/packages/admin/admin-react-select/src/ReactSelect.tsx
+++ b/packages/admin/admin-react-select/src/ReactSelect.tsx
@@ -3,7 +3,7 @@ import { createComponentSlot } from "@comet/admin";
 import { ChevronDown, Clear, Close } from "@comet/admin-icons";
 import { Chip, ComponentsOverrides, InputBase, inputBaseClasses, MenuItem, Paper, SvgIconProps, Theme, Typography, useTheme } from "@mui/material";
 import { css } from "@mui/material/styles";
-import * as React from "react";
+import { ComponentType } from "react";
 import Select, { OptionTypeBase } from "react-select";
 import AsyncSelect, { Props as ReactSelectAsyncProps } from "react-select/async";
 import AsyncCreatableSelect from "react-select/async-creatable";
@@ -298,10 +298,10 @@ const components = {
 };
 
 export interface SelectProps<OptionType extends OptionTypeBase, IsMulti extends boolean = false> {
-    selectComponent: React.ComponentType<ReactSelectProps<OptionType, IsMulti>>;
-    clearIcon?: React.ComponentType<SvgIconProps>;
-    dropdownIcon?: React.ComponentType<SvgIconProps>;
-    dropdownIconOpen?: React.ComponentType<SvgIconProps>;
+    selectComponent: ComponentType<ReactSelectProps<OptionType, IsMulti>>;
+    clearIcon?: ComponentType<SvgIconProps>;
+    dropdownIcon?: ComponentType<SvgIconProps>;
+    dropdownIconOpen?: ComponentType<SvgIconProps>;
 }
 
 function SelectWrapper<OptionType extends OptionTypeBase, IsMulti extends boolean = false>({

--- a/packages/admin/tsconfig.base.json
+++ b/packages/admin/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.core.json",
     "compilerOptions": {
-        "jsx": "react",
+        "jsx": "react-jsx",
         "lib": ["DOM", "ES2015", "ES2016", "ES2017", "ES2018", "ES2019", "ESNext.AsyncIterable"],
         "noImplicitAny": true,
         "sourceMap": true,


### PR DESCRIPTION
Use named imports instead of barrel importing React. Doing so will result in less code and better readability. The new [React docs](https://react.dev/) also use named imports and never import React itself.

To avoid conflicts, we temporarily add the eslint rules in the packages on main. The restrict-import rule will be added in the v8 (next) branch in the eslint-config package, then they will be removed there again.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-1026