### PR TITLE
`admin-rte`: remove barrel react import

### DIFF
--- a/packages/admin/admin-rte/.eslintrc.json
+++ b/packages/admin/admin-rte/.eslintrc.json
@@ -4,6 +4,18 @@
     "rules": {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
-        "@comet/no-other-module-relative-import": "off"
+        "@comet/no-other-module-relative-import": "off",
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/packages/admin/admin-rte/.eslintrc.json
+++ b/packages/admin/admin-rte/.eslintrc.json
@@ -5,17 +5,6 @@
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@comet/no-other-module-relative-import": "off",
-        "react/react-in-jsx-scope": "off",
-        "no-restricted-imports": [
-            "error",
-            {
-                "paths": [
-                    {
-                        "name": "react",
-                        "importNames": ["default"]
-                    }
-                ]
-            }
-        ]
+        "react/react-in-jsx-scope": "off"
     }
 }

--- a/packages/admin/admin-rte/src/core/BlockElement.tsx
+++ b/packages/admin/admin-rte/src/core/BlockElement.tsx
@@ -1,6 +1,6 @@
 import { createComponentSlot, ThemedComponentBaseProps } from "@comet/admin";
 import { ComponentsOverrides, css, Theme, Typography, TypographyProps, useThemeProps } from "@mui/material";
-import * as React from "react";
+import { ElementType } from "react";
 
 import { SupportedThings } from "./Rte";
 
@@ -108,7 +108,7 @@ export interface RteBlockElementProps
         }>,
         TypographyProps {
     type?: StylableBlockTypes;
-    component?: React.ElementType;
+    component?: ElementType;
 }
 
 export function BlockElement(inProps: RteBlockElementProps) {

--- a/packages/admin/admin-rte/src/core/Controls/BlockTypesControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/BlockTypesControls.tsx
@@ -10,7 +10,7 @@ import {
     Theme,
     useThemeProps,
 } from "@mui/material";
-import * as React from "react";
+import { ReactNode } from "react";
 
 import { IControlProps } from "../types";
 import getRteTheme from "../utils/getRteTheme";
@@ -70,7 +70,7 @@ export function StyledBlockTypesControls(inProps: Props) {
     const { disabled, blockTypes, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminRteBlockTypeControls" });
     const { dropdownFeatures, activeDropdownBlockType, handleBlockTypeChange } = blockTypes;
 
-    const blockTypesListItems: Array<{ name: string; label: React.ReactNode }> = dropdownFeatures.map((c) => ({ name: c.name, label: c.label }));
+    const blockTypesListItems: Array<{ name: string; label: ReactNode }> = dropdownFeatures.map((c) => ({ name: c.name, label: c.label }));
 
     return (
         <Root {...slotProps?.root} {...restProps}>

--- a/packages/admin/admin-rte/src/core/Controls/ControlButton.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/ControlButton.tsx
@@ -2,7 +2,7 @@ import { createComponentSlot, ThemedComponentBaseProps } from "@comet/admin";
 import { ComponentsOverrides } from "@mui/material";
 import { css, Theme, useThemeProps } from "@mui/material/styles";
 import { SvgIconProps } from "@mui/material/SvgIcon";
-import * as React from "react";
+import { MouseEvent, PropsWithChildren } from "react";
 
 import getRteTheme from "../utils/getRteTheme";
 
@@ -69,15 +69,14 @@ export interface IProps
     }> {
     disabled?: boolean;
     selected?: boolean;
-    onButtonClick?: (e: React.MouseEvent) => void;
+    onButtonClick?: (e: MouseEvent) => void;
     icon?: (props: SvgIconProps) => JSX.Element | null;
-    children?: React.ReactNode;
 
     /** @deprecated use icon instead */
     Icon?: (props: SvgIconProps) => JSX.Element | null;
 }
 
-export function ControlButton(inProps: IProps) {
+export function ControlButton(inProps: PropsWithChildren<IProps>) {
     const {
         disabled = false,
         selected = false,

--- a/packages/admin/admin-rte/src/core/Controls/Controls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/Controls.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { IControlProps } from "../types";
 import BlockTypesControls from "./BlockTypesControls";
 import CustomControls from "./CustomControls";

--- a/packages/admin/admin-rte/src/core/Controls/CustomControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/CustomControls.tsx
@@ -1,5 +1,4 @@
 import ButtonGroup from "@mui/material/ButtonGroup";
-import * as React from "react";
 
 import { IControlProps } from "../types";
 

--- a/packages/admin/admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
@@ -2,7 +2,7 @@ import { createComponentSlot, ThemedComponentBaseProps } from "@comet/admin";
 import { MoreHorizontal } from "@comet/admin-icons";
 import { ComponentsOverrides, css, ListItemIcon as MuiListItemIcon, Menu, MenuItem, Theme, Tooltip, useThemeProps } from "@mui/material";
 import { Editor } from "draft-js";
-import * as React from "react";
+import { MouseEvent, RefObject, useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { IFeatureConfig } from "../types";
@@ -17,7 +17,7 @@ interface IProps
     }> {
     features: IFeatureConfig[];
     disabled?: boolean;
-    editorRef: React.RefObject<Editor>;
+    editorRef: RefObject<Editor>;
     maxVisible?: number;
 }
 
@@ -30,9 +30,9 @@ export function FeaturesButtonGroup(inProps: IProps) {
         slotProps,
         ...restProps
     } = useThemeProps({ props: inProps, name: "CometAdminRteFeaturesButtonGroup" });
-    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-    const handleMoreOptionsClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const handleMoreOptionsClick = (event: MouseEvent<HTMLButtonElement>) => {
         setAnchorEl(event.currentTarget);
     };
 

--- a/packages/admin/admin-rte/src/core/Controls/HistoryContols.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/HistoryContols.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { IControlProps } from "../types";
 import { FeaturesButtonGroup } from "./FeaturesButtonGroup";
 import useHistory from "./useHistory";

--- a/packages/admin/admin-rte/src/core/Controls/InlineStyleTypeControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/InlineStyleTypeControls.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { IControlProps } from "../types";
 import { FeaturesButtonGroup } from "./FeaturesButtonGroup";
 import useInlineStyleType from "./useInlineStyleType";

--- a/packages/admin/admin-rte/src/core/Controls/LinkControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/LinkControls.tsx
@@ -1,6 +1,5 @@
 import { createComponentSlot, ThemedComponentBaseProps } from "@comet/admin";
 import { ButtonGroup, ComponentsOverrides, css, Theme, useThemeProps } from "@mui/material";
-import * as React from "react";
 
 import LinkToolbarButton from "../extension/Link/ToolbarButton";
 import LinksRemoveToolbarButton from "../extension/LinksRemove/ToolbarButton";

--- a/packages/admin/admin-rte/src/core/Controls/ListsControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/ListsControls.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { IControlProps } from "../types";
 import { FeaturesButtonGroup } from "./FeaturesButtonGroup";
 import useBlockTypes from "./useBlockTypes";

--- a/packages/admin/admin-rte/src/core/Controls/ListsIndentControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/ListsIndentControls.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { IControlProps } from "../types";
 import { FeaturesButtonGroup } from "./FeaturesButtonGroup";
 import useListIndent from "./useListIndent";

--- a/packages/admin/admin-rte/src/core/Controls/SpecialCharactersControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/SpecialCharactersControls.tsx
@@ -1,5 +1,4 @@
 import { ButtonGroup } from "@mui/material";
-import * as React from "react";
 
 import NonBreakingSpaceToolbarButton from "../extension/NonBreakingSpace/ToolbarButton";
 import { ToolbarButton as SoftHyphenToolbarButton } from "../extension/SoftHyphen/ToolbarButton";

--- a/packages/admin/admin-rte/src/core/Controls/Toolbar/Toolbar.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/Toolbar/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { ThemedComponentBaseProps } from "@comet/admin";
 import { ComponentsOverrides, Theme } from "@mui/material";
 import { useThemeProps } from "@mui/material/styles";
-import React from "react";
+import { createElement } from "react";
 
 import { IControlProps } from "../../types";
 import { Root, RteToolbarClassKey, Slot } from "./Toolbar.styles";
@@ -25,7 +25,7 @@ export function Toolbar(inProps: RteToolbarProps) {
         })
         .map((c) => {
             const Comp = c;
-            return React.createElement(Comp, restProps);
+            return createElement(Comp, restProps);
         });
 
     return (

--- a/packages/admin/admin-rte/src/core/Controls/TranslationControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/TranslationControls.tsx
@@ -1,6 +1,5 @@
 import { useContentTranslationService } from "@comet/admin";
 import { ButtonGroup } from "@mui/material";
-import * as React from "react";
 
 import TranslationToolbarButton from "../translation/ToolbarButton";
 import { IControlProps } from "../types";

--- a/packages/admin/admin-rte/src/core/Controls/useBlockTypes.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/useBlockTypes.tsx
@@ -1,6 +1,6 @@
 import { SelectChangeEvent } from "@mui/material";
 import { DraftBlockType, Editor, EditorState, RichUtils } from "draft-js";
-import * as React from "react";
+import { MouseEvent, RefObject, useCallback, useMemo } from "react";
 
 import { SupportedThings } from "../Rte";
 import { IBlocktypeMap, IFeatureConfig } from "../types";
@@ -11,7 +11,7 @@ interface IProps {
     setEditorState: (editorState: EditorState) => void;
     supportedThings: SupportedThings[];
     blocktypeMap: IBlocktypeMap;
-    editorRef: React.RefObject<Editor>;
+    editorRef: RefObject<Editor>;
     standardBlockType: DraftBlockType;
 }
 
@@ -19,7 +19,7 @@ interface IFeaturesFromBlocktypeMapArg {
     blocktypeMap: IBlocktypeMap;
     supports: (a?: SupportedThings) => boolean;
     blockTypeActive: (a: DraftBlockType) => boolean;
-    handleBlockTypeButtonClick: (blockType: DraftBlockType, e: React.MouseEvent) => void;
+    handleBlockTypeButtonClick: (blockType: DraftBlockType, e: MouseEvent) => void;
     standardBlockType: DraftBlockType;
 }
 
@@ -63,12 +63,9 @@ export default function useBlockTypes({
     standardBlockType,
 }: IProps): BlockTypesApi {
     // can check if blocktype is supported by the editor
-    const supports = React.useCallback(
-        (supportedBy?: SupportedThings) => (supportedBy ? supportedThings.includes(supportedBy) : true),
-        [supportedThings],
-    );
+    const supports = useCallback((supportedBy?: SupportedThings) => (supportedBy ? supportedThings.includes(supportedBy) : true), [supportedThings]);
 
-    const blockTypeActive = React.useCallback(
+    const blockTypeActive = useCallback(
         (blockType: DraftBlockType) => {
             const currentBlock = getCurrentBlock(editorState);
             if (!currentBlock) {
@@ -79,15 +76,15 @@ export default function useBlockTypes({
         [editorState],
     );
 
-    const handleBlockTypeButtonClick = React.useCallback(
-        (blockType: DraftBlockType, e: React.MouseEvent) => {
+    const handleBlockTypeButtonClick = useCallback(
+        (blockType: DraftBlockType, e: MouseEvent) => {
             e.preventDefault();
             setEditorState(RichUtils.toggleBlockType(editorState, blockType));
         },
         [setEditorState, editorState],
     );
 
-    const handleBlockTypeChange = React.useCallback(
+    const handleBlockTypeChange = useCallback(
         (e: BlockChangeEvent) => {
             e.preventDefault();
 
@@ -109,17 +106,17 @@ export default function useBlockTypes({
         [setEditorState, editorState, editorRef],
     );
 
-    const dropdownFeatures: IFeatureConfig[] = React.useMemo(
+    const dropdownFeatures: IFeatureConfig[] = useMemo(
         () => createFeaturesFromBlocktypeMap("dropdown")({ supports, blockTypeActive, handleBlockTypeButtonClick, blocktypeMap, standardBlockType }),
         [supports, blockTypeActive, handleBlockTypeButtonClick, blocktypeMap, standardBlockType],
     );
 
-    const listsFeatures: IFeatureConfig[] = React.useMemo(
+    const listsFeatures: IFeatureConfig[] = useMemo(
         () => createFeaturesFromBlocktypeMap("button")({ supports, blockTypeActive, handleBlockTypeButtonClick, blocktypeMap, standardBlockType }),
         [supports, blockTypeActive, handleBlockTypeButtonClick, blocktypeMap, standardBlockType],
     );
 
-    const activeDropdownBlockType: string = React.useMemo(() => {
+    const activeDropdownBlockType: string = useMemo(() => {
         const activeFeature = dropdownFeatures.find((c) => c.selected);
         return activeFeature ? activeFeature.name : "unstyled";
     }, [dropdownFeatures]);

--- a/packages/admin/admin-rte/src/core/Controls/useHistory.ts
+++ b/packages/admin/admin-rte/src/core/Controls/useHistory.ts
@@ -1,6 +1,6 @@
 import { RteRedo, RteUndo } from "@comet/admin-icons";
 import { EditorState } from "draft-js";
-import * as React from "react";
+import { MouseEvent, useCallback, useMemo } from "react";
 import { useIntl } from "react-intl";
 
 import { SupportedThings } from "../Rte";
@@ -16,12 +16,12 @@ export default function useHistory({ editorState, setEditorState, supportedThing
     const intl = useIntl();
 
     // can check if history is supported
-    const supported = React.useMemo(() => supportedThings.includes("history"), [supportedThings]);
-    const canRedo = React.useMemo(() => !editorState.getRedoStack().isEmpty(), [editorState]);
-    const canUndo = React.useMemo(() => !editorState.getUndoStack().isEmpty(), [editorState]);
+    const supported = useMemo(() => supportedThings.includes("history"), [supportedThings]);
+    const canRedo = useMemo(() => !editorState.getRedoStack().isEmpty(), [editorState]);
+    const canUndo = useMemo(() => !editorState.getUndoStack().isEmpty(), [editorState]);
 
-    const handleUndoClick = React.useCallback(
-        (e: React.MouseEvent) => {
+    const handleUndoClick = useCallback(
+        (e: MouseEvent) => {
             e.preventDefault();
             const newEditorState = EditorState.undo(editorState);
             setEditorState(newEditorState);
@@ -29,8 +29,8 @@ export default function useHistory({ editorState, setEditorState, supportedThing
         [editorState, setEditorState],
     );
 
-    const handleRedoClick = React.useCallback(
-        (e: React.MouseEvent) => {
+    const handleRedoClick = useCallback(
+        (e: MouseEvent) => {
             e.preventDefault();
             const newEditorState = EditorState.redo(editorState);
             setEditorState(newEditorState);
@@ -38,7 +38,7 @@ export default function useHistory({ editorState, setEditorState, supportedThing
         [editorState, setEditorState],
     );
 
-    const features: IFeatureConfig[] = React.useMemo(
+    const features: IFeatureConfig[] = useMemo(
         () =>
             supported
                 ? [

--- a/packages/admin/admin-rte/src/core/Controls/useInlineStyleType.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/useInlineStyleType.tsx
@@ -1,7 +1,7 @@
 import { RteBold, RteItalic, RteStrikethrough, RteSub, RteSup, RteUnderlined } from "@comet/admin-icons";
 import * as detectBrowser from "detect-browser";
 import { Editor, EditorState, RichUtils } from "draft-js";
-import * as React from "react";
+import { RefObject, useCallback, useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { SupportedThings } from "../Rte";
@@ -13,7 +13,7 @@ interface IProps {
     editorState: EditorState;
     setEditorState: (editorState: EditorState) => void;
     supportedThings: SupportedThings[];
-    editorRef: React.RefObject<Editor>;
+    editorRef: RefObject<Editor>;
     customInlineStyles?: CustomInlineStyles;
 }
 
@@ -70,7 +70,7 @@ const defaultFeatures: Array<IFeatureConfig<InlineStyleType>> = [
 
 export default function useInlineStyleType({ editorState, setEditorState, supportedThings, editorRef, customInlineStyles }: IProps) {
     // can check if inlineStyleType is supported by the editor
-    const supports = React.useCallback(
+    const supports = useCallback(
         (inlineStyle: InlineStyleType) => {
             switch (inlineStyle) {
                 case "BOLD":
@@ -92,7 +92,7 @@ export default function useInlineStyleType({ editorState, setEditorState, suppor
         [supportedThings],
     );
 
-    const inlineStyleActive = React.useCallback(
+    const inlineStyleActive = useCallback(
         (draftInlineStyleType: InlineStyleType) => {
             const currentStyle = editorState.getCurrentInlineStyle();
             return currentStyle.has(draftInlineStyleType);
@@ -100,15 +100,15 @@ export default function useInlineStyleType({ editorState, setEditorState, suppor
         [editorState],
     );
 
-    const handleInlineStyleButtonClick = React.useCallback(
-        (draftInlineStyleType: InlineStyleType, e: React.MouseEvent) => {
+    const handleInlineStyleButtonClick = useCallback(
+        (draftInlineStyleType: InlineStyleType, e: MouseEvent) => {
             e.preventDefault();
             setEditorState(RichUtils.toggleInlineStyle(editorState, draftInlineStyleType));
         },
         [setEditorState, editorState],
     );
 
-    const features: Array<IFeatureConfig<InlineStyleType>> = React.useMemo(
+    const features: Array<IFeatureConfig<InlineStyleType>> = useMemo(
         () => [
             ...defaultFeatures
                 .filter((c) => supports(c.name))

--- a/packages/admin/admin-rte/src/core/Controls/useListIndent.ts
+++ b/packages/admin/admin-rte/src/core/Controls/useListIndent.ts
@@ -1,6 +1,6 @@
 import { RteIndentDecrease, RteIndentIncrease } from "@comet/admin-icons";
 import { BlockMap, ContentState, EditorState } from "draft-js";
-import * as React from "react";
+import { MouseEvent, useCallback, useMemo } from "react";
 import { useIntl } from "react-intl";
 
 import { SupportedThings } from "../Rte";
@@ -71,12 +71,12 @@ export default function useListIndent({ editorState, setEditorState, supportedTh
     const intl = useIntl();
 
     // can check if indenting lists is supported
-    const supported = React.useMemo(
+    const supported = useMemo(
         () => supportedThings.some((c) => ["ordered-list", "unordered-list"].includes(c) && listLevelMax !== 0),
         [supportedThings, listLevelMax],
     );
 
-    const active = React.useMemo(() => {
+    const active = useMemo(() => {
         const currentBlock = getCurrentBlock(editorState);
         if (!currentBlock) {
             return false;
@@ -84,27 +84,24 @@ export default function useListIndent({ editorState, setEditorState, supportedTh
         return ["ordered-list-item", "unordered-list-item"].includes(currentBlock.getType()) && selectionIsInOneBlock(editorState);
     }, [editorState]);
 
-    const canIndentLeft = React.useMemo(() => active && getCurrentBlock(editorState)!.getDepth() > 0, [active, editorState]);
-    const canIndentRight = React.useMemo(
-        () => active && getCurrentBlock(editorState)!.getDepth() < listLevelMax - 1,
-        [active, editorState, listLevelMax],
-    );
+    const canIndentLeft = useMemo(() => active && getCurrentBlock(editorState)!.getDepth() > 0, [active, editorState]);
+    const canIndentRight = useMemo(() => active && getCurrentBlock(editorState)!.getDepth() < listLevelMax - 1, [active, editorState, listLevelMax]);
 
-    const handleListIndentLeftClick = React.useCallback(
-        (e: React.MouseEvent) => {
+    const handleListIndentLeftClick = useCallback(
+        (e: MouseEvent) => {
             e.preventDefault();
             setEditorState(adjustBlockDepth("decrease", editorState, listLevelMax));
         },
         [editorState, setEditorState, listLevelMax],
     );
-    const handleListIndentRightClick = React.useCallback(
-        (e: React.MouseEvent) => {
+    const handleListIndentRightClick = useCallback(
+        (e: MouseEvent) => {
             e.preventDefault();
             setEditorState(adjustBlockDepth("increase", editorState, listLevelMax));
         },
         [editorState, setEditorState, listLevelMax],
     );
-    const features: IFeatureConfig[] = React.useMemo(() => {
+    const features: IFeatureConfig[] = useMemo(() => {
         return supported
             ? [
                   {

--- a/packages/admin/admin-rte/src/core/RteReadOnly.tsx
+++ b/packages/admin/admin-rte/src/core/RteReadOnly.tsx
@@ -1,7 +1,7 @@
 import "draft-js/dist/Draft.css"; // important for nesting of ul/ol
 
 import { Editor as DraftJsEditor, EditorState } from "draft-js";
-import * as React from "react";
+import { useRef } from "react";
 
 import defaultBlocktypeMap, { cleanBlockTypeMap, mergeBlocktypeMaps } from "./defaultBlocktypeMap";
 import { styleMap } from "./Rte";
@@ -28,8 +28,8 @@ const defaultOptions: IRteReadOnlyOptions = {
     blocktypeMap: defaultBlocktypeMap,
 };
 
-const RteReadOnly: React.FC<IProps> = ({ value: editorState, options: passedOptions, plainTextOnly }) => {
-    const editorRef = React.useRef<DraftJsEditor>(null);
+const RteReadOnly = ({ value: editorState, options: passedOptions, plainTextOnly }: IProps) => {
+    const editorRef = useRef<DraftJsEditor>(null);
 
     // merge default options with passed options
     let options = passedOptions ? { ...defaultOptions, ...passedOptions } : defaultOptions;

--- a/packages/admin/admin-rte/src/core/defaultBlocktypeMap.tsx
+++ b/packages/admin/admin-rte/src/core/defaultBlocktypeMap.tsx
@@ -1,5 +1,4 @@
 import { RteOl, RteUl } from "@comet/admin-icons";
-import * as React from "react";
 import { defineMessage, FormattedMessage } from "react-intl";
 
 import { BlockElement } from "./BlockElement";

--- a/packages/admin/admin-rte/src/core/extension/Link/EditorComponent.tsx
+++ b/packages/admin/admin-rte/src/core/extension/Link/EditorComponent.tsx
@@ -1,17 +1,16 @@
 import { ContentState } from "draft-js";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 interface IProps {
     contentState: ContentState;
     entityKey: string;
-    children?: React.ReactNode;
 }
 
 export interface ILinkProps {
     url: string;
 }
 
-function EditorComponent(props: IProps) {
+const EditorComponent = (props: PropsWithChildren<IProps>) => {
     const { url } = props.contentState.getEntity(props.entityKey).getData() as ILinkProps; // not typed
     return (
         <a
@@ -24,6 +23,6 @@ function EditorComponent(props: IProps) {
             {props.children}
         </a>
     );
-}
+};
 
 export default EditorComponent;

--- a/packages/admin/admin-rte/src/core/extension/Link/ToolbarButton.tsx
+++ b/packages/admin/admin-rte/src/core/extension/Link/ToolbarButton.tsx
@@ -1,7 +1,7 @@
 import { Check, Close, Delete, RteLink } from "@comet/admin-icons";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormLabel, Grid, InputBase } from "@mui/material";
 import { EditorState, RichUtils } from "draft-js";
-import * as React from "react";
+import { MouseEvent, useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { ControlButton } from "../../Controls/ControlButton";
@@ -13,14 +13,14 @@ import { ENTITY_TYPE } from "./Decorator";
 import { ILinkProps } from "./EditorComponent";
 
 export default function ToolbarButton(props: IControlProps) {
-    const [open, setOpen] = React.useState(false);
+    const [open, setOpen] = useState(false);
     const linkData = findEntityDataInCurrentSelection<ILinkProps>(props.editorState, ENTITY_TYPE);
     const { entity: previousLinkEntity, entitySelection: linkEntitySelection } = findEntityInCurrentSelection(props.editorState, ENTITY_TYPE);
     const selection = props.editorState.getSelection();
     const linkEditCreateDisabled = (selection.isCollapsed() && !linkData) || !selectionIsInOneBlock(props.editorState);
     const globallyDisabled = !!props.disabled;
 
-    function handleClick(e: React.MouseEvent) {
+    function handleClick(e: MouseEvent) {
         if (linkEditCreateDisabled) {
             return;
         }
@@ -57,9 +57,9 @@ function LinkDialog(props: {
 }) {
     const { onClose, open, linkData, editorState, onChange } = props;
     const linkDataUrl = linkData ? linkData.url : "";
-    const [newUrl, setNewUrl] = React.useState(linkDataUrl);
+    const [newUrl, setNewUrl] = useState(linkDataUrl);
 
-    React.useEffect(() => {
+    useEffect(() => {
         setNewUrl(linkDataUrl);
     }, [linkDataUrl, setNewUrl]);
 
@@ -67,7 +67,7 @@ function LinkDialog(props: {
         onClose();
     };
 
-    const handleRemove = (e: React.MouseEvent) => {
+    const handleRemove = (e: MouseEvent) => {
         e.preventDefault();
 
         setNewUrl("");
@@ -78,7 +78,7 @@ function LinkDialog(props: {
         onClose();
     };
 
-    const handleUpdate = (e: React.MouseEvent) => {
+    const handleUpdate = (e: MouseEvent) => {
         e.preventDefault();
         const contentState = editorState.getCurrentContent();
         const contentStateWithEntity = contentState.createEntity("LINK", "MUTABLE", { url: newUrl });

--- a/packages/admin/admin-rte/src/core/extension/LinksRemove/ToolbarButton.tsx
+++ b/packages/admin/admin-rte/src/core/extension/LinksRemove/ToolbarButton.tsx
@@ -1,6 +1,6 @@
 import { RteClearLink } from "@comet/admin-icons";
 import { RichUtils } from "draft-js";
-import * as React from "react";
+import { MouseEvent } from "react";
 
 import { ControlButton } from "../../Controls/ControlButton";
 import { IControlProps } from "../../types";
@@ -10,7 +10,7 @@ export default function ToolbarButton(props: IControlProps) {
     const globallyDisabled = !!props.disabled;
 
     const buttonEnabled = !selection.isCollapsed(); // @TODO: better to scan the selection if any link-entities are in the selection
-    function handleClick(e: React.MouseEvent) {
+    function handleClick(e: MouseEvent) {
         e.preventDefault();
         if (buttonEnabled) {
             props.setEditorState(RichUtils.toggleLink(props.editorState, selection, null)); // @TODO, this removes all entities not only LINK entity, should be improved, now its ok as there are no other entities than links

--- a/packages/admin/admin-rte/src/core/extension/NonBreakingSpace/EditorComponent.tsx
+++ b/packages/admin/admin-rte/src/core/extension/NonBreakingSpace/EditorComponent.tsx
@@ -1,22 +1,21 @@
 import { RteNonBreakingSpace } from "@comet/admin-icons";
 import { styled } from "@mui/material/styles";
 import { ContentState } from "draft-js";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 interface Props {
     contentState: ContentState;
     entityKey: string;
-    children?: React.ReactNode;
 }
 
-function EditorComponent({ children }: Props): React.ReactElement {
+const EditorComponent = ({ children }: PropsWithChildren<Props>) => {
     return (
         <Root>
             <Icon />
             {children}
         </Root>
     );
-}
+};
 
 const Root = styled("span")`
     position: relative;

--- a/packages/admin/admin-rte/src/core/extension/NonBreakingSpace/ToolbarButton.tsx
+++ b/packages/admin/admin-rte/src/core/extension/NonBreakingSpace/ToolbarButton.tsx
@@ -1,7 +1,7 @@
 import { RteNonBreakingSpace } from "@comet/admin-icons";
 import Tooltip from "@mui/material/Tooltip";
 import { EditorState, Modifier } from "draft-js";
-import * as React from "react";
+import { MouseEvent } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { ControlButton } from "../../Controls/ControlButton";
@@ -9,8 +9,8 @@ import { IControlProps } from "../../types";
 
 const NO_BREAK_SPACE_UNICODE_CHAR = 0x00a0;
 
-function ToolbarButton({ editorState, setEditorState }: IControlProps): React.ReactElement {
-    function handleClick(event: React.MouseEvent) {
+function ToolbarButton({ editorState, setEditorState }: IControlProps) {
+    function handleClick(event: MouseEvent) {
         event.preventDefault(); // Preserve focus in editor
 
         const currentContent = editorState.getCurrentContent();

--- a/packages/admin/admin-rte/src/core/extension/SoftHyphen/EditorComponent.tsx
+++ b/packages/admin/admin-rte/src/core/extension/SoftHyphen/EditorComponent.tsx
@@ -1,23 +1,22 @@
 import { RteSoftHyphen } from "@comet/admin-icons";
 import { styled } from "@mui/material/styles";
 import { ContentState } from "draft-js";
-import * as React from "react";
+import { PropsWithChildren } from "react";
 
 interface Props {
     contentState: ContentState;
     entityKey: string;
-    children?: React.ReactNode;
 }
 
 //TODO: Allow text selection for SoftHyphen
-export function EditorComponent({ children }: Props): React.ReactElement {
+export const EditorComponent = ({ children }: PropsWithChildren<Props>) => {
     return (
         <span>
             <VisibleHyphen />
             {children}
         </span>
     );
-}
+};
 
 const VisibleHyphen = styled(RteSoftHyphen)`
     font-size: inherit;

--- a/packages/admin/admin-rte/src/core/extension/SoftHyphen/ToolbarButton.tsx
+++ b/packages/admin/admin-rte/src/core/extension/SoftHyphen/ToolbarButton.tsx
@@ -1,7 +1,7 @@
 import { RteSoftHyphen } from "@comet/admin-icons";
 import Tooltip from "@mui/material/Tooltip";
 import { EditorState, Modifier } from "draft-js";
-import * as React from "react";
+import { MouseEvent } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { ControlButton } from "../../Controls/ControlButton";
@@ -9,8 +9,8 @@ import { IControlProps } from "../../types";
 
 const SHY_UNICODE_CHAR = 0x00ad;
 
-export function ToolbarButton({ editorState, setEditorState }: IControlProps): React.ReactElement {
-    function handleClick(e: React.MouseEvent) {
+export function ToolbarButton({ editorState, setEditorState }: IControlProps) {
+    function handleClick(e: MouseEvent) {
         e.preventDefault(); // important to preserve focus
         const currentContent = editorState.getCurrentContent();
         const selection = editorState.getSelection();

--- a/packages/admin/admin-rte/src/core/makeRteApi.ts
+++ b/packages/admin/admin-rte/src/core/makeRteApi.ts
@@ -1,5 +1,5 @@
 import { CompositeDecorator, ContentState, convertFromRaw, convertToRaw, DraftDecorator, EditorState, RawDraftContentState } from "draft-js";
-import * as React from "react";
+import { useEffect, useState } from "react";
 
 import useDebounce from "../useDebounce";
 import usePrevious from "../usePrevious";
@@ -60,13 +60,13 @@ function makeRteApi<T = any>(o?: IMakeRteApiProps<T>) {
         const options: IRteApiOptions<T> = passedProps ? { ...defaultRteApiOptions, ...passedProps } : defaultRteApiOptions; // merge default options with passed props
         const { defaultValue, onDebouncedContentChange, debounceDelay } = options;
 
-        const [editorState, setEditorState] = React.useState(defaultValue ? createStateFromRawContent(defaultValue) : createEmptyState());
+        const [editorState, setEditorState] = useState(defaultValue ? createStateFromRawContent(defaultValue) : createEmptyState());
 
         const debouncedEditorState = useDebounce(editorState, debounceDelay);
         const previousDebouncedContent = usePrevious(debouncedEditorState.getCurrentContent());
         const debouncedContent = debouncedEditorState.getCurrentContent();
 
-        React.useEffect(() => {
+        useEffect(() => {
             if (onDebouncedContentChange) {
                 if (previousDebouncedContent !== debouncedContent) {
                     onDebouncedContentChange(debouncedEditorState, convertStateToRawContent);

--- a/packages/admin/admin-rte/src/core/translation/EditorStateTranslationDialog.tsx
+++ b/packages/admin/admin-rte/src/core/translation/EditorStateTranslationDialog.tsx
@@ -1,6 +1,5 @@
 import { BaseTranslationDialog } from "@comet/admin";
 import { EditorState } from "draft-js";
-import * as React from "react";
 
 import { Rte } from "../Rte";
 import RteReadOnly from "../RteReadOnly";
@@ -13,7 +12,7 @@ interface EditorStateTranslationDialogProps {
     onApplyTranslation: (newValue: EditorState) => void;
 }
 
-export const EditorStateTranslationDialog: React.FC<EditorStateTranslationDialogProps> = (props) => {
+export const EditorStateTranslationDialog = (props: EditorStateTranslationDialogProps) => {
     const { open, onClose, originalText, translatedText, onApplyTranslation } = props;
 
     return (

--- a/packages/admin/admin-rte/src/core/translation/ToolbarButton.tsx
+++ b/packages/admin/admin-rte/src/core/translation/ToolbarButton.tsx
@@ -1,7 +1,7 @@
 import { Tooltip, useContentTranslationService } from "@comet/admin";
 import { Translate } from "@comet/admin-icons";
 import { EditorState } from "draft-js";
-import * as React from "react";
+import { MouseEvent, useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { ControlButton } from "../Controls/ControlButton";
@@ -10,13 +10,13 @@ import { EditorStateTranslationDialog } from "./EditorStateTranslationDialog";
 import { htmlToState } from "./htmlToState";
 import { stateToHtml } from "./stateToHtml";
 
-function ToolbarButton({ editorState, setEditorState, options }: IControlProps): React.ReactElement {
+function ToolbarButton({ editorState, setEditorState, options }: IControlProps) {
     const translationContext = useContentTranslationService();
 
-    const [open, setOpen] = React.useState<boolean>(false);
-    const [pendingTranslation, setPendingTranslation] = React.useState<EditorState | undefined>(undefined);
+    const [open, setOpen] = useState<boolean>(false);
+    const [pendingTranslation, setPendingTranslation] = useState<EditorState | undefined>(undefined);
 
-    async function handleClick(event: React.MouseEvent) {
+    async function handleClick(event: MouseEvent) {
         if (!translationContext) return;
 
         event.preventDefault();

--- a/packages/admin/admin-rte/src/core/types.ts
+++ b/packages/admin/admin-rte/src/core/types.ts
@@ -1,19 +1,19 @@
 import { SvgIconProps } from "@mui/material/SvgIcon";
 import { DraftInlineStyleType, Editor, EditorState } from "draft-js";
-import * as React from "react";
+import { ComponentType, CSSProperties, MouseEvent, ReactNode, RefObject } from "react";
 
 import { IRteOptions, SupportedThings } from "./Rte";
 
 // overwrite draftjs' insufficient type for Draft.DraftBlockRenderConfig
 interface DraftBlockRenderConfig {
-    element: string | React.ComponentType;
-    wrapper?: React.ReactNode;
+    element: string | ComponentType;
+    wrapper?: ReactNode;
     aliasedElements?: string[];
 }
 
 export interface IBlocktypeConfig {
     renderConfig?: DraftBlockRenderConfig; // visual appearance of the blocktype
-    label?: string | React.ReactNode; // displayed in the dropdown
+    label?: string | ReactNode; // displayed in the dropdown
     group?: "dropdown" | "button"; // displays the element in the dropdown or as button
     icon?: (props: SvgIconProps) => JSX.Element | null;
     supportedBy?: SupportedThings; // blocktype is active when this "supported thing" is active
@@ -25,12 +25,12 @@ export interface IBlocktypeMap {
 
 export interface IFeatureConfig<T extends string = string> {
     name: T;
-    label: React.ReactNode;
+    label: ReactNode;
     disabled?: boolean;
     selected?: boolean;
-    onButtonClick?: (e: React.MouseEvent) => void;
+    onButtonClick?: (e: MouseEvent) => void;
     icon?: (props: SvgIconProps) => JSX.Element | null;
-    tooltipText?: React.ReactNode;
+    tooltipText?: ReactNode;
 
     /** @deprecated use icon instead */
     Icon?: (props: SvgIconProps) => JSX.Element | null;
@@ -44,7 +44,7 @@ export interface IControlProps {
     editorState: EditorState;
     setEditorState: (editorState: EditorState) => void;
     options: IRteOptions;
-    editorRef: React.RefObject<Editor>;
+    editorRef: RefObject<Editor>;
     disabled?: boolean;
 }
 
@@ -69,9 +69,9 @@ export interface ICustomBlockTypeMap_Deprecated {
 
 export interface CustomInlineStyles {
     [name: string]: {
-        label: React.ReactNode;
+        label: ReactNode;
         icon?: (props: SvgIconProps) => JSX.Element | null;
-        tooltipText?: React.ReactNode;
-        style: React.CSSProperties;
+        tooltipText?: ReactNode;
+        style: CSSProperties;
     };
 }

--- a/packages/admin/admin-rte/src/core/utils/getRteTheme.ts
+++ b/packages/admin/admin-rte/src/core/utils/getRteTheme.ts
@@ -1,17 +1,17 @@
 import { grey as greyPalette } from "@mui/material/colors";
-import * as React from "react";
+import { CSSProperties } from "react";
 
 import { RteProps } from "../Rte";
 
 export interface RteTheme {
     colors: {
-        border: React.CSSProperties["color"];
-        toolbarBackground: React.CSSProperties["color"];
-        buttonIcon: React.CSSProperties["color"];
-        buttonIconDisabled: React.CSSProperties["color"];
-        buttonBackgroundHover: React.CSSProperties["color"];
-        buttonBorderHover: React.CSSProperties["color"];
-        buttonBorderDisabled: React.CSSProperties["color"];
+        border: CSSProperties["color"];
+        toolbarBackground: CSSProperties["color"];
+        buttonIcon: CSSProperties["color"];
+        buttonIconDisabled: CSSProperties["color"];
+        buttonBackgroundHover: CSSProperties["color"];
+        buttonBorderHover: CSSProperties["color"];
+        buttonBorderDisabled: CSSProperties["color"];
     };
 }
 

--- a/packages/admin/admin-rte/src/field/createFinalFormRte.tsx
+++ b/packages/admin/admin-rte/src/field/createFinalFormRte.tsx
@@ -1,5 +1,5 @@
 import { EditorState } from "draft-js";
-import * as React from "react";
+import { FunctionComponent, useRef } from "react";
 import { FieldRenderProps } from "react-final-form";
 
 import makeRteApi, { IMakeRteApiProps, OnDebouncedContentChangeFn } from "../core/makeRteApi";
@@ -17,13 +17,13 @@ function createFinalFormRte<T = any>(config: IConfig<T> = defaultConfig) {
     const { rteApiOptions, rteOptions } = config;
     const [useRteApi, { createStateFromRawContent }] = makeRteApi(rteApiOptions);
 
-    const RteField: React.FunctionComponent<FieldRenderProps<T, HTMLInputElement> & Pick<RteProps, "options">> = ({
+    const RteField: FunctionComponent<FieldRenderProps<T, HTMLInputElement> & Pick<RteProps, "options">> = ({
         input: { value, onChange, ...restInput },
         meta,
         value: remove,
         ...rest
     }) => {
-        const ref = React.useRef<any>();
+        const ref = useRef<any>();
 
         const onDebouncedContentChange: OnDebouncedContentChangeFn<T> = (debouncedEditorState: EditorState, convertStateToRawContent) => {
             onChange(convertStateToRawContent(debouncedEditorState));
@@ -48,7 +48,7 @@ function createFinalFormRte<T = any>(config: IConfig<T> = defaultConfig) {
         );
     };
 
-    const RteReadOnly: React.FunctionComponent<{ content?: T; plainTextOnly?: boolean }> = ({ content, plainTextOnly }) => {
+    const RteReadOnly: FunctionComponent<{ content?: T; plainTextOnly?: boolean }> = ({ content, plainTextOnly }) => {
         if (!content) {
             return null;
         }

--- a/packages/admin/admin-rte/src/icons/TextFormatSub.tsx
+++ b/packages/admin/admin-rte/src/icons/TextFormatSub.tsx
@@ -1,5 +1,4 @@
 import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
-import * as React from "react";
 
 export default function TextFormatSub({ viewBox, ...props }: SvgIconProps) {
     return (

--- a/packages/admin/admin-rte/src/icons/TextFormatSup.tsx
+++ b/packages/admin/admin-rte/src/icons/TextFormatSup.tsx
@@ -1,5 +1,4 @@
 import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
-import * as React from "react";
 
 export default function TextFormatSup({ viewBox, ...props }: SvgIconProps) {
     return (

--- a/packages/admin/admin-rte/src/useDebounce.ts
+++ b/packages/admin/admin-rte/src/useDebounce.ts
@@ -1,12 +1,12 @@
-import * as React from "react";
+import { useEffect, useState } from "react";
 
 // https://usehooks.com/useDebounce/
 
 export default function useDebounce<T>(value: T, delay: number) {
     // State and setters for debounced value
-    const [debouncedValue, setDebouncedValue] = React.useState(value);
+    const [debouncedValue, setDebouncedValue] = useState(value);
 
-    React.useEffect(() => {
+    useEffect(() => {
         // Update debounced value after delay
         const handler = setTimeout(() => {
             setDebouncedValue(value);

--- a/packages/admin/admin-rte/src/usePrevious.ts
+++ b/packages/admin/admin-rte/src/usePrevious.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useEffect, useRef } from "react";
 
 // https://usehooks.com/usePrevious/
 
@@ -7,10 +7,10 @@ type GenericOrUndefined<T> = T | undefined;
 export default function usePrevious<T>(value: T): GenericOrUndefined<T> {
     // The ref object is a generic container whose current property is mutable ...
     // ... and can hold any value, similar to an instance property on a class
-    const ref = React.useRef<T>();
+    const ref = useRef<T>();
 
     // Store current value in ref
-    React.useEffect(() => {
+    useEffect(() => {
         ref.current = value;
     }, [value]); // Only re-run if value changes
 

--- a/packages/admin/tsconfig.base.json
+++ b/packages/admin/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.core.json",
     "compilerOptions": {
-        "jsx": "react",
+        "jsx": "react-jsx",
         "lib": ["DOM", "ES2015", "ES2016", "ES2017", "ES2018", "ES2019", "ESNext.AsyncIterable"],
         "noImplicitAny": true,
         "sourceMap": true,


### PR DESCRIPTION
Use named imports instead of barrel importing React. Doing so will result in less code and better readability. The new [React docs](https://react.dev/) also use named imports and never import React itself.

To avoid conflicts, we temporarily add the eslint rules in the packages on main. The restrict-import rule will be added in the v8 (next) branch in the eslint-config package, then they will be removed there again.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-1026
