### PR TITLE
`admin-theme`: remove barrel react imports

### DIFF
--- a/packages/admin/admin-theme/.eslintrc.json
+++ b/packages/admin/admin-theme/.eslintrc.json
@@ -2,6 +2,7 @@
     "extends": "@comet/eslint-config/react",
     "ignorePatterns": ["src/*.generated.ts", "lib/**"],
     "rules": {
-        "@comet/no-other-module-relative-import": "off"
+        "@comet/no-other-module-relative-import": "off",
+        "react/react-in-jsx-scope": "off"
     }
 }

--- a/packages/admin/admin-theme/src/componentsTheme/MuiAlert.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiAlert.tsx
@@ -1,5 +1,4 @@
 import { Check, Error, Info, Warning } from "@comet/admin-icons";
-import React from "react";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";

--- a/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
@@ -1,6 +1,5 @@
 import { Clear } from "@comet/admin-icons";
 import { autocompleteClasses } from "@mui/material";
-import * as React from "react";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";

--- a/packages/admin/admin-theme/src/componentsTheme/MuiCheckbox.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiCheckbox.tsx
@@ -1,6 +1,5 @@
 import { CheckboxChecked, CheckboxUnchecked } from "@comet/admin-icons";
 import { checkboxClasses, svgIconClasses } from "@mui/material";
-import * as React from "react";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";

--- a/packages/admin/admin-theme/src/componentsTheme/MuiChip.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiChip.tsx
@@ -1,6 +1,5 @@
 import { Clear } from "@comet/admin-icons";
 import { chipClasses } from "@mui/material";
-import React from "react";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -14,7 +14,6 @@ import {
 } from "@mui/material";
 import { getDataGridUtilityClass, GRID_DEFAULT_LOCALE_TEXT, gridClasses } from "@mui/x-data-grid";
 import type {} from "@mui/x-data-grid/themeAugmentation";
-import React from "react";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";

--- a/packages/admin/admin-theme/src/componentsTheme/MuiRadio.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiRadio.tsx
@@ -1,7 +1,6 @@
 import { RadioChecked, RadioUnchecked } from "@comet/admin-icons";
 import { radioClasses, svgIconClasses } from "@mui/material";
 import { Components } from "@mui/material/styles/components";
-import * as React from "react";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";

--- a/packages/admin/admin-theme/src/componentsTheme/MuiSelect.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSelect.tsx
@@ -1,5 +1,4 @@
 import { InputBase } from "@mui/material";
-import React from "react";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { commonSelectDefaultProps, commonSelectStyleOverrides, getCommonIconStyleOverrides } from "./getCommonSelectTheme";

--- a/packages/admin/tsconfig.base.json
+++ b/packages/admin/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.core.json",
     "compilerOptions": {
-        "jsx": "react",
+        "jsx": "react-jsx",
         "lib": ["DOM", "ES2015", "ES2016", "ES2017", "ES2018", "ES2019", "ESNext.AsyncIterable"],
         "noImplicitAny": true,
         "sourceMap": true,


### PR DESCRIPTION
Use named imports instead of barrel importing React. Doing so will result in less code and better readability. The new [React docs](https://react.dev/) also use named imports and never import React itself.

To avoid conflicts, we temporarily add the eslint rules in the packages on main. The restrict-import rule will be added in the v8 (next) branch in the eslint-config package, then they will be removed there again.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-1026
