### PR TITLE
Allow emptying `targetUrl` in `ExternalLinkBlock`

### DIFF
--- a/.changeset/rude-games-decide.md
+++ b/.changeset/rude-games-decide.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Allow emptying `targetUrl` in `ExternalLinkBlock`

--- a/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
@@ -59,7 +59,7 @@ export const ExternalLinkBlock: BlockInterface<ExternalLinkBlockData, State, Ext
             <SelectPreviewComponent>
                 <BlocksFinalForm
                     onSubmit={(newState) => {
-                        updateState((prevState) => ({ ...prevState, ...newState }));
+                        updateState(newState);
                     }}
                     initialValues={state}
                 >


### PR DESCRIPTION
`targetUrl` is optional but until now it wasn't possible to clear it once it was set

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Previously:


https://github.com/user-attachments/assets/93aeb6ab-a5f1-440f-981c-4b5b26c4afb4

Now:


https://github.com/user-attachments/assets/2c5fd48f-3c29-4800-ab8b-3fcb373f10de



</details>
