### PR TITLE
Allow emptying `targetUrl` in `ExternalLinkBlock` (v5)

### DIFF
--- a/.changeset/rude-games-decide.md
+++ b/.changeset/rude-games-decide.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Allow emptying `targetUrl` in `ExternalLinkBlock`

--- a/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/ExternalLinkBlock.tsx
@@ -59,7 +59,7 @@ export const ExternalLinkBlock: BlockInterface<ExternalLinkBlockData, State, Ext
             <SelectPreviewComponent>
                 <BlocksFinalForm
                     onSubmit={(newState) => {
-                        updateState((prevState) => ({ ...prevState, ...newState }));
+                        updateState(newState);
                     }}
                     initialValues={state}
                 >


### PR DESCRIPTION
Backport of https://github.com/vivid-planet/comet/pull/2474