### PR TITLE
Include rendered `cellContent` in `valueOptions` of column-config directly

### DIFF
--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -18,7 +18,7 @@ import {
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Add as AddIcon, Edit, StateFilled } from "@comet/admin-icons";
+import { Add as AddIcon, Edit, StateFilled as StateFilledIcon } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { Button, IconButton, useTheme } from "@mui/material";
 import { DataGridPro, GridFilterInputSingleSelect, GridFilterInputValue, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
@@ -161,22 +161,49 @@ export function ProductsGrid() {
         },
         {
             field: "inStock",
-            headerName: "In Stock",
+            headerName: intl.formatMessage({ id: "product.inStock", defaultMessage: "In Stock" }),
+            type: "singleSelect",
+            valueOptions: [
+                {
+                    value: "true",
+                    label: intl.formatMessage({ id: "product.inStock.true.primary", defaultMessage: "In stock" }),
+                    cellContent: (
+                        <GridCellContent
+                            primaryText={<FormattedMessage id="product.inStock.true.primary" defaultMessage="In stock" />}
+                            icon={<StateFilledIcon color="success" />}
+                        />
+                    ),
+                },
+                {
+                    value: "false",
+                    label: intl.formatMessage({ id: "product.inStock.false.primary", defaultMessage: "Out of stock" }),
+                    cellContent: (
+                        <GridCellContent
+                            primaryText={<FormattedMessage id="product.inStock.false.primary" defaultMessage="Out of stock" />}
+                            icon={<StateFilledIcon color="error" />}
+                        />
+                    ),
+                },
+            ],
+            renderCell: ({ value, colDef }) => {
+                const valueOptions: GridColDef["valueOptions"] = colDef.valueOptions;
+
+                if (Array.isArray(valueOptions)) {
+                    const renderCellValue = valueOptions?.find((option) => typeof option === "object" && option.value === value.toString());
+
+                    if (typeof renderCellValue === "object") {
+                        if ("cellContent" in renderCellValue) {
+                            return renderCellValue.cellContent;
+                        }
+
+                        return renderCellValue.label;
+                    }
+                }
+
+                return value.toString();
+            },
             flex: 1,
             minWidth: 80,
-            visible: theme.breakpoints.up("md"),
-            renderCell: (params) => (
-                <GridCellContent
-                    icon={<StateFilled color={params.row.inStock ? "success" : "error"} />}
-                    primaryText={
-                        params.row.inStock ? (
-                            <FormattedMessage id="products.inStock" defaultMessage="In Stock" />
-                        ) : (
-                            <FormattedMessage id="products.outOfStock" defaultMessage="Out of Stock" />
-                        )
-                    }
-                />
-            ),
         },
         {
             field: "availableSince",

--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -9,7 +9,29 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
     toolbarActionProp: true,
     rowActionProp: true,
     columns: [
-        { type: "boolean", name: "inStock", headerName: "In stock", width: 90 },
+        {
+            type: "staticSelect",
+            name: "inStock",
+            headerName: "In stock",
+            flex: 1,
+            minWidth: 80,
+            values: [
+                {
+                    value: "true",
+                    label: {
+                        primaryText: "In stock",
+                        icon: { name: "StateFilled", color: "success" },
+                    },
+                },
+                {
+                    value: "false",
+                    label: {
+                        primaryText: "Out of stock",
+                        icon: { name: "StateFilled", color: "error" },
+                    },
+                },
+            ],
+        },
         { type: "text", name: "title", headerName: "Titel", minWidth: 200, maxWidth: 250 },
         { type: "text", name: "description", headerName: "Description" },
         { type: "number", name: "price", headerName: "Price", maxWidth: 150 },

--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -17,7 +17,7 @@ import {
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Add as AddIcon, Edit } from "@comet/admin-icons";
+import { Add as AddIcon, Edit as EditIcon } from "@comet/admin-icons";
 import { Button, IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import * as React from "react";
@@ -198,7 +198,7 @@ export function ManufacturersGrid(): React.ReactElement {
                 return (
                     <>
                         <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
-                            <Edit color="primary" />
+                            <EditIcon color="primary" />
                         </IconButton>
                         <CrudContextMenu
                             copyData={() => {

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -17,7 +17,7 @@ import {
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Add as AddIcon, Edit } from "@comet/admin-icons";
+import { Add as AddIcon, Edit as EditIcon } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { Button, IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
@@ -124,7 +124,7 @@ export function ProductVariantsGrid({ product }: Props): React.ReactElement {
                 return (
                     <>
                         <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
-                            <Edit color="primary" />
+                            <EditIcon color="primary" />
                         </IconButton>
                         <CrudContextMenu
                             copyData={() => {

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -22,7 +22,7 @@ import { DamImageBlock } from "@comet/cms-admin";
 import { DataGridPro, GridRenderCellParams, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import { GQLProductFilter } from "@src/graphql.generated";
 import * as React from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import {
     GQLCreateProductMutation,
@@ -113,13 +113,13 @@ export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React
                 const valueLabels: Record<string, React.ReactNode> = {
                     true: (
                         <GridCellContent
-                            primaryText={intl.formatMessage({ id: "product.inStock.true.primary", defaultMessage: "In stock" })}
+                            primaryText={<FormattedMessage id="product.inStock.true.primary" defaultMessage="In stock" />}
                             icon={<StateFilledIcon color="success" />}
                         />
                     ),
                     false: (
                         <GridCellContent
-                            primaryText={intl.formatMessage({ id: "product.inStock.false.primary", defaultMessage: "Out of stock" })}
+                            primaryText={<FormattedMessage id="product.inStock.false.primary" defaultMessage="Out of stock" />}
                             icon={<StateFilledIcon color="error" />}
                         />
                     ),

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -124,6 +124,15 @@ export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React
                 { value: "Shirt", label: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }) },
                 { value: "Tie", label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }) },
             ],
+            renderCell: ({ row }) => {
+                const valueOptions = [
+                    { value: "Cap", label: intl.formatMessage({ id: "product.type.cap", defaultMessage: "great Cap" }) },
+                    { value: "Shirt", label: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }) },
+                    { value: "Tie", label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }) },
+                ];
+                const selectedOption = valueOptions.find(({ value }) => value === row.type);
+                return selectedOption ? selectedOption.label : row.type;
+            },
             flex: 1,
             maxWidth: 150,
             minWidth: 150,

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -5,6 +5,7 @@ import {
     CrudContextMenu,
     DataGridToolbar,
     filterByFragment,
+    GridCellContent,
     GridColDef,
     GridFilterButton,
     muiGridFilterToGql,
@@ -16,6 +17,7 @@ import {
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
+import { StateFilled as StateFilledIcon } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { DataGridPro, GridRenderCellParams, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import { GQLProductFilter } from "@src/graphql.generated";
@@ -99,7 +101,34 @@ export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };
 
     const columns: GridColDef<GQLProductsGridFutureFragment>[] = [
-        { field: "inStock", headerName: intl.formatMessage({ id: "product.inStock", defaultMessage: "In stock" }), type: "boolean", width: 90 },
+        {
+            field: "inStock",
+            headerName: intl.formatMessage({ id: "product.inStock", defaultMessage: "In Stock" }),
+            type: "singleSelect",
+            valueOptions: [
+                { value: "true", label: intl.formatMessage({ id: "product.inStock.true.primary", defaultMessage: "In stock" }) },
+                { value: "false", label: intl.formatMessage({ id: "product.inStock.false.primary", defaultMessage: "Out of stock" }) },
+            ],
+            renderCell: ({ row }) => {
+                const valueLabels: Record<string, React.ReactNode> = {
+                    true: (
+                        <GridCellContent
+                            primaryText={intl.formatMessage({ id: "product.inStock.true.primary", defaultMessage: "In stock" })}
+                            icon={<StateFilledIcon color="success" />}
+                        />
+                    ),
+                    false: (
+                        <GridCellContent
+                            primaryText={intl.formatMessage({ id: "product.inStock.false.primary", defaultMessage: "Out of stock" })}
+                            icon={<StateFilledIcon color="error" />}
+                        />
+                    ),
+                };
+                return row.inStock.toString() in valueLabels ? valueLabels[row.inStock.toString()] : row.inStock.toString();
+            },
+            flex: 1,
+            minWidth: 80,
+        },
         { field: "title", headerName: intl.formatMessage({ id: "product.title", defaultMessage: "Titel" }), flex: 1, maxWidth: 250, minWidth: 200 },
         {
             field: "description",
@@ -125,13 +154,12 @@ export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React
                 { value: "Tie", label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }) },
             ],
             renderCell: ({ row }) => {
-                const valueOptions = [
-                    { value: "Cap", label: intl.formatMessage({ id: "product.type.cap", defaultMessage: "great Cap" }) },
-                    { value: "Shirt", label: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }) },
-                    { value: "Tie", label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }) },
-                ];
-                const selectedOption = valueOptions.find(({ value }) => value === row.type);
-                return selectedOption ? selectedOption.label : row.type;
+                const valueLabels: Record<string, React.ReactNode> = {
+                    Cap: intl.formatMessage({ id: "product.type.cap", defaultMessage: "great Cap" }),
+                    Shirt: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }),
+                    Tie: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }),
+                };
+                return row.type.toString() in valueLabels ? valueLabels[row.type.toString()] : row.type.toString();
             },
             flex: 1,
             maxWidth: 150,

--- a/packages/admin/admin/src/dataGrid/GridColDef.ts
+++ b/packages/admin/admin/src/dataGrid/GridColDef.ts
@@ -2,9 +2,20 @@ import {
     // eslint-disable-next-line no-restricted-imports
     GridColDef as MuiGridColDef,
     GridValidRowModel,
+    GridValueOptionsParams,
 } from "@mui/x-data-grid";
 
+type ValueOptions =
+    | string
+    | number
+    | {
+          value: any;
+          label: string;
+          cellContent?: React.ReactNode;
+      };
+
 export interface GridColDef<R extends GridValidRowModel = any, V = any, F = V> extends MuiGridColDef<R, V, F> {
+    valueOptions?: Array<ValueOptions> | ((params: GridValueOptionsParams<R>) => Array<ValueOptions>);
     /**
      * Media query to define when the column is visible.
      * Requires DataGridPro or DataGridPremium.

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -90,14 +90,19 @@ const getLabelData = (messageId: string, label: string | StaticSelectLabelCellCo
         };
     }
 
+    const textLabelParts: string[] = [];
     const gridCellContentProps: Record<string, string> = {};
 
     if (label.primaryText) {
-        gridCellContentProps.primaryText = `intl.formatMessage({ id: "${messageId}.primary", defaultMessage: "${label.primaryText}" })`;
+        const primaryMessageId = `${messageId}.primary`;
+        textLabelParts.push(`intl.formatMessage({ id: "${primaryMessageId}", defaultMessage: "${label.primaryText}" })`);
+        gridCellContentProps.primaryText = `<FormattedMessage id="${primaryMessageId}" defaultMessage="${label.primaryText}" />`;
     }
 
     if (label.secondaryText) {
-        gridCellContentProps.secondaryText = `intl.formatMessage({ id: "${messageId}.secondary", defaultMessage: "${label.secondaryText}" })`;
+        const secondaryMessageId = `${messageId}.secondary`;
+        textLabelParts.push(`intl.formatMessage({ id: "${secondaryMessageId}", defaultMessage: "${label.secondaryText}" })`);
+        gridCellContentProps.secondaryText = `<FormattedMessage id="${secondaryMessageId}" defaultMessage="${label.secondaryText}" />`;
     }
 
     if (typeof label.icon === "string") {
@@ -122,7 +127,7 @@ const getLabelData = (messageId: string, label: string | StaticSelectLabelCellCo
     />`;
 
     return {
-        textLabel: [gridCellContentProps.primaryText, gridCellContentProps.secondaryText].filter(Boolean).join(" + ' ' + "),
+        textLabel: textLabelParts.join(" + ' ' + "),
         gridCellContent,
     };
 };

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -7,12 +7,13 @@ import {
     IntrospectionQuery,
 } from "graphql";
 import { plural } from "pluralize";
+import { ReactNode } from "react";
 
 import { findInputObjectType } from "./generateGrid/findInputObjectType";
 import { generateGqlFieldList } from "./generateGrid/generateGqlFieldList";
 import { getForwardedGqlArgs } from "./generateGrid/getForwardedGqlArgs";
 import { getPropsForFilterProp } from "./generateGrid/getPropsForFilterProp";
-import { GeneratorReturn, GridConfig } from "./generator";
+import { GeneratorReturn, GridConfig, StaticSelectLabelCellContent } from "./generator";
 import { camelCaseToHumanReadable } from "./utils/camelCaseToHumanReadable";
 import { findMutationType } from "./utils/findMutationType";
 import { findRootBlocks } from "./utils/findRootBlocks";
@@ -75,6 +76,57 @@ function generateGridPropsCode(props: Prop[]): { gridPropsTypeCode: string; grid
     };
 }
 
+type LabelData = {
+    textLabel: string;
+    gridCellContent: ReactNode;
+};
+
+const getLabelData = (messageId: string, label: string | StaticSelectLabelCellContent): LabelData => {
+    if (typeof label === "string") {
+        const labelText = `intl.formatMessage({ id: "${messageId}", defaultMessage: "${label}" })`;
+        return {
+            textLabel: labelText,
+            gridCellContent: labelText,
+        };
+    }
+
+    const gridCellContentProps: Record<string, string> = {};
+
+    if (label.primaryText) {
+        gridCellContentProps.primaryText = `intl.formatMessage({ id: "${messageId}.primary", defaultMessage: "${label.primaryText}" })`;
+    }
+
+    if (label.secondaryText) {
+        gridCellContentProps.secondaryText = `intl.formatMessage({ id: "${messageId}.secondary", defaultMessage: "${label.secondaryText}" })`;
+    }
+
+    if (typeof label.icon === "string") {
+        gridCellContentProps.icon = `<${label.icon}Icon />`;
+    } else if (typeof label.icon === "object") {
+        if ("import" in label.icon) {
+            gridCellContentProps.icon = `<${label.icon.name} />`;
+        } else {
+            const { name, ...iconProps } = label.icon;
+            gridCellContentProps.icon = `<${name}Icon
+                ${Object.entries(iconProps)
+                    .map(([key, value]) => `${key}="${value}"`)
+                    .join("\n")}
+            />`;
+        }
+    }
+
+    const gridCellContent = `<GridCellContent
+        ${Object.entries(gridCellContentProps)
+            .map(([key, value]) => `${key}={${value}}`)
+            .join("\n")}
+    />`;
+
+    return {
+        textLabel: [gridCellContentProps.primaryText, gridCellContentProps.secondaryText].filter(Boolean).join(" + ' ' + "),
+        gridCellContent,
+    };
+};
+
 export function generateGrid(
     {
         exportName,
@@ -93,6 +145,7 @@ export function generateGrid(
     const gridQuery = config.query ? config.query : instanceGqlType != instanceGqlTypePlural ? instanceGqlTypePlural : `${instanceGqlTypePlural}List`;
     const gqlDocuments: Record<string, string> = {};
     const imports: Imports = [];
+    const iconsToImport: string[] = ["Add", "Edit"];
     const props: Prop[] = [];
 
     const fieldList = generateGqlFieldList({ columns: config.columns.filter((column) => column.name !== "id") }); // exclude id because it's always required
@@ -254,9 +307,35 @@ export function generateGrid(
             const enumType = gqlIntrospection.__schema.types.find(
                 (t) => t.kind === "ENUM" && t.name === (introspectionFieldType as IntrospectionNamedTypeRef).name,
             ) as IntrospectionEnumType | undefined;
-            if (!enumType) throw new Error(`Enum type not found`);
 
-            const values = (column.values ? column.values : enumType.enumValues.map((i) => i.name)).map((value) => {
+            column.values?.forEach((value) => {
+                if (typeof value === "object" && typeof value.label === "object" && "icon" in value.label) {
+                    if (typeof value.label.icon === "string") {
+                        iconsToImport.push(value.label.icon);
+                    } else if (typeof value.label.icon?.name === "string") {
+                        if ("import" in value.label.icon) {
+                            imports.push({
+                                name: value.label.icon.name,
+                                importPath: value.label.icon.import,
+                            });
+                        } else {
+                            iconsToImport.push(value.label.icon.name);
+                        }
+                    }
+                }
+            });
+
+            let columnValues = [];
+
+            if (column.values) {
+                columnValues = column.values;
+            } else if (enumType) {
+                columnValues = enumType.enumValues.map((i) => i.name);
+            } else {
+                throw new Error(`Enum type not found`);
+            }
+
+            const values = columnValues.map((value) => {
                 if (typeof value === "string") {
                     return {
                         value,
@@ -267,18 +346,22 @@ export function generateGrid(
                 }
             });
 
-            const valueOptions = `[${values
-                .map((i) => {
-                    const id = `${instanceGqlType}.${name}.${i.value.charAt(0).toLowerCase() + i.value.slice(1)}`;
-                    const label = `intl.formatMessage({ id: "${id}", defaultMessage: "${i.label}" })`;
-                    return `{value: ${JSON.stringify(i.value)}, label: ${label}}, `;
+            const labelData = values.map(({ value, label }) => ({
+                value,
+                ...getLabelData(`${instanceGqlType}.${name}.${value.charAt(0).toLowerCase() + value.slice(1)}`, label),
+            }));
+
+            const valueOptions = `[${labelData.map(({ value, textLabel }) => `{value: ${JSON.stringify(value)}, label: ${textLabel}}, `).join(" ")}]`;
+
+            const valueLabels = `{${labelData
+                .map(({ value, gridCellContent }) => {
+                    return `${JSON.stringify(value)}: ${gridCellContent},`;
                 })
-                .join(" ")}]`;
+                .join(" ")}}`;
 
             renderCell = `({ row }) => {
-                const valueOptions = ${valueOptions};
-                const selectedOption = valueOptions.find(({ value }) => value === row.${name});
-                return selectedOption ? selectedOption.label : row.${name};
+                const valueLabels: Record<string, React.ReactNode> = ${valueLabels};
+                return row.${name}.toString() in valueLabels ? valueLabels[row.${name}.toString()] : row.${name}.toString();
             }`;
 
             return {
@@ -308,6 +391,13 @@ export function generateGrid(
             maxWidth: column.maxWidth,
             flex: column.flex,
         };
+    });
+
+    iconsToImport.forEach((icon) => {
+        imports.push({
+            name: `${icon} as ${icon}Icon`,
+            importPath: "@comet/admin-icons",
+        });
     });
 
     let createMutationInputFields: readonly IntrospectionInputValue[] = [];
@@ -342,6 +432,7 @@ export function generateGrid(
         filterByFragment,
         GridFilterButton,
         GridColDef,
+        GridCellContent,
         muiGridFilterToGql,
         muiGridSortToGql,
         StackLink,
@@ -352,7 +443,6 @@ export function generateGrid(
         useDataGridRemote,
         usePersistentColumnState,
     } from "@comet/admin";
-    import { Add as AddIcon, Edit } from "@comet/admin-icons";
     import { BlockPreviewContent } from "@comet/blocks-admin";
     import { Alert, Button, Box, IconButton } from "@mui/material";
     import { DataGridPro, GridRenderCellParams, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
@@ -541,7 +631,7 @@ export function generateGrid(
                                             ? `{rowAction && rowAction(params)}`
                                             : `
                                         <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
-                                            <Edit color="primary" />
+                                            <EditIcon color="primary" />
                                         </IconButton>`
                                         : ""
                                 }${

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -275,11 +275,18 @@ export function generateGrid(
                 })
                 .join(" ")}]`;
 
+            renderCell = `({ row }) => {
+                const valueOptions = ${valueOptions};
+                const selectedOption = valueOptions.find(({ value }) => value === row.${name});
+                return selectedOption ? selectedOption.label : row.${name};
+            }`;
+
             return {
                 name,
                 type,
                 gridType: "singleSelect" as const,
                 valueOptions,
+                renderCell,
                 width: column.width,
                 minWidth: column.minWidth,
                 maxWidth: column.maxWidth,

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -1,6 +1,7 @@
 import { GridColDef } from "@comet/admin";
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 import { loadSchema } from "@graphql-tools/load";
+import { IconProps } from "@mui/material";
 import { glob } from "glob";
 import { introspectionFromSchema } from "graphql";
 import { basename, dirname } from "path";
@@ -57,13 +58,25 @@ export type TabsConfig = { type: "tabs"; tabs: { name: string; content: Generato
 
 type DataGridSettings = Pick<GridColDef, "headerName" | "width" | "minWidth" | "maxWidth" | "flex">;
 
+type IconKey = string; // TODO: Use `IconName` type from `@comet/admin-icons` after merged: https://github.com/vivid-planet/comet/pull/2421
+
+type IconObject = Pick<IconProps, "color" | "fontSize"> & {
+    name: IconKey;
+};
+
+export type StaticSelectLabelCellContent = {
+    primaryText?: string;
+    secondaryText?: string;
+    icon?: IconKey | IconObject | ImportReference;
+};
+
 export type GridColumnConfig<T> = (
     | { type: "text" }
     | { type: "number" }
     | { type: "boolean" }
     | { type: "date" }
     | { type: "dateTime" }
-    | { type: "staticSelect"; values?: Array<{ value: string; label: string } | string> }
+    | { type: "staticSelect"; values?: Array<{ value: string; label: string | StaticSelectLabelCellContent } | string> }
     | { type: "block"; block: ImportReference }
 ) & { name: UsableFields<T> } & DataGridSettings;
 export type GridConfig<T extends { __typename?: string }> = {


### PR DESCRIPTION
Suggestion for this discussion: https://github.com/vivid-planet/comet/pull/2422#discussion_r1732247785

> I'm not really a fan of this approach, as it requires changing the type of valueOptions to support an additional renderCell/cellContent key and also requires a bunch of additional type-checks.
> 
> That's not something I would ever write by myself, so I don't think that something like this should be generated either.