### PR TITLE
`admin-babel-preset`: upgrade jsx transform

### DIFF
--- a/packages/admin/admin-babel-preset/index.js
+++ b/packages/admin/admin-babel-preset/index.js
@@ -1,6 +1,8 @@
 module.exports = function () {
     return {
-        presets: ["@babel/preset-env", "@babel/react", "@babel/preset-typescript"],
+        presets: ["@babel/preset-env", "@babel/preset-typescript", ["@babel/preset-react", {
+            "runtime": "automatic"
+        }]],
         plugins: [
             [
                 "@emotion",


### PR DESCRIPTION
Due to test pipeline and compile/transform errors in #2438 (https://github.com/vivid-planet/comet/actions/runs/10573989168/job/29294566816?pr=2438) we need to upgrade the JSX transform.

https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

https://stackoverflow.com/questions/58980934/referenceerror-react-is-not-defined-in-jest-tests

