### PR TITLE
Admin Generator (Future): Improve/fix generated filter-var if ui-filter not enabled

### DIFF
--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -151,8 +151,10 @@ export function generateGrid(
     imports.push(...forwardedGqlArgsImports);
     props.push(...forwardedGqlArgsProps);
 
+    const toolbar = config.toolbar ?? true;
+
     const filterArg = gridQueryType.args.find((arg) => arg.name === "filter");
-    const hasFilter = !!filterArg;
+    const hasFilter = !!filterArg && toolbar;
     let hasFilterProp = false;
     let filterFields: string[] = [];
     if (filterArg) {
@@ -169,8 +171,6 @@ export function generateGrid(
         imports.push(...filterPropImports);
         props.push(...filterPropProps);
     }
-
-    const toolbar = config.toolbar ?? true;
 
     const forwardToolbarAction = allowAdding && toolbar && config.toolbarActionProp;
     if (forwardToolbarAction) {
@@ -398,7 +398,7 @@ export function generateGrid(
         ...[`$offset: Int!`, `$limit: Int!`],
         ...(hasSort ? [`$sort: [${gqlType}Sort!]`] : []),
         ...(hasSearch ? [`$search: String`] : []),
-        ...(hasFilter ? [`$filter: ${gqlType}Filter`] : []),
+        ...(filterArg && (hasFilter || hasFilterProp) ? [`$filter: ${gqlType}Filter`] : []),
         ...(hasScope ? [`$scope: ${gqlType}ContentScopeInput!`] : []),
     ].join(", ")}) {
     ${gridQuery}(${[
@@ -406,7 +406,7 @@ export function generateGrid(
         ...[`offset: $offset`, `limit: $limit`],
         ...(hasSort ? [`sort: $sort`] : []),
         ...(hasSearch ? [`search: $search`] : []),
-        ...(hasFilter ? [`filter: $filter`] : []),
+        ...(filterArg && (hasFilter || hasFilterProp) ? [`filter: $filter`] : []),
         ...(hasScope ? [`scope: $scope`] : []),
     ].join(", ")}) {
                 nodes {
@@ -641,7 +641,15 @@ export function generateGrid(
                 ${[
                     ...gqlArgs.filter((gqlArg) => gqlArg.queryOrMutationName === gridQueryType.name).map((arg) => arg.name),
                     ...(hasScope ? ["scope"] : []),
-                    ...(hasFilter ? (hasFilterProp ? ["filter: filter ? { and: [gqlFilter, filter] } : gqlFilter"] : ["filter: gqlFilter"]) : []),
+                    ...(filterArg
+                        ? hasFilter && hasFilterProp
+                            ? ["filter: filter ? { and: [gqlFilter, filter] } : gqlFilter"]
+                            : hasFilter
+                            ? ["filter: gqlFilter"]
+                            : hasFilterProp
+                            ? ["filter"]
+                            : []
+                        : []),
                     ...(hasSearch ? ["search: gqlSearch"] : []),
                     ...[
                         `offset: dataGridProps.page * dataGridProps.pageSize`,


### PR DESCRIPTION
## Requirement
Grid-config without toolbar (= no ui-filter) but with filterProp=true generates code still using ui-filter value.

## Solution
Check for toolbar=false, differentiate between hasFilter and hasFilterProp for generated query and generated variables assignment.

**example config**
```
export const ProductsGrid: GridConfig<GQLProduct> = {
    ...
    toolbar: false,
    filterProp: true,
    ...
}
```
generated code changed from 
```
const { data, loading, error } = useQuery<GQL...Query, GQL...QueryVariables>(productsQuery, {
    variables: {
        filter: filter ? { and: [gqlFilter, filter] } : gqlFilter,
        ...
    },
});
```
to
```
const { data, loading, error } = useQuery<GQL...Query, GQL...QueryVariables>(productsQuery, {
    variables: {
        filter,
        ...
    },
});
```