### PR TITLE
Add eslint rule to restrict barrel react imports

### DIFF
--- a/demo/site-pages/.eslintrc.json
+++ b/demo/site-pages/.eslintrc.json
@@ -3,6 +3,17 @@
     "ignorePatterns": ["**/**/*.generated.ts", "dist/**"],
     "rules": {
         "@calm/react-intl/missing-formatted-message": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/demo/site/.eslintrc.json
+++ b/demo/site/.eslintrc.json
@@ -3,6 +3,17 @@
     "ignorePatterns": ["**/**/*.generated.ts", "dist/**"],
     "rules": {
         "@calm/react-intl/missing-formatted-message": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/packages/admin/admin-color-picker/.eslintrc.json
+++ b/packages/admin/admin-color-picker/.eslintrc.json
@@ -3,6 +3,17 @@
     "ignorePatterns": ["src/*.generated.ts", "lib/**"],
     "rules": {
         "@comet/no-other-module-relative-import": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/packages/admin/admin-date-time/.eslintrc.json
+++ b/packages/admin/admin-date-time/.eslintrc.json
@@ -3,6 +3,17 @@
     "ignorePatterns": ["src/*.generated.ts", "lib/**"],
     "rules": {
         "@comet/no-other-module-relative-import": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/packages/admin/admin-icons/.eslintrc.json
+++ b/packages/admin/admin-icons/.eslintrc.json
@@ -3,6 +3,17 @@
     "ignorePatterns": ["src/*.generated.ts", "src/generated/", "lib/**"],
     "rules": {
         "@comet/no-other-module-relative-import": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/packages/admin/admin-react-select/.eslintrc.json
+++ b/packages/admin/admin-react-select/.eslintrc.json
@@ -3,6 +3,17 @@
     "ignorePatterns": ["src/*.generated.ts", "lib/**"],
     "rules": {
         "@comet/no-other-module-relative-import": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/packages/admin/admin-rte/.eslintrc.json
+++ b/packages/admin/admin-rte/.eslintrc.json
@@ -5,6 +5,17 @@
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@comet/no-other-module-relative-import": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/packages/admin/admin-theme/.eslintrc.json
+++ b/packages/admin/admin-theme/.eslintrc.json
@@ -3,6 +3,17 @@
     "ignorePatterns": ["src/*.generated.ts", "lib/**"],
     "rules": {
         "@comet/no-other-module-relative-import": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/packages/admin/blocks-admin/.eslintrc.json
+++ b/packages/admin/blocks-admin/.eslintrc.json
@@ -3,6 +3,17 @@
     "ignorePatterns": ["src/*.generated.ts", "lib/**"],
     "rules": {
         "@comet/no-other-module-relative-import": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/packages/site/cms-site/.eslintrc.json
+++ b/packages/site/cms-site/.eslintrc.json
@@ -4,6 +4,17 @@
     "rules": {
         "@next/next/no-html-link-for-pages": "off", // disabled because lib has no pages dir
         "@comet/no-other-module-relative-import": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["default"]
+                    }
+                ]
+            }
+        ]
     }
 }


### PR DESCRIPTION
Use named imports instead of barrel importing React. Doing so will result in less code and better readability. The new [React docs](https://react.dev/) also use named imports and never import React itself.

To avoid conflicts, we temporarily add the eslint rules in the packages on main where it is possible. The restrict-import rule will be added in the v8 (next) branch in the eslint-config package, then they will be removed there again.

We can not add it on main for the `demo/admin` and the `admin/cms-admin` package because of the generator. The generated files can not be modified without a breaking change and will be done in next/v8.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-1026

