### PR TITLE
`BuildsService`: Start all jobs that match the scope exactly

### DIFF
--- a/.changeset/tiny-books-bathe.md
+++ b/.changeset/tiny-books-bathe.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+`BuildsService`: Start all jobs that match the scope exactly
+
+Previously, the first job that matched the scope exactly would be started, and the rest would be ignored. This has been fixed so that all jobs that match the scope exactly are started.

--- a/packages/api/cms-api/src/builds/builds.service.spec.ts
+++ b/packages/api/cms-api/src/builds/builds.service.spec.ts
@@ -27,6 +27,15 @@ const jobMainEnglish = {
     },
 };
 
+const jobMainEnglish2 = {
+    metadata: {
+        name: "main-en-2",
+        annotations: {
+            [CONTENT_SCOPE_ANNOTATION]: '{"domain":"main","language":"en"}',
+        },
+    },
+};
+
 const jobMainGerman = {
     metadata: {
         name: "main-de",
@@ -60,6 +69,11 @@ describe("BuildsService", () => {
     describe("getBuilderCronJobsToStart", () => {
         it("should return single job for exact match", async () => {
             await expect(service.getBuilderCronJobsToStart([{ domain: "main", language: "en" }])).resolves.toEqual([jobMainEnglish]);
+        });
+
+        it("should return two jobs if two jobs have the exact same scope", async () => {
+            mockedBuildTemplatesService.getAllBuilderCronJobs.mockResolvedValueOnce([jobMainEnglish, jobMainEnglish2]);
+            await expect(service.getBuilderCronJobsToStart([{ domain: "main", language: "en" }])).resolves.toEqual([jobMainEnglish, jobMainEnglish2]);
         });
 
         it("should return multiple jobs for multiple exact matches", async () => {


### PR DESCRIPTION
Previously, the first job that matched the scope exactly would be started, and the rest would be ignored. This has been fixed so that all jobs that match the scope exactly are started.

This bug occurred in one of our client's projects where we have two frontends: the site and a newsletter frontend. Both use the same scope:

<img width="479" alt="Bildschirmfoto 2024-08-29 um 14 16 11" src="https://github.com/user-attachments/assets/2c27fd64-6897-4e20-bd77-6df5aaad89a8">

If a change was detected, only the newsletter frontend was built but the site wasn't. This lead to cases where it took 24h until changes were visible on the site (because everything is rebuilt every 24h).

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
