### PR TITLE
Admin Generator (Future): Fix the default width of "actions" columns

### DIFF
--- a/demo/admin/src/products/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/ManufacturersGrid.tsx
@@ -127,6 +127,8 @@ export function ManufacturersGrid() {
             headerName: "",
             sortable: false,
             filterable: false,
+            pinned: "right",
+            width: 84,
             renderCell: (params) => {
                 return (
                     <>

--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -195,6 +195,7 @@ export function ManufacturersGrid(): React.ReactElement {
             type: "actions",
             align: "right",
             pinned: "right",
+            width: 84,
             renderCell: (params) => {
                 return (
                     <>

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -121,6 +121,7 @@ export function ProductVariantsGrid({ product }: Props): React.ReactElement {
             type: "actions",
             align: "right",
             pinned: "right",
+            width: 84,
             renderCell: (params) => {
                 return (
                     <>

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -235,6 +235,7 @@ export function generateGrid(
         type: actionsColumnType,
         headerName: actionsColumnHeaderName,
         pinned: actionsColumnPinned = "right",
+        width: actionsColumnWidth = 84,
         ...restActionsColumnConfig
     } = actionsColumnConfig ?? {};
 
@@ -547,6 +548,7 @@ export function generateGrid(
                               type: '"actions"',
                               align: '"right"',
                               pinned: `"${actionsColumnPinned}"`,
+                              width: actionsColumnWidth,
                               ...restActionsColumnConfig,
                               renderCell: `(params) => {
                             return (


### PR DESCRIPTION
When there are exactly two icon buttons inside the actions cell, which is the default for generated grids, it should be 84px wide. If more actions are added, the width needs to be adjusted manually anyway, see the existing (future generator) `ProductsGrid`.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists:  COM-1031
-   [x] Provide screenshots/screencasts if the change contains visual changes


### Manufacturers Grid

| Previously | Now |
| --- | --- |
| <img width="827" alt="Manufacturers Grid Previously" src="https://github.com/user-attachments/assets/25a38138-2b93-4e0a-adc8-1001a8ef5c2c"> | <img width="827" alt="Manufacturers Grid Now" src="https://github.com/user-attachments/assets/063a2977-54e9-4904-b740-694ee5ec9b7e"> |

### Product Grid _(no change)_

<img width="827" alt="Product Grid" src="https://github.com/user-attachments/assets/2d3a1a13-1b71-4d4a-96e7-6288a889ead5">
