### PR TITLE
Set FileUploadField width in admin generator

### DIFF
--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -278,11 +278,13 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                             <FileUploadField
                                 name="priceList"
                                 label={<FormattedMessage id="product.priceList" defaultMessage="Price List" />}
+                                variant="horizontal"
                                 maxFileSize={4194304}
                             />
                             <FileUploadField
                                 name="datasheets"
                                 label={<FormattedMessage id="product.datasheets" defaultMessage="Datasheets" />}
+                                variant="horizontal"
                                 multiple
                                 maxFileSize={4194304}
                             />

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -197,6 +197,7 @@ export function generateFormField({
     } else if (config.type === "fileUpload") {
         const multiple = config.multiple || (typeof config.maxFiles === "number" && config.maxFiles > 1);
         code = `<FileUploadField name="${name}" label={${fieldLabel}}
+            variant="horizontal"
             ${config.multiple ? "multiple" : ""}
             ${config.maxFiles ? `maxFiles={${config.maxFiles}}` : ""}
             ${config.maxFileSize ? `maxFileSize={${config.maxFileSize}}` : ""}


### PR DESCRIPTION
---
The field variant is now set to `variant="horizontal"`, it was unset before. The field width now matches the other generated fields.

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [ ] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: Extension to SVK-321
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>

<img width="1868" alt="Screenshot 2024-09-02 at 10 30 43" src="https://github.com/user-attachments/assets/d3b15f74-00e8-4f6e-aae4-63c2aed3404e">

</details>
