### PR TITLE
Allow overriding the block context in `BlocksTransformerService#transformToPlain` (v5)

### DIFF
--- a/.changeset/flat-laws-decide.md
+++ b/.changeset/flat-laws-decide.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Allow overriding the block context in `BlocksTransformerService#transformToPlain`

--- a/packages/api/cms-api/src/blocks/blocks-transformer.service.ts
+++ b/packages/api/cms-api/src/blocks/blocks-transformer.service.ts
@@ -42,7 +42,7 @@ export class BlocksTransformerService {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async transformToPlain(block: BlockDataInterface): Promise<any> {
-        return transformToPlain(block, this.dependencies, this.blockContext);
+    async transformToPlain(block: BlockDataInterface, context?: BlockContext): Promise<any> {
+        return transformToPlain(block, this.dependencies, context ?? this.blockContext);
     }
 }


### PR DESCRIPTION
Backport of https://github.com/vivid-planet/comet/pull/1766

Required for bugfix https://github.com/vivid-planet/comet-brevo-module/pull/82