### PR TITLE
Admin Generator (Future): Add initialValuesProp setting to form-field

### DIFF
--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -16,6 +16,7 @@ export const ProductForm: FormConfig<GQLProduct> = {
                 {
                     type: "text",
                     name: "title",
+                    initialValueProp: true,
                     label: "Titel", // default is generated from name (camelCaseToHumanReadable)
                     required: true, // default is inferred from gql schema
                     validate: { name: "validateTitle", import: "./validateTitle" },
@@ -23,7 +24,14 @@ export const ProductForm: FormConfig<GQLProduct> = {
                 { type: "text", name: "slug" },
                 { type: "date", name: "createdAt", label: "Created", readOnly: true },
                 { type: "text", name: "description", label: "Description", multiline: true },
-                { type: "staticSelect", name: "type", label: "Type", required: true, values: [{ value: "Cap", label: "great Cap" }, "Shirt", "Tie"] },
+                {
+                    type: "staticSelect",
+                    initialValueProp: true,
+                    name: "type",
+                    label: "Type",
+                    required: true,
+                    values: [{ value: "Cap", label: "great Cap" }, "Shirt", "Tie"],
+                },
                 { type: "asyncSelect", name: "category", rootQuery: "productCategories" },
             ],
         },

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -29,6 +29,7 @@ import {
     useFormSaveConflict,
 } from "@comet/cms-admin";
 import { FormControlLabel, InputAdornment, MenuItem } from "@mui/material";
+import { GQLProductType } from "@src/graphql.generated";
 import { FormApi } from "final-form";
 import isEqual from "lodash.isequal";
 import React from "react";
@@ -63,9 +64,11 @@ type FormValues = ProductFormDetailsFragment & {
 
 interface FormProps {
     id?: string;
+    title?: string;
+    type?: GQLProductType;
 }
 
-export function ProductForm({ id }: FormProps): React.ReactElement {
+export function ProductForm({ id, title, type }: FormProps): React.ReactElement {
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
     const formApiRef = useFormApiRef<FormValues>();
@@ -86,10 +89,12 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                       image: rootBlocks.image.input2State(data.product.image),
                   }
                 : {
+                      title: title,
+                      type: type,
                       inStock: false,
                       image: rootBlocks.image.defaultValues(),
                   },
-        [data],
+        [data, title, type],
     );
 
     const saveConflict = useFormSaveConflict({

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -73,8 +73,6 @@ export function generateForm(
         }
     }
 
-    const { formPropsTypeCode, formPropsParamsCode } = generateFormPropsCode(props);
-
     const rootBlockFields = formFields
         .filter((field) => field.type == "block")
         .map((field) => {
@@ -106,10 +104,13 @@ export function generateForm(
         gqlDocuments[name] = generatedFields.gqlDocuments[name];
     }
     imports.push(...generatedFields.imports);
+    props.push(...generatedFields.props);
     hooksCode += generatedFields.hooksCode;
     formValueToGqlInputCode += generatedFields.formValueToGqlInputCode;
     formFragmentFields.push(...generatedFields.formFragmentFields);
     formValuesConfig.push(...generatedFields.formValuesConfig);
+
+    const { formPropsTypeCode, formPropsParamsCode } = generateFormPropsCode(props);
 
     const fragmentName = config.fragmentName ?? `${gqlType}Form`;
     gqlDocuments[`${instanceGqlType}FormFragment`] = `

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -313,7 +313,12 @@ export function generateForm(
                 .map((config) => config.defaultInitializationCode)
                 .join(",\n")}
         }
-    , [data]);`
+    , [${[
+        "data",
+        ...formValuesConfig
+            .filter((formValueConfig) => !!formValueConfig.initializationVarDependency)
+            .map((formValueConfig) => formValueConfig.initializationVarDependency),
+    ].join(", ")}]);`
                 : `const initialValues = {
                 ${formValuesConfig
                     .filter((config) => !!config.defaultInitializationCode)

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -18,6 +18,7 @@ export type GenerateFieldsReturn = GeneratorReturn & {
         typeCode?: string;
         initializationCode?: string;
         defaultInitializationCode?: string;
+        initializationVarDependency?: string;
     }[];
 };
 

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -1,5 +1,6 @@
 import { IntrospectionQuery } from "graphql";
 
+import { Prop } from "../generateForm";
 import { FormConfig, GeneratorReturn, isFormFieldConfig, isFormLayoutConfig } from "../generator";
 import { Imports } from "../utils/generateImportsCode";
 import { generateFormField } from "./generateFormField";
@@ -10,6 +11,7 @@ export type GenerateFieldsReturn = GeneratorReturn & {
     hooksCode: string;
     formFragmentFields: string[];
     formValueToGqlInputCode: string;
+    props: Prop[];
     formValuesConfig: {
         omitFromFragmentType?: string;
         destructFromFormValues?: string; // equals omitting from formValues copied directly to mutation-input
@@ -37,6 +39,7 @@ export function generateFields({
     let formValueToGqlInputCode = "";
     const formFragmentFields: string[] = [];
     const imports: Imports = [];
+    const props: Prop[] = [];
     const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
 
     const code = fields
@@ -54,6 +57,7 @@ export function generateFields({
                 gqlDocuments[name] = generated.gqlDocuments[name];
             }
             imports.push(...generated.imports);
+            props.push(...generated.props);
             hooksCode += generated.hooksCode;
             formValueToGqlInputCode += generated.formValueToGqlInputCode;
             formFragmentFields.push(...generated.formFragmentFields);
@@ -64,6 +68,7 @@ export function generateFields({
 
     return {
         code,
+        props,
         hooksCode,
         formValueToGqlInputCode,
         formFragmentFields,

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -1,5 +1,6 @@
 import { IntrospectionEnumType, IntrospectionNamedTypeRef, IntrospectionObjectType, IntrospectionQuery } from "graphql";
 
+import { Prop } from "../generateForm";
 import { FormConfig, FormFieldConfig } from "../generator";
 import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
 import { Imports } from "../utils/generateImportsCode";
@@ -43,6 +44,8 @@ export function generateFormField({
     const readOnlyPropsWithLock = `${readOnlyProps} ${endAdornmentWithLockIconProp}`;
 
     const imports: Imports = [];
+    const props: Prop[] = [];
+
     const defaultFormValuesConfig: GenerateFieldsReturn["formValuesConfig"][0] = {
         destructFromFormValues: config.virtual ? name : undefined,
     };
@@ -321,6 +324,7 @@ export function generateFormField({
     }
     return {
         code,
+        props,
         hooksCode,
         formValueToGqlInputCode,
         formFragmentFields: [formFragmentField],

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
@@ -1,5 +1,6 @@
 import { IntrospectionQuery } from "graphql";
 
+import { Prop } from "../generateForm";
 import { FormConfig, FormLayoutConfig } from "../generator";
 import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
 import { Imports } from "../utils/generateImportsCode";
@@ -27,6 +28,7 @@ export function generateFormLayout({
     const formFragmentFields: string[] = [];
     const gqlDocuments: Record<string, string> = {};
     const imports: Imports = [];
+    const props: Prop[] = [];
     const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
 
     if (config.type === "fieldSet") {
@@ -40,6 +42,7 @@ export function generateFormLayout({
             gqlDocuments[name] = generatedFields.gqlDocuments[name];
         }
         imports.push(...generatedFields.imports);
+        props.push(...generatedFields.props);
         formValuesConfig.push(...generatedFields.formValuesConfig);
 
         imports.push({ name: "FieldSet", importPath: "@comet/admin" });
@@ -73,6 +76,7 @@ export function generateFormLayout({
     }
     return {
         code,
+        props,
         hooksCode,
         formValueToGqlInputCode,
         formFragmentFields,

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -37,7 +37,16 @@ export type FormFieldConfig<T> = (
     | { type: "block"; block: ImportReference }
     | SingleFileFormFieldConfig
     | MultiFileFormFieldConfig
-) & { name: keyof T; label?: string; required?: boolean; virtual?: boolean; validate?: ImportReference; helperText?: string; readOnly?: boolean };
+) & {
+    name: keyof T;
+    label?: string;
+    initialValueProp?: boolean;
+    required?: boolean;
+    virtual?: boolean;
+    validate?: ImportReference;
+    helperText?: string;
+    readOnly?: boolean;
+};
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export function isFormFieldConfig<T>(arg: any): arg is FormFieldConfig<T> {
     return !isFormLayoutConfig(arg);


### PR DESCRIPTION
## Requirement
Generate a form able to pre-fill fields with runtime values, e.g. firstname/lastname filled in some previous step/form.

## Solution
Add form-field setting to add prop in generated form to provide a default-value used in create-mode.

```
export const ProductForm: FormConfig<GQLProduct> = {
    type: "form",
    ...
    fields: [
        {
            ...
            initialValueProp: true,
        },
    ]
}
```

## Open issues
- [ ] handling nesting introduced with #2352 if merged earlier
- [ ] dependent on generateFormField.ts able to define props (currently also used in 2 other pull-requests, #2465 and #2404)
- [ ] dependent on adding var to useMemo-dependency (currently also used in [another pull-request](https://github.com/vivid-planet/comet/pull/2465/commits/54e998cba51ec739dac4aece3138caab0d5b7a07))