### PR TITLE
Update required validator in Field to correctly handle falsey values

### DIFF
--- a/.changeset/quiet-bats-mate.md
+++ b/.changeset/quiet-bats-mate.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": patch
+---
+
+Update required validator in `Field` to correctly handle falsey values
+
+Previously, the validator incorrectly returned errors for all falsey values, e.g. the number `0`.
+Now, it only returns an error for `undefined`, `null` and empty strings.

--- a/.changeset/quiet-bats-mate.md
+++ b/.changeset/quiet-bats-mate.md
@@ -5,4 +5,4 @@
 Update required validator in `Field` to correctly handle falsey values
 
 Previously, the validator incorrectly returned errors for all falsey values, e.g. the number `0`.
-Now, it only returns an error for `undefined`, `null` and empty strings.
+Now, it only returns an error for `undefined`, `null`, `false` and empty strings.

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -7,7 +7,7 @@ import { FieldContainer, FieldContainerProps } from "./FieldContainer";
 import { useFinalFormContext } from "./FinalFormContextProvider";
 
 const requiredValidator = (value: any) => {
-    if (value === undefined || value === null || value === "") {
+    if (value === undefined || value === null || value === false || value === "") {
         return <FormattedMessage id="comet.form.required" defaultMessage="Required" />;
     }
     return undefined;

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -6,7 +6,12 @@ import { FormattedMessage } from "react-intl";
 import { FieldContainer, FieldContainerProps } from "./FieldContainer";
 import { useFinalFormContext } from "./FinalFormContextProvider";
 
-const requiredValidator = (value: any) => (value ? undefined : <FormattedMessage id="comet.form.required" defaultMessage="Required" />);
+const requiredValidator = (value: any) => {
+    if (value === undefined || value === null || value === "") {
+        return <FormattedMessage id="comet.form.required" defaultMessage="Required" />;
+    }
+    return undefined;
+};
 
 const composeValidators =
     (...validators: Array<(value: any, allValues: object) => any>) =>


### PR DESCRIPTION
Previously, the validator incorrectly returned errors for all falsey values, e.g. the number `0`.
Now, it only returns an error for `undefined`, `null`, `false` and empty strings.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Previously:

<img width="1493" alt="Bildschirmfoto 2024-09-02 um 22 11 15" src="https://github.com/user-attachments/assets/91599301-242f-4346-adc8-2d3f8e2485d6">


Now:

<img width="1486" alt="Bildschirmfoto 2024-09-02 um 22 11 29" src="https://github.com/user-attachments/assets/eb11df45-1576-4690-a6d4-43a23a999023">


</details>
