### PR TITLE
Fix validation for `NumberField` and `FinalFormNumberInput`

### DIFF
--- a/.changeset/selfish-humans-repair.md
+++ b/.changeset/selfish-humans-repair.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix validation for `NumberField` and `FinalFormNumberInput` by calling the `onBlur` event, passed in by the `Field`

--- a/packages/admin/admin/src/form/FinalFormNumberInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormNumberInput.tsx
@@ -43,6 +43,7 @@ export function FinalFormNumberInput({ meta, input, innerRef, clearable, endAdor
     );
 
     const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+        input.onBlur(event);
         const { value } = event.target;
         const numberParts = intl.formatNumberToParts(1111.111);
         const decimalSymbol = numberParts.find(({ type }) => type === "decimal")?.value;


### PR DESCRIPTION
By calling the `onBlur` event, passed in by the `Field`.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)