### PR TITLE
Admin Generator (Future): Delete generated files prior to generating

### DIFF
--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -1,6 +1,7 @@
 import { GridColDef } from "@comet/admin";
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 import { loadSchema } from "@graphql-tools/load";
+import { promises as fs } from "fs";
 import { glob } from "glob";
 import { introspectionFromSchema } from "graphql";
 import { basename, dirname } from "path";
@@ -104,7 +105,13 @@ export type GeneratorConfig = FormConfig<any> | GridConfig<any> | TabsConfig;
 
 export type GeneratorReturn = { code: string; gqlDocuments: Record<string, string> };
 
-export async function runFutureGenerate(filePattern = "src/**/*.cometGen.ts") {
+export async function runFutureGenerate({
+    filePattern = "src/**/*.cometGen.ts",
+    deleteGeneratedFilesPreGeneration = false,
+}: {
+    filePattern?: string;
+    deleteGeneratedFilesPreGeneration?: boolean;
+}) {
     const schema = await loadSchema("./schema.gql", {
         loaders: [new GraphQLFileLoader()],
     });
@@ -118,6 +125,11 @@ export async function runFutureGenerate(filePattern = "src/**/*.cometGen.ts") {
         const baseOutputFilename = basename(file).replace(/\.cometGen\.ts$/, "");
         const configs = await import(`${process.cwd()}/${file.replace(/\.ts$/, "")}`);
         //const configs = await import(`${process.cwd()}/${file}`);
+
+        const codeOuputFilename = `${targetDirectory}/${basename(file.replace(/\.cometGen\.ts$/, ""))}.tsx`;
+        if (deleteGeneratedFilesPreGeneration) await fs.rm(codeOuputFilename).catch((e) => false);;
+        // eslint-disable-next-line no-console
+        console.log(`generating ${file}`);
 
         for (const exportName in configs) {
             const config = configs[exportName] as GeneratorConfig;
@@ -135,13 +147,11 @@ export async function runFutureGenerate(filePattern = "src/**/*.cometGen.ts") {
             }
         }
 
-        {
-            const codeOuputFilename = `${targetDirectory}/${basename(file.replace(/\.cometGen\.ts$/, ""))}.tsx`;
-            await writeGenerated(codeOuputFilename, outputCode);
-        }
+        await writeGenerated(codeOuputFilename, outputCode);
 
         if (gqlDocumentsOutputCode != "") {
             const gqlDocumentsOuputFilename = `${targetDirectory}/${basename(file.replace(/\.cometGen\.ts$/, ""))}.gql.tsx`;
+            if (deleteGeneratedFilesPreGeneration) await fs.rm(gqlDocumentsOuputFilename).catch((e) => false);
             gqlDocumentsOutputCode = `import { gql } from "@apollo/client";
                 import { finalFormFileUploadFragment } from "@comet/cms-admin";
 

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -105,13 +105,7 @@ export type GeneratorConfig = FormConfig<any> | GridConfig<any> | TabsConfig;
 
 export type GeneratorReturn = { code: string; gqlDocuments: Record<string, string> };
 
-export async function runFutureGenerate({
-    filePattern = "src/**/*.cometGen.ts",
-    deleteGeneratedFilesPreGeneration = false,
-}: {
-    filePattern?: string;
-    deleteGeneratedFilesPreGeneration?: boolean;
-}) {
+export async function runFutureGenerate(filePattern = "src/**/*.cometGen.ts") {
     const schema = await loadSchema("./schema.gql", {
         loaders: [new GraphQLFileLoader()],
     });
@@ -127,7 +121,7 @@ export async function runFutureGenerate({
         //const configs = await import(`${process.cwd()}/${file}`);
 
         const codeOuputFilename = `${targetDirectory}/${basename(file.replace(/\.cometGen\.ts$/, ""))}.tsx`;
-        if (deleteGeneratedFilesPreGeneration) await fs.rm(codeOuputFilename).catch((e) => false);;
+        await fs.rm(codeOuputFilename).catch((e) => false);
         // eslint-disable-next-line no-console
         console.log(`generating ${file}`);
 
@@ -151,7 +145,7 @@ export async function runFutureGenerate({
 
         if (gqlDocumentsOutputCode != "") {
             const gqlDocumentsOuputFilename = `${targetDirectory}/${basename(file.replace(/\.cometGen\.ts$/, ""))}.gql.tsx`;
-            if (deleteGeneratedFilesPreGeneration) await fs.rm(gqlDocumentsOuputFilename).catch((e) => false);
+            await fs.rm(gqlDocumentsOuputFilename).catch((e) => false);
             gqlDocumentsOutputCode = `import { gql } from "@apollo/client";
                 import { finalFormFileUploadFragment } from "@comet/cms-admin";
 

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -121,7 +121,7 @@ export async function runFutureGenerate(filePattern = "src/**/*.cometGen.ts") {
         //const configs = await import(`${process.cwd()}/${file}`);
 
         const codeOuputFilename = `${targetDirectory}/${basename(file.replace(/\.cometGen\.ts$/, ""))}.tsx`;
-        await fs.rm(codeOuputFilename).catch((e) => false);
+        await fs.rm(codeOuputFilename, { force: true });
         // eslint-disable-next-line no-console
         console.log(`generating ${file}`);
 
@@ -145,7 +145,7 @@ export async function runFutureGenerate(filePattern = "src/**/*.cometGen.ts") {
 
         if (gqlDocumentsOutputCode != "") {
             const gqlDocumentsOuputFilename = `${targetDirectory}/${basename(file.replace(/\.cometGen\.ts$/, ""))}.gql.tsx`;
-            await fs.rm(gqlDocumentsOuputFilename).catch((e) => false);
+            await fs.rm(gqlDocumentsOuputFilename, { force: true });
             gqlDocumentsOutputCode = `import { gql } from "@apollo/client";
                 import { finalFormFileUploadFragment } from "@comet/cms-admin";
 

--- a/packages/admin/cms-admin/src/generator/generate.ts
+++ b/packages/admin/cms-admin/src/generator/generate.ts
@@ -33,8 +33,9 @@ program.addCommand(
 program.addCommand(
     new Command("future-generate")
         .option("-f, --file <file>", "path to config file or glob pattern to generate specific files")
-        .action(async ({ file: filePattern }: { file?: string }) => {
-            await runFutureGenerate(filePattern);
+        .option("-d, --delete", "delete ")
+        .action(async ({ file: filePattern, delete: deleteGeneratedFilesPreGeneration }: { file?: string; delete?: boolean }) => {
+            await runFutureGenerate({ filePattern, deleteGeneratedFilesPreGeneration });
         }),
 );
 

--- a/packages/admin/cms-admin/src/generator/generate.ts
+++ b/packages/admin/cms-admin/src/generator/generate.ts
@@ -33,9 +33,8 @@ program.addCommand(
 program.addCommand(
     new Command("future-generate")
         .option("-f, --file <file>", "path to config file or glob pattern to generate specific files")
-        .option("-d, --delete", "delete ")
-        .action(async ({ file: filePattern, delete: deleteGeneratedFilesPreGeneration }: { file?: string; delete?: boolean }) => {
-            await runFutureGenerate({ filePattern, deleteGeneratedFilesPreGeneration });
+        .action(async ({ file: filePattern }: { file?: string }) => {
+            await runFutureGenerate(filePattern);
         }),
 );
 


### PR DESCRIPTION
## Requirement
Fix/improve regenerate a single config-file for easier development. Previously there where (lint-)issues if the generated file already existed.

## Solution
Remove the generated file before writing.

## Open issues
 - [x] ~~If changed config wouldn't create the same files, previously created wont be deleted~~ We can neglect this