### PR TITLE
Admin Generator (Future): Support fields for gql-root-props

### DIFF
--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -103,6 +103,7 @@ export function generateForm(
         baseOutputFilename,
         fields: config.fields,
         formConfig: config,
+        createMutationType: createMutationType || undefined,
     });
     for (const name in generatedFields.gqlDocuments) {
         gqlDocuments[name] = generatedFields.gqlDocuments[name];

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -52,21 +52,6 @@ export function generateForm(
         return acc;
     }, []);
 
-    if (createMutationType) {
-        const {
-            imports: forwardedGqlArgsImports,
-            props: forwardedGqlArgsProps,
-            gqlArgs: forwardedGqlArgs,
-        } = getForwardedGqlArgs({
-            fields: formFields,
-            gqlOperation: createMutationType,
-            gqlIntrospection,
-        });
-        imports.push(...forwardedGqlArgsImports);
-        props.push(...forwardedGqlArgsProps);
-        gqlArgs.push(...forwardedGqlArgs);
-    }
-
     if (editMode) {
         if (mode === "all") {
             props.push({ name: "id", optional: true, type: "string" });
@@ -114,6 +99,21 @@ export function generateForm(
     formValueToGqlInputCode += generatedFields.formValueToGqlInputCode;
     formFragmentFields.push(...generatedFields.formFragmentFields);
     formValuesConfig.push(...generatedFields.formValuesConfig);
+
+    if (createMutationType) {
+        const {
+            imports: forwardedGqlArgsImports,
+            props: forwardedGqlArgsProps,
+            gqlArgs: forwardedGqlArgs,
+        } = getForwardedGqlArgs({
+            gqlOperation: createMutationType,
+            gqlIntrospection,
+            skipGqlArgs: gqlArgs,
+        });
+        imports.push(...forwardedGqlArgsImports);
+        props.push(...forwardedGqlArgsProps);
+        gqlArgs.push(...forwardedGqlArgs);
+    }
 
     const fragmentName = config.fragmentName ?? `${gqlType}Form`;
     gqlDocuments[`${instanceGqlType}FormFragment`] = `

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -1,4 +1,4 @@
-import { IntrospectionQuery } from "graphql";
+import { IntrospectionField, IntrospectionQuery } from "graphql";
 
 import { GqlArg } from "../generateForm";
 import { FormConfig, GeneratorReturn, isFormFieldConfig, isFormLayoutConfig } from "../generator";
@@ -26,6 +26,7 @@ export function generateFields({
     baseOutputFilename,
     fields,
     formConfig,
+    createMutationType,
 }: {
     gqlIntrospection: IntrospectionQuery;
     baseOutputFilename: string;
@@ -33,6 +34,7 @@ export function generateFields({
     fields: FormConfig<any>["fields"];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     formConfig: FormConfig<any>;
+    createMutationType?: IntrospectionField;
 }): GenerateFieldsReturn {
     const gqlDocuments: Record<string, string> = {};
     let hooksCode = "";
@@ -46,9 +48,9 @@ export function generateFields({
         .map((field) => {
             let generated: GenerateFieldsReturn;
             if (isFormFieldConfig(field)) {
-                generated = generateFormField({ gqlIntrospection, baseOutputFilename, config: field, formConfig });
+                generated = generateFormField({ gqlIntrospection, baseOutputFilename, config: field, formConfig, createMutationType });
             } else if (isFormLayoutConfig(field)) {
-                generated = generateFormLayout({ gqlIntrospection, baseOutputFilename, config: field, formConfig });
+                generated = generateFormLayout({ gqlIntrospection, baseOutputFilename, config: field, formConfig, createMutationType });
             } else {
                 throw new Error("Not supported config");
             }

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFields.ts
@@ -1,5 +1,6 @@
 import { IntrospectionQuery } from "graphql";
 
+import { GqlArg } from "../generateForm";
 import { FormConfig, GeneratorReturn, isFormFieldConfig, isFormLayoutConfig } from "../generator";
 import { Imports } from "../utils/generateImportsCode";
 import { generateFormField } from "./generateFormField";
@@ -10,6 +11,7 @@ export type GenerateFieldsReturn = GeneratorReturn & {
     hooksCode: string;
     formFragmentFields: string[];
     formValueToGqlInputCode: string;
+    gqlArgs: GqlArg[];
     formValuesConfig: {
         omitFromFragmentType?: string;
         destructFromFormValues?: string; // equals omitting from formValues copied directly to mutation-input
@@ -37,6 +39,7 @@ export function generateFields({
     let formValueToGqlInputCode = "";
     const formFragmentFields: string[] = [];
     const imports: Imports = [];
+    const gqlArgs: GqlArg[] = [];
     const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
 
     const code = fields
@@ -54,6 +57,7 @@ export function generateFields({
                 gqlDocuments[name] = generated.gqlDocuments[name];
             }
             imports.push(...generated.imports);
+            gqlArgs.push(...generated.gqlArgs);
             hooksCode += generated.hooksCode;
             formValueToGqlInputCode += generated.formValueToGqlInputCode;
             formFragmentFields.push(...generated.formFragmentFields);
@@ -64,6 +68,7 @@ export function generateFields({
 
     return {
         code,
+        gqlArgs,
         hooksCode,
         formValueToGqlInputCode,
         formFragmentFields,

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -1,4 +1,4 @@
-import { IntrospectionEnumType, IntrospectionNamedTypeRef, IntrospectionObjectType, IntrospectionQuery } from "graphql";
+import { IntrospectionEnumType, IntrospectionField, IntrospectionNamedTypeRef, IntrospectionObjectType, IntrospectionQuery } from "graphql";
 
 import { GqlArg } from "../generateForm";
 import { FormConfig, FormFieldConfig } from "../generator";
@@ -12,6 +12,7 @@ export function generateFormField({
     baseOutputFilename,
     config,
     formConfig,
+    createMutationType,
 }: {
     gqlIntrospection: IntrospectionQuery;
     baseOutputFilename: string;
@@ -19,6 +20,7 @@ export function generateFormField({
     config: FormFieldConfig<any>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     formConfig: FormConfig<any>;
+    createMutationType?: IntrospectionField;
 }): GenerateFieldsReturn {
     const gqlArgs: GqlArg[] = [];
 

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -30,6 +30,13 @@ export function generateFormField({
     const name = String(config.name);
     const label = config.label ?? camelCaseToHumanReadable(name);
 
+    gqlArgs.push({
+        name,
+        type: "unknown", // doesn't matter because currently only input-fields supported
+        isInputArgSubfield: true,
+        isInOutputVar: true,
+    });
+
     const introspectionObject = gqlIntrospection.__schema.types.find((type) => type.kind === "OBJECT" && type.name === gqlType) as
         | IntrospectionObjectType
         | undefined;

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -75,13 +75,15 @@ export function generateFormField({
 
               return {
                   isFieldForRootProp: !isInputArgSubfield,
+                  isReadOnlyOnEdit: !isInputArgSubfield, // we assume root-args are not changeable, alternatively check update-mutation
               };
           })()
         : undefined;
 
-    const endAdornmentWithLockIconProp = `endAdornment={<InputAdornment position="end"><Lock /></InputAdornment>}`;
-    const readOnlyProps = `readOnly disabled`;
-    const readOnlyPropsWithLock = `${readOnlyProps} ${endAdornmentWithLockIconProp}`;
+    type RenderProp = { name: string; value?: string };
+    const endAdornmentWithLockIconProp: RenderProp = { name: "endAdornment", value: `<InputAdornment position="end"><Lock /></InputAdornment>` };
+    const readOnlyProps: RenderProp[] = [{ name: "readOnly" }, { name: "disabled" }];
+    const readOnlyPropsWithLock: RenderProp[] = [...readOnlyProps, endAdornmentWithLockIconProp];
 
     const imports: Imports = [];
     const defaultFormValuesConfig: GenerateFieldsReturn["formValuesConfig"][0] = {
@@ -116,7 +118,17 @@ export function generateFormField({
         code = `
         <${TextInputComponent}
             ${required ? "required" : ""}
-            ${config.readOnly ? readOnlyPropsWithLock : ""}
+            ${
+                config.readOnly
+                    ? readOnlyPropsWithLock.map((prop) => (prop.value ? `${prop.name}={${prop.value}}` : prop.name)).join(" ")
+                    : gqlArgConfig?.isReadOnlyOnEdit
+                    ? readOnlyPropsWithLock
+                          .map((prop) =>
+                              prop.value ? `${prop.name}={mode === "edit" ? ${prop.value} : undefined}` : `${prop.name}={mode === "edit"}`,
+                          )
+                          .join(" ")
+                    : ""
+            }
             variant="horizontal"
             fullWidth
             name="${name}"
@@ -132,7 +144,17 @@ export function generateFormField({
         code = `
             <Field
                 ${required ? "required" : ""}
-                ${config.readOnly ? readOnlyPropsWithLock : ""}
+                ${
+                    config.readOnly
+                        ? readOnlyPropsWithLock.map((prop) => (prop.value ? `${prop.name}={${prop.value}}` : prop.name)).join(" ")
+                        : gqlArgConfig?.isReadOnlyOnEdit
+                        ? readOnlyPropsWithLock
+                              .map((prop) =>
+                                  prop.value ? `${prop.name}={mode === "edit" ? ${prop.value} : undefined}` : `${prop.name}={mode === "edit"}`,
+                              )
+                              .join(" ")
+                        : ""
+                }
                 variant="horizontal"
                 fullWidth
                 name="${name}"
@@ -174,7 +196,17 @@ export function generateFormField({
             {(props) => (
                 <FormControlLabel
                     label={${fieldLabel}}
-                    control={<FinalFormCheckbox ${config.readOnly ? readOnlyProps : ""} {...props} />}
+                    control={<FinalFormCheckbox ${
+                        config.readOnly
+                            ? readOnlyProps.map((prop) => (prop.value ? `${prop.name}={${prop.value}}` : prop.name)).join(" ")
+                            : gqlArgConfig?.isReadOnlyOnEdit
+                            ? readOnlyProps
+                                  .map((prop) =>
+                                      prop.value ? `${prop.name}={mode === "edit" ? ${prop.value} : undefined}` : `${prop.name}={mode === "edit"}`,
+                                  )
+                                  .join(" ")
+                            : ""
+                    } {...props} />}
                     ${
                         config.helperText
                             ? `helperText={<FormattedMessage id=` +
@@ -197,7 +229,17 @@ export function generateFormField({
         code = `
             <Field
                 ${required ? "required" : ""}
-                ${config.readOnly ? readOnlyPropsWithLock : ""}
+                ${
+                    config.readOnly
+                        ? readOnlyPropsWithLock.map((prop) => (prop.value ? `${prop.name}={${prop.value}}` : prop.name)).join(" ")
+                        : gqlArgConfig?.isReadOnlyOnEdit
+                        ? readOnlyPropsWithLock
+                              .map((prop) =>
+                                  prop.value ? `${prop.name}={mode === "edit" ? ${prop.value} : undefined}` : `${prop.name}={mode === "edit"}`,
+                              )
+                              .join(" ")
+                        : ""
+                }
                 variant="horizontal"
                 fullWidth
                 name="${name}"
@@ -280,7 +322,17 @@ export function generateFormField({
             }
             ${validateCode}
             {(props) =>
-                <FinalFormSelect ${config.readOnly ? readOnlyPropsWithLock : ""} {...props}>
+                <FinalFormSelect ${
+                    config.readOnly
+                        ? readOnlyPropsWithLock.map((prop) => (prop.value ? `${prop.name}={${prop.value}}` : prop.name)).join(" ")
+                        : gqlArgConfig?.isReadOnlyOnEdit
+                        ? readOnlyPropsWithLock
+                              .map((prop) =>
+                                  prop.value ? `${prop.name}={mode === "edit" ? ${prop.value} : undefined}` : `${prop.name}={mode === "edit"}`,
+                              )
+                              .join(" ")
+                        : ""
+                } {...props}>
                 ${values
                     .map((value) => {
                         const id = `${instanceGqlType}.${name}.${value.value.charAt(0).toLowerCase() + value.value.slice(1)}`;
@@ -346,6 +398,17 @@ export function generateFormField({
                 ${required ? "required" : ""}
                 variant="horizontal"
                 fullWidth
+                ${
+                    config.readOnly
+                        ? readOnlyProps.map((prop) => (prop.value ? `${prop.name}={${prop.value}}` : prop.name)).join(" ")
+                        : gqlArgConfig?.isReadOnlyOnEdit
+                        ? readOnlyProps
+                              .map((prop) =>
+                                  prop.value ? `${prop.name}={mode === "edit" ? ${prop.value} : undefined}` : `${prop.name}={mode === "edit"}`,
+                              )
+                              .join(" ")
+                        : ""
+                }
                 name="${name}"
                 label={${fieldLabel}}
                 loadOptions={async () => {

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -1,5 +1,6 @@
 import { IntrospectionEnumType, IntrospectionNamedTypeRef, IntrospectionObjectType, IntrospectionQuery } from "graphql";
 
+import { GqlArg } from "../generateForm";
 import { FormConfig, FormFieldConfig } from "../generator";
 import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
 import { Imports } from "../utils/generateImportsCode";
@@ -19,6 +20,8 @@ export function generateFormField({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     formConfig: FormConfig<any>;
 }): GenerateFieldsReturn {
+    const gqlArgs: GqlArg[] = [];
+
     const gqlType = formConfig.gqlType;
     const instanceGqlType = gqlType[0].toLowerCase() + gqlType.substring(1);
 
@@ -322,6 +325,7 @@ export function generateFormField({
     }
     return {
         code,
+        gqlArgs,
         hooksCode,
         formValueToGqlInputCode,
         formFragmentFields: [formFragmentField],

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
@@ -1,4 +1,4 @@
-import { IntrospectionQuery } from "graphql";
+import { IntrospectionField, IntrospectionQuery } from "graphql";
 
 import { GqlArg } from "../generateForm";
 import { FormConfig, FormLayoutConfig } from "../generator";
@@ -11,6 +11,7 @@ export function generateFormLayout({
     baseOutputFilename,
     config,
     formConfig,
+    createMutationType,
 }: {
     gqlIntrospection: IntrospectionQuery;
     baseOutputFilename: string;
@@ -18,6 +19,7 @@ export function generateFormLayout({
     config: FormLayoutConfig<any>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     formConfig: FormConfig<any>;
+    createMutationType?: IntrospectionField;
 }): GenerateFieldsReturn {
     const gqlType = formConfig.gqlType;
     const instanceGqlType = gqlType[0].toLowerCase() + gqlType.substring(1);
@@ -34,7 +36,7 @@ export function generateFormLayout({
     if (config.type === "fieldSet") {
         const title = config.title ?? camelCaseToHumanReadable(config.name);
 
-        const generatedFields = generateFields({ gqlIntrospection, baseOutputFilename, fields: config.fields, formConfig });
+        const generatedFields = generateFields({ gqlIntrospection, baseOutputFilename, fields: config.fields, formConfig, createMutationType });
         hooksCode += generatedFields.hooksCode;
         formValueToGqlInputCode += generatedFields.formValueToGqlInputCode;
         formFragmentFields.push(...generatedFields.formFragmentFields);

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
@@ -1,5 +1,6 @@
 import { IntrospectionQuery } from "graphql";
 
+import { GqlArg } from "../generateForm";
 import { FormConfig, FormLayoutConfig } from "../generator";
 import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
 import { Imports } from "../utils/generateImportsCode";
@@ -27,6 +28,7 @@ export function generateFormLayout({
     const formFragmentFields: string[] = [];
     const gqlDocuments: Record<string, string> = {};
     const imports: Imports = [];
+    const gqlArgs: GqlArg[] = [];
     const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [];
 
     if (config.type === "fieldSet") {
@@ -40,6 +42,7 @@ export function generateFormLayout({
             gqlDocuments[name] = generatedFields.gqlDocuments[name];
         }
         imports.push(...generatedFields.imports);
+        gqlArgs.push(...generatedFields.gqlArgs);
         formValuesConfig.push(...generatedFields.formValuesConfig);
 
         imports.push({ name: "FieldSet", importPath: "@comet/admin" });
@@ -73,6 +76,7 @@ export function generateFormLayout({
     }
     return {
         code,
+        gqlArgs,
         hooksCode,
         formValueToGqlInputCode,
         formFragmentFields,

--- a/packages/admin/cms-admin/src/generator/future/generateForm/getForwardedGqlArgs.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/getForwardedGqlArgs.ts
@@ -1,18 +1,16 @@
 import { IntrospectionField, IntrospectionInputValue, IntrospectionQuery } from "graphql";
 
 import { GqlArg, Prop } from "../generateForm";
-import { FormFieldConfig } from "../generator";
 import { Imports } from "../utils/generateImportsCode";
 
 export function getForwardedGqlArgs({
-    fields,
     gqlOperation,
     gqlIntrospection,
+    skipGqlArgs,
 }: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fields: FormFieldConfig<any>[];
     gqlOperation: IntrospectionField;
     gqlIntrospection: IntrospectionQuery;
+    skipGqlArgs: GqlArg[];
 }): {
     imports: Imports;
     props: Prop[];
@@ -22,10 +20,14 @@ export function getForwardedGqlArgs({
     const props: Prop[] = [];
     const gqlArgs: GqlArg[] = [];
 
-    const skipGqlInputArgFields = fields.map((field) => String(field.name));
-
     getArgsIncludingInputArgSubfields(gqlOperation, gqlIntrospection).forEach((arg) => {
-        if (arg.isInputArgSubfield && skipGqlInputArgFields.includes(arg.name)) return;
+        if (
+            skipGqlArgs.find(
+                (skipGqlArg) => skipGqlArg.name == arg.name && skipGqlArg.type == arg.type && skipGqlArg.isInputArgSubfield == arg.isInputArgSubfield,
+            )
+        ) {
+            return;
+        }
 
         if (arg.type === "ID" || arg.type === "String" || arg.type === "DateTime") {
             props.push({ name: arg.name, optional: false, type: "string" });

--- a/packages/admin/cms-admin/src/generator/future/generateForm/getForwardedGqlArgs.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/getForwardedGqlArgs.ts
@@ -1,10 +1,8 @@
 import { IntrospectionField, IntrospectionInputValue, IntrospectionQuery } from "graphql";
 
-import { Prop } from "../generateForm";
+import { GqlArg, Prop } from "../generateForm";
 import { FormFieldConfig } from "../generator";
 import { Imports } from "../utils/generateImportsCode";
-
-type GqlArg = { type: string; name: string; isInputArgSubfield: boolean };
 
 export function getForwardedGqlArgs({
     fields,


### PR DESCRIPTION
## Requirement
Generating a form providing form-fields for root-args (=dedicatedResolverArgs)

### Example
Form for [createProductVariant(product: ID!, input: ProductVariantInput!): ProductVariant!](https://github.com/vivid-planet/comet/blob/main/demo/api/schema.gql#L1206) could contain product-asyncSelect.

## Solution
Check create-mutation root-args and input-arg for entries with form-field-name to detect if form-field belongs to a root-arg. FormValue submitted via root-arg need to be destructed from formValues to be excluded from input-object, and added explicitly for mutation-variables. Typically root-args are only provided for create-mutation and can not be changed/updated, so those form-fields should be readonly for editing.

changes:
1. extend generateFormField, adding option to provide GqlArg's (required for forwardGqlArgs-Feature to correctly detect what to skip and to generate a correct create-mutation)
2. implement root-arg detection
3. implement "readOnly on edit" for form-fields submitted as root-arg