### PR TITLE
Use `ref.current` directly in `useObservedWidth`

### DIFF
--- a/.changeset/lovely-bananas-tan.md
+++ b/.changeset/lovely-bananas-tan.md
@@ -1,0 +1,10 @@
+---
+"@comet/admin": patch
+---
+
+Fix `FieldContainer` layout on first render
+
+Previously, `FieldContainer` displayed vertically on desktop instead of horizontally due to the container width not being available during the first render (because `ref.current` was null).
+The layout corrected itself after interacting with the field, triggering a rerender.
+
+Now, the rerender is triggered automatically when `ref.current` is set resulting in the correct layout from the start.

--- a/packages/admin/admin/src/utils/useObservedWidth.tsx
+++ b/packages/admin/admin/src/utils/useObservedWidth.tsx
@@ -3,26 +3,27 @@ import { RefObject, useEffect, useMemo, useState } from "react";
 
 export const useObservedWidth = (ref: RefObject<HTMLElement>): number => {
     const [containerWidth, setContainerWidth] = useState(ref.current?.clientWidth ?? 0);
-    const element = ref.current;
 
     const elementObserver = useMemo(() => {
         return new ResizeObserver(() => {
             debounce(() => {
-                if (!element) return;
-                setContainerWidth(element.clientWidth);
+                if (!ref.current) return;
+                setContainerWidth(ref.current.clientWidth);
             }, 500)();
         });
-    }, [element]);
+    }, [ref]);
 
     useEffect(() => {
-        if (!element) return;
+        if (!ref.current) return;
+        const element = ref.current;
+
         elementObserver.observe(element);
         setContainerWidth(element.clientWidth);
 
         return () => {
             elementObserver.unobserve(element);
         };
-    }, [element, elementObserver]);
+    }, [elementObserver, ref]);
 
     return containerWidth;
 };


### PR DESCRIPTION
Fix `FieldContainer` layout on first render

Previously, `FieldContainer` displayed vertically on desktop instead of horizontally due to the container width not being available during the first render (because `ref.current` was null).
The layout corrected itself after interacting with the field, triggering a rerender.

Now, the rerender is triggered automatically when `ref.current` is set resulting in the correct layout from the start.


---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Previously:

https://github.com/user-attachments/assets/d0c7c8a5-621c-4f7a-8c00-18c39b216918


Now:


https://github.com/user-attachments/assets/51c14bc4-e97b-440c-a6b8-e9e6cc95e9d7



</details>
