### PR TITLE
FinalFormSelect: Fix value `0` and `false` not being clearable

### DIFF
--- a/.changeset/six-vans-hang.md
+++ b/.changeset/six-vans-hang.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin": minor
+"@comet/admin": patch
 ---
 
 FinalFormSelect: Fix value `0` and `false` not being clearable

--- a/.changeset/six-vans-hang.md
+++ b/.changeset/six-vans-hang.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-Fix bug that made the number 0 unclearable when used inside a `SelectField`
+FinalFormSelect: Fix value `0` and `false` not being clearable

--- a/.changeset/six-vans-hang.md
+++ b/.changeset/six-vans-hang.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Fix bug that made the number 0 unclearable when used inside a `SelectField`

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -47,7 +47,7 @@ export const FinalFormSelect = <T,>({
     const endAdornment = !required ? (
         <ClearInputAdornment
             position="end"
-            hasClearableContent={Boolean(multiple ? (Array.isArray(value) ? value.length : value) : value === 0 ? `${value}` : value)}
+            hasClearableContent={Boolean(multiple ? (Array.isArray(value) ? value.length : value !== undefined) : value !== undefined)}
             onClick={() => onChange(multiple ? [] : undefined)}
         />
     ) : null;

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -47,7 +47,7 @@ export const FinalFormSelect = <T,>({
     const endAdornment = !required ? (
         <ClearInputAdornment
             position="end"
-            hasClearableContent={Boolean(multiple ? (Array.isArray(value) ? value.length : value) : value)}
+            hasClearableContent={Boolean(multiple ? (Array.isArray(value) ? value.length : value) : value === 0 ? `${value}` : value)}
             onClick={() => onChange(multiple ? [] : undefined)}
         />
     ) : null;


### PR DESCRIPTION
Fix bug that made the number 0 unclearable when used as a value inside a SelectField

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-1040
-   [x] Provide screenshots/screencasts if the change contains visual changes
