### PR TITLE
Fix the top position of the rich text editor toolbar

### DIFF
--- a/.changeset/sour-houses-play.md
+++ b/.changeset/sour-houses-play.md
@@ -2,6 +2,6 @@
 "@comet/blocks-admin": patch
 ---
 
-Fix the top position of the rich-text toolbar
+Fix the top position of the rich text editor toolbar
 
-Previously, the rich-text toolbar would be moved too far down when used inside `AdminComponentRoot`, but not as a direct child.
+Previously, the rich text editor's toolbar would be moved too far down when used inside `AdminComponentRoot`, but not as a direct child.

--- a/.changeset/sour-houses-play.md
+++ b/.changeset/sour-houses-play.md
@@ -1,0 +1,7 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Fix the top position of the rich-text toolbar
+
+Previously, the rich-text toolbar would be moved too far down when used inside `AdminComponentRoot`, but not as a direct child.

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
@@ -31,7 +31,6 @@ const AdminComponentRoot = (props: PropsWithChildren<Props>) => {
 export { AdminComponentRoot };
 
 const ChildrenContainer = styled("div")`
-    // TODO: Find another way to access this element, other than the className
     > .CometAdminRte-root > .CometAdminRteToolbar-root {
         top: 70px;
     }

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
@@ -32,7 +32,7 @@ export { AdminComponentRoot };
 
 const ChildrenContainer = styled("div")`
     // TODO: Find another way to access this element, other than the className
-    .CometAdminRteToolbar-root {
+    > .CometAdminRte-root > .CometAdminRteToolbar-root {
         top: 70px;
     }
 `;


### PR DESCRIPTION
When used inside `AdminComponentRoot` but not as a direct child, the top position should not take the height of the breadcrumbs into account, as this will move the toolbar too far down.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-1075
-   [x] Provide screenshots/screencasts if the change contains visual changes

| Previously | Now |
| --- | --- |
| <img width="659" alt="RichText Previously" src="https://github.com/user-attachments/assets/cbe8fb5f-16b0-413e-8f98-aeee86b947e0"> | <img width="659" alt="RichText Now" src="https://github.com/user-attachments/assets/2dad137a-f662-47fa-8f31-f6a9c79e849d"> |