### PR TITLE
Fix optional `PageTreeReadApi` in `BlocksTransformerMiddlewareFactory` (v5)

### DIFF
--- a/.changeset/fresh-dolls-exist.md
+++ b/.changeset/fresh-dolls-exist.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix optional `PageTreeReadApi` in `BlocksTransformerMiddlewareFactory`

--- a/packages/api/cms-api/src/blocks/blocks-transformer-middleware.factory.ts
+++ b/packages/api/cms-api/src/blocks/blocks-transformer-middleware.factory.ts
@@ -17,9 +17,11 @@ export class BlocksTransformerMiddlewareFactory {
                     fieldValue,
                     {
                         ...dependencies,
-                        pageTreeReadApi: (dependencies.pageTreeService as PageTreeService).createReadApi({
-                            visibility: [PageTreeNodeVisibility.Published, ...(includeInvisiblePages || [])],
-                        }),
+                        pageTreeReadApi: dependencies.pageTreeService
+                            ? (dependencies.pageTreeService as PageTreeService).createReadApi({
+                                  visibility: [PageTreeNodeVisibility.Published, ...(includeInvisiblePages || [])],
+                              })
+                            : undefined,
                     },
                     { includeInvisibleContent: includeInvisibleBlocks, previewDamUrls },
                 );


### PR DESCRIPTION
Backport of #2530 into v5.