### PR TITLE
[RFC] Add specific `ApiConfigProvider`

### DIFF
--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -6,6 +6,7 @@ import "@src/polyfills";
 import { ApolloProvider } from "@apollo/client";
 import { ErrorDialogHandler, MasterLayout, MuiThemeProvider, RouterBrowserRouter, SnackbarProvider } from "@comet/admin";
 import {
+    ApiConfigProvider,
     CmsBlockContextProvider,
     ContentScopeInterface,
     createDamFileDependency,
@@ -62,102 +63,104 @@ class App extends Component {
     public render(): JSX.Element {
         return (
             <ConfigProvider config={config}>
-                <ApolloProvider client={apolloClient}>
-                    <SitesConfigProvider
-                        value={{
-                            configs: config.sitesConfig,
-                            resolveSiteConfigForScope: (configs, scope: ContentScope) => configs[scope.domain],
-                        }}
-                    >
-                        <DamConfigProvider
+                <ApiConfigProvider config={{ url: config.apiUrl }}>
+                    <ApolloProvider client={apolloClient}>
+                        <SitesConfigProvider
                             value={{
-                                scopeParts: ["domain"],
-                                additionalToolbarItems: <ImportFromUnsplash />,
-                                importSources: {
-                                    unsplash: {
-                                        label: <FormattedMessage id="dam.importSource.unsplash.label" defaultMessage="Unsplash" />,
-                                    },
-                                },
-                                contentGeneration: {
-                                    generateAltText: true,
-                                    generateImageTitle: true,
-                                },
+                                configs: config.sitesConfig,
+                                resolveSiteConfigForScope: (configs, scope: ContentScope) => configs[scope.domain],
                             }}
                         >
-                            <DependenciesConfigProvider
-                                entityDependencyMap={{
-                                    Page,
-                                    Link,
-                                    News: NewsDependency,
-                                    DamFile: createDamFileDependency(),
+                            <DamConfigProvider
+                                value={{
+                                    scopeParts: ["domain"],
+                                    additionalToolbarItems: <ImportFromUnsplash />,
+                                    importSources: {
+                                        unsplash: {
+                                            label: <FormattedMessage id="dam.importSource.unsplash.label" defaultMessage="Unsplash" />,
+                                        },
+                                    },
+                                    contentGeneration: {
+                                        generateAltText: true,
+                                        generateImageTitle: true,
+                                    },
                                 }}
                             >
-                                <IntlProvider locale="en" messages={getMessages()}>
-                                    <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.domain}>
-                                        <MuiThemeProvider theme={theme}>
-                                            <ErrorDialogHandler />
-                                            <CurrentUserProvider>
-                                                <RouterBrowserRouter>
-                                                    <DndProvider options={HTML5toTouch}>
-                                                        <SnackbarProvider>
-                                                            <CmsBlockContextProvider
-                                                                damConfig={{
-                                                                    apiUrl: config.apiUrl,
-                                                                    apiClient,
-                                                                    maxFileSize: config.dam.uploadsMaxFileSize,
-                                                                    maxSrcResolution: config.imgproxy.maxSrcResolution,
-                                                                    allowedImageAspectRatios: config.dam.allowedImageAspectRatios,
-                                                                }}
-                                                                pageTreeCategories={pageTreeCategories}
-                                                                pageTreeDocumentTypes={pageTreeDocumentTypes}
-                                                                additionalPageTreeNodeFragment={additionalPageTreeNodeFieldsFragment}
-                                                            >
-                                                                <Fragment>
-                                                                    <GlobalStyle />
-                                                                    <ContentScopeProvider>
-                                                                        {({ match }) => (
-                                                                            <Switch>
-                                                                                {/* @TODO: add preview to contentScope once site is capable of contentScope */}
-                                                                                <Route
-                                                                                    path={`${match.path}/preview`}
-                                                                                    render={(props) => (
-                                                                                        <SitePreview
-                                                                                            resolvePath={(
-                                                                                                path: string,
-                                                                                                scope: ContentScopeInterface,
-                                                                                            ) => {
-                                                                                                return `/${scope.language}${path}`;
-                                                                                            }}
-                                                                                            {...props}
-                                                                                        />
-                                                                                    )}
-                                                                                />
-                                                                                <Route
-                                                                                    render={() => (
-                                                                                        <MasterLayout
-                                                                                            headerComponent={MasterHeader}
-                                                                                            menuComponent={MasterMenu}
-                                                                                        >
-                                                                                            <MasterMenuRoutes menu={masterMenuData} />
-                                                                                        </MasterLayout>
-                                                                                    )}
-                                                                                />
-                                                                            </Switch>
-                                                                        )}
-                                                                    </ContentScopeProvider>
-                                                                </Fragment>
-                                                            </CmsBlockContextProvider>
-                                                        </SnackbarProvider>
-                                                    </DndProvider>
-                                                </RouterBrowserRouter>
-                                            </CurrentUserProvider>
-                                        </MuiThemeProvider>
-                                    </LocaleProvider>
-                                </IntlProvider>
-                            </DependenciesConfigProvider>
-                        </DamConfigProvider>
-                    </SitesConfigProvider>
-                </ApolloProvider>
+                                <DependenciesConfigProvider
+                                    entityDependencyMap={{
+                                        Page,
+                                        Link,
+                                        News: NewsDependency,
+                                        DamFile: createDamFileDependency(),
+                                    }}
+                                >
+                                    <IntlProvider locale="en" messages={getMessages()}>
+                                        <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.domain}>
+                                            <MuiThemeProvider theme={theme}>
+                                                <ErrorDialogHandler />
+                                                <CurrentUserProvider>
+                                                    <RouterBrowserRouter>
+                                                        <DndProvider options={HTML5toTouch}>
+                                                            <SnackbarProvider>
+                                                                <CmsBlockContextProvider
+                                                                    damConfig={{
+                                                                        apiUrl: config.apiUrl,
+                                                                        apiClient,
+                                                                        maxFileSize: config.dam.uploadsMaxFileSize,
+                                                                        maxSrcResolution: config.imgproxy.maxSrcResolution,
+                                                                        allowedImageAspectRatios: config.dam.allowedImageAspectRatios,
+                                                                    }}
+                                                                    pageTreeCategories={pageTreeCategories}
+                                                                    pageTreeDocumentTypes={pageTreeDocumentTypes}
+                                                                    additionalPageTreeNodeFragment={additionalPageTreeNodeFieldsFragment}
+                                                                >
+                                                                    <Fragment>
+                                                                        <GlobalStyle />
+                                                                        <ContentScopeProvider>
+                                                                            {({ match }) => (
+                                                                                <Switch>
+                                                                                    {/* @TODO: add preview to contentScope once site is capable of contentScope */}
+                                                                                    <Route
+                                                                                        path={`${match.path}/preview`}
+                                                                                        render={(props) => (
+                                                                                            <SitePreview
+                                                                                                resolvePath={(
+                                                                                                    path: string,
+                                                                                                    scope: ContentScopeInterface,
+                                                                                                ) => {
+                                                                                                    return `/${scope.language}${path}`;
+                                                                                                }}
+                                                                                                {...props}
+                                                                                            />
+                                                                                        )}
+                                                                                    />
+                                                                                    <Route
+                                                                                        render={() => (
+                                                                                            <MasterLayout
+                                                                                                headerComponent={MasterHeader}
+                                                                                                menuComponent={MasterMenu}
+                                                                                            >
+                                                                                                <MasterMenuRoutes menu={masterMenuData} />
+                                                                                            </MasterLayout>
+                                                                                        )}
+                                                                                    />
+                                                                                </Switch>
+                                                                            )}
+                                                                        </ContentScopeProvider>
+                                                                    </Fragment>
+                                                                </CmsBlockContextProvider>
+                                                            </SnackbarProvider>
+                                                        </DndProvider>
+                                                    </RouterBrowserRouter>
+                                                </CurrentUserProvider>
+                                            </MuiThemeProvider>
+                                        </LocaleProvider>
+                                    </IntlProvider>
+                                </DependenciesConfigProvider>
+                            </DamConfigProvider>
+                        </SitesConfigProvider>
+                    </ApolloProvider>
+                </ApiConfigProvider>
             </ConfigProvider>
         );
     }

--- a/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { PixelImageBlockData, PixelImageBlockInput } from "../blocks.generated";
+import { useApiConfig } from "../config/ApiConfigContext";
 import { useContentScope } from "../contentScope/Provider";
 import { useDamAcceptedMimeTypes } from "../dam/config/useDamAcceptedMimeTypes";
 import { useDependenciesConfig } from "../dependencies/DependenciesConfig";
@@ -27,7 +28,6 @@ import { FileField } from "../form/file/FileField";
 import { CmsBlockContext } from "./CmsBlockContextProvider";
 import { EditImageDialog } from "./image/EditImageDialog";
 import { GQLImageBlockDamFileQuery, GQLImageBlockDamFileQueryVariables } from "./PixelImageBlock.generated";
-import { useCmsBlockContext } from "./useCmsBlockContext";
 
 export type ImageBlockState = Omit<PixelImageBlockData, "urlTemplate">;
 
@@ -158,7 +158,7 @@ export const PixelImageBlock: BlockInterface<PixelImageBlockData, ImageBlockStat
     AdminComponent: ({ state, updateState }) => {
         const [open, setOpen] = React.useState(false);
         const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
-        const context = useCmsBlockContext();
+        const apiConfig = useApiConfig();
         const { filteredAcceptedMimeTypes } = useDamAcceptedMimeTypes();
         const contentScope = useContentScope();
         const apolloClient = useApolloClient();
@@ -180,7 +180,7 @@ export const PixelImageBlock: BlockInterface<PixelImageBlockData, ImageBlockStat
             setAnchorEl(null);
         };
 
-        const previewUrl = createPreviewUrl(state, context.damConfig.apiUrl, { width: 320, height: 320 });
+        const previewUrl = createPreviewUrl(state, apiConfig.url, { width: 320, height: 320 });
 
         return (
             <SelectPreviewComponent>

--- a/packages/admin/cms-admin/src/config/ApiConfigContext.tsx
+++ b/packages/admin/cms-admin/src/config/ApiConfigContext.tsx
@@ -1,0 +1,25 @@
+// TODO Remove React import once https://github.com/vivid-planet/comet/pull/2526 has been merged.
+import React, { createContext, PropsWithChildren, useContext } from "react";
+
+type ApiConfig = {
+    url: string;
+};
+
+const ApiConfigContext = createContext<ApiConfig | undefined>(undefined);
+
+function ApiConfigProvider({ config, children }: PropsWithChildren<{ config: ApiConfig }>) {
+    return <ApiConfigContext.Provider value={config}>{children}</ApiConfigContext.Provider>;
+}
+
+function useApiConfig() {
+    const context = useContext(ApiConfigContext);
+
+    if (!context) {
+        throw new Error("No ApiConfigContext instance can be found. Please ensure that you have called `ApiConfigProvider` higher up in your tree.");
+    }
+
+    return context;
+}
+
+export type { ApiConfig };
+export { ApiConfigProvider, useApiConfig };

--- a/packages/admin/cms-admin/src/dam/DataGrid/DamContextMenu.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/DamContextMenu.tsx
@@ -6,8 +6,8 @@ import { saveAs } from "file-saver";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { useCmsBlockContext } from "../../blocks/useCmsBlockContext";
 import { UnknownError } from "../../common/errors/errorMessages";
+import { useApiConfig } from "../../config/ApiConfigContext";
 import { GQLDamFile, GQLDamFolder } from "../../graphql.generated";
 import { ConfirmDeleteDialog } from "../FileActions/ConfirmDeleteDialog";
 import { clearDamItemCache } from "../helpers/clearDamItemCache";
@@ -31,7 +31,7 @@ const FolderInnerMenu = ({ folder, openMoveDialog }: FolderInnerMenuProps): Reac
     const editDialogApi = useEditDialogApi();
     const errorDialog = useErrorDialog();
     const apolloClient = useApolloClient();
-    const context = useCmsBlockContext();
+    const apiConfig = useApiConfig();
 
     const [deleteDialogOpen, setDeleteDialogOpen] = React.useState<boolean>(false);
 
@@ -58,7 +58,7 @@ const FolderInnerMenu = ({ folder, openMoveDialog }: FolderInnerMenuProps): Reac
         }
     };
 
-    const downloadUrl = `${context.damConfig.apiUrl}/dam/folders/${folder.id}/zip`;
+    const downloadUrl = `${apiConfig.url}/dam/folders/${folder.id}/zip`;
 
     return (
         <>

--- a/packages/admin/cms-admin/src/form/file/FinalFormFileUpload.tsx
+++ b/packages/admin/cms-admin/src/form/file/FinalFormFileUpload.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
-import { useCmsBlockContext } from "../../blocks/useCmsBlockContext";
+import { useApiConfig } from "../../config/ApiConfigContext";
 import { GQLFinalFormFileUploadFragment } from "./FinalFormFileUpload.generated";
 
 export const finalFormFileUploadFragment = gql`
@@ -54,9 +54,7 @@ export const FinalFormFileUpload = <Multiple extends boolean | undefined>({
     const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
     const [uploadingFiles, setUploadingFiles] = React.useState<LoadingFileSelectItem[]>([]);
     const [failedUploads, setFailedUploads] = React.useState<ErrorFileSelectItem[]>([]);
-    const {
-        damConfig: { apiUrl }, // TODO: Think of a better solution to get the apiUrl, as this has nothing to do with DAM
-    } = useCmsBlockContext();
+    const apiConfig = useApiConfig();
 
     const singleFile = (!multiple && typeof maxFiles === "undefined") || maxFiles === 1;
     const inputValue = React.useMemo(() => (Array.isArray(fieldValue) ? fieldValue : fieldValue ? [fieldValue] : []), [fieldValue]);
@@ -103,7 +101,7 @@ export const FinalFormFileUpload = <Multiple extends boolean | undefined>({
                 for (const file of acceptedFiles) {
                     const formData = new FormData();
                     formData.append("file", file);
-                    const response = await fetch(`${apiUrl}/file-uploads/upload`, {
+                    const response = await fetch(`${apiConfig.url}/file-uploads/upload`, {
                         method: "POST",
                         body: formData,
                     });

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -38,6 +38,8 @@ export { PageList } from "./common/PageList";
 export { PageName } from "./common/PageName";
 export { useEditState } from "./common/useEditState";
 export { useSaveState } from "./common/useSaveState";
+export type { ApiConfig } from "./config/ApiConfigContext";
+export { ApiConfigProvider, useApiConfig } from "./config/ApiConfigContext";
 export { ContentScopeIndicator } from "./contentScope/ContentScopeIndicator";
 export { ContentScopeSelect } from "./contentScope/ContentScopeSelect";
 export { ContentScopeControls } from "./contentScope/Controls";


### PR DESCRIPTION
## Motivation

We need to provide the API URL for file uploads. As a temporary workaround, we use the `damConfig.apiUrl` from `useCmsBlockContext` in https://github.com/vivid-planet/comet/pull/2151#discussion_r1653055138. Now we want to find a better solution.

## Solution

Create a specific `ApiConfigProvider` to provide the API URL. 

Advantages:
- Specific solution to a specific problem
- No need to configure unneeded options

Disadvantages:
- YAP (Yet another provider)
- Inflexible

## Open questions/TODOs

- [ ] Decide whether to use #2538 or #2539
- [ ] Add a changeset
- [ ] Decide whether this change should be breaking

## Further information

- Alternative: #2539
- JIRA-Task: https://vivid-planet.atlassian.net/browse/COM-953

I've also updated other instances (PixelImageBlock, DamContextMenu) to show how it can be used in multiple places.
