### PR TITLE
[RFC] Add generic `CometConfigProvider`

### DIFF
--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -7,6 +7,7 @@ import { ApolloProvider } from "@apollo/client";
 import { ErrorDialogHandler, MasterLayout, MuiThemeProvider, RouterBrowserRouter, SnackbarProvider } from "@comet/admin";
 import {
     CmsBlockContextProvider,
+    CometConfigProvider,
     ContentScopeInterface,
     createDamFileDependency,
     createHttpClient,
@@ -22,7 +23,7 @@ import { css, Global } from "@emotion/react";
 import { createApolloClient } from "@src/common/apollo/createApolloClient";
 import ContentScopeProvider, { ContentScope } from "@src/common/ContentScopeProvider";
 import { additionalPageTreeNodeFieldsFragment } from "@src/common/EditPageNode";
-import { ConfigProvider, createConfig } from "@src/config";
+import { createConfig } from "@src/config";
 import { ImportFromUnsplash } from "@src/dam/ImportFromUnsplash";
 import { pageTreeCategories } from "@src/pageTree/pageTreeCategories";
 import { theme } from "@src/theme";
@@ -61,7 +62,7 @@ class App extends Component {
 
     public render(): JSX.Element {
         return (
-            <ConfigProvider config={config}>
+            <CometConfigProvider config={config}>
                 <ApolloProvider client={apolloClient}>
                     <SitesConfigProvider
                         value={{
@@ -158,7 +159,7 @@ class App extends Component {
                         </DamConfigProvider>
                     </SitesConfigProvider>
                 </ApolloProvider>
-            </ConfigProvider>
+            </CometConfigProvider>
         );
     }
 }

--- a/demo/admin/src/config.tsx
+++ b/demo/admin/src/config.tsx
@@ -1,10 +1,15 @@
-import { SiteConfig } from "@comet/cms-admin";
-import { createContext, PropsWithChildren, useContext } from "react";
+import { BaseCometConfig, CometConfig, SiteConfig } from "@comet/cms-admin";
+
+declare module "@comet/cms-admin" {
+    interface CometConfig extends BaseCometConfig {
+        sitesConfig: SitesConfig;
+    }
+}
 
 import cometConfig from "./comet-config.json";
 import { environment } from "./environment";
 
-export function createConfig() {
+export function createConfig(): CometConfig {
     const environmentVariables = {} as Record<(typeof environment)[number], string>;
     for (const variableName of environment) {
         const externalVariableName = `EXTERNAL__${variableName}__`;
@@ -26,21 +31,3 @@ export function createConfig() {
 }
 
 export type SitesConfig = Record<string, SiteConfig>;
-
-export type Config = ReturnType<typeof createConfig>;
-
-const ConfigContext = createContext<Config | undefined>(undefined);
-
-export function ConfigProvider({ config, children }: PropsWithChildren<{ config: Config }>) {
-    return <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>;
-}
-
-export function useConfig(): Config {
-    const config = useContext(ConfigContext);
-
-    if (config === undefined) {
-        throw new Error("useConfig must be used within a ConfigProvider");
-    }
-
-    return config;
-}

--- a/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { PixelImageBlockData, PixelImageBlockInput } from "../blocks.generated";
+import { useCometConfig } from "../config/CometConfigContext";
 import { useContentScope } from "../contentScope/Provider";
 import { useDamAcceptedMimeTypes } from "../dam/config/useDamAcceptedMimeTypes";
 import { useDependenciesConfig } from "../dependencies/DependenciesConfig";
@@ -27,7 +28,6 @@ import { FileField } from "../form/file/FileField";
 import { CmsBlockContext } from "./CmsBlockContextProvider";
 import { EditImageDialog } from "./image/EditImageDialog";
 import { GQLImageBlockDamFileQuery, GQLImageBlockDamFileQueryVariables } from "./PixelImageBlock.generated";
-import { useCmsBlockContext } from "./useCmsBlockContext";
 
 export type ImageBlockState = Omit<PixelImageBlockData, "urlTemplate">;
 
@@ -158,7 +158,7 @@ export const PixelImageBlock: BlockInterface<PixelImageBlockData, ImageBlockStat
     AdminComponent: ({ state, updateState }) => {
         const [open, setOpen] = React.useState(false);
         const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
-        const context = useCmsBlockContext();
+        const cometConfig = useCometConfig();
         const { filteredAcceptedMimeTypes } = useDamAcceptedMimeTypes();
         const contentScope = useContentScope();
         const apolloClient = useApolloClient();
@@ -180,7 +180,7 @@ export const PixelImageBlock: BlockInterface<PixelImageBlockData, ImageBlockStat
             setAnchorEl(null);
         };
 
-        const previewUrl = createPreviewUrl(state, context.damConfig.apiUrl, { width: 320, height: 320 });
+        const previewUrl = createPreviewUrl(state, cometConfig.apiUrl, { width: 320, height: 320 });
 
         return (
             <SelectPreviewComponent>

--- a/packages/admin/cms-admin/src/config/CometConfigContext.tsx
+++ b/packages/admin/cms-admin/src/config/CometConfigContext.tsx
@@ -1,0 +1,43 @@
+// TODO Remove React import once https://github.com/vivid-planet/comet/pull/2526 has been merged.
+import React, { createContext, PropsWithChildren, useContext } from "react";
+
+interface BaseCometConfig {
+    apiUrl: string;
+    adminUrl: string;
+    fileUploads?: {
+        maxFileSize: number;
+    };
+    imgproxy: {
+        maxSrcResolution: number;
+        quality: number;
+    };
+    dam: {
+        uploadsMaxFileSize: number;
+        allowedImageSizes: number[];
+        allowedImageAspectRatios: string[];
+    };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface CometConfig extends BaseCometConfig {}
+
+const CometConfigContext = createContext<CometConfig | undefined>(undefined);
+
+function CometConfigProvider({ config, children }: PropsWithChildren<{ config: CometConfig }>) {
+    return <CometConfigContext.Provider value={config}>{children}</CometConfigContext.Provider>;
+}
+
+function useCometConfig() {
+    const context = useContext(CometConfigContext);
+
+    if (!context) {
+        throw new Error(
+            "No CometConfigContext instance can be found. Please ensure that you have called `CometConfigProvider` higher up in your tree.",
+        );
+    }
+
+    return context;
+}
+
+export type { BaseCometConfig, CometConfig };
+export { CometConfigProvider, useCometConfig };

--- a/packages/admin/cms-admin/src/dam/DataGrid/DamContextMenu.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/DamContextMenu.tsx
@@ -6,8 +6,8 @@ import { saveAs } from "file-saver";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { useCmsBlockContext } from "../../blocks/useCmsBlockContext";
 import { UnknownError } from "../../common/errors/errorMessages";
+import { useCometConfig } from "../../config/CometConfigContext";
 import { GQLDamFile, GQLDamFolder } from "../../graphql.generated";
 import { ConfirmDeleteDialog } from "../FileActions/ConfirmDeleteDialog";
 import { clearDamItemCache } from "../helpers/clearDamItemCache";
@@ -31,7 +31,7 @@ const FolderInnerMenu = ({ folder, openMoveDialog }: FolderInnerMenuProps): Reac
     const editDialogApi = useEditDialogApi();
     const errorDialog = useErrorDialog();
     const apolloClient = useApolloClient();
-    const context = useCmsBlockContext();
+    const cometConfig = useCometConfig();
 
     const [deleteDialogOpen, setDeleteDialogOpen] = React.useState<boolean>(false);
 
@@ -58,7 +58,7 @@ const FolderInnerMenu = ({ folder, openMoveDialog }: FolderInnerMenuProps): Reac
         }
     };
 
-    const downloadUrl = `${context.damConfig.apiUrl}/dam/folders/${folder.id}/zip`;
+    const downloadUrl = `${cometConfig.apiUrl}/dam/folders/${folder.id}/zip`;
 
     return (
         <>

--- a/packages/admin/cms-admin/src/form/file/FinalFormFileUpload.tsx
+++ b/packages/admin/cms-admin/src/form/file/FinalFormFileUpload.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
-import { useCmsBlockContext } from "../../blocks/useCmsBlockContext";
+import { useCometConfig } from "../../config/CometConfigContext";
 import { GQLFinalFormFileUploadFragment } from "./FinalFormFileUpload.generated";
 
 export const finalFormFileUploadFragment = gql`
@@ -54,9 +54,7 @@ export const FinalFormFileUpload = <Multiple extends boolean | undefined>({
     const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
     const [uploadingFiles, setUploadingFiles] = React.useState<LoadingFileSelectItem[]>([]);
     const [failedUploads, setFailedUploads] = React.useState<ErrorFileSelectItem[]>([]);
-    const {
-        damConfig: { apiUrl }, // TODO: Think of a better solution to get the apiUrl, as this has nothing to do with DAM
-    } = useCmsBlockContext();
+    const cometConfig = useCometConfig();
 
     const singleFile = (!multiple && typeof maxFiles === "undefined") || maxFiles === 1;
     const inputValue = React.useMemo(() => (Array.isArray(fieldValue) ? fieldValue : fieldValue ? [fieldValue] : []), [fieldValue]);
@@ -103,7 +101,7 @@ export const FinalFormFileUpload = <Multiple extends boolean | undefined>({
                 for (const file of acceptedFiles) {
                     const formData = new FormData();
                     formData.append("file", file);
-                    const response = await fetch(`${apiUrl}/file-uploads/upload`, {
+                    const response = await fetch(`${cometConfig.apiUrl}/file-uploads/upload`, {
                         method: "POST",
                         body: formData,
                     });

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -38,6 +38,8 @@ export { PageList } from "./common/PageList";
 export { PageName } from "./common/PageName";
 export { useEditState } from "./common/useEditState";
 export { useSaveState } from "./common/useSaveState";
+export type { BaseCometConfig, CometConfig } from "./config/CometConfigContext";
+export { CometConfigProvider, useCometConfig } from "./config/CometConfigContext";
 export { ContentScopeIndicator } from "./contentScope/ContentScopeIndicator";
 export { ContentScopeSelect } from "./contentScope/ContentScopeSelect";
 export { ContentScopeControls } from "./contentScope/Controls";


### PR DESCRIPTION
## Motivation

We need to provide the API URL for file uploads. As a temporary workaround, we use the `damConfig.apiUrl` from `useCmsBlockContext` in https://github.com/vivid-planet/comet/pull/2151#discussion_r1653055138. Now we want to find a better solution.

## Solution

Create a generic `CometConfigProvider` that provides the config created by [createConfig](https://github.com/vivid-planet/comet/blob/main/demo/admin/src/config.tsx#L7-L26). 

We introduced the Comet config in #955 but never incorporated it into the library. This would be changed with this approach. Existing providers (DamConfigProvider, CmsBlockContextProvider) could possibly be slimmed down thanks to this new provider.

Advantages:
- Removes duplicate configuration of the same options (DamConfigProvider, CmsBlockContextProvider)
- Extend the interface via module augmentation (do we even need that?)

Disadvantages:
- Possibly need to configure unneeded options (could be fixed by making everything optional)
- Could be easily bloated
- comet-config.json isn't an application-only thing anymore

## Open questions/TODOs

- [ ] Decide whether to use #2538 or #2539
- [ ] Add a changeset
- [ ] Decide whether this change should be breaking

## Further information

- Alternative: #2538
- JIRA-Task: https://vivid-planet.atlassian.net/browse/COM-953

I've also updated other instances (PixelImageBlock, DamContextMenu) to show how it can be used in multiple places.
