### PR TITLE
COM-1063: Add optional icon to VideoPreviewImage

### DIFF
--- a/.changeset/silly-scissors-fetch.md
+++ b/.changeset/silly-scissors-fetch.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": minor
+---
+
+Add optional `icon` prop to `VideoPreviewImage` to enable setting a custom play icon

--- a/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
+++ b/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
@@ -13,11 +13,11 @@ export interface VideoPreviewImageProps {
     icon?: ReactNode;
 }
 
-export const VideoPreviewImage = ({ onPlay, image, aspectRatio, sizes = "100vw", fill, icon }: VideoPreviewImageProps) => {
+export const VideoPreviewImage = ({ onPlay, image, aspectRatio, sizes = "100vw", fill, icon = <PlayIcon /> }: VideoPreviewImageProps) => {
     return (
         <Root $fill={fill}>
             <PixelImageBlock data={image} aspectRatio={aspectRatio} sizes={sizes} fill={fill} />
-            <IconWrapper onClick={onPlay}>{icon ? icon : <PlayIcon />}</IconWrapper>
+            <IconWrapper onClick={onPlay}>{icon}</IconWrapper>
         </Root>
     );
 };

--- a/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
+++ b/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
@@ -9,15 +9,14 @@ export interface VideoPreviewImageProps {
     aspectRatio: string;
     sizes?: string;
     fill?: boolean;
+    icon?: React.ReactElement;
 }
 
-export const VideoPreviewImage = ({ onPlay, image, aspectRatio, sizes = "100vw", fill }: VideoPreviewImageProps) => {
+export const VideoPreviewImage = ({ onPlay, image, aspectRatio, sizes = "100vw", fill, icon }: VideoPreviewImageProps) => {
     return (
         <Root $fill={fill}>
             <PixelImageBlock data={image} aspectRatio={aspectRatio} sizes={sizes} fill={fill} />
-            <IconWrapper onClick={onPlay}>
-                <PlayIcon />
-            </IconWrapper>
+            <IconWrapper onClick={onPlay}>{icon ? icon : <PlayIcon />}</IconWrapper>
         </Root>
     );
 };

--- a/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
+++ b/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import styled, { css } from "styled-components";
 
 import { PixelImageBlockData } from "../../blocks.generated";
@@ -9,7 +10,7 @@ export interface VideoPreviewImageProps {
     aspectRatio: string;
     sizes?: string;
     fill?: boolean;
-    icon?: React.ReactElement;
+    icon?: ReactNode;
 }
 
 export const VideoPreviewImage = ({ onPlay, image, aspectRatio, sizes = "100vw", fill, icon }: VideoPreviewImageProps) => {


### PR DESCRIPTION
Add optional `icon` prop to VideoPreviewImage to enable adding a custom icon.

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
