### PR TITLE
Fix Next peer dependency

### DIFF
--- a/.changeset/angry-paws-pay.md
+++ b/.changeset/angry-paws-pay.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-site": patch
+---
+
+Fix Next peer dependency
+
+The peer dependency was incorrectly set to `14`.
+We require `14.2.0` or later due to relying on [optimizePackageImports](https://nextjs.org/docs/app/api-reference/next-config-js/optimizePackageImports).

--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -57,7 +57,7 @@
         "typescript": "^4.0.0"
     },
     "peerDependencies": {
-        "next": "14",
+        "next": "^14.2.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "styled-components": "^6.0.0"


### PR DESCRIPTION
The peer dependency was incorrectly set to `14`.
We require `14.2.0` or later due to relying on [optimizePackageImports](https://nextjs.org/docs/app/api-reference/next-config-js/optimizePackageImports).

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

- [x] I have verified if my change requires a changeset

## Further information

I decided to treat this as non-breaking since we require 14.2.0 or later in Comet 7 anyway.