### PR TITLE
Display validation errors of file name field in DAM

### DIFF
--- a/.changeset/thirty-lemons-accept.md
+++ b/.changeset/thirty-lemons-accept.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Display validation errors of file name field in DAM

--- a/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
@@ -110,6 +110,8 @@ export const FileSettingsFields = ({ file }: SettingsFormProps) => {
                         }
                     }}
                     onBlur={() => {
+                        formApi.blur("name");
+
                         const filename: string | undefined = formApi.getFieldState("name")?.value;
                         const nameWithoutExtension = filename?.split(".").slice(0, -1).join(".");
                         const extension = file.name.split(".").pop();


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->


### Problem:

The duplicate name error in the DAM isn't shown.


### Reason

I override the `onBlur` function of the field. However, I never called `formApi.blur()`. This function sets the field's `touched` property. Since `touched` was always false, the error was never shown.


### Solution:

I now call `blur()`






## Screenshots/screencasts

Before:

https://github.com/user-attachments/assets/fef6cafa-b067-4bfc-87fe-aca3b90d6606



After:


https://github.com/user-attachments/assets/cec88ba5-0dcd-4d3d-a0c5-6a3b63a50a24



## Changeset


-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1076
