### PR TITLE
Support numbers as content scope values

### DIFF
--- a/.changeset/yellow-toes-beg.md
+++ b/.changeset/yellow-toes-beg.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Support numbers as content scope values in User Permissions administration panel

--- a/packages/admin/cms-admin/src/userPermissions/utils/camelCaseToHumanReadable.ts
+++ b/packages/admin/cms-admin/src/userPermissions/utils/camelCaseToHumanReadable.ts
@@ -1,4 +1,4 @@
-export function camelCaseToHumanReadable(s: string) {
-    const words = s.match(/[A-Za-z][a-z]*/g) || [];
+export function camelCaseToHumanReadable(s: string | number) {
+    const words = s.toString().match(/[A-Za-z0-9][a-z0-9]*/g) || [];
     return words.map((word) => word.charAt(0).toUpperCase() + word.substring(1)).join(" ");
 }


### PR DESCRIPTION
## Description

Problem was that numeric content scope value were not displayed in the user permissions admin panel

