### PR TITLE
Admin Generator (Future): Implement formattedMessage type for combination column

### DIFF
--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -85,8 +85,8 @@ export function ProductsGrid() {
                     row.type,
                     row.category?.title,
                     row.inStock
-                        ? intl.formatMessage({ id: "comet.products.product.inStock", defaultMessage: "In Stock" })
-                        : intl.formatMessage({ id: "comet.products.product.outOfStock", defaultMessage: "Out of Stock" }),
+                        ? intl.formatMessage({ id: "comet.products.product.inStock", defaultMessage: "In stock" })
+                        : intl.formatMessage({ id: "comet.products.product.outOfStock", defaultMessage: "Out of stock" }),
                 ];
                 return <GridCellContent primaryText={row.title} secondaryText={secondaryValues.filter(Boolean).join(" • ")} />;
             },

--- a/demo/admin/src/products/future/CombinationFieldsTestProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/CombinationFieldsTestProductsGrid.cometGen.ts
@@ -86,5 +86,52 @@ export const CombinationFieldsTestProductsGrid: GridConfig<GQLProduct> = {
                 decimals: 1,
             },
         },
+        {
+            type: "combination",
+            name: "combinedAndNestedValues",
+            headerName: "Custom formatting with nested values",
+            primaryText: {
+                type: "formattedMessage",
+                message: 'This product is named "{title}" and is a "{type}"',
+                valueFields: {
+                    title: "title",
+                    type: "type",
+                },
+            },
+            secondaryText: {
+                type: "formattedMessage",
+                message: "Price: {price} • Category: {category} • Same values again: ({nestedValues})",
+                valueFields: {
+                    price: {
+                        type: "number",
+                        field: "price",
+                        currency: "EUR",
+                        emptyValue: "No price set",
+                    },
+                    category: {
+                        type: "text",
+                        field: "category.title",
+                        emptyValue: "No category set",
+                    },
+                    nestedValues: {
+                        type: "formattedMessage",
+                        message: "Price: {price} • Category: {category}",
+                        valueFields: {
+                            price: {
+                                type: "number",
+                                field: "price",
+                                currency: "EUR",
+                                emptyValue: "No price set",
+                            },
+                            category: {
+                                type: "text",
+                                field: "category.title",
+                                emptyValue: "No category set",
+                            },
+                        },
+                    },
+                },
+            },
+        },
     ],
 };

--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -23,6 +23,7 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
             minWidth: 200,
             primaryText: "title",
             secondaryText: {
+                // TODO: Change this to use the "group" type instead of "formattedMessage", once implemented (SVK-368)
                 type: "formattedMessage",
                 message: "{price} • {type} • {category} • {inStock}",
                 valueFields: {

--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -1,6 +1,8 @@
 import { future_GridConfig as GridConfig } from "@comet/cms-admin";
 import { GQLProduct } from "@src/graphql.generated";
 
+const typeValues = [{ value: "Cap", label: "great Cap" }, "Shirt", "Tie"];
+
 export const ProductsGrid: GridConfig<GQLProduct> = {
     type: "grid",
     gqlType: "Product",
@@ -19,17 +21,46 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
             name: "overview",
             headerName: "Overview",
             minWidth: 200,
-            maxWidth: 250,
             primaryText: "title",
-            secondaryText: "description",
+            secondaryText: {
+                type: "formattedMessage",
+                message: "{price} • {type} • {category} • {inStock}",
+                valueFields: {
+                    price: {
+                        type: "number",
+                        field: "price",
+                        currency: "EUR",
+                        emptyValue: "No price",
+                    },
+                    type: {
+                        type: "staticSelect",
+                        field: "type",
+                        values: typeValues,
+                        emptyValue: "No type",
+                    },
+                    category: {
+                        type: "text",
+                        field: "category.title",
+                        emptyValue: "No category",
+                    },
+                    inStock: {
+                        type: "staticSelect",
+                        field: "inStock",
+                        values: [
+                            { value: true, label: "In stock" },
+                            { value: false, label: "Out of stock" },
+                        ],
+                    },
+                },
+            },
             visible: "down('md')",
-            sortBy: ["title", "description"],
+            sortBy: ["title", "price", "type", "category", "inStock"],
             disableExport: true, // TODO: Implement `valueFormatter` for type "combination"
         },
         { type: "text", name: "title", headerName: "Titel", minWidth: 200, maxWidth: 250, visible: "up('md')" },
-        { type: "text", name: "description", headerName: "Description", visible: "up('md')" },
+        { type: "text", name: "description", headerName: "Description" },
         // TODO: Allow setting options for `intl.formatNumber` through `valueFormatter` (type "number")
-        { type: "number", name: "price", headerName: "Price", maxWidth: 150, headerInfoTooltip: "Price in EUR" },
+        { type: "number", name: "price", headerName: "Price", maxWidth: 150, headerInfoTooltip: "Price in EUR", visible: "up('md')" },
         {
             // TODO: Implement showing actual label in `valueFormatter` (type "staticSelect")
             type: "staticSelect",
@@ -37,6 +68,7 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
             headerName: "In stock",
             flex: 1,
             minWidth: 80,
+            visible: "up('md')",
             values: [
                 {
                     value: "true",
@@ -55,7 +87,7 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
             ],
         },
         // TODO: Implement showing actual label in `valueFormatter` (type "staticSelect")
-        { type: "staticSelect", name: "type", maxWidth: 150, values: [{ value: "Cap", label: "great Cap" }, "Shirt", "Tie"] },
+        { type: "staticSelect", name: "type", maxWidth: 150, values: typeValues, visible: "up('md')" },
         // TODO: Allow setting options for `intl.formatDate` through `valueFormatter` (type "date")
         { type: "date", name: "availableSince", width: 140 },
         // TODO: Allow setting options for `intl.formatDate` through `valueFormatter` (type "dateTime")

--- a/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
@@ -116,16 +116,13 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const primaryTextTypeLabels: Record<string, React.ReactNode> = {
+                const typeLabels: Record<string, React.ReactNode> = {
                     Cap: <FormattedMessage id="product.staticSelectType.primaryText.Cap" defaultMessage="great Cap" />,
                     Shirt: <FormattedMessage id="product.staticSelectType.primaryText.Shirt" defaultMessage="Shirt" />,
                     Tie: <FormattedMessage id="product.staticSelectType.primaryText.Tie" defaultMessage="Tie" />,
                 };
                 return (
-                    <GridCellContent
-                        primaryText={row.type == null ? "-" : primaryTextTypeLabels[`${row.type}`] ?? row.type}
-                        secondaryText={row.type ?? "-"}
-                    />
+                    <GridCellContent primaryText={row.type == null ? "-" : typeLabels[`${row.type}`] ?? row.type} secondaryText={row.type ?? "-"} />
                 );
             },
             flex: 1,
@@ -137,7 +134,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const primaryTextInStockLabels: Record<string, React.ReactNode> = {
+                const inStockLabels: Record<string, React.ReactNode> = {
                     true: <FormattedMessage id="product.staticSelectInStock.primaryText.true" defaultMessage={`It's in stock :D`} />,
                     false: <FormattedMessage id="product.staticSelectInStock.primaryText.false" defaultMessage="No longer available :(" />,
                 };
@@ -147,7 +144,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                             row.inStock == null ? (
                                 <FormattedMessage id="product.staticSelectInStock.primaryText.empty" defaultMessage="No stock info" />
                             ) : (
-                                primaryTextInStockLabels[`${row.inStock}`] ?? row.inStock
+                                inStockLabels[`${row.inStock}`] ?? row.inStock
                             )
                         }
                     />

--- a/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
@@ -116,15 +116,15 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const primaryEmptyMessage = "-";
-                const typePrimaryLabels: Record<string, React.ReactNode> = {
+                const primaryTextTypeEmptyMessage = "-";
+                const primaryTextTypeLabels: Record<string, React.ReactNode> = {
                     Cap: <FormattedMessage id="product.staticSelectType.primaryText.Cap" defaultMessage="great Cap" />,
                     Shirt: <FormattedMessage id="product.staticSelectType.primaryText.Shirt" defaultMessage="Shirt" />,
                     Tie: <FormattedMessage id="product.staticSelectType.primaryText.Tie" defaultMessage="Tie" />,
                 };
                 return (
                     <GridCellContent
-                        primaryText={row.type == null ? primaryEmptyMessage : typePrimaryLabels[`${row.type}`] ?? row.type}
+                        primaryText={row.type == null ? primaryTextTypeEmptyMessage : primaryTextTypeLabels[`${row.type}`] ?? row.type}
                         secondaryText={row.type ?? "-"}
                     />
                 );
@@ -138,14 +138,16 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const primaryEmptyMessage = <FormattedMessage id="product.staticSelectInStock.primaryText.empty" defaultMessage="No stock info" />;
-                const inStockPrimaryLabels: Record<string, React.ReactNode> = {
+                const primaryTextInStockEmptyMessage = (
+                    <FormattedMessage id="product.staticSelectInStock.primaryText.empty" defaultMessage="No stock info" />
+                );
+                const primaryTextInStockLabels: Record<string, React.ReactNode> = {
                     true: <FormattedMessage id="product.staticSelectInStock.primaryText.true" defaultMessage={`It's in stock :D`} />,
                     false: <FormattedMessage id="product.staticSelectInStock.primaryText.false" defaultMessage="No longer available :(" />,
                 };
                 return (
                     <GridCellContent
-                        primaryText={row.inStock == null ? primaryEmptyMessage : inStockPrimaryLabels[`${row.inStock}`] ?? row.inStock}
+                        primaryText={row.inStock == null ? primaryTextInStockEmptyMessage : primaryTextInStockLabels[`${row.inStock}`] ?? row.inStock}
                     />
                 );
             },
@@ -230,6 +232,85 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                                     unitDisplay="short"
                                 />
                             )
+                        }
+                    />
+                );
+            },
+            flex: 1,
+            minWidth: 150,
+        },
+        {
+            field: "combinedAndNestedValues",
+            headerName: intl.formatMessage({ id: "product.combinedAndNestedValues", defaultMessage: "Custom formatting with nested values" }),
+            filterable: false,
+            sortable: false,
+            renderCell: ({ row }) => {
+                return (
+                    <GridCellContent
+                        primaryText={
+                            <FormattedMessage
+                                id="product.combinedAndNestedValues.primaryText"
+                                defaultMessage={`This product is named "{title}" and is a "{type}"`}
+                                values={{ title: row.title ?? "-", type: row.type ?? "-" }}
+                            />
+                        }
+                        secondaryText={
+                            <FormattedMessage
+                                id="product.combinedAndNestedValues.secondaryText"
+                                defaultMessage="Price: {price} • Category: {category} • Same values again: ({nestedValues})"
+                                values={{
+                                    price:
+                                        typeof row.price === "undefined" || row.price === null ? (
+                                            <FormattedMessage
+                                                id="product.combinedAndNestedValues.secondaryText.price.empty"
+                                                defaultMessage="No price set"
+                                            />
+                                        ) : (
+                                            <FormattedNumber
+                                                value={row.price}
+                                                minimumFractionDigits={2}
+                                                maximumFractionDigits={2}
+                                                style="currency"
+                                                currency="EUR"
+                                            />
+                                        ),
+                                    category: row.category?.title ?? (
+                                        <FormattedMessage
+                                            id="product.combinedAndNestedValues.secondaryText.category.empty"
+                                            defaultMessage="No category set"
+                                        />
+                                    ),
+                                    nestedValues: (
+                                        <FormattedMessage
+                                            id="product.combinedAndNestedValues.secondaryText.nestedValues"
+                                            defaultMessage="Price: {price} • Category: {category}"
+                                            values={{
+                                                price:
+                                                    typeof row.price === "undefined" || row.price === null ? (
+                                                        <FormattedMessage
+                                                            id="product.combinedAndNestedValues.secondaryText.nestedValues.price.empty"
+                                                            defaultMessage="No price set"
+                                                        />
+                                                    ) : (
+                                                        <FormattedNumber
+                                                            value={row.price}
+                                                            minimumFractionDigits={2}
+                                                            maximumFractionDigits={2}
+                                                            style="currency"
+                                                            currency="EUR"
+                                                        />
+                                                    ),
+                                                category: row.category?.title ?? (
+                                                    <FormattedMessage
+                                                        id="product.combinedAndNestedValues.secondaryText.nestedValues.category.empty"
+                                                        defaultMessage="No category set"
+                                                    />
+                                                ),
+                                            }}
+                                        />
+                                    ),
+                                }}
+                            />
                         }
                     />
                 );

--- a/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
@@ -116,7 +116,6 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const primaryTextTypeEmptyMessage = "-";
                 const primaryTextTypeLabels: Record<string, React.ReactNode> = {
                     Cap: <FormattedMessage id="product.staticSelectType.primaryText.Cap" defaultMessage="great Cap" />,
                     Shirt: <FormattedMessage id="product.staticSelectType.primaryText.Shirt" defaultMessage="Shirt" />,
@@ -124,7 +123,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                 };
                 return (
                     <GridCellContent
-                        primaryText={row.type == null ? primaryTextTypeEmptyMessage : primaryTextTypeLabels[`${row.type}`] ?? row.type}
+                        primaryText={row.type == null ? "-" : primaryTextTypeLabels[`${row.type}`] ?? row.type}
                         secondaryText={row.type ?? "-"}
                     />
                 );
@@ -138,16 +137,19 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const primaryTextInStockEmptyMessage = (
-                    <FormattedMessage id="product.staticSelectInStock.primaryText.empty" defaultMessage="No stock info" />
-                );
                 const primaryTextInStockLabels: Record<string, React.ReactNode> = {
                     true: <FormattedMessage id="product.staticSelectInStock.primaryText.true" defaultMessage={`It's in stock :D`} />,
                     false: <FormattedMessage id="product.staticSelectInStock.primaryText.false" defaultMessage="No longer available :(" />,
                 };
                 return (
                     <GridCellContent
-                        primaryText={row.inStock == null ? primaryTextInStockEmptyMessage : primaryTextInStockLabels[`${row.inStock}`] ?? row.inStock}
+                        primaryText={
+                            row.inStock == null ? (
+                                <FormattedMessage id="product.staticSelectInStock.primaryText.empty" defaultMessage="No stock info" />
+                            ) : (
+                                primaryTextInStockLabels[`${row.inStock}`] ?? row.inStock
+                            )
+                        }
                     />
                 );
             },

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -29,7 +29,7 @@ import { CircularProgress, useTheme } from "@mui/material";
 import { DataGridPro, GridColumnHeaderTitle, GridRenderCellParams, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import { GQLProductFilter } from "@src/graphql.generated";
 import * as React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
 
 import { ProductsGridPreviewAction } from "../../ProductsGridPreviewAction";
 import {
@@ -46,10 +46,13 @@ const productsFragment = gql`
     fragment ProductsGridFuture on Product {
         id
         title
-        description
         price
-        inStock
         type
+        category {
+            title
+        }
+        inStock
+        description
         availableSince
         createdAt
     }
@@ -136,14 +139,56 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                return <GridCellContent primaryText={row.title ?? "-"} secondaryText={row.description ?? "-"} />;
+                const secondaryTextTypeEmptyMessage = <FormattedMessage id="product.overview.secondaryText.type.empty" defaultMessage="No type" />;
+                const secondaryTextTypeLabels: Record<string, React.ReactNode> = {
+                    Cap: <FormattedMessage id="product.overview.secondaryText.type.Cap" defaultMessage="great Cap" />,
+                    Shirt: <FormattedMessage id="product.overview.secondaryText.type.Shirt" defaultMessage="Shirt" />,
+                    Tie: <FormattedMessage id="product.overview.secondaryText.type.Tie" defaultMessage="Tie" />,
+                };
+                const secondaryTextInStockEmptyMessage = "-";
+                const secondaryTextInStockLabels: Record<string, React.ReactNode> = {
+                    true: <FormattedMessage id="product.overview.secondaryText.inStock.true" defaultMessage="In stock" />,
+                    false: <FormattedMessage id="product.overview.secondaryText.inStock.false" defaultMessage="Out of stock" />,
+                };
+                return (
+                    <GridCellContent
+                        primaryText={row.title ?? "-"}
+                        secondaryText={
+                            <FormattedMessage
+                                id="product.overview.secondaryText"
+                                defaultMessage="{price} • {type} • {category} • {inStock}"
+                                values={{
+                                    price:
+                                        typeof row.price === "undefined" || row.price === null ? (
+                                            <FormattedMessage id="product.overview.secondaryText.price.empty" defaultMessage="No price" />
+                                        ) : (
+                                            <FormattedNumber
+                                                value={row.price}
+                                                minimumFractionDigits={2}
+                                                maximumFractionDigits={2}
+                                                style="currency"
+                                                currency="EUR"
+                                            />
+                                        ),
+                                    type: row.type == null ? secondaryTextTypeEmptyMessage : secondaryTextTypeLabels[`${row.type}`] ?? row.type,
+                                    category: row.category?.title ?? (
+                                        <FormattedMessage id="product.overview.secondaryText.category.empty" defaultMessage="No category" />
+                                    ),
+                                    inStock:
+                                        row.inStock == null
+                                            ? secondaryTextInStockEmptyMessage
+                                            : secondaryTextInStockLabels[`${row.inStock}`] ?? row.inStock,
+                                }}
+                            />
+                        }
+                    />
+                );
             },
             flex: 1,
             visible: theme.breakpoints.down("md"),
             disableExport: true,
-            sortBy: ["title", "description"],
+            sortBy: ["title", "price", "type", "category", "inStock"],
             minWidth: 200,
-            maxWidth: 250,
         },
         {
             field: "title",
@@ -157,7 +202,6 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             field: "description",
             headerName: intl.formatMessage({ id: "product.description", defaultMessage: "Description" }),
             flex: 1,
-            visible: theme.breakpoints.up("md"),
             minWidth: 150,
         },
         {
@@ -172,6 +216,7 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             ),
             type: "number",
             flex: 1,
+            visible: theme.breakpoints.up("md"),
             minWidth: 150,
             maxWidth: 150,
         },
@@ -204,6 +249,7 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             ],
             renderCell: renderStaticSelectCell,
             flex: 1,
+            visible: theme.breakpoints.up("md"),
             minWidth: 80,
         },
         {
@@ -227,6 +273,7 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             ],
             renderCell: renderStaticSelectCell,
             flex: 1,
+            visible: theme.breakpoints.up("md"),
             minWidth: 150,
             maxWidth: 150,
         },

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -139,12 +139,12 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const secondaryTextTypeLabels: Record<string, React.ReactNode> = {
+                const typeLabels: Record<string, React.ReactNode> = {
                     Cap: <FormattedMessage id="product.overview.secondaryText.type.Cap" defaultMessage="great Cap" />,
                     Shirt: <FormattedMessage id="product.overview.secondaryText.type.Shirt" defaultMessage="Shirt" />,
                     Tie: <FormattedMessage id="product.overview.secondaryText.type.Tie" defaultMessage="Tie" />,
                 };
-                const secondaryTextInStockLabels: Record<string, React.ReactNode> = {
+                const inStockLabels: Record<string, React.ReactNode> = {
                     true: <FormattedMessage id="product.overview.secondaryText.inStock.true" defaultMessage="In stock" />,
                     false: <FormattedMessage id="product.overview.secondaryText.inStock.false" defaultMessage="Out of stock" />,
                 };
@@ -172,12 +172,12 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
                                         row.type == null ? (
                                             <FormattedMessage id="product.overview.secondaryText.type.empty" defaultMessage="No type" />
                                         ) : (
-                                            secondaryTextTypeLabels[`${row.type}`] ?? row.type
+                                            typeLabels[`${row.type}`] ?? row.type
                                         ),
                                     category: row.category?.title ?? (
                                         <FormattedMessage id="product.overview.secondaryText.category.empty" defaultMessage="No category" />
                                     ),
-                                    inStock: row.inStock == null ? "-" : secondaryTextInStockLabels[`${row.inStock}`] ?? row.inStock,
+                                    inStock: row.inStock == null ? "-" : inStockLabels[`${row.inStock}`] ?? row.inStock,
                                 }}
                             />
                         }

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -139,13 +139,11 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const secondaryTextTypeEmptyMessage = <FormattedMessage id="product.overview.secondaryText.type.empty" defaultMessage="No type" />;
                 const secondaryTextTypeLabels: Record<string, React.ReactNode> = {
                     Cap: <FormattedMessage id="product.overview.secondaryText.type.Cap" defaultMessage="great Cap" />,
                     Shirt: <FormattedMessage id="product.overview.secondaryText.type.Shirt" defaultMessage="Shirt" />,
                     Tie: <FormattedMessage id="product.overview.secondaryText.type.Tie" defaultMessage="Tie" />,
                 };
-                const secondaryTextInStockEmptyMessage = "-";
                 const secondaryTextInStockLabels: Record<string, React.ReactNode> = {
                     true: <FormattedMessage id="product.overview.secondaryText.inStock.true" defaultMessage="In stock" />,
                     false: <FormattedMessage id="product.overview.secondaryText.inStock.false" defaultMessage="Out of stock" />,
@@ -170,14 +168,16 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
                                                 currency="EUR"
                                             />
                                         ),
-                                    type: row.type == null ? secondaryTextTypeEmptyMessage : secondaryTextTypeLabels[`${row.type}`] ?? row.type,
+                                    type:
+                                        row.type == null ? (
+                                            <FormattedMessage id="product.overview.secondaryText.type.empty" defaultMessage="No type" />
+                                        ) : (
+                                            secondaryTextTypeLabels[`${row.type}`] ?? row.type
+                                        ),
                                     category: row.category?.title ?? (
                                         <FormattedMessage id="product.overview.secondaryText.category.empty" defaultMessage="No category" />
                                     ),
-                                    inStock:
-                                        row.inStock == null
-                                            ? secondaryTextInStockEmptyMessage
-                                            : secondaryTextInStockLabels[`${row.inStock}`] ?? row.inStock,
+                                    inStock: row.inStock == null ? "-" : secondaryTextInStockLabels[`${row.inStock}`] ?? row.inStock,
                                 }}
                             />
                         }

--- a/packages/admin/cms-admin/src/generator/future/generateGrid/combinationColumn.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid/combinationColumn.ts
@@ -1,5 +1,4 @@
 import { GridColDef } from "@comet/admin";
-import { pascalCase } from "change-case";
 import { FormattedNumber } from "react-intl";
 
 import { BaseColumnConfig } from "../generator";
@@ -65,7 +64,7 @@ type CellContent = {
     variableDefinitions?: string[];
 };
 
-const getTextForCellContent = (textConfig: Field<string>, messageIdPrefix: string, target: "primary" | "secondary"): CellContent => {
+const getTextForCellContent = (textConfig: Field<string>, messageIdPrefix: string): CellContent => {
     if (typeof textConfig !== "string" && textConfig.type === "static") {
         return {
             textContent: getFormattedMessageNode(messageIdPrefix, textConfig.text),
@@ -77,11 +76,7 @@ const getTextForCellContent = (textConfig: Field<string>, messageIdPrefix: strin
 
         const values = Object.entries(textConfig.valueFields)
             .map(([key, value]) => {
-                const { textContent, variableDefinitions: cellVariableDefinitions } = getTextForCellContent(
-                    value,
-                    `${messageIdPrefix}.${key}`,
-                    target,
-                );
+                const { textContent, variableDefinitions: cellVariableDefinitions } = getTextForCellContent(value, `${messageIdPrefix}.${key}`);
 
                 if (cellVariableDefinitions?.length) {
                     variableDefinitions.push(...cellVariableDefinitions);
@@ -157,7 +152,7 @@ const getTextForCellContent = (textConfig: Field<string>, messageIdPrefix: strin
     }
 
     if (textConfig.type === "staticSelect") {
-        const labelsVariableName = `${target}Text${pascalCase(textConfig.field)}Labels`;
+        const labelsVariableName = `${textConfig.field}Labels`;
 
         const labelMapping = textConfig.values
             .map((valueOption) => {
@@ -186,17 +181,13 @@ export const getCombinationColumnRenderCell = (column: GridCombinationColumnConf
     const allVariableDefinitions: string[] = [];
 
     if (column.primaryText) {
-        const { textContent, variableDefinitions = [] } = getTextForCellContent(column.primaryText, `${messageIdPrefix}.primaryText`, "primary");
+        const { textContent, variableDefinitions = [] } = getTextForCellContent(column.primaryText, `${messageIdPrefix}.primaryText`);
         gridCellContentProps.primaryText = textContent;
         allVariableDefinitions.push(...variableDefinitions);
     }
 
     if (column.secondaryText) {
-        const { textContent, variableDefinitions = [] } = getTextForCellContent(
-            column.secondaryText,
-            `${messageIdPrefix}.secondaryText`,
-            "secondary",
-        );
+        const { textContent, variableDefinitions = [] } = getTextForCellContent(column.secondaryText, `${messageIdPrefix}.secondaryText`);
         gridCellContentProps.secondaryText = textContent;
         allVariableDefinitions.push(...variableDefinitions);
     }

--- a/packages/admin/cms-admin/src/generator/future/generateGrid/combinationColumn.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid/combinationColumn.ts
@@ -157,11 +157,7 @@ const getTextForCellContent = (textConfig: Field<string>, messageIdPrefix: strin
     }
 
     if (textConfig.type === "staticSelect") {
-        const variableNamePrefix = `${target}Text${pascalCase(textConfig.field)}`;
-        const labelsVariableName = `${variableNamePrefix}Labels`;
-        const emptyMessageVariableName = `${variableNamePrefix}EmptyMessage`;
-
-        const emptyMessage = `const ${emptyMessageVariableName} = ${emptyText};`;
+        const labelsVariableName = `${target}Text${pascalCase(textConfig.field)}Labels`;
 
         const labelMapping = textConfig.values
             .map((valueOption) => {
@@ -172,12 +168,11 @@ const getTextForCellContent = (textConfig: Field<string>, messageIdPrefix: strin
             .join(", ");
 
         const labelMappingVar = `const ${labelsVariableName}: Record<string, React.ReactNode> = { ${labelMapping} };`;
-        const textContent =
-            `(${rowValue} == null ? ${emptyMessageVariableName} : ${labelsVariableName}[` + `\`\${${rowValue}}\`` + `] ?? ${rowValue})`;
+        const textContent = `(${rowValue} == null ? ${emptyText} : ${labelsVariableName}[` + `\`\${${rowValue}}\`` + `] ?? ${rowValue})`;
 
         return {
             textContent,
-            variableDefinitions: [emptyMessage, labelMappingVar],
+            variableDefinitions: [labelMappingVar],
         };
     }
 


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

This allows combining multiple fields into a single column to make the grid more compact or to combine related information. For instance, you could combine all address related values into a string such as: `Hopfgartenstraße 10, 5302 Henndorf, Austria`

```ts
{
    type: "combination",
    name: "address",
    headerName: "Address",
    primaryText: {
        type: "formattedMessage",
        message: "{street} {streetNumber}, {zip} {city}, {country}",
        valueFields: {
            street: "street",
            streetNumber: "streetNumber",
            zip: "zip",
            city: "city",
            country: {
                type: "staticSelect",
                field: "countryCode",
                values: [
                    { value: "AT", label: "Austria" },
                    { value: "DE", label: "Germany" },
                    { value: "CH", label: "Switzerland" },
                ],
            },
        },
    },
},
```

<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Example

<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A dev story in Storybook
-   A unit test

--->

-   [x] I have verified if my change requires an example

## Screenshots/screencasts

| Future generator ProductsGrid | Combination fields example grid |
| -------- | ------- |
| <img width="315" alt="Future generator ProductsGrid" src="https://github.com/user-attachments/assets/f0c64cf3-a842-4bfe-a345-61886746cb13"> | <img width="654" alt="Combination fields example grid" src="https://github.com/user-attachments/assets/f27839cd-1080-4680-b272-8ab4120a2f35"> |

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

- https://vivid-planet.atlassian.net/browse/SVK-373

## Open TODOs/questions

-   [x] Merge parent PR https://github.com/vivid-planet/comet/pull/2558
-   [x] Should the types name really be `formattedMessage`?
-   [x] Should the settings `message` and `valueFields` be named to match the props of the react-intl component? (`defaultMessage`/`values`)