### PR TITLE
Fix showing the clear button when the value of SelectField is empty

### DIFF
--- a/.changeset/six-rules-hope.md
+++ b/.changeset/six-rules-hope.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix an issue where the clear button of `SelectField` would be shown, even if the value is `undefined`

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -13,6 +13,14 @@ export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputEl
     required?: boolean;
 }
 
+const getHasClearableContent = (value: unknown, multiple: boolean | undefined) => {
+    if (multiple && Array.isArray(value)) {
+        return value.length > 0;
+    }
+
+    return value !== undefined && value !== "";
+};
+
 export const FinalFormSelect = <T,>({
     input: { checked, value, name, onChange, onFocus, onBlur, ...restInput },
     meta,
@@ -47,7 +55,7 @@ export const FinalFormSelect = <T,>({
     const endAdornment = !required ? (
         <ClearInputAdornment
             position="end"
-            hasClearableContent={Boolean(multiple ? (Array.isArray(value) ? value.length : value !== undefined) : value !== undefined)}
+            hasClearableContent={getHasClearableContent(value, multiple)}
             onClick={() => onChange(multiple ? [] : undefined)}
         />
     ) : null;


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

When the fields value in the form state is `undefined`, the internal value of the input itself is an empty string, as is always the case when accessing the value of an empty HTML input. 

<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Example

<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A dev story in Storybook
-   A unit test

--->

-   [x] I have verified if my change requires an example
    - See https://github.com/vivid-planet/comet/pull/2563

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

- https://vivid-planet.atlassian.net/browse/COM-1096
