### PR TITLE
Remove predefined page type from page link fragment

### DIFF
--- a/demo/site/src/header/PageLink.fragment.ts
+++ b/demo/site/src/header/PageLink.fragment.ts
@@ -12,9 +12,6 @@ export const pageLinkFragment = gql`
             ... on Link {
                 content
             }
-            ... on PredefinedPage {
-                type
-            }
         }
     }
 `;


### PR DESCRIPTION
Leftover from https://github.com/vivid-planet/comet/pull/2293.
