### PR TITLE
Improve GraphQLFetch error handling

### DIFF
--- a/.changeset/soft-spoons-deliver.md
+++ b/.changeset/soft-spoons-deliver.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-site": minor
+---
+
+gql: Handle non-string variables in GraphQL documents
+
+Non-string variables were incorrectly converted to strings, e.g., `'[object Object]'`. This error usually occurred when trying to import a GraphQL fragment from a React Client Component. The `gql` helper now throws an error for non-string variables.

--- a/.changeset/spotty-pigs-reply.md
+++ b/.changeset/spotty-pigs-reply.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": patch
+---
+
+GraphQLFetch: Correctly report GraphQL schema validation errors


### PR DESCRIPTION
Certain GraphQL-related errors were hard to debug in applications. We make two changes to improve this:
1. Add the request body to the error message if the request fails. GraphQL schema validation errors are treated as 400 errors, so the error handling for GraphQL errors was never "reached".
2. Add a useful error message when importing a GraphQL document from a React Client Component.

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Example

-   [x] I have verified if my change requires an example

## Screenshots/screencasts

### GraphQL schema validation errors

| Before   | After   |
| -------- | ------- |
| <img width="1011" alt="graphql error before" src="https://github.com/user-attachments/assets/13dc422a-ac7d-40b9-87e2-5d8287b2e15b"> | <img width="1011" alt="graphql error after" src="https://github.com/user-attachments/assets/2fb731fb-68d2-4619-8ddb-f8d5619716ab"> |


### GraphQL imports from React Client Components

| Before   | After   |
| -------- | ------- |
| <img width="1011" alt="client component before" src="https://github.com/user-attachments/assets/2f4dd6e0-ef0b-4ad9-955f-cef94d5d4d29"> | <img width="1011" alt="client component after" src="https://github.com/user-attachments/assets/4efd2162-66a3-46a2-b96c-2c9a184a46fc"> |


## Changeset

-   [x] I have verified if my change requires a changeset
