### PR TITLE
Update GitHub actions versions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,12 +21,12 @@ jobs:
         steps:
             - run: echo "${{ github.actor }}"
 
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - uses: pnpm/action-setup@v4
 
             - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18
                   registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - run: echo "${{ github.actor }}"
 
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
             - run: |
@@ -19,7 +19,7 @@ jobs:
                   git config user.email github-actions@github.com
 
             - name: "Library: Clone translations"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: vivid-planet/comet-lang
                   token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
             - uses: pnpm/action-setup@v4
 
             - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18
                   registry-url: "https://registry.npmjs.org"
@@ -47,7 +47,7 @@ jobs:
                   cwd: "./demo/admin/lang/comet-lang"
 
             - name: "Demo Admin: Clone translations"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: vivid-planet/comet-demo-lang
                   token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
@@ -65,7 +65,7 @@ jobs:
                   cwd: "./demo/admin/lang/comet-demo-lang"
 
             - name: "Demo Site: Clone translations"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: vivid-planet/comet-demo-lang
                   token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         steps:
             - run: echo "${{ github.actor }}"
 
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
             - run: |
@@ -26,28 +26,28 @@ jobs:
                   git config user.email github-actions@github.com
 
             - name: "Library: Clone translations"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: vivid-planet/comet-lang
                   token: ${{ secrets.GITHUB_TOKEN }}
                   path: "demo/admin/lang/comet-lang"
 
             - name: "Demo Admin: Clone translations"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: vivid-planet/comet-demo-lang
                   token: ${{ secrets.GITHUB_TOKEN }}
                   path: "demo/admin/lang/comet-demo-lang"
 
             - name: "Demo Site: Clone translations"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: vivid-planet/comet-demo-lang
                   token: ${{ secrets.GITHUB_TOKEN }}
                   path: "demo/site/lang/comet-demo-lang"
 
             - name: "Demo Site Pages: Clone translations"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: vivid-planet/comet-demo-lang
                   token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
             - uses: pnpm/action-setup@v4
 
             - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18
                   registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -15,7 +15,7 @@ jobs:
             in-prerelease-mode: ${{ steps.check-if-prerelease-mode.outputs.in-prerelease-mode }}
         steps:
             - name: Checkout Repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - id: check-if-prerelease-mode
               name: Check if in Prerelease Mode
@@ -32,12 +32,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: pnpm/action-setup@v4
 
             - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18
                   registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -14,12 +14,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: pnpm/action-setup@v4
 
             - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18
                   registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
             cancel-in-progress: true
         steps:
             - name: Checkout Repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: pnpm/action-setup@v4
 
             - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18
                   registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         steps:
             - run: echo "${{ github.actor }}"
 
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
             - run: |
@@ -28,7 +28,7 @@ jobs:
             - uses: pnpm/action-setup@v4
 
             - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18
                   registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Addresses the following warning: `The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-node@v3.`
