### PR TITLE
Set content scopes in request object

### DIFF
--- a/.changeset/blue-moons-travel.md
+++ b/.changeset/blue-moons-travel.md
@@ -1,0 +1,33 @@
+---
+"@comet/cms-api": minor
+---
+
+Set content scopes in request object
+
+This allows accessing the affected content scopes inside a block's transformer service.
+
+**Example**
+
+```ts
+import { Inject, Injectable } from "@nestjs/common";
+import { CONTEXT } from "@nestjs/graphql";
+
+/* ... */
+
+@Injectable()
+export class PixelImageBlockTransformerService implements BlockTransformerServiceInterface<PixelImageBlockData, TransformResponse> {
+    constructor(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        @Inject(CONTEXT) private readonly context: any,
+    ) {}
+
+    async transformToPlain(block: PixelImageBlockData) {
+        // Get the affected content scopes
+        const contentScopes = this.context.req.contentScopes;
+
+        // Do something with the content scopes
+
+        /* ... */
+    }
+}
+```

--- a/packages/api/cms-api/src/common/decorators/utils.ts
+++ b/packages/api/cms-api/src/common/decorators/utils.ts
@@ -1,8 +1,7 @@
 import { ExecutionContext } from "@nestjs/common";
 import { GqlExecutionContext } from "@nestjs/graphql";
-import { Request } from "express";
 
-export const getRequestFromExecutionContext = (ctx: ExecutionContext): Request => {
+export const getRequestFromExecutionContext = (ctx: ExecutionContext) => {
     if (ctx.getType().toString() === "graphql") {
         return GqlExecutionContext.create(ctx).getContext().req;
     }

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
@@ -2,6 +2,7 @@ import { CanActivate, ExecutionContext, Inject, Injectable } from "@nestjs/commo
 import { Reflector } from "@nestjs/core";
 import { GqlContextType, GqlExecutionContext } from "@nestjs/graphql";
 
+import { getRequestFromExecutionContext } from "../../common/decorators/utils";
 import { ContentScopeService } from "../content-scope.service";
 import { DisablePermissionCheck, RequiredPermissionMetadata } from "../decorators/required-permission.decorator";
 import { CurrentUser } from "../dto/current-user";
@@ -19,6 +20,13 @@ export class UserPermissionsGuard implements CanActivate {
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const location = `${context.getClass().name}::${context.getHandler().name}()`;
+
+        const requiredContentScopes = await this.contentScopeService.getScopesForPermissionCheck(context);
+
+        if (!this.isResolvingGraphQLField(context)) {
+            const request = getRequestFromExecutionContext(context);
+            request.contentScopes = this.contentScopeService.getUniqueScopes(requiredContentScopes);
+        }
 
         if (this.getDecorator(context, "disableCometGuards")) return true;
 
@@ -38,7 +46,6 @@ export class UserPermissionsGuard implements CanActivate {
             // At least one permission is required
             return requiredPermissions.some((permission) => this.accessControlService.isAllowed(user, permission));
         } else {
-            const requiredContentScopes = await this.contentScopeService.getScopesForPermissionCheck(context);
             if (requiredContentScopes.length === 0)
                 throw new Error(
                     `Could not get content scope. Either pass a scope-argument or add an @AffectedEntity()-decorator or enable skipScopeCheck in the @RequiredPermission()-decorator of ${location}`,

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
@@ -23,6 +23,7 @@ export class UserPermissionsGuard implements CanActivate {
 
         const requiredContentScopes = await this.contentScopeService.getScopesForPermissionCheck(context);
 
+        // Ignore field resolvers as they have no scopes and would overwrite the scopes of the root query.
         if (!this.isResolvingGraphQLField(context)) {
             const request = getRequestFromExecutionContext(context);
             request.contentScopes = this.contentScopeService.getUniqueScopes(requiredContentScopes);

--- a/packages/api/cms-api/src/user-permissions/content-scope.service.ts
+++ b/packages/api/cms-api/src/user-permissions/content-scope.service.ts
@@ -43,7 +43,19 @@ export class ContentScopeService {
     }
 
     async inferScopesFromExecutionContext(context: ExecutionContext): Promise<ContentScope[]> {
-        return [...new Set((await this.getScopesForPermissionCheck(context)).flat())];
+        return this.getUniqueScopes(await this.getScopesForPermissionCheck(context));
+    }
+
+    getUniqueScopes(scopes: ContentScope[][]): ContentScope[] {
+        const uniqueScopes: ContentScope[] = [];
+
+        scopes.flat().forEach((incomingScope) => {
+            if (!uniqueScopes.some((existingScope) => this.scopesAreEqual(existingScope, incomingScope))) {
+                uniqueScopes.push(incomingScope);
+            }
+        });
+
+        return uniqueScopes;
     }
 
     private async getContentScopesFromEntity(affectedEntity: AffectedEntityMeta, args: Record<string, string>): Promise<ContentScope[][]> {

--- a/packages/api/cms-api/src/user-permissions/decorators/content-scopes.decorator.ts
+++ b/packages/api/cms-api/src/user-permissions/decorators/content-scopes.decorator.ts
@@ -1,9 +1,0 @@
-import { createParamDecorator, ExecutionContext } from "@nestjs/common";
-
-import { getRequestFromExecutionContext } from "../../common/decorators/utils";
-import { ContentScope } from "../interfaces/content-scope.interface";
-
-export const ContentScopes = createParamDecorator((data: unknown, context: ExecutionContext): ContentScope[] | undefined => {
-    const request = getRequestFromExecutionContext(context);
-    return request.contentScopes;
-});

--- a/packages/api/cms-api/src/user-permissions/decorators/content-scopes.decorator.ts
+++ b/packages/api/cms-api/src/user-permissions/decorators/content-scopes.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+
+import { getRequestFromExecutionContext } from "../../common/decorators/utils";
+import { ContentScope } from "../interfaces/content-scope.interface";
+
+export const ContentScopes = createParamDecorator((data: unknown, context: ExecutionContext): ContentScope[] | undefined => {
+    const request = getRequestFromExecutionContext(context);
+    return request.contentScopes;
+});


### PR DESCRIPTION
## Description

We sometimes need the affected content scope(s) in a block's transformer service. To enable this, we set the content scopes retrieved in the `UserPermissionsGuard` in the `request` object (similar to how the `AuthGuard` sets the `user` ). This then allows accessing the content scopes in the transformer service.

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Example

<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A dev story in Storybook
-   A unit test

--->

-   [x] I have verified if my change requires an example

```ts
import { Inject, Injectable } from "@nestjs/common";
import { CONTEXT } from "@nestjs/graphql";

/* ... */

@Injectable()
export class PixelImageBlockTransformerService implements BlockTransformerServiceInterface<PixelImageBlockData, TransformResponse> {
    constructor(
        // eslint-disable-next-line @typescript-eslint/no-explicit-any
        @Inject(CONTEXT) private readonly context: any,
    ) {}

    async transformToPlain(block: PixelImageBlockData) {
        // Get the affected content scopes
        const contentScopes = this.context.req.contentScopes;

        // Do something with the content scopes

        /* ... */
    }
}
```

We don't have a block in Demo where having the content scopes would be useful. IMO it's fine to not have a working example in the Demo.

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset
