### PR TITLE
COM-1014: Prevent rendering of RichTextBlock without content

### DIFF
--- a/.changeset/wise-mirrors-rescue.md
+++ b/.changeset/wise-mirrors-rescue.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-site": patch
+---
+
+Prevent rendering of blocks without content
+
+In order to prevent rendering empty blocks in site and cause unwanted placeholders, the `PreviewSkeleton` returns children only if the wrapped block has content.
+For instance, an empty rich text block would still render a HTML tag.

--- a/.changeset/wise-mirrors-rescue.md
+++ b/.changeset/wise-mirrors-rescue.md
@@ -2,7 +2,9 @@
 "@comet/cms-site": patch
 ---
 
-Prevent rendering of blocks without content
+Prevent rendering of empty blocks in `PreviewSkeleton`
 
-In order to prevent rendering empty blocks in site and cause unwanted placeholders, the `PreviewSkeleton` returns children only if the wrapped block has content.
-For instance, an empty rich text block would still render a HTML tag.
+Previously, in non-preview environments, `PreviewSkeleton` would still render its children, even if `hasChanges` was set to `false`, causing unwanted empty HTML tags in the site.
+For instance, an empty rich text block would still render a `<p>` tag.
+Now, the children will only be rendered if `hasContent` is set to `true`.
+Doing so removes the need for duplicate empty checks.

--- a/packages/site/cms-site/src/previewskeleton/PreviewSkeleton.tsx
+++ b/packages/site/cms-site/src/previewskeleton/PreviewSkeleton.tsx
@@ -53,6 +53,11 @@ const PreviewSkeleton = ({
             );
         }
     }
+
+    if (!hasContent) {
+        return null;
+    }
+
     return <>{children}</>;
 };
 


### PR DESCRIPTION
## Description

Currently, blocks using the `PreviewSkeleton` are rendered empty in the site if they do not contain any content. This causes unwanted HTML tags in the site. This change prevents these blocks from being rendered without content.

## Example

-   [x] I have verified if my change requires an example

## Screenshots/screencasts

| Before   | After   |
| -------- | ------- |
| <img width="1389" alt="site-before-change" src="https://github.com/user-attachments/assets/8feb342c-6290-4642-a8f6-aa42b2f7a5b5"> | <img width="1398" alt="site-after-change" src="https://github.com/user-attachments/assets/64ea92e4-6104-4c52-a820-8d0b45a06bdb"> |

## Changeset

-   [x] I have verified if my change requires a changeset

