### PR TITLE
Add file size to `DamFileDownloadLinkBlock`

### DIFF
--- a/.changeset/odd-donuts-behave.md
+++ b/.changeset/odd-donuts-behave.md
@@ -1,0 +1,6 @@
+---
+"@comet/cms-admin": minor
+"@comet/cms-api": minor
+---
+
+Add file size to `DamFileDownloadLinkBlock`

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -182,6 +182,11 @@
                             "name": "fileUrl",
                             "kind": "String",
                             "nullable": false
+                        },
+                        {
+                            "name": "size",
+                            "kind": "Number",
+                            "nullable": false
                         }
                     ]
                 },

--- a/demo/site/src/blocks/TextLinkBlock.tsx
+++ b/demo/site/src/blocks/TextLinkBlock.tsx
@@ -7,6 +7,16 @@ import { LinkBlock } from "./LinkBlock";
 
 export const TextLinkBlock = withPreview(
     ({ data: { link, text } }: PropsWithData<DemoTextLinkBlockData>) => {
+        if (link.block && link.block.type === "damFileDownload" && "file" in link.block.props && link.block.props.file) {
+            return (
+                <Link data={link}>
+                    <>
+                        {text} ({Math.round(link.block.props.file.size / 1024)} KB)
+                    </>
+                </Link>
+            );
+        }
+
         return <Link data={link}>{text}</Link>;
     },
     { label: "Link" },

--- a/packages/admin/cms-admin/src/dam/blocks/DamFileDownloadLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/dam/blocks/DamFileDownloadLinkBlock.tsx
@@ -47,6 +47,7 @@ export const DamFileDownloadLinkBlock: BlockInterface<DamFileDownloadLinkBlockDa
                         id
                         name
                         fileUrl
+                        size
                     }
                 }
             `,
@@ -59,6 +60,7 @@ export const DamFileDownloadLinkBlock: BlockInterface<DamFileDownloadLinkBlockDa
             id: damFile.id,
             name: damFile.name,
             fileUrl: damFile.fileUrl,
+            size: damFile.size,
         };
 
         return ret;

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -38,6 +38,11 @@
                             "name": "fileUrl",
                             "kind": "String",
                             "nullable": false
+                        },
+                        {
+                            "name": "size",
+                            "kind": "Number",
+                            "nullable": false
                         }
                     ]
                 },

--- a/packages/api/cms-api/src/dam/blocks/dam-file-download-link-block-transformer.service.ts
+++ b/packages/api/cms-api/src/dam/blocks/dam-file-download-link-block-transformer.service.ts
@@ -9,6 +9,7 @@ type TransformResponse = {
         id: string;
         name: string;
         fileUrl: string;
+        size: number;
     };
 };
 
@@ -32,12 +33,14 @@ export class DamFileDownloadLinkBlockTransformerService implements BlockTransfor
                 id: file.id,
                 name: file.name,
                 fileUrl: await this.filesService.createFileUrl(file, { previewDamUrls, relativeDamUrls }),
+                size: Number(file.size),
             };
         } else if (file && block.openFileType === "Download") {
             ret.file = {
                 id: file.id,
                 name: file.name,
                 fileUrl: await this.filesService.createFileDownloadUrl(file, { previewDamUrls, relativeDamUrls }),
+                size: Number(file.size),
             };
         }
 

--- a/packages/api/cms-api/src/dam/blocks/dam-file-download-link.block.ts
+++ b/packages/api/cms-api/src/dam/blocks/dam-file-download-link.block.ts
@@ -85,6 +85,11 @@ class Meta extends AnnotationBlockMeta {
                             kind: BlockMetaFieldKind.String,
                             nullable: false,
                         },
+                        {
+                            name: "size",
+                            kind: BlockMetaFieldKind.Number,
+                            nullable: false,
+                        },
                     ],
                 },
             },


### PR DESCRIPTION
## Description

This can be useful to display the size of the file to download in the link.

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Example

<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A dev story in Storybook
-   A unit test

--->

-   [x] I have verified if my change requires an example

## Screenshots/screencasts

<img width="110" alt="image" src="https://github.com/user-attachments/assets/a9bac1ac-6860-4f0e-afbc-c798ea7e5cdb">


## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset
