### PR TITLE
Adapt the `DeleteDialog` in `CrudContextMenu` to match the updated Comet CI

### DIFF
--- a/.changeset/brown-trainers-build.md
+++ b/.changeset/brown-trainers-build.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-Refactor styling and text of `DeleteDialog` in `CrudContextMenu`
+Adapt the `DeleteDialog` in `CrudContextMenu` to match the updated Comet CI

--- a/.changeset/brown-trainers-build.md
+++ b/.changeset/brown-trainers-build.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Refactor styling and text of `DeleteDialog` in `CrudContextMenu`

--- a/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
@@ -1,11 +1,12 @@
 import { ApolloClient, RefetchQueriesOptions, useApolloClient } from "@apollo/client";
-import { Copy, Delete as DeleteIcon, Domain, Paste, ThreeDotSaving } from "@comet/admin-icons";
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Divider } from "@mui/material";
+import { Copy, Delete as DeleteIcon, Domain, Paste, ThreeDotSaving, WarningSolid } from "@comet/admin-icons";
+import { Dialog, DialogActions, DialogContent, DialogTitle, Divider } from "@mui/material";
 import { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { readClipboardText } from "../clipboard/readClipboardText";
 import { writeClipboardText } from "../clipboard/writeClipboardText";
+import { CancelButton } from "../common/buttons/cancel/CancelButton";
 import { FeedbackButton } from "../common/buttons/feedback/FeedbackButton";
 import { useErrorDialog } from "../error/errordialog/useErrorDialog";
 import { messages } from "../messages";
@@ -22,25 +23,24 @@ const DeleteDialog = (props: DeleteDialogProps) => {
     const { dialogOpen, onDelete, onCancel } = props;
 
     return (
-        <Dialog open={dialogOpen} onClose={onDelete}>
+        <Dialog open={dialogOpen} onClose={onDelete} maxWidth="sm">
             <DialogTitle>
-                <FormattedMessage id="comet.table.deleteDialog.title" defaultMessage="Delete item?" />
+                <FormattedMessage id="comet.table.deleteDialog.title" defaultMessage="Attention. Please confirm." />
             </DialogTitle>
-            <DialogContent>
-                <FormattedMessage id="comet.table.deleteDialog.content" defaultMessage="WARNING: This cannot be undone!" />
+            <DialogContent sx={{ gap: (theme) => theme.spacing(2), display: "flex", alignItems: "center" }}>
+                <WarningSolid color="error" />
+                <FormattedMessage id="comet.table.deleteDialog.content" defaultMessage="You are about to delete this item permanently." />
             </DialogContent>
             <DialogActions>
-                <Button onClick={onCancel} color="primary">
-                    <FormattedMessage {...messages.no} />
-                </Button>
+                <CancelButton onClick={onCancel} />
                 <FeedbackButton
                     startIcon={<DeleteIcon />}
                     onClick={onDelete}
-                    color="primary"
-                    variant="contained"
+                    color="error"
+                    variant="outlined"
                     tooltipErrorMessage={<FormattedMessage id="comet.common.deleteFailed" defaultMessage="Failed to delete" />}
                 >
-                    <FormattedMessage {...messages.yes} />
+                    <FormattedMessage {...messages.delete} />
                 </FeedbackButton>
             </DialogActions>
         </Dialog>


### PR DESCRIPTION
## Description

Change styling and text of `DeleteDialog` in `CrudContextMenu` to match the updated Comet CI.

## Screenshots/screencasts

| Before   | After   |
| -------- | ------- |
|<img width="705" alt="Bildschirmfoto 2024-10-02 um 10 05 20" src="https://github.com/user-attachments/assets/9d75a0f0-1a03-488c-a02f-79219ea4aefa"> | <img width="702" alt="Bildschirmfoto 2024-10-02 um 09 58 24" src="https://github.com/user-attachments/assets/f6a4dc27-b2c5-40ca-8cfb-03f3199c2c38">    |


## Changeset

-   [x] I have verified if my change requires a changeset


## Further information

Based on following Figma design:

<img width="468" alt="Bildschirmfoto 2024-10-02 um 10 08 42" src="https://github.com/user-attachments/assets/13dc6868-e1f6-4e84-bf50-ae83a79f2a72">
