### PR TITLE
Admin Generator (Future): Fix width of actions column in grid

### DIFF
--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -51,7 +51,6 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
         { type: "dateTime", name: "createdAt", width: 170 },
         {
             type: "actions",
-            width: 116,
             component: { name: "ProductsGridPreviewAction", import: "../../ProductsGridPreviewAction" },
         },
     ],

--- a/demo/admin/src/products/future/ProductsPage.tsx
+++ b/demo/admin/src/products/future/ProductsPage.tsx
@@ -61,6 +61,7 @@ export function ProductsPage() {
                                     <Edit color="primary" />
                                 </IconButton>
                             )}
+                            actionsColumnWidth={116}
                         />
                     </MainContent>
                 </StackPage>

--- a/demo/admin/src/products/future/ProductsWithLowPricePage.tsx
+++ b/demo/admin/src/products/future/ProductsWithLowPricePage.tsx
@@ -6,7 +6,7 @@ export function ProductsWithLowPricePage() {
     // This grid needs no add or edit-button
     return (
         <MainContent fullHeight>
-            <ProductsGrid filter={{ price: { lowerThan: 10 } }} />
+            <ProductsGrid filter={{ price: { lowerThan: 10 } }} actionsColumnWidth={84} />
         </MainContent>
     );
 }

--- a/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
@@ -88,9 +88,10 @@ type Props = {
     toolbarAction?: React.ReactNode;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     rowAction?: (params: GridRenderCellParams<any, GQLCombinationFieldsTestProductsGridFutureFragment, any>) => React.ReactNode;
+    actionsColumnWidth?: number;
 };
 
-export function ProductsGrid({ toolbarAction, rowAction }: Props): React.ReactElement {
+export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52 }: Props): React.ReactElement {
     const client = useApolloClient();
     const intl = useIntl();
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };
@@ -209,7 +210,7 @@ export function ProductsGrid({ toolbarAction, rowAction }: Props): React.ReactEl
             type: "actions",
             align: "right",
             pinned: "right",
-            width: 84,
+            width: actionsColumnWidth,
             renderCell: (params) => {
                 return (
                     <>

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -97,9 +97,10 @@ type Props = {
     toolbarAction?: React.ReactNode;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     rowAction?: (params: GridRenderCellParams<any, GQLProductsGridFutureFragment, any>) => React.ReactNode;
+    actionsColumnWidth?: number;
 };
 
-export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React.ReactElement {
+export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWidth = 52 }: Props): React.ReactElement {
     const client = useApolloClient();
     const intl = useIntl();
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductsGrid") };
@@ -226,7 +227,7 @@ export function ProductsGrid({ filter, toolbarAction, rowAction }: Props): React
             type: "actions",
             align: "right",
             pinned: "right",
-            width: 116,
+            width: actionsColumnWidth,
             renderCell: (params) => {
                 return (
                     <>


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

The width of the columns is now calculated correctly depending on how many items are rendered in the actions column. 
For the case that custom actions are passed in, you can:

**Set the `width` in the config of the column with `type: "actions"` – the same as was previously possible:**

```tsx
{
    type: "actions",
    width: 116,
    component: { name: "ProductsGridPreviewAction", import: "../../ProductsGridPreviewAction" },
},
```

**Or use the optional `actionsColumnWidth` prop on the grid directly, in case the same grid is used multiple times with a different number of actions, per usage:** 

```tsx
<ProductsGrid rowAction={(params) => <SingleCustomAction />} actionsColumnWidth={116} />
<ProductsGrid rowAction={(params) => <TwoCustomActions />} actionsColumnWidth={148} />
```


<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Example

<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A dev story in Storybook
-   A unit test

--->

-   [x] I have verified if my change requires an example

## Screenshots/screencasts

| Before   | After   |
| -------- | ------- |
| <img width="694" alt="Products grid previously and now" src="https://github.com/user-attachments/assets/d176405f-53ea-41a2-8694-a5f9db5df348">     | <img width="694" alt="Products grid previously and now" src="https://github.com/user-attachments/assets/d176405f-53ea-41a2-8694-a5f9db5df348">    |
| <img width="694" alt="Combination fields grid previously" src="https://github.com/user-attachments/assets/67a7b68d-52ac-4b50-8929-2d7a7e078c84"> | <img width="694" alt="Combination fields grid now" src="https://github.com/user-attachments/assets/86c0b899-2a3f-4986-89b0-de7485951a5d"> |
| <img width="694" alt="Products with low price previously" src="https://github.com/user-attachments/assets/59de502f-c2d9-450a-8c39-abfc784c280d"> | <img width="694" alt="Products with low price now" src="https://github.com/user-attachments/assets/1d69bcfc-0c4b-4442-ad4d-3c622c53e3fb"> |

<!--

When making a visual change, please provide either screenshots or screencasts.

Hint: For before/after views, you can use a table:

| Before   | After   |
| -------- | ------- |
| Link     | Link    |

-->

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1103

<!--

Link to related tasks and documents, for instance, https://vivid-planet.atlassian.net/browse/COM-XXX.

MAKE SURE THAT EVERYTHING REQUIRED TO UNDERSTAND YOUR CHANGE IS IN THE PR DESCRIPTION.
Reviewers shouldn't need to review tasks, JIRA conversations etc. to understand what you're doing.

-->
