### PR TITLE
Fix copy/paste for documents containing a `DamFileDownloadLinkBlock`

### DIFF
--- a/.changeset/few-jobs-refuse.md
+++ b/.changeset/few-jobs-refuse.md
@@ -1,0 +1,6 @@
+---
+"@comet/cms-admin": patch
+"@comet/cms-api": patch
+---
+
+Fix copy/paste for documents containing a `DamFileDownloadLinkBlock`

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -187,6 +187,11 @@
                             "name": "size",
                             "kind": "Number",
                             "nullable": false
+                        },
+                        {
+                            "name": "scope",
+                            "kind": "Json",
+                            "nullable": true
                         }
                     ]
                 },

--- a/packages/admin/cms-admin/src/dam/blocks/DamFileDownloadLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/dam/blocks/DamFileDownloadLinkBlock.tsx
@@ -1,8 +1,17 @@
 import { gql } from "@apollo/client";
 import { Field, FinalFormSelect, messages } from "@comet/admin";
 import { Delete } from "@comet/admin-icons";
-import { AdminComponentButton, AdminComponentPaper, BlockCategory, BlockInterface, BlocksFinalForm, createBlockSkeleton } from "@comet/blocks-admin";
+import {
+    AdminComponentButton,
+    AdminComponentPaper,
+    BlockCategory,
+    BlockDependency,
+    BlockInterface,
+    BlocksFinalForm,
+    createBlockSkeleton,
+} from "@comet/blocks-admin";
 import { Box, Divider, MenuItem, Typography } from "@mui/material";
+import { deepClone } from "@mui/x-data-grid/utils/utils";
 import { FormattedMessage } from "react-intl";
 
 import { DamFileDownloadLinkBlockData, DamFileDownloadLinkBlockInput } from "../../blocks.generated";
@@ -64,6 +73,33 @@ export const DamFileDownloadLinkBlock: BlockInterface<DamFileDownloadLinkBlockDa
         };
 
         return ret;
+    },
+
+    dependencies: (state) => {
+        const dependencies: BlockDependency[] = [];
+
+        if (state.file?.id) {
+            dependencies.push({
+                targetGraphqlObjectType: "DamFile",
+                id: state.file.id,
+                data: {
+                    damFile: state.file,
+                },
+            });
+        }
+
+        return dependencies;
+    },
+
+    replaceDependenciesInOutput: (output, replacements) => {
+        const clonedOutput: DamFileDownloadLinkBlockInput = deepClone(output);
+        const replacement = replacements.find((replacement) => replacement.type === "DamFile" && replacement.originalId === output.fileId);
+
+        if (replacement) {
+            clonedOutput.fileId = replacement.replaceWithId;
+        }
+
+        return clonedOutput;
     },
 
     definesOwnPadding: true,

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -43,6 +43,11 @@
                             "name": "size",
                             "kind": "Number",
                             "nullable": false
+                        },
+                        {
+                            "name": "scope",
+                            "kind": "Json",
+                            "nullable": true
                         }
                     ]
                 },

--- a/packages/api/cms-api/src/dam/blocks/dam-file-download-link-block-transformer.service.ts
+++ b/packages/api/cms-api/src/dam/blocks/dam-file-download-link-block-transformer.service.ts
@@ -34,6 +34,7 @@ export class DamFileDownloadLinkBlockTransformerService implements BlockTransfor
                 name: file.name,
                 fileUrl: await this.filesService.createFileUrl(file, { previewDamUrls, relativeDamUrls }),
                 size: Number(file.size),
+                scope: file.scope,
             };
         } else if (file && block.openFileType === "Download") {
             ret.file = {
@@ -41,6 +42,7 @@ export class DamFileDownloadLinkBlockTransformerService implements BlockTransfor
                 name: file.name,
                 fileUrl: await this.filesService.createFileDownloadUrl(file, { previewDamUrls, relativeDamUrls }),
                 size: Number(file.size),
+                scope: file.scope,
             };
         }
 

--- a/packages/api/cms-api/src/dam/blocks/dam-file-download-link.block.ts
+++ b/packages/api/cms-api/src/dam/blocks/dam-file-download-link.block.ts
@@ -90,6 +90,11 @@ class Meta extends AnnotationBlockMeta {
                             kind: BlockMetaFieldKind.Number,
                             nullable: false,
                         },
+                        {
+                            name: "scope",
+                            kind: BlockMetaFieldKind.Json,
+                            nullable: true,
+                        },
                     ],
                 },
             },


### PR DESCRIPTION
## Description

### Previously

The linked file wasn't copied to the target scope when copying a document containing a `DamFileDownloadLinkBlock` between scopes

### Now

The file referenced by the `DamFileDownloadLinkBlock`  is correctly copied to the target scope

## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1058
