### PR TITLE
Allow customization of `CrudContextMenu`

### DIFF
--- a/.changeset/gentle-crews-drum.md
+++ b/.changeset/gentle-crews-drum.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+`CrudContextMenu`: Allow customization using `slotProps`, `iconMapping` and `messagesMapping`

--- a/.changeset/gentle-crews-drum.md
+++ b/.changeset/gentle-crews-drum.md
@@ -2,4 +2,23 @@
 "@comet/admin": patch
 ---
 
-`CrudContextMenu`: Allow customization using `slotProps`, `iconMapping` and `messagesMapping`
+Allow customizing `CrudContextMenu`
+
+Customize existing parts of `CrudContextMenu` using the `slotProps`, `iconMapping` and `messagesMapping` props.
+Add custom actions by adding instances of `RowActionsItem` to the `children`:
+
+```tsx
+<CrudContextMenu
+// ...
+>
+    <RowActionsItem
+        icon={<Favorite />}
+        onClick={() => {
+            // Do something
+        }}
+    >
+        Custom action
+    </RowActionsItem>
+    <Divider />
+</CrudContextMenu>
+```

--- a/packages/admin/admin/src/common/DeleteDialog.tsx
+++ b/packages/admin/admin/src/common/DeleteDialog.tsx
@@ -1,0 +1,41 @@
+import { Delete as DeleteIcon, WarningSolid } from "@comet/admin-icons";
+import { Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import { FormattedMessage } from "react-intl";
+
+import { messages } from "../messages";
+import { CancelButton } from "./buttons/cancel/CancelButton";
+import { FeedbackButton } from "./buttons/feedback/FeedbackButton";
+
+interface DeleteDialogProps {
+    dialogOpen: boolean;
+    onDelete: () => Promise<void>;
+    onCancel: () => void;
+}
+
+export const DeleteDialog = (props: DeleteDialogProps) => {
+    const { dialogOpen, onDelete, onCancel } = props;
+
+    return (
+        <Dialog open={dialogOpen} onClose={onDelete} maxWidth="sm">
+            <DialogTitle>
+                <FormattedMessage id="comet.table.deleteDialog.title" defaultMessage="Attention. Please confirm." />
+            </DialogTitle>
+            <DialogContent sx={{ gap: (theme) => theme.spacing(2), display: "flex", alignItems: "center" }}>
+                <WarningSolid color="error" />
+                <FormattedMessage id="comet.table.deleteDialog.content" defaultMessage="You are about to delete this item permanently." />
+            </DialogContent>
+            <DialogActions>
+                <CancelButton onClick={onCancel} />
+                <FeedbackButton
+                    startIcon={<DeleteIcon />}
+                    onClick={onDelete}
+                    color="error"
+                    variant="outlined"
+                    tooltipErrorMessage={<FormattedMessage id="comet.common.deleteFailed" defaultMessage="Failed to delete" />}
+                >
+                    <FormattedMessage {...messages.delete} />
+                </FeedbackButton>
+            </DialogActions>
+        </Dialog>
+    );
+};

--- a/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
@@ -56,6 +56,10 @@ export interface CrudContextMenuProps<CopyData>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     refetchQueries?: RefetchQueriesOptions<any, unknown>["include"];
     copyData?: () => Promise<CopyData> | CopyData;
+    /**
+     * Render custom `RowActionsItem` components to be added to the menu.
+     */
+    children?: ReactNode;
 }
 
 export function CrudContextMenu<CopyData>(inProps: CrudContextMenuProps<CopyData>) {
@@ -68,6 +72,7 @@ export function CrudContextMenu<CopyData>(inProps: CrudContextMenuProps<CopyData
         slotProps,
         iconMapping = {},
         messagesMapping = {},
+        children,
         ...restProp
     } = useThemeProps({
         props: inProps,
@@ -161,6 +166,7 @@ export function CrudContextMenu<CopyData>(inProps: CrudContextMenuProps<CopyData
         <>
             <Root {...slotProps?.root} {...restProp}>
                 <ItemsMenu {...slotProps?.itemsMenu}>
+                    {children}
                     {url && (
                         <CopyUrlItem
                             icon={copyUrlIcon}

--- a/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
@@ -1,51 +1,16 @@
 import { ApolloClient, RefetchQueriesOptions, useApolloClient } from "@apollo/client";
-import { Copy, Delete as DeleteIcon, Domain, Paste, ThreeDotSaving, WarningSolid } from "@comet/admin-icons";
-import { Dialog, DialogActions, DialogContent, DialogTitle, Divider } from "@mui/material";
+import { Copy, Delete as DeleteIcon, Domain, Paste, ThreeDotSaving } from "@comet/admin-icons";
+import { Divider } from "@mui/material";
 import { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { readClipboardText } from "../clipboard/readClipboardText";
 import { writeClipboardText } from "../clipboard/writeClipboardText";
-import { CancelButton } from "../common/buttons/cancel/CancelButton";
-import { FeedbackButton } from "../common/buttons/feedback/FeedbackButton";
+import { DeleteDialog } from "../common/DeleteDialog";
 import { useErrorDialog } from "../error/errordialog/useErrorDialog";
 import { messages } from "../messages";
 import { RowActionsItem } from "../rowActions/RowActionsItem";
 import { RowActionsMenu } from "../rowActions/RowActionsMenu";
-
-interface DeleteDialogProps {
-    dialogOpen: boolean;
-    onDelete: () => Promise<void>;
-    onCancel: () => void;
-}
-
-const DeleteDialog = (props: DeleteDialogProps) => {
-    const { dialogOpen, onDelete, onCancel } = props;
-
-    return (
-        <Dialog open={dialogOpen} onClose={onDelete} maxWidth="sm">
-            <DialogTitle>
-                <FormattedMessage id="comet.table.deleteDialog.title" defaultMessage="Attention. Please confirm." />
-            </DialogTitle>
-            <DialogContent sx={{ gap: (theme) => theme.spacing(2), display: "flex", alignItems: "center" }}>
-                <WarningSolid color="error" />
-                <FormattedMessage id="comet.table.deleteDialog.content" defaultMessage="You are about to delete this item permanently." />
-            </DialogContent>
-            <DialogActions>
-                <CancelButton onClick={onCancel} />
-                <FeedbackButton
-                    startIcon={<DeleteIcon />}
-                    onClick={onDelete}
-                    color="error"
-                    variant="outlined"
-                    tooltipErrorMessage={<FormattedMessage id="comet.common.deleteFailed" defaultMessage="Failed to delete" />}
-                >
-                    <FormattedMessage {...messages.delete} />
-                </FeedbackButton>
-            </DialogActions>
-        </Dialog>
-    );
-};
 
 export interface CrudContextMenuProps<CopyData> {
     url?: string;

--- a/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
@@ -1,18 +1,55 @@
 import { ApolloClient, RefetchQueriesOptions, useApolloClient } from "@apollo/client";
 import { Copy, Delete as DeleteIcon, Domain, Paste, ThreeDotSaving } from "@comet/admin-icons";
-import { Divider } from "@mui/material";
-import { useState } from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { ComponentsOverrides, Divider, Theme, useThemeProps } from "@mui/material";
+import { ReactNode, useState } from "react";
+import { FormattedMessage } from "react-intl";
 
 import { readClipboardText } from "../clipboard/readClipboardText";
 import { writeClipboardText } from "../clipboard/writeClipboardText";
-import { DeleteDialog } from "../common/DeleteDialog";
+import { DeleteDialog as CommonDeleteDialog } from "../common/DeleteDialog";
 import { useErrorDialog } from "../error/errordialog/useErrorDialog";
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 import { messages } from "../messages";
 import { RowActionsItem } from "../rowActions/RowActionsItem";
 import { RowActionsMenu } from "../rowActions/RowActionsMenu";
 
-export interface CrudContextMenuProps<CopyData> {
+export type CrudContextMenuClassKey =
+    | "root"
+    | "itemsMenu"
+    | "copyUrlItem"
+    | "deleteItem"
+    | "copyItem"
+    | "pasteItem"
+    | "itemsDivider"
+    | "deleteItem"
+    | "deleteDialog";
+
+export interface CrudContextMenuProps<CopyData>
+    extends ThemedComponentBaseProps<{
+        root: typeof RowActionsMenu;
+        itemsMenu: typeof RowActionsMenu;
+        copyUrlItem: typeof RowActionsItem;
+        copyItem: typeof RowActionsItem;
+        pasteItem: typeof RowActionsItem;
+        itemsDivider: typeof Divider;
+        deleteItem: typeof RowActionsItem;
+        deleteDialog: typeof CommonDeleteDialog;
+    }> {
+    iconMapping?: {
+        copyUrl?: ReactNode;
+        copy?: ReactNode;
+        copyLoading?: ReactNode;
+        paste?: ReactNode;
+        pasteLoading?: ReactNode;
+        delete?: ReactNode;
+    };
+    messagesMapping?: {
+        copyUrl?: ReactNode;
+        copy?: ReactNode;
+        paste?: ReactNode;
+        delete?: ReactNode;
+    };
     url?: string;
     onPaste?: (options: { input: CopyData; client: ApolloClient<object> }) => Promise<void>;
     onDelete?: (options: { client: ApolloClient<object> }) => Promise<void>;
@@ -21,8 +58,38 @@ export interface CrudContextMenuProps<CopyData> {
     copyData?: () => Promise<CopyData> | CopyData;
 }
 
-export function CrudContextMenu<CopyData>({ url, onPaste, onDelete, refetchQueries, copyData }: CrudContextMenuProps<CopyData>) {
-    const intl = useIntl();
+export function CrudContextMenu<CopyData>(inProps: CrudContextMenuProps<CopyData>) {
+    const {
+        url,
+        onPaste,
+        onDelete,
+        refetchQueries,
+        copyData,
+        slotProps,
+        iconMapping = {},
+        messagesMapping = {},
+        ...restProp
+    } = useThemeProps({
+        props: inProps,
+        name: "CometAdminCrudContextMenu",
+    });
+
+    const {
+        copyUrl: copyUrlIcon = <Domain />,
+        copy: copyIcon = <Copy />,
+        copyLoading: copyLoadingIcon = <ThreeDotSaving />,
+        paste: pasteIcon = <Paste />,
+        pasteLoading: pasteLoadingIcon = <ThreeDotSaving />,
+        delete: deleteIcon = <DeleteIcon />,
+    } = iconMapping;
+
+    const {
+        copyUrl: copyUrlMessage = <FormattedMessage {...messages.copyUrl} />,
+        copy: copyMessage = <FormattedMessage {...messages.copy} />,
+        paste: pasteMessage = <FormattedMessage {...messages.paste} />,
+        delete: deleteMessage = <FormattedMessage {...messages.delete} />,
+    } = messagesMapping;
+
     const client = useApolloClient();
     const errorDialog = useErrorDialog();
 
@@ -92,56 +159,122 @@ export function CrudContextMenu<CopyData>({ url, onPaste, onDelete, refetchQueri
 
     return (
         <>
-            <RowActionsMenu>
-                <RowActionsMenu>
+            <Root {...slotProps?.root} {...restProp}>
+                <ItemsMenu {...slotProps?.itemsMenu}>
                     {url && (
-                        <RowActionsItem
-                            icon={<Domain />}
+                        <CopyUrlItem
+                            icon={copyUrlIcon}
                             onClick={() => {
                                 writeClipboardText(url);
                             }}
+                            {...slotProps?.copyUrlItem}
                         >
-                            {intl.formatMessage(messages.copyUrl)}
-                        </RowActionsItem>
+                            {copyUrlMessage}
+                        </CopyUrlItem>
                     )}
                     {copyData && (
-                        <RowActionsItem
-                            icon={copyLoading ? <ThreeDotSaving /> : <Copy />}
+                        <CopyItem
+                            icon={copyLoading ? copyLoadingIcon : copyIcon}
                             onClick={async () => {
                                 setCopyLoading(true);
                                 await handleCopyClick();
                                 setCopyLoading(false);
                             }}
+                            {...slotProps?.copyItem}
                         >
-                            {intl.formatMessage(messages.copy)}
-                        </RowActionsItem>
+                            {copyMessage}
+                        </CopyItem>
                     )}
                     {onPaste && (
-                        <RowActionsItem
-                            icon={pasting ? <ThreeDotSaving /> : <Paste />}
+                        <PasteItem
+                            icon={pasting ? pasteLoadingIcon : pasteIcon}
                             onClick={async () => {
                                 setPasting(true);
                                 await handlePasteClick();
                                 setPasting(false);
                             }}
+                            {...slotProps?.pasteItem}
                         >
-                            {intl.formatMessage(messages.paste)}
-                        </RowActionsItem>
+                            {pasteMessage}
+                        </PasteItem>
                     )}
-                    {onDelete && (onPaste || copyData || url) && <Divider />}
+                    {onDelete && (onPaste || copyData || url) && <ItemsDivider {...slotProps?.itemsDivider} />}
                     {onDelete && (
-                        <RowActionsItem
-                            icon={<DeleteIcon />}
+                        <DeleteItem
+                            icon={deleteIcon}
                             onClick={() => {
                                 setDeleteDialogOpen(true);
                             }}
+                            {...slotProps?.deleteItem}
                         >
-                            {intl.formatMessage(messages.deleteItem)}
-                        </RowActionsItem>
+                            {deleteMessage}
+                        </DeleteItem>
                     )}
-                </RowActionsMenu>
-            </RowActionsMenu>
-            <DeleteDialog dialogOpen={deleteDialogOpen} onCancel={() => setDeleteDialogOpen(false)} onDelete={handleDeleteClick} />
+                </ItemsMenu>
+            </Root>
+            <DeleteDialog
+                dialogOpen={deleteDialogOpen}
+                onCancel={() => setDeleteDialogOpen(false)}
+                onDelete={handleDeleteClick}
+                {...slotProps?.deleteDialog}
+            />
         </>
     );
+}
+
+const Root = createComponentSlot(RowActionsMenu)<CrudContextMenuClassKey>({
+    componentName: "CrudContextMenu",
+    slotName: "root",
+})();
+
+const ItemsMenu = createComponentSlot(RowActionsMenu)<CrudContextMenuClassKey>({
+    componentName: "CrudContextMenu",
+    slotName: "itemsMenu",
+})();
+
+const CopyUrlItem = createComponentSlot(RowActionsItem)<CrudContextMenuClassKey>({
+    componentName: "CrudContextMenu",
+    slotName: "copyUrlItem",
+})();
+
+const CopyItem = createComponentSlot(RowActionsItem)<CrudContextMenuClassKey>({
+    componentName: "CrudContextMenu",
+    slotName: "copyItem",
+})();
+
+const PasteItem = createComponentSlot(RowActionsItem)<CrudContextMenuClassKey>({
+    componentName: "CrudContextMenu",
+    slotName: "pasteItem",
+})();
+
+const ItemsDivider = createComponentSlot(Divider)<CrudContextMenuClassKey>({
+    componentName: "CrudContextMenu",
+    slotName: "itemsDivider",
+})();
+
+const DeleteItem = createComponentSlot(RowActionsItem)<CrudContextMenuClassKey>({
+    componentName: "CrudContextMenu",
+    slotName: "deleteItem",
+})();
+
+const DeleteDialog = createComponentSlot(CommonDeleteDialog)<CrudContextMenuClassKey>({
+    componentName: "CrudContextMenu",
+    slotName: "deleteDialog",
+})();
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminCrudContextMenu: CrudContextMenuProps<unknown>;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminCrudContextMenu: CrudContextMenuClassKey;
+    }
+
+    interface Components {
+        CometAdminCrudContextMenu?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminCrudContextMenu"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminCrudContextMenu"];
+        };
+    }
 }

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -41,7 +41,7 @@ export { ToolbarTitleItem, ToolbarTitleItemClassKey, ToolbarTitleItemProps } fro
 export { Toolbar, ToolbarClassKey, ToolbarProps } from "./common/toolbar/Toolbar";
 export { Tooltip, TooltipClassKey, TooltipProps } from "./common/Tooltip";
 export { ContentOverflow, ContentOverflowClassKey, ContentOverflowProps } from "./ContentOverflow";
-export { CrudContextMenu } from "./dataGrid/CrudContextMenu";
+export { CrudContextMenu, CrudContextMenuClassKey, CrudContextMenuProps } from "./dataGrid/CrudContextMenu";
 export { CrudMoreActionsMenu, CrudMoreActionsMenuProps } from "./dataGrid/CrudMoreActionsMenu";
 export { CrudVisibility, CrudVisibilityProps } from "./dataGrid/CrudVisibility";
 export { ExportApi, useDataGridExcelExport } from "./dataGrid/excelExport/useDataGridExcelExport";

--- a/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
+++ b/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
@@ -8,6 +8,7 @@ import {
     GridFilterButton,
     Loading,
     muiGridFilterToGql,
+    RowActionsItem,
     Toolbar,
     ToolbarActions,
     ToolbarFillSpace,
@@ -17,8 +18,8 @@ import {
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Delete, Download, MoreVertical, Move } from "@comet/admin-icons";
-import { Button, Menu, MenuItem, useTheme } from "@mui/material";
+import { Delete, Download, Favorite, MoreVertical, Move } from "@comet/admin-icons";
+import { Button, Divider, Menu, MenuItem, useTheme } from "@mui/material";
 import Box from "@mui/material/Box";
 import { DataGrid } from "@mui/x-data-grid";
 import { DataGridPro } from "@mui/x-data-grid-pro";
@@ -342,7 +343,12 @@ storiesOf("stories/components/DataGrid", module)
                                     lastName: params.row.lastName,
                                 };
                             }}
-                        />
+                        >
+                            <RowActionsItem icon={<Favorite />} onClick={() => alert(`Doing a custom action on ${params.row.firstName}`)}>
+                                Custom action
+                            </RowActionsItem>
+                            <Divider />
+                        </CrudContextMenu>
                     );
                 },
             },

--- a/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
+++ b/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
@@ -297,16 +297,20 @@ storiesOf("stories/components/DataGrid", module)
             {
                 field: "firstName",
                 headerName: "First name",
+                flex: 1,
             },
             {
                 field: "lastName",
                 headerName: "Last name",
+                flex: 1,
             },
             {
-                field: "action",
+                field: "actions",
                 headerName: "",
                 sortable: false,
                 filterable: false,
+                pinned: "right",
+                width: 52,
                 renderCell: (params) => {
                     return (
                         <CrudContextMenu
@@ -345,7 +349,7 @@ storiesOf("stories/components/DataGrid", module)
         ];
 
         return (
-            <Box sx={{ height: 400, width: "100%" }}>
+            <Box height={400}>
                 <DataGrid rows={exampleRows} columns={columns} />
             </Box>
         );


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

Customize existing parts of `CrudContextMenu` using `slotProps`, `iconMapping` and `messagesMapping`.
Add custom actions by adding instances of `RowActionsItem` to the `children`. 

Also moves the component's `DeleteDialog` into a separate file for improved readability. 

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.
--->

## Example

-   [x] I have verified if my change requires an example

## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1081