### PR TITLE
Keep current location when changing scope on publisher and user permissions page

### DIFF
--- a/.changeset/nine-phones-think.md
+++ b/.changeset/nine-phones-think.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": patch
 ---
 
-Add redirect to the current page (important when changing the scope)
+Keep current location when changing scope on publisher and user permissions page

--- a/.changeset/nine-phones-think.md
+++ b/.changeset/nine-phones-think.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Add redirect to the current page (important when changing the scope)

--- a/packages/admin/cms-admin/src/builds/PublisherPage.tsx
+++ b/packages/admin/cms-admin/src/builds/PublisherPage.tsx
@@ -4,8 +4,11 @@ import { styled } from "@mui/material/styles";
 import { DataGrid } from "@mui/x-data-grid";
 import { parseISO } from "date-fns";
 import { FormattedMessage, useIntl } from "react-intl";
+import { useRouteMatch } from "react-router";
 
 import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
+import { useContentScope } from "../contentScope/Provider";
+import { useContentScopeConfig } from "../contentScope/useContentScopeConfig";
 import { JobRuntime } from "../cronJobs/JobRuntime";
 import { PublishButton } from "./PublishButton";
 import { GQLBuildsQuery } from "./PublisherPage.generated";
@@ -30,6 +33,11 @@ const DataGridContainer = styled("div")`
 `;
 
 export function PublisherPage() {
+    const { match } = useContentScope();
+    const routeMatch = useRouteMatch();
+    const location = routeMatch.url.replace(match.url, "");
+    useContentScopeConfig({ redirectPathAfterChange: location });
+
     const intl = useIntl();
 
     const { data, loading, error } = useQuery<GQLBuildsQuery, undefined>(buildsQuery);

--- a/packages/admin/cms-admin/src/userPermissions/UserPermissionsPage.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/UserPermissionsPage.tsx
@@ -1,20 +1,30 @@
 import { MainContent, Stack, StackPage, StackSwitch, Toolbar } from "@comet/admin";
 import { FormattedMessage } from "react-intl";
+import { useRouteMatch } from "react-router";
 
 import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
+import { useContentScope } from "../contentScope/Provider";
+import { useContentScopeConfig } from "../contentScope/useContentScopeConfig";
 import { UserPage } from "./user/UserPage";
 import { UserGrid } from "./UserGrid";
 
-export const UserPermissionsPage = () => (
-    <Stack topLevelTitle={<FormattedMessage id="comet.userPermissions.title" defaultMessage="User Management" />}>
-        <StackSwitch>
-            <StackPage name="table">
-                <Toolbar scopeIndicator={<ContentScopeIndicator global />} />
-                <MainContent fullHeight>
-                    <UserGrid />
-                </MainContent>
-            </StackPage>
-            <StackPage name="edit">{(userId) => <UserPage userId={userId} />}</StackPage>
-        </StackSwitch>
-    </Stack>
-);
+export const UserPermissionsPage = () => {
+    const { match } = useContentScope();
+    const routeMatch = useRouteMatch();
+    const location = routeMatch.url.replace(match.url, "");
+    useContentScopeConfig({ redirectPathAfterChange: location });
+
+    return (
+        <Stack topLevelTitle={<FormattedMessage id="comet.userPermissions.title" defaultMessage="User Management" />}>
+            <StackSwitch>
+                <StackPage name="table">
+                    <Toolbar scopeIndicator={<ContentScopeIndicator global />} />
+                    <MainContent fullHeight>
+                        <UserGrid />
+                    </MainContent>
+                </StackPage>
+                <StackPage name="edit">{(userId) => <UserPage userId={userId} />}</StackPage>
+            </StackSwitch>
+        </Stack>
+    );
+};


### PR DESCRIPTION
Until now, when changing the scope, you were redirected to the home page if you were on the publisher page or the user permission page. However, when changing the scope, the menu should not change, so a redirect to the desired page has been added.