### PR TITLE
Call deprecated function afterwards

### DIFF
--- a/.changeset/fresh-tables-clean.md
+++ b/.changeset/fresh-tables-clean.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-api": patch
+---
+
+Call `createUserFromRequest` before `createUserFromIdToken`
+
+The latter is marked as deprecated and should only be used if the
+first one is not defined.

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -63,8 +63,8 @@ export class UserPermissionsService {
     }
 
     async createUser(request: Request, idToken: JwtPayload): Promise<User> {
-        if (this.userService?.createUserFromIdToken) return this.userService.createUserFromIdToken(idToken);
         if (this.userService?.createUserFromRequest) return this.userService.createUserFromRequest(request, idToken);
+        if (this.userService?.createUserFromIdToken) return this.userService.createUserFromIdToken(idToken);
         if (!idToken.sub) throw new Error("JwtPayload does not contain sub.");
         return {
             id: idToken.sub,


### PR DESCRIPTION
## Description

With this PR we can use `createUserFromRequest` in dependent packages without comprising backwards compatibility (by removing _createUserFromIdToken_)


