### PR TITLE
Fix validation of empty `PhoneLinkBlock`

### DIFF
--- a/.changeset/dry-donuts-sing.md
+++ b/.changeset/dry-donuts-sing.md
@@ -1,0 +1,10 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix validation of empty `PhoneLinkBlock`
+
+Previously, the default phone value was an empty string, meaning `@IsOptional()` didn't prevent validation.
+Since an empty string is not a valid phone number, the validation failed.
+
+This change sets the default value to `undefined`.

--- a/packages/admin/cms-admin/src/blocks/PhoneLinkBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/PhoneLinkBlock.tsx
@@ -13,7 +13,7 @@ export const PhoneLinkBlock: BlockInterface<PhoneLinkBlockData, PhoneLinkBlockDa
 
     displayName: <FormattedMessage id="comet.blocks.link.phone" defaultMessage="Phone Number" />,
 
-    defaultValues: () => ({ phone: "" }),
+    defaultValues: () => ({ phone: undefined }),
 
     category: BlockCategory.Navigation,
 


### PR DESCRIPTION
Fix validation of empty `PhoneLinkBlock`

Previously, the default phone value was an empty string, meaning `@IsOptional()` didn't prevent validation.
Since an empty string is not a valid phone number, the validation failed.

This change sets the default value to `undefined`.
