### PR TITLE
Admin Generator (Future): Add  `FinalFormRangeInput` to form generator

### DIFF
--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -32,6 +32,7 @@ export const ProductForm: FormConfig<GQLProduct> = {
                     values: [{ value: "Cap", label: "great Cap" }, "Shirt", "Tie"],
                 },
                 { type: "asyncSelect", name: "category", rootQuery: "productCategories" },
+                { type: "numberRange", name: "priceRange", minValue: 25, maxValue: 500, disableSlider: true, startAdornment: "€" },
                 {
                     type: "optionalNestedFields",
                     name: "dimensions",

--- a/demo/admin/src/products/future/generated/ProductForm.gql.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.gql.tsx
@@ -14,6 +14,10 @@ export const productFormFragment = gql`
             id
             title
         }
+        priceRange {
+            min
+            max
+        }
         dimensions {
             width
             height

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -9,6 +9,7 @@ import {
     FinalForm,
     FinalFormCheckbox,
     FinalFormInput,
+    FinalFormRangeInput,
     FinalFormSubmitEvent,
     FinalFormSwitch,
     Loading,
@@ -66,7 +67,8 @@ type ProductFormDetailsFragment = Omit<GQLProductFormDetailsFragment, "priceList
     datasheets: GQLFinalFormFileUploadFragment[];
 };
 
-type FormValues = Omit<ProductFormDetailsFragment, "dimensions"> & {
+type FormValues = Omit<ProductFormDetailsFragment, "priceRange" | "dimensions"> & {
+    priceRange?: { min: string; max: string };
     dimensionsEnabled: boolean;
     dimensions: Omit<NonNullable<GQLProductFormDetailsFragment["dimensions"]>, "width" | "height" | "depth"> & {
         width: string;
@@ -97,6 +99,9 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                 ? {
                       ...filterByFragment<ProductFormDetailsFragment>(productFormFragment, data.product),
                       createdAt: data.product.createdAt ? new Date(data.product.createdAt) : undefined,
+                      priceRange: data.product.priceRange
+                          ? { min: String(data.product.priceRange.min), max: String(data.product.priceRange.max) }
+                          : undefined,
                       dimensionsEnabled: !!data.product.dimensions,
                       dimensions: data.product.dimensions
                           ? {
@@ -131,6 +136,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
         const output = {
             ...formValues,
             category: formValues.category?.id,
+            priceRange: formValues.priceRange ? { min: parseFloat(formValues.priceRange.min), max: parseFloat(formValues.priceRange.max) } : null,
             dimensions:
                 dimensionsEnabled && formValues.dimensions
                     ? {
@@ -284,6 +290,18 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                     return data.productCategories.nodes;
                                 }}
                                 getOptionLabel={(option) => option.title}
+                            />
+
+                            <Field
+                                variant="horizontal"
+                                fullWidth
+                                name="priceRange"
+                                component={FinalFormRangeInput}
+                                label={<FormattedMessage id="product.priceRange" defaultMessage="Price Range" />}
+                                min={25}
+                                max={500}
+                                disableSlider
+                                startAdornment={<InputAdornment position="start">€</InputAdornment>}
                             />
                             <Field
                                 fullWidth

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -67,8 +67,7 @@ type ProductFormDetailsFragment = Omit<GQLProductFormDetailsFragment, "priceList
     datasheets: GQLFinalFormFileUploadFragment[];
 };
 
-type FormValues = Omit<ProductFormDetailsFragment, "priceRange" | "dimensions"> & {
-    priceRange?: { min: string; max: string };
+type FormValues = Omit<ProductFormDetailsFragment, "dimensions"> & {
     dimensionsEnabled: boolean;
     dimensions: Omit<NonNullable<GQLProductFormDetailsFragment["dimensions"]>, "width" | "height" | "depth"> & {
         width: string;
@@ -99,9 +98,6 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                 ? {
                       ...filterByFragment<ProductFormDetailsFragment>(productFormFragment, data.product),
                       createdAt: data.product.createdAt ? new Date(data.product.createdAt) : undefined,
-                      priceRange: data.product.priceRange
-                          ? { min: String(data.product.priceRange.min), max: String(data.product.priceRange.max) }
-                          : undefined,
                       dimensionsEnabled: !!data.product.dimensions,
                       dimensions: data.product.dimensions
                           ? {
@@ -136,7 +132,6 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
         const output = {
             ...formValues,
             category: formValues.category?.id,
-            priceRange: formValues.priceRange ? { min: parseFloat(formValues.priceRange.min), max: parseFloat(formValues.priceRange.max) } : null,
             dimensions:
                 dimensionsEnabled && formValues.dimensions
                     ? {

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -250,6 +250,7 @@ export function generateForm(
         FinalForm,
         FinalFormCheckbox,
         FinalFormInput,
+        FinalFormRangeInput,
         FinalFormSelect,
         FinalFormSubmitEvent,
         Loading,

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -190,28 +190,6 @@ export function generateFormField({
                 ${validateCode}
             />`;
 
-        //TODO MUI suggest not using type=number https://mui.com/material-ui/react-text-field/#type-quot-number-quot
-        let assignment = `{min: parseFloat(formValues.${nameWithPrefix}.min), max: parseFloat(formValues.${nameWithPrefix}.max)}`;
-        if (isFieldOptional({ config, gqlIntrospection: gqlIntrospection, gqlType: gqlType })) {
-            assignment = `formValues.${nameWithPrefix} ? ${assignment} : null`;
-        }
-        formValueToGqlInputCode = !config.virtual ? `${name}: ${assignment},` : ``;
-
-        let initializationAssignment = `{min: String(data.${dataRootName}.${nameWithPrefix}.min), max: String(data.${dataRootName}.${nameWithPrefix}.max)}`;
-        if (!required) {
-            initializationAssignment = `data.${dataRootName}.${nameWithPrefix} ? ${initializationAssignment} : undefined`;
-        }
-        formValuesConfig = [
-            {
-                ...defaultFormValuesConfig,
-                ...{
-                    omitFromFragmentType: name,
-                    typeCode: `${name}${!required ? `?` : ``}: {min: string, max: string};`,
-                    initializationCode: `${name}: ${initializationAssignment}`,
-                },
-            },
-        ];
-
         formFragmentField = `${name} { min max }`;
     } else if (config.type == "boolean") {
         code = `<Field name="${nameWithPrefix}" label="" type="checkbox" variant="horizontal" fullWidth ${validateCode}>

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -165,6 +165,54 @@ export function generateFormField({
                 },
             },
         ];
+    } else if (config.type === "numberRange") {
+        code = `
+            <Field
+                ${required ? "required" : ""}
+                ${config.readOnly ? readOnlyPropsWithLock : ""}
+                variant="horizontal"
+                fullWidth
+                name="${nameWithPrefix}"
+                component={FinalFormRangeInput}
+                label={${fieldLabel}}
+                min={${config.minValue}}
+                max={${config.maxValue}}
+                ${config.disableSlider ? "disableSlider" : ""}
+                ${config.startAdornment ? `startAdornment={<InputAdornment position="start">${config.startAdornment}</InputAdornment>}` : ""}
+                ${config.endAdornment ? `endAdornment={<InputAdornment position="end">${config.endAdornment}</InputAdornment>}` : ""}
+                ${
+                    config.helperText
+                        ? `helperText={<FormattedMessage id=` +
+                          `"${formattedMessageRootId}.${name}.helperText" ` +
+                          `defaultMessage="${config.helperText}" />}`
+                        : ""
+                }
+                ${validateCode}
+            />`;
+
+        //TODO MUI suggest not using type=number https://mui.com/material-ui/react-text-field/#type-quot-number-quot
+        let assignment = `{min: parseFloat(formValues.${nameWithPrefix}.min), max: parseFloat(formValues.${nameWithPrefix}.max)}`;
+        if (isFieldOptional({ config, gqlIntrospection: gqlIntrospection, gqlType: gqlType })) {
+            assignment = `formValues.${nameWithPrefix} ? ${assignment} : null`;
+        }
+        formValueToGqlInputCode = !config.virtual ? `${name}: ${assignment},` : ``;
+
+        let initializationAssignment = `{min: String(data.${dataRootName}.${nameWithPrefix}.min), max: String(data.${dataRootName}.${nameWithPrefix}.max)}`;
+        if (!required) {
+            initializationAssignment = `data.${dataRootName}.${nameWithPrefix} ? ${initializationAssignment} : undefined`;
+        }
+        formValuesConfig = [
+            {
+                ...defaultFormValuesConfig,
+                ...{
+                    omitFromFragmentType: name,
+                    typeCode: `${name}${!required ? `?` : ``}: {min: string, max: string};`,
+                    initializationCode: `${name}: ${initializationAssignment}`,
+                },
+            },
+        ];
+
+        formFragmentField = `${name} { min max }`;
     } else if (config.type == "boolean") {
         code = `<Field name="${nameWithPrefix}" label="" type="checkbox" variant="horizontal" fullWidth ${validateCode}>
             {(props) => (

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -8,6 +8,7 @@ import { promises as fs } from "fs";
 import { glob } from "glob";
 import { introspectionFromSchema } from "graphql";
 import { basename, dirname } from "path";
+import { ReactNode } from "react";
 
 import { FinalFormFileUploadProps } from "../../form/file/FinalFormFileUpload";
 import { generateForm } from "./generateForm";
@@ -35,6 +36,14 @@ type MultiFileFormFieldConfig = { type: "fileUpload"; multiple: true; maxFiles?:
 export type FormFieldConfig<T> = (
     | { type: "text"; multiline?: boolean }
     | { type: "number" }
+    | {
+          type: "numberRange";
+          minValue: number;
+          maxValue: number;
+          disableSlider?: boolean;
+          startAdornment?: ReactNode;
+          endAdornment?: ReactNode;
+      }
     | { type: "boolean" }
     | { type: "date" }
     // TODO | { type: "dateTime" }

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -8,7 +8,6 @@ import { promises as fs } from "fs";
 import { glob } from "glob";
 import { introspectionFromSchema } from "graphql";
 import { basename, dirname } from "path";
-import { ReactNode } from "react";
 
 import { FinalFormFileUploadProps } from "../../form/file/FinalFormFileUpload";
 import { generateForm } from "./generateForm";
@@ -41,8 +40,8 @@ export type FormFieldConfig<T> = (
           minValue: number;
           maxValue: number;
           disableSlider?: boolean;
-          startAdornment?: ReactNode;
-          endAdornment?: ReactNode;
+          startAdornment?: string;
+          endAdornment?: string;
       }
     | { type: "boolean" }
     | { type: "date" }


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description
`FinalFormRangeInput` fields can now be generated in forms. The new field type is `numberRange`. Data of the field is saved in this format: `{ min: number, max: number }` 

The names `min` and `max` are currently hardcoded, as they **have to** be named this way. `FinalFormRangeInput` passes the values named like this.

<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Example

The field with all possible options:

```
{ 
     type: "numberRange",
     name: "priceRange", 
     minValue: 25, // required
     maxValue: 500, // required
     disableSlider: true, //  optional, default is false
     startAdornment: "€" // optional
     endAdornment: "€" // optional, both adornments can be added for a field
 }
```

The field in product.entity:

```
@ObjectType()
@InputType("ProductPriceRangeInput")
export class ProductPriceRange {
    @Field()
    @IsNumber()
    min: number;

    @Field()
    @IsNumber()
    max: number;
}

{...}

export class Product extends BaseEntity<Product, "id"> {

{...}

    @Property({ type: "json", nullable: true })
    @Field(() => ProductPriceRange, { nullable: true })
    priceRange?: ProductPriceRange = undefined;

{...}

}
```
<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A dev story in Storybook
-   A unit test

--->

-   [x] I have verified if my change requires an example

Example in demo: https://github.com/vivid-planet/comet/pull/2593

## Screenshots/screencasts

Creating a Product with a price range:

https://github.com/user-attachments/assets/bde61e5c-7f9e-4ae6-a4a7-bd54ea7d33d9

Example of editing a price range:

https://github.com/user-attachments/assets/52ea6f9e-115b-4714-8416-a32be5dc6efd



<!--

When making a visual change, please provide either screenshots or screencasts.

Hint: For before/after views, you can use a table:

| Before   | After   |
| -------- | ------- |
| Link     | Link    |

-->

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

Jira Task: https://vivid-planet.atlassian.net/browse/SVK-124

<!--

Link to related tasks and documents, for instance, https://vivid-planet.atlassian.net/browse/COM-XXX.

MAKE SURE THAT EVERYTHING REQUIRED TO UNDERSTAND YOUR CHANGE IS IN THE PR DESCRIPTION.
Reviewers shouldn't need to review tasks, JIRA conversations etc. to understand what you're doing.

-->

## Open TODOs/questions

<!--

-   [ ] Need to validate that this actually works
-   [ ] Merge parent PR

-->

## Further information

<!--

Further information that helps reviewing the PR, for instance:
-   Alternative solutions you have considered
-   Dependent PRs
-   Links to relevant documentation, blog posts etc.

-->
