### PR TITLE
Admin Generator (Future): Set color of edit button on correct element

### DIFF
--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -239,8 +239,8 @@ export function ManufacturersGrid(): React.ReactElement {
             renderCell: (params) => {
                 return (
                     <>
-                        <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
-                            <EditIcon color="primary" />
+                        <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
+                            <EditIcon />
                         </IconButton>
                         <CrudContextMenu
                             copyData={() => {

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -126,8 +126,8 @@ export function ProductVariantsGrid({ product }: Props): React.ReactElement {
             renderCell: (params) => {
                 return (
                     <>
-                        <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
-                            <EditIcon color="primary" />
+                        <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
+                            <EditIcon />
                         </IconButton>
                         <CrudContextMenu
                             copyData={() => {

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -731,8 +731,8 @@ export function generateGrid(
                                       ? forwardRowAction
                                           ? `{rowAction && rowAction(params)}`
                                           : `
-                                        <IconButton component={StackLink} pageName="edit" payload={params.row.id}>
-                                            <EditIcon color="primary" />
+                                        <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
+                                            <EditIcon />
                                         </IconButton>`
                                       : ""
                               }${


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

The color should be set on the `IconButton` so not just the icon itself but also the hover/click highlights of the button itself are correct. 