### PR TITLE
Admin Generator (Future): Implement `group` type for combination column

### DIFF
--- a/demo/admin/src/products/future/CombinationFieldsTestProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/CombinationFieldsTestProductsGrid.cometGen.ts
@@ -133,5 +133,120 @@ export const CombinationFieldsTestProductsGrid: GridConfig<GQLProduct> = {
                 },
             },
         },
+        {
+            type: "combination",
+            name: "combinedAndNestedValuesWithGroupInsideGroup",
+            headerName: "Custom formatting with nested values (group inside group)",
+            primaryText: {
+                type: "formattedMessage",
+                message: 'This product is named "{title}" and is a "{type}"',
+                valueFields: {
+                    title: "title",
+                    type: "type",
+                },
+            },
+            secondaryText: {
+                type: "group",
+                fields: [
+                    {
+                        type: "number",
+                        field: "price",
+                        currency: "EUR",
+                    },
+                    {
+                        type: "text",
+                        field: "category.title",
+                    },
+                    {
+                        type: "group",
+                        fields: [
+                            {
+                                type: "number",
+                                field: "price",
+                                currency: "EUR",
+                            },
+                            {
+                                type: "text",
+                                field: "category.title",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        {
+            type: "combination",
+            name: "twoGroups",
+            headerName: "Two groups",
+            primaryText: {
+                type: "group",
+                fields: [
+                    {
+                        type: "text",
+                        field: "category.title",
+                    },
+                    {
+                        type: "number",
+                        field: "price",
+                        currency: "EUR",
+                    },
+                ],
+            },
+            secondaryText: {
+                type: "group",
+                fields: [
+                    {
+                        type: "text",
+                        field: "category.title",
+                    },
+                    {
+                        type: "text",
+                        field: "description",
+                    },
+                ],
+            },
+        },
+        {
+            type: "combination",
+            name: "combinedAndNestedValuesWithGroupInsideFormattedMessage",
+            headerName: "Custom formatting with nested values (group inside formatted message)",
+            primaryText: {
+                type: "formattedMessage",
+                message: 'This product is named "{title}" and is a "{type}"',
+                valueFields: {
+                    title: "title",
+                    type: "type",
+                },
+            },
+            secondaryText: {
+                type: "formattedMessage",
+                message: "Price: {price} • Category: {category} • Same values again: ({nestedValues})",
+                valueFields: {
+                    price: {
+                        type: "number",
+                        field: "price",
+                        currency: "EUR",
+                    },
+                    category: {
+                        type: "text",
+                        field: "category.title",
+                    },
+                    nestedValues: {
+                        type: "group",
+                        fields: [
+                            {
+                                type: "number",
+                                field: "price",
+                                currency: "EUR",
+                            },
+                            {
+                                type: "text",
+                                field: "category.title",
+                            },
+                        ],
+                    },
+                },
+            },
+        },
     ],
 };

--- a/demo/admin/src/products/future/CombinationFieldsTestProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/CombinationFieldsTestProductsGrid.cometGen.ts
@@ -135,8 +135,8 @@ export const CombinationFieldsTestProductsGrid: GridConfig<GQLProduct> = {
         },
         {
             type: "combination",
-            name: "combinedAndNestedValuesWithGroupInsideGroup",
-            headerName: "Custom formatting with nested values (group inside group)",
+            name: "nestedGroups",
+            headerName: "Nested groups",
             primaryText: {
                 type: "formattedMessage",
                 message: 'This product is named "{title}" and is a "{type}"',
@@ -208,8 +208,8 @@ export const CombinationFieldsTestProductsGrid: GridConfig<GQLProduct> = {
         },
         {
             type: "combination",
-            name: "combinedAndNestedValuesWithGroupInsideFormattedMessage",
-            headerName: "Custom formatting with nested values (group inside formatted message)",
+            name: "groupInFormattedMessage",
+            headerName: "Group in formatted message",
             primaryText: {
                 type: "formattedMessage",
                 message: 'This product is named "{title}" and is a "{type}"',

--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -24,28 +24,24 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
             minWidth: 200,
             primaryText: "title",
             secondaryText: {
-                // TODO: Change this to use the "group" type instead of "formattedMessage", once implemented (SVK-368)
-                type: "formattedMessage",
-                message: "{price} • {type} • {category} • {inStock}",
-                valueFields: {
-                    price: {
+                type: "group",
+                fields: [
+                    {
                         type: "number",
                         field: "price",
                         currency: "EUR",
-                        emptyValue: "No price",
+                        emptyValue: "Price unknown",
                     },
-                    type: {
+                    {
                         type: "staticSelect",
                         field: "type",
                         values: typeValues,
-                        emptyValue: "No type",
                     },
-                    category: {
+                    {
                         type: "text",
                         field: "category.title",
-                        emptyValue: "No category",
                     },
-                    inStock: {
+                    {
                         type: "staticSelect",
                         field: "inStock",
                         values: [
@@ -53,13 +49,13 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
                             { value: false, label: "Out of stock" },
                         ],
                     },
-                },
+                ],
             },
             visible: "down('md')",
             sortBy: ["title", "price", "type", "category", "inStock"],
             disableExport: true, // TODO: Implement `valueFormatter` for type "combination"
         },
-        { type: "text", name: "title", headerName: "Titel", minWidth: 200, maxWidth: 250, visible: "up('md')" },
+        { type: "text", name: "title", headerName: "Title", minWidth: 200, maxWidth: 250, visible: "up('md')" },
         { type: "text", name: "description", headerName: "Description" },
         // TODO: Allow setting options for `intl.formatNumber` through `valueFormatter` (type "number")
         { type: "number", name: "price", headerName: "Price", maxWidth: 150, headerInfoTooltip: "Price in EUR", visible: "up('md')" },

--- a/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
@@ -105,7 +105,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                return <GridCellContent primaryText={row.title ?? "-"} secondaryText={row.category?.title ?? "-"} />;
+                return <GridCellContent primaryText={row.title ?? ""} secondaryText={row.category?.title ?? ""} />;
             },
             flex: 1,
             minWidth: 150,
@@ -121,9 +121,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                     Shirt: <FormattedMessage id="product.staticSelectType.primaryText.Shirt" defaultMessage="Shirt" />,
                     Tie: <FormattedMessage id="product.staticSelectType.primaryText.Tie" defaultMessage="Tie" />,
                 };
-                return (
-                    <GridCellContent primaryText={row.type == null ? "-" : typeLabels[`${row.type}`] ?? row.type} secondaryText={row.type ?? "-"} />
-                );
+                return <GridCellContent primaryText={row.type == null ? "" : typeLabels[`${row.type}`] ?? row.type} secondaryText={row.type ?? ""} />;
             },
             flex: 1,
             minWidth: 150,
@@ -192,7 +190,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                         }
                         secondaryText={
                             typeof row.price === "undefined" || row.price === null ? (
-                                "-"
+                                ""
                             ) : (
                                 <FormattedNumber value={row.price} minimumFractionDigits={4} maximumFractionDigits={4} />
                             )
@@ -213,14 +211,14 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                     <GridCellContent
                         primaryText={
                             typeof row.price === "undefined" || row.price === null ? (
-                                "-"
+                                ""
                             ) : (
                                 <FormattedNumber value={row.price} style="unit" unit="kilogram" />
                             )
                         }
                         secondaryText={
                             typeof row.price === "undefined" || row.price === null ? (
-                                "-"
+                                ""
                             ) : (
                                 <FormattedNumber
                                     value={row.price}
@@ -250,7 +248,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                             <FormattedMessage
                                 id="product.combinedAndNestedValues.primaryText"
                                 defaultMessage={`This product is named "{title}" and is a "{type}"`}
-                                values={{ title: row.title ?? "-", type: row.type ?? "-" }}
+                                values={{ title: row.title ?? "", type: row.type ?? "" }}
                             />
                         }
                         secondaryText={

--- a/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
@@ -42,6 +42,7 @@ const productsFragment = gql`
         type
         inStock
         price
+        description
     }
 `;
 
@@ -306,6 +307,116 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                                             }}
                                         />
                                     ),
+                                }}
+                            />
+                        }
+                    />
+                );
+            },
+            flex: 1,
+            minWidth: 150,
+        },
+        {
+            field: "combinedAndNestedValuesWithGroupInsideGroup",
+            headerName: intl.formatMessage({
+                id: "product.combinedAndNestedValuesWithGroupInsideGroup",
+                defaultMessage: "Custom formatting with nested values (group inside group)",
+            }),
+            filterable: false,
+            sortable: false,
+            renderCell: ({ row }) => {
+                const groupValues: string[] = [
+                    typeof row.price === "undefined" || row.price === null
+                        ? ""
+                        : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
+                    row.category?.title ?? "",
+                ];
+                const groupValues: string[] = [
+                    typeof row.price === "undefined" || row.price === null
+                        ? ""
+                        : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
+                    row.category?.title ?? "",
+                    groupValues.filter(Boolean).join(" • "),
+                ];
+                return (
+                    <GridCellContent
+                        primaryText={
+                            <FormattedMessage
+                                id="product.combinedAndNestedValuesWithGroupInsideGroup.primaryText"
+                                defaultMessage={`This product is named "{title}" and is a "{type}"`}
+                                values={{ title: row.title ?? "", type: row.type ?? "" }}
+                            />
+                        }
+                        secondaryText={groupValues.filter(Boolean).join(" • ")}
+                    />
+                );
+            },
+            flex: 1,
+            minWidth: 150,
+        },
+        {
+            field: "twoGroups",
+            headerName: intl.formatMessage({ id: "product.twoGroups", defaultMessage: "Two groups" }),
+            filterable: false,
+            sortable: false,
+            renderCell: ({ row }) => {
+                const groupValues: string[] = [
+                    row.category?.title ?? "",
+                    typeof row.price === "undefined" || row.price === null
+                        ? ""
+                        : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
+                ];
+                const groupValues: string[] = [row.category?.title ?? "", row.description ?? ""];
+                return (
+                    <GridCellContent primaryText={groupValues.filter(Boolean).join(" • ")} secondaryText={groupValues.filter(Boolean).join(" • ")} />
+                );
+            },
+            flex: 1,
+            minWidth: 150,
+        },
+        {
+            field: "combinedAndNestedValuesWithGroupInsideFormattedMessage",
+            headerName: intl.formatMessage({
+                id: "product.combinedAndNestedValuesWithGroupInsideFormattedMessage",
+                defaultMessage: "Custom formatting with nested values (group inside formatted message)",
+            }),
+            filterable: false,
+            sortable: false,
+            renderCell: ({ row }) => {
+                const groupValues: string[] = [
+                    typeof row.price === "undefined" || row.price === null
+                        ? ""
+                        : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
+                    row.category?.title ?? "",
+                ];
+                return (
+                    <GridCellContent
+                        primaryText={
+                            <FormattedMessage
+                                id="product.combinedAndNestedValuesWithGroupInsideFormattedMessage.primaryText"
+                                defaultMessage={`This product is named "{title}" and is a "{type}"`}
+                                values={{ title: row.title ?? "", type: row.type ?? "" }}
+                            />
+                        }
+                        secondaryText={
+                            <FormattedMessage
+                                id="product.combinedAndNestedValuesWithGroupInsideFormattedMessage.secondaryText"
+                                defaultMessage="Price: {price} • Category: {category} • Same values again: ({nestedValues})"
+                                values={{
+                                    price:
+                                        typeof row.price === "undefined" || row.price === null ? (
+                                            ""
+                                        ) : (
+                                            <FormattedNumber
+                                                value={row.price}
+                                                minimumFractionDigits={2}
+                                                maximumFractionDigits={2}
+                                                style="currency"
+                                                currency="EUR"
+                                            />
+                                        ),
+                                    category: row.category?.title ?? "",
+                                    nestedValues: groupValues.filter(Boolean).join(" • "),
                                 }}
                             />
                         }

--- a/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
@@ -317,37 +317,34 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             minWidth: 150,
         },
         {
-            field: "combinedAndNestedValuesWithGroupInsideGroup",
-            headerName: intl.formatMessage({
-                id: "product.combinedAndNestedValuesWithGroupInsideGroup",
-                defaultMessage: "Custom formatting with nested values (group inside group)",
-            }),
+            field: "nestedGroups",
+            headerName: intl.formatMessage({ id: "product.nestedGroups", defaultMessage: "Nested groups" }),
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const groupValues: string[] = [
+                const productNestedGroupsSecondaryText__TODO__GroupValues: string[] = [
                     typeof row.price === "undefined" || row.price === null
                         ? ""
                         : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
                     row.category?.title ?? "",
                 ];
-                const groupValues: string[] = [
+                const productNestedGroupsSecondaryTextGroupValues: string[] = [
                     typeof row.price === "undefined" || row.price === null
                         ? ""
                         : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
                     row.category?.title ?? "",
-                    groupValues.filter(Boolean).join(" • "),
+                    productNestedGroupsSecondaryText__TODO__GroupValues.filter(Boolean).join(" • "),
                 ];
                 return (
                     <GridCellContent
                         primaryText={
                             <FormattedMessage
-                                id="product.combinedAndNestedValuesWithGroupInsideGroup.primaryText"
+                                id="product.nestedGroups.primaryText"
                                 defaultMessage={`This product is named "{title}" and is a "{type}"`}
                                 values={{ title: row.title ?? "", type: row.type ?? "" }}
                             />
                         }
-                        secondaryText={groupValues.filter(Boolean).join(" • ")}
+                        secondaryText={productNestedGroupsSecondaryTextGroupValues.filter(Boolean).join(" • ")}
                     />
                 );
             },
@@ -360,30 +357,30 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const groupValues: string[] = [
+                const productTwoGroupsPrimaryTextGroupValues: string[] = [
                     row.category?.title ?? "",
                     typeof row.price === "undefined" || row.price === null
                         ? ""
                         : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
                 ];
-                const groupValues: string[] = [row.category?.title ?? "", row.description ?? ""];
+                const productTwoGroupsSecondaryTextGroupValues: string[] = [row.category?.title ?? "", row.description ?? ""];
                 return (
-                    <GridCellContent primaryText={groupValues.filter(Boolean).join(" • ")} secondaryText={groupValues.filter(Boolean).join(" • ")} />
+                    <GridCellContent
+                        primaryText={productTwoGroupsPrimaryTextGroupValues.filter(Boolean).join(" • ")}
+                        secondaryText={productTwoGroupsSecondaryTextGroupValues.filter(Boolean).join(" • ")}
+                    />
                 );
             },
             flex: 1,
             minWidth: 150,
         },
         {
-            field: "combinedAndNestedValuesWithGroupInsideFormattedMessage",
-            headerName: intl.formatMessage({
-                id: "product.combinedAndNestedValuesWithGroupInsideFormattedMessage",
-                defaultMessage: "Custom formatting with nested values (group inside formatted message)",
-            }),
+            field: "groupInFormattedMessage",
+            headerName: intl.formatMessage({ id: "product.groupInFormattedMessage", defaultMessage: "Group in formatted message" }),
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const groupValues: string[] = [
+                const productGroupInFormattedMessageSecondaryTextNestedValuesGroupValues: string[] = [
                     typeof row.price === "undefined" || row.price === null
                         ? ""
                         : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
@@ -393,14 +390,14 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                     <GridCellContent
                         primaryText={
                             <FormattedMessage
-                                id="product.combinedAndNestedValuesWithGroupInsideFormattedMessage.primaryText"
+                                id="product.groupInFormattedMessage.primaryText"
                                 defaultMessage={`This product is named "{title}" and is a "{type}"`}
                                 values={{ title: row.title ?? "", type: row.type ?? "" }}
                             />
                         }
                         secondaryText={
                             <FormattedMessage
-                                id="product.combinedAndNestedValuesWithGroupInsideFormattedMessage.secondaryText"
+                                id="product.groupInFormattedMessage.secondaryText"
                                 defaultMessage="Price: {price} • Category: {category} • Same values again: ({nestedValues})"
                                 values={{
                                     price:
@@ -416,7 +413,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                                             />
                                         ),
                                     category: row.category?.title ?? "",
-                                    nestedValues: groupValues.filter(Boolean).join(" • "),
+                                    nestedValues: productGroupInFormattedMessageSecondaryTextNestedValuesGroupValues.filter(Boolean).join(" • "),
                                 }}
                             />
                         }

--- a/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
@@ -322,18 +322,18 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const productNestedGroupsSecondaryText__TODO__GroupValues: string[] = [
+                const secondaryTextNestedItem3GroupValues: string[] = [
                     typeof row.price === "undefined" || row.price === null
                         ? ""
                         : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
                     row.category?.title ?? "",
                 ];
-                const productNestedGroupsSecondaryTextGroupValues: string[] = [
+                const secondaryTextGroupValues: string[] = [
                     typeof row.price === "undefined" || row.price === null
                         ? ""
                         : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
                     row.category?.title ?? "",
-                    productNestedGroupsSecondaryText__TODO__GroupValues.filter(Boolean).join(" • "),
+                    secondaryTextNestedItem3GroupValues.filter(Boolean).join(" • "),
                 ];
                 return (
                     <GridCellContent
@@ -344,7 +344,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                                 values={{ title: row.title ?? "", type: row.type ?? "" }}
                             />
                         }
-                        secondaryText={productNestedGroupsSecondaryTextGroupValues.filter(Boolean).join(" • ")}
+                        secondaryText={secondaryTextGroupValues.filter(Boolean).join(" • ")}
                     />
                 );
             },
@@ -357,17 +357,17 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const productTwoGroupsPrimaryTextGroupValues: string[] = [
+                const primaryTextGroupValues: string[] = [
                     row.category?.title ?? "",
                     typeof row.price === "undefined" || row.price === null
                         ? ""
                         : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
                 ];
-                const productTwoGroupsSecondaryTextGroupValues: string[] = [row.category?.title ?? "", row.description ?? ""];
+                const secondaryTextGroupValues: string[] = [row.category?.title ?? "", row.description ?? ""];
                 return (
                     <GridCellContent
-                        primaryText={productTwoGroupsPrimaryTextGroupValues.filter(Boolean).join(" • ")}
-                        secondaryText={productTwoGroupsSecondaryTextGroupValues.filter(Boolean).join(" • ")}
+                        primaryText={primaryTextGroupValues.filter(Boolean).join(" • ")}
+                        secondaryText={secondaryTextGroupValues.filter(Boolean).join(" • ")}
                     />
                 );
             },
@@ -380,7 +380,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const productGroupInFormattedMessageSecondaryTextNestedValuesGroupValues: string[] = [
+                const secondaryTextNestedValuesGroupValues: string[] = [
                     typeof row.price === "undefined" || row.price === null
                         ? ""
                         : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
@@ -413,7 +413,7 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
                                             />
                                         ),
                                     category: row.category?.title ?? "",
-                                    nestedValues: productGroupInFormattedMessageSecondaryTextNestedValuesGroupValues.filter(Boolean).join(" • "),
+                                    nestedValues: secondaryTextNestedValuesGroupValues.filter(Boolean).join(" • "),
                                 }}
                             />
                         }

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -31,7 +31,7 @@ import { CircularProgress, useTheme } from "@mui/material";
 import { DataGridPro, GridColumnHeaderTitle, GridRenderCellParams, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import { GQLProductFilter } from "@src/graphql.generated";
 import * as React from "react";
-import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { ProductsGridPreviewAction } from "../../ProductsGridPreviewAction";
 import { ManufacturerFilterOperators } from "../ManufacturerFilter";
@@ -146,50 +146,24 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             filterable: false,
             sortable: false,
             renderCell: ({ row }) => {
-                const typeLabels: Record<string, React.ReactNode> = {
-                    Cap: <FormattedMessage id="product.overview.secondaryText.type.Cap" defaultMessage="great Cap" />,
-                    Shirt: <FormattedMessage id="product.overview.secondaryText.type.Shirt" defaultMessage="Shirt" />,
-                    Tie: <FormattedMessage id="product.overview.secondaryText.type.Tie" defaultMessage="Tie" />,
+                const typeLabels: Record<string, string> = {
+                    Cap: intl.formatMessage({ id: "product.overview.secondaryText.type.Cap", defaultMessage: `great Cap` }),
+                    Shirt: intl.formatMessage({ id: "product.overview.secondaryText.type.Shirt", defaultMessage: `Shirt` }),
+                    Tie: intl.formatMessage({ id: "product.overview.secondaryText.type.Tie", defaultMessage: `Tie` }),
                 };
-                const inStockLabels: Record<string, React.ReactNode> = {
-                    true: <FormattedMessage id="product.overview.secondaryText.inStock.true" defaultMessage="In stock" />,
-                    false: <FormattedMessage id="product.overview.secondaryText.inStock.false" defaultMessage="Out of stock" />,
+                const inStockLabels: Record<string, string> = {
+                    true: intl.formatMessage({ id: "product.overview.secondaryText.inStock.true", defaultMessage: `In stock` }),
+                    false: intl.formatMessage({ id: "product.overview.secondaryText.inStock.false", defaultMessage: `Out of stock` }),
                 };
-                return (
-                    <GridCellContent
-                        primaryText={row.title ?? "-"}
-                        secondaryText={
-                            <FormattedMessage
-                                id="product.overview.secondaryText"
-                                defaultMessage="{price} • {type} • {category} • {inStock}"
-                                values={{
-                                    price:
-                                        typeof row.price === "undefined" || row.price === null ? (
-                                            <FormattedMessage id="product.overview.secondaryText.price.empty" defaultMessage="No price" />
-                                        ) : (
-                                            <FormattedNumber
-                                                value={row.price}
-                                                minimumFractionDigits={2}
-                                                maximumFractionDigits={2}
-                                                style="currency"
-                                                currency="EUR"
-                                            />
-                                        ),
-                                    type:
-                                        row.type == null ? (
-                                            <FormattedMessage id="product.overview.secondaryText.type.empty" defaultMessage="No type" />
-                                        ) : (
-                                            typeLabels[`${row.type}`] ?? row.type
-                                        ),
-                                    category: row.category?.title ?? (
-                                        <FormattedMessage id="product.overview.secondaryText.category.empty" defaultMessage="No category" />
-                                    ),
-                                    inStock: row.inStock == null ? "-" : inStockLabels[`${row.inStock}`] ?? row.inStock,
-                                }}
-                            />
-                        }
-                    />
-                );
+                const groupValues: string[] = [
+                    typeof row.price === "undefined" || row.price === null
+                        ? intl.formatMessage({ id: "product.overview.secondaryText.price.empty", defaultMessage: `Price unknown` })
+                        : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
+                    row.type == null ? "" : typeLabels[`${row.type}`] ?? row.type,
+                    row.category?.title ?? "",
+                    row.inStock == null ? "" : inStockLabels[`${row.inStock}`] ?? row.inStock,
+                ];
+                return <GridCellContent primaryText={row.title ?? ""} secondaryText={groupValues.filter(Boolean).join(" • ")} />;
             },
             flex: 1,
             visible: theme.breakpoints.down("md"),
@@ -199,7 +173,7 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
         },
         {
             field: "title",
-            headerName: intl.formatMessage({ id: "product.title", defaultMessage: "Titel" }),
+            headerName: intl.formatMessage({ id: "product.title", defaultMessage: "Title" }),
             flex: 1,
             visible: theme.breakpoints.up("md"),
             minWidth: 200,

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -155,7 +155,7 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
                     true: intl.formatMessage({ id: "product.overview.secondaryText.inStock.true", defaultMessage: `In stock` }),
                     false: intl.formatMessage({ id: "product.overview.secondaryText.inStock.false", defaultMessage: `Out of stock` }),
                 };
-                const productOverviewSecondaryTextGroupValues: string[] = [
+                const secondaryTextGroupValues: string[] = [
                     typeof row.price === "undefined" || row.price === null
                         ? intl.formatMessage({ id: "product.overview.secondaryText.price.empty", defaultMessage: `Price unknown` })
                         : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
@@ -163,12 +163,7 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
                     row.category?.title ?? "",
                     row.inStock == null ? "" : inStockLabels[`${row.inStock}`] ?? row.inStock,
                 ];
-                return (
-                    <GridCellContent
-                        primaryText={row.title ?? ""}
-                        secondaryText={productOverviewSecondaryTextGroupValues.filter(Boolean).join(" • ")}
-                    />
-                );
+                return <GridCellContent primaryText={row.title ?? ""} secondaryText={secondaryTextGroupValues.filter(Boolean).join(" • ")} />;
             },
             flex: 1,
             visible: theme.breakpoints.down("md"),

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -155,7 +155,7 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
                     true: intl.formatMessage({ id: "product.overview.secondaryText.inStock.true", defaultMessage: `In stock` }),
                     false: intl.formatMessage({ id: "product.overview.secondaryText.inStock.false", defaultMessage: `Out of stock` }),
                 };
-                const groupValues: string[] = [
+                const productOverviewSecondaryTextGroupValues: string[] = [
                     typeof row.price === "undefined" || row.price === null
                         ? intl.formatMessage({ id: "product.overview.secondaryText.price.empty", defaultMessage: `Price unknown` })
                         : intl.formatNumber(row.price, { minimumFractionDigits: 2, maximumFractionDigits: 2, style: "currency", currency: "EUR" }),
@@ -163,7 +163,12 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
                     row.category?.title ?? "",
                     row.inStock == null ? "" : inStockLabels[`${row.inStock}`] ?? row.inStock,
                 ];
-                return <GridCellContent primaryText={row.title ?? ""} secondaryText={groupValues.filter(Boolean).join(" • ")} />;
+                return (
+                    <GridCellContent
+                        primaryText={row.title ?? ""}
+                        secondaryText={productOverviewSecondaryTextGroupValues.filter(Boolean).join(" • ")}
+                    />
+                );
             },
             flex: 1,
             visible: theme.breakpoints.down("md"),

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -432,7 +432,7 @@ export function generateGrid(
                 disableExport: column.disableExport,
             };
         } else if (type == "combination") {
-            renderCell = getCombinationColumnRenderCell(column, `${instanceGqlType}.${name}`);
+            renderCell = getCombinationColumnRenderCell(column, instanceGqlType, name);
         }
 
         //TODO suppoort n:1 relation with singleSelect

--- a/packages/admin/cms-admin/src/generator/future/generateGrid/combinationColumn.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid/combinationColumn.ts
@@ -127,10 +127,18 @@ const getTextForCellContent = (textConfig: Field<string>, messageIdPrefix: strin
             return textContent;
         });
 
-        variableDefinitions.push(`const groupValues: string[] = [${items.join(", ")}];`); // TODO: Variable name should contain "primary" or "secondary"
+        // TODO: Find a way to do this without using for formatted message id prefix
+        const uniqueVariableNamePrefix = messageIdPrefix
+            .split(".")
+            .map((part, index) => (index === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
+            .join("");
+
+        const groupValuesVariableName = `${uniqueVariableNamePrefix}GroupValues`;
+
+        variableDefinitions.push(`const ${groupValuesVariableName}: string[] = [${items.join(", ")}];`); // TODO: Variable name should contain "primary" or "secondary"
 
         return {
-            textContent: `groupValues.filter(Boolean).join(" • ")`,
+            textContent: `${groupValuesVariableName}.filter(Boolean).join(" • ")`,
             variableDefinitions,
         };
     }

--- a/packages/admin/cms-admin/src/generator/future/utils/intl.ts
+++ b/packages/admin/cms-admin/src/generator/future/utils/intl.ts
@@ -1,3 +1,31 @@
-export const getFormattedMessageNode = (id: string, defaultMessage = "", values?: string) => {
+import { ComponentProps } from "react";
+import { FormattedNumber } from "react-intl";
+
+export const getFormattedMessageNode = (id: string, defaultMessage: string, values?: string) => {
+    if (defaultMessage === "") {
+        return '""';
+    }
     return `<FormattedMessage id="${id}" defaultMessage={\`${defaultMessage}\`} ${values ? `values={${values}}` : ""} />`;
+};
+
+export const getFormattedMessageString = (id: string, defaultMessage: string, values?: string) => {
+    if (defaultMessage === "") {
+        return '""';
+    }
+    return `intl.formatMessage({ id: "${id}", defaultMessage: \`${defaultMessage}\`${values ? `, values: {${values}}` : ""}})`;
+};
+
+export type FormattedNumberOptions = {
+    [K in keyof Omit<ComponentProps<typeof FormattedNumber>, "value">]: unknown;
+};
+
+export const getFormattedNumberNode = (value: string, options: FormattedNumberOptions) => {
+    return `<FormattedNumber value={${value}} ${Object.entries(options)
+        .filter(([, value]) => value !== undefined)
+        .map(([key, value]) => `${key}=${typeof value === "string" ? `"${value}"` : `{${value}}`}`)
+        .join(" ")} />`;
+};
+
+export const getFormattedNumberString = (value: string, options: FormattedNumberOptions) => {
+    return `intl.formatNumber(${value}, ${JSON.stringify(options)})`;
 };


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

The `group` type in combination columns is used to group multiple values, separated by a `•`. 
This makes it easier than creating a custom `formattedMessage` and allows empty values instead of requiring an `emptyText` to prevent results like `€13.00 • Shirt • • •`. 

Another change worth mentioning: the default `emptyText` value of `"-"` was changed to an empty string `""`, as with a single dash, it's unclear what this value was supposed to be, and when nested in groups, the empty text should not be shown in most cases, to prevent results like `€13.00 • Shirt • - • - •`.  Instead, a custom `emptyText` should be defined in the config when relevant. 

<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Screenshot of `Overview` column in `ProductGrid`

| Before | After |
| --- | --- |
| <img width="312" alt="Overview column previously" src="https://github.com/user-attachments/assets/74cd1e06-0b66-4058-a9aa-a0815b129188" /> | <img width="312" alt="Overview column now" src="https://github.com/user-attachments/assets/246699e1-b446-4877-a72e-06484efb054b" /> |

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/SVK-368

## Open TODOs/questions

-   [x] Merge parent PR https://github.com/vivid-planet/comet/pull/2553
-   [x] Find a way to generate a unique formatted-message ID for when a child-field has no `field` e.g., for fields of type "group" or "formattedMessage" (the current value is `__TODO__`)
-   [x] Make sure the variableName `groupValues` is always unique, e.g. when `primaryText` and `secondaryText` both use the "group" type or when there are nested "group" types.
-   [x] Figure out what the default value of `emptyValue` should be. Currently it is "-". For the "group" type it would make sense to be an empty string, so empty values are not joined into the value-separated string. Maybe it should be consistent with non-group fields, so always an empty string, not just in the "group" type. 