### PR TITLE
Make sure date and time are formatted consistently across the admin interface

### DIFF
--- a/.changeset/brown-eggs-remember.md
+++ b/.changeset/brown-eggs-remember.md
@@ -1,0 +1,33 @@
+---
+"@comet/admin": minor
+---
+
+Add `gridColumnTypes`, a group of helpers for using the "date" and "dateTime" types in Data Grid
+
+```diff
+ import { useIntl } from "react-intl";
+-import { GridColDef } from "@comet/admin";
++import { GridColDef, gridColumnTypes } from "@comet/admin";
+
+ // ...
+
+ const intl = useIntl();
+ const columns: GridColDef[] = [
+     {
+-       type: "date",
+-       valueGetter: ({ value }) => value && new Date(value),
+-       valueFormatter: ({ value }) => value && intl.formatDate(value, { dateStyle: "medium" }),
++       ...gridColumnTypes.date(intl),
+        field: "createdAt",
+        headerName: "Created At",
+     },
+     {
+-      type: "dateTime",
+-      valueGetter: ({ value }) => value && new Date(value),
+-      valueFormatter: ({ value }) => value && intl.formatDate(value, { dateStyle: "medium", timeStyle: "short" }),
++      ...gridColumnTypes.dateTime(intl),
+       field: "updatedAt",
+       headerName: "Updated At",
+     },
+ ];
+```

--- a/.changeset/hot-turkeys-notice.md
+++ b/.changeset/hot-turkeys-notice.md
@@ -1,0 +1,6 @@
+---
+"@comet/cms-admin": patch
+"@comet/admin": patch
+---
+
+Use consistent date and time formatting across the Admin UI

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -16,6 +16,7 @@ import {
     useFormApiRef,
     useStackSwitchApi,
 } from "@comet/admin";
+import { DateField } from "@comet/admin-date-time";
 import { BlockState, createFinalFormBlock } from "@comet/blocks-admin";
 import {
     DamImageBlock,
@@ -194,6 +195,12 @@ export function ProductForm({ id }: FormProps) {
                             fullWidth
                             name="description"
                             label={<FormattedMessage id="product.description" defaultMessage="Description" />}
+                        />
+                        <DateField
+                            required
+                            fullWidth
+                            name="availableSince"
+                            label={<FormattedMessage id="product.availableSince" defaultMessage="Available Since" />}
                         />
                         <AsyncSelectField
                             name="manufacturerCountry"

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -7,6 +7,7 @@ import {
     GridCellContent,
     GridColDef,
     GridColumnsButton,
+    gridColumnTypes,
     GridFilterButton,
     MainContent,
     muiGridFilterToGql,
@@ -190,11 +191,10 @@ export function ProductsGrid() {
             minWidth: 80,
         },
         {
+            ...gridColumnTypes.date(intl),
             field: "availableSince",
             headerName: "Available Since",
             width: 130,
-            type: "date",
-            valueGetter: ({ row }) => row.availableSince && new Date(row.availableSince),
         },
         {
             field: "status",

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -6,6 +6,7 @@ import {
     DataGridToolbar,
     filterByFragment,
     GridColDef,
+    gridColumnTypes,
     GridFilterButton,
     muiGridFilterToGql,
     muiGridSortToGql,
@@ -106,11 +107,9 @@ export function ProductVariantsGrid({ product }: Props): React.ReactElement {
     const columns: GridColDef<GQLProductVariantsGridFutureFragment>[] = [
         { field: "name", headerName: intl.formatMessage({ id: "productVariant.name", defaultMessage: "Name" }), flex: 1, minWidth: 150 },
         {
+            ...gridColumnTypes.date(intl),
             field: "createdAt",
             headerName: intl.formatMessage({ id: "productVariant.createdAt", defaultMessage: "Created at" }),
-            type: "date",
-            valueGetter: ({ row }) => row.createdAt && new Date(row.createdAt),
-            valueFormatter: ({ value }) => (value ? intl.formatDate(value) : ""),
             flex: 1,
             minWidth: 150,
         },

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -9,6 +9,7 @@ import {
     filterByFragment,
     GridCellContent,
     GridColDef,
+    gridColumnTypes,
     GridFilterButton,
     messages,
     muiGridFilterToGql,
@@ -231,20 +232,15 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             maxWidth: 150,
         },
         {
+            ...gridColumnTypes.date(intl),
             field: "availableSince",
             headerName: intl.formatMessage({ id: "product.availableSince", defaultMessage: "Available Since" }),
-            type: "date",
-            valueGetter: ({ row }) => row.availableSince && new Date(row.availableSince),
-            valueFormatter: ({ value }) => (value ? intl.formatDate(value) : ""),
             width: 140,
         },
         {
+            ...gridColumnTypes.dateTime(intl),
             field: "createdAt",
             headerName: intl.formatMessage({ id: "product.createdAt", defaultMessage: "Created At" }),
-            type: "dateTime",
-            valueGetter: ({ row }) => row.createdAt && new Date(row.createdAt),
-            valueFormatter: ({ value }) =>
-                value ? intl.formatDate(value, { day: "numeric", month: "numeric", year: "numeric", hour: "numeric", minute: "numeric" }) : "",
             width: 170,
         },
         {

--- a/packages/admin/admin/src/dataGrid/gridColumnTypes.tsx
+++ b/packages/admin/admin/src/dataGrid/gridColumnTypes.tsx
@@ -1,0 +1,19 @@
+import { GridColTypeDef } from "@mui/x-data-grid";
+import { IntlShape } from "react-intl";
+
+const date = (intl: IntlShape): GridColTypeDef => ({
+    type: "date",
+    valueGetter: ({ value }) => value && new Date(value),
+    valueFormatter: ({ value }) => value && intl.formatDate(value, { dateStyle: "medium" }),
+});
+
+const dateTime = (intl: IntlShape): GridColTypeDef => ({
+    type: "dateTime",
+    valueGetter: ({ value }) => value && new Date(value),
+    valueFormatter: ({ value }) => value && intl.formatDate(value, { dateStyle: "medium", timeStyle: "short" }),
+});
+
+export const gridColumnTypes = {
+    date,
+    dateTime,
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -48,6 +48,7 @@ export { ExportApi, useDataGridExcelExport } from "./dataGrid/excelExport/useDat
 export { GridCellContent, GridCellContentClassKey, GridCellContentProps } from "./dataGrid/GridCellContent";
 export { GridColDef } from "./dataGrid/GridColDef";
 export { GridColumnsButton } from "./dataGrid/GridColumnsButton";
+export { gridColumnTypes } from "./dataGrid/gridColumnTypes";
 export { GridFilterButton } from "./dataGrid/GridFilterButton";
 export { muiGridFilterToGql } from "./dataGrid/muiGridFilterToGql";
 export { muiGridPagingToGql } from "./dataGrid/muiGridPagingToGql";

--- a/packages/admin/cms-admin/src/common/header/about/AboutModal.tsx
+++ b/packages/admin/cms-admin/src/common/header/about/AboutModal.tsx
@@ -3,7 +3,7 @@ import { Dialog, DialogContent as MuiDialogContent, DialogTitle, IconButton, Lin
 import Backdrop from "@mui/material/Backdrop";
 import { styled } from "@mui/material/styles";
 import { ReactElement } from "react";
-import { FormattedDate, FormattedMessage, FormattedTime } from "react-intl";
+import { FormattedDate, FormattedMessage } from "react-intl";
 
 import { version } from "../../..";
 import { useBuildInformation } from "./build-information/useBuildInformation";
@@ -50,7 +50,7 @@ export function AboutModal({ open, onClose, logo = <CometDigitalExperienceLogo /
                         )}
                         {buildInformation?.date && (
                             <Typography>
-                                <FormattedDate value={buildInformation.date} /> <FormattedTime value={buildInformation.date} />
+                                <FormattedDate value={buildInformation.date} dateStyle="medium" timeStyle="short" />
                             </Typography>
                         )}
                     </VersionContainer>

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -15,7 +15,7 @@ import { Slide, SlideProps, Snackbar } from "@mui/material";
 import { DataGrid, GridColumns, GridRowClassNameParams, GridSelectionModel } from "@mui/x-data-grid";
 import { useEffect, useState } from "react";
 import { FileRejection, useDropzone } from "react-dropzone";
-import { FormattedDate, FormattedMessage, FormattedTime, useIntl } from "react-intl";
+import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
 import { useDebouncedCallback } from "use-debounce";
 
 import { GQLDamItemType } from "../../graphql.generated";
@@ -473,7 +473,7 @@ const FolderDataGrid = ({
                                               <>
                                                   <FormattedMessage id="comet.dam.file.license.validUntil" defaultMessage="Valid until:" />{" "}
                                                   {row.license.durationTo ? (
-                                                      <FormattedDate value={row.license.durationTo} day="2-digit" month="2-digit" year="numeric" />
+                                                      <FormattedDate value={row.license.durationTo} dateStyle="medium" />
                                                   ) : (
                                                       <FormattedMessage id="comet.dam.file.license.unlimited" defaultMessage="Unlimited" />
                                                   )}
@@ -499,13 +499,7 @@ const FolderDataGrid = ({
             headerAlign: "left",
             align: "left",
             minWidth: 180,
-            renderCell: ({ row }) => (
-                <div>
-                    <FormattedDate value={row.createdAt} day="2-digit" month="2-digit" year="numeric" />
-                    {", "}
-                    <FormattedTime value={row.createdAt} />
-                </div>
-            ),
+            valueFormatter: ({ value }) => (value ? intl.formatDate(value, { dateStyle: "medium", timeStyle: "short" }) : ""),
             sortable: false,
             hideSortIcons: true,
             disableColumnMenu: true,
@@ -519,13 +513,7 @@ const FolderDataGrid = ({
             headerAlign: "left",
             align: "left",
             minWidth: 180,
-            renderCell: ({ row }) => (
-                <div>
-                    <FormattedDate value={row.updatedAt} day="2-digit" month="2-digit" year="numeric" />
-                    {", "}
-                    <FormattedTime value={row.updatedAt} />
-                </div>
-            ),
+            valueFormatter: ({ value }) => (value ? intl.formatDate(value, { dateStyle: "medium", timeStyle: "short" }) : ""),
             sortable: false,
             hideSortIcons: true,
             disableColumnMenu: true,

--- a/packages/admin/cms-admin/src/dam/FileForm/ImageInfos.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/ImageInfos.tsx
@@ -2,7 +2,7 @@ import { FormSection, PrettyBytes, Table } from "@comet/admin";
 import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { isDateString } from "class-validator";
-import { FormattedDate, FormattedTime, useIntl } from "react-intl";
+import { FormattedDate, useIntl } from "react-intl";
 import { v4 as uuid } from "uuid";
 
 interface ImageInfos {
@@ -109,13 +109,7 @@ export const ImageInfos = ({ imageInfos: { width, height, fileSize, fileFormat, 
                                     if (typeof row.value === "object") {
                                         return JSON.stringify(row.value);
                                     } else if (typeof row.value === "string" && isDateString(row.value)) {
-                                        return (
-                                            <>
-                                                <FormattedDate value={row.value} day="2-digit" month="2-digit" year="numeric" />
-                                                {" - "}
-                                                <FormattedTime value={row.value} />
-                                            </>
-                                        );
+                                        return <FormattedDate value={row.value} dateStyle="medium" timeStyle="short" />;
                                     }
 
                                     return String(row.value);

--- a/packages/admin/cms-admin/src/dashboard/widgets/LatestContentUpdatesDashboardWidget.tsx
+++ b/packages/admin/cms-admin/src/dashboard/widgets/LatestContentUpdatesDashboardWidget.tsx
@@ -2,7 +2,7 @@ import { GridColDef } from "@comet/admin";
 import { ArrowRight, Reload } from "@comet/admin-icons";
 import { IconButton } from "@mui/material";
 import { DataGrid, DataGridProps } from "@mui/x-data-grid";
-import { FormattedDate, FormattedMessage, FormattedTime, useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { Link } from "react-router-dom";
 
 import { DashboardWidgetRoot } from "./DashboardWidgetRoot";
@@ -38,13 +38,7 @@ export const LatestContentUpdatesDashboardWidget = <Row extends MinimalRow>({
             headerName: intl.formatMessage({ id: "dashboard.latestContentUpdates.updatedAt", defaultMessage: "Updated At" }),
             type: "dateTime",
             flex: 1,
-            renderCell: ({ row }) => (
-                <>
-                    <FormattedDate value={row.updatedAt} day="2-digit" month="2-digit" year="numeric" />
-                    {", "}
-                    <FormattedTime value={row.updatedAt} />
-                </>
-            ),
+            valueFormatter: ({ value }) => (value ? intl.formatDate(value, { dateStyle: "medium", timeStyle: "short" }) : ""),
         },
         {
             ...disableFieldOptions,

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -25,8 +25,8 @@ import { generateImportsCode, Imports } from "./utils/generateImportsCode";
 
 type TsCodeRecordToStringObject = Record<string, string | number | undefined>;
 
-function tsCodeRecordToString(object: TsCodeRecordToStringObject) {
-    return `{${Object.entries(object)
+function tsCodeRecordToString(object: TsCodeRecordToStringObject, spreadAbove?: string) {
+    return `{${spreadAbove ? `${spreadAbove}` : ""}${Object.entries(object)
         .filter(([key, value]) => value !== undefined)
         .map(([key, value]) => `${key}: ${value},`)
         .join("\n")}}`;
@@ -318,20 +318,16 @@ export function generateGrid(
         const type = column.type;
         const name = String(column.name);
 
+        let gridColumnType: string | undefined = undefined;
         let renderCell: string | undefined = undefined;
-        let valueGetter: string | undefined = name.includes(".") ? `({ row }) => row.${name.replace(/\./g, "?.")}` : undefined;
         let valueFormatter: string | undefined = undefined;
 
         let gridType: "number" | "boolean" | "dateTime" | "date" | undefined;
 
         if (type == "dateTime") {
-            valueGetter = `({ row }) => row.${name} && new Date(row.${name})`;
-            valueFormatter = `({ value }) => value ? intl.formatDate(value, { day: "numeric", month: "numeric", year: "numeric", hour: "numeric", minute: "numeric" }) : ""`;
-            gridType = "dateTime";
+            gridColumnType = "...gridColumnTypes.dateTime(intl),";
         } else if (type == "date") {
-            valueGetter = `({ row }) => row.${name} && new Date(row.${name})`;
-            valueFormatter = `({ value }) => value ? intl.formatDate(value) : ""`;
-            gridType = "date";
+            gridColumnType = "...gridColumnTypes.date(intl),";
         } else if (type == "number") {
             gridType = "number";
         } else if (type == "boolean") {
@@ -406,6 +402,7 @@ export function generateGrid(
                 name,
                 type,
                 gridType: "singleSelect" as const,
+                columnType: gridColumnType,
                 valueOptions,
                 renderCell,
                 valueFormatter,
@@ -429,8 +426,9 @@ export function generateGrid(
             headerName: column.headerName,
             type,
             gridType,
+            columnType: gridColumnType,
             renderCell,
-            valueGetter,
+            valueGetter: name.includes(".") ? `({ row }) => row.${name.replace(/\./g, "?.")}` : undefined,
             valueFormatter,
             width: column.width,
             minWidth: column.minWidth,
@@ -492,6 +490,7 @@ export function generateGrid(
         GridFilterButton,
         GridCellContent,
         GridColDef,
+        gridColumnTypes,
         renderStaticSelectCell,
         messages,
         muiGridFilterToGql,
@@ -704,7 +703,7 @@ export function generateGrid(
                         columnDefinition.maxWidth = maxWidth;
                     }
 
-                    return tsCodeRecordToString(columnDefinition);
+                    return tsCodeRecordToString(columnDefinition, column.columnType);
                 })
                 .join(",\n")},
                 ${

--- a/storybook/src/admin/form/Typography.tsx
+++ b/storybook/src/admin/form/Typography.tsx
@@ -44,7 +44,7 @@ function Story() {
                                 <Typography>Of course you can use any formatting:</Typography>
                                 <FieldContainer label="Today">
                                     <Typography>
-                                        <FormattedDate value={new Date()} />
+                                        <FormattedDate value={new Date()} dateStyle="medium" />
                                     </Typography>
                                 </FieldContainer>
                             </CardContent>


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

According to UX, we want the admin UI to consistently use the "medium" date-style in most places, such as Data Grids. 

### About the `gridColumnTypes` helpers

The idea comes from MUIs [Custom Data Grid Columns](https://mui.com/x/react-data-grid/custom-columns/).

Unfortunately there is no way of getting around using a function that takes in `intl`. 
The `valueFormatter` function must return a `string` and cannot call hooks itself. 

<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Example

<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A dev story in Storybook
-   A unit test

--->

-   [x] I have verified if my change requires an example

## Screenshots/screencasts

| Locale | Before   | After   |
| --- | --- | --- |
| EN |<img width="342" alt="Previously EN" src="https://github.com/user-attachments/assets/3340e372-93cd-4518-bdeb-ce9a57f19ca1"> | <img width="342" alt="Now EN" src="https://github.com/user-attachments/assets/f43e71fc-c970-42d1-8b93-23e9d9f44137"> |
| DE | <img width="342" alt="Previously DE" src="https://github.com/user-attachments/assets/45732a73-25f5-4a10-8fcb-ae386f9495ae"> | <img width="342" alt="Now DE" src="https://github.com/user-attachments/assets/3214ca6f-f313-485f-8793-d38843d612bc"> |

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

- https://vivid-planet.atlassian.net/browse/SVK-380
- https://vivid-planet.atlassian.net/browse/SVK-416
- https://vivid-planet.atlassian.net/browse/SVK-419