### PR TITLE
Demo Site: Output Cache-Control header for all requests that should be cached by a CDN

### DIFF
--- a/demo/site/server.ts
+++ b/demo/site/server.ts
@@ -29,6 +29,23 @@ app.prepare().then(() => {
                     return;
                 }
             }
+            if (
+                parsedUrl.pathname?.startsWith("/assets/") || // TODO move public/* files into public/assets folder
+                parsedUrl.pathname == "/favicon.ico" ||
+                parsedUrl.pathname == "/robots.txt" ||
+                parsedUrl.pathname == "/sitemap.xml"
+            ) {
+                res.setHeader("Cache-Control", "public, max-age=900");
+                const origSetHeader = res.setHeader;
+                res.setHeader = function (name: string, value: string | number | readonly string[]) {
+                    if (name === "cache-control" || name === "Cache-Control") {
+                        // ignore
+                        return;
+                    }
+                    return origSetHeader.call(this, name, value);
+                };
+            }
+
             await handle(req, res, parsedUrl);
         } catch (err) {
             console.error("Error occurred handling", req.url, err);

--- a/demo/site/server.ts
+++ b/demo/site/server.ts
@@ -32,6 +32,8 @@ app.prepare().then(() => {
             if (
                 parsedUrl.pathname?.startsWith("/assets/") || // TODO move public/* files into public/assets folder
                 parsedUrl.pathname == "/favicon.ico" ||
+                parsedUrl.pathname == "/apple-icon.png" ||
+                parsedUrl.pathname == "/icon.svg" ||
                 parsedUrl.pathname == "/robots.txt" ||
                 parsedUrl.pathname == "/sitemap.xml"
             ) {

--- a/demo/site/src/util/graphQLClient.ts
+++ b/demo/site/src/util/graphQLClient.ts
@@ -14,7 +14,9 @@ export function createGraphQLFetch(previewData?: SitePreviewData) {
           }
         : undefined;
     return createGraphQLFetchLibrary(
-        createFetchWithDefaults(createFetchWithPreviewHeaders(fetch, previewData), { next: { revalidate: 15 * 60 }, headers }),
+        // set a default revalidate time of 7.5 minutes to get an effective cache duration of 15 minutes if a CDN cache is enabled
+        // see cache-handler.ts for maximum cache duration (24 hours)
+        createFetchWithDefaults(createFetchWithPreviewHeaders(fetch, previewData), { next: { revalidate: 7.5 * 60 }, headers }),
         graphQLApiUrl,
     );
 }


### PR DESCRIPTION
This PR adds `Cache-Control` header to all site requests that should be cached by a CDN, so we don't need any custom cache rules in the CDN configuration.

Different cases:

1. html document
    - nextjs does out of the box output `Cache-Control: s-maxage=900, stale-while-revalidate`
        - (this is not true in dev mode(!) or preview mode)
    - maxage is based on minimum revalidate of fetch calls (data caches) 
    - `public` is missing (might not be a problem?)
    - possible workaround: override `Cache-Control` by setting it before `handle()` - nextjs won't overwrite it (since https://github.com/vercel/next.js/pull/69802)
        - however we are unable to easily differenciate api-requests (that potentially should not have maxage=60) and html requests
        - except some magic api part in the path, but api routes can have any path
    - :arrow_right: we won't change the nextjs default, but change revalidation from 15min to 7.5min 
2. rsc for document (html document with ?_rsc=xxx)
    - exactly the same as html document
3. api route
    - no `Cache-Control` headers are added 
    - workaround: none required
4. favicon/robots.txt/sitemap.xml
    - nextjs: `Cache-Control: public, max-age=0, must-revalidate`
    - :arrow_right: workaround: set our own and ignore nextjs's value by monkey patching `response.setHeader` before calling handle()
5. static asset (public/*)
    - nextjs: `Cache-Control: public, max-age=0`
    - :arrow_right: workaround: monkey-patch from above
    - alternative workaround: serve files on our own (eg using serve-static)
6. static, built files, /_next/*
    - nextjs: `Cache-Control: public, max-age=31536000, immutable`
    - workaround: none required
7. any other I didn't think of?