### PR TITLE
Update changeset action

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -56,7 +56,7 @@ jobs:
 
             - name: Create Release Pull Request or Publish to npm
               id: changesets
-              uses: dotansimha/changesets-action@cbc5ff3569ae9861100a48b290f4e9c1b94e45b5
+              uses: dotansimha/changesets-action@v1.5.2
               with:
                   version: pnpm run version
                   publish: pnpm run publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
             - name: Create Release Pull Request or Publish to npm
               id: changesets
-              uses: dotansimha/changesets-action@cbc5ff3569ae9861100a48b290f4e9c1b94e45b5
+              uses: dotansimha/changesets-action@v1.5.2
               with:
                   version: pnpm run version
                   publish: pnpm run publish


### PR DESCRIPTION
The action we're currently using is a specific commit of a fork. We change this to the published version of the fork.
