### PR TITLE
Stay on same page when changing scopes

### DIFF
--- a/.changeset/little-students-attend.md
+++ b/.changeset/little-students-attend.md
@@ -1,0 +1,26 @@
+---
+"@comet/cms-admin": major
+---
+
+Stay on same page when changing scopes
+
+Previously, `redirectPathAfterChange` of `useContentScopeConfig` had to be explicitly set to ensure that the Admin stays on the same page after changing scopes.
+This was often forgotten, resulting in redirects to the default page (usually the dashboard page).
+Now, as it is the preferred behavior, the Admin will stay on the same page per default.
+
+To upgrade, perform the following changes:
+
+1. Remove the `path` prop from the `PagesPage` component
+2. Remove the `redirectPathAfterChange` prop from the `RedirectsPage` component
+3. Remove unnecessary usages of the `useContentScopeConfig` hook
+
+To restore the previous behavior, add the `useContentScopeConfig` hook:
+
+```tsx
+import { useContentScopeConfig } from "@comet/cms-admin";
+
+function MainMenuPage() {
+    // We want to redirect to the dashboard page after changing the scope.
+    useContentScopeConfig({ redirectPathAfterChange: "/dashboard" });
+}
+```

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -77,7 +77,6 @@ export const masterMenuData: MasterMenuData = [
 
                 return (
                     <PagesPage
-                        path={`/pages/pagetree/${match.params.category}`}
                         allCategories={pageTreeCategories}
                         documentTypes={(category): Record<DocumentType, DocumentInterface> => {
                             if (category === "TopMenu") {
@@ -172,7 +171,7 @@ export const masterMenuData: MasterMenuData = [
                 primary: <FormattedMessage id="menu.redirects" defaultMessage="Redirects" />,
                 route: {
                     path: "/system/redirects",
-                    render: () => <RedirectsPage redirectPathAfterChange="/system/redirects" />,
+                    component: RedirectsPage,
                 },
                 requiredPermission: "pageTree",
             },

--- a/docs/docs/migration/migration-from-v7-to-v8.md
+++ b/docs/docs/migration/migration-from-v7-to-v8.md
@@ -16,3 +16,47 @@ It automatically installs the new versions of all `@comet` libraries, runs an ES
 -   Run MUI codemods
 
 </details>
+
+## Admin
+
+### Stay on same page after changing scope
+
+The Admin now stays on the same page per default when changing scopes.
+Perform the following changes:
+
+1.  Remove the `path` prop from the `PagesPage` component
+
+    ```diff title="admin/src/common/MasterMenu.tsx"
+    <PagesPage
+    -   path="/pages/pagetree/main-navigation"
+        allCategories={pageTreeCategories}
+        documentTypes={pageTreeDocumentTypes}
+        category="MainNavigation"
+        renderContentScopeIndicator={(scope) => <ContentScopeIndicator scope={scope} />}
+    />
+    ```
+
+2.  Remove the `redirectPathAfterChange` prop from the `RedirectsPage` component
+
+    ```diff title="admin/src/common/MasterMenu.tsx"
+    {
+        type: "route",
+        primary: <FormattedMessage id="menu.redirects" defaultMessage="Redirects" />,
+        route: {
+            path: "/system/redirects",
+    -       render: () => <RedirectsPage redirectPathAfterChange="/system/redirects" />,
+    +       component: RedirectsPage
+        },
+        requiredPermission: "pageTree",
+    },
+    ```
+
+3.  Optional: Remove unnecessary usages of the `useContentScopeConfig` hook
+
+    ```diff
+    export function ProductsPage() {
+        const intl = useIntl();
+
+    -   useContentScopeConfig({ redirectPathAfterChange: "/structured-content/products" });
+    }
+    ```

--- a/packages/admin/cms-admin/src/builds/PublisherPage.tsx
+++ b/packages/admin/cms-admin/src/builds/PublisherPage.tsx
@@ -4,11 +4,8 @@ import { styled } from "@mui/material/styles";
 import { DataGrid } from "@mui/x-data-grid";
 import { parseISO } from "date-fns";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useRouteMatch } from "react-router";
 
 import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
-import { useContentScope } from "../contentScope/Provider";
-import { useContentScopeConfig } from "../contentScope/useContentScopeConfig";
 import { JobRuntime } from "../cronJobs/JobRuntime";
 import { PublishButton } from "./PublishButton";
 import { GQLBuildsQuery } from "./PublisherPage.generated";
@@ -33,11 +30,6 @@ const DataGridContainer = styled("div")`
 `;
 
 export function PublisherPage() {
-    const { match } = useContentScope();
-    const routeMatch = useRouteMatch();
-    const location = routeMatch.url.replace(match.url, "");
-    useContentScopeConfig({ redirectPathAfterChange: location });
-
     const intl = useIntl();
 
     const { data, loading, error } = useQuery<GQLBuildsQuery, undefined>(buildsQuery);

--- a/packages/admin/cms-admin/src/contentScope/Provider.tsx
+++ b/packages/admin/cms-admin/src/contentScope/Provider.tsx
@@ -1,5 +1,5 @@
 import { createContext, Dispatch, ReactNode, SetStateAction, useCallback, useContext, useMemo, useState } from "react";
-import { generatePath, match, Redirect, Route, Switch, useHistory, useRouteMatch } from "react-router";
+import { generatePath, match, Redirect, Route, Switch, useHistory, useLocation, useRouteMatch } from "react-router";
 
 export interface ContentScopeInterface {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -141,10 +141,22 @@ export function ContentScopeProvider<S extends ContentScopeInterface = ContentSc
     const path = location.createPath(values);
     const defaultUrl = location.createUrl(defaultValue);
     const match = useRouteMatch<NonNullRecord<S>>(path);
-    const [redirectPathAfterChange, setRedirectPathAfterChange] = useState<undefined | string>("");
+    const [redirectPathAfterChange, setRedirectPathAfterChange] = useState<string>();
+    const currentLocation = useLocation();
+
+    let defaultRedirectPathAfterChange: string | undefined;
+
+    if (match) {
+        // Location: /main/en/dashboard
+        // Match: /main/en
+        // Page: Location - Match = /dashboard
+        defaultRedirectPathAfterChange = currentLocation.pathname.replace(match.url, "");
+    }
 
     return (
-        <Context.Provider value={{ path, redirectPathAfterChange, setRedirectPathAfterChange, values }}>
+        <Context.Provider
+            value={{ path, redirectPathAfterChange: redirectPathAfterChange ?? defaultRedirectPathAfterChange, setRedirectPathAfterChange, values }}
+        >
             <Switch>
                 {match && (
                     <Route exact={false} strict={false} path={path}>

--- a/packages/admin/cms-admin/src/dam/DamPage.tsx
+++ b/packages/admin/cms-admin/src/dam/DamPage.tsx
@@ -1,10 +1,8 @@
 import { styled } from "@mui/material/styles";
 import { ReactNode } from "react";
-import { useRouteMatch } from "react-router";
 
 import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
 import { ContentScopeInterface, useContentScope } from "../contentScope/Provider";
-import { useContentScopeConfig } from "../contentScope/useContentScopeConfig";
 import { DamScopeProvider } from "./config/DamScopeProvider";
 import { useDamConfig } from "./config/useDamConfig";
 import { useDamScope } from "./config/useDamScope";
@@ -36,10 +34,7 @@ const DamTableWrapper = styled("div")`
 `;
 
 function DamPage({ renderContentScopeIndicator, additionalToolbarItems }: Props) {
-    const { scope, match } = useContentScope();
-    const routeMatch = useRouteMatch();
-    const damRouteLocation = routeMatch.url.replace(match.url, "");
-    useContentScopeConfig({ redirectPathAfterChange: damRouteLocation });
+    const { scope } = useContentScope();
     const damConfig = useDamConfig();
 
     return (

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -16,12 +16,11 @@ import {
 } from "@comet/admin";
 import { Add } from "@comet/admin-icons";
 import { Box, Button, Divider, FormControlLabel, LinearProgress, Paper, Switch } from "@mui/material";
-import { ComponentType, ReactNode, useCallback, useEffect, useMemo, useRef } from "react";
+import { ComponentType, ReactNode, useCallback, useMemo, useRef } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { ContentScopeInterface, createEditPageNode, useCmsBlockContext } from "../..";
 import { useContentScope } from "../../contentScope/Provider";
-import { useContentScopeConfig } from "../../contentScope/useContentScopeConfig";
 import { DamScopeProvider } from "../../dam/config/DamScopeProvider";
 import { DocumentInterface, DocumentType } from "../../documents/types";
 import { useSiteConfig } from "../../sitesConfig/useSiteConfig";
@@ -36,7 +35,6 @@ import { PagesPageActionToolbar } from "./PagesPageActionToolbar";
 
 interface Props {
     category: string;
-    path: string;
     allCategories: AllCategories;
     documentTypes: Record<DocumentType, DocumentInterface> | ((category: string) => Record<DocumentType, DocumentInterface>);
     editPageNode?: ComponentType<EditPageNodeProps>;
@@ -47,27 +45,18 @@ const DefaultEditPageNode = createEditPageNode({});
 
 export function PagesPage({
     category,
-    path,
     allCategories,
     documentTypes: passedDocumentTypes,
     editPageNode: EditPageNode = DefaultEditPageNode,
     renderContentScopeIndicator,
 }: Props) {
     const intl = useIntl();
-    const { scope, setRedirectPathAfterChange } = useContentScope();
+    const { scope } = useContentScope();
     const { additionalPageTreeNodeFragment } = useCmsBlockContext();
-    useContentScopeConfig({ redirectPathAfterChange: path });
 
     const siteConfig = useSiteConfig({ scope });
     const pagesQuery = useMemo(() => createPagesQuery({ additionalPageTreeNodeFragment }), [additionalPageTreeNodeFragment]);
     const documentTypes = typeof passedDocumentTypes === "function" ? passedDocumentTypes(category) : passedDocumentTypes;
-
-    useEffect(() => {
-        setRedirectPathAfterChange(path);
-        return () => {
-            setRedirectPathAfterChange(undefined);
-        };
-    }, [setRedirectPathAfterChange, path]);
 
     const { loading, data, error, refetch, startPolling, stopPolling } = useQuery<GQLPagesQuery, GQLPagesQueryVariables>(pagesQuery, {
         fetchPolicy: "cache-and-network",

--- a/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
+++ b/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
@@ -7,20 +7,15 @@ import { ExternalLinkBlock } from "../blocks/ExternalLinkBlock";
 import { InternalLinkBlock } from "../blocks/InternalLinkBlock";
 import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
 import { useContentScope } from "../contentScope/Provider";
-import { useContentScopeConfig } from "../contentScope/useContentScopeConfig";
 import { RedirectForm } from "./RedirectForm";
 import { RedirectsGrid } from "./RedirectsGrid";
-
-interface RedirectsPageProps {
-    redirectPathAfterChange?: string;
-}
 
 interface CreateRedirectsPageOptions {
     customTargets?: Record<string, BlockInterface>;
     scopeParts?: string[];
 }
 
-function createRedirectsPage({ customTargets, scopeParts = [] }: CreateRedirectsPageOptions = {}): ComponentType<RedirectsPageProps> {
+function createRedirectsPage({ customTargets, scopeParts = [] }: CreateRedirectsPageOptions = {}): ComponentType {
     const linkBlock = createOneOfBlock({
         supportedBlocks: { internal: InternalLinkBlock, external: ExternalLinkBlock, ...customTargets },
         name: "RedirectsLink",
@@ -28,9 +23,8 @@ function createRedirectsPage({ customTargets, scopeParts = [] }: CreateRedirects
         allowEmpty: false,
     });
 
-    function Redirects({ redirectPathAfterChange }: RedirectsPageProps): JSX.Element {
+    function Redirects(): JSX.Element {
         const intl = useIntl();
-        useContentScopeConfig({ redirectPathAfterChange });
 
         const { scope: completeScope } = useContentScope();
         const scope = scopeParts.reduce((acc, scopePart) => {

--- a/packages/admin/cms-admin/src/userPermissions/UserPermissionsPage.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/UserPermissionsPage.tsx
@@ -1,19 +1,11 @@
 import { MainContent, Stack, StackPage, StackSwitch, Toolbar } from "@comet/admin";
 import { FormattedMessage } from "react-intl";
-import { useRouteMatch } from "react-router";
 
 import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
-import { useContentScope } from "../contentScope/Provider";
-import { useContentScopeConfig } from "../contentScope/useContentScopeConfig";
 import { UserPage } from "./user/UserPage";
 import { UserGrid } from "./UserGrid";
 
 export const UserPermissionsPage = () => {
-    const { match } = useContentScope();
-    const routeMatch = useRouteMatch();
-    const location = routeMatch.url.replace(match.url, "");
-    useContentScopeConfig({ redirectPathAfterChange: location });
-
     return (
         <Stack topLevelTitle={<FormattedMessage id="comet.userPermissions.title" defaultMessage="User Management" />}>
             <StackSwitch>


### PR DESCRIPTION
## Description

Previously, `redirectPathAfterChange` of `useContentScopeConfig` had to be explicitly set to ensure that the Admin stays on the same page after changing scopes.
This was often forgotten, resulting in redirects to the default page (usually the dashboard page).
Now, as it is the preferred behavior, the Admin will stay on the same page per default.

The previous behavior can be restored by using the `useContentScopeConfig` hook:

```tsx
import { useContentScopeConfig } from "@comet/cms-admin";

function MainMenuPage() {
    // We want to redirect to the dashboard page after changing the scope.
    useContentScopeConfig({ redirectPathAfterChange: "/dashboard" });
}
```
<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->

## Example

<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A dev story in Storybook
-   A unit test

--->

-   [x] I have verified if my change requires an example

## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1102