### PR TITLE
Demo Site cache handler: Fine-tune Redis config

### DIFF
--- a/demo/site/cache-handler.ts
+++ b/demo/site/cache-handler.ts
@@ -17,21 +17,17 @@ if (!REDIS_PASSWORD) {
 
 const REDIS_KEY_PREFIX = process.env.REDIS_KEY_PREFIX || "";
 
-const REDIS_ENABLE_AUTOPIPELINING = process.env.REDIS_ENABLE_AUTOPIPELINING === "true";
-
 const CACHE_HANDLER_DEBUG = process.env.CACHE_HANDLER_DEBUG === "true";
 
 const CACHE_TTL_IN_S = 24 * 60 * 60; // 1 day
 
 const redis = new Redis({
-    commandTimeout: 1000,
     enableOfflineQueue: false,
     host: REDIS_HOST,
     keyPrefix: REDIS_KEY_PREFIX,
     password: REDIS_PASSWORD,
     port: REDIS_PORT,
-    socketTimeout: 1000,
-    enableAutoPipelining: REDIS_ENABLE_AUTOPIPELINING, // https://github.com/redis/ioredis?tab=readme-ov-file#autopipelining
+    enableAutoPipelining: true,
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/demo/site/cache-handler.ts
+++ b/demo/site/cache-handler.ts
@@ -50,13 +50,8 @@ function parseBodyForGqlError(body: string) {
     }
 }
 
-export default class CacheHandler extends NextCacheHandler {
-    //constructor(_ctx: NextCacheHandlerContext) {}
-
-    async get(
-        key: string,
-        //ctx: Parameters<NextCacheHandler["get"]>[1]
-    ): ReturnType<NextCacheHandler["get"]> {
+export default class CacheHandler {
+    async get(key: string): ReturnType<NextCacheHandler["get"]> {
         if (redis.status === "ready") {
             try {
                 if (CACHE_HANDLER_DEBUG) {
@@ -90,11 +85,7 @@ export default class CacheHandler extends NextCacheHandler {
         return fallbackCache.get(key) ?? null;
     }
 
-    async set(
-        key: string,
-        value: Parameters<NextCacheHandler["set"]>[1],
-        // ctx: Parameters<NextCacheHandler["set"]>[2],
-    ): Promise<void> {
+    async set(key: string, value: Parameters<NextCacheHandler["set"]>[1]): Promise<void> {
         if (value?.kind === "FETCH") {
             const responseBody = parseBodyForGqlError(value.data.body);
             if (responseBody?.errors) {


### PR DESCRIPTION
- Remove timeouts (because under load a timeout can happen just because the main loop is blocked another request)
- Remove environment variable for `autoPipelining`, instead enable it always