### PR TITLE
API CrudSingleGenerator: Run `transformToBlockData()` for block fields on create (v5)

### DIFF
--- a/.changeset/lemon-eyes-kick.md
+++ b/.changeset/lemon-eyes-kick.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+API CrudSingleGenerator: Run `transformToBlockData()` for block fields on create

--- a/demo/api/src/footer/generated/footer.resolver.ts
+++ b/demo/api/src/footer/generated/footer.resolver.ts
@@ -39,6 +39,7 @@ export class FooterResolver {
         if (!footer) {
             footer = this.repository.create({
                 ...input,
+                content: input.content.transformToBlockData(),
                 scope,
             });
         } else if (lastUpdatedAt) {

--- a/packages/api/cms-api/src/generator/generate-crud-single.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-single.ts
@@ -86,6 +86,7 @@ export async function generateCrudSingle(generatorOptions: CrudSingleGeneratorOp
             if (!${instanceNameSingular}) {
                 ${instanceNameSingular} = this.repository.create({ 
                     ...input,
+                    ${blockProps.length ? `${blockProps.map((prop) => `${prop.name}: input.${prop.name}.transformToBlockData()`).join(", ")}, ` : ""}
                     ${scopeProp ? `scope,` : ""} 
                 });
             } else if (lastUpdatedAt) {


### PR DESCRIPTION
Backport of https://github.com/vivid-planet/comet/pull/2145 into v5.