### PR TITLE
Allow setting the DAM file license on upload

### DIFF
--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
@@ -7,6 +7,7 @@ import { Accept, FileRejection } from "react-dropzone";
 import { useCmsBlockContext } from "../../..";
 import { NetworkError, UnknownError } from "../../../common/errors/errorMessages";
 import { replace, upload } from "../../../form/file/upload";
+import { GQLLicenseInput } from "../../../graphql.generated";
 import { useDamAcceptedMimeTypes } from "../../config/useDamAcceptedMimeTypes";
 import { useDamScope } from "../../config/useDamScope";
 import { clearDamItemCache } from "../../helpers/clearDamItemCache";
@@ -30,11 +31,12 @@ import {
     GQLDamFolderForFolderUploadMutationVariables,
 } from "./useDamFileUpload.gql.generated";
 
-interface FileWithPath extends File {
+interface FileWithPathAndLicenseInfo extends File {
     path?: string;
+    license?: GQLLicenseInput;
 }
 
-export interface FileWithFolderPath extends FileWithPath {
+export interface FileWithFolderPath extends FileWithPathAndLicenseInfo {
     folderPath?: string;
 }
 
@@ -43,7 +45,7 @@ interface UploadDamFileOptions {
 }
 
 interface Files {
-    acceptedFiles: FileWithPath[];
+    acceptedFiles: FileWithPathAndLicenseInfo[];
     fileRejections: FileRejection[];
 }
 
@@ -52,6 +54,7 @@ type ImportSource = { importSourceType: never; importSourceId: never } | { impor
 interface UploadFilesOptions {
     folderId?: string;
     importSource?: ImportSource;
+    license?: GQLLicenseInput;
 }
 
 export interface FileUploadApi {
@@ -79,7 +82,7 @@ interface RejectedFile {
     file: File;
 }
 
-const addFolderPathToFiles = async (acceptedFiles: FileWithPath[]): Promise<FileWithFolderPath[]> => {
+const addFolderPathToFiles = async (acceptedFiles: FileWithPathAndLicenseInfo[]): Promise<FileWithFolderPath[]> => {
     const newFiles = [];
 
     for (const file of acceptedFiles) {
@@ -103,6 +106,7 @@ const addFolderPathToFiles = async (acceptedFiles: FileWithPath[]): Promise<File
         const buffer = await file.arrayBuffer();
         const newFile: FileWithFolderPath = new File([buffer], file.name, { lastModified: file.lastModified, type: file.type });
         newFile.path = file.path;
+        newFile.license = file.license;
 
         const folderPath = harmonizedPath?.split("/").slice(0, -1).join("/");
         newFile.folderPath = folderPath && folderPath?.length > 0 ? folderPath : undefined;
@@ -368,7 +372,7 @@ export const useDamFileUpload = (options: UploadDamFileOptions): FileUploadApi =
 
     const uploadFiles = async (
         { acceptedFiles, fileRejections }: Files,
-        { folderId, importSource }: UploadFilesOptions,
+        { folderId, importSource, license }: UploadFilesOptions,
     ): Promise<{ hasError: boolean; rejectedFiles: RejectedFile[]; uploadedItems: NewlyUploadedItem[] }> => {
         setProgressDialogOpen(true);
         setValidationErrors(undefined);
@@ -417,6 +421,7 @@ export const useDamFileUpload = (options: UploadDamFileOptions): FileUploadApi =
                         scope,
                         importSourceId: importSource?.importSourceId,
                         importSourceType: importSource?.importSourceType,
+                        license,
                     };
 
                     const onUploadProgress = (progressEvent: ProgressEvent) => {

--- a/packages/admin/cms-admin/src/form/file/upload.ts
+++ b/packages/admin/cms-admin/src/form/file/upload.ts
@@ -40,6 +40,9 @@ function uploadOrReplace<ResponseData>({
         formData.append("importSourceId", data.importSourceId);
         formData.append("importSourceType", data.importSourceType);
     }
+    if (data.license) {
+        formData.append("license", JSON.stringify(data.license));
+    }
     if (data.folderId !== undefined) {
         formData.append("folderId", data.folderId);
     }

--- a/packages/api/cms-api/src/dam/files/dto/file.input.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.input.ts
@@ -1,5 +1,5 @@
 import { Field, ID, InputType } from "@nestjs/graphql";
-import { Type } from "class-transformer";
+import { Transform, Type } from "class-transformer";
 import {
     IsDate,
     IsEnum,
@@ -58,11 +58,13 @@ export class LicenseInput {
     author?: string;
 
     @Field(() => Date, { nullable: true })
+    @Transform(({ value }) => new Date(value))
     @IsOptional()
     @IsDate()
     durationFrom?: Date;
 
     @Field(() => Date, { nullable: true })
+    @Transform(({ value }) => new Date(value))
     @IsOptional()
     @IsDate()
     durationTo?: Date;


### PR DESCRIPTION
## Description

Not all files are manually uploaded to the DAM, but they might still include important license details. This Pull Request adds support for uploading files along with their associated license information.

## Screenshots/screencasts

### Test if manually changing still works and if via file upload too

https://github.com/user-attachments/assets/f6de6031-6015-4ecb-afcd-b93188e333d6

### Test setup in demo:

![Screenshot 2024-11-22 at 14 04 39](https://github.com/user-attachments/assets/1f0dbd42-d72e-45f7-87e2-5f557b27bb54)
![Screenshot 2024-11-22 at 14 04 49](https://github.com/user-attachments/assets/0e31f838-3526-43fa-8535-a1ae5f1e415f)
![Screenshot 2024-11-22 at 14 05 03](https://github.com/user-attachments/assets/a5095d43-5c83-4181-a9ef-45e940a52e0a)

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1132