### PR TITLE
Use non-preview DAM URLs for the site preview

### DIFF
--- a/.changeset/plenty-shirts-tie.md
+++ b/.changeset/plenty-shirts-tie.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": minor
+---
+
+Use non-preview dam urls for site preview

--- a/.changeset/plenty-shirts-tie.md
+++ b/.changeset/plenty-shirts-tie.md
@@ -2,4 +2,4 @@
 "@comet/cms-site": minor
 ---
 
-Use non-preview dam urls for site preview
+Use non-preview DAM URLs for the site preview

--- a/packages/site/cms-site/src/graphQLFetch/graphQLFetch.ts
+++ b/packages/site/cms-site/src/graphQLFetch/graphQLFetch.ts
@@ -3,10 +3,9 @@ import { SitePreviewData } from "../sitePreview/SitePreviewUtils";
 type Fetch = typeof fetch;
 
 function graphQLHeaders(previewData?: SitePreviewData) {
-    const { includeInvisibleBlocks, includeInvisiblePages, previewDamUrls } = {
+    const { includeInvisibleBlocks, includeInvisiblePages } = {
         includeInvisiblePages: !!previewData,
         includeInvisibleBlocks: previewData && previewData.includeInvisible,
-        previewDamUrls: !!previewData,
     };
 
     const headers: Record<string, string> = {};
@@ -21,11 +20,6 @@ function graphQLHeaders(previewData?: SitePreviewData) {
     // authentication is required when this header is used
     if (includeInvisibleContentHeaderEntries.length > 0) {
         headers["x-include-invisible-content"] = includeInvisibleContentHeaderEntries.join(",");
-    }
-    // tells api to create preview image urls
-    // authentication is required when this header is used
-    if (previewDamUrls) {
-        headers["x-preview-dam-urls"] = "1";
     }
     return headers;
 }


### PR DESCRIPTION
Since https://github.com/vivid-planet/comet/pull/2554 the site preview isn't behind an auth proxy anymore. As a consequence, the preview urls don't work anymore, but creating normal hashed urls should be sufficient.
