### PR TITLE
Add support for multiple paths in `ContentScopeProvider`

### DIFF
--- a/.changeset/perfect-eyes-tease.md
+++ b/.changeset/perfect-eyes-tease.md
@@ -1,0 +1,27 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add support for multiple paths in `ContentScopeProvider`
+
+This enables using different paths for scopes with non-overlapping dimensions.
+The `location.createPath` and `location.createUrl` functions can be used to override the default behavior.
+
+**Example**
+
+```tsx
+<ContentScopeProvider
+    location={{
+        createPath: () => ["/organization/:organizationId", "/channel/:channelId"],
+        createUrl: (scope) => {
+            if (scope.organizationId) {
+                return `/organization/${scope.organizationId}`;
+            } else if (scope.channelId) {
+                return `/channel/${scope.channelId}`;
+            } else {
+                throw new Error("Invalid scope");
+            }
+        },
+    }}
+/>
+```

--- a/packages/admin/cms-admin/src/contentScope/Provider.tsx
+++ b/packages/admin/cms-admin/src/contentScope/Provider.tsx
@@ -1,16 +1,24 @@
 import { createContext, Dispatch, ReactNode, SetStateAction, useCallback, useContext, useMemo, useState } from "react";
-import { generatePath, match, Redirect, Route, Switch, useHistory, useRouteMatch } from "react-router";
+import { match, Redirect, Route, Switch, useHistory, useRouteMatch } from "react-router";
 
 export interface ContentScopeInterface {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
 }
 
+type ContentScopeLocation<S extends ContentScopeInterface = ContentScopeInterface> = {
+    createPath: (scope: ContentScopeValues<S>) => string | string[];
+    createUrl: (scope: S) => string;
+};
+
+const defaultContentScopeLocation = { createPath: defaultCreatePath, createUrl: defaultCreateUrl };
+
 interface ContentScopeContext {
-    path: string;
+    path: string | string[];
     redirectPathAfterChange?: string; // define where the user should be redirected to after a scope change
     setRedirectPathAfterChange: Dispatch<SetStateAction<string | undefined>>;
     values: ContentScopeValues;
+    location: ContentScopeLocation;
 }
 
 const defaultContentScopeContext: ContentScopeContext = {
@@ -19,6 +27,7 @@ const defaultContentScopeContext: ContentScopeContext = {
         //
     },
     values: [],
+    location: defaultContentScopeLocation,
 };
 
 type NonNull<T> = T extends null ? never : T;
@@ -100,16 +109,15 @@ export function useContentScope<S extends ContentScopeInterface = ContentScopeIn
 
     const matchParamsString = JSON.stringify(match.params); // convert matchParams to string, like this we can memoize or callbacks more easily
     const scope = useMemo(() => parseScopeFromRouterMatchParams<S>(JSON.parse(matchParamsString)), [matchParamsString]);
-    const matchPath = match.path;
     const redirectPath = context.redirectPathAfterChange;
     const setScope = useCallback(
         (action: SetContentScopeAction) => {
             const newContentScope = action(scope);
             const pathAfterScopePath = redirectPath || "";
-            const url = generatePath(matchPath, formatScopeToRouterMatchParams(newContentScope));
+            const url = context.location.createUrl(newContentScope);
             history.push({ pathname: url + pathAfterScopePath });
         },
-        [scope, matchPath, history, redirectPath],
+        [scope, history, redirectPath, context.location],
     );
 
     return {
@@ -126,17 +134,14 @@ export interface ContentScopeProviderProps<S extends ContentScopeInterface = Con
     defaultValue: S;
     values: ContentScopeValues<S>;
     children: (p: { match: match<NonNullRecord<S>> }) => ReactNode;
-    location?: {
-        createPath: (scope: ContentScopeValues<S>) => string;
-        createUrl: (scope: S) => string;
-    };
+    location?: ContentScopeLocation<S>;
 }
 
 export function ContentScopeProvider<S extends ContentScopeInterface = ContentScopeInterface>({
     children,
     defaultValue,
     values,
-    location = { createPath: defaultCreatePath, createUrl: defaultCreateUrl },
+    location = defaultContentScopeLocation,
 }: ContentScopeProviderProps<S>) {
     const path = location.createPath(values);
     const defaultUrl = location.createUrl(defaultValue);
@@ -144,7 +149,16 @@ export function ContentScopeProvider<S extends ContentScopeInterface = ContentSc
     const [redirectPathAfterChange, setRedirectPathAfterChange] = useState<undefined | string>("");
 
     return (
-        <Context.Provider value={{ path, redirectPathAfterChange, setRedirectPathAfterChange, values }}>
+        <Context.Provider
+            value={{
+                path,
+                redirectPathAfterChange,
+                setRedirectPathAfterChange,
+                values,
+                // @ts-expect-error type mismatch because React Context can't be generic and default value is less specific
+                location,
+            }}
+        >
             <Switch>
                 {match && (
                     <Route exact={false} strict={false} path={path}>

--- a/packages/admin/cms-admin/src/contentScope/Provider.tsx
+++ b/packages/admin/cms-admin/src/contentScope/Provider.tsx
@@ -155,8 +155,7 @@ export function ContentScopeProvider<S extends ContentScopeInterface = ContentSc
                 redirectPathAfterChange,
                 setRedirectPathAfterChange,
                 values,
-                // @ts-expect-error type mismatch because React Context can't be generic and default value is less specific
-                location,
+                location: location as ContentScopeLocation,
             }}
         >
             <Switch>

--- a/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.tsx
+++ b/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.tsx
@@ -1,0 +1,74 @@
+import { AppHeader, AppHeaderFillSpace, AppHeaderMenuButton, CometLogo, MainContent } from "@comet/admin";
+import { ContentScopeControls, ContentScopeProvider, ContentScopeValues, useContentScope } from "@comet/cms-admin";
+import { Typography } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+storiesOf("@comet/cms-admin/Content Scope Provider", module)
+    .addDecorator(storyRouterDecorator())
+    .add("Optional dimensions", function () {
+        type ContentScope = { organizationId?: string; channelId?: string };
+
+        const values: ContentScopeValues<ContentScope> = [
+            { organizationId: { value: "organization-1", label: "Organization 1" } },
+            { channelId: { value: "channel-1", label: "Channel 1" } },
+        ];
+
+        function PrintContentScope() {
+            const { scope } = useContentScope();
+
+            return <>{JSON.stringify(scope)}</>;
+        }
+
+        return (
+            <ContentScopeProvider
+                values={values}
+                defaultValue={{ organizationId: "organization-1" }}
+                location={{
+                    createPath: () => ["/organization/:organizationId", "/channel/:channelId"],
+                    createUrl: (scope) => {
+                        if (scope.organizationId) {
+                            return `/organization/${scope.organizationId}`;
+                        } else if (scope.channelId) {
+                            return `/channel/${scope.channelId}`;
+                        } else {
+                            throw new Error("Invalid scope");
+                        }
+                    },
+                }}
+            >
+                {({ match }) => {
+                    return (
+                        <>
+                            <AppHeader position="relative" headerHeight={60}>
+                                <AppHeaderMenuButton />
+                                <CometLogo />
+                                <AppHeaderFillSpace />
+                                <ContentScopeControls />
+                            </AppHeader>
+                            <MainContent>
+                                <Typography gutterBottom>
+                                    This is a development story to test optional scope dimensions in the content scope provider. Try changing the
+                                    scope in the content scope select.
+                                </Typography>
+                                <Typography>
+                                    Path: <strong>{match.path}</strong>
+                                </Typography>
+                                <Typography>
+                                    URL: <strong>{match.url}</strong>
+                                </Typography>
+                                <Typography>
+                                    Scope:{" "}
+                                    <strong>
+                                        <PrintContentScope />
+                                    </strong>
+                                </Typography>
+                            </MainContent>
+                        </>
+                    );
+                }}
+            </ContentScopeProvider>
+        );
+    });


### PR DESCRIPTION
## Description

This enables using different paths for scopes with non-overlapping dimensions. The `location.createPath` and `location.createUrl` functions can be used to override the default behavior.

## Screencast

https://github.com/user-attachments/assets/9d75a883-71bd-4944-9db3-e7513b6c0f42
