### PR TITLE
Allow url parameters for redirects

### DIFF
--- a/demo/site/src/middleware.ts
+++ b/demo/site/src/middleware.ts
@@ -6,13 +6,13 @@ import { getPredefinedPageRedirect, getPredefinedPageRewrite } from "./middlewar
 import { createRedirects } from "./middleware/redirects";
 
 export async function middleware(request: NextRequest) {
-    const { pathname } = new URL(request.url);
+    const { pathname, search } = new URL(request.url);
 
     const scope = { domain };
 
     const redirects = await createRedirects(scope);
 
-    const redirect = redirects.get(pathname);
+    const redirect = redirects.get(pathname + search);
     if (redirect) {
         const destination: string = redirect.destination;
         return NextResponse.redirect(new URL(destination, request.url), redirect.permanent ? 308 : 307);


### PR DESCRIPTION
## Description

This change allows URL Parameters in the redirect url source.
I tested it with the following:
<img width="964" alt="Screenshot 2024-10-22 at 09 07 02" src="https://github.com/user-attachments/assets/40d56c65-1bd9-46b9-b2df-77059e63d4ec">


## Screenshots/screencasts


https://github.com/user-attachments/assets/30d44ab6-d1c1-47bc-ab71-148ff803441f

