### PR TITLE
createCompositeBlock: use formatted message instead of literal string

### DIFF
--- a/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx
@@ -276,10 +276,20 @@ export const createCompositeBlock = <Options extends CreateCompositeBlockOptions
                         ...nestedBlocks.map(([key, { title }]) => {
                             const block = blockConfigNormalized[key].block[0];
 
-                            // @TODO: change literal string "Settings" on next line to: <FormattedMessage id="comet.blocks.createCompositeBlock.settings" defaultMessage="Settings" />
-                            // when https://github.com/vivid-planet/comet/pull/340 is fixed
                             return (
-                                <StackPage key={key} name={key} title={title ? title : isBlockInterface(block) ? block.displayName : "Settings"}>
+                                <StackPage
+                                    key={key}
+                                    name={key}
+                                    title={
+                                        title ? (
+                                            title
+                                        ) : isBlockInterface(block) ? (
+                                            block.displayName
+                                        ) : (
+                                            <FormattedMessage id="comet.blocks.createCompositeBlock.settings" defaultMessage="Settings" />
+                                        )
+                                    }
+                                >
                                     {blockAdminComponents[key]}
                                 </StackPage>
                             );


### PR DESCRIPTION
resolves 3 year old todo task