### PR TITLE
Display global `ContentScopeIndicator` if redirects are scoped globally

### DIFF
--- a/.changeset/olive-clocks-relate.md
+++ b/.changeset/olive-clocks-relate.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Display global `ContentScopeIndicator` if redirects are scoped globally
+
+Previously, an empty `ContentScopeIndicator` was displayed if no `scopeParts` were passed to `createRedirectsPage`.

--- a/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
+++ b/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
@@ -37,12 +37,13 @@ function createRedirectsPage({ customTargets, scopeParts = [] }: CreateRedirects
             acc[scopePart] = completeScope[scopePart];
             return acc;
         }, {} as { [key: string]: unknown });
+        const isGlobalScoped = Object.keys(scope).length === 0;
 
         return (
             <Stack topLevelTitle={intl.formatMessage({ id: "comet.pages.redirects", defaultMessage: "Redirects" })}>
                 <StackSwitch initialPage="grid">
                     <StackPage name="grid">
-                        <StackToolbar scopeIndicator={<ContentScopeIndicator scope={scope} />} />
+                        <StackToolbar scopeIndicator={<ContentScopeIndicator global={isGlobalScoped} scope={isGlobalScoped ? undefined : scope} />} />
                         <RedirectsGrid linkBlock={linkBlock} scope={scope} />
                     </StackPage>
                     <StackPage name="edit" title={intl.formatMessage({ id: "comet.pages.redirects.edit", defaultMessage: "edit" })}>


### PR DESCRIPTION
## Description

Display global `ContentScopeIndicator` if redirects are scoped globally

Previously, an empty `ContentScopeIndicator` was displayed if no `scopeParts` were passed to `createRedirectsPage`.

## Screenshots/screencasts

<!--

When making a visual change, please provide either screenshots or screencasts.

Hint: For before/after views, you can use a table:

| Before   | After   |
| -------- | ------- |
| Link     | Link    |

-->

| Before   | After   |
| -------- | ------- |
| <img width="244" alt="Bildschirmfoto 2024-10-28 um 09 00 54" src="https://github.com/user-attachments/assets/73256316-1d4b-4f23-81fa-a03bfbc2147f"> | <img width="238" alt="Bildschirmfoto 2024-10-28 um 09 01 33" src="https://github.com/user-attachments/assets/4c3d32f7-df28-455e-86bb-cbe1a7139413">    |

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset

