### PR TITLE
Improve error message in `Migration20240702123233`

### DIFF
--- a/.changeset/forty-beans-burn.md
+++ b/.changeset/forty-beans-burn.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-api": patch
+---
+
+Improve error message in `Migration20240702123233`
+
+`Migration20240702123233` adds a valid file extension to every DamFile#name that doesn't have an extension yet.
+Previously, the migration crashed without a helpful error message if the mimetype of a file wasn't in [mime-db](https://www.npmjs.com/package/mime-db).
+Now, the migration throws an error including the problematic mimetype.

--- a/packages/api/cms-api/src/mikro-orm/migrations/Migration20240702123233.ts
+++ b/packages/api/cms-api/src/mikro-orm/migrations/Migration20240702123233.ts
@@ -25,6 +25,11 @@ export class Migration20240702123233 extends Migration {
         const mimetypeToExtensionsMap: { [key: string]: string[] } = mimetypes.reduce((prev, m) => {
             const mimetype = m.mimetype;
             const extensions = getValidExtensionsForMimetype(mimetype);
+
+            if(extensions === undefined || extensions.length === 0) {
+                throw new Error(`No valid extensions found for mimetype ${mimetype}`);
+            }
+
             return { ...prev, [mimetype]: extensions };
         }, {});
 


### PR DESCRIPTION
Improve error message in `Migration20240702123233`

`Migration20240702123233` adds a valid file extension to every DamFile#name that doesn't have an extension yet.
Previously, the migration crashed without a helpful error message if the mimetype of a file wasn't in [mime-db](https://www.npmjs.com/package/mime-db).
Now, the migration throws an error including the problematic mimetype.
