### PR TITLE
Fix `ContentScopeIndicator` for scope with optional dimensions

### DIFF
--- a/.changeset/tiny-moose-sip.md
+++ b/.changeset/tiny-moose-sip.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix ContentScopeIndicator for scope with first dimension undefined.

--- a/.changeset/tiny-moose-sip.md
+++ b/.changeset/tiny-moose-sip.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": patch
 ---
 
-Fix ContentScopeIndicator for scope with first dimension undefined.
+Fix `ContentScopeIndicator` for scope with optional dimensions

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
@@ -23,7 +23,7 @@ export const ContentScopeIndicator = ({ global = false, scope: passedScope, chil
 
     const findLabelForScopePart = (scopePart: keyof ContentScopeInterface) => {
         const label = values.find((value) => {
-            return value[scopePart].value === scope[scopePart];
+            return value[scopePart] && value[scopePart].value === scope[scopePart];
         })?.[scopePart].label;
 
         return label ?? capitalizeString(scope[scopePart]);

--- a/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.tsx
+++ b/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.tsx
@@ -1,5 +1,5 @@
 import { AppHeader, AppHeaderFillSpace, AppHeaderMenuButton, CometLogo, MainContent } from "@comet/admin";
-import { ContentScopeControls, ContentScopeProvider, ContentScopeValues, useContentScope } from "@comet/cms-admin";
+import { ContentScopeControls, ContentScopeIndicator, ContentScopeProvider, ContentScopeValues, useContentScope } from "@comet/cms-admin";
 import { Typography } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import React from "react";
@@ -49,6 +49,7 @@ storiesOf("@comet/cms-admin/Content Scope Provider", module)
                                 <ContentScopeControls />
                             </AppHeader>
                             <MainContent>
+                                <ContentScopeIndicator />
                                 <Typography gutterBottom>
                                     This is a development story to test optional scope dimensions in the content scope provider. Try changing the
                                     scope in the content scope select.


### PR DESCRIPTION
Also added ContentScopeIndicator to story to check functionality.

## Description

Finding label for scope with first dimension set to undefined threw "access .value of undefined". This is can happen because dimensions can now be optional. Checking if scopePart is set fixed the issue.