### PR TITLE
Fix `disabled` prop not being passed to the children of `Field` (v6)

### DIFF
--- a/.changeset/dry-monkeys-worry.md
+++ b/.changeset/dry-monkeys-worry.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix a bug where the `disabled` prop would not be passed to the children of `Field`

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -62,7 +62,12 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
     const shouldShowWarning = passedShouldShowWarning ?? finalFormContext.shouldShowFieldWarning;
     const shouldScrollToField = passedShouldScrollTo ?? finalFormContext.shouldScrollToField;
 
-    function renderField({ input, meta, fieldContainerProps, ...rest }: FieldRenderProps<FieldValue, FieldElement> & { warning?: string }) {
+    function renderField({
+        input,
+        meta,
+        fieldContainerProps,
+        ...rest
+    }: FieldRenderProps<FieldValue, FieldElement> & { warning?: string; disabled?: boolean }) {
         function render() {
             if (component) {
                 return React.createElement(component, { ...rest, input, meta });
@@ -70,7 +75,7 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
                 if (typeof children !== "function") {
                     throw new Error(`Warning: Must specify either a render function as children, or a component prop to ${name}`);
                 }
-                return children({ input, meta });
+                return children({ input, meta, disabled });
             }
         }
         return (


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

Backport of https://github.com/vivid-planet/comet/pull/1812 into v6.

## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1157
