### PR TITLE
Fix deprecated import from `@storybook/addon-docs/blocks`

### DIFF
--- a/storybook/src/docs/components/Rte/Rte.stories.mdx
+++ b/storybook/src/docs/components/Rte/Rte.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Rich Text Editor" />
 


### PR DESCRIPTION
## Description

Use `@storybook/addon-docs` instead.

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-891