### PR TITLE
Update docs for predefinedPages

### DIFF
--- a/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
+++ b/demo/admin/src/predefinedPage/EditPredefinedPage.tsx
@@ -66,8 +66,8 @@ export const EditPredefinedPage = ({ id }: Props) => {
         <FinalForm
             mode="edit"
             initialValues={{ type: data?.page?.document?.__typename === "PredefinedPage" ? data.page.document.type : undefined }}
-            onSubmit={() => {
-                mutation({ variables: { pageId: id, input: { type: "News" }, attachedPageTreeNodeId: id } });
+            onSubmit={({ type }) => {
+                mutation({ variables: { pageId: id, input: { type }, attachedPageTreeNodeId: id } });
             }}
         >
             {({ pristine, hasValidationErrors, submitting, handleSubmit, hasSubmitErrors }) => {

--- a/docs/docs/documents/predefined-pages.mdx
+++ b/docs/docs/documents/predefined-pages.mdx
@@ -242,16 +242,7 @@ Add a new page tree node with the document type "Predefined Page" to test whethe
 
 If you want to add another predefined page type (e.g., products), make the following changes:
 
-1. API: Add the new type to the GraphQL enum:
-
-    ```diff title="src/documents/predefined-pages/entities/predefined-page.entity.ts"
-    export enum PredefinedPageType {
-        News = "News",
-    +   Products = "Products",
-    }
-    ```
-
-2. Admin: Add the new type to the labels:
+1. Admin: Add the new type to the labels:
 
     ```diff title="src/documents/predefinedPages/predefinedPageLabels.tsx"
     export const predefinedPageLabels: Record<GQLPredefinedPageType, ReactNode> = {
@@ -260,7 +251,7 @@ If you want to add another predefined page type (e.g., products), make the follo
     };
     ```
 
-3. Site: Add the new type to the code paths:
+2. Site: Add the new type to the code paths:
 
     ```diff title="src/documents/predefinedPages/predefinedPagePaths.ts"
     export const predefinedPagePaths = {

--- a/docs/docs/documents/predefined-pages.mdx
+++ b/docs/docs/documents/predefined-pages.mdx
@@ -38,7 +38,7 @@ The following steps are required in the API:
 #### Creation of the predefined pages module
 
 Create the module in `src/documents/predefined-pages`.
-To do this, copy the corresponding [folder](https://github.com/vivid-planet/comet/tree/main/demo/api/src/documents/predefined-pages) from the Demo project.
+To do this, copy the corresponding [folder](https://github.com/vivid-planet/comet/tree/main/demo/api/src/predefined-page) from the Demo project.
 The following files should be copied:
 
 -   `predefined-pages.module.ts`: The module
@@ -128,13 +128,11 @@ The following steps are required in the Admin:
 #### Creation of the predefined pages module
 
 Create the module in `src/documents/predefinedPages`.
-To do this, copy the corresponding [folder](https://github.com/vivid-planet/comet/tree/main/demo/admin/src/documents/predefinedPages) from the Demo project.
+To do this, copy the corresponding [folder](https://github.com/vivid-planet/comet/tree/main/demo/admin/src/predefinedPage) from the Demo project.
 The following files should be copied:
 
 -   `EditPredefinedPage.tsx`: The editing component
--   `EditPredefinedPage.gql.ts`: The GraphQL operations for the edit component
 -   `PredefinedPage.tsx`: The document type
--   `PredefinedPageLabels`: The labels for the predefined page types
 
 #### Registration of the `PredefinedPage` document type
 
@@ -163,7 +161,7 @@ The following steps are required in the Site:
 #### Creation of the predefined pages module
 
 Create the module in `src/documents/predefinedPages`.
-To do this, copy the corresponding [folder](https://github.com/vivid-planet/comet/tree/main/demo/site/src/documents/predefinedPages) from the Demo project.
+To do this, copy the corresponding [folder](https://github.com/vivid-planet/comet/tree/main/demo/site/src/predefinedPages) from the Demo project.
 The following files should be copied:
 
 -   `predefinedPagePaths.ts`: The paths where the predefined pages are located in the code


### PR DESCRIPTION
## Description

Docs for predefinedPages are outdated and template-code contains a bug.

## Open TODOs/questions

I'm no fan of loose connections between api, admin and site. It's really hard to find the places where changes are required if a developer needs to add a new predefinedPage. I'm not sure if the enum was the best solution to this problem, but maybe we should think about this again...

Also did you think about some "helper" to setup like the comet-upgrade script (we did something like that with add-symfony.php in our koala-framework...). If the template is clean with some comments it could even replace the docs for cases where the script can't be applied.