### PR TITLE
Add `fileUpload` query

### DIFF
--- a/.changeset/new-geese-boil.md
+++ b/.changeset/new-geese-boil.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Add `fileUpload` query

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -784,6 +784,7 @@ type Query {
   damFoldersList(offset: Int! = 0, limit: Int! = 25, sortColumnName: String, sortDirection: SortDirection! = ASC, scope: DamScopeInput!, parentId: ID, includeArchived: Boolean, filter: FolderFilterInput): PaginatedDamFolders!
   damFolder(id: ID!): DamFolder!
   damFolderByNameAndParentId(scope: DamScopeInput!, name: String!, parentId: ID): DamFolder
+  fileUpload(id: ID!): FileUpload!
   news(id: ID!): News!
   newsBySlug(slug: String!, scope: NewsContentScopeInput!): News
   newsList(offset: Int! = 0, limit: Int! = 25, scope: NewsContentScopeInput!, status: [NewsStatus!]! = [Active], search: String, filter: NewsFilter, sort: [NewsSort!]): PaginatedNews!

--- a/packages/api/cms-api/generate-schema.ts
+++ b/packages/api/cms-api/generate-schema.ts
@@ -1,6 +1,6 @@
 import { createOneOfBlock, ExternalLinkBlock } from "@comet/blocks-api";
 import { NestFactory } from "@nestjs/core";
-import { Field, GraphQLSchemaBuilderModule, GraphQLSchemaFactory, ObjectType, Query, Resolver } from "@nestjs/graphql";
+import { Field, GraphQLSchemaBuilderModule, GraphQLSchemaFactory, ObjectType } from "@nestjs/graphql";
 import { writeFile } from "fs/promises";
 import { printSchema } from "graphql";
 
@@ -13,7 +13,6 @@ import {
     DependentsResolverFactory,
     DocumentInterface,
     FileImagesResolver,
-    FileUpload,
     InternalLinkBlock,
     PageTreeNodeBase,
     PageTreeNodeCategory,
@@ -81,15 +80,6 @@ async function generateSchema(): Promise<void> {
     const File = createFileEntity({ Folder });
     const FileDependentsResolver = DependentsResolverFactory.create(File);
 
-    // Required to force the generation of the FileUpload type in the schema
-    @Resolver(() => FileUpload)
-    class MockFileUploadResolver {
-        @Query(() => FileUpload)
-        fileUploadForTypesGenerationDoNotUse(): void {
-            // Noop
-        }
-    }
-
     const schema = await gqlSchemaFactory.create([
         BuildsResolver,
         BuildTemplatesResolver,
@@ -109,7 +99,6 @@ async function generateSchema(): Promise<void> {
         UserResolver,
         UserPermissionResolver,
         UserContentScopesResolver,
-        MockFileUploadResolver,
         AzureAiTranslatorResolver,
         GenerateAltTextResolver,
         GenerateImageTitleResolver,

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -380,8 +380,8 @@ type Query {
   userPermissionsAvailablePermissions: [String!]!
   userPermissionsContentScopes(userId: String!, skipManual: Boolean): [JSONObject!]!
   userPermissionsAvailableContentScopes: [JSONObject!]!
-  fileUploadForTypesGenerationDoNotUse: FileUpload!
   azureAiTranslate(input: AzureAiTranslationInput!): String!
+  fileUpload(id: ID!): FileUpload!
   sitePreviewJwt(scope: JSONObject!, path: String!, includeInvisible: Boolean!): String!
 }
 

--- a/packages/api/cms-api/src/file-uploads/file-uploads.resolver.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.resolver.ts
@@ -1,5 +1,7 @@
+import { InjectRepository } from "@mikro-orm/nestjs";
+import { EntityRepository } from "@mikro-orm/postgresql";
 import { Inject } from "@nestjs/common";
-import { Args, Int, Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, ID, Int, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { FileUpload } from "./entities/file-upload.entity";
@@ -10,7 +12,17 @@ import { FileUploadsService } from "./file-uploads.service";
 @Resolver(() => FileUpload)
 @RequiredPermission("fileUploads", { skipScopeCheck: true })
 export class FileUploadsResolver {
-    constructor(private readonly fileUploadsService: FileUploadsService, @Inject(FILE_UPLOADS_CONFIG) private readonly config: FileUploadsConfig) {}
+    constructor(
+        private readonly fileUploadsService: FileUploadsService,
+        @Inject(FILE_UPLOADS_CONFIG) private readonly config: FileUploadsConfig,
+        @InjectRepository(FileUpload)
+        private readonly repository: EntityRepository<FileUpload>,
+    ) {}
+
+    @Query(() => FileUpload)
+    fileUpload(@Args("id", { type: () => ID }) id: string): Promise<FileUpload> {
+        return this.repository.findOneOrFail(id);
+    }
 
     @ResolveField(() => String, { nullable: true })
     downloadUrl(@Parent() fileUpload: FileUpload): string | null {


### PR DESCRIPTION
## Description

Nest currently throws the error `"FileUpload" defined in resolvers, but not in schema` when trying to use the file uploads module without a GraphQL resolver that references the FileUpload DTO. This is due to the field resolvers in [FileUploadsResolver](https://github.com/vivid-planet/comet/blob/main/packages/api/cms-api/src/file-uploads/file-uploads.resolver.ts). We fix this by adding a query `fileUpload` in the library.

## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

Fixes #2677 

https://vivid-planet.atlassian.net/browse/COM-1217
