### PR TITLE
Execute JSON.parse() twice to parse escaped JSON string in `KubernetesService#getContentScope` (v5)

### DIFF
--- a/.changeset/kind-sloths-relate.md
+++ b/.changeset/kind-sloths-relate.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix parsing of `contentScopeAnnotation` in `KubernetesService#getContentScope`

--- a/packages/api/cms-api/src/kubernetes/kubernetes.service.ts
+++ b/packages/api/cms-api/src/kubernetes/kubernetes.service.ts
@@ -151,6 +151,19 @@ export class KubernetesService {
 
     getContentScope(resource: V1Job | V1CronJob): ContentScope {
         const contentScopeAnnotation = resource.metadata?.annotations?.[CONTENT_SCOPE_ANNOTATION];
-        return contentScopeAnnotation ? JSON.parse(contentScopeAnnotation) : {};
+
+        if (contentScopeAnnotation) {
+            let json = JSON.parse(contentScopeAnnotation);
+
+            // the contentScopeAnnotation is an escaped json string (e.g. "{ \"domain\": \"main\", \"language\": \"en\" }")
+            // therefore JSON.parse() must be executed twice (https://stackoverflow.com/a/25721227)
+            if (typeof json !== "object") {
+                json = JSON.parse(json);
+            }
+
+            return json;
+        }
+
+        return {};
     }
 }


### PR DESCRIPTION
Backport of #1778 into v5.