### PR TITLE
Rework the DAM crop/focus settings UI

### DIFF
--- a/.changeset/proud-ties-arrive.md
+++ b/.changeset/proud-ties-arrive.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": patch
 ---
 
-Adapt styling of `CropSettingsFields` and `ChooseFocalPoint`
+Adapt the styling of the DAM image settings

--- a/.changeset/proud-ties-arrive.md
+++ b/.changeset/proud-ties-arrive.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Adapt styling of `CropSettingsFields` and `ChooseFocalPoint`

--- a/.changeset/proud-ties-arrive.md
+++ b/.changeset/proud-ties-arrive.md
@@ -1,5 +1,5 @@
 ---
-"@comet/cms-admin": patch
+"@comet/cms-admin": minor
 ---
 
-Adapt the styling of the DAM image settings
+Rework the DAM crop/focus settings UI

--- a/packages/admin/cms-admin/src/blocks/image/EditImageDialog.tsx
+++ b/packages/admin/cms-admin/src/blocks/image/EditImageDialog.tsx
@@ -183,7 +183,7 @@ export function EditImageDialog({ image, initialValues, onSubmit, onClose, inher
                                         {dependencyMap["DamFile"] && damFileId && (
                                             <Box padding={7} paddingTop={0}>
                                                 <Button
-                                                    variant="text"
+                                                    variant="outlined"
                                                     color="inherit"
                                                     onClick={async () => {
                                                         const path = await dependencyMap["DamFile"].resolvePath({

--- a/packages/admin/cms-admin/src/blocks/image/EditImageDialog.tsx
+++ b/packages/admin/cms-admin/src/blocks/image/EditImageDialog.tsx
@@ -160,7 +160,7 @@ export function EditImageDialog({ image, initialValues, onSubmit, onClose, inher
                             <div>
                                 {inheritedDamSettings !== undefined && (
                                     <>
-                                        <Box padding={8} paddingBottom={6}>
+                                        <Box padding={8} paddingTop={0}>
                                             <FormSection
                                                 title={<FormattedMessage id="comet.blocks.image.dam" defaultMessage="DAM" />}
                                                 disableMarginBottom

--- a/packages/admin/cms-admin/src/blocks/image/EditImageDialog.tsx
+++ b/packages/admin/cms-admin/src/blocks/image/EditImageDialog.tsx
@@ -199,7 +199,7 @@ export function EditImageDialog({ image, initialValues, onSubmit, onClose, inher
                                                 </Button>
                                             </Box>
                                         )}
-                                        <Divider />
+                                        <Divider sx={{ marginLeft: 8, marginRight: 8 }} />
                                     </>
                                 )}
                                 <Box padding={8}>

--- a/packages/admin/cms-admin/src/common/image/ChooseFocalPoint.tsx
+++ b/packages/admin/cms-admin/src/common/image/ChooseFocalPoint.tsx
@@ -1,6 +1,6 @@
 import { FocusPointCenter, FocusPointNortheast, FocusPointNorthwest, FocusPointSoutheast, FocusPointSouthwest } from "@comet/admin-icons";
 import { AdminComponentSection } from "@comet/blocks-admin";
-import { ToggleButton, ToggleButtonGroup, Typography } from "@mui/material";
+import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { FormattedMessage } from "react-intl";
 
 import { GQLFocalPoint } from "../../graphql.generated";
@@ -12,7 +12,10 @@ interface ChooseFocalPointProps {
 
 export const ChooseFocalPoint = ({ focalPoint, onChangeFocalPoint }: ChooseFocalPointProps) => {
     return (
-        <AdminComponentSection title={<FormattedMessage id="comet.blocks.image.focalPoint" defaultMessage="Set manual focus point" />}>
+        <AdminComponentSection
+            title={<FormattedMessage id="comet.blocks.image.focalPoint" defaultMessage="Set manual focus point" />}
+            disableBottomMargin
+        >
             <ToggleButtonGroup
                 value={focalPoint}
                 onChange={(event, newFocalPoint: GQLFocalPoint) => {
@@ -40,12 +43,6 @@ export const ChooseFocalPoint = ({ focalPoint, onChangeFocalPoint }: ChooseFocal
                     <FocusPointSoutheast />
                 </ToggleButton>
             </ToggleButtonGroup>
-            <Typography variant="caption" color="text.secondary" paragraph style={{ marginBottom: 0 }}>
-                <FormattedMessage
-                    id="comet.blocks.image.hintSelectFocalPoint"
-                    defaultMessage="You can also select the focus point by clicking on the bullets in the image."
-                />
-            </Typography>
         </AdminComponentSection>
     );
 };

--- a/packages/admin/cms-admin/src/common/image/ChooseFocalPoint.tsx
+++ b/packages/admin/cms-admin/src/common/image/ChooseFocalPoint.tsx
@@ -40,7 +40,7 @@ export const ChooseFocalPoint = ({ focalPoint, onChangeFocalPoint }: ChooseFocal
                     <FocusPointSoutheast />
                 </ToggleButton>
             </ToggleButtonGroup>
-            <Typography variant="caption" color="text.secondary" paragraph>
+            <Typography variant="caption" color="text.secondary" paragraph style={{ marginBottom: 0 }}>
                 <FormattedMessage
                     id="comet.blocks.image.hintSelectFocalPoint"
                     defaultMessage="You can also select the focus point by clicking on the bullets in the image."

--- a/packages/admin/cms-admin/src/common/image/ChooseFocalPoint.tsx
+++ b/packages/admin/cms-admin/src/common/image/ChooseFocalPoint.tsx
@@ -40,7 +40,7 @@ export const ChooseFocalPoint = ({ focalPoint, onChangeFocalPoint }: ChooseFocal
                     <FocusPointSoutheast />
                 </ToggleButton>
             </ToggleButtonGroup>
-            <Typography variant="body2" component="p" color="textSecondary">
+            <Typography variant="caption" color="text.secondary" paragraph>
                 <FormattedMessage
                     id="comet.blocks.image.hintSelectFocalPoint"
                     defaultMessage="You can also select the focus point by clicking on the bullets in the image."

--- a/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
@@ -40,14 +40,14 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
                         control={<Switch checked={focalPoint === "SMART"} onChange={handleSmartFocalPointChange} />}
                         label={<FormattedMessage id="comet.dam.file.smartFocusPoint" defaultMessage="Smart focus point" />}
                     />
-                    <Box mt={2} pl={2}>
-                        <Typography variant="body2" paragraph>
+                    <Box>
+                        <Typography variant="caption" color="text.secondary" paragraph>
                             <FormattedMessage
                                 id="comet.dam.file.croppingInfoText"
                                 defaultMessage="Cropping selects the maximum visible area. Depending on the aspect ratio, the image may be cropped further on the page."
                             />
                         </Typography>
-                        <Typography variant="body2">
+                        <Typography variant="caption" color="text.secondary" paragraph>
                             <FormattedMessage
                                 id="comet.dam.file.focusPointInfoText"
                                 defaultMessage="The focus point marks the most important part of the image, which is always visible. Choose it wisely."

--- a/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
@@ -68,7 +68,7 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
                     </AdminComponentSection>
                 </FieldContainer>
                 {showChooseManualFocusPointButtons && (
-                    <Field name="focalPoint">
+                    <Field name="focalPoint" fullWidth>
                         {({ input: { value, onChange } }) => <ChooseFocalPoint focalPoint={value} onChangeFocalPoint={onChange} />}
                     </Field>
                 )}

--- a/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
@@ -61,7 +61,7 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
                     </Field>
                 )}
                 {showResetCropAreaButton && (
-                    <Field name="crop">
+                    <Field name="crop" fullWidth>
                         {({ input: { value, onChange } }) => (
                             <Button
                                 startIcon={<Reset />}

--- a/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
@@ -36,7 +36,7 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
     return (
         <Container>
             <FormSection title={<FormattedMessage id="comet.dam.file.cropSettings.sectionTitle" defaultMessage="Crop/Focus settings" />}>
-                <FieldContainer>
+                <FieldContainer fullWidth>
                     <AdminComponentSection
                         title={<FormattedMessage id="comet.dam.file.cropSettings.smartFocusPoint.title" defaultMessage="Smart focus point" />}
                     >

--- a/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
@@ -75,6 +75,7 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
                                     });
                                 }}
                                 color="info"
+                                variant="outlined"
                             >
                                 <FormattedMessage id="comet.dam.file.resetCropArea" defaultMessage="Reset crop area" />
                             </Button>

--- a/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
@@ -1,5 +1,6 @@
 import { Field, FieldContainer, FormSection } from "@comet/admin";
 import { Reset } from "@comet/admin-icons";
+import { AdminComponentSection } from "@comet/blocks-admin";
 import { Box, Button, FormControlLabel, Switch, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { ChangeEvent } from "react";
@@ -36,24 +37,35 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
         <Container>
             <FormSection title={<FormattedMessage id="comet.dam.file.cropSettings.sectionTitle" defaultMessage="Crop/Focus settings" />}>
                 <FieldContainer>
-                    <FormControlLabel
-                        control={<Switch checked={focalPoint === "SMART"} onChange={handleSmartFocalPointChange} />}
-                        label={<FormattedMessage id="comet.dam.file.smartFocusPoint" defaultMessage="Smart focus point" />}
-                    />
-                    <Box>
-                        <Typography variant="caption" color="text.secondary" paragraph>
-                            <FormattedMessage
-                                id="comet.dam.file.croppingInfoText"
-                                defaultMessage="Cropping selects the maximum visible area. Depending on the aspect ratio, the image may be cropped further on the page."
-                            />
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary" paragraph>
-                            <FormattedMessage
-                                id="comet.dam.file.focusPointInfoText"
-                                defaultMessage="The focus point marks the most important part of the image, which is always visible. Choose it wisely."
-                            />
-                        </Typography>
-                    </Box>
+                    <AdminComponentSection
+                        title={<FormattedMessage id="comet.dam.file.cropSettings.smartFocusPoint.title" defaultMessage="Smart focus point" />}
+                    >
+                        <FormControlLabel
+                            control={<Switch checked={focalPoint === "SMART"} onChange={handleSmartFocalPointChange} />}
+                            label={
+                                focalPoint === "SMART" ? (
+                                    <FormattedMessage id="comet.dam.file.smartFocusPoint.yes" defaultMessage="Yes" />
+                                ) : (
+                                    <FormattedMessage id="comet.dam.file.smartFocusPoint.no" defaultMessage="No" />
+                                )
+                            }
+                            style={{ marginBottom: "4px" }}
+                        />
+                        <Box>
+                            <Typography variant="caption" color="text.secondary" paragraph>
+                                <FormattedMessage
+                                    id="comet.dam.file.croppingInfoText"
+                                    defaultMessage="Cropping selects the maximum visible area. Depending on the aspect ratio, the image may be cropped further on the page."
+                                />
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary" paragraph>
+                                <FormattedMessage
+                                    id="comet.dam.file.focusPointInfoText"
+                                    defaultMessage="The focus point marks the most important part of the image, which is always visible. Choose it wisely."
+                                />
+                            </Typography>
+                        </Box>
+                    </AdminComponentSection>
                 </FieldContainer>
                 {showChooseManualFocusPointButtons && (
                     <Field name="focalPoint">

--- a/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
@@ -36,21 +36,9 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
     return (
         <Container>
             <FormSection title={<FormattedMessage id="comet.dam.file.cropSettings.sectionTitle" defaultMessage="Crop/Focus settings" />}>
-                <FieldContainer fullWidth>
-                    <AdminComponentSection
-                        title={<FormattedMessage id="comet.dam.file.cropSettings.smartFocusPoint.title" defaultMessage="Smart focus point" />}
-                    >
-                        <FormControlLabel
-                            control={<Switch checked={focalPoint === "SMART"} onChange={handleSmartFocalPointChange} />}
-                            label={
-                                focalPoint === "SMART" ? (
-                                    <FormattedMessage id="comet.dam.file.smartFocusPoint.yes" defaultMessage="Yes" />
-                                ) : (
-                                    <FormattedMessage id="comet.dam.file.smartFocusPoint.no" defaultMessage="No" />
-                                )
-                            }
-                            style={{ marginBottom: "4px" }}
-                        />
+                <FieldContainer
+                    fullWidth
+                    helperText={
                         <Box>
                             <Typography variant="caption" color="text.secondary" paragraph>
                                 <FormattedMessage
@@ -65,10 +53,36 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
                                 />
                             </Typography>
                         </Box>
+                    }
+                >
+                    <AdminComponentSection
+                        title={<FormattedMessage id="comet.dam.file.cropSettings.smartFocusPoint.title" defaultMessage="Smart focus point" />}
+                    >
+                        <FormControlLabel
+                            control={<Switch checked={focalPoint === "SMART"} onChange={handleSmartFocalPointChange} />}
+                            label={
+                                focalPoint === "SMART" ? (
+                                    <FormattedMessage id="comet.dam.file.smartFocusPoint.yes" defaultMessage="Yes" />
+                                ) : (
+                                    <FormattedMessage id="comet.dam.file.smartFocusPoint.no" defaultMessage="No" />
+                                )
+                            }
+                        />
                     </AdminComponentSection>
                 </FieldContainer>
                 {showChooseManualFocusPointButtons && (
-                    <Field name="focalPoint" fullWidth>
+                    <Field
+                        name="focalPoint"
+                        fullWidth
+                        helperText={
+                            <Typography variant="caption" color="text.secondary" paragraph>
+                                <FormattedMessage
+                                    id="comet.blocks.image.hintSelectFocalPoint"
+                                    defaultMessage="You can also select the focus point by clicking on the bullets in the image."
+                                />
+                            </Typography>
+                        }
+                    >
                         {({ input: { value, onChange } }) => <ChooseFocalPoint focalPoint={value} onChangeFocalPoint={onChange} />}
                     </Field>
                 )}

--- a/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
@@ -1,7 +1,7 @@
 import { Field, FieldContainer, FormSection } from "@comet/admin";
 import { Reset } from "@comet/admin-icons";
 import { AdminComponentSection } from "@comet/blocks-admin";
-import { Box, Button, FormControlLabel, Switch, Typography } from "@mui/material";
+import { Box, Button, FormControlLabel, Switch } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { ChangeEvent } from "react";
 import { useForm, useFormState } from "react-final-form";
@@ -40,18 +40,16 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
                     fullWidth
                     helperText={
                         <Box>
-                            <Typography variant="caption" color="text.secondary" paragraph>
-                                <FormattedMessage
-                                    id="comet.dam.file.croppingInfoText"
-                                    defaultMessage="Cropping selects the maximum visible area. Depending on the aspect ratio, the image may be cropped further on the page."
-                                />
-                            </Typography>
-                            <Typography variant="caption" color="text.secondary" paragraph>
-                                <FormattedMessage
-                                    id="comet.dam.file.focusPointInfoText"
-                                    defaultMessage="The focus point marks the most important part of the image, which is always visible. Choose it wisely."
-                                />
-                            </Typography>
+                            <FormattedMessage
+                                id="comet.dam.file.croppingInfoText"
+                                defaultMessage="Cropping selects the maximum visible area. Depending on the aspect ratio, the image may be cropped further on the page."
+                            />
+                            <br />
+                            <br />
+                            <FormattedMessage
+                                id="comet.dam.file.focusPointInfoText"
+                                defaultMessage="The focus point marks the most important part of the image, which is always visible. Choose it wisely."
+                            />
                         </Box>
                     }
                 >
@@ -75,12 +73,10 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
                         name="focalPoint"
                         fullWidth
                         helperText={
-                            <Typography variant="caption" color="text.secondary" paragraph>
-                                <FormattedMessage
-                                    id="comet.blocks.image.hintSelectFocalPoint"
-                                    defaultMessage="You can also select the focus point by clicking on the bullets in the image."
-                                />
-                            </Typography>
+                            <FormattedMessage
+                                id="comet.blocks.image.hintSelectFocalPoint"
+                                defaultMessage="You can also select the focus point by clicking on the bullets in the image."
+                            />
                         }
                     >
                         {({ input: { value, onChange } }) => <ChooseFocalPoint focalPoint={value} onChangeFocalPoint={onChange} />}

--- a/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/CropSettingsFields.tsx
@@ -1,7 +1,7 @@
 import { Field, FieldContainer, FormSection } from "@comet/admin";
 import { Reset } from "@comet/admin-icons";
 import { AdminComponentSection } from "@comet/blocks-admin";
-import { Box, Button, FormControlLabel, Switch } from "@mui/material";
+import { Button, FormControlLabel, Switch } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { ChangeEvent } from "react";
 import { useForm, useFormState } from "react-final-form";
@@ -39,7 +39,7 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
                 <FieldContainer
                     fullWidth
                     helperText={
-                        <Box>
+                        <>
                             <FormattedMessage
                                 id="comet.dam.file.croppingInfoText"
                                 defaultMessage="Cropping selects the maximum visible area. Depending on the aspect ratio, the image may be cropped further on the page."
@@ -50,7 +50,7 @@ export function CropSettingsFields({ disabled }: Props): JSX.Element {
                                 id="comet.dam.file.focusPointInfoText"
                                 defaultMessage="The focus point marks the most important part of the image, which is always visible. Choose it wisely."
                             />
-                        </Box>
+                        </>
                     }
                 >
                     <AdminComponentSection


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

Adapt styling of Crop/Focus settings:

- Correct labels (to Yes/No)
- Remove padding from helper texts
- Adjust typography of helper texts
- Style button (add border) and fix position


<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

-->

## Screenshots/screencasts

![Screenshot 2024-10-31 at 14 39 30](https://github.com/user-attachments/assets/de3859e5-a8b5-40b4-8013-e5f0689e3a7e)


![Screenshot 2024-10-31 at 14 39 37](https://github.com/user-attachments/assets/33686287-1d5c-4546-ae89-3d8de58ed6cf)


## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1219

## Further information

Screenshot from Design:
![Screenshot 2024-10-31 at 14 58 15](https://github.com/user-attachments/assets/b5508702-ba79-4c79-a07e-ecccfbc6ff63)
