### PR TITLE
Use separate jwt's for invoking preview and storing preview state

### DIFF
--- a/packages/api/cms-api/src/page-tree/site-preview.resolver.ts
+++ b/packages/api/cms-api/src/page-tree/site-preview.resolver.ts
@@ -30,7 +30,7 @@ export class SitePreviewResolver {
             },
         })
             .setProtectedHeader({ alg: "HS256" })
-            .setExpirationTime("1 day")
+            .setExpirationTime("10 seconds")
             .sign(new TextEncoder().encode(this.config.secret));
     }
 }

--- a/packages/site/cms-site/src/sitePreview/appRouter/sitePreviewRoute.ts
+++ b/packages/site/cms-site/src/sitePreview/appRouter/sitePreviewRoute.ts
@@ -11,12 +11,12 @@ export async function sitePreviewRoute(request: NextRequest, _graphQLFetch: unkn
     const params = request.nextUrl.searchParams;
     const jwt = params.get("jwt");
     if (!jwt) {
-        return NextResponse.json({ error: "JWT-Parameter is missing." });
+        return NextResponse.json({ error: "JWT-Parameter is missing." }, { status: 400 });
     }
 
     const data = await verifySitePreviewJwt(jwt);
     if (!data) {
-        return NextResponse.json({ error: "JWT-validation failed." });
+        return NextResponse.json({ error: "JWT-validation failed." }, { status: 400 });
     }
 
     const cookieJwt = await new SignJWT({

--- a/packages/site/cms-site/src/sitePreview/pagesRouter/legacyPagesRouterSitePreviewApiHandler.ts
+++ b/packages/site/cms-site/src/sitePreview/pagesRouter/legacyPagesRouterSitePreviewApiHandler.ts
@@ -11,12 +11,12 @@ async function legacyPagesRouterSitePreviewApiHandler(
     const jwt = params.jwt;
 
     if (typeof jwt !== "string") {
-        return res.end("JWT-Parameter is missing.");
+        return res.status(400).json({ error: "JWT-Parameter is missing." });
     }
 
     const data = await verifySitePreviewJwt(jwt);
     if (!data) {
-        return res.end("JWT-validation failed.");
+        return res.status(400).json({ error: "JWT-validation failed." });
     }
 
     res.setPreviewData(data);

--- a/packages/site/cms-site/src/sitePreview/pagesRouter/legacyPagesRouterSitePreviewApiHandler.ts
+++ b/packages/site/cms-site/src/sitePreview/pagesRouter/legacyPagesRouterSitePreviewApiHandler.ts
@@ -11,10 +11,13 @@ async function legacyPagesRouterSitePreviewApiHandler(
     const jwt = params.jwt;
 
     if (typeof jwt !== "string") {
-        throw new Error("Missing jwt parameter");
+        return res.end("JWT-Parameter is missing.");
     }
 
     const data = await verifySitePreviewJwt(jwt);
+    if (!data) {
+        return res.end("JWT-validation failed.");
+    }
 
     res.setPreviewData(data);
     res.redirect(data.path);


### PR DESCRIPTION
## Description

The JWT to invoke the site preview has to be transferred via a GET-Parameter (see [Draft Mode in Next.JS](https://nextjs.org/docs/app/building-your-application/configuring/draft-mode#step-2-access-the-route-handler-from-your-headless-cms)). This PR shortens the validity time of this JWT to 10 seconds as the site creates a new JWT (which is not transferred via GET) for itself which stores the preview state.

Additional, do not throw a server error when JWT is not valid. This also prevents an error when the preview-state jwt is not valid anymore, it just will be ignored.

## Changeset

-   [X] I have verified if my change requires a changeset -> No changeset needed for this internal change of a newly added feature.
