### PR TITLE
Avoid duplicate file extension in `createFileUploadInputFromUrl`

### DIFF
--- a/.changeset/tricky-geese-breathe.md
+++ b/.changeset/tricky-geese-breathe.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Avoid duplicate file extension in `createFileUploadInputFromUrl`

--- a/demo/api/src/db/fixtures/generators/image-file-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/image-file-fixture.service.ts
@@ -17,11 +17,8 @@ export class ImageFileFixtureService {
 
             const downloadedImage = await createFileUploadInputFromUrl(image_path);
             console.log(`Downloading ${IMAGE_FILE_PATHS[index]} done.`);
-            downloadedImage.mimetype = "image/png";
-            downloadedImage.originalname = `${IMAGE_FILE_PATHS[index]}.png`;
 
             console.log(`Uploading ${downloadedImage.originalname}.`);
-
             const file = await this.filesService.upload(downloadedImage, { scope });
             console.log(`Uploading ${downloadedImage.originalname} done.`);
             images.push(file);

--- a/packages/api/cms-api/src/dam/files/files.utils.ts
+++ b/packages/api/cms-api/src/dam/files/files.utils.ts
@@ -5,6 +5,7 @@ import { unlink } from "fs/promises";
 import got from "got";
 import * as mimedb from "mime-db";
 import os from "os";
+import { basename, extname } from "path";
 import slugify from "slugify";
 import stream from "stream";
 import { promisify } from "util";
@@ -116,11 +117,11 @@ export async function createFileUploadInputFromUrl(url: string): Promise<FileUpl
 
     const fileType = await FileType.fromFile(tempFile);
     const stats = fs.statSync(tempFile); // TODO don't use sync
-    const filename = url.substring(url.lastIndexOf("/") + 1);
+    const filenameWithoutExtension = basename(url, extname(url));
 
     return {
         fieldname: FilesService.UPLOAD_FIELD,
-        originalname: `${filename}.${fileType?.ext}`,
+        originalname: `${filenameWithoutExtension}.${fileType?.ext}`,
         encoding: "utf8",
         mimetype: fileType?.mime as string,
         size: stats.size,


### PR DESCRIPTION

## Description

Previously, `createFileUploadInputFromUrl` would return a filename with two extensions if the URI already had an extension:

| Before   | After   |
| -------- | ------- |
| <img width="799" alt="Bildschirmfoto 2024-10-31 um 09 06 21" src="https://github.com/user-attachments/assets/5fd94f4f-6396-4e93-91c5-d5a2229e9cf8">     | <img width="810" alt="Bildschirmfoto 2024-10-31 um 09 05 25" src="https://github.com/user-attachments/assets/11254738-b422-4753-bc52-66e7f98443a5">    |

This made it necessary to override the name of the file (e.g. in fixtures)