### PR TITLE
Draft: Support SVG in `createFileUploadInputFromUrl`

### DIFF
--- a/.changeset/nasty-suits-vanish.md
+++ b/.changeset/nasty-suits-vanish.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Support svg files in `createFileUploadInputFromUrl`

--- a/.changeset/tricky-geese-breathe.md
+++ b/.changeset/tricky-geese-breathe.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Avoid duplicate file extension in `createFileUploadInputFromUrl`

--- a/demo/api/src/db/fixtures/generators/image-file-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/image-file-fixture.service.ts
@@ -17,11 +17,8 @@ export class ImageFileFixtureService {
 
             const downloadedImage = await createFileUploadInputFromUrl(image_path);
             console.log(`Downloading ${IMAGE_FILE_PATHS[index]} done.`);
-            downloadedImage.mimetype = "image/png";
-            downloadedImage.originalname = `${IMAGE_FILE_PATHS[index]}.png`;
 
             console.log(`Uploading ${downloadedImage.originalname}.`);
-
             const file = await this.filesService.upload(downloadedImage, { scope });
             console.log(`Uploading ${downloadedImage.originalname} done.`);
             images.push(file);

--- a/demo/api/src/db/fixtures/generators/svg-image-file-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/svg-image-file-fixture.service.ts
@@ -9,9 +9,6 @@ export class SvgImageFileFixtureService {
 
     async generateImage(scope: DamScope): Promise<FileInterface> {
         const file = await createFileUploadInputFromUrl(path.resolve(`./src/db/fixtures/generators/images/comet-logo-claim.svg`));
-        // Convert to what the browser would send
-        file.mimetype = "image/svg+xml";
-        file.originalname = "comet-logo-claim.svg";
         return this.filesService.upload(file, { scope });
     }
 }

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -60,6 +60,7 @@
         "graphql-parse-resolve-info": "^4.13.0",
         "graphql-scalars": "^1.23.0",
         "hasha": "^5.2.2",
+        "is-svg": "^4.4.0",
         "jose": "^5.2.4",
         "jsonwebtoken": "^8.5.1",
         "jszip": "^3.10.1",

--- a/packages/api/cms-api/src/dam/files/files.utils.ts
+++ b/packages/api/cms-api/src/dam/files/files.utils.ts
@@ -5,6 +5,7 @@ import { unlink } from "fs/promises";
 import got from "got";
 import * as mimedb from "mime-db";
 import os from "os";
+import { basename, extname } from "path";
 import slugify from "slugify";
 import stream from "stream";
 import { promisify } from "util";
@@ -116,11 +117,11 @@ export async function createFileUploadInputFromUrl(url: string): Promise<FileUpl
 
     const fileType = await FileType.fromFile(tempFile);
     const stats = fs.statSync(tempFile); // TODO don't use sync
-    const filename = url.substring(url.lastIndexOf("/") + 1);
+    const filenameWithoutExtension = basename(url, extname(url));
 
     return {
         fieldname: FilesService.UPLOAD_FIELD,
-        originalname: `${filename}.${fileType?.ext}`,
+        originalname: `${filenameWithoutExtension}.${fileType?.ext}`,
         encoding: "utf8",
         mimetype: fileType?.mime as string,
         size: stats.size,

--- a/packages/api/cms-api/src/dam/files/files.utils.ts
+++ b/packages/api/cms-api/src/dam/files/files.utils.ts
@@ -123,7 +123,7 @@ export async function createFileUploadInputFromUrl(url: string): Promise<FileUpl
     let determinedMimetype: string | undefined = fileType?.mime;
     let determinedExtension: string | undefined = fileType?.ext;
 
-    if (determinedMimetype === "application/xml") {
+    if (determinedMimetype === "application/xml" || determinedMimetype === undefined) {
         // could be svg because it's not supported by the file-type library
         if (isSvg(fs.readFileSync(tempFile, "utf8"))) {
             determinedMimetype = "image/svg+xml";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2387,6 +2387,9 @@ importers:
       hasha:
         specifier: ^5.2.2
         version: 5.2.2
+      is-svg:
+        specifier: ^4.4.0
+        version: 4.4.0
       jose:
         specifier: ^5.2.4
         version: 5.6.3
@@ -21966,13 +21969,6 @@ packages:
       punycode: 1.4.1
     dev: false
 
-  /fast-xml-parser@3.21.1:
-    resolution: {integrity: sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==}
-    hasBin: true
-    dependencies:
-      strnum: 1.0.5
-    dev: false
-
   /fast-xml-parser@4.2.7:
     resolution: {integrity: sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==}
     hasBin: true
@@ -22818,7 +22814,7 @@ packages:
     dependencies:
       cheerio: 0.22.0
       chroma-js: 2.4.2
-      is-svg: 4.3.2
+      is-svg: 4.4.0
       lodash.compact: 3.0.1
       lodash.uniq: 4.5.0
     dev: false
@@ -24676,11 +24672,11 @@ packages:
       better-path-resolve: 1.0.0
     dev: false
 
-  /is-svg@4.3.2:
-    resolution: {integrity: sha512-mM90duy00JGMyjqIVHu9gNTjywdZV+8qNasX8cm/EEYZ53PHDgajvbBwNVvty5dwSAxLUD3p3bdo+7sR/UMrpw==}
+  /is-svg@4.4.0:
+    resolution: {integrity: sha512-v+AgVwiK5DsGtT9ng+m4mClp6zDAmwrW8nZi6Gg15qzvBnRWWdfWA1TGaXyCDnWq5g5asofIgMVl3PjKxvk1ug==}
     engines: {node: '>=6'}
     dependencies:
-      fast-xml-parser: 3.21.1
+      fast-xml-parser: 4.4.1
     dev: false
 
   /is-symbol@1.0.4:


### PR DESCRIPTION
depends on https://github.com/vivid-planet/comet/pull/2696

## Description

Currently, `createFileUploadInputFromUrl` depends entirely on [file-type](https://github.com/sindresorhus/file-type) to determine the mimetype and extension of a file. However, file-type [doesn't support many common file types like svg, csv or txt](https://github.com/sindresorhus/file-type?tab=readme-ov-file#:~:text=This%20package%20is%20for%20detecting%20binary%2Dbased%20file%20formats%2C%20not%20text%2Dbased%20formats%20like%20.txt%2C%20.csv%2C%20.svg%2C%20etc.).

I built this fix for SVGs because SVGs are commonly used in the fixtures where this causes problems.

## Screenshots/screencasts


| Before   | After   |
| -------- | ------- |
| <img width="800" alt="Bildschirmfoto 2024-10-31 um 09 18 21" src="https://github.com/user-attachments/assets/f4b33bcc-4c03-4a38-a79b-8d9047bb8f8f">     | <img width="803" alt="Bildschirmfoto 2024-10-31 um 09 25 05" src="https://github.com/user-attachments/assets/63534bc2-12bc-45a5-a895-8a6b74cdaf9a">    |

## Changeset

-   [x] I have verified if my change requires a changeset

## Open TODOs/questions

This is only a half-solution since csv and txt still don't work. So a better solution could be to implement a multi-step approach to detect mimetype and extension:

1. Use file-type to determine mimetype and extension
2. If undefined or unclear: Use value from `Content-Type` header
3. If undefined or unclear or not possible (local file): Check if there is an extension. If so, use keep it and get the mimetype from mime-db

We could also use the OS function `const { stdout } = await execPromise(`file --mime-type -b ${filePath}`);`. This only works on Mac and Linux but shouldn't be a problem since we don't support Windows anyway. 

What do you think?

---

https://vivid-planet.atlassian.net/browse/COM-1629