### PR TITLE
Fix `parentUrlSubRoute` logic

### DIFF
--- a/.changeset/shiny-bottles-approve.md
+++ b/.changeset/shiny-bottles-approve.md
@@ -1,0 +1,7 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Fix linking from block preview to block admin for composite + list/blocks/columns block combinations
+
+Previously, the generated route was wrong if a composite contained multiple nested list, blocks or columns blocks.

--- a/demo/admin/src/pages/blocks/ColumnsBlock.tsx
+++ b/demo/admin/src/pages/blocks/ColumnsBlock.tsx
@@ -8,6 +8,7 @@ import {
 } from "@comet/blocks-admin";
 import { DamImageBlock } from "@comet/cms-admin";
 import { HeadlineBlock } from "@src/common/blocks/HeadlineBlock";
+import { LinkListBlock } from "@src/common/blocks/LinkListBlock";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import { FormattedMessage } from "react-intl";
 
@@ -18,6 +19,7 @@ const ColumnsContentBlock = createBlocksBlock({
         richtext: RichTextBlock,
         headline: HeadlineBlock,
         image: DamImageBlock,
+        linkList: LinkListBlock,
     },
 });
 

--- a/demo/admin/src/pages/blocks/TeaserBlock.tsx
+++ b/demo/admin/src/pages/blocks/TeaserBlock.tsx
@@ -2,6 +2,7 @@ import { BlockCategory, createCompositeBlock } from "@comet/blocks-admin";
 import { DamImageBlock } from "@comet/cms-admin";
 import { HeadlineBlock } from "@src/common/blocks/HeadlineBlock";
 import { LinkListBlock } from "@src/common/blocks/LinkListBlock";
+import { ColumnsBlock } from "@src/pages/blocks/ColumnsBlock";
 import { FormattedMessage } from "react-intl";
 
 const TeaserBlock = createCompositeBlock(
@@ -30,6 +31,10 @@ const TeaserBlock = createCompositeBlock(
                 block: LinkListBlock,
                 title: <FormattedMessage id="blocks.teaser.buttons" defaultMessage="Buttons" />,
                 nested: true,
+            },
+            columns: {
+                block: ColumnsBlock,
+                title: <FormattedMessage id="blocks.teaser.columns" defaultMessage="Columns" />,
             },
         },
     },

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -113,7 +113,8 @@
                                 "space": "Space",
                                 "richtext": "RichText",
                                 "headline": "Headline",
-                                "image": "DamImage"
+                                "image": "DamImage",
+                                "linkList": "LinkList"
                             },
                             "nullable": false
                         }
@@ -150,7 +151,8 @@
                                 "space": "Space",
                                 "richtext": "RichText",
                                 "headline": "Headline",
-                                "image": "DamImage"
+                                "image": "DamImage",
+                                "linkList": "LinkList"
                             },
                             "nullable": false
                         }
@@ -2046,6 +2048,12 @@
                 "kind": "Block",
                 "block": "LinkList",
                 "nullable": false
+            },
+            {
+                "name": "columns",
+                "kind": "Block",
+                "block": "Columns",
+                "nullable": false
             }
         ],
         "inputFields": [
@@ -2071,6 +2079,12 @@
                 "name": "buttons",
                 "kind": "Block",
                 "block": "LinkList",
+                "nullable": false
+            },
+            {
+                "name": "columns",
+                "kind": "Block",
+                "block": "Columns",
                 "nullable": false
             }
         ]

--- a/demo/api/src/pages/blocks/columns.block.ts
+++ b/demo/api/src/pages/blocks/columns.block.ts
@@ -1,5 +1,6 @@
 import { ColumnsBlockFactory, createBlocksBlock, SpaceBlock } from "@comet/blocks-api";
 import { DamImageBlock } from "@comet/cms-api";
+import { LinkListBlock } from "@src/common/blocks/link-list.block";
 import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 
 import { HeadlineBlock } from "./headline.block";
@@ -11,6 +12,7 @@ const ColumnsContentBlock = createBlocksBlock(
             richtext: RichTextBlock,
             headline: HeadlineBlock,
             image: DamImageBlock,
+            linkList: LinkListBlock,
         },
     },
     "ColumnsContent",

--- a/demo/api/src/pages/blocks/teaser.block.ts
+++ b/demo/api/src/pages/blocks/teaser.block.ts
@@ -11,6 +11,7 @@ import {
 } from "@comet/blocks-api";
 import { DamImageBlock } from "@comet/cms-api";
 import { LinkListBlock } from "@src/common/blocks/link-list.block";
+import { ColumnsBlock } from "@src/pages/blocks/columns.block";
 
 import { HeadlineBlock } from "./headline.block";
 
@@ -26,6 +27,9 @@ class TeaserBlockData extends BlockData {
 
     @ChildBlock(LinkListBlock)
     buttons: ExtractBlockData<typeof LinkListBlock>;
+
+    @ChildBlock(ColumnsBlock)
+    columns: ExtractBlockData<typeof ColumnsBlock>;
 }
 
 class TeaserBlockInput extends BlockInput {
@@ -40,6 +44,9 @@ class TeaserBlockInput extends BlockInput {
 
     @ChildBlockInput(LinkListBlock)
     buttons: ExtractBlockInput<typeof LinkListBlock>;
+
+    @ChildBlockInput(ColumnsBlock)
+    columns: ExtractBlockInput<typeof ColumnsBlock>;
 
     transformToBlockData(): BlockDataInterface {
         return inputToData(TeaserBlockData, this);

--- a/demo/site-pages/src/blocks/ColumnsBlock.tsx
+++ b/demo/site-pages/src/blocks/ColumnsBlock.tsx
@@ -1,5 +1,6 @@
 import { BlocksBlock, PropsWithData, SupportedBlocks, withPreview } from "@comet/cms-site";
 import { ColumnsBlockData, ColumnsContentBlockData } from "@src/blocks.generated";
+import { LinkListBlock } from "@src/blocks/LinkListBlock";
 import styled from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";
@@ -12,6 +13,7 @@ const supportedBlocks: SupportedBlocks = {
     richtext: (props) => <RichTextBlock data={props} />,
     headline: (props) => <HeadlineBlock data={props} />,
     image: (props) => <DamImageBlock data={props} aspectRatio="inherit" />,
+    linkList: (props) => <LinkListBlock data={props} />,
 };
 
 const ColumnsContentBlock = withPreview(

--- a/demo/site-pages/src/documents/pages/blocks/TeaserBlock.tsx
+++ b/demo/site-pages/src/documents/pages/blocks/TeaserBlock.tsx
@@ -1,18 +1,20 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { TeaserBlockData } from "@src/blocks.generated";
+import { ColumnsBlock } from "@src/blocks/ColumnsBlock";
 import { DamImageBlock } from "@src/blocks/DamImageBlock";
 import { HeadlineBlock } from "@src/blocks/HeadlineBlock";
 import { LinkListBlock } from "@src/blocks/LinkListBlock";
 import styled from "styled-components";
 
 const TeaserBlock = withPreview(
-    ({ data: { headline, image, links, buttons } }: PropsWithData<TeaserBlockData>) => {
+    ({ data: { headline, image, links, buttons, columns } }: PropsWithData<TeaserBlockData>) => {
         return (
             <Root>
                 <HeadlineBlock data={headline} />
                 <DamImageBlock data={image} aspectRatio="1x1" />
                 <LinkListBlock data={links} />
                 <LinkListBlock data={buttons} />
+                <ColumnsBlock data={columns} />
             </Root>
         );
     },

--- a/demo/site/src/blocks/ColumnsBlock.tsx
+++ b/demo/site/src/blocks/ColumnsBlock.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { BlocksBlock, PropsWithData, SupportedBlocks, withPreview } from "@comet/cms-site";
 import { ColumnsBlockData, ColumnsContentBlockData } from "@src/blocks.generated";
+import { LinkListBlock } from "@src/blocks/LinkListBlock";
 import styled from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";
@@ -13,6 +14,7 @@ const supportedBlocks: SupportedBlocks = {
     richtext: (props) => <RichTextBlock data={props} />,
     headline: (props) => <HeadlineBlock data={props} />,
     image: (props) => <DamImageBlock data={props} aspectRatio="inherit" />,
+    linkList: (props) => <LinkListBlock data={props} />,
 };
 
 const ColumnsContentBlock = withPreview(

--- a/demo/site/src/documents/pages/blocks/TeaserBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/TeaserBlock.tsx
@@ -1,19 +1,21 @@
 "use client";
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { TeaserBlockData } from "@src/blocks.generated";
+import { ColumnsBlock } from "@src/blocks/ColumnsBlock";
 import { DamImageBlock } from "@src/blocks/DamImageBlock";
 import { HeadlineBlock } from "@src/blocks/HeadlineBlock";
 import { LinkListBlock } from "@src/blocks/LinkListBlock";
 import styled from "styled-components";
 
 const TeaserBlock = withPreview(
-    ({ data: { headline, image, links, buttons } }: PropsWithData<TeaserBlockData>) => {
+    ({ data: { headline, image, links, buttons, columns } }: PropsWithData<TeaserBlockData>) => {
         return (
             <Root>
                 <HeadlineBlock data={headline} />
                 <DamImageBlock data={image} aspectRatio="1x1" />
                 <LinkListBlock data={links} />
                 <LinkListBlock data={buttons} />
+                <ColumnsBlock data={columns} />
             </Root>
         );
     },

--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
@@ -233,7 +233,7 @@ export function createBlocksBlock<AdditionalItemFields extends Record<string, un
                             visible: child.visible,
                             type: child.type,
                             adminRoute: blockAdminRoute,
-                            props: block.createPreviewState(child.props, { ...previewCtx, parentUrl: blockAdminRoute }),
+                            props: block.createPreviewState(child.props, { ...previewCtx, parentUrlSubRoute: undefined, parentUrl: blockAdminRoute }),
                             // Type cast to suppress "'AdditionalItemFields' could be instantiated with a different subtype of constraint 'Record<string, unknown>'" error
                             ...(Object.keys(additionalItemFields ?? {}).reduce(
                                 (fields, field) => ({ ...fields, [field]: child[field] }),

--- a/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
@@ -165,7 +165,11 @@ export function createColumnsBlock<T extends BlockInterface>({
                     return {
                         key: column.key,
                         visible: column.visible,
-                        props: contentBlock.createPreviewState(column.props, { ...previewContext, parentUrl: blockAdminRoute }),
+                        props: contentBlock.createPreviewState(column.props, {
+                            ...previewContext,
+                            parentUrlSubRoute: undefined,
+                            parentUrl: blockAdminRoute,
+                        }),
                         adminRoute: blockAdminRoute,
                         adminMeta: { route: blockAdminRoute },
                     };

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -205,7 +205,11 @@ export function createListBlock<T extends BlockInterface, AdditionalItemFields e
                         return {
                             key: child.key,
                             visible: child.visible,
-                            props: block.createPreviewState(child.props, { ...previewCtx, parentUrl: blockAdminRoute }),
+                            props: block.createPreviewState(child.props, {
+                                ...previewCtx,
+                                parentUrlSubRoute: undefined,
+                                parentUrl: blockAdminRoute,
+                            }),
                             // Type cast to suppress "'AdditionalItemFields' could be instantiated with a different subtype of constraint 'Record<string, unknown>'" error
                             ...(Object.keys(additionalItemFields ?? {}).reduce(
                                 (fields, field) => ({ ...fields, [field]: child[field] }),


### PR DESCRIPTION
The actual fix is in e1b11fa5a62809d005223fbadaac63cefca91ac2

14fb120693bc8a39b0e98d5cdc527c23d941c1b3 adds an example

## Description

### Problem

The content sidebar shows "Can't find column" when clicking on an element in the block preview. This error occurs if there is a composite block that contains multiple nested list-, blocks-, or columns blocks. E.g.

- Composite block
    - columns block
        - list block

### Reason

In some cases the composite block sets a `parentUrlSubRoute` additionally to the `parentUrl`. If `parentUrlSubRoute` is set, list/blocks/columns blocks always use the `parentUrlSubRoute` (instead of `parentUrl`). However, they also pass on the same `parentUrlSubRoute`, meaning the next list/blocks/columns block still "thinks" its a direct child of the composite.

For context: This bug was introduced in https://github.com/vivid-planet/comet/pull/1569 while fixing another issue. 

### Solution

The `parentUrlSubRoute` should only affect direct children of a composite block. Therefore, I set parentUrlSubRoute = undefined` in list/blocks/columns blocks.

## Example

I implemented an example in 14fb120693bc8a39b0e98d5cdc527c23d941c1b3. However, it doesn't make that much sense. Maybe we should remove it before merging. 

What do you think?

## Screenshots/screencasts

### Before


https://github.com/user-attachments/assets/b1499bf3-a548-41d8-acc5-362292c81e2f



### After


https://github.com/user-attachments/assets/dc4697a4-bbb2-4311-bdfe-e6b4f1a772bb



## Changeset

-   [x] I have verified if my change requires a changeset


## Open TODOs/questions

-   [ ] Backport
