### PR TITLE
Fix `parentUrlSubRoute` logic (v5)

### DIFF
--- a/.changeset/shiny-bottles-approve.md
+++ b/.changeset/shiny-bottles-approve.md
@@ -1,0 +1,7 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Fix linking from block preview to block admin for composite + list/blocks/columns block combinations
+
+Previously, the generated route was wrong if a composite contained multiple nested list, blocks or columns blocks.

--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
@@ -222,7 +222,7 @@ export function createBlocksBlock<AdditionalItemFields extends Record<string, un
                             visible: child.visible,
                             type: child.type,
                             adminRoute: blockAdminRoute,
-                            props: block.createPreviewState(child.props, { ...previewCtx, parentUrl: blockAdminRoute }),
+                            props: block.createPreviewState(child.props, { ...previewCtx, parentUrlSubRoute: undefined, parentUrl: blockAdminRoute }),
                             // Type cast to suppress "'AdditionalItemFields' could be instantiated with a different subtype of constraint 'Record<string, unknown>'" error
                             ...(Object.keys(additionalItemFields ?? {}).reduce(
                                 (fields, field) => ({ ...fields, [field]: child[field] }),

--- a/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
@@ -165,7 +165,11 @@ export function createColumnsBlock<T extends BlockInterface>({
                     return {
                         key: column.key,
                         visible: column.visible,
-                        props: contentBlock.createPreviewState(column.props, { ...previewContext, parentUrl: blockAdminRoute }),
+                        props: contentBlock.createPreviewState(column.props, {
+                            ...previewContext,
+                            parentUrlSubRoute: undefined,
+                            parentUrl: blockAdminRoute,
+                        }),
                         adminRoute: blockAdminRoute,
                         adminMeta: { route: blockAdminRoute },
                     };

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -195,7 +195,11 @@ export function createListBlock<T extends BlockInterface, AdditionalItemFields e
                         return {
                             key: child.key,
                             visible: child.visible,
-                            props: block.createPreviewState(child.props, { ...previewCtx, parentUrl: blockAdminRoute }),
+                            props: block.createPreviewState(child.props, {
+                                ...previewCtx,
+                                parentUrlSubRoute: undefined,
+                                parentUrl: blockAdminRoute,
+                            }),
                             // Type cast to suppress "'AdditionalItemFields' could be instantiated with a different subtype of constraint 'Record<string, unknown>'" error
                             ...(Object.keys(additionalItemFields ?? {}).reduce(
                                 (fields, field) => ({ ...fields, [field]: child[field] }),


### PR DESCRIPTION
Backport of https://github.com/vivid-planet/comet/pull/2707 (without example)

Note: v5 has no bug support. But this fix was specifically requested by one customer and I see no reason to deny this.