### PR TITLE
Set the select field in `OneOfBlock` to `required` based on the `allowEmpty` prop

### DIFF
--- a/.changeset/green-poems-remain.md
+++ b/.changeset/green-poems-remain.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Set the select field in `OneOfBlock` to `required` based on the `allowEmpty` prop

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -1,5 +1,5 @@
-import { Field, FieldContainer, FinalFormRadio, FinalFormSelect } from "@comet/admin";
-import { Box, Divider, FormControlLabel, MenuItem, ToggleButton as MuiToggleButton, ToggleButtonGroup as MuiToggleButtonGroup } from "@mui/material";
+import { Field, FieldContainer, FinalFormRadio, SelectField } from "@comet/admin";
+import { Box, Divider, FormControlLabel, ToggleButton as MuiToggleButton, ToggleButtonGroup as MuiToggleButtonGroup } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import isEqual from "lodash.isequal";
 import { ReactNode, useCallback } from "react";
@@ -366,17 +366,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
                                 {variant === "select" && (
                                     <>
                                         <Box padding={isInPaper ? 3 : 0}>
-                                            <Field name="blockType" fullWidth>
-                                                {(props) => (
-                                                    <FinalFormSelect {...props} fullWidth>
-                                                        {options.map((option) => (
-                                                            <MenuItem value={option.value} key={option.value}>
-                                                                {option.label}
-                                                            </MenuItem>
-                                                        ))}
-                                                    </FinalFormSelect>
-                                                )}
-                                            </Field>
+                                            <SelectField name="blockType" options={options} fullWidth />
                                         </Box>
                                         {isInPaper && activeBlock.block && <Divider />}
                                     </>

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -366,7 +366,7 @@ export const createOneOfBlock = <T extends boolean = boolean>({
                                 {variant === "select" && (
                                     <>
                                         <Box padding={isInPaper ? 3 : 0}>
-                                            <SelectField name="blockType" options={options} fullWidth />
+                                            <SelectField name="blockType" options={options} fullWidth required={!allowEmpty} />
                                         </Box>
                                         {isInPaper && activeBlock.block && <Divider />}
                                     </>


### PR DESCRIPTION
## Description

- Replace deprecated `FinalFormSelect` with `SelectField`
- Set the select field in `OneOfBlock` to `required` based on the `allowEmpty` prop