### PR TITLE
Disable showing related videos from other channels in `YouTubeVideoBlock`

### DIFF
--- a/.changeset/fast-carrots-divide.md
+++ b/.changeset/fast-carrots-divide.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-site": minor
+---
+
+Add rel=0 to youtube search parameters
+
+By setting the parameter rel to 0 in the `YouTubeVideoBlock` only related videos from the same channel as the embedded video are shown.

--- a/.changeset/fast-carrots-divide.md
+++ b/.changeset/fast-carrots-divide.md
@@ -2,6 +2,6 @@
 "@comet/cms-site": minor
 ---
 
-Add rel=0 to youtube search parameters
+Disable showing related videos from other channels in `YouTubeVideoBlock`
 
-By setting the parameter rel to 0 in the `YouTubeVideoBlock` only related videos from the same channel as the embedded video are shown.
+By setting the parameter `rel` to `0` only related videos from the same channel as the embedded video are shown.

--- a/packages/site/cms-site/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/site/cms-site/src/blocks/YouTubeVideoBlock.tsx
@@ -48,6 +48,7 @@ export const YouTubeVideoBlock = withPreview(
         const identifier = parseYoutubeIdentifier(youtubeIdentifier);
         const searchParams = new URLSearchParams();
         searchParams.append("modestbranding", "1");
+        searchParams.append("rel", "0");
 
         if (autoplay !== undefined || (hasPreviewImage && !showPreviewImage))
             searchParams.append("autoplay", Number(autoplay || (hasPreviewImage && !showPreviewImage)).toString());


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

Currently, recommendations from all channels are displayed when a video is embedded and played in the `YouTubeVideoBlock`. This update restricts the recommendations to only show content from the same channel as the embedded video, enhancing relevance and user experience.

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

-->

## Example

-   [x] I have verified if my change requires an example

## Screenshots/screencasts

<details><summary>Before: YouTube Video with related videos </summary>

https://github.com/user-attachments/assets/d7b3e628-7681-4c14-85fc-90886aa20c96

</details>

<details><summary>After:  YouTube Video without related videos / only with related videos from same channel</summary>

https://github.com/user-attachments/assets/cd31ea39-40b9-48ff-a476-5935fe4d3e88 

</details>

## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/PHSB2C-4492
