### PR TITLE
Block preview credentials

### DIFF
--- a/.changeset/giant-swans-compete.md
+++ b/.changeset/giant-swans-compete.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-site": patch
+---
+
+The `graphQLFetch` helper for block preview uses `credentials: "include"`
+
+This is necessary for the block preview when using block loaders because they load the data from the API on the client side.

--- a/packages/site/cms-site/src/iframebridge/useBlockPreviewFetch.tsx
+++ b/packages/site/cms-site/src/iframebridge/useBlockPreviewFetch.tsx
@@ -20,5 +20,8 @@ export function useBlockPreviewFetch(graphqlApiUrl: string) {
 }
 
 function createBlockPreviewFetch(graphqlApiUrl: string, includeInvisible: boolean) {
-    return createGraphQLFetch(createFetchWithDefaults(cachingFetch, { headers: convertPreviewDataToHeaders({ includeInvisible }) }), graphqlApiUrl);
+    return createGraphQLFetch(
+        createFetchWithDefaults(cachingFetch, { headers: convertPreviewDataToHeaders({ includeInvisible }), credentials: "include" }),
+        graphqlApiUrl,
+    );
 }


### PR DESCRIPTION
## Description

Since https://github.com/vivid-planet/comet/pull/2554 the block preview is not behind an auth proxy anymore (and hence does not have an own authentication cookie).

If the site uses loader functions (which are client rendered in the block preview) it is necessary that the cookies for the api are submitted, this is accomplished through `credentials: true`.

## Further information

Depends on https://github.com/vivid-planet/comet/pull/2716