### PR TITLE
Don't move files to a folder called "." when uploading them to the DAM

### DIFF
--- a/.changeset/shaggy-rocks-love.md
+++ b/.changeset/shaggy-rocks-love.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Don't move files to a folder called "." when uploading them to the DAM
+
+This bug only occurred in projects with a `react-dropzone` version >= 14.3.2.

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -67,7 +67,7 @@
         "pluralize": "^8.0.0",
         "prop-types": "^15.7.2",
         "react-cool-dimensions": "^2.0.0",
-        "react-dropzone": "^14.0.0",
+        "react-dropzone": "^14.3.5",
         "react-final-form-arrays": "^3.1.3",
         "react-hotkeys-hook": "^3.0.0",
         "react-image-crop": "^8.0.0",

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
@@ -84,10 +84,11 @@ const addFolderPathToFiles = async (acceptedFiles: FileWithPath[]): Promise<File
 
     for (const file of acceptedFiles) {
         let harmonizedPath: string | undefined;
-        // when files are uploaded via input field, the path does not have a "/" prefix
-        // when files are uploaded via drag and drop, the path does have a "/" prefix
-        // if the path has a "/" prefix, this prefix is removed => path is harmonized
-        if (file.path?.startsWith("/")) {
+        // when a file is uploaded, the file path is prefixed with "./"
+        // when a folder is uploaded via drag and drop, the file paths are prefixed with "/"
+        // when a folder is uploaded via input field, the file paths don't have any prefix
+        if (file.path?.startsWith("./") || file.path?.startsWith("/")) {
+            // if the path has a "./" or "/" prefix, this prefix is removed => path is harmonized
             harmonizedPath = file.path?.split("/").splice(1).join("/");
         } else {
             harmonizedPath = file.path;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2026,8 +2026,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.7(react@17.0.2)
       react-dropzone:
-        specifier: ^14.0.0
-        version: 14.2.3(react@17.0.2)
+        specifier: ^14.3.5
+        version: 14.3.5(react@17.0.2)
       react-final-form-arrays:
         specifier: ^3.1.3
         version: 3.1.4(final-form-arrays@3.1.0)(final-form@4.20.9)(react-final-form@6.5.9)(react@17.0.2)
@@ -3467,7 +3467,7 @@ packages:
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.609.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-crypto/crc32c@5.2.0:
@@ -3475,7 +3475,7 @@ packages:
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.609.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-crypto/sha1-browser@5.2.0:
@@ -3486,7 +3486,7 @@ packages:
       '@aws-sdk/types': 3.609.0
       '@aws-sdk/util-locate-window': 3.208.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-crypto/sha256-browser@5.2.0:
@@ -3498,7 +3498,7 @@ packages:
       '@aws-sdk/types': 3.609.0
       '@aws-sdk/util-locate-window': 3.208.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-crypto/sha256-js@5.2.0:
@@ -3507,13 +3507,13 @@ packages:
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.609.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-crypto/supports-web-crypto@5.2.0:
     resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-crypto/util@5.2.0:
@@ -3521,7 +3521,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.609.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/client-s3@3.645.0:
@@ -3635,7 +3635,7 @@ packages:
       '@smithy/util-middleware': 3.0.8
       '@smithy/util-retry': 3.0.8
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -3681,7 +3681,7 @@ packages:
       '@smithy/util-middleware': 3.0.8
       '@smithy/util-retry': 3.0.8
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -3729,7 +3729,7 @@ packages:
       '@smithy/util-middleware': 3.0.8
       '@smithy/util-retry': 3.0.8
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -3747,7 +3747,7 @@ packages:
       '@smithy/types': 3.6.0
       '@smithy/util-middleware': 3.0.8
       fast-xml-parser: 4.4.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/credential-provider-env@3.620.1:
@@ -3757,7 +3757,7 @@ packages:
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.8
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/credential-provider-http@3.635.0:
@@ -3772,7 +3772,7 @@ packages:
       '@smithy/smithy-client': 3.4.2
       '@smithy/types': 3.6.0
       '@smithy/util-stream': 3.2.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/credential-provider-ini@3.645.0(@aws-sdk/client-sso-oidc@3.645.0)(@aws-sdk/client-sts@3.645.0):
@@ -3792,7 +3792,7 @@ packages:
       '@smithy/property-provider': 3.1.8
       '@smithy/shared-ini-file-loader': 3.1.9
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
@@ -3813,7 +3813,7 @@ packages:
       '@smithy/property-provider': 3.1.8
       '@smithy/shared-ini-file-loader': 3.1.9
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - '@aws-sdk/client-sts'
@@ -3828,7 +3828,7 @@ packages:
       '@smithy/property-provider': 3.1.8
       '@smithy/shared-ini-file-loader': 3.1.9
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/credential-provider-sso@3.645.0(@aws-sdk/client-sso-oidc@3.645.0):
@@ -3841,7 +3841,7 @@ packages:
       '@smithy/property-provider': 3.1.8
       '@smithy/shared-ini-file-loader': 3.1.9
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
@@ -3857,7 +3857,7 @@ packages:
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.8
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/middleware-bucket-endpoint@3.620.0:
@@ -3870,7 +3870,7 @@ packages:
       '@smithy/protocol-http': 4.1.5
       '@smithy/types': 3.6.0
       '@smithy/util-config-provider': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/middleware-expect-continue@3.620.0:
@@ -3880,7 +3880,7 @@ packages:
       '@aws-sdk/types': 3.609.0
       '@smithy/protocol-http': 4.1.5
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/middleware-flexible-checksums@3.620.0:
@@ -3894,7 +3894,7 @@ packages:
       '@smithy/protocol-http': 4.1.5
       '@smithy/types': 3.6.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/middleware-host-header@3.620.0:
@@ -3904,7 +3904,7 @@ packages:
       '@aws-sdk/types': 3.609.0
       '@smithy/protocol-http': 4.1.5
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/middleware-location-constraint@3.609.0:
@@ -3913,7 +3913,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.609.0
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/middleware-logger@3.609.0:
@@ -3922,7 +3922,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.609.0
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/middleware-recursion-detection@3.620.0:
@@ -3932,7 +3932,7 @@ packages:
       '@aws-sdk/types': 3.609.0
       '@smithy/protocol-http': 4.1.5
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/middleware-sdk-s3@3.635.0:
@@ -3952,7 +3952,7 @@ packages:
       '@smithy/util-middleware': 3.0.8
       '@smithy/util-stream': 3.2.1
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/middleware-ssec@3.609.0:
@@ -3961,7 +3961,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.609.0
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/middleware-user-agent@3.645.0:
@@ -3972,7 +3972,7 @@ packages:
       '@aws-sdk/util-endpoints': 3.645.0
       '@smithy/protocol-http': 4.1.5
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/region-config-resolver@3.614.0:
@@ -3984,7 +3984,7 @@ packages:
       '@smithy/types': 3.6.0
       '@smithy/util-config-provider': 3.0.0
       '@smithy/util-middleware': 3.0.8
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/signature-v4-multi-region@3.635.0:
@@ -3996,7 +3996,7 @@ packages:
       '@smithy/protocol-http': 4.1.5
       '@smithy/signature-v4': 4.2.1
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.645.0):
@@ -4010,7 +4010,7 @@ packages:
       '@smithy/property-provider': 3.1.8
       '@smithy/shared-ini-file-loader': 3.1.9
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/types@3.609.0:
@@ -4024,7 +4024,7 @@ packages:
     resolution: {integrity: sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/util-endpoints@3.645.0:
@@ -4034,14 +4034,14 @@ packages:
       '@aws-sdk/types': 3.609.0
       '@smithy/types': 3.6.0
       '@smithy/util-endpoints': 2.1.4
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/util-locate-window@3.208.0:
     resolution: {integrity: sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/util-user-agent-browser@3.609.0:
@@ -4050,7 +4050,7 @@ packages:
       '@aws-sdk/types': 3.609.0
       '@smithy/types': 3.6.0
       bowser: 2.11.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/util-user-agent-node@3.614.0:
@@ -4065,7 +4065,7 @@ packages:
       '@aws-sdk/types': 3.609.0
       '@smithy/node-config-provider': 3.1.9
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@aws-sdk/xml-builder@3.609.0:
@@ -4073,7 +4073,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure-rest/ai-translation-text@1.0.0:
@@ -4098,7 +4098,7 @@ packages:
       '@azure/core-rest-pipeline': 1.16.3
       '@azure/core-tracing': 1.1.2
       '@azure/core-util': 1.1.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4107,14 +4107,14 @@ packages:
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/abort-controller@2.1.2:
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/core-auth@1.4.0:
@@ -4122,7 +4122,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/core-client@1.9.2:
@@ -4135,7 +4135,7 @@ packages:
       '@azure/core-tracing': 1.1.2
       '@azure/core-util': 1.9.2
       '@azure/logger': 1.0.3
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4157,14 +4157,14 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/logger': 1.0.3
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/core-paging@1.4.0:
     resolution: {integrity: sha512-tabFtZTg8D9XqZKEfNUOGh63SuYeOxmvH4GDcOJN+R1bZWZ1FZskctgY9Pmuwzhn+0Xvq9rmimK9hsvtLkeBsw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/core-rest-pipeline@1.16.3:
@@ -4178,7 +4178,7 @@ packages:
       '@azure/logger': 1.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4187,14 +4187,14 @@ packages:
     resolution: {integrity: sha512-yf+pFIu8yCzXu9RbH2+8kp9vITIKJLHgkLgFNA6hxiDHK3fxeP596cHUj4c8Cm8JlooaUnYdHmF84KCZt3jbmw==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/core-tracing@1.1.2:
     resolution: {integrity: sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/core-util@1.1.1:
@@ -4202,7 +4202,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/core-util@1.9.2:
@@ -4210,7 +4210,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/core-xml@1.4.3:
@@ -4218,14 +4218,14 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       fast-xml-parser: 4.4.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/logger@1.0.3:
     resolution: {integrity: sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@azure/openai@1.0.0-beta.11:
@@ -7604,7 +7604,7 @@ packages:
       cssnano-preset-advanced: 5.3.10(postcss@8.4.38)
       postcss: 8.4.38
       postcss-sort-media-queries: 4.4.1(postcss@8.4.38)
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@docusaurus/logger@2.4.1:
@@ -7612,7 +7612,7 @@ packages:
     engines: {node: '>=16.14'}
     dependencies:
       chalk: 4.1.2
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@docusaurus/mdx-loader@2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.2)(react@17.0.2):
@@ -7636,7 +7636,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       remark-emoji: 2.2.0
       stringify-object: 3.3.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       unified: 9.2.2
       unist-util-visit: 2.0.3
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
@@ -7693,7 +7693,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       reading-time: 1.5.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       unist-util-visit: 2.0.3
       utility-types: 3.10.0
       webpack: 5.88.2
@@ -7737,7 +7737,7 @@ packages:
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.6.3
+      tslib: 2.8.1
       utility-types: 3.10.0
       webpack: 5.88.2
     transitivePeerDependencies:
@@ -7773,7 +7773,7 @@ packages:
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.6.3
+      tslib: 2.8.1
       webpack: 5.88.2
     transitivePeerDependencies:
       - '@parcel/css'
@@ -7807,7 +7807,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-json-view: 1.21.3(@types/react@17.0.53)(react-dom@17.0.2)(react@17.0.2)
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -7840,7 +7840,7 @@ packages:
       '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -7871,7 +7871,7 @@ packages:
       '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -7902,7 +7902,7 @@ packages:
       '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -7938,7 +7938,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       sitemap: 7.1.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -8042,7 +8042,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       react-router-dom: 5.3.4(react@17.0.2)
       rtlcss: 3.5.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       utility-types: 3.10.0
     transitivePeerDependencies:
       - '@parcel/css'
@@ -8202,7 +8202,7 @@ packages:
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.6.3
+      tslib: 2.8.1
       utility-types: 3.10.0
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -8231,7 +8231,7 @@ packages:
     engines: {node: '>=16.14'}
     dependencies:
       fs-extra: 10.1.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@docusaurus/types@2.4.1(react-dom@17.0.2)(react@17.0.2):
@@ -8266,7 +8266,7 @@ packages:
         optional: true
     dependencies:
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@docusaurus/utils-validation@2.4.1(@docusaurus/types@2.4.1):
@@ -8277,7 +8277,7 @@ packages:
       '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
       joi: 17.7.0
       js-yaml: 4.1.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -8310,7 +8310,7 @@ packages:
       micromatch: 4.0.5
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
-      tslib: 2.6.3
+      tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
       webpack: 5.88.2
     transitivePeerDependencies:
@@ -8621,7 +8621,7 @@ packages:
       lodash.get: 4.4.2
       make-error: 1.3.6
       ts-node: 9.1.1(typescript@4.9.4)
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -8949,26 +8949,26 @@ packages:
     resolution: {integrity: sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==}
     dependencies:
       '@formatjs/intl-localematcher': 0.2.32
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@formatjs/ecma402-abstract@1.18.2:
     resolution: {integrity: sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==}
     dependencies:
       '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@formatjs/fast-memoize@2.2.0:
     resolution: {integrity: sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@formatjs/icu-messageformat-parser@2.1.14:
     resolution: {integrity: sha512-0KqeVOb72losEhUW+59vhZGGd14s1f35uThfEMVKZHKLEObvJdFTiI3ZQwvTMUCzLEMxnS6mtnYPmG4mTvwd3Q==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.14.3
       '@formatjs/icu-skeleton-parser': 1.3.18
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@formatjs/icu-messageformat-parser@2.7.6:
@@ -8976,45 +8976,45 @@ packages:
     dependencies:
       '@formatjs/ecma402-abstract': 1.18.2
       '@formatjs/icu-skeleton-parser': 1.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@formatjs/icu-skeleton-parser@1.3.18:
     resolution: {integrity: sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.14.3
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@formatjs/icu-skeleton-parser@1.8.0:
     resolution: {integrity: sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.18.2
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@formatjs/intl-displaynames@6.6.6:
     resolution: {integrity: sha512-Dg5URSjx0uzF8VZXtHb6KYZ6LFEEhCbAbKoYChYHEOnMFTw/ZU3jIo/NrujzQD2EfKPgQzIq73LOUvW6Z/LpFA==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.18.2
       '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@formatjs/intl-listformat@7.5.5:
     resolution: {integrity: sha512-XoI52qrU6aBGJC9KJddqnacuBbPlb/bXFN+lIFVFhQ1RnFHpzuFrlFdjD9am2O7ZSYsyqzYRpkVcXeT1GHkwDQ==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.18.2
       '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@formatjs/intl-localematcher@0.2.32:
     resolution: {integrity: sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@formatjs/intl-localematcher@0.5.4:
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@formatjs/intl@2.10.2(typescript@4.9.4):
     resolution: {integrity: sha512-raPGWr3JRv3neXV78SqPFrGC05fIbhhNzVghHNxFde27ls2KkXiMhtP7HBybjGpikVSjjhdhaZto+4p1vmm9bQ==}
@@ -9030,7 +9030,7 @@ packages:
       '@formatjs/intl-displaynames': 6.6.6
       '@formatjs/intl-listformat': 7.5.5
       intl-messageformat: 10.5.12
-      tslib: 2.6.3
+      tslib: 2.8.1
       typescript: 4.9.4
 
   /@formatjs/ts-transformer@3.11.5:
@@ -9046,7 +9046,7 @@ packages:
       '@types/node': 17.0.45
       chalk: 4.1.2
       json-stable-stringify: 1.0.2
-      tslib: 2.6.3
+      tslib: 2.8.1
       typescript: 4.9.4
     dev: false
 
@@ -9499,7 +9499,7 @@ packages:
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       dataloader: 2.1.0
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     dev: true
 
@@ -9576,7 +9576,7 @@ packages:
       graphql: 15.8.0
       graphql-ws: 5.11.2(graphql@15.8.0)
       isomorphic-ws: 5.0.0(ws@8.12.0)
-      tslib: 2.6.3
+      tslib: 2.8.1
       ws: 8.12.0
     transitivePeerDependencies:
       - bufferutil
@@ -9595,7 +9595,7 @@ packages:
       extract-files: 11.0.0
       graphql: 15.8.0
       meros: 1.2.1(@types/node@18.15.3)
-      tslib: 2.6.3
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
@@ -9611,7 +9611,7 @@ packages:
       '@types/ws': 8.5.4
       graphql: 15.8.0
       isomorphic-ws: 5.0.0(ws@8.12.0)
-      tslib: 2.6.3
+      tslib: 2.8.1
       ws: 8.12.0
     transitivePeerDependencies:
       - bufferutil
@@ -9627,7 +9627,7 @@ packages:
       '@graphql-typed-document-node/core': 3.1.1(graphql@15.8.0)
       '@repeaterjs/repeater': 3.0.4
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     dev: true
 
@@ -9746,7 +9746,7 @@ packages:
       '@babel/types': 7.22.11
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -9763,7 +9763,7 @@ packages:
       '@babel/types': 7.22.11
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -9777,7 +9777,7 @@ packages:
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
       resolve-from: 5.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/import@6.7.18(graphql@15.8.0):
@@ -9788,7 +9788,7 @@ packages:
       '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       graphql: 15.8.0
       resolve-from: 5.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@graphql-tools/json-file-loader@6.2.6(graphql@15.8.0):
     resolution: {integrity: sha512-CnfwBSY5926zyb6fkDBHnlTblHnHI4hoBALFYXnrg0Ev4yWU8B04DZl/pBRUc459VNgO2x8/mxGIZj2hPJG1EA==}
@@ -9870,7 +9870,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 8.9.0(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@graphql-tools/merge@8.3.12(graphql@15.8.0):
@@ -9880,7 +9880,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.1.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@graphql-tools/merge@8.3.15(graphql@15.8.0):
     resolution: {integrity: sha512-hYYOlsqkUlL6oOo7zzuk6hIv7xQzy+x21sgK84d5FWaiWYkLYh9As8myuDd9SD5xovWWQ9m/iRhIOVDEMSyEKA==}
@@ -9889,7 +9889,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@graphql-tools/merge@8.3.6(graphql@15.8.0):
     resolution: {integrity: sha512-uUBokxXi89bj08P+iCvQk3Vew4vcfL5ZM6NTylWi8PIpoq4r5nJ625bRuN8h2uubEdRiH8ntN9M4xkd/j7AybQ==}
@@ -9898,7 +9898,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 8.12.0(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/merge@8.4.2(graphql@15.8.0):
@@ -9908,7 +9908,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@graphql-tools/mock@8.7.15(graphql@15.8.0):
     resolution: {integrity: sha512-0zImG5tuObhowqtijlB6TMAIVtCIBsnGGwNW8gnCOa+xZAqfGdUMsSma17tHC2XuI7xhv7A0O8pika9e3APLUg==}
@@ -9919,7 +9919,7 @@ packages:
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       fast-json-stable-stringify: 2.1.0
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@graphql-tools/optimize@1.3.1(graphql@15.8.0):
@@ -9928,7 +9928,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/prisma-loader@7.2.54(@types/node@18.15.3)(graphql@15.8.0):
@@ -9972,7 +9972,7 @@ packages:
       '@ardatan/relay-compiler': 12.0.0(graphql@15.8.0)
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9997,7 +9997,7 @@ packages:
       '@graphql-tools/merge': 8.3.1(graphql@15.8.0)
       '@graphql-tools/utils': 8.9.0(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       value-or-promise: 1.0.11
     dev: false
 
@@ -10009,7 +10009,7 @@ packages:
       '@graphql-tools/merge': 8.3.12(graphql@15.8.0)
       '@graphql-tools/utils': 9.1.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       value-or-promise: 1.0.11
 
   /@graphql-tools/schema@9.0.13(graphql@15.8.0):
@@ -10020,7 +10020,7 @@ packages:
       '@graphql-tools/merge': 8.3.15(graphql@15.8.0)
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       value-or-promise: 1.0.12
 
   /@graphql-tools/schema@9.0.19(graphql@15.8.0):
@@ -10031,7 +10031,7 @@ packages:
       '@graphql-tools/merge': 8.4.2(graphql@15.8.0)
       '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       value-or-promise: 1.0.12
 
   /@graphql-tools/schema@9.0.4(graphql@15.8.0):
@@ -10042,7 +10042,7 @@ packages:
       '@graphql-tools/merge': 8.3.6(graphql@15.8.0)
       '@graphql-tools/utils': 8.12.0(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       value-or-promise: 1.0.11
     dev: true
 
@@ -10121,7 +10121,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/utils@8.13.1(graphql@15.8.0):
@@ -10139,7 +10139,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@graphql-tools/utils@9.1.1(graphql@15.8.0):
@@ -10148,7 +10148,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@graphql-tools/utils@9.1.4(graphql@15.8.0):
     resolution: {integrity: sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==}
@@ -10165,7 +10165,7 @@ packages:
     dependencies:
       '@graphql-typed-document-node/core': 3.1.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@graphql-tools/wrap@7.0.8(graphql@15.8.0):
     resolution: {integrity: sha512-1NDUymworsOlb53Qfh7fonDi2STvqCtbeE68ntKY9K/Ju/be2ZNxrFSbrBHwnxWcN9PjISNnLcAyJ1L5tCUyhg==}
@@ -10189,7 +10189,7 @@ packages:
       '@graphql-tools/schema': 9.0.13(graphql@15.8.0)
       '@graphql-tools/utils': 9.1.4(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.3
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     dev: true
 
@@ -12635,14 +12635,14 @@ packages:
     dependencies:
       asn1js: 3.0.5
       pvtsutils: 1.3.2
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /@peculiar/json-schema@1.1.12:
     resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /@peculiar/webcrypto@1.4.1:
@@ -12652,7 +12652,7 @@ packages:
       '@peculiar/asn1-schema': 2.3.3
       '@peculiar/json-schema': 1.1.12
       pvtsutils: 1.3.2
-      tslib: 2.6.3
+      tslib: 2.8.1
       webcrypto-core: 1.7.5
     dev: true
 
@@ -12686,7 +12686,7 @@ packages:
       open: 8.4.0
       picocolors: 1.0.0
       tiny-glob: 0.2.9
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(@types/webpack@5.28.0)(react-refresh@0.11.0)(webpack@5.88.2):
@@ -13041,20 +13041,20 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/chunked-blob-reader-native@3.0.1:
     resolution: {integrity: sha512-VEYtPvh5rs/xlyqpm5NRnfYLZn+q0SRPELbvBV+C/G7IQ+ouTuo+NKKa3ShG5OaFR8NYVMXls9hPYLTvIKKDrQ==}
     dependencies:
       '@smithy/util-base64': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/chunked-blob-reader@4.0.0:
     resolution: {integrity: sha512-jSqRnZvkT4egkq/7b6/QRCNXmmYVcHwnJldqJ3IhVpQE2atObVJ137xmGeuGFhjFUr8gCEVAOKwSY79OvpbDaQ==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/config-resolver@3.0.10:
@@ -13065,7 +13065,7 @@ packages:
       '@smithy/types': 3.6.0
       '@smithy/util-config-provider': 3.0.0
       '@smithy/util-middleware': 3.0.8
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/core@2.5.1:
@@ -13079,7 +13079,7 @@ packages:
       '@smithy/util-middleware': 3.0.8
       '@smithy/util-stream': 3.2.1
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/credential-provider-imds@3.2.5:
@@ -13090,7 +13090,7 @@ packages:
       '@smithy/property-provider': 3.1.8
       '@smithy/types': 3.6.0
       '@smithy/url-parser': 3.0.8
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/eventstream-codec@3.1.7:
@@ -13099,7 +13099,7 @@ packages:
       '@aws-crypto/crc32': 5.2.0
       '@smithy/types': 3.6.0
       '@smithy/util-hex-encoding': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/eventstream-serde-browser@3.0.11:
@@ -13108,7 +13108,7 @@ packages:
     dependencies:
       '@smithy/eventstream-serde-universal': 3.0.10
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/eventstream-serde-config-resolver@3.0.8:
@@ -13116,7 +13116,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/eventstream-serde-node@3.0.10:
@@ -13125,7 +13125,7 @@ packages:
     dependencies:
       '@smithy/eventstream-serde-universal': 3.0.10
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/eventstream-serde-universal@3.0.10:
@@ -13134,7 +13134,7 @@ packages:
     dependencies:
       '@smithy/eventstream-codec': 3.1.7
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/fetch-http-handler@3.2.9:
@@ -13144,7 +13144,7 @@ packages:
       '@smithy/querystring-builder': 3.0.8
       '@smithy/types': 3.6.0
       '@smithy/util-base64': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/fetch-http-handler@4.0.0:
@@ -13154,7 +13154,7 @@ packages:
       '@smithy/querystring-builder': 3.0.8
       '@smithy/types': 3.6.0
       '@smithy/util-base64': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/hash-blob-browser@3.1.7:
@@ -13163,7 +13163,7 @@ packages:
       '@smithy/chunked-blob-reader': 4.0.0
       '@smithy/chunked-blob-reader-native': 3.0.1
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/hash-node@3.0.8:
@@ -13173,7 +13173,7 @@ packages:
       '@smithy/types': 3.6.0
       '@smithy/util-buffer-from': 3.0.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/hash-stream-node@3.1.7:
@@ -13182,28 +13182,28 @@ packages:
     dependencies:
       '@smithy/types': 3.6.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/invalid-dependency@3.0.8:
     resolution: {integrity: sha512-7Qynk6NWtTQhnGTTZwks++nJhQ1O54Mzi7fz4PqZOiYXb4Z1Flpb2yRvdALoggTS8xjtohWUM+RygOtB30YL3Q==}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/is-array-buffer@2.2.0:
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/is-array-buffer@3.0.0:
     resolution: {integrity: sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/md5-js@3.0.8:
@@ -13211,7 +13211,7 @@ packages:
     dependencies:
       '@smithy/types': 3.6.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/middleware-content-length@3.0.10:
@@ -13220,7 +13220,7 @@ packages:
     dependencies:
       '@smithy/protocol-http': 4.1.5
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/middleware-endpoint@3.2.1:
@@ -13234,7 +13234,7 @@ packages:
       '@smithy/types': 3.6.0
       '@smithy/url-parser': 3.0.8
       '@smithy/util-middleware': 3.0.8
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/middleware-retry@3.0.25:
@@ -13248,7 +13248,7 @@ packages:
       '@smithy/types': 3.6.0
       '@smithy/util-middleware': 3.0.8
       '@smithy/util-retry': 3.0.8
-      tslib: 2.6.3
+      tslib: 2.8.1
       uuid: 9.0.1
     dev: false
 
@@ -13257,7 +13257,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/middleware-stack@3.0.8:
@@ -13265,7 +13265,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/node-config-provider@3.1.9:
@@ -13275,7 +13275,7 @@ packages:
       '@smithy/property-provider': 3.1.8
       '@smithy/shared-ini-file-loader': 3.1.9
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/node-http-handler@3.1.4:
@@ -13297,7 +13297,7 @@ packages:
       '@smithy/protocol-http': 4.1.5
       '@smithy/querystring-builder': 3.0.8
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/property-provider@3.1.8:
@@ -13305,7 +13305,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/protocol-http@4.1.5:
@@ -13313,7 +13313,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/querystring-builder@3.0.8:
@@ -13322,7 +13322,7 @@ packages:
     dependencies:
       '@smithy/types': 3.6.0
       '@smithy/util-uri-escape': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/querystring-parser@3.0.8:
@@ -13330,7 +13330,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/service-error-classification@3.0.8:
@@ -13345,7 +13345,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/signature-v4@4.2.1:
@@ -13359,7 +13359,7 @@ packages:
       '@smithy/util-middleware': 3.0.8
       '@smithy/util-uri-escape': 3.0.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/smithy-client@3.4.2:
@@ -13372,21 +13372,21 @@ packages:
       '@smithy/protocol-http': 4.1.5
       '@smithy/types': 3.6.0
       '@smithy/util-stream': 3.2.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/types@3.6.0:
     resolution: {integrity: sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@smithy/url-parser@3.0.8:
     resolution: {integrity: sha512-4FdOhwpTW7jtSFWm7SpfLGKIBC9ZaTKG5nBF0wK24aoQKQyDIKUw3+KFWCQ9maMzrgTJIuOvOnsV2lLGW5XjTg==}
     dependencies:
       '@smithy/querystring-parser': 3.0.8
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-base64@3.0.0:
@@ -13395,20 +13395,20 @@ packages:
     dependencies:
       '@smithy/util-buffer-from': 3.0.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-body-length-browser@3.0.0:
     resolution: {integrity: sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-body-length-node@3.0.0:
     resolution: {integrity: sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-buffer-from@2.2.0:
@@ -13416,7 +13416,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-buffer-from@3.0.0:
@@ -13424,14 +13424,14 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/is-array-buffer': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-config-provider@3.0.0:
     resolution: {integrity: sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-defaults-mode-browser@3.0.25:
@@ -13442,7 +13442,7 @@ packages:
       '@smithy/smithy-client': 3.4.2
       '@smithy/types': 3.6.0
       bowser: 2.11.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-defaults-mode-node@3.0.25:
@@ -13455,7 +13455,7 @@ packages:
       '@smithy/property-provider': 3.1.8
       '@smithy/smithy-client': 3.4.2
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-endpoints@2.1.4:
@@ -13464,14 +13464,14 @@ packages:
     dependencies:
       '@smithy/node-config-provider': 3.1.9
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-hex-encoding@3.0.0:
     resolution: {integrity: sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-middleware@3.0.8:
@@ -13479,7 +13479,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-retry@3.0.8:
@@ -13488,7 +13488,7 @@ packages:
     dependencies:
       '@smithy/service-error-classification': 3.0.8
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-stream@3.2.1:
@@ -13502,14 +13502,14 @@ packages:
       '@smithy/util-buffer-from': 3.0.0
       '@smithy/util-hex-encoding': 3.0.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-uri-escape@3.0.0:
     resolution: {integrity: sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-utf8@2.3.0:
@@ -13517,7 +13517,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-utf8@3.0.0:
@@ -13525,7 +13525,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/util-buffer-from': 3.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@smithy/util-waiter@3.1.7:
@@ -13534,7 +13534,7 @@ packages:
     dependencies:
       '@smithy/abort-controller': 3.1.6
       '@smithy/types': 3.6.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /@storybook/addon-actions@6.5.16(react-dom@17.0.2)(react@17.0.2):
@@ -14459,7 +14459,7 @@ packages:
       flat-cache: 3.0.4
       micromatch: 4.0.5
       react-docgen-typescript: 2.2.2(typescript@4.9.4)
-      tslib: 2.6.3
+      tslib: 2.8.1
       typescript: 4.9.4
       webpack: 5.88.2
     transitivePeerDependencies:
@@ -14967,7 +14967,7 @@ packages:
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
     dependencies:
       '@swc/counter': 0.1.3
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /@swc/plugin-emotion@2.5.120:
     resolution: {integrity: sha512-vEA0lJTzY0NUnp+INB5SGYPYGxszOOzEgs3xXg/H34ngDpJ4xftZ3LfvYGxsJD+BgpxwOPh79XSTg1NRiefCTw==}
@@ -17396,7 +17396,7 @@ packages:
     dependencies:
       pvtsutils: 1.3.2
       pvutils: 1.1.3
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /assert-plus@1.0.0:
@@ -17423,7 +17423,7 @@ packages:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /astral-regex@2.0.0:
@@ -17484,6 +17484,11 @@ packages:
 
   /attr-accept@2.2.2:
     resolution: {integrity: sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /attr-accept@2.2.5:
+    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
     engines: {node: '>=4'}
     dev: false
 
@@ -18488,7 +18493,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -18548,7 +18553,7 @@ packages:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
       upper-case-first: 2.0.2
 
   /capture-exit@2.0.0:
@@ -19226,7 +19231,7 @@ packages:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
       upper-case: 2.0.2
 
   /constants-browserify@1.0.0:
@@ -20958,7 +20963,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -22650,6 +22655,13 @@ packages:
       tslib: 2.6.3
     dev: false
 
+  /file-selector@2.1.0:
+    resolution: {integrity: sha512-ZuXAqGePcSPz4JuerOY06Dzzq0hrmQ6VGoXVzGyFI1npeOfBgqGIKKpznfYWRkSLJlXutkqVC5WvGZtkFVhu9Q==}
+    engines: {node: '>= 12'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
   /file-system-cache@1.1.0:
     resolution: {integrity: sha512-IzF5MBq+5CR0jXx5RxPe4BICl/oEhBSXKaL9fLhAXrIfIUS77Hr4vzrYyqYMHN6uTt+BOqi3fDCTjjEBCjERKw==}
     dependencies:
@@ -24128,7 +24140,7 @@ packages:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /headers-utils@3.0.2:
     resolution: {integrity: sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==}
@@ -24724,7 +24736,7 @@ packages:
       '@formatjs/ecma402-abstract': 1.18.2
       '@formatjs/fast-memoize': 2.2.0
       '@formatjs/icu-messageformat-parser': 2.7.6
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -25074,7 +25086,7 @@ packages:
   /is-lower-case@2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /is-map@2.0.2:
@@ -25314,7 +25326,7 @@ packages:
   /is-upper-case@2.0.2:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /is-utf8@0.2.1:
@@ -26937,13 +26949,13 @@ packages:
   /lower-case-first@2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /lowercase-keys@1.0.1:
     resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==}
@@ -28541,7 +28553,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -28711,7 +28723,7 @@ packages:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /path-dirname@1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
@@ -30196,7 +30208,7 @@ packages:
   /pvtsutils@1.3.2:
     resolution: {integrity: sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /pvutils@1.1.3:
@@ -30576,6 +30588,18 @@ packages:
     dependencies:
       attr-accept: 2.2.2
       file-selector: 0.6.0
+      prop-types: 15.8.1
+      react: 17.0.2
+    dev: false
+
+  /react-dropzone@14.3.5(react@17.0.2):
+    resolution: {integrity: sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.0
       prop-types: 15.8.1
       react: 17.0.2
     dev: false
@@ -31992,7 +32016,7 @@ packages:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
       upper-case-first: 2.0.2
 
   /serialize-javascript@4.0.0:
@@ -32330,7 +32354,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /snapdragon-node@2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -32537,7 +32561,7 @@ packages:
   /sponge-case@1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /sprintf-js@1.0.3:
@@ -33156,7 +33180,7 @@ packages:
   /swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /swiper@6.8.4:
@@ -33209,7 +33233,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/utils': 2.3.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: false
 
   /synthetic-dom@1.4.0:
@@ -33483,7 +33507,7 @@ packages:
   /title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /tmp-promise@3.0.3:
@@ -33884,6 +33908,9 @@ packages:
 
   /tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
+
+  /tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   /tsutils@3.21.0(typescript@4.9.4):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -34362,12 +34389,12 @@ packages:
   /upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -34855,7 +34882,7 @@ packages:
       '@peculiar/json-schema': 1.1.12
       asn1js: 3.0.5
       pvtsutils: 1.3.2
-      tslib: 2.6.3
+      tslib: 2.8.1
     dev: true
 
   /webidl-conversions@3.0.1:


### PR DESCRIPTION
## Description

### Problem

When uploading files to the DAM, they were put into a folder called ".":

### Reason

This bug only occurred in projects with a `react-dropzone` version >= 14.3.2. In [v14.3.2](https://github.com/react-dropzone/react-dropzone/releases/tag/v14.3.2), react-dropzone updated to [v2.0.0](https://github.com/react-dropzone/file-selector/releases/tag/v2.0.0) of file-selector. This version has a breaking change making file.path relative.

### Solution

We remove the `./` prefix from the path when harmonizing file.path.

## Screenshots / Screencasts

### Before

https://github.com/user-attachments/assets/d5434ae6-5ce2-4bf9-abee-c16ab7e89cb3


### After

https://github.com/user-attachments/assets/c267ddd1-7fbd-4b74-9fd7-275f4aa5854f





## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1270
