### PR TITLE
Demo Site: move admin redirect and dam rewrite into middleware

### DIFF
--- a/demo/site/next.config.js
+++ b/demo/site/next.config.js
@@ -11,28 +11,6 @@ const cometConfig = require("./src/comet-config.json");
  * @type {import('next').NextConfig}
  **/
 const nextConfig = {
-    async rewrites() {
-        return [
-            {
-                source: "/dam/:path*",
-                destination: process.env.API_URL + "/dam/:path*",
-            },
-        ];
-    },
-    async redirects() {
-        const adminUrl = process.env.ADMIN_URL;
-
-        if (!adminUrl) {
-            throw Error("ADMIN_URL is not defined");
-        }
-        return [
-            {
-                source: "/admin",
-                destination: adminUrl,
-                permanent: false,
-            },
-        ];
-    },
     images: {
         deviceSizes: cometConfig.dam.allowedImageSizes,
     },

--- a/demo/site/src/middleware.ts
+++ b/demo/site/src/middleware.ts
@@ -21,6 +21,14 @@ export async function middleware(request: NextRequest) {
         return NextResponse.rewrite(new URL(predefinedPageRewrite, request.url));
     }
 
+    if (pathname.startsWith("/dam/")) {
+        return NextResponse.rewrite(new URL(`${process.env.API_URL_INTERNAL}${request.nextUrl.pathname}`));
+    }
+
+    if (request.nextUrl.pathname === "/admin" && process.env.ADMIN_URL) {
+        return NextResponse.redirect(new URL(process.env.ADMIN_URL));
+    }
+
     return NextResponse.next();
 }
 


### PR DESCRIPTION
Accessing env vars in next.config.js doesn't work correctly when built image is deployed in different environments.

We don't deploy demo, so this is not an actual issue - still the demo implementation should be as similar as possible to real implementations