### PR TITLE
Fix collapsible menu item not opening on refresh

### DIFF
--- a/.changeset/curvy-radios-study.md
+++ b/.changeset/curvy-radios-study.md
@@ -2,4 +2,4 @@
 "@comet/admin": patch
 ---
 
-Fix collapsible menuitem not open on refresh if child selected
+Open collapsible menu item on refresh if its child or sub-child is selected

--- a/.changeset/curvy-radios-study.md
+++ b/.changeset/curvy-radios-study.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix collapsible menuitem not open on refresh if child selected

--- a/packages/admin/admin/src/mui/menu/CollapsibleItem.tsx
+++ b/packages/admin/admin/src/mui/menu/CollapsibleItem.tsx
@@ -78,6 +78,7 @@ export const MenuCollapsibleItem = (inProps: MenuCollapsibleItemProps) => {
             // child is selected
             if (checkIfPathInLocation(child)) {
                 hasSelectedChild.current = true;
+                setIsSubmenuOpen(true);
             }
 
             // sub child is selected
@@ -85,6 +86,7 @@ export const MenuCollapsibleItem = (inProps: MenuCollapsibleItemProps) => {
                 "children" in child.props ? Children.map(child?.props?.children, (child: MenuChild) => child) : ([] as MenuChild[]);
             if (subChildElements?.some((child: MenuChild) => child.props && checkIfPathInLocation(child))) {
                 hasSelectedChild.current = true;
+                setIsSubmenuOpen(true);
             }
 
             const newItemLevel = itemLevel + 1;


### PR DESCRIPTION
## Description
Fix collapsible menu-item, with child matching current url, not open on refresh