### PR TITLE
Add basic layout block

### DIFF
--- a/demo/admin/src/pages/PageContentBlock.tsx
+++ b/demo/admin/src/pages/PageContentBlock.tsx
@@ -7,6 +7,7 @@ import { SpaceBlock } from "@src/common/blocks/SpaceBlock";
 import { TextImageBlock } from "@src/common/blocks/TextImageBlock";
 import { NewsDetailBlock } from "@src/news/blocks/NewsDetailBlock";
 import { NewsListBlock } from "@src/news/blocks/NewsListBlock";
+import { LayoutBlock } from "@src/pages/blocks/LayoutBlock";
 import { userGroupAdditionalItemFields } from "@src/userGroups/userGroupAdditionalItemFields";
 import { UserGroupChip } from "@src/userGroups/UserGroupChip";
 import { UserGroupContextMenuItem } from "@src/userGroups/UserGroupContextMenuItem";
@@ -36,6 +37,7 @@ export const PageContentBlock = createBlocksBlock({
         newsDetail: NewsDetailBlock,
         imageLink: ImageLinkBlock,
         newsList: NewsListBlock,
+        layout: LayoutBlock,
     },
     additionalItemFields: {
         ...userGroupAdditionalItemFields,

--- a/demo/admin/src/pages/blocks/LayoutBlock.tsx
+++ b/demo/admin/src/pages/blocks/LayoutBlock.tsx
@@ -1,0 +1,152 @@
+import { Field } from "@comet/admin";
+import {
+    BlockCategory,
+    BlocksFinalForm,
+    ColumnsBlockLayout,
+    ColumnsLayoutPreview,
+    ColumnsLayoutPreviewContent,
+    ColumnsLayoutPreviewSpacing,
+    createCompositeBlock,
+    createCompositeSetting,
+    FinalFormLayoutSelect,
+} from "@comet/blocks-admin";
+import { LayoutBlockData } from "@src/blocks.generated";
+import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
+import { MediaBlock } from "@src/pages/blocks/MediaBlock";
+import { FormattedMessage } from "react-intl";
+
+const layoutOptions: ColumnsBlockLayout[] = [
+    {
+        name: "layout1",
+        label: <FormattedMessage id="layoutBlock.layout.layout1" defaultMessage="Layout 1" />,
+        columns: 3,
+        preview: (
+            <ColumnsLayoutPreview>
+                <ColumnsLayoutPreviewContent width={10} />
+                <ColumnsLayoutPreviewSpacing width={1} />
+                <ColumnsLayoutPreviewContent width={7} />
+                <ColumnsLayoutPreviewSpacing width={1} />
+                <ColumnsLayoutPreviewContent width={7} />
+            </ColumnsLayoutPreview>
+        ),
+    },
+    {
+        name: "layout2",
+        label: <FormattedMessage id="layoutBlock.layout.layout1" defaultMessage="Layout 2" />,
+        columns: 3,
+        preview: (
+            <ColumnsLayoutPreview>
+                <ColumnsLayoutPreviewContent width={7} />
+                <ColumnsLayoutPreviewSpacing width={1} />
+                <ColumnsLayoutPreviewContent width={10} />
+                <ColumnsLayoutPreviewSpacing width={1} />
+                <ColumnsLayoutPreviewContent width={7} />
+            </ColumnsLayoutPreview>
+        ),
+    },
+    {
+        name: "layout3",
+        label: <FormattedMessage id="layoutBlock.layout.layout1" defaultMessage="Layout 3" />,
+        columns: 3,
+        preview: (
+            <ColumnsLayoutPreview>
+                <ColumnsLayoutPreviewContent width={6} />
+                <ColumnsLayoutPreviewSpacing width={1} />
+                <ColumnsLayoutPreviewContent width={6} />
+                <ColumnsLayoutPreviewSpacing width={1} />
+                <ColumnsLayoutPreviewContent width={12} />
+            </ColumnsLayoutPreview>
+        ),
+    },
+    {
+        name: "layout4",
+        label: <FormattedMessage id="layoutBlock.layout.layout1" defaultMessage="Layout 4" />,
+        columns: 2,
+        preview: (
+            <ColumnsLayoutPreview>
+                <ColumnsLayoutPreviewContent width={14} />
+                <ColumnsLayoutPreviewSpacing width={1} />
+                <ColumnsLayoutPreviewContent width={10} />
+            </ColumnsLayoutPreview>
+        ),
+    },
+    {
+        name: "layout5",
+        label: <FormattedMessage id="layoutBlock.layout.layout1" defaultMessage="Layout 5" />,
+        columns: 2,
+        preview: (
+            <ColumnsLayoutPreview>
+                <ColumnsLayoutPreviewContent width={10} />
+                <ColumnsLayoutPreviewSpacing width={1} />
+                <ColumnsLayoutPreviewContent width={14} />
+            </ColumnsLayoutPreview>
+        ),
+    },
+    {
+        name: "layout6",
+        label: <FormattedMessage id="layoutBlock.layout.layout1" defaultMessage="Layout 6" />,
+        columns: 2,
+        preview: (
+            <ColumnsLayoutPreview>
+                <ColumnsLayoutPreviewContent width={12} />
+                <ColumnsLayoutPreviewSpacing width={1} />
+                <ColumnsLayoutPreviewContent width={12} />
+            </ColumnsLayoutPreview>
+        ),
+    },
+    {
+        name: "layout7",
+        label: <FormattedMessage id="layoutBlock.layout.layout1" defaultMessage="Layout 7" />,
+        columns: 2,
+        preview: (
+            <ColumnsLayoutPreview>
+                <ColumnsLayoutPreviewContent width={12} />
+                <ColumnsLayoutPreviewSpacing width={1} />
+                <ColumnsLayoutPreviewContent width={12} />
+            </ColumnsLayoutPreview>
+        ),
+    },
+];
+
+export const LayoutBlock = createCompositeBlock(
+    {
+        name: "Layout",
+        displayName: <FormattedMessage id="layoutBlock.displayName" defaultMessage="Layout" />,
+        blocks: {
+            layout: {
+                block: createCompositeSetting<LayoutBlockData["layout"]>({
+                    defaultValue: "layout1",
+                    AdminComponent: ({ state, updateState }) => (
+                        <BlocksFinalForm<{ layout: ColumnsBlockLayout }>
+                            onSubmit={({ layout }) => updateState(layout.name as LayoutBlockData["layout"])}
+                            initialValues={{ layout: layoutOptions.find((layout) => layout.name === state) }}
+                        >
+                            <Field name="layout" component={FinalFormLayoutSelect} layouts={layoutOptions} fullWidth />
+                        </BlocksFinalForm>
+                    ),
+                }),
+                title: <FormattedMessage id="layoutBlock.layout" defaultMessage="Layout" />,
+            },
+            media1: {
+                block: MediaBlock,
+                title: <FormattedMessage id="layoutBlock.media1" defaultMessage="Media 1" />,
+            },
+            text1: {
+                block: RichTextBlock,
+                title: <FormattedMessage id="layoutBlock.text1" defaultMessage="Text 1" />,
+            },
+            media2: {
+                block: MediaBlock,
+                title: <FormattedMessage id="layoutBlock.media2" defaultMessage="Media 2" />,
+            },
+            text2: {
+                block: RichTextBlock,
+                title: <FormattedMessage id="layoutBlock.text2" defaultMessage="Text 2" />,
+            },
+        },
+    },
+    (block) => {
+        block.category = BlockCategory.Layout;
+        return block;
+    },
+);

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -849,6 +849,89 @@
         ]
     },
     {
+        "name": "Layout",
+        "fields": [
+            {
+                "name": "layout",
+                "kind": "Enum",
+                "enum": [
+                    "layout1",
+                    "layout2",
+                    "layout3",
+                    "layout4",
+                    "layout5",
+                    "layout6",
+                    "layout7"
+                ],
+                "nullable": false
+            },
+            {
+                "name": "media1",
+                "kind": "Block",
+                "block": "Media",
+                "nullable": false
+            },
+            {
+                "name": "text1",
+                "kind": "Block",
+                "block": "RichText",
+                "nullable": false
+            },
+            {
+                "name": "media2",
+                "kind": "Block",
+                "block": "Media",
+                "nullable": false
+            },
+            {
+                "name": "text2",
+                "kind": "Block",
+                "block": "RichText",
+                "nullable": false
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "layout",
+                "kind": "Enum",
+                "enum": [
+                    "layout1",
+                    "layout2",
+                    "layout3",
+                    "layout4",
+                    "layout5",
+                    "layout6",
+                    "layout7"
+                ],
+                "nullable": false
+            },
+            {
+                "name": "media1",
+                "kind": "Block",
+                "block": "Media",
+                "nullable": false
+            },
+            {
+                "name": "text1",
+                "kind": "Block",
+                "block": "RichText",
+                "nullable": false
+            },
+            {
+                "name": "media2",
+                "kind": "Block",
+                "block": "Media",
+                "nullable": false
+            },
+            {
+                "name": "text2",
+                "kind": "Block",
+                "block": "RichText",
+                "nullable": false
+            }
+        ]
+    },
+    {
         "name": "Link",
         "fields": [
             {
@@ -1340,7 +1423,8 @@
                                 "teaser": "Teaser",
                                 "newsDetail": "NewsDetail",
                                 "imageLink": "ImageLink",
-                                "newsList": "NewsList"
+                                "newsList": "NewsList",
+                                "layout": "Layout"
                             },
                             "nullable": false
                         },
@@ -1398,7 +1482,8 @@
                                 "teaser": "Teaser",
                                 "newsDetail": "NewsDetail",
                                 "imageLink": "ImageLink",
-                                "newsList": "NewsList"
+                                "newsList": "NewsList",
+                                "layout": "Layout"
                             },
                             "nullable": false
                         },

--- a/demo/api/src/pages/blocks/layout.block.ts
+++ b/demo/api/src/pages/blocks/layout.block.ts
@@ -1,0 +1,67 @@
+import {
+    BlockData,
+    BlockDataInterface,
+    BlockField,
+    BlockInput,
+    ChildBlock,
+    ChildBlockInput,
+    createBlock,
+    ExtractBlockInput,
+    inputToData,
+} from "@comet/blocks-api";
+import { RichTextBlock } from "@src/common/blocks/rich-text.block";
+import { MediaBlock } from "@src/pages/blocks/media.block";
+import { IsEnum } from "class-validator";
+
+enum LayoutBlockLayout {
+    layout1 = "layout1",
+    layout2 = "layout2",
+    layout3 = "layout3",
+    layout4 = "layout4",
+    layout5 = "layout5",
+    layout6 = "layout6",
+    layout7 = "layout7",
+}
+
+class LayoutBlockData extends BlockData {
+    @BlockField({ type: "enum", enum: LayoutBlockLayout })
+    layout: LayoutBlockLayout;
+
+    @ChildBlock(MediaBlock)
+    media1: BlockDataInterface;
+
+    @ChildBlock(RichTextBlock)
+    text1: BlockDataInterface;
+
+    @ChildBlock(MediaBlock)
+    media2: BlockDataInterface;
+
+    @ChildBlock(RichTextBlock)
+    text2: BlockDataInterface;
+}
+
+class LayoutBlockInput extends BlockInput {
+    @IsEnum(LayoutBlockLayout)
+    @BlockField({ type: "enum", enum: LayoutBlockLayout })
+    layout: LayoutBlockLayout;
+
+    @ChildBlockInput(MediaBlock)
+    media1: ExtractBlockInput<typeof MediaBlock>;
+
+    @ChildBlockInput(RichTextBlock)
+    text1: ExtractBlockInput<typeof RichTextBlock>;
+
+    @ChildBlockInput(MediaBlock)
+    media2: ExtractBlockInput<typeof MediaBlock>;
+
+    @ChildBlockInput(RichTextBlock)
+    text2: ExtractBlockInput<typeof RichTextBlock>;
+
+    transformToBlockData(): LayoutBlockData {
+        return inputToData(LayoutBlockData, this);
+    }
+}
+
+export const LayoutBlock = createBlock(LayoutBlockData, LayoutBlockInput, {
+    name: "Layout",
+});

--- a/demo/api/src/pages/blocks/page-content.block.ts
+++ b/demo/api/src/pages/blocks/page-content.block.ts
@@ -5,6 +5,7 @@ import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { SpaceBlock } from "@src/common/blocks/space.block";
 import { NewsDetailBlock } from "@src/news/blocks/news-detail.block";
 import { NewsListBlock } from "@src/news/blocks/news-list.block";
+import { LayoutBlock } from "@src/pages/blocks/layout.block";
 import { UserGroup } from "@src/user-groups/user-group";
 import { IsEnum } from "class-validator";
 
@@ -33,6 +34,7 @@ const supportedBlocks = {
     newsDetail: NewsDetailBlock,
     imageLink: ImageLinkBlock,
     newsList: NewsListBlock,
+    layout: LayoutBlock,
 };
 
 class BlocksBlockItemData extends BaseBlocksBlockItemData(supportedBlocks) {

--- a/demo/site/src/blocks/LayoutBlock.tsx
+++ b/demo/site/src/blocks/LayoutBlock.tsx
@@ -1,0 +1,151 @@
+"use client";
+import { PropsWithData, withPreview } from "@comet/cms-site";
+import { LayoutBlockData } from "@src/blocks.generated";
+import { MediaBlock } from "@src/blocks/MediaBlock";
+import RichTextBlock from "@src/blocks/RichTextBlock";
+import styled, { css } from "styled-components";
+
+const layoutOptions: Array<{ name: LayoutBlockData["layout"]; blocks: string[] }> = [
+    {
+        name: "layout1",
+        blocks: ["media1", "text1", "media2"],
+    },
+    {
+        name: "layout2",
+        blocks: ["text1", "media2", "text2"],
+    },
+    {
+        name: "layout3",
+        blocks: ["media1", "text1", "media2"],
+    },
+    {
+        name: "layout4",
+        blocks: ["media1", "text1"],
+    },
+    {
+        name: "layout5",
+        blocks: ["text1", "media1"],
+    },
+    {
+        name: "layout6",
+        blocks: ["media1", "text1"],
+    },
+    {
+        name: "layout7",
+        blocks: ["text1", "media1"],
+    },
+];
+
+const LayoutBlock = withPreview(
+    ({ data: { layout, media1, text1, media2, text2 } }: PropsWithData<LayoutBlockData>) => {
+        const layoutVariant = layoutOptions.find((option) => option.name === layout);
+
+        const blockForKey = (key: string) =>
+            key === "media1" ? (
+                <MediaBlock data={media1} />
+            ) : key === "text1" ? (
+                <RichTextBlock data={text1} />
+            ) : key === "media2" ? (
+                <MediaBlock data={media2} />
+            ) : (
+                <RichTextBlock data={text2} />
+            );
+
+        return (
+            <Root>
+                {layoutVariant?.blocks.map((key) => (
+                    <Box key={key} $layout={layoutVariant.name}>
+                        {blockForKey(key)}
+                    </Box>
+                ))}
+            </Root>
+        );
+    },
+    { label: "Columns" },
+);
+
+const Root = styled.div`
+    display: grid;
+    grid-template-columns: repeat(24, 1fr);
+`;
+
+const Box = styled.div<{ $layout: string }>`
+    grid-column: 1 / -1;
+
+    ${({ theme }) => theme.breakpoints.b560.mediaQuery} {
+        ${({ $layout }) =>
+            $layout === "layout1" &&
+            css`
+                &:nth-child(3n + 1) {
+                    grid-column: 1 / 11;
+                }
+
+                &:nth-child(3n + 2) {
+                    grid-column: 11 / 18;
+                }
+
+                &:nth-child(3n + 3) {
+                    grid-column: 18 / -1;
+                }
+            `};
+        ${({ $layout }) =>
+            $layout === "layout2" &&
+            css`
+                &:nth-child(3n + 1) {
+                    grid-column: 1 / 8;
+                }
+
+                &:nth-child(3n + 2) {
+                    grid-column: 8 / 18;
+                }
+
+                &:nth-child(3n + 3) {
+                    grid-column: 18 / -1;
+                }
+            `};
+        ${({ $layout }) =>
+            $layout === "layout3" &&
+            css`
+                &:nth-child(3n + 1) {
+                    grid-column: 1 / 7;
+                }
+
+                &:nth-child(3n + 2) {
+                    grid-column: 7 / 13;
+                }
+
+                &:nth-child(3n + 3) {
+                    grid-column: 13 / -1;
+                }
+            `};
+        ${({ $layout }) =>
+            $layout === "layout4" &&
+            css`
+                grid-column: 1 / 15;
+
+                &:nth-child(even) {
+                    grid-column: 15 / -1;
+                }
+            `};
+        ${({ $layout }) =>
+            $layout === "layout5" &&
+            css`
+                grid-column: 1 / 11;
+
+                &:nth-child(even) {
+                    grid-column: 11 / -1;
+                }
+            `};
+        ${({ $layout }) =>
+            ($layout === "layout6" || $layout === "layout7") &&
+            css`
+                grid-column: 1 / 13;
+
+                &:nth-child(even) {
+                    grid-column: 13 / -1;
+                }
+            `};
+    }
+`;
+
+export { LayoutBlock };

--- a/demo/site/src/blocks/PageContentBlock.tsx
+++ b/demo/site/src/blocks/PageContentBlock.tsx
@@ -2,6 +2,7 @@
 import { BlocksBlock, DamVideoBlock, PropsWithData, SupportedBlocks } from "@comet/cms-site";
 import { PageContentBlockData } from "@src/blocks.generated";
 import { CookieSafeYouTubeVideoBlock } from "@src/blocks/CookieSafeYouTubeVideoBlock";
+import { LayoutBlock } from "@src/blocks/LayoutBlock";
 import { ImageLinkBlock } from "@src/documents/pages/blocks/ImageLinkBlock";
 import { TeaserBlock } from "@src/documents/pages/blocks/TeaserBlock";
 import { NewsDetailBlock } from "@src/news/blocks/NewsDetailBlock";
@@ -37,6 +38,7 @@ const supportedBlocks: SupportedBlocks = {
     newsDetail: (props) => <NewsDetailBlock data={props} />,
     imageLink: (props) => <ImageLinkBlock data={props} />,
     newsList: (props) => <NewsListBlock data={props} />,
+    layout: (props) => <LayoutBlock data={props} />,
 };
 
 export const PageContentBlock = ({ data }: PropsWithData<PageContentBlockData>) => {


### PR DESCRIPTION
## Description

Add basic layout block to show usage with current available tools.
Follow up PR will improve the block:
- https://github.com/vivid-planet/comet/pull/2699 (change sort order and hide not needed composite blocks)
- Improve FinalFormLayoutSelect options

## Screenshots/screencasts

<img width="1772" alt="Screenshot 2024-11-18 at 08 19 24" src="https://github.com/user-attachments/assets/43873921-52a0-486d-a0e5-4a584c4f55ad">