### PR TITLE
Remove `currentUser` option from `createAuthResolver`

### DIFF
--- a/.changeset/nervous-otters-hunt.md
+++ b/.changeset/nervous-otters-hunt.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": major
+---
+
+`createAuthResolver` does not support the `currentUser` config option anymore

--- a/packages/api/cms-api/src/auth/resolver/auth.resolver.ts
+++ b/packages/api/cms-api/src/auth/resolver/auth.resolver.ts
@@ -12,7 +12,6 @@ import { AccessControlServiceInterface } from "../../user-permissions/user-permi
 import { GetCurrentUser } from "../decorators/get-current-user.decorator";
 
 interface AuthResolverConfig {
-    currentUser?: Type<CurrentUser>; // TODO Remove in future version as it is not used and here for backwards compatibility
     endSessionEndpoint?: string;
     postLogoutRedirectUri?: string;
 }


### PR DESCRIPTION
Is documented since quite a long time now: https://github.com/vivid-planet/comet/pull/1683/files#diff-1875116eb2f2ab44a1643f7d354619c63f4d6c49a456b1adaa4fc27968c9a00eR55