### PR TITLE
Remove `createUserFromIdToken` from `UserPermissionsUserServiceInterface`

### DIFF
--- a/.changeset/ten-onions-wash.md
+++ b/.changeset/ten-onions-wash.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": major
+---
+
+Remove `createUserFromIdToken` from `UserPermissionsUserServiceInterface`
+
+`createUserFromRequest` (available since Comet v7.6.0) should be used instead.

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -64,7 +64,6 @@ export class UserPermissionsService {
 
     async createUser(request: Request, idToken: JwtPayload): Promise<User> {
         if (this.userService?.createUserFromRequest) return this.userService.createUserFromRequest(request, idToken);
-        if (this.userService?.createUserFromIdToken) return this.userService.createUserFromIdToken(idToken);
         if (!idToken.sub) throw new Error("JwtPayload does not contain sub.");
         return {
             id: idToken.sub,

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -35,10 +35,6 @@ export interface UserPermissionsUserServiceInterface {
     getUser: (id: string) => Promise<User> | User;
     findUsers: (args: FindUsersArgs) => Promise<Users> | Users;
     createUserFromRequest?: (request: Request, idToken: JwtPayload) => Promise<User> | User;
-    /**
-     * @deprecated TODO Remove in Comet 8
-     */
-    createUserFromIdToken?: (idToken: JwtPayload) => Promise<User> | User;
 }
 
 export interface UserPermissionsOptions {


### PR DESCRIPTION
Mention in migration guide is not necessary since this API wasn't ever used in projects and the only known implementation is already updated.