### PR TITLE
Fix broken changeset

### DIFF
--- a/.changeset/seven-wasps-jump.md
+++ b/.changeset/seven-wasps-jump.md
@@ -1,5 +1,4 @@
 ---
-"@comet/blocks-api": patch
 "@comet/cms-api": patch
 ---
 


### PR DESCRIPTION
The `@comet/blocks-api` package doesn't exist anymore in the `next` branch.