### PR TITLE
Demo Site Cache Handler: disable full route cache

### DIFF
--- a/demo/site/cache-handler.ts
+++ b/demo/site/cache-handler.ts
@@ -73,8 +73,16 @@ function parseBodyForGqlError(body: string) {
     }
 }
 
+function isCacheKeyFullRoute(key: string) {
+    //full-route-cache keys are the page url (and start with /), data caches are a hash
+    return key.startsWith("/");
+}
+
 export default class CacheHandler {
     async get(key: string): ReturnType<NextCacheHandler["get"]> {
+        if (isCacheKeyFullRoute(key)) {
+            return null;
+        }
         if (redis.status === "ready") {
             try {
                 if (CACHE_HANDLER_DEBUG) {
@@ -122,6 +130,9 @@ export default class CacheHandler {
     }
 
     async set(key: string, value: Parameters<NextCacheHandler["set"]>[1]): Promise<void> {
+        if (isCacheKeyFullRoute(key)) {
+            return;
+        }
         if (value?.kind === "FETCH") {
             const responseBody = parseBodyForGqlError(value.data.body);
             if (responseBody?.errors) {


### PR DESCRIPTION
Detect Full Route Cache by checking if the key starts with "/", as Full Route Cache keys are the page url (and start with /), data caches are a hash.

## Motivation

- We don't want to use Full Route Cache (by default) as it might be too large to fit into memory
- We don't want to make pages dynamic, as that would result in cache-control: no-store response headers as well

Based on https://github.com/vivid-planet/comet-starter/pull/522
