### PR TITLE
Demo API: Fix circular import

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -204,64 +204,6 @@ type PaginatedUserList {
   totalCount: Int!
 }
 
-type NewsComment {
-  id: ID!
-  comment: String!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-}
-
-type NewsContentScope {
-  domain: String!
-  language: String!
-}
-
-type News {
-  id: ID!
-  scope: NewsContentScope!
-  slug: String!
-  title: String!
-  status: NewsStatus!
-  date: DateTime!
-  category: NewsCategory!
-  image: DamImageBlockData!
-  content: NewsContentBlockData!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  comments: [NewsComment!]!
-  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
-}
-
-enum NewsStatus {
-  Active
-  Deleted
-}
-
-enum NewsCategory {
-  Events
-  Company
-  Awards
-}
-
-"""DamImage root block data"""
-scalar DamImageBlockData @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
-
-"""NewsContent root block data"""
-scalar NewsContentBlockData @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
-
-input DependencyFilter {
-  targetGraphqlObjectType: String
-  targetId: String
-  rootColumnName: String
-}
-
-input DependentFilter {
-  rootGraphqlObjectType: String
-  rootId: String
-  rootColumnName: String
-}
-
 type Link implements DocumentInterface {
   id: ID!
   updatedAt: DateTime!
@@ -293,6 +235,12 @@ scalar PageContentBlockData @specifiedBy(url: "http://www.ecma-international.org
 
 """Seo root block data"""
 scalar SeoBlockData @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+input DependencyFilter {
+  targetGraphqlObjectType: String
+  targetId: String
+  rootColumnName: String
+}
 
 type PageTreeNodeScope {
   domain: String!
@@ -339,6 +287,12 @@ enum UserGroup {
 }
 
 union PageContentUnion = Page | Link | PredefinedPage
+
+input DependentFilter {
+  rootGraphqlObjectType: String
+  rootId: String
+  rootColumnName: String
+}
 
 type DamScope {
   domain: String!
@@ -425,6 +379,52 @@ scalar RichTextBlockData @specifiedBy(url: "http://www.ecma-international.org/pu
 type MainMenu {
   items: [MainMenuItem!]!
 }
+
+type NewsComment {
+  id: ID!
+  comment: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+type NewsContentScope {
+  domain: String!
+  language: String!
+}
+
+type News {
+  id: ID!
+  scope: NewsContentScope!
+  slug: String!
+  title: String!
+  status: NewsStatus!
+  date: DateTime!
+  category: NewsCategory!
+  image: DamImageBlockData!
+  content: NewsContentBlockData!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  comments: [NewsComment!]!
+  dependencies(offset: Int! = 0, limit: Int! = 25, filter: DependencyFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
+}
+
+enum NewsStatus {
+  Active
+  Deleted
+}
+
+enum NewsCategory {
+  Events
+  Company
+  Awards
+}
+
+"""DamImage root block data"""
+scalar DamImageBlockData @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+"""NewsContent root block data"""
+scalar NewsContentBlockData @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 type PaginatedNews {
   nodes: [News!]!
@@ -682,11 +682,6 @@ type PaginatedDamFolders {
   totalCount: Int!
 }
 
-input NewsContentScopeInput {
-  domain: String!
-  language: String!
-}
-
 input PageTreeNodeScopeInput {
   domain: String!
   language: String!
@@ -697,6 +692,11 @@ input DamScopeInput {
 }
 
 input FooterContentScopeInput {
+  domain: String!
+  language: String!
+}
+
+input NewsContentScopeInput {
   domain: String!
   language: String!
 }

--- a/demo/api/src/news/blocks/news-link-block-transformer.service.ts
+++ b/demo/api/src/news/blocks/news-link-block-transformer.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
 
-import { News } from "../entities/news.entity";
+import type { News } from "../entities/news.entity";
 import { NewsLinkBlockData } from "./news-link.block";
 
 type TransformResponse = {
@@ -19,7 +19,7 @@ type TransformResponse = {
 
 @Injectable()
 export class NewsLinkBlockTransformerService implements BlockTransformerServiceInterface<NewsLinkBlockData, TransformResponse> {
-    constructor(@InjectRepository(News) private readonly repository: EntityRepository<News>) {}
+    constructor(@InjectRepository("News") private readonly repository: EntityRepository<News>) {}
 
     async transformToPlain(block: NewsLinkBlockData) {
         if (!block.id) {

--- a/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
+++ b/packages/api/blocks-api/src/blocks/createRichTextBlock.ts
@@ -71,6 +71,10 @@ export function createRichTextBlock<LinkBlock extends Block>(
     { link: LinkBlock, indexSearchText = true }: CreateRichTextBlockOptions,
     nameOrOptions: BlockFactoryNameOrOptions = "RichText",
 ): Block<RichTextBlockDataInterface, RichTextBlockInputInterface<ExtractBlockInput<LinkBlock>>> {
+    if (!LinkBlock) {
+        throw new Error("Provided 'link' is undefined. This is most likely due to a circular import");
+    }
+
     const blockName = typeof nameOrOptions === "string" ? nameOrOptions : nameOrOptions.name;
     const migrate = typeof nameOrOptions !== "string" && nameOrOptions.migrate ? nameOrOptions.migrate : { migrations: [], version: 0 };
 


### PR DESCRIPTION
## Description

Import chain: RichTextBlock -> LinkBlock -> NewsLinkBlock -> NewsLinkBlockTransformerService -> News -> NewsContentBlock -> RichTextBlock. Fixed by using a type import for News in NewsLinkBlockTransformerService.

## Example

-   [x] I have verified if my change requires an example

## Changeset

-   [x] I have verified if my change requires a changeset

We didn't add a changeset for #2323, so I wouldn't add one here either.
