### PR TITLE
Update all API Generator test to use `defineConfig` instead of `type: "postgresql"`

### DIFF
--- a/packages/api/cms-api/src/generator/generate-crud-dedicated-resolver-arg.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-dedicated-resolver-arg.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Property, Ref } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -38,11 +38,12 @@ describe("GenerateCrud dedicatedResolverArg", () => {
     describe("resolver class", () => {
         it("input type must not include product relation", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityProductVariant],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityProductVariant],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProductVariant"));
             const lintedOut = await lintGeneratedFiles(out);
@@ -62,11 +63,12 @@ describe("GenerateCrud dedicatedResolverArg", () => {
         });
         it("query list must include product arg", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityProductVariant],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityProductVariant],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProductVariant"));
             const lintedOut = await lintGeneratedFiles(out);
@@ -87,11 +89,12 @@ describe("GenerateCrud dedicatedResolverArg", () => {
         });
         it("create mutation must include product arg", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityProductVariant],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityProductVariant],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProductVariant"));
             const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-embeddable.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-embeddable.spec.ts
@@ -1,4 +1,5 @@
 import { BaseEntity, Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
 import { Field, InputType } from "@nestjs/graphql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
@@ -55,11 +56,12 @@ describe("GenerateCrudInputEmbedded", () => {
         let orm: MikroORM;
         beforeEach(async () => {
             LazyMetadataStorage.load();
-            orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithEmbedded, TestEmbedded],
-            });
+            orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithEmbedded, TestEmbedded],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithEmbedded"));
             lintedOut = await lintGeneratedFiles(out);
@@ -151,11 +153,12 @@ describe("GenerateCrudInputEmbedded", () => {
         let orm: MikroORM;
         beforeEach(async () => {
             LazyMetadataStorage.load();
-            orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithoutEmbedded, TestWithoutEmbedded],
-            });
+            orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithoutEmbedded, TestWithoutEmbedded],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithoutEmbedded"));
             lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-enum-array.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-enum-array.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Entity, Enum, PrimaryKey } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { Field, registerEnumType } from "@nestjs/graphql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
@@ -28,11 +28,12 @@ class TestEntity extends BaseEntity<TestEntity, "id"> {
 describe("GenerateCrudEnumArray", () => {
     it("should correctly add EnumArrayType in input type", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntity],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntity],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntity"));
         const lintedOut = await lintGeneratedFiles(out);
@@ -59,11 +60,12 @@ describe("GenerateCrudEnumArray", () => {
     });
     it("should correctly add EnumArrayType in filter type", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntity],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntity],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntity"));
         const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-enum-multi-use.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-enum-multi-use.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Entity, Enum, PrimaryKey } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { Field, registerEnumType } from "@nestjs/graphql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
@@ -34,11 +34,12 @@ const isArrayUnique = (arr: unknown[]) => Array.isArray(arr) && new Set(arr).siz
 describe("GenerateCrudEnumMultiUse", () => {
     it("should import a enum reference only once if used multiple times", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntity],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntity],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntity"));
         const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-enum-optional.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-enum-optional.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Entity, Enum, PrimaryKey } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { Field, registerEnumType } from "@nestjs/graphql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
@@ -28,11 +28,12 @@ class TestEntity extends BaseEntity<TestEntity, "id"> {
 describe("GenerateCrudEnumOptional", () => {
     it("should correctly determine enum import path", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntity],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntity],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntity"));
         const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-input-array.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input-array.spec.ts
@@ -1,4 +1,5 @@
 import { ArrayType, BaseEntity, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
 import { Field } from "@nestjs/graphql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
@@ -35,11 +36,12 @@ export class TestEntityArrayString extends BaseEntity<TestEntityArrayString, "id
 describe("GenerateCrudInputArray", () => {
     it("should support all string array variants", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntityArrayString],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntityArrayString],
+            }),
+        );
 
         const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityArrayString"));
         const lintedOutput = await lintSource(out[0].content);

--- a/packages/api/cms-api/src/generator/generate-crud-input-integer.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input-integer.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Entity, PrimaryKey, Property } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { Field, Int } from "@nestjs/graphql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
@@ -56,11 +56,12 @@ class TestEntityWithIntegerTypes extends BaseEntity<TestEntityWithIntegerTypes, 
 describe("GenerateCrudInputInteger", () => {
     it("should generate correct input type for integer values", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntityWithIntegerTypes],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntityWithIntegerTypes],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithIntegerTypes"));
         const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-input-json.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input-json.spec.ts
@@ -1,4 +1,5 @@
 import { BaseEntity, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
 import { InputType } from "@nestjs/graphql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
@@ -47,11 +48,12 @@ describe("GenerateCrudInputJson", () => {
     describe("input class literal array", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithJsonLiteralArray],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithJsonLiteralArray],
+                }),
+            );
 
             const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithJsonLiteralArray"));
             const lintedOutput = await lintSource(out[0].content);
@@ -86,11 +88,12 @@ describe("GenerateCrudInputJson", () => {
     describe("input class json object", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithJsonObject],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithJsonObject],
+                }),
+            );
 
             const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithJsonObject"));
             const lintedOutput = await lintSource(out[0].content);
@@ -124,11 +127,12 @@ describe("GenerateCrudInputJson", () => {
     describe("input class record", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithRecord],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithRecord],
+                }),
+            );
 
             const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithRecord"));
             const lintedOutput = await lintSource(out[0].content);

--- a/packages/api/cms-api/src/generator/generate-crud-input-relations.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input-relations.spec.ts
@@ -1,4 +1,5 @@
 import { BaseEntity, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Ref } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -26,11 +27,12 @@ export class Product extends BaseEntity<Product, "id"> {
 describe("GenerateCrudInputRelations", () => {
     it("n:1 input dto should contain relation id", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [Product, ProductCategory],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [Product, ProductCategory],
+            }),
+        );
 
         const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("Product"));
         const lintedOutput = await lintSource(out[0].content);
@@ -58,11 +60,12 @@ describe("GenerateCrudInputRelations", () => {
 
     it("1:n input dto should contain relation id", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [Product, ProductCategory],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [Product, ProductCategory],
+            }),
+        );
 
         const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("ProductCategory"));
         const lintedOutput = await lintSource(out[0].content);

--- a/packages/api/cms-api/src/generator/generate-crud-input-validators.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input-validators.spec.ts
@@ -1,4 +1,5 @@
 import { BaseEntity, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import {
     IsEmail,
@@ -94,11 +95,12 @@ describe("GenerateDefinedValidatorDecorators", () => {
     describe("simple validator", () => {
         it("should set IsEmail decorator", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithEmail],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithEmail],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithEmail"));
             const lintedOut = await lintGeneratedFiles(out);
@@ -129,11 +131,12 @@ describe("GenerateDefinedValidatorDecorators", () => {
         describe("case sensitive validator", () => {
             it("should set IsISO8601 decorator", async () => {
                 LazyMetadataStorage.load();
-                const orm = await MikroORM.init({
-                    type: "postgresql",
-                    dbName: "test-db",
-                    entities: [TestEntityWithCaseSensitiveConstraintName],
-                });
+                const orm = await MikroORM.init(
+                    defineConfig({
+                        dbName: "test-db",
+                        entities: [TestEntityWithCaseSensitiveConstraintName],
+                    }),
+                );
 
                 const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithCaseSensitiveConstraintName"));
                 const lintedOut = await lintGeneratedFiles(out);
@@ -164,11 +167,12 @@ describe("GenerateDefinedValidatorDecorators", () => {
         describe("shortened decorator name", () => {
             it("should set Length decorator", async () => {
                 LazyMetadataStorage.load();
-                const orm = await MikroORM.init({
-                    type: "postgresql",
-                    dbName: "test-db",
-                    entities: [TestEntityWithShortenedDecoratorName],
-                });
+                const orm = await MikroORM.init(
+                    defineConfig({
+                        dbName: "test-db",
+                        entities: [TestEntityWithShortenedDecoratorName],
+                    }),
+                );
 
                 const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithShortenedDecoratorName"));
                 const lintedOut = await lintGeneratedFiles(out);
@@ -199,11 +203,12 @@ describe("GenerateDefinedValidatorDecorators", () => {
         describe("decorator with arguments", () => {
             it("should set defined arguments", async () => {
                 LazyMetadataStorage.load();
-                const orm = await MikroORM.init({
-                    type: "postgresql",
-                    dbName: "test-db",
-                    entities: [TestEntityWithShortenedDecoratorName],
-                });
+                const orm = await MikroORM.init(
+                    defineConfig({
+                        dbName: "test-db",
+                        entities: [TestEntityWithShortenedDecoratorName],
+                    }),
+                );
 
                 const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithShortenedDecoratorName"));
                 const lintedOut = await lintGeneratedFiles(out);
@@ -235,11 +240,12 @@ describe("GenerateDefinedValidatorDecorators", () => {
         describe("relative path", () => {
             it("should set IsValidRedirectSource decorator", async () => {
                 LazyMetadataStorage.load();
-                const orm = await MikroORM.init({
-                    type: "postgresql",
-                    dbName: "test-db",
-                    entities: [TestEntityWithRelativeImportDecorator],
-                });
+                const orm = await MikroORM.init(
+                    defineConfig({
+                        dbName: "test-db",
+                        entities: [TestEntityWithRelativeImportDecorator],
+                    }),
+                );
 
                 const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithRelativeImportDecorator"));
                 const lintedOut = await lintGeneratedFiles(out);
@@ -271,11 +277,12 @@ describe("GenerateDefinedValidatorDecorators", () => {
     describe("validator defined in file", () => {
         it("should set IsTrueAsString decorator", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithValidatorDefinedInFile],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithValidatorDefinedInFile],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithValidatorDefinedInFile"));
             const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-input.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.spec.ts
@@ -1,4 +1,5 @@
 import { BaseEntity, DateType, Entity, Enum, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
 import { Field, ObjectType, registerEnumType } from "@nestjs/graphql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
@@ -90,11 +91,12 @@ describe("GenerateCrudInput", () => {
     describe("string input class", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithString],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithString],
+                }),
+            );
 
             const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithString"));
             //console.log(out);
@@ -124,11 +126,12 @@ describe("GenerateCrudInput", () => {
     describe("date input class", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithDate],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithDate],
+                }),
+            );
             const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithDate"));
             //console.log(out);
             const lintedOutput = await lintSource(out[0].content);
@@ -158,11 +161,12 @@ describe("GenerateCrudInput", () => {
     describe("boolean input class", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithBoolean],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithBoolean],
+                }),
+            );
             const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithBoolean"));
             //console.log(out);
             const lintedOutput = await lintSource(out[0].content);
@@ -193,11 +197,12 @@ describe("GenerateCrudInput", () => {
     describe("enum input class", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithEnum],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithEnum],
+                }),
+            );
             const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithEnum"));
             const lintedOutput = await lintSource(out[0].content);
             //console.log(lintedOutput);
@@ -228,11 +233,12 @@ describe("GenerateCrudInput", () => {
     describe("uuid input class", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithUuid],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithUuid],
+                }),
+            );
             const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithUuid"));
             const lintedOutput = await lintSource(out[0].content);
             //console.log(lintedOutput);
@@ -263,11 +269,12 @@ describe("GenerateCrudInput", () => {
     describe("text type input class", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithTextRuntimeType],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithTextRuntimeType],
+                }),
+            );
             const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithTextRuntimeType"));
             const lintedOutput = await lintSource(out[0].content);
             //console.log(lintedOutput);
@@ -298,11 +305,12 @@ describe("GenerateCrudInput", () => {
     describe("nullable props input class with initializer", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithNullablePropWithInitializer],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithNullablePropWithInitializer],
+                }),
+            );
             const out = await generateCrudInput(
                 { targetDirectory: __dirname },
                 orm.em.getMetadata().get("TestEntityWithNullablePropWithInitializer"),
@@ -343,11 +351,12 @@ describe("GenerateCrudInput", () => {
     describe("nullable props input class without initializer", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithNullablePropWithoutInitializer],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithNullablePropWithoutInitializer],
+                }),
+            );
             const out = await generateCrudInput(
                 { targetDirectory: __dirname },
                 orm.em.getMetadata().get("TestEntityWithNullablePropWithoutInitializer"),

--- a/packages/api/cms-api/src/generator/generate-crud-position.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-position.spec.ts
@@ -1,4 +1,5 @@
 import { BaseEntity, Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
 import { Field, Int } from "@nestjs/graphql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { Min } from "class-validator";
@@ -57,11 +58,12 @@ class TestEntityWithPositionGroup extends BaseEntity<TestEntityWithPositionGroup
 describe("GenerateCrudPosition", () => {
     it("input should contain optional position with Int and Min(1)", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntityWithPositionField],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntityWithPositionField],
+            }),
+        );
 
         const out = await generateCrudInput({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithPositionField"));
         const lintedOutput = await lintSource(out[0].content);
@@ -94,11 +96,12 @@ describe("GenerateCrudPosition", () => {
     });
     it("service should implement position-functions", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntityWithPositionField],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntityWithPositionField],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithPositionField"));
         const file = out.find((file) => file.name == "test-entity-with-position-fields.service.ts");
@@ -128,11 +131,12 @@ describe("GenerateCrudPosition", () => {
     });
     it("service should implement getPositionGroupCondition-function if scope existent", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntityWithPositionFieldAndScope, TestEntityWithPositionGroup],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntityWithPositionFieldAndScope, TestEntityWithPositionGroup],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithPositionFieldAndScope"));
         const file = out.find((file) => file.name == "test-entity-with-position-field-and-scopes.service.ts");
@@ -156,11 +160,12 @@ describe("GenerateCrudPosition", () => {
     });
     it("service should implement getPositionGroupCondition-function if configured", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntityWithPositionGroup],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntityWithPositionGroup],
+            }),
+        );
 
         const out = await generateCrud(
             { targetDirectory: __dirname, position: { groupByFields: ["country"] } },

--- a/packages/api/cms-api/src/generator/generate-crud-relation-many-to-many.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relation-many-to-many.spec.ts
@@ -1,4 +1,5 @@
 import { BaseEntity, Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Ref, types } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -44,11 +45,12 @@ describe("GenerateCrud Relation n:m with additional column", () => {
     let orm: MikroORM;
     beforeEach(async () => {
         LazyMetadataStorage.load();
-        orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [Product, ProductToCategory, Category],
-        });
+        orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [Product, ProductToCategory, Category],
+            }),
+        );
 
         const out = await generateCrud(
             { targetDirectory: __dirname, create: false, update: true, delete: false },

--- a/packages/api/cms-api/src/generator/generate-crud-relations-id-integer.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-id-integer.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Ref } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -40,11 +40,12 @@ describe("GenerateCrudRelationsIdNumber", () => {
     describe("resolver class", () => {
         it("input type to category relation with primary key type integer should be number with integer validator", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityCategoryWithIntegerId, TestEntityCategoryWithIntId],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityCategoryWithIntegerId, TestEntityCategoryWithIntId],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProduct"));
             const lintedOut = await lintGeneratedFiles(out);
@@ -71,11 +72,12 @@ describe("GenerateCrudRelationsIdNumber", () => {
 
         it("input type to category relation with primary key type int should be number with integer validator", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityCategoryWithIntegerId, TestEntityCategoryWithIntId],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityCategoryWithIntegerId, TestEntityCategoryWithIntId],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProduct"));
             const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-relations-id-string.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-id-string.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Ref } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -28,11 +28,12 @@ describe("GenerateCrudRelationsIdString", () => {
     describe("resolver class", () => {
         it("input type to category relation should be string with isString and not IsUuid validator", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityCategoryWithStringId],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityCategoryWithStringId],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProduct"));
             const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-relations-multi-use.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-multi-use.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Ref } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -35,11 +35,12 @@ const isArrayUnique = (arr: unknown[]) => Array.isArray(arr) && new Set(arr).siz
 describe("GenerateCrudRelationsMultiUse", () => {
     it("should import a relation reference only once if used multiple times", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntityCategory, TestEntitiyProduct],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntityCategory, TestEntitiyProduct],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntitiyProduct"));
         const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-relations-nested.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-nested.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Property, Ref } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -34,11 +34,12 @@ describe("GenerateCrudRelationsNested", () => {
     describe("resolver class", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityVariant],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityVariant],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProduct"));
             const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-relations-two-levels.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations-two-levels.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property, Ref } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -45,11 +45,12 @@ class Product extends BaseEntity<Product, "id"> {
 describe("generate-crud relations two levels", () => {
     it("should be a valid generated ts file", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [Product, ProductData, ProductVariant],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [Product, ProductData, ProductVariant],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("Product"));
         const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-relations.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-relations.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Property, Ref } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -50,11 +50,12 @@ describe("GenerateCrudRelations", () => {
     describe("resolver class", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityCategory],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityCategory],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProduct"));
             const lintedOut = await lintGeneratedFiles(out);
@@ -78,11 +79,12 @@ describe("GenerateCrudRelations", () => {
 
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityCategory],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityCategory],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityCategory"));
             const lintedOut = await lintGeneratedFiles(out);
@@ -106,11 +108,12 @@ describe("GenerateCrudRelations", () => {
 
         it("input type to category relation should be string with uuid validator", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityCategory],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityCategory],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProduct"));
             const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-resolve-field.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-resolve-field.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, Entity, ManyToMany, PrimaryKey } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -36,11 +36,12 @@ describe("GenerateCrudResolveField", () => {
     describe("Resolve field", () => {
         it("should not include categories in resolver", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityProduct, TestEntityCategory],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityProduct, TestEntityCategory],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityProduct"));
             const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-resolve-id-integer.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-resolve-id-integer.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Entity, PrimaryKey } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 
 import { generateCrud } from "./generate-crud";
@@ -14,11 +14,12 @@ class TestEntityWithIntegerId extends BaseEntity<TestEntityWithIntegerId, "id"> 
 describe("GenerateCrudResolveIdInteger", () => {
     it("should generate item resolver with correctly typed id parameter", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntityWithIntegerId],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntityWithIntegerId],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithIntegerId"));
         const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-scope.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-scope.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Embeddable, Embedded, Entity, PrimaryKey, Property } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -23,11 +23,12 @@ export class TestEntityWithScopedEntity extends BaseEntity<TestEntityWithScopedE
 describe("GenerateCrud with ScopedEntity", () => {
     it("resolver must not have skipScopeCheck", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntityWithScopedEntity],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntityWithScopedEntity],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithScopedEntity"));
         const lintedOut = await lintGeneratedFiles(out);
@@ -66,11 +67,12 @@ export class TestEntityWithScope extends BaseEntity<TestEntityWithScope, "id"> {
 describe("GenerateCrud with Scope", () => {
     it("resolver must not have skipScopeCheck", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntityWithScope],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntityWithScope],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithScope"));
         const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud-update-status.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-update-status.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Entity, Enum, PrimaryKey, Property } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { Field, registerEnumType } from "@nestjs/graphql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
@@ -34,11 +34,12 @@ describe("GenerateCrud Status with active", () => {
     let orm: MikroORM;
     beforeAll(async () => {
         LazyMetadataStorage.load();
-        orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntity1],
-        });
+        orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntity1],
+            }),
+        );
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntity1"));
         lintedOut = await lintGeneratedFiles(out);
     });
@@ -126,11 +127,12 @@ describe("GenerateCrud Status with published/unpublished", () => {
     let orm: MikroORM;
     beforeAll(async () => {
         LazyMetadataStorage.load();
-        orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntity2],
-        });
+        orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntity2],
+            }),
+        );
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntity2"));
         lintedOut = await lintGeneratedFiles(out);
     });
@@ -189,11 +191,12 @@ describe("GenerateCrud Status with published/unpublished", () => {
     let orm: MikroORM;
     beforeAll(async () => {
         LazyMetadataStorage.load();
-        orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntity3],
-        });
+        orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntity3],
+            }),
+        );
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntity3"));
         lintedOut = await lintGeneratedFiles(out);
     });

--- a/packages/api/cms-api/src/generator/generate-crud-without-find.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-without-find.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Embeddable, Embedded, Entity, PrimaryKey, Property } from "@mikro-orm/core";
-import { MikroORM } from "@mikro-orm/postgresql";
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -24,11 +24,12 @@ export class TestEntity extends BaseEntity<TestEntity, "id"> {
 describe("GenerateCrud without find condition", () => {
     it("where should be typed as ObjectQuery as it is when findCondition is used", async () => {
         LazyMetadataStorage.load();
-        const orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntity, TestEntityScope],
-        });
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntity, TestEntityScope],
+            }),
+        );
 
         const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntity"));
         const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/generator/generate-crud.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud.spec.ts
@@ -1,4 +1,5 @@
 import { BaseEntity, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { v4 as uuid } from "uuid";
 
@@ -36,11 +37,12 @@ describe("GenerateCrud", () => {
     describe("resolver class", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithString],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithString],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithString"));
             const lintedOut = await lintGeneratedFiles(out);
@@ -67,11 +69,12 @@ describe("GenerateCrud", () => {
     describe("string filter", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithString],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithString],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithString"));
             const lintedOut = await lintGeneratedFiles(out);
@@ -101,11 +104,12 @@ describe("GenerateCrud", () => {
     describe("number filter", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithNumber],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithNumber],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithNumber"));
             const lintedOut = await lintGeneratedFiles(out);
@@ -135,11 +139,12 @@ describe("GenerateCrud", () => {
     describe("text type filter", () => {
         it("should be a valid generated ts file", async () => {
             LazyMetadataStorage.load();
-            const orm = await MikroORM.init({
-                type: "postgresql",
-                dbName: "test-db",
-                entities: [TestEntityWithTextRuntimeType],
-            });
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    entities: [TestEntityWithTextRuntimeType],
+                }),
+            );
 
             const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithTextRuntimeType"));
             const lintedOut = await lintGeneratedFiles(out);

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
@@ -1,5 +1,6 @@
 import { createMock } from "@golevelup/ts-jest";
 import { BaseEntity, Entity, MikroORM, PrimaryKey } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
 import { ExecutionContext } from "@nestjs/common";
 import { ModuleRef, Reflector } from "@nestjs/core";
 
@@ -66,13 +67,14 @@ describe("UserPermissionsGuard", () => {
 
     beforeEach(async () => {
         reflector = new Reflector();
-        orm = await MikroORM.init({
-            type: "postgresql",
-            dbName: "test-db",
-            entities: [TestEntity],
-            connect: false,
-            allowGlobalContext: true,
-        });
+        orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                entities: [TestEntity],
+                connect: false,
+                allowGlobalContext: true,
+            }),
+        );
         moduleRef = createMock<ModuleRef>();
         contentScopeService = new ContentScopeService(reflector, orm, moduleRef);
         accessControlService = new AccessControlService();


### PR DESCRIPTION
The option has been previously deprecated and is removed in MikroORM v6.
