### PR TITLE
Remove type grouping in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,6 @@
     "extends": ["config:recommended", ":semanticCommitsDisabled"],
     "packageRules": [
         {
-            "groupName": "types",
-            "matchPackageNames": ["/@types/*/"]
-        },
-        {
             "groupName": "babel",
             "matchPackageNames": ["/@babel/*/"]
         },


### PR DESCRIPTION
type groupings can lead to unintended groupings