### PR TITLE
Rename docs script to dev:docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "dev:demo:admin": "dev-pm start @demo-admin",
         "dev:demo:api": "dev-pm start @demo-api",
         "dev:demo:site": "dev-pm start @demo-site",
+        "dev:docs": "dev-pm start docs",
         "postinstall": "husky install",
         "intl:extract": "formatjs extract './packages/admin/**/*.ts*' --out-file 'lang/en.json' --ignore './**.d.ts' --ignore './**.d.ts.map' --format simple --throws",
         "lint": "pnpm lint:root && pnpm recursive run lint",
@@ -29,7 +30,6 @@
         "lint:eslint": "pnpm recursive run lint:eslint",
         "lint:tsc": "pnpm recursive run lint:tsc",
         "storybook": "dev-pm start storybook",
-        "docs": "dev-pm start docs",
         "test": "pnpm recursive run test",
         "version": "$npm_execpath changeset version && pnpm install --lockfile-only",
         "publish": "pnpm run build:packages && $npm_execpath changeset publish"


### PR DESCRIPTION
## Description

refactor `docs` script to `dev:docs`.

Even though `pnpm run docs` started the actual script in the package json.

Currently `pnpm docs` opens Github documentation which is quite irritating, because in the package json the `docs` script does not get started.



New Behaviour:
`pnpm docs` -> open Github documentation of comet
`pnpm dev:docs`  starts documentation process (docusaurus)