### PR TITLE
DAM: Fix/set cache-control headers (v6)

### DIFF
--- a/.changeset/real-lizards-drum.md
+++ b/.changeset/real-lizards-drum.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-api": patch
+---
+
+DAM: Fix/set cache-control headers
+
+-   Public endpoints should cache files for 1 day
+-   Private endpoints should cache files for 1 year - but only in local caches (not CDN)

--- a/packages/api/cms-api/src/dam/files/files.controller.ts
+++ b/packages/api/cms-api/src/dam/files/files.controller.ts
@@ -107,7 +107,7 @@ export function createFilesController({ Scope: PassedScope }: { Scope?: Type<Dam
                 throw new ForbiddenException();
             }
 
-            return this.streamFile(file, res, { range, overrideHeaders: { "Cache-control": "private" } });
+            return this.streamFile(file, res, { range, overrideHeaders: { "cache-control": "max-age=31536000, private" } }); // Local caches only (1 year)
         }
 
         @Get(`/download/preview/${fileUrl}`)
@@ -128,7 +128,7 @@ export function createFilesController({ Scope: PassedScope }: { Scope?: Type<Dam
             }
 
             res.setHeader("Content-Disposition", "attachment");
-            return this.streamFile(file, res, { range, overrideHeaders: { "Cache-control": "private" } });
+            return this.streamFile(file, res, { range, overrideHeaders: { "cache-control": "max-age=31536000, private" } }); // Local caches only (1 year)
         }
 
         @DisableGlobalGuard()
@@ -152,7 +152,7 @@ export function createFilesController({ Scope: PassedScope }: { Scope?: Type<Dam
             }
 
             res.setHeader("Content-Disposition", "attachment");
-            return this.streamFile(file, res, { range });
+            return this.streamFile(file, res, { range, overrideHeaders: { "cache-control": "max-age=86400, public" } }); // Public cache (1 day)
         }
 
         @DisableGlobalGuard()
@@ -175,7 +175,7 @@ export function createFilesController({ Scope: PassedScope }: { Scope?: Type<Dam
                 throw new NotFoundException();
             }
 
-            return this.streamFile(file, res, { range });
+            return this.streamFile(file, res, { range, overrideHeaders: { "cache-control": "max-age=86400, public" } }); // Public cache (1 day)
         }
 
         private checkCdnOrigin(incomingCdnOriginHeader: string): void {

--- a/packages/api/cms-api/src/dam/images/images.controller.ts
+++ b/packages/api/cms-api/src/dam/images/images.controller.ts
@@ -76,7 +76,7 @@ export class ImagesController {
         }
 
         return this.getCroppedImage(file, params, accept, res, {
-            "cache-control": "private",
+            "cache-control": "max-age=31536000, private", // Local caches only (1 year)
         });
     }
 
@@ -102,7 +102,7 @@ export class ImagesController {
         }
 
         return this.getCroppedImage(file, params, accept, res, {
-            "cache-control": "private",
+            "cache-control": "max-age=31536000, private", // Local caches only (1 year)
         });
     }
 
@@ -126,7 +126,9 @@ export class ImagesController {
             throw new NotFoundException();
         }
 
-        return this.getCroppedImage(file, params, accept, res);
+        return this.getCroppedImage(file, params, accept, res, {
+            "cache-control": "max-age=86400, public", // Public cache (1 day)
+        });
     }
 
     @DisableGlobalGuard()
@@ -149,7 +151,9 @@ export class ImagesController {
             throw new NotFoundException();
         }
 
-        return this.getCroppedImage(file, params, accept, res);
+        return this.getCroppedImage(file, params, accept, res, {
+            "cache-control": "max-age=86400, public", // Public cache (1 day)
+        });
     }
 
     private isValidHash({ hash, ...imageParams }: HashImageParams): boolean {


### PR DESCRIPTION
Backport of https://github.com/vivid-planet/comet/pull/2653

---

As far as I've seen this was only merged in main and backported to v5, but not v6