### PR TITLE
Fix showing only the first story in docs

### DIFF
--- a/storybook/src/docs/components/AppHeader/AppHeader.mdx
+++ b/storybook/src/docs/components/AppHeader/AppHeader.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as AppHeaderStories from "./AppHeader.stories";
 
@@ -11,9 +11,7 @@ It should contain the controls for the main-menu and other commonly needed actio
 
 _**Note:** When using the component inside `MasterLayout`, the props `position` and `headerHeight` should not be set, they may only be useful, if the component is used on it's own._
 
-<Canvas>
-    <Story of={AppHeaderStories.Basic} />
-</Canvas>
+<Canvas of={AppHeaderStories.Basic} />
 
 ## Components
 
@@ -29,52 +27,36 @@ The AppHeader system consists of multiple basic components that can be combined 
 
 `AppHeader` gives you a blank header, to which you can add things like a menu-button, a application-specific logo and buttons to the `children`.
 
-<Canvas>
-    <Story of={AppHeaderStories.Empty} />
-</Canvas>
+<Canvas of={AppHeaderStories.Empty} />
 
 ### AppHeaderMenuButton
 
 `AppHeaderMenuButton` will give you the default menu-button.
 Optionally you can add a custom icon as `children` or add a custom `onClick` if you want it to do something other than toggling the menu in `MasterLayout`.
 
-<Canvas>
-    <Story of={AppHeaderStories.MenuButton} />
-</Canvas>
+<Canvas of={AppHeaderStories.MenuButton} />
 
 ### AppHeaderFillSpace
 
 The `AppHeaderFillSpace` component is used to separate the left and right elements of the `AppHeader` children.
 Basically everything after `AppHeaderFillSpace` is pushed to the right of the `AppHeader`.
 
-<Canvas>
-    <Story of={AppHeaderStories.FillSpace} />
-</Canvas>
+<Canvas of={AppHeaderStories.FillSpace} />
 
 ### AppHeaderButton
 
 `AppHeaderButton` should generally be used for buttons on the right side of the `AppHeader`.
 
-<Canvas>
-    <Story of={AppHeaderStories.ButtonText} />
-</Canvas>
+<Canvas of={AppHeaderStories.ButtonText} />
 
-<Canvas>
-    <Story of={AppHeaderStories.ButtonTextAndIcon} />
-</Canvas>
+<Canvas of={AppHeaderStories.ButtonTextAndIcon} />
 
-<Canvas>
-    <Story of={AppHeaderStories.ButtonIcon} />
-</Canvas>
+<Canvas of={AppHeaderStories.ButtonIcon} />
 
-<Canvas>
-    <Story of={AppHeaderStories.CustomButton} />
-</Canvas>
+<Canvas of={AppHeaderStories.CustomButton} />
 
 ### AppHeaderDropdown
 
 `AppHeaderDropdown` can be used for dropdown menus or other dropdown content.
 
-<Canvas>
-    <Story of={AppHeaderStories.Dropdown} />
-</Canvas>
+<Canvas of={AppHeaderStories.Dropdown} />

--- a/storybook/src/docs/components/ClearInputAdornment/ClearInputAdornment.mdx
+++ b/storybook/src/docs/components/ClearInputAdornment/ClearInputAdornment.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as ClearInputAdornmentStories from "./ClearInputAdornment.stories";
 
@@ -9,14 +9,10 @@ import * as ClearInputAdornmentStories from "./ClearInputAdornment.stories";
 `ClearInputAdornment` adds a button to clear the value of an input field.<br />
 It is based on and therefore used the same way as [MuiInputAdornment](https://mui.com/api/input-adornment/).
 
-<Canvas>
-    <Story of={ClearInputAdornmentStories.Basic} />
-</Canvas>
+<Canvas of={ClearInputAdornmentStories.Basic} />
 
 ## Existing `clearable` prop
 
 Many components in Comet Admin already implement the ClearInputAdornment. It can be enabled with the `clearable` prop.
 
-<Canvas>
-    <Story of={ClearInputAdornmentStories.ClearableProp} />
-</Canvas>
+<Canvas of={ClearInputAdornmentStories.ClearableProp} />

--- a/storybook/src/docs/components/ClearInputButton/ClearInputButton.mdx
+++ b/storybook/src/docs/components/ClearInputButton/ClearInputButton.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as ClearInputButtonStories from "./ClearInputButton.stories";
 
@@ -10,26 +10,18 @@ The ClearInputButton is a Button which is used inside a clearable Input Field. I
 The ClearInputButton extends the props from the [Material UI ButtonBase](https://mui.com/api/button-base/) component with the `icon` prop.
 It lets you specify which ClearIcon you want to display.
 
-<Canvas>
-    <Story of={ClearInputButtonStories.Default} />
-</Canvas>
+<Canvas of={ClearInputButtonStories.Default} />
 
 ## Examples
 
 ### Clearable Input Field
 
-<Canvas>
-    <Story of={ClearInputButtonStories.ClearableInputField} />
-</Canvas>
+<Canvas of={ClearInputButtonStories.ClearableInputField} />
 
 ### Disabled Clear InputButton
 
-<Canvas>
-    <Story of={ClearInputButtonStories.Disabled} />
-</Canvas>
+<Canvas of={ClearInputButtonStories.Disabled} />
 
 ### Custom Clear Icon
 
-<Canvas>
-    <Story of={ClearInputButtonStories.CustomClearIcon} />
-</Canvas>
+<Canvas of={ClearInputButtonStories.CustomClearIcon} />

--- a/storybook/src/docs/components/ColorPicker/ColorPicker.mdx
+++ b/storybook/src/docs/components/ColorPicker/ColorPicker.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as ColorPickerStories from "./ColorPicker.stories";
 
@@ -12,18 +12,12 @@ _Note: For use inside forms built with final-form, use the `FinalFormColorPicker
 
 ## Normal Usage
 
-<Canvas>
-    <Story of={ColorPickerStories.Basic} />
-</Canvas>
+<Canvas of={ColorPickerStories.Basic} />
 
 ## Usage Inside FinalForm
 
-<Canvas>
-    <Story of={ColorPickerStories.FinalForm} />
-</Canvas>
+<Canvas of={ColorPickerStories.FinalForm} />
 
 ## Customization
 
-<Canvas>
-    <Story of={ColorPickerStories.Customized} />
-</Canvas>
+<Canvas of={ColorPickerStories.Customized} />

--- a/storybook/src/docs/components/ContentOverflow/ContentOverflow.mdx
+++ b/storybook/src/docs/components/ContentOverflow/ContentOverflow.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as ContentOverflowStories from "./ContentOverflow.stories";
 
@@ -26,12 +26,8 @@ If used outside a `DataGrid`, the height must be limited by a parent container, 
 
 ## Basic Usage
 
-<Canvas>
-    <Story of={ContentOverflowStories.BasicUsage} />
-</Canvas>
+<Canvas of={ContentOverflowStories.BasicUsage} />
 
 ## Usage inside `DataGrid`
 
-<Canvas>
-    <Story of={ContentOverflowStories.InDataGrid} />
-</Canvas>
+<Canvas of={ContentOverflowStories.InDataGrid} />

--- a/storybook/src/docs/components/CopyToClipboardButton/CopyToClipboardButton.mdx
+++ b/storybook/src/docs/components/CopyToClipboardButton/CopyToClipboardButton.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as CopyToClipboardButtonStories from "./CopyToClipboardButton.stories";
 
@@ -8,6 +8,4 @@ import * as CopyToClipboardButtonStories from "./CopyToClipboardButton.stories";
 
 A user-friendly way for the user to copy a string to the clipboard.
 
-<Canvas>
-    <Story of={CopyToClipboardButtonStories.Basic} />
-</Canvas>
+<Canvas of={CopyToClipboardButtonStories.Basic} />

--- a/storybook/src/docs/components/DataGrid/DataGrid.mdx
+++ b/storybook/src/docs/components/DataGrid/DataGrid.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as DataGridStories from "./DataGrid.stories";
 
@@ -29,21 +29,15 @@ It's up to the application code to pass filterModel, sortModel and page/pageSize
 
 #### Example
 
-<Canvas>
-    <Story of={DataGridStories.UseDataGridRemote} />
-</Canvas>
+<Canvas of={DataGridStories.UseDataGridRemote} />
 
 #### Example Initial Sort
 
-<Canvas>
-    <Story of={DataGridStories.UseDataGridRemoteInitialSort} />
-</Canvas>
+<Canvas of={DataGridStories.UseDataGridRemoteInitialSort} />
 
 #### Example Initial Filter
 
-<Canvas>
-    <Story of={DataGridStories.UseDataGridRemoteInitialFilter} />
-</Canvas>
+<Canvas of={DataGridStories.UseDataGridRemoteInitialFilter} />
 
 ## usePersistentColumnState
 
@@ -64,9 +58,7 @@ Supported states:
 
 #### Example
 
-<Canvas>
-    <Story of={DataGridStories.UsePersistentColumnState} />
-</Canvas>
+<Canvas of={DataGridStories.UsePersistentColumnState} />
 
 ## useBufferedRowCount
 
@@ -85,9 +77,7 @@ Hook for excel export functionality. To use it, the following steps are necessar
 
 Typical Usage Example:
 
-<Canvas>
-    <Story of={DataGridStories.UseDataGridExcelExport} />
-</Canvas>
+<Canvas of={DataGridStories.UseDataGridExcelExport} />
 
 ## Responsive column visibility
 
@@ -101,17 +91,13 @@ When defining the columns, use the `GridColDef` type from `@comet/admin` instead
 In this example, the `First name` and `Last name` columns are combined into a single `Full name` column when the screen size is below 900px.
 Since the `ID` column has no `visible` setting, it will always be shown.
 
-<Canvas>
-    <Story of={DataGridStories.ResponsiveColumns} />
-</Canvas>
+<Canvas of={DataGridStories.ResponsiveColumns} />
 
 ## GridFilterButton
 
 Small Component that can be placed in the Toolbar that will show the Filter. Must be used as DataGrid child as shown in the story below.
 
-<Canvas>
-    <Story of={DataGridStories._GridFilterButton} />
-</Canvas>
+<Canvas of={DataGridStories._GridFilterButton} />
 
 ## CrudContextMenu
 
@@ -123,9 +109,7 @@ Component that can be rendered as ContextMenu in a row that has some basic CRUD 
 -   `onDelete: (options: { client: ApolloClient<object> }) => Promise<void>;`: Shows a "Delete" Menu Item, implementation should delete the row.
 -   `refetchQueries: RefetchQueriesOptions<any, unknown>["include"];`: called on apollo after executing delete or paste
 
-<Canvas>
-    <Story of={DataGridStories._CrudContextMenu} />
-</Canvas>
+<Canvas of={DataGridStories._CrudContextMenu} />
 
 ## CrudMoreActionsMenu
 
@@ -141,9 +125,7 @@ The `ActionItem` type has the following properties:
 -   `icon?: React.ReactNode`: The icon of the action displayed at the start of an action.
 -   `divider?: boolean`: If true, a divider will be displayed below the action.
 
-<Canvas>
-    <Story of={DataGridStories._CrudMoreActionsMenu} />
-</Canvas>
+<Canvas of={DataGridStories._CrudMoreActionsMenu} />
 
 ## DataGrid to Comet Graphl API Converter
 

--- a/storybook/src/docs/components/EditDialog/EditDialog.mdx
+++ b/storybook/src/docs/components/EditDialog/EditDialog.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as EditDialogStories from "./EditDialog.stories";
 
@@ -18,18 +18,14 @@ There are two ways to integrate an EditDialog.
 The recommended way is to use the `useEditDialog` hook.
 It returns an instance of `EditDialog` and the corresponding `editDialogApi`.
 
-<Canvas>
-    <Story of={EditDialogStories.Hook} />
-</Canvas>
+<Canvas of={EditDialogStories.Hook} />
 
 ### 2) EditDialog Component
 
 Alternatively, you can import the `EditDialog` component from `@comet/admin` and use it directly.
 To gain access to the `editDialogApi`, you need to attach a ref to the component.
 
-<Canvas>
-    <Story of={EditDialogStories.Component} />
-</Canvas>
+<Canvas of={EditDialogStories.Component} />
 
 ## useEditDialogApi and EditDialogApiContext
 
@@ -37,26 +33,20 @@ You can access the `editDialogApi` using the `useEditDialogApi` hook.
 As a prerequisite, you need to pass the `editDialogApi` to the `EditDialogApiContext.Provider` somewhere higher up
 in the component tree.
 
-<Canvas>
-    <Story of={EditDialogStories.UseEditDialogApi} />
-</Canvas>
+<Canvas of={EditDialogStories.UseEditDialogApi} />
 
 ## Form in EditDialog
 
 The `EditDialog` typically contains a form for editing a resource.
 When submitting the changes to an API via GraphQL mutation, the loading and error states are displayed automatically by the `SaveButton`.
 
-<Canvas>
-    <Story of={EditDialogStories.WithForm} />
-</Canvas>
+<Canvas of={EditDialogStories.WithForm} />
 
 ## EditDialog and Table
 
 The most common use case for an EditDialog is for editing single rows in a table.
 
-<Canvas>
-    <Story of={EditDialogStories.WithTable} />
-</Canvas>
+<Canvas of={EditDialogStories.WithTable} />
 
 ## EditDialog and Selection API
 
@@ -75,12 +65,8 @@ The `id` then specifies which resource is edited and is appended to the URL (e.g
 
 ### Example with useEditDialog (Recommended)
 
-<Canvas>
-    <Story of={EditDialogStories.SelectionWithHook} />
-</Canvas>
+<Canvas of={EditDialogStories.SelectionWithHook} />
 
 ### Example with EditDialog Component
 
-<Canvas>
-    <Story of={EditDialogStories.SelectionWithComponent} />
-</Canvas>
+<Canvas of={EditDialogStories.SelectionWithComponent} />

--- a/storybook/src/docs/components/ErrorHandling/ErrorDialog/ErrorDialog.mdx
+++ b/storybook/src/docs/components/ErrorHandling/ErrorDialog/ErrorDialog.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as ErrorDialogStories from "./ErrorDialog.stories";
 
@@ -50,12 +50,8 @@ return new ApolloClient({
 
 Error Dialog can be used to display an error in a dialog. Try it out by simply pressing the Button below. You can also use the errorDialog with the `useErrorDialog` Hook
 
-<Canvas>
-    <Story of={ErrorDialogStories.ManualErrorDialog} />
-</Canvas>
+<Canvas of={ErrorDialogStories.ManualErrorDialog} />
 
 ### Automatic Error Dialog on GraphQL Error
 
-<Canvas>
-    <Story of={ErrorDialogStories.AutomaticErrorOnGraphqlError} />
-</Canvas>
+<Canvas of={ErrorDialogStories.AutomaticErrorOnGraphqlError} />

--- a/storybook/src/docs/components/FileDropzone/FileDropzone.mdx
+++ b/storybook/src/docs/components/FileDropzone/FileDropzone.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as FileDropzoneStories from "./FileDropzone.stories";
 
@@ -14,12 +14,8 @@ A wrapper around [react-dropzone](https://www.npmjs.com/package/react-dropzone) 
 -   Use the `disabled` and `hasError` props to manage the disabled and error states.
 -   Use the `hideDroppableArea` and `hideButton` props to hide the droppable area and button, respectively.
 
-<Canvas>
-    <Story of={FileDropzoneStories.Default} />
-</Canvas>
+<Canvas of={FileDropzoneStories.Default} />
 
 ### Example of disabled and error states
 
-<Canvas>
-    <Story of={FileDropzoneStories.DisabledAndErrorStates} />
-</Canvas>
+<Canvas of={FileDropzoneStories.DisabledAndErrorStates} />

--- a/storybook/src/docs/components/FileSelect/FileSelect.mdx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as FileSelectStories from "./FileSelect.stories";
 
@@ -16,18 +16,12 @@ Used to combine `FileDropzone` and `FileSelectListItem` to handle the user's sel
 -   Set the `layout` prop to `grid` to display the files as a grid of cards with a file preview.
 -   Limit the amount of files and the size of the individual files with the `maxFiles` and `maxFileSize` props.
 
-<Canvas>
-    <Story of={FileSelectStories.Basic} />
-</Canvas>
+<Canvas of={FileSelectStories.Basic} />
 
 ### ReadOnly FileSelect
 
-<Canvas>
-    <Story of={FileSelectStories.Readonly} />
-</Canvas>
+<Canvas of={FileSelectStories.Readonly} />
 
 ### ReadOnly FileSelect (Grid with preview)
 
-<Canvas>
-    <Story of={FileSelectStories.GridWithPreview} />
-</Canvas>
+<Canvas of={FileSelectStories.GridWithPreview} />

--- a/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.mdx
+++ b/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as FileSelectListItemStories from "./FileSelectListItem.stories";
 
@@ -18,12 +18,8 @@ Used to display a list of files, including loading, skeleton, and error states a
 -   Use the `downloadUrl`, `onClickDownload` and `onClickDelete` props to handle what happens when clicking the download and delete buttons.
 -   Set the `filePreview` prop to `true` or pass in a image url to display the item as a card with a preview.
 
-<Canvas>
-    <Story of={FileSelectListItemStories.Basic} />
-</Canvas>
+<Canvas of={FileSelectListItemStories.Basic} />
 
 ### File preview card
 
-<Canvas>
-    <Story of={FileSelectListItemStories.Preview} />
-</Canvas>
+<Canvas of={FileSelectListItemStories.Preview} />

--- a/storybook/src/docs/components/FinalFormRangeInput/FinalFormRangeInput.mdx
+++ b/storybook/src/docs/components/FinalFormRangeInput/FinalFormRangeInput.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as FinalFormRangeInputStories from "./FinalFormRangeInput.stories";
 
@@ -9,38 +9,26 @@ import * as FinalFormRangeInputStories from "./FinalFormRangeInput.stories";
 The Final Form Range Input Component lets you set a Range Value (min/max) either by dragging a slider or setting the value in the associated input fields.
 **This Component can only operate inside a Final Form Component.**
 
-<Canvas>
-    <Story of={FinalFormRangeInputStories.Default} />
-</Canvas>
+<Canvas of={FinalFormRangeInputStories.Default} />
 
 ## Examples
 
 ### With Initial Values
 
-<Canvas>
-    <Story of={FinalFormRangeInputStories.WithInitialValues} />
-</Canvas>
+<Canvas of={FinalFormRangeInputStories.WithInitialValues} />
 
 ### With StartAdornment Prop
 
-<Canvas>
-    <Story of={FinalFormRangeInputStories.StartAdornment} />
-</Canvas>
+<Canvas of={FinalFormRangeInputStories.StartAdornment} />
 
 ### With EndAdornment Prop
 
-<Canvas>
-    <Story of={FinalFormRangeInputStories.EndAdornment} />
-</Canvas>
+<Canvas of={FinalFormRangeInputStories.EndAdornment} />
 
 ### Different Initial Values and Range Values
 
-<Canvas>
-    <Story of={FinalFormRangeInputStories.WithDifferentInitialAndRangeValues} />
-</Canvas>
+<Canvas of={FinalFormRangeInputStories.WithDifferentInitialAndRangeValues} />
 
 ### Different Slider Thumb
 
-<Canvas>
-    <Story of={FinalFormRangeInputStories.DifferentSliderThumb} />
-</Canvas>
+<Canvas of={FinalFormRangeInputStories.DifferentSliderThumb} />

--- a/storybook/src/docs/components/GridCellContent/GridCellContent.mdx
+++ b/storybook/src/docs/components/GridCellContent/GridCellContent.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as GridCellContentStories from "./GridCellContent.stories";
 
@@ -8,6 +8,4 @@ import * as GridCellContentStories from "./GridCellContent.stories";
 
 Used to display primary and secondary texts and an icon in a `DataGrid` cell using the columns `renderCell` function.
 
-<Canvas>
-    <Story of={GridCellContentStories.Basic} />
-</Canvas>
+<Canvas of={GridCellContentStories.Basic} />

--- a/storybook/src/docs/components/HoverActions/HoverActions.mdx
+++ b/storybook/src/docs/components/HoverActions/HoverActions.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as HoverActionsStories from "./HoverActions.stories";
 
@@ -12,6 +12,4 @@ For example, a `CopyToClipboardButton` inside a table cell.
 _Note: `HoverActions` uses absolute positioning to show the actions when hovering above the parent.  
 This may require setting `position: relative` to the parent to prevent overlaying other content._
 
-<Canvas>
-    <Story of={HoverActionsStories.Basic} />
-</Canvas>
+<Canvas of={HoverActionsStories.Basic} />

--- a/storybook/src/docs/components/Master/Master.mdx
+++ b/storybook/src/docs/components/Master/Master.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as MasterStories from "./Master.stories";
 
@@ -14,9 +14,7 @@ The master components are used to create the root of your application.
 </MasterLayout>
 ```
 
-<Canvas>
-    <Story of={MasterStories.Master} height="500px" />
-</Canvas>
+<Canvas of={MasterStories.Master} height="500px" />
 
 ## MasterLayout
 

--- a/storybook/src/docs/components/PrettyBytes/PrettyBytes.mdx
+++ b/storybook/src/docs/components/PrettyBytes/PrettyBytes.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as PrettyBytesStories from "./PrettyBytes.stories";
 
@@ -10,22 +10,16 @@ The PrettyBytes component can be used to display file sizes or other byte values
 
 Supported units are: `"byte" | "kilobyte" | "megabyte" | "gigabyte" | "terabyte" | "petabyte"`
 
-<Canvas>
-    <Story of={PrettyBytesStories.Basic} />
-</Canvas>
+<Canvas of={PrettyBytesStories.Basic} />
 
 ## Fixed Unit
 
 Per default, the unit is determined automatically. But it is also possible to manually set the unit. In the following example, the unit is manually set to `kilobyte`.
 
-<Canvas>
-    <Story of={PrettyBytesStories.FixedUnit} />
-</Canvas>
+<Canvas of={PrettyBytesStories.FixedUnit} />
 
 ## Custom Maximum Fraction Digits
 
 The default value for `maximumFractionDigits` is `2`. But it is possible to override this value. In the following example, the maximumFractionDigits are set to `4`.
 
-<Canvas>
-    <Story of={PrettyBytesStories.CustomMaximumFractionDigits} />
-</Canvas>
+<Canvas of={PrettyBytesStories.CustomMaximumFractionDigits} />

--- a/storybook/src/docs/components/RowActions/RowActions.mdx
+++ b/storybook/src/docs/components/RowActions/RowActions.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as RowActionsStories from "./RowActions.stories";
 
@@ -21,6 +21,4 @@ When nested within multiple menus, they are rendered as a ListItem inside a Menu
 
 ## Edit & Context Menu Example
 
-<Canvas>
-    <Story of={RowActionsStories.EditContextMenuExample} />
-</Canvas>
+<Canvas of={RowActionsStories.EditContextMenuExample} />

--- a/storybook/src/docs/components/Rte/Rte.mdx
+++ b/storybook/src/docs/components/Rte/Rte.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as RteStories from "./Rte.stories";
 
@@ -31,9 +31,7 @@ export default function MyRte() {
 }
 ```
 
-<Canvas>
-    <Story of={RteStories.Minimal} />
-</Canvas>
+<Canvas of={RteStories.Minimal} />
 
 ## Define format of your source data
 
@@ -51,9 +49,7 @@ const [useRteApi] = makeRteApi({
 });
 ```
 
-<Canvas>
-    <Story of={RteStories.SourceDataDefault} />
-</Canvas>
+<Canvas of={RteStories.SourceDataDefault} />
 
 When your persistence layer supports storing JSON-objects, string serialization is not needed. This is the implementation in Comet CMS.
 
@@ -80,9 +76,7 @@ const [useRteApi] = makeRteApi<Markdown>({
 });
 ```
 
-<Canvas>
-    <Story of={RteStories.SourceDataMarkdown} />
-</Canvas>
+<Canvas of={RteStories.SourceDataMarkdown} />
 
 ### Setup with HTML as source data
 
@@ -103,6 +97,4 @@ const [useRteApi] = makeRteApi<Html>({
 });
 ```
 
-<Canvas>
-    <Story of={RteStories.SourceDataHtml} />
-</Canvas>
+<Canvas of={RteStories.SourceDataHtml} />

--- a/storybook/src/docs/components/SaveButton/SaveButton.mdx
+++ b/storybook/src/docs/components/SaveButton/SaveButton.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as SaveButtonStories from "./SaveButton.stories";
 
@@ -6,6 +6,4 @@ import * as SaveButtonStories from "./SaveButton.stories";
 
 ## Save
 
-<Canvas>
-    <Story of={SaveButtonStories.Basic} />
-</Canvas>
+<Canvas of={SaveButtonStories.Basic} />

--- a/storybook/src/docs/components/Selection/Selection.mdx
+++ b/storybook/src/docs/components/Selection/Selection.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as SelectionStories from "./Selection.stories";
 
@@ -31,9 +31,7 @@ The first object contains two values:
 
 The second object is the [Selection API](#selection-api).
 
-<Canvas>
-    <Story of={SelectionStories.UseSelectionHook} />
-</Canvas>
+<Canvas of={SelectionStories.UseSelectionHook} />
 
 ### Selection Component
 
@@ -45,9 +43,7 @@ It provides the same values as `useSelection()`, but the variable names are slig
 -   `selectionMode` instead of `mode`
 -   `selectionApi` contains the [Selection API](#selection-api)
 
-<Canvas>
-    <Story of={SelectionStories.SelectionComponent} />
-</Canvas>
+<Canvas of={SelectionStories.SelectionComponent} />
 
 ## Selection with URL State
 
@@ -65,18 +61,14 @@ The main difference is that it returns three objects instead of two.
 The first - and additional - object is now a `SelectionRoute`.
 This `SelectionRoute` must wrap the selection-specific part of your application for the routing to function correctly.
 
-<Canvas>
-    <Story of={SelectionStories.UseSelectionRouteHook} />
-</Canvas>
+<Canvas of={SelectionStories.UseSelectionRouteHook} />
 
 ### SelectionRoute Component
 
 The `SelectionRoute` is the URL-stateful equivalent of the `Selection` component.
 You can use it exactly like `Selection` since it provides the same values.
 
-<Canvas>
-    <Story of={SelectionStories.SelectionRouteComponent} />
-</Canvas>
+<Canvas of={SelectionStories.SelectionRouteComponent} />
 
 ## Selection API
 

--- a/storybook/src/docs/components/Snackbar/Snackbar.mdx
+++ b/storybook/src/docs/components/Snackbar/Snackbar.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Source, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Source } from "@storybook/addon-docs";
 import dedent from "ts-dedent";
 
 import * as SnackbarStories from "./Snackbar.stories";
@@ -33,9 +33,7 @@ This ensures that there is only one snackbar at a time as recommended by the [Ma
 The `useSnackbarApi()` hook provides an Api to interact with the snackbar.
 It is only available if a `SnackbarProvider` is present higher up in the tree.
 
-<Canvas>
-    <Story of={SnackbarStories.UseSnackbarApi} />
-</Canvas>
+<Canvas of={SnackbarStories.UseSnackbarApi} />
 
 ### showSnackbar()
 
@@ -45,17 +43,13 @@ More info on the `Snackbar` and a list of available props can be found [in the M
 
 Only `open` is not available since the `SnackbarProvider` manages the open state.
 
-<Canvas>
-    <Story of={SnackbarStories.ShowSnackbar} />
-</Canvas>
+<Canvas of={SnackbarStories.ShowSnackbar} />
 
 ### hideSnackbar()
 
 `hideSnackbar()` hides the currently visible snackbar.
 
-<Canvas>
-    <Story of={SnackbarStories.HideSnackbar} />
-</Canvas>
+<Canvas of={SnackbarStories.HideSnackbar} />
 
 ## UndoSnackbar
 
@@ -66,6 +60,4 @@ It has three distinctions compared to the vanilla `Snackbar`:
 -   a `payload` prop. After a change, the previous state should be passed as payload
 -   a `onUndoClick` prop. This method is called once the user clicks on the undo button. The method receives the payload as parameter and can utilize it to restore the previous state
 
-<Canvas>
-    <Story of={SnackbarStories.Undo} />
-</Canvas>
+<Canvas of={SnackbarStories.Undo} />

--- a/storybook/src/docs/components/SplitButton/SplitButton.mdx
+++ b/storybook/src/docs/components/SplitButton/SplitButton.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as SplitButtonStories from "./SplitButton.stories";
 
@@ -8,68 +8,46 @@ import * as SplitButtonStories from "./SplitButton.stories";
 
 ## Uncontrolled Split Button
 
-<Canvas>
-    <Story of={SplitButtonStories.Uncontrolled} />
-</Canvas>
+<Canvas of={SplitButtonStories.Uncontrolled} />
 
 ## Controlled Split Button
 
-<Canvas>
-    <Story of={SplitButtonStories.Controlled} />
-</Canvas>
+<Canvas of={SplitButtonStories.Controlled} />
 
 ## LocalStorage Index
 
-<Canvas>
-    <Story of={SplitButtonStories.LocalStorageIndex} />
-</Canvas>
+<Canvas of={SplitButtonStories.LocalStorageIndex} />
 
 ## SessionStorage Index
 
-<Canvas>
-    <Story of={SplitButtonStories.SessionStorageIndex} />
-</Canvas>
+<Canvas of={SplitButtonStories.SessionStorageIndex} />
 
 ## One Button
 
 With only one Child the `SplitButton` automatically hides Split Button Selector, but it can be enabled by manually setting the `showSelectButton={true}`s
 
-<Canvas>
-    <Story of={SplitButtonStories.OneChild} />
-</Canvas>
+<Canvas of={SplitButtonStories.OneChild} />
 
 ## One Button with select
 
-<Canvas>
-    <Story of={SplitButtonStories.OneChildWithSelect} />
-</Canvas>
+<Canvas of={SplitButtonStories.OneChildWithSelect} />
 
 ## One Button Disabled
 
-<Canvas>
-    <Story of={SplitButtonStories.OneChildDisabled} />
-</Canvas>
+<Canvas of={SplitButtonStories.OneChildDisabled} />
 
 ## Color Change
 
-<Canvas>
-    <Story of={SplitButtonStories.ColorChange} />
-</Canvas>
+<Canvas of={SplitButtonStories.ColorChange} />
 
 ### Variant Change
 
-<Canvas>
-    <Story of={SplitButtonStories.VariantChange} />
-</Canvas>
+<Canvas of={SplitButtonStories.VariantChange} />
 
 ### Custom Component
 
-<Canvas>
-    <Story of={SplitButtonStories.CustomComponent} />
-</Canvas>
+<Canvas of={SplitButtonStories.CustomComponent} />
 
 ### Override Popover props
 
-<Canvas>
-    <Story of={SplitButtonStories.OverridePopoverProps} />
-</Canvas>
+<Canvas of={SplitButtonStories.OverridePopoverProps} />

--- a/storybook/src/docs/components/Stack/Stack.mdx
+++ b/storybook/src/docs/components/Stack/Stack.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Source, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Source } from "@storybook/addon-docs";
 import dedent from "ts-dedent";
 
 import * as StackStories from "./Stack.stories";
@@ -12,9 +12,7 @@ A single page will be displayed at a time.
 
 ## Stack Components
 
-<Canvas>
-    <Story of={StackStories.Basic} />
-</Canvas>
+<Canvas of={StackStories.Basic} />
 
 A stack consists of 3 components: `Stack`, `StackSwitch` and `StackPage`:
 
@@ -44,15 +42,11 @@ More infos on this functionality can be found in the [Routing Libraries section 
 
 #### Material UI Link with underlying StackLink
 
-<Canvas>
-    <Story of={StackStories.StackLinkMuiLink} />
-</Canvas>
+<Canvas of={StackStories.StackLinkMuiLink} />
 
 #### Material UI Button and IconButton with underlying StackLink
 
-<Canvas>
-    <Story of={StackStories.StackLinkButton} />
-</Canvas>
+<Canvas of={StackStories.StackLinkButton} />
 
 ### activatePage
 
@@ -106,17 +100,13 @@ The payload needs to be a string as it is used in the url.
 
 ### Example
 
-<Canvas>
-    <Story of={StackStories.Payload} />
-</Canvas>
+<Canvas of={StackStories.Payload} />
 
 ## Nested Stacks
 
 It is possible to nest `StackSwitch`, just render another `StackSwitch` (plus `StackPage`s) in a `StackPage`. You will get automatic Breadcrumbs showing this nesting.
 
-<Canvas>
-    <Story of={StackStories.Nested} />
-</Canvas>
+<Canvas of={StackStories.Nested} />
 
 A nested `Stack` component is usually not desired, as it will have it's own breadcrumbs.
 
@@ -126,9 +116,7 @@ A nested `Stack` component is usually not desired, as it will have it's own brea
 
 Comet Admin Stack provides a unique way to create a StackSwitch associated with its api using `useStackSwitch` hook:
 
-<Canvas>
-    <Story of={StackStories.UseStackSwitch} />
-</Canvas>
+<Canvas of={StackStories.UseStackSwitch} />
 
 ## Breadcrumbs
 
@@ -144,16 +132,12 @@ Simple components showing breadcrumbs of the current stack, see Nested Stacks ex
 
 Toolbar components that integrate stack nicely into the Comet Toolbar System.
 
-<Canvas>
-    <Story of={StackStories.BreadcrumbsToolbar} />
-</Canvas>
+<Canvas of={StackStories.BreadcrumbsToolbar} />
 
 ### Custom/Dynamic Breadcrumb Title
 
 Breadcrumbs by default show the title of the `StackPage`. If you want to show something dynamic based on the payload (like the name of the selected item) you can use `StackPageTitle` component:
 
-<Canvas>
-    <Story of={StackStories.DynamicTitle} />
-</Canvas>
+<Canvas of={StackStories.DynamicTitle} />
 
 You can also do a graphql query to fetch data needed for creating the title.

--- a/storybook/src/docs/components/Table/01_Basics.mdx
+++ b/storybook/src/docs/components/Table/01_Basics.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Source, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Source } from "@storybook/addon-docs";
 import dedent from "ts-dedent";
 
 import * as BasicsStories from "./01_Basics.stories";
@@ -94,9 +94,7 @@ Keep reading to learn more.
 
 ## Table
 
-<Canvas>
-    <Story of={BasicsStories.BasicTable} />
-</Canvas>
+<Canvas of={BasicsStories.BasicTable} />
 
 `Table` has three required parameters: `data`, `totalCount` and `columns`.
 
@@ -117,24 +115,18 @@ More information can be found in the [column section](#table-column).
 The only required property of a column is its `name`.
 Per default, the `name` is matched to a property of `data`, which is then rendered:
 
-<Canvas>
-    <Story of={BasicsStories.TableColumnNameProp} />
-</Canvas>
+<Canvas of={BasicsStories.TableColumnNameProp} />
 
 Matching also works for nested properties if the `name` is separated by dots:
 
-<Canvas>
-    <Story of={BasicsStories.TableColumnNestedNameProp} />
-</Canvas>
+<Canvas of={BasicsStories.TableColumnNestedNameProp} />
 
 ### render
 
 Passing a function to the `render` prop overrides the default rendering behavior.
 The render function can be used for altering the styling of a column or for rendering columns that don't have a corresponding prop in `data`:
 
-<Canvas>
-    <Story of={BasicsStories.TableColumnRenderProp} />
-</Canvas>
+<Canvas of={BasicsStories.TableColumnRenderProp} />
 
 ### header
 
@@ -143,17 +135,13 @@ It can be a string or a JSX element.
 
 If no header is set, the heading of a column is empty.
 
-<Canvas>
-    <Story of={BasicsStories.TableColumnHeaderProp} />
-</Canvas>
+<Canvas of={BasicsStories.TableColumnHeaderProp} />
 
 ### visible
 
 `visible` can be used to hide a column.
 
-<Canvas>
-    <Story of={BasicsStories.TableColumnVisibleProp} />
-</Canvas>
+<Canvas of={BasicsStories.TableColumnVisibleProp} />
 
 ### cellProps & headerProps
 

--- a/storybook/src/docs/components/Table/02_TableQuery.mdx
+++ b/storybook/src/docs/components/Table/02_TableQuery.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as TableQueryStories from "./02_TableQuery.stories";
 
@@ -20,6 +20,4 @@ The `useTableQuery()` hook returns the converted response (`tableData`), an `api
 It has a built-in loading state and error handling.
 All you have to do is pass the `api`, `error` and `loading` props returned by `useTableQuery()` to `TableQuery`.
 
-<Canvas>
-    <Story of={TableQueryStories._TableQuery} />
-</Canvas>
+<Canvas of={TableQueryStories._TableQuery} />

--- a/storybook/src/docs/components/Table/03_Sorting.mdx
+++ b/storybook/src/docs/components/Table/03_Sorting.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as SortingStories from "./03_Sorting.stories";
 
@@ -18,6 +18,4 @@ To use this functionality, you have to follow the following steps:
 
 You can then sort the table ascending or descending by column by clicking on the column header.
 
-<Canvas>
-    <Story of={SortingStories.SortableTable} />
-</Canvas>
+<Canvas of={SortingStories.SortableTable} />

--- a/storybook/src/docs/components/Table/04_Pagination.mdx
+++ b/storybook/src/docs/components/Table/04_Pagination.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as PaginationStories from "./04_Pagination.stories";
 
@@ -27,6 +27,4 @@ Comet Admin supports multiple types of pagination:
 -   Offset-based Pagination for REST APIs (`createRestStartLimitPagingActions()`)
 -   Page-based Pagination for REST APIs (`createRestPagingActions()`)
 
-<Canvas>
-    <Story of={PaginationStories.PaginationTable} />
-</Canvas>
+<Canvas of={PaginationStories.PaginationTable} />

--- a/storybook/src/docs/components/Table/05_FilterBar.mdx
+++ b/storybook/src/docs/components/Table/05_FilterBar.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as FilterBarStories from "./05_FilterBar.stories";
 
@@ -17,9 +17,7 @@ To implement various filters, stick to the following steps:
 4. add filters to the `FilterBar`. A filter typically consists of a `FilterBarPopoverFilter` with one or multiple `Field`s
 5. use the values of `filterApi` for filtering. Typically, this will happen by passing them as variables to a GraphQL query (in the following example, filtering is done on the client-side for simplicity reasons)
 
-<Canvas>
-    <Story of={FilterBarStories.TableWithFilterbar} />
-</Canvas>
+<Canvas of={FilterBarStories.TableWithFilterbar} />
 
 ## Filterbar and Persisted State
 
@@ -30,6 +28,4 @@ To prevent this behaviour, you can pass a `persistedStateId` to the `useTableQue
 Then, the filters are saved in a global variable once the user leaves the table page.
 When the user returns, the filters are recovered from the global variable.
 
-<Canvas>
-    <Story of={FilterBarStories.TableWithFilterbarAndPersistedState} />
-</Canvas>
+<Canvas of={FilterBarStories.TableWithFilterbarAndPersistedState} />

--- a/storybook/src/docs/components/Table/06_ExcelExport.mdx
+++ b/storybook/src/docs/components/Table/06_ExcelExport.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as ExcelExportStories from "./06_ExcelExport.stories";
 
@@ -15,9 +15,7 @@ To use it, the following steps are necessary:
 2. pass the `exportApi` to the `Table`
 3. add an `ExcelExportButton` and pass the `exportApi`
 
-<Canvas>
-    <Story of={ExcelExportStories.BasicExcelExportTable} />
-</Canvas>
+<Canvas of={ExcelExportStories.BasicExcelExportTable} />
 
 ## Excel Export and Custom Rendered Columns
 
@@ -33,9 +31,7 @@ Excel can't handle JSX.
 If you use a `render()` function that returns JSX, you must provide a `renderExcel()` function that returns a plain string.
 Otherwise, the column will be empty in the excel sheet.
 
-<Canvas>
-    <Story of={ExcelExportStories.ExcelExportAndCustomRenderedColumns} />
-</Canvas>
+<Canvas of={ExcelExportStories.ExcelExportAndCustomRenderedColumns} />
 
 ## Excel Export and Visibility
 
@@ -43,21 +39,15 @@ It's possible to control the visibility of a column in the browser and the excel
 
 In the example below, columns 1 and 5 are shown in the browser and columns 1, 3 and 4 are shown in the Excel sheet.
 
-<Canvas>
-    <Story of={ExcelExportStories.ExcelExportAndVisibility} />
-</Canvas>
+<Canvas of={ExcelExportStories.ExcelExportAndVisibility} />
 
 ## Excel Export and Pagination
 
 If you want to export data from multiple pages, you can use the `useExportPagedTableQuery()` hook.
 
-<Canvas>
-    <Story of={ExcelExportStories.ExcelExportAndPaginationUseExportPagedTableQuery} />
-</Canvas>
+<Canvas of={ExcelExportStories.ExcelExportAndPaginationUseExportPagedTableQuery} />
 
 If you want to export more (or other) data than displayed independently of pages, you can use the `useExportTableQuery()` hook.
 This also has the advantage that all data is queried in a single request (while `useExportPagedTableQuery()` makes one request per page).
 
-<Canvas>
-    <Story of={ExcelExportStories.ExcelExportAndPaginationUseExportTableQuery} />
-</Canvas>
+<Canvas of={ExcelExportStories.ExcelExportAndPaginationUseExportTableQuery} />

--- a/storybook/src/docs/components/Table/07_TableDndOrder.mdx
+++ b/storybook/src/docs/components/Table/07_TableDndOrder.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as TableDndOrderStories from "./07_TableDndOrder.stories";
 
@@ -19,6 +19,4 @@ For most use cases, you can wrap the `TableDndOrder` in a `TableLocalChanges` co
 `TableLocalChanges` provides a built-in `moveRow()` function for simple reordering (amongst other convenience functions).
 You can see it in action in the example below.
 
-<Canvas>
-    <Story of={TableDndOrderStories._TableDndOrder} />
-</Canvas>
+<Canvas of={TableDndOrderStories._TableDndOrder} />

--- a/storybook/src/docs/components/Table/08_SelectionTable.mdx
+++ b/storybook/src/docs/components/Table/08_SelectionTable.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as SelectionTableStories from "./08_SelectionTable.stories";
 
@@ -19,6 +19,4 @@ To use this functionality, follow these steps:
 3. set the `selectable` prop to `true` and pass `selectedId` and `selectionApi` to the `Table`
 4. use the `Selected` component to access the currently selected item. Pass the item to your form
 
-<Canvas>
-    <Story of={SelectionTableStories.SelectionTable} />
-</Canvas>
+<Canvas of={SelectionTableStories.SelectionTable} />

--- a/storybook/src/docs/components/Tabs/01_Tabs.mdx
+++ b/storybook/src/docs/components/Tabs/01_Tabs.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Source, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Source } from "@storybook/addon-docs";
 import dedent from "ts-dedent";
 
 import * as TabsStories from "./01_Tabs.stories";
@@ -27,9 +27,7 @@ As children, an array of `Tab` elements should be passed to `Tabs`.
 -   a `label` that is shown in the tab bar
 -   optionally a [forceRender flag](#tabs-and-forcerender)
 
-<Canvas>
-    <Story of={TabsStories.Basic} />
-</Canvas>
+<Canvas of={TabsStories.Basic} />
 
 ## Tabs and forceRender
 
@@ -51,15 +49,11 @@ You don't want to lose the form content if the user switches the tab.
 
 ❌ Without `forceRender` the form content is lost after a tab switch
 
-<Canvas>
-    <Story of={TabsStories.FormInTabsWithoutForceRender} />
-</Canvas>
+<Canvas of={TabsStories.FormInTabsWithoutForceRender} />
 
 ✅ With `forceRender` the form content is preserved
 
-<Canvas>
-    <Story of={TabsStories.FormInTabsWithForceRender} />
-</Canvas>
+<Canvas of={TabsStories.FormInTabsWithForceRender} />
 
 2. You implement a form whose fields are distributed over multiple tabs.
 
@@ -69,16 +63,12 @@ Therefore, the form is not marked as dirty anymore as soon as you switch to a ta
 ❌ Without `forceRender` the form is marked as pristine after switching from `Tab 1` to `Tab 2`.
 This means that the user can't save their progress and can leave the page without getting a "Discard unsaved changes" dialog.
 
-<Canvas>
-    <Story of={TabsStories.TabsInFormWithoutForceRender} />
-</Canvas>
+<Canvas of={TabsStories.TabsInFormWithoutForceRender} />
 
 ✅ With `forceRender` the fields stay mounted and the form is correctly marked as dirty after a tab switch.
 Saving is possible.
 
-<Canvas>
-    <Story of={TabsStories.TabsInFormWithForceRender} />
-</Canvas>
+<Canvas of={TabsStories.TabsInFormWithForceRender} />
 
 ## Differences between Comet Admin `Tabs` and `MuiTabs`
 

--- a/storybook/src/docs/components/Tabs/02_RouterTabs.mdx
+++ b/storybook/src/docs/components/Tabs/02_RouterTabs.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as RouterTabsStories from "./02_RouterTabs.stories";
 
@@ -21,9 +21,7 @@ Each `RouterTab` needs:
 -   a unique `path` of the tab that is attached to the URL
 -   optionally a `forceRender` flag ([see Tabs docs for examples](?path=/docs/docs-components-tabs-tabs--docs#tabs-and-forcerender))
 
-<Canvas>
-    <Story of={RouterTabsStories.Basic} />
-</Canvas>
+<Canvas of={RouterTabsStories.Basic} />
 
 ## RouterTabs and Nested Stack
 
@@ -31,6 +29,4 @@ When used on a nested `StackPage`, `RouterTabs` automatically hides other `Route
 In this way, only the `RouterTabs` on the current level are shown.
 That ensures that the UI doesn't appear cluttered with tabs.
 
-<Canvas>
-    <Story of={RouterTabsStories.NestedStackSwitchWithRouterTabs} />
-</Canvas>
+<Canvas of={RouterTabsStories.NestedStackSwitchWithRouterTabs} />

--- a/storybook/src/docs/components/Toolbar/Toolbar.mdx
+++ b/storybook/src/docs/components/Toolbar/Toolbar.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as ToolbarStories from "./Toolbar.stories";
 
@@ -32,23 +32,17 @@ The `ToolbarAutomaticTitleItem` uses the StackApi to evaluate the title. Just dr
 
 If you need a custom title, simple build your own `CustomToolbarTitleItem`. For custom appearance - see more on custom title stories.
 
-<Canvas>
-    <Story of={ToolbarStories.AutomaticTitleItem} />
-</Canvas>
+<Canvas of={ToolbarStories.AutomaticTitleItem} />
 
 ### ToolbarTitleItem
 
 If you only want a consistent Title over the all application, we recommend to use our ToolbarTitleItem. Simple put your Component in it, and if it is a string, it will get a consistent styling over the whole application
 
-<Canvas>
-    <Story of={ToolbarStories.TitleItem} />
-</Canvas>
+<Canvas of={ToolbarStories.TitleItem} />
 
 ### ToolbarTitleItem internationalization
 
-<Canvas>
-    <Story of={ToolbarStories.LocalizedTitleItem} />
-</Canvas>
+<Canvas of={ToolbarStories.LocalizedTitleItem} />
 
 ### ToolbarBreadcrumbs
 
@@ -56,9 +50,7 @@ The ToolbarBreadcrumbs Component uses the StackApi to evaluate all necessary Bre
 
 Breadcrumb entries get displayed side by side and are clickable.
 
-<Canvas>
-    <Story of={ToolbarStories.Breadcrumbs} />
-</Canvas>
+<Canvas of={ToolbarStories.Breadcrumbs} />
 
 ### ToolbarBackButton
 
@@ -66,9 +58,7 @@ The `ToolbarBackButton` uses the `StackApiContext` to evaluate, if the user can 
 
 The back button will only be shown, if there is a `StackApiContext` and the user can go back. If you want to use a custom back button - see more how to customize the back button on custom back button story.
 
-<Canvas>
-    <Story of={ToolbarStories.BackButton} />
-</Canvas>
+<Canvas of={ToolbarStories.BackButton} />
 
 ### ToolbarFillSpace
 
@@ -76,105 +66,69 @@ The `ToolbarFillSpace` Component is a layout component that can fill space betwe
 
 Here are some examples how one can use this component.
 
-<Canvas>
-    <Story of={ToolbarStories.FillSpaceLeft} />
-</Canvas>
+<Canvas of={ToolbarStories.FillSpaceLeft} />
 
-<Canvas>
-    <Story of={ToolbarStories.FillSpaceRight} />
-</Canvas>
+<Canvas of={ToolbarStories.FillSpaceRight} />
 
-<Canvas>
-    <Story of={ToolbarStories.FillSpaceMiddle} />
-</Canvas>
+<Canvas of={ToolbarStories.FillSpaceMiddle} />
 
-<Canvas>
-    <Story of={ToolbarStories.FillSpaceMiddle2} />
-</Canvas>
+<Canvas of={ToolbarStories.FillSpaceMiddle2} />
 
 ### ToolbarItem
 
 This component is meant to separate components in the toolbar, it adds a consistent separator on the right side.
 
-<Canvas>
-    <Story of={ToolbarStories._ToolbarItem} />
-</Canvas>
+<Canvas of={ToolbarStories._ToolbarItem} />
 
 The `ToolbarItem` can be easily mixed up with other drop in compoents like `ToolbarAutomaticTitleItem`
 
-<Canvas>
-    <Story of={ToolbarStories.ToolbarItemMixingWithOtherComponents} />
-</Canvas>
+<Canvas of={ToolbarStories.ToolbarItemMixingWithOtherComponents} />
 
 ### ToolbarActions
 
-<Canvas>
-    <Story of={ToolbarStories.ToolbarActionsOneAction} />
-</Canvas>
+<Canvas of={ToolbarStories.ToolbarActionsOneAction} />
 
-<Canvas>
-    <Story of={ToolbarStories.ToolbarActionsTwoActions} />
-</Canvas>
+<Canvas of={ToolbarStories.ToolbarActionsTwoActions} />
 
 ### Custom Title Item
 
 Here one can find some examples, how one can deal with custom titles. Add a `ToolbarItem` which encapsulates a `Typography` or maybe any other React component.
 
-<Canvas>
-    <Story of={ToolbarStories.CustomTitleH1} />
-</Canvas>
+<Canvas of={ToolbarStories.CustomTitleH1} />
 
-<Canvas>
-    <Story of={ToolbarStories.CustomTitleH2} />
-</Canvas>
+<Canvas of={ToolbarStories.CustomTitleH2} />
 
 One can also use totally custom components in it.
 
-<Canvas>
-    <Story of={ToolbarStories.CustomTitleH3} />
-</Canvas>
+<Canvas of={ToolbarStories.CustomTitleH3} />
 
 The Toolbar expands automatically if it needs more space
 
-<Canvas>
-    <Story of={ToolbarStories.CustomTitleH4} />
-</Canvas>
+<Canvas of={ToolbarStories.CustomTitleH4} />
 
 ### Custom Back Button
 
-<Canvas>
-    <Story of={ToolbarStories.CustomBackButton} />
-</Canvas>
+<Canvas of={ToolbarStories.CustomBackButton} />
 
 ### Search - Final Form Search
 
-<Canvas>
-    <Story of={ToolbarStories.FinalFormSearch} />
-</Canvas>
+<Canvas of={ToolbarStories.FinalFormSearch} />
 
 ### Search - Final Form Search Custom Icon
 
-<Canvas>
-    <Story of={ToolbarStories.FinalFormSearchCustomIcon} />
-</Canvas>
+<Canvas of={ToolbarStories.FinalFormSearchCustomIcon} />
 
 ### Search - Final Form Input
 
-<Canvas>
-    <Story of={ToolbarStories.WithFinalFormInput} />
-</Canvas>
+<Canvas of={ToolbarStories.WithFinalFormInput} />
 
 ### Search - Autocomplete
 
-<Canvas>
-    <Story of={ToolbarStories.SearchAutocomplete} />
-</Canvas>
+<Canvas of={ToolbarStories.SearchAutocomplete} />
 
 ### Save
 
-<Canvas>
-    <Story of={ToolbarStories.Save} />
-</Canvas>
+<Canvas of={ToolbarStories.Save} />
 
 ### Final Form Save Button
 
@@ -182,17 +136,13 @@ There is also a component (`FinalFormSaveButton`) which automatically handles sa
 
 This component uses final form data (e.g. pristine, hasValidationErrors, submitting, hasSubmitErrors,...) for displaying statuses (disabled, saving, error, success).
 
-<Canvas>
-    <Story of={ToolbarStories._FinalFormSaveButton} />
-</Canvas>
+<Canvas of={ToolbarStories._FinalFormSaveButton} />
 
 ### SplitButton Save
 
 > ⚠️`SplitButton` is deprecated since v7 and shouldn't be used
 
-<Canvas>
-    <Story of={ToolbarStories.SaveSplitButton} />
-</Canvas>
+<Canvas of={ToolbarStories.SaveSplitButton} />
 
 ### Final Form Save Split Button
 
@@ -202,6 +152,4 @@ The `FinalFormSaveSplitButton` component automatically handles **saving** and **
 
 This component uses final form data (e.g. pristine, hasValidationErrors, submitting, hasSubmitErrors,...) for displaying statuses (disabled, saving, saving successfully) and also handles back navigation on automatically.
 
-<Canvas>
-    <Story of={ToolbarStories._FinalFormSaveSplitButton} />
-</Canvas>
+<Canvas of={ToolbarStories._FinalFormSaveSplitButton} />

--- a/storybook/src/docs/components/Tooltip/Tooltip.mdx
+++ b/storybook/src/docs/components/Tooltip/Tooltip.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as TooltipStories from "./Tooltip.stories";
 
@@ -23,12 +23,8 @@ In addition to its own props, the Tooltip component also accepts all props from 
 
 #### Example trigger
 
-<Canvas>
-    <Story of={TooltipStories.BasicTooltip} />
-</Canvas>
+<Canvas of={TooltipStories.BasicTooltip} />
 
 #### Example variant
 
-<Canvas>
-    <Story of={TooltipStories.TooltipVariant} />
-</Canvas>
+<Canvas of={TooltipStories.TooltipVariant} />

--- a/storybook/src/docs/form/Layout.mdx
+++ b/storybook/src/docs/form/Layout.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as LayoutStories from "./Layout.stories";
 
@@ -22,15 +22,11 @@ One way to do this is by using a `Grid` which can be used to have uniform size a
 
 **Example without fixed width**
 
-<Canvas>
-    <Story of={LayoutStories.InlineFields} />
-</Canvas>
+<Canvas of={LayoutStories.InlineFields} />
 
 **Example with fixed width using Grid**
 
-<Canvas>
-    <Story of={LayoutStories.GridLayout} />
-</Canvas>
+<Canvas of={LayoutStories.GridLayout} />
 
 ### Full-Width Layout
 
@@ -59,15 +55,11 @@ When using the full-width layout with larger, more complex forms, it makes sense
 
 **Sidebar Example, using FormSection**
 
-<Canvas>
-    <Story of={LayoutStories.FieldsInSidebar} />
-</Canvas>
+<Canvas of={LayoutStories.FieldsInSidebar} />
 
 **Dialog Example**
 
-<Canvas>
-    <Story of={LayoutStories.FieldsInDialog} />
-</Canvas>
+<Canvas of={LayoutStories.FieldsInDialog} />
 
 ### Horizontal layout
 
@@ -99,6 +91,4 @@ const theme = createCometTheme({
 
 **Example form, using the horizontal layout**
 
-<Canvas>
-    <Story of={LayoutStories.HorizontalFields} />
-</Canvas>
+<Canvas of={LayoutStories.HorizontalFields} />

--- a/storybook/src/docs/form/Overview.mdx
+++ b/storybook/src/docs/form/Overview.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as OverviewStories from "./Overview.stories";
 
@@ -38,9 +38,7 @@ It's built on top of [React Final Form's `Form` component](https://final-form.or
 
 You can find more information on the [FinalForm component page](?path=/docs/docs-form-components-finalform--docs).
 
-<Canvas>
-    <Story of={OverviewStories.BasicFinalForm} />
-</Canvas>
+<Canvas of={OverviewStories.BasicFinalForm} />
 
 ### FieldContainer
 

--- a/storybook/src/docs/form/Validation.mdx
+++ b/storybook/src/docs/form/Validation.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as ValidationStories from "./Validation.stories";
 
@@ -12,17 +12,13 @@ Form validation can be done in two ways, either for the whole form (record-level
 
 ### Record-level validation
 
-<Canvas>
-    <Story of={ValidationStories.RecordLevelValidation} />
-</Canvas>
+<Canvas of={ValidationStories.RecordLevelValidation} />
 
 > Use the special key `FORM_ERROR` to display a validation error concerning the whole form.
 
 ### Field-level validation
 
-<Canvas>
-    <Story of={ValidationStories.FieldLevelValidation} />
-</Canvas>
+<Canvas of={ValidationStories.FieldLevelValidation} />
 
 ### Warnings
 
@@ -30,6 +26,4 @@ In addition to error validation, Comet Admin also supports warnings for the `Fin
 
 > Please note that a warning _does not_ mark the form as `invalid`, and therefore _does not_ prevent the form from being submitted. If you wish to achieve this, use error validation instead.
 
-<Canvas>
-    <Story of={ValidationStories.Warnings} />
-</Canvas>
+<Canvas of={ValidationStories.Warnings} />

--- a/storybook/src/docs/form/components/DateAndTimePickers/01_DatePicker.mdx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/01_DatePicker.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as DatePickerStories from "./01_DatePicker.stories";
 import DatePickerLocalisation from "./common/DatePickerLocalization.mdx";
@@ -17,12 +17,8 @@ The `value` prop and the value returned by `onChange` are a string in the format
 
 ## Basic usage
 
-<Canvas>
-    <Story of={DatePickerStories.Basic} />
-</Canvas>
+<Canvas of={DatePickerStories.Basic} />
 
 ## Usage inside a Final Form
 
-<Canvas>
-    <Story of={DatePickerStories.FinalForm} />
-</Canvas>
+<Canvas of={DatePickerStories.FinalForm} />

--- a/storybook/src/docs/form/components/DateAndTimePickers/02_TimePicker.mdx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/02_TimePicker.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as TimePickerStories from "./02_TimePicker.stories";
 
@@ -20,12 +20,8 @@ The `value` prop and the value returned by `onChange` are 24-hour strings format
 
 ## Basic usage
 
-<Canvas>
-    <Story of={TimePickerStories.Basic} />
-</Canvas>
+<Canvas of={TimePickerStories.Basic} />
 
 ## Usage inside a Final Form
 
-<Canvas>
-    <Story of={TimePickerStories.FinalForm} />
-</Canvas>
+<Canvas of={TimePickerStories.FinalForm} />

--- a/storybook/src/docs/form/components/DateAndTimePickers/03_DateTimePicker.mdx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/03_DateTimePicker.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as DateTimePickerStories from "./03_DateTimePicker.stories";
 import DatePickerLocalisation from "./common/DatePickerLocalization.mdx";
@@ -17,12 +17,8 @@ The `value` prop and the value returned by `onChange` are of type `Date`.
 
 ## Basic usage
 
-<Canvas>
-    <Story of={DateTimePickerStories.Basic} />
-</Canvas>
+<Canvas of={DateTimePickerStories.Basic} />
 
 ## Usage inside a Final Form
 
-<Canvas>
-    <Story of={DateTimePickerStories.FinalForm} />
-</Canvas>
+<Canvas of={DateTimePickerStories.FinalForm} />

--- a/storybook/src/docs/form/components/DateAndTimePickers/04_DateRangePicker.mdx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/04_DateRangePicker.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as DateRangePickerStories from "./04_DateRangePicker.stories";
 import DatePickerLocalisation from "./common/DatePickerLocalization.mdx";
@@ -24,12 +24,8 @@ type DateRange = {
 
 ## Basic usage
 
-<Canvas>
-    <Story of={DateRangePickerStories.Basic} />
-</Canvas>
+<Canvas of={DateRangePickerStories.Basic} />
 
 ## Usage inside a Final Form
 
-<Canvas>
-    <Story of={DateRangePickerStories.FinalForm} />
-</Canvas>
+<Canvas of={DateRangePickerStories.FinalForm} />

--- a/storybook/src/docs/form/components/DateAndTimePickers/05_TimeRangePicker.mdx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/05_TimeRangePicker.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as TimeRangePickerStories from "./05_TimeRangePicker.stories";
 
@@ -22,12 +22,8 @@ type TimeRange = {
 
 ## Basic usage
 
-<Canvas>
-    <Story of={TimeRangePickerStories.Basic} />
-</Canvas>
+<Canvas of={TimeRangePickerStories.Basic} />
 
 ## Usage inside a Final Form
 
-<Canvas>
-    <Story of={TimeRangePickerStories.FinalForm} />
-</Canvas>
+<Canvas of={TimeRangePickerStories.FinalForm} />

--- a/storybook/src/docs/form/components/Field.mdx
+++ b/storybook/src/docs/form/components/Field.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as FieldStories from "./Field.stories";
 
@@ -10,6 +10,4 @@ import * as FieldStories from "./Field.stories";
 
 _Note: If your form is not built with final-form, use [FieldContainer](?path=/docs/docs-form-components-fieldcontainer--docs) instead._
 
-<Canvas>
-    <Story of={FieldStories.Basic} />
-</Canvas>
+<Canvas of={FieldStories.Basic} />

--- a/storybook/src/docs/form/components/FieldContainer.mdx
+++ b/storybook/src/docs/form/components/FieldContainer.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as FieldContainerStories from "./FieldContainer.stories";
 
@@ -11,6 +11,4 @@ It is also used to set a label, error--messages and other common form-field attr
 
 _Note: If your form is built with final-form, use [Field](?path=/docs/docs-form-components-field--docs) instead._
 
-<Canvas>
-    <Story of={FieldContainerStories.Basic} />
-</Canvas>
+<Canvas of={FieldContainerStories.Basic} />

--- a/storybook/src/docs/form/components/FinalForm.mdx
+++ b/storybook/src/docs/form/components/FinalForm.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Source, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Source } from "@storybook/addon-docs";
 import dedent from "ts-dedent";
 
 import * as FinalFormStories from "./FinalForm.stories";
@@ -15,9 +15,7 @@ There are two required properties:
 -   `mode` can be `add` (for creating a new resource) or `edit` (for editing an existing resource)
 -   `onSubmit()` handles the submission of form values to the API
 
-<Canvas>
-    <Story of={FinalFormStories.BasicFinalForm} />
-</Canvas>
+<Canvas of={FinalFormStories.BasicFinalForm} />
 
 ## Differences between Comet Admin `FinalForm` and React Final Form's `Form`
 
@@ -77,9 +75,7 @@ Comet Admin `FinalForm`:
 
 This allows us to access the Final-Form FormApi outside the form.
 
-<Canvas>
-    <Story of={FinalFormStories.FinalFormApiRef} />
-</Canvas>
+<Canvas of={FinalFormStories.FinalFormApiRef} />
 
 ## FinalForm in a Table
 
@@ -220,6 +216,4 @@ Also, `apolloClient.mutate()` helps you avoid a difficult variable naming proces
 
 **Note:** You have to enter "John" and "Doe" for this example to work.
 
-<Canvas>
-    <Story of={FinalFormStories.SubmitMutationBestPractices} />
-</Canvas>
+<Canvas of={FinalFormStories.SubmitMutationBestPractices} />

--- a/storybook/src/docs/form/components/FinalFormFields.mdx
+++ b/storybook/src/docs/form/components/FinalFormFields.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as FinalFormFieldsStories from "./FinalFormFields.stories";
 
@@ -13,9 +13,7 @@ Comet Admin provides a set of FinalForm compatible form fields.
 `FinalFormInput` is a plain input field.
 You can use it like the HTML input element.
 
-<Canvas>
-    <Story of={FinalFormFieldsStories._FinalFormInput} />
-</Canvas>
+<Canvas of={FinalFormFieldsStories._FinalFormInput} />
 
 ## FinalFormSearchTextField
 
@@ -23,9 +21,7 @@ You can use it like the HTML input element.
 You can use it for implementing a search field.
 It doesn't have any built-in search functionality.
 
-<Canvas>
-    <Story of={FinalFormFieldsStories._FinalFormSearchTextField} />
-</Canvas>
+<Canvas of={FinalFormFieldsStories._FinalFormSearchTextField} />
 
 ## FinalFormSelect
 
@@ -33,36 +29,28 @@ It doesn't have any built-in search functionality.
 For async options, use the special `FinalFormAsyncSelect` component that uses the `useAsyncOptionsProps()` hook internally.
 It expects the value to be an object to be able to display the current value without having to load the async options.
 
-<Canvas>
-    <Story of={FinalFormFieldsStories._FinalFormSelect} />
-</Canvas>
+<Canvas of={FinalFormFieldsStories._FinalFormSelect} />
 
 ## FinalFormAutocomplete
 
 `FinalFormAutocomplete` provides a select with a search field.
 It can be used similarly to [FinalFormSelect](#finalformselect).
 
-<Canvas>
-    <Story of={FinalFormFieldsStories._FinalFormAutocomplete} />
-</Canvas>
+<Canvas of={FinalFormFieldsStories._FinalFormAutocomplete} />
 
 ## FinalFormCheckbox
 
 `FinalFormCheckbox` provides a checkbox.
 It should be used inside a [Material UI `FormControlLabel`](https://v4.mui.com/api/form-control-label/#formcontrollabel-api).
 
-<Canvas>
-    <Story of={FinalFormFieldsStories._FinalFormCheckbox} />
-</Canvas>
+<Canvas of={FinalFormFieldsStories._FinalFormCheckbox} />
 
 ## FinalFormSwitch
 
 `FinalFormSwitch` provides a switch.
 It should be used inside a [Material UI `FormControlLabel`](https://v4.mui.com/api/form-control-label/#formcontrollabel-api).
 
-<Canvas>
-    <Story of={FinalFormFieldsStories._FinalFormSwitch} />
-</Canvas>
+<Canvas of={FinalFormFieldsStories._FinalFormSwitch} />
 
 ## FinalFormRadio
 
@@ -72,9 +60,7 @@ It should be used inside a [Material UI `FormControlLabel`](https://v4.mui.com/a
 Each radio option must be a separate `Field`.
 All the Fields should be wrapped in a `FieldContainer`.
 
-<Canvas>
-    <Story of={FinalFormFieldsStories._FinalFormRadio} />
-</Canvas>
+<Canvas of={FinalFormFieldsStories._FinalFormRadio} />
 
 ## FinalFormRangeInput
 
@@ -82,6 +68,4 @@ All the Fields should be wrapped in a `FieldContainer`.
 It consists of two text input fields and a slider.
 This range input can, for example, be used for filtering products by price.
 
-<Canvas>
-    <Story of={FinalFormFieldsStories._FinalFormRangeInput} />
-</Canvas>
+<Canvas of={FinalFormFieldsStories._FinalFormRangeInput} />

--- a/storybook/src/docs/form/components/FormSection.mdx
+++ b/storybook/src/docs/form/components/FormSection.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as FormSectionStories from "./FormSection.stories";
 
@@ -9,6 +9,4 @@ import * as FormSectionStories from "./FormSection.stories";
 The FormSection is used to separate larger forms into smaller groups of inputs/fields that can be described with a title.<br/>
 This should result in a less cluttered and easier to understand form.
 
-<Canvas>
-    <Story of={FormSectionStories.Basic} />
-</Canvas>
+<Canvas of={FormSectionStories.Basic} />

--- a/storybook/src/docs/form/components/NumberField.mdx
+++ b/storybook/src/docs/form/components/NumberField.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as NumberFieldStories from "./NumberField.stories";
 
@@ -10,20 +10,14 @@ The NumberField can be used for number inputs. It automatically formats the numb
 
 ## Basic usage
 
-<Canvas>
-    <Story of={NumberFieldStories.Basic} />
-</Canvas>
+<Canvas of={NumberFieldStories.Basic} />
 
 ## Usage with decimals
 
 The decimals prop is used to define, how many decimal digits the value should have.
 
-<Canvas>
-    <Story of={NumberFieldStories.WithDecimals} />
-</Canvas>
+<Canvas of={NumberFieldStories.WithDecimals} />
 
 ## Usage as Currency Field
 
-<Canvas>
-    <Story of={NumberFieldStories.Currency} />
-</Canvas>
+<Canvas of={NumberFieldStories.Currency} />

--- a/storybook/src/docs/helper/clipboard.mdx
+++ b/storybook/src/docs/helper/clipboard.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as ClipboardStories from "./clipboard.stories";
 
@@ -10,12 +10,8 @@ Comet Admin contains small helpers to make the browser clipboard API easier to u
 
 ## writeClipboardText
 
-<Canvas>
-    <Story of={ClipboardStories.Write} />
-</Canvas>
+<Canvas of={ClipboardStories.Write} />
 
 ## readClipboardText
 
-<Canvas>
-    <Story of={ClipboardStories.Read} />
-</Canvas>
+<Canvas of={ClipboardStories.Read} />

--- a/storybook/src/docs/hooks/useAsyncOptionsProps/useAsyncOptionsProps.mdx
+++ b/storybook/src/docs/hooks/useAsyncOptionsProps/useAsyncOptionsProps.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as UseAsyncOptionsPropsStories from "./useAsyncOptionsProps.stories";
 
@@ -12,12 +12,8 @@ The shape of the object (in the examples: `interface Option`) can vary and deter
 
 ### FinalFormSelect
 
-<Canvas>
-    <Story of={UseAsyncOptionsPropsStories.Select} />
-</Canvas>
+<Canvas of={UseAsyncOptionsPropsStories.Select} />
 
 ### FinalFormAutocomplete
 
-<Canvas>
-    <Story of={UseAsyncOptionsPropsStories.Autocomplete} />
-</Canvas>
+<Canvas of={UseAsyncOptionsPropsStories.Autocomplete} />

--- a/storybook/src/docs/hooks/useFocusAwarePolling/useFocusAwarePolling.mdx
+++ b/storybook/src/docs/hooks/useFocusAwarePolling/useFocusAwarePolling.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as UseFocusAwarePollingStories from "./useFocusAwarePolling.stories";
 
@@ -12,14 +12,10 @@ Additionally, the query will be updated immediately on focus using `refetch`.
 
 ## Basic example
 
-<Canvas>
-    <Story of={UseFocusAwarePollingStories.BasicExample} />
-</Canvas>
+<Canvas of={UseFocusAwarePollingStories.BasicExample} />
 
 ### Query with `skip` option
 
 When using the `useQuery` hook with the `skip` option enabled (for instance, to pause polling when a dialog is not open), add the `skip` option to `useFocusAwarePolling`.
 
-<Canvas>
-    <Story of={UseFocusAwarePollingStories.WithSkipOption} />
-</Canvas>
+<Canvas of={UseFocusAwarePollingStories.WithSkipOption} />

--- a/storybook/src/docs/hooks/useStoredState/useStoredState.mdx
+++ b/storybook/src/docs/hooks/useStoredState/useStoredState.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as UseStoredStateStories from "./useStoredState.stories";
 
@@ -10,14 +10,10 @@ The `useStoredState()` hook has a similar api like the `React.useState()` hook. 
 
 ### Local Storage
 
-<Canvas>
-    <Story of={UseStoredStateStories.LocalStorage} />
-</Canvas>
+<Canvas of={UseStoredStateStories.LocalStorage} />
 
 ### Session Storage
 
 There is also the possibility to store the state in session storage by setting the kind of storage (`window.localStorage` or `window.sessionStorage`) after the initial state. The session storage is not persistent over tabs and lasts only for the current session.
 
-<Canvas>
-    <Story of={UseStoredStateStories.SessionStorage} />
-</Canvas>
+<Canvas of={UseStoredStateStories.SessionStorage} />

--- a/storybook/src/docs/icons/AllIcons.mdx
+++ b/storybook/src/docs/icons/AllIcons.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as AllIconsStories from "./AllIcons.stories";
 
@@ -8,4 +8,4 @@ import * as AllIconsStories from "./AllIcons.stories";
 
 ## All Icons
 
-<Story of={AllIconsStories.AllIcons} />
+<Canvas of={AllIconsStories.AllIcons} />

--- a/storybook/src/docs/icons/IconsUsage.mdx
+++ b/storybook/src/docs/icons/IconsUsage.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import * as IconsUsageStories from "./IconsUsage.stories";
 
@@ -14,33 +14,25 @@ Import desired icon from `comet/admin-icons` and use it like a regular React Com
 import { Attachment } from "@comet/admin-icons";
 ```
 
-<Canvas>
-    <Story of={IconsUsageStories.Icon} />
-</Canvas>
+<Canvas of={IconsUsageStories.Icon} />
 
 ## Sizes
 
-<Canvas>
-    <Story of={IconsUsageStories.SmallSizeIcon} />
-    <Story of={IconsUsageStories.DefaultSizeIcon} />
-    <Story of={IconsUsageStories.LargeSizeIcon} />
-    <Story of={IconsUsageStories.CustomSizeIcon} />
-</Canvas>
+<Canvas of={IconsUsageStories.SmallSizeIcon} />
+<Canvas of={IconsUsageStories.DefaultSizeIcon} />
+<Canvas of={IconsUsageStories.LargeSizeIcon} />
+<Canvas of={IconsUsageStories.CustomSizeIcon} />
 
 ## Render icon in text
 
-<Canvas>
-    <Story of={IconsUsageStories.RenderIconInText} />
-</Canvas>
+<Canvas of={IconsUsageStories.RenderIconInText} />
 
 ## Colors
 
-<Canvas>
-    <Story of={IconsUsageStories.DefaultColor} />
-    <Story of={IconsUsageStories.PrimaryColor} />
-    <Story of={IconsUsageStories.SecondaryColor} />
-    <Story of={IconsUsageStories.ErrorColor} />
-    <Story of={IconsUsageStories.DisabledColor} />
-    <Story of={IconsUsageStories.ActionColor} />
-    <Story of={IconsUsageStories.CustomColor} />
-</Canvas>
+<Canvas of={IconsUsageStories.DefaultColor} />
+<Canvas of={IconsUsageStories.PrimaryColor} />
+<Canvas of={IconsUsageStories.SecondaryColor} />
+<Canvas of={IconsUsageStories.ErrorColor} />
+<Canvas of={IconsUsageStories.DisabledColor} />
+<Canvas of={IconsUsageStories.ActionColor} />
+<Canvas of={IconsUsageStories.CustomColor} />


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

Previously each canvas would show the same story on a given page, the first one that was loaded. This is fixed by only rendering the `Canvas` directly, instead of a `Story`, nested within a `Canvas`.

This seems to be the correct way to render stories, according to the Storybook docs: https://storybook.js.org/docs/writing-docs/mdx#basic-example

<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

-->

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1317