### PR TITLE
Fix replace file by filename and folder

### DIFF
--- a/packages/api/cms-api/src/dam/files/files.controller.ts
+++ b/packages/api/cms-api/src/dam/files/files.controller.ts
@@ -20,6 +20,7 @@ import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
 import { Response } from "express";
 import { OutgoingHttpHeaders } from "http";
+import { basename, extname } from "path";
 import { Readable } from "stream";
 
 import { DisableCometGuards } from "../../auth/decorators/disable-comet-guards.decorator";
@@ -42,7 +43,7 @@ import { FileParams, HashFileParams } from "./dto/file.params";
 import { FileUploadInput } from "./dto/file-upload.input";
 import { FileInterface } from "./entities/file.entity";
 import { FilesService } from "./files.service";
-import { calculatePartialRanges } from "./files.utils";
+import { calculatePartialRanges, slugifyFilename } from "./files.utils";
 import { FoldersService } from "./folders.service";
 
 const fileUrl = `:fileId/:filename`;
@@ -139,7 +140,11 @@ export function createFilesController({ Scope: PassedScope }: { Scope?: Type<Dam
                 }
             }
 
-            const fileToReplace = await this.filesService.findOneByFilenameAndFolder({ filename: file.originalname, folderId });
+            const extension = extname(file.originalname);
+            const filename = basename(file.originalname, extension);
+            const slugifiedFilename = slugifyFilename(filename, extension);
+
+            const fileToReplace = await this.filesService.findOneByFilenameAndFolder({ filename: slugifiedFilename, folderId });
             if (!fileToReplace) {
                 throw new NotFoundException(`File not found`);
             }


### PR DESCRIPTION
depends on #2803 

## Description

### Problem

Files with more "complicated" names (e.g. containing spaces) couldn't be replaced.

### Reason

The filename wasn't slugified before searching for the duplicate in the DB.

### Solution

Slugify the filename before getting the duplicate.


## Screenshots/screencasts

### Before

https://github.com/user-attachments/assets/59ccd5da-7d16-4799-b732-d4c434407861


### After


https://github.com/user-attachments/assets/6c70feb7-df32-4a40-9f46-188839d856f5


## Changeset

-   [x] I have verified if my change requires a changeset

Doesn't require one since it fixes an unreleased bug

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1133
