### PR TITLE
Add DataGrid to CrudMoreActionsMenu story

### DIFF
--- a/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
+++ b/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
@@ -547,7 +547,7 @@ export const _CrudMoreActionsMenu = {
         }
 
         return (
-            <Box sx={{ height: 600, width: "100%" }}>
+            <Box height={600}>
                 <DataGrid
                     {...dataGridProps}
                     rows={exampleRows}

--- a/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
+++ b/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
@@ -21,9 +21,10 @@ import {
 import { Delete, Download, Favorite, MoreVertical, Move } from "@comet/admin-icons";
 import { Button, Divider, Menu, MenuItem, useTheme } from "@mui/material";
 import Box from "@mui/material/Box";
-import { DataGrid } from "@mui/x-data-grid";
+import { DataGrid, GridSelectionModel } from "@mui/x-data-grid";
 import { DataGridPro } from "@mui/x-data-grid-pro";
 import * as React from "react";
+import { useState } from "react";
 
 import { apolloStoryDecorator } from "../../../apollo-story.decorator";
 import { storyRouterDecorator } from "../../../story-router.decorator";
@@ -505,48 +506,16 @@ export const UseDataGridExcelExport = {
 
 export const _CrudMoreActionsMenu = {
     render: () => {
-        return (
-            <Box sx={{ height: 300, width: "100%" }}>
-                <h2>Without selection:</h2>
-                <DataGridToolbar>
-                    <ToolbarFillSpace />
-                    <ToolbarItem>
-                        <CrudMoreActionsMenu
-                            selectionSize={0}
-                            overallActions={[
-                                {
-                                    label: "Export to excel",
-                                    onClick: () => {},
-                                },
-                            ]}
-                            selectiveActions={[
-                                {
-                                    label: "Move",
-                                    onClick: () => {},
-                                    icon: <Move />,
-                                },
-                                {
-                                    label: "Delete",
-                                    onClick: () => {},
-                                    icon: <Delete />,
-                                    divider: true,
-                                },
-                                {
-                                    label: "Download",
-                                    onClick: () => {},
-                                    icon: <Download />,
-                                },
-                            ]}
-                        />
-                    </ToolbarItem>
-                </DataGridToolbar>
+        const [selectionModel, setSelectionModel] = useState<GridSelectionModel>([]);
+        const dataGridProps = useDataGridRemote();
 
-                <h2>With selection:</h2>
+        function DemoToolBar() {
+            return (
                 <DataGridToolbar>
                     <ToolbarFillSpace />
                     <ToolbarItem>
                         <CrudMoreActionsMenu
-                            selectionSize={2}
+                            selectionSize={selectionModel.length}
                             overallActions={[
                                 {
                                     label: "Export to excel",
@@ -574,6 +543,25 @@ export const _CrudMoreActionsMenu = {
                         />
                     </ToolbarItem>
                 </DataGridToolbar>
+            );
+        }
+
+        return (
+            <Box sx={{ height: 600, width: "100%" }}>
+                <DataGrid
+                    {...dataGridProps}
+                    rows={exampleRows}
+                    columns={exampleColumns}
+                    checkboxSelection
+                    disableSelectionOnClick
+                    onSelectionModelChange={(newSelectionModel) => {
+                        setSelectionModel(newSelectionModel);
+                    }}
+                    selectionModel={selectionModel}
+                    components={{
+                        Toolbar: DemoToolBar,
+                    }}
+                />
             </Box>
         );
     },


### PR DESCRIPTION
## Description

Add a DataGrid to CrudMoreActionsMenu story to demonstrate selected row count in the `CrudMoreActionsMenu`

## Example

-   [x] I have verified if my change requires an example

## Screenshots/screencasts

| Before   | After   |
| -------- | ------- |
| ![Bildschirmfoto 2024-11-25 um 12 32 58](https://github.com/user-attachments/assets/ee3d1705-8358-4025-84a0-b436c9265b44)     | ![Bildschirmfoto 2024-11-25 um 12 32 39](https://github.com/user-attachments/assets/e40ee96d-37b5-4b1b-a0d1-d63343c4b098)|

## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1286
