### PR TITLE
Fix a bug that prevented dynamically rendered tabs in `Tabs`

### DIFF
--- a/.changeset/early-eyes-return.md
+++ b/.changeset/early-eyes-return.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix a bug that prevented `Tabs` to be dynamically rendered inside Storybook

--- a/.changeset/early-eyes-return.md
+++ b/.changeset/early-eyes-return.md
@@ -2,4 +2,4 @@
 "@comet/admin": patch
 ---
 
-Fix a bug that prevented `Tabs` to be dynamically rendered inside Storybook
+Fix a bug that prevented dynamically rendered tabs in `Tabs`

--- a/packages/admin/admin/src/tabs/Tabs.tsx
+++ b/packages/admin/admin/src/tabs/Tabs.tsx
@@ -125,15 +125,14 @@ export function Tabs(inProps: TabsProps) {
                 })}
             </StyledTabs>
             {Children.map(children, (child: ReactElement<TabProps>, index) => {
-                const ownerState: OwnerState = {
-                    contentHidden: index !== value && child.props.forceRender,
-                };
-
                 if (!isValidElement<TabProps>(child)) {
                     return null;
                 }
 
                 if (index === value || child.props.forceRender) {
+                    const ownerState: OwnerState = {
+                        contentHidden: index !== value && child.props.forceRender,
+                    };
                     return (
                         <Content ownerState={ownerState} {...slotProps?.content}>
                             {child.props.children}


### PR DESCRIPTION

## Description
Fix a Bug in the Tabs component that stopped it from dynamically rendering in Storybook
- child props were sometimes undefined and cause the Story to stop working
<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->



## Example


-   [x] I have verified if my change requires an example


## Changeset



-   [x] I have verified if my change requires a changeset


