### PR TITLE
Don't show empty menu in mobile version of `ToolbarBreadcrumbs`

### DIFF
--- a/.changeset/twenty-roses-rest.md
+++ b/.changeset/twenty-roses-rest.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix a bug in `ToolbarBreadcrumbs` where it was possible to open the mobile breadcrumbs menu when there were no items to be shown in the menu

--- a/packages/admin/admin/src/common/toolbar/ToolbarBreadcrumbs.tsx
+++ b/packages/admin/admin/src/common/toolbar/ToolbarBreadcrumbs.tsx
@@ -14,6 +14,7 @@ type ToolbarBreadcrumbsClassKey =
     | "mobileBreadcrumbsButton"
     | "currentBreadcrumbsItem"
     | "breadcrumbsItem"
+    | "mobileStandaloneCurrentBreadcrumbItem"
     | "breadcrumbsItemSeparator"
     | "breadcrumbsEllipsisItem"
     | "mobileMenu"
@@ -29,6 +30,7 @@ interface ToolbarBreadcrumbsProps
         mobileBreadcrumbsButton: typeof ButtonBase;
         currentBreadcrumbsItem: typeof Typography;
         breadcrumbsItem: typeof Typography;
+        mobileStandaloneCurrentBreadcrumbItem: "div";
         breadcrumbsItemSeparator: "div";
         breadcrumbsEllipsisItem: typeof Typography;
         mobileMenu: typeof Menu;
@@ -70,6 +72,12 @@ export const ToolbarBreadcrumbs = (inProps: ToolbarBreadcrumbsProps) => {
 
     const itemSeparator = <BreadcrumbsItemSeparator>{itemSeparatorIcon}</BreadcrumbsItemSeparator>;
 
+    const currentBreadcrumbItem = (
+        <CurrentBreadcrumbsItem variant="body2" {...slotProps?.currentBreadcrumbsItem}>
+            {lastBreadcrumb.title}
+        </CurrentBreadcrumbsItem>
+    );
+
     return (
         <>
             <Root ref={rootRef} {...slotProps?.root} {...restProps}>
@@ -106,20 +114,22 @@ export const ToolbarBreadcrumbs = (inProps: ToolbarBreadcrumbsProps) => {
                         );
                     })}
                 </BreadcrumbsList>
-                <MobileBreadcrumbsButton disableRipple {...slotProps?.mobileBreadcrumbsButton} onClick={toggleMobileMenu}>
-                    {breadcrumbs.length > 1 && (
+                {breadcrumbs.length > 1 ? (
+                    <MobileBreadcrumbsButton disableRipple {...slotProps?.mobileBreadcrumbsButton} onClick={toggleMobileMenu}>
                         <>
                             <BreadcrumbsEllipsisItem variant="body2" {...slotProps?.breadcrumbsEllipsisItem}>
                                 ...
                             </BreadcrumbsEllipsisItem>
                             {itemSeparator}
                         </>
-                    )}
-                    <CurrentBreadcrumbsItem variant="body2" {...slotProps?.currentBreadcrumbsItem}>
-                        {lastBreadcrumb.title}
-                    </CurrentBreadcrumbsItem>
-                    <MobileMenuIcon {...slotProps?.mobileMenuIcon}>{showMobileMenu ? closeMobileMenuIcon : openMobileMenuIcon}</MobileMenuIcon>
-                </MobileBreadcrumbsButton>
+                        {currentBreadcrumbItem}
+                        <MobileMenuIcon {...slotProps?.mobileMenuIcon}>{showMobileMenu ? closeMobileMenuIcon : openMobileMenuIcon}</MobileMenuIcon>
+                    </MobileBreadcrumbsButton>
+                ) : (
+                    <MobileStandaloneCurrentBreadcrumbItem {...slotProps?.mobileStandaloneCurrentBreadcrumbItem}>
+                        {currentBreadcrumbItem}
+                    </MobileStandaloneCurrentBreadcrumbItem>
+                )}
             </Root>
             <MobileMenu
                 open={showMobileMenu}
@@ -214,6 +224,17 @@ const MobileBreadcrumbsButton = createComponentSlot(ButtonBase)<ToolbarBreadcrum
         padding-top: ${theme.spacing(2)};
         padding-bottom: ${theme.spacing(2)};
 
+        ${theme.breakpoints.up("md")} {
+            display: none;
+        }
+    `,
+);
+
+const MobileStandaloneCurrentBreadcrumbItem = createComponentSlot("div")<ToolbarBreadcrumbsClassKey>({
+    componentName: "ToolbarBreadcrumbs",
+    slotName: "mobileStandaloneCurrentBreadcrumbItem",
+})(
+    ({ theme }) => css`
         ${theme.breakpoints.up("md")} {
             display: none;
         }


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description 

This prevents opening the mobile menu for breadcrumbs if there are no breadcrumbs to be shown. 

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

-->

## Screenshots

| Before (closed menu) | Before (open menu) | After |
| --- | --- | --- |
| <img width="375" alt="ToolbarBreadcrumbs Before (closed menu)" src="https://github.com/user-attachments/assets/6b349c08-0852-4c33-afa3-362079b810e7"> | <img width="375" alt="ToolbarBreadcrumbs Before (open menu)" src="https://github.com/user-attachments/assets/4dd225fb-9b76-4bd9-9f24-4c22a79ef4a5"> | <img width="375" alt="ToolbarBreadcrumbs After" src="https://github.com/user-attachments/assets/dbb975a0-3702-4262-a1ed-f1bcfef77d36"> |

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1326
