### PR TITLE
Fix width of ToolbarBreadcrumbs mobile menu

### DIFF
--- a/.changeset/young-files-kneel.md
+++ b/.changeset/young-files-kneel.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Prevent the width of the mobile breadcrumbs menu of `ToolbarBreadcrumbs` from being far too small

--- a/packages/admin/admin/src/common/toolbar/ToolbarBreadcrumbs.tsx
+++ b/packages/admin/admin/src/common/toolbar/ToolbarBreadcrumbs.tsx
@@ -60,21 +60,16 @@ export const ToolbarBreadcrumbs = (inProps: ToolbarBreadcrumbsProps) => {
     const breadcrumbs = stackApi?.breadCrumbs ?? [];
     const menuWidth = useObservedWidth(rootRef);
 
-    if (!breadcrumbs.length) {
-        return null;
-    }
-
-    const lastBreadcrumb = breadcrumbs[breadcrumbs.length - 1];
-
     const toggleMobileMenu = () => {
         setShowMobileMenu((val) => !val);
     };
 
     const itemSeparator = <BreadcrumbsItemSeparator>{itemSeparatorIcon}</BreadcrumbsItemSeparator>;
 
+    const lastBreadcrumbTitle = breadcrumbs.length ? breadcrumbs[breadcrumbs.length - 1].title : null;
     const currentBreadcrumbItem = (
         <CurrentBreadcrumbsItem variant="body2" {...slotProps?.currentBreadcrumbsItem}>
-            {lastBreadcrumb.title}
+            {lastBreadcrumbTitle}
         </CurrentBreadcrumbsItem>
     );
 
@@ -317,6 +312,10 @@ const MobileMenu = createComponentSlot(Menu)<ToolbarBreadcrumbsClassKey>({
     slotName: "mobileMenu",
 })(
     ({ theme }) => css`
+        .MuiPopover-paper {
+            min-width: 220px;
+        }
+
         .MuiMenu-list {
             padding-top: ${theme.spacing(3)};
             padding-bottom: ${theme.spacing(3)};


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

The width of the menu was previously set to the width of the components `Root` slot. 
This broke with https://github.com/vivid-planet/comet/pull/2824, the width was always be `0` since then. 
Previously the `Root` slot was not be rendered on the initial render, due to the `breadcrumbs` array being empty. 
Now the `Root` slot is always rendered, causing the ref to exist initially, allowing `useObservedWidth()` to start listening to the element correctly. 

Additionally a min-width of `220px` was added to make sure the menu has a useful width, even if the name of the visible breadcrumbs is short. 

<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

-->


## Screenshots/screencasts

| Before   | After   |
| -------- | ------- |
| <img width="375" alt="ToolbarBreadcrumbs Before" src="https://github.com/user-attachments/assets/82430352-42f6-4663-98be-0a37b8bc45e3"> | <img width="375" alt="ToolbarBreadcrumbs After" src="https://github.com/user-attachments/assets/5600d928-288b-40ba-82c5-97b9f51111f1"> |

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1326

## Open TODOs/questions

- [x] Merge parent PR https://github.com/vivid-planet/comet/pull/2824