### PR TITLE
Add missing spacing to the clear-color button of `ColorPicker`

### DIFF
--- a/.changeset/afraid-rivers-talk.md
+++ b/.changeset/afraid-rivers-talk.md
@@ -2,4 +2,4 @@
 "@comet/admin-color-picker": patch
 ---
 
-Add a gap to `FooterClearButton` slot to prevent the typography from sticking to the color preview
+Add missing spacing to the clear-color button of `ColorPicker`

--- a/.changeset/afraid-rivers-talk.md
+++ b/.changeset/afraid-rivers-talk.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-color-picker": patch
+---
+
+Add a gap to `FooterClearButton` slot to prevent the typography from sticking to the color preview

--- a/packages/admin/admin-color-picker/src/ColorPicker.slots.ts
+++ b/packages/admin/admin-color-picker/src/ColorPicker.slots.ts
@@ -203,6 +203,7 @@ export const FooterClearButton = createComponentSlot(ButtonBase)<ColorPickerClas
     ({ theme }) => css`
         padding: ${theme.spacing(2)};
         border-radius: ${theme.shape.borderRadius};
+        gap: 8px;
     `,
 );
 


### PR DESCRIPTION
## Description

Add spacing to `FooterClearButton` in `ColorPicker`


## Screenshots/screencasts

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/14b90887-7875-4f04-91aa-ed323e4f60f2) | ![After](https://github.com/user-attachments/assets/cd55e63d-4536-4bce-ab0e-9ff67a6a65c2) |


## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1264


