### PR TITLE
Add hover styling for MUI's `Switch`

### DIFF
--- a/.changeset/wild-lions-study.md
+++ b/.changeset/wild-lions-study.md
@@ -2,4 +2,4 @@
 "@comet/admin-theme": minor
 ---
 
-Add hover styling to `MuiSwitch`
+Add hover styling for MUI's `Switch`

--- a/.changeset/wild-lions-study.md
+++ b/.changeset/wild-lions-study.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": minor
+---
+
+Add hover styling to `MuiSwitch`

--- a/packages/admin/admin-theme/src/componentsTheme/MuiSwitch.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSwitch.ts
@@ -20,6 +20,13 @@ export const getMuiSwitch: GetMuiComponentTheme<"MuiSwitch"> = (component, { pal
             margin: 9,
             padding: 3,
             color: palette.grey[200],
+            "&:hover": {
+                color: palette.grey[400],
+
+                [`& + .${switchClasses.track}`]: {
+                    border: `1px solid ${palette.grey[400]}`,
+                },
+            },
 
             [`&.${switchClasses.checked}`]: {
                 transform: "translateX(20px)",
@@ -43,6 +50,13 @@ export const getMuiSwitch: GetMuiComponentTheme<"MuiSwitch"> = (component, { pal
         colorPrimary: {
             [`&.${switchClasses.switchBase}.${switchClasses.checked}`]: {
                 color: palette.primary.main,
+                "&:hover": {
+                    color: palette.primary.dark,
+
+                    [`& + .${switchClasses.track}`]: {
+                        border: `1px solid ${palette.primary.dark}`,
+                    },
+                },
             },
             [`&.${switchClasses.checked} + .${switchClasses.track}`]: {
                 backgroundColor: "#fff",


### PR DESCRIPTION


## Description

Add hover styling for MuiSwitch (selected and unselected)


## Screenshots/screencasts


https://github.com/user-attachments/assets/5d56d454-29e8-487b-9d24-eaaf1fe6905c



## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents
https://vivid-planet.atlassian.net/browse/COM-1269

Design: https://www.figma.com/design/Swzee5YSEkPVlCXHcyL7mp/COMET-DXP-Library?node-id=1227-14460&node-type=canvas&t=7w36iKp7jlPCvlg4-0


