### PR TITLE
Add middleware to prevent hard error on site preview without preview params

### DIFF
--- a/demo/site/src/middleware.ts
+++ b/demo/site/src/middleware.ts
@@ -6,8 +6,10 @@ import { withDamRewriteMiddleware } from "./middleware/damRewrite";
 import { withDomainRewriteMiddleware } from "./middleware/domainRewrite";
 import { withPredefinedPagesMiddleware } from "./middleware/predefinedPages";
 import { withRedirectToMainHostMiddleware } from "./middleware/redirectToMainHost";
+import { withSitePreviewMiddleware } from "./middleware/sitePreview";
 
 export default chain([
+    withSitePreviewMiddleware,
     withRedirectToMainHostMiddleware,
     withAdminRedirectMiddleware,
     withDamRewriteMiddleware,

--- a/demo/site/src/middleware/sitePreview.ts
+++ b/demo/site/src/middleware/sitePreview.ts
@@ -1,0 +1,15 @@
+import { getHostByHeaders, getSiteConfigForHost } from "@src/util/siteConfig";
+import { NextRequest, NextResponse } from "next/server";
+
+import { CustomMiddleware } from "./chain";
+
+export function withSitePreviewMiddleware(middleware: CustomMiddleware) {
+    return async (request: NextRequest) => {
+        const host = getHostByHeaders(request.headers);
+        const siteConfig = await getSiteConfigForHost(host);
+        if (!siteConfig && host === process.env.PREVIEW_DOMAIN) {
+            return NextResponse.json({ error: "Preview has to be called from within Comet Web preview" }, { status: 404 });
+        }
+        return middleware(request);
+    };
+}


### PR DESCRIPTION
In deployed instances we use separate domains for site preview and site. The site preview is called from Comet via invoking an API of the site which then sets preview params as a cookie.

The current implementation presents a hard error when the preview domain is called without the prior invocation of the site preview api which leads to unwanted error logs.

This PR adds a middleware to check for this case. However, since we don't use a separate preview domain in Demo this code never get's called. Nevertheless we will need this in the Starter.