### PR TITLE
Add `label` prop to `ColumnsLayoutPreview`

### DIFF
--- a/.changeset/modern-berries-marry.md
+++ b/.changeset/modern-berries-marry.md
@@ -1,0 +1,12 @@
+---
+"@comet/blocks-admin": minor
+---
+
+Add `label` prop to `ColumnsLayoutPreview`.
+Use it to customize the label of the column displayed in the `FinalFormLayoutSelect`. For e.g. to add an icon or add custom text.
+
+Example:
+
+```tsx
+<ColumnsLayoutPreviewContent width={10} label={<Image />} />
+```

--- a/.changeset/modern-berries-marry.md
+++ b/.changeset/modern-berries-marry.md
@@ -4,9 +4,8 @@
 
 Add `label` prop to `ColumnsLayoutPreview`
 
-Use it to customize the label of the column displayed in the `FinalFormLayoutSelect`. For e.g. to add an icon or add custom text.
-
-Example:
+Use it to customize the label of the column displayed in the `FinalFormLayoutSelect`.
+For instance, to add an icon or add custom text:
 
 ```tsx
 <ColumnsLayoutPreviewContent width={10} label={<Image />} />

--- a/.changeset/modern-berries-marry.md
+++ b/.changeset/modern-berries-marry.md
@@ -2,7 +2,8 @@
 "@comet/blocks-admin": minor
 ---
 
-Add `label` prop to `ColumnsLayoutPreview`.
+Add `label` prop to `ColumnsLayoutPreview`
+
 Use it to customize the label of the column displayed in the `FinalFormLayoutSelect`. For e.g. to add an icon or add custom text.
 
 Example:

--- a/demo/admin/src/pages/blocks/LayoutBlock.tsx
+++ b/demo/admin/src/pages/blocks/LayoutBlock.tsx
@@ -1,4 +1,5 @@
 import { Field } from "@comet/admin";
+import { Hamburger, Image } from "@comet/admin-icons";
 import {
     BlockCategory,
     BlocksFinalForm,
@@ -22,11 +23,11 @@ const layoutOptions: (ColumnsBlockLayout & { visibleBlocks: string[] })[] = [
         columns: 3,
         preview: (
             <ColumnsLayoutPreview>
-                <ColumnsLayoutPreviewContent width={10} />
+                <ColumnsLayoutPreviewContent width={10} label={<Image />} />
                 <ColumnsLayoutPreviewSpacing width={1} />
-                <ColumnsLayoutPreviewContent width={7} />
+                <ColumnsLayoutPreviewContent width={7} label={<Hamburger />} />
                 <ColumnsLayoutPreviewSpacing width={1} />
-                <ColumnsLayoutPreviewContent width={7} />
+                <ColumnsLayoutPreviewContent width={7} label={<Image />} />
             </ColumnsLayoutPreview>
         ),
         visibleBlocks: ["layout", "media1", "text1", "media2"],
@@ -37,11 +38,11 @@ const layoutOptions: (ColumnsBlockLayout & { visibleBlocks: string[] })[] = [
         columns: 3,
         preview: (
             <ColumnsLayoutPreview>
-                <ColumnsLayoutPreviewContent width={7} />
+                <ColumnsLayoutPreviewContent width={7} label={<Hamburger />} />
                 <ColumnsLayoutPreviewSpacing width={1} />
-                <ColumnsLayoutPreviewContent width={10} />
+                <ColumnsLayoutPreviewContent width={10} label={<Image />} />
                 <ColumnsLayoutPreviewSpacing width={1} />
-                <ColumnsLayoutPreviewContent width={7} />
+                <ColumnsLayoutPreviewContent width={7} label={<Hamburger />} />
             </ColumnsLayoutPreview>
         ),
         visibleBlocks: ["layout", "text1", "media1", "text2"],
@@ -52,11 +53,11 @@ const layoutOptions: (ColumnsBlockLayout & { visibleBlocks: string[] })[] = [
         columns: 3,
         preview: (
             <ColumnsLayoutPreview>
-                <ColumnsLayoutPreviewContent width={6} />
+                <ColumnsLayoutPreviewContent width={6} label={<Image />} />
                 <ColumnsLayoutPreviewSpacing width={1} />
-                <ColumnsLayoutPreviewContent width={6} />
+                <ColumnsLayoutPreviewContent width={6} label={<Hamburger />} />
                 <ColumnsLayoutPreviewSpacing width={1} />
-                <ColumnsLayoutPreviewContent width={12} />
+                <ColumnsLayoutPreviewContent width={12} label={<Image />} />
             </ColumnsLayoutPreview>
         ),
         visibleBlocks: ["layout", "media1", "text1", "media2"],
@@ -67,9 +68,9 @@ const layoutOptions: (ColumnsBlockLayout & { visibleBlocks: string[] })[] = [
         columns: 2,
         preview: (
             <ColumnsLayoutPreview>
-                <ColumnsLayoutPreviewContent width={14} />
+                <ColumnsLayoutPreviewContent width={14} label={<Image />} />
                 <ColumnsLayoutPreviewSpacing width={1} />
-                <ColumnsLayoutPreviewContent width={10} />
+                <ColumnsLayoutPreviewContent width={10} label={<Hamburger />} />
             </ColumnsLayoutPreview>
         ),
         visibleBlocks: ["layout", "media1", "text1"],
@@ -80,9 +81,9 @@ const layoutOptions: (ColumnsBlockLayout & { visibleBlocks: string[] })[] = [
         columns: 2,
         preview: (
             <ColumnsLayoutPreview>
-                <ColumnsLayoutPreviewContent width={10} />
+                <ColumnsLayoutPreviewContent width={10} label={<Hamburger />} />
                 <ColumnsLayoutPreviewSpacing width={1} />
-                <ColumnsLayoutPreviewContent width={14} />
+                <ColumnsLayoutPreviewContent width={14} label={<Image />} />
             </ColumnsLayoutPreview>
         ),
         visibleBlocks: ["layout", "text1", "media1"],
@@ -93,9 +94,9 @@ const layoutOptions: (ColumnsBlockLayout & { visibleBlocks: string[] })[] = [
         columns: 2,
         preview: (
             <ColumnsLayoutPreview>
-                <ColumnsLayoutPreviewContent width={12} />
+                <ColumnsLayoutPreviewContent width={12} label={<Image />} />
                 <ColumnsLayoutPreviewSpacing width={1} />
-                <ColumnsLayoutPreviewContent width={12} />
+                <ColumnsLayoutPreviewContent width={12} label={<Hamburger />} />
             </ColumnsLayoutPreview>
         ),
         visibleBlocks: ["layout", "media1", "text1"],
@@ -106,9 +107,9 @@ const layoutOptions: (ColumnsBlockLayout & { visibleBlocks: string[] })[] = [
         columns: 2,
         preview: (
             <ColumnsLayoutPreview>
-                <ColumnsLayoutPreviewContent width={12} />
+                <ColumnsLayoutPreviewContent width={12} label={<Hamburger />} />
                 <ColumnsLayoutPreviewSpacing width={1} />
-                <ColumnsLayoutPreviewContent width={12} />
+                <ColumnsLayoutPreviewContent width={12} label={<Image />} />
             </ColumnsLayoutPreview>
         ),
         visibleBlocks: ["layout", "text1", "media1"],

--- a/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/ColumnsLayoutPreview.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/columnsBlock/ColumnsLayoutPreview.tsx
@@ -1,13 +1,14 @@
 import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { Children, ReactElement } from "react";
-
-interface ContainerProps {
-    children: ReactElement<ItemProps>[];
-}
+import { Children, ReactElement, ReactNode } from "react";
 
 interface ItemProps {
     width: number;
+    label?: ReactNode;
+}
+
+interface ContainerProps {
+    children: ReactElement<ItemProps>[];
 }
 
 export function ColumnsLayoutPreview({ children }: ContainerProps) {
@@ -34,6 +35,6 @@ const RootContent = styled(ColumnsLayoutPreviewSpacing)`
     align-items: center;
 `;
 
-export function ColumnsLayoutPreviewContent({ width }: ItemProps): ReactElement<ItemProps> {
-    return <RootContent width={width}>{width > 3 ? <Typography variant="subtitle1">{width}</Typography> : null}</RootContent>;
+export function ColumnsLayoutPreviewContent({ width, label }: ItemProps) {
+    return <RootContent width={width}>{label ? label : width > 3 ? <Typography variant="subtitle1">{width}</Typography> : null}</RootContent>;
 }


### PR DESCRIPTION
## Description

Add `label` prop to `ColumnsLayoutPreview`. For additional customization we add this prop, so in the preview of the `FinalFormLayoutSelect` there can icons or additional text be added. Fallback is furthermore the width number.

## Screenshots/screencasts

<img width="757" alt="Screenshot 2024-11-29 at 13 00 11" src="https://github.com/user-attachments/assets/a34cc758-8f94-43f3-bb5b-8f91b15ac47d">


