### PR TITLE
Don't add non-existing scope parts to the damScope as undefined

### DIFF
--- a/.changeset/seven-nails-applaud.md
+++ b/.changeset/seven-nails-applaud.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Don't add non-existing scope parts to the `DamScope` as `undefined`

--- a/packages/admin/cms-admin/src/dam/config/DamScopeProvider.tsx
+++ b/packages/admin/cms-admin/src/dam/config/DamScopeProvider.tsx
@@ -9,7 +9,9 @@ export function DamScopeProvider({ children }: { children?: ReactNode }) {
     const { scope: completeScope } = useContentScope();
 
     const damScope = scopeParts.reduce((damScope, scope) => {
-        damScope[scope] = completeScope[scope];
+        if (completeScope[scope] !== undefined) {
+            damScope[scope] = completeScope[scope];
+        }
         return damScope;
     }, {} as Record<string, unknown>);
 


### PR DESCRIPTION
## Description

### Problem:

A scope in an application can either have a organization or a company, so it can either look like this:

```
{
    organizationId: "id"
}
```

or like this

```
{
    companyId: "id"
}
```

You want to have a separate DAM for each company and each organization, so you must pass both scope parts to the `DamConfigProvider`:

```tsx
<DamConfigProvider
    value={{
        scopeParts: ["companyId", "organizationId"],
    }}
>
```

However, the `DamScopeProvider` transformed the scopes into 

```
{
    organizationId: "id",
    companyId: undefined
}
```

or like this

```
{
     organizationId: undefined,
    companyId: "id"
}
```

This caused problems down the road in the `ContentScopeIndicator`

--- 

Tests for this are included in https://github.com/vivid-planet/comet/pull/2860