### PR TITLE
Prevent `ContentScopeIndicator` from crashing when a scope part is `undefined`

### DIFF
--- a/.changeset/nice-ants-eat.md
+++ b/.changeset/nice-ants-eat.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Prevent `ContentScopeIndicator` from crashing when a scope part is `undefined`

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
@@ -23,10 +23,10 @@ export const ContentScopeIndicator = ({ global = false, scope: passedScope, chil
 
     const findLabelForScopePart = (scopePart: keyof ContentScopeInterface) => {
         const label = values.find((value) => {
-            return value[scopePart] && value[scopePart].value === scope[scopePart];
+            return value[scopePart] && value[scopePart]?.value === scope[scopePart];
         })?.[scopePart].label;
 
-        return label ?? capitalizeString(scope[scopePart]);
+        return label ?? (scope[scopePart] ? capitalizeString(scope[scopePart]) : undefined);
     };
 
     let content: ReactNode;
@@ -34,16 +34,8 @@ export const ContentScopeIndicator = ({ global = false, scope: passedScope, chil
         content = <FormattedMessage {...messages.globalContentScope} />;
     } else {
         const scopeParts = Object.keys(scope);
-        content = scopeParts.map((scopePart, index, array) => {
-            const isLastPart = index === array.length - 1;
-
-            const ret = [findLabelForScopePart(scopePart)];
-            if (!isLastPart) {
-                ret.push(" / ");
-            }
-
-            return ret;
-        });
+        const scopeLabels = scopeParts.map((scopePart) => findLabelForScopePart(scopePart)).filter((label) => typeof label === "string") as string[];
+        content = scopeLabels.join(" / ");
     }
 
     return (


### PR DESCRIPTION
## Description

Related to https://github.com/vivid-planet/comet/pull/2858:

Normally, no part of the scope should be `undefined`. It should either have a value or be non-existent. Still, I think in practice it will happen that scope parts become undefined for some reason. 

So this PR makes the ContentScopeIndicator more resistant. Instead of crashing if a scope part is `undefined`, it now just ignores it.

---

Tests for this are included in https://github.com/vivid-planet/comet/pull/2860