### PR TITLE
Revert "Adapt mui link styling"

### DIFF
--- a/.changeset/cold-dots-buy.md
+++ b/.changeset/cold-dots-buy.md
@@ -1,5 +1,0 @@
----
-"@comet/admin-theme": minor
----
-
-Adapt styling of `MuiLink` according to design of Comet DXP

--- a/packages/admin/admin-theme/src/componentsTheme/MuiLink.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiLink.ts
@@ -9,16 +9,11 @@ export const getMuiLink: GetMuiComponentTheme<"MuiLink"> = (component, { palette
     },
     styleOverrides: mergeOverrideStyles<"MuiLink">(component?.styleOverrides, {
         root: {
-            color: palette.primary.main,
+            color: palette.grey[600],
             fontWeight: 250,
             fontSize: 16,
             lineHeight: "16px",
             letterSpacing: 0,
-
-            "&:hover": {
-                backgroundColor: palette.primary.main,
-                color: "#fff",
-            },
         },
     }),
 });


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

Reverts vivid-planet/comet#2844

This accidentally broke the styling of existing usages, e.g., in the DAM. 
This styling will be added back later with a fix for existing usages where the new styling is not desired. 

## Screenshots/screencasts

https://github.com/user-attachments/assets/dfc7b589-4d39-4dd3-bad0-d2294fe911d5

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1251

