### PR TITLE
Fix DAM license duration input when no values are provided

### DIFF
--- a/.changeset/ten-tenors-sing.md
+++ b/.changeset/ten-tenors-sing.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Update @Transform to avoid initializing new Date(null) for license input by treating null as undefined.

--- a/.changeset/ten-tenors-sing.md
+++ b/.changeset/ten-tenors-sing.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": patch
 ---
 
-Update @Transform to avoid initializing new Date(null) for license input by treating null as undefined.
+Fix DAM license duration input when no values are provided

--- a/packages/api/cms-api/src/dam/files/dto/file.input.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.input.ts
@@ -61,7 +61,7 @@ export class LicenseInput {
     @Transform(({ value }) => (value ? new Date(value) : undefined))
     @IsOptional()
     @IsDate()
-    durationFrom?: Date | null;
+    durationFrom?: Date;
 
     @Field(() => Date, { nullable: true })
     @Transform(({ value }) => (value ? new Date(value) : undefined))

--- a/packages/api/cms-api/src/dam/files/dto/file.input.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.input.ts
@@ -58,13 +58,13 @@ export class LicenseInput {
     author?: string;
 
     @Field(() => Date, { nullable: true })
-    @Transform(({ value }) => (value === null || value === undefined ? null : new Date(value)))
+    @Transform(({ value }) => (value ? new Date(value) : null))
     @IsOptional()
     @IsDate()
     durationFrom?: Date;
 
     @Field(() => Date, { nullable: true })
-    @Transform(({ value }) => (value === null || value === undefined ? null : new Date(value)))
+    @Transform(({ value }) => (value ? new Date(value) : null))
     @IsOptional()
     @IsDate()
     durationTo?: Date;

--- a/packages/api/cms-api/src/dam/files/dto/file.input.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.input.ts
@@ -61,13 +61,13 @@ export class LicenseInput {
     @Transform(({ value }) => (value ? new Date(value) : null))
     @IsOptional()
     @IsDate()
-    durationFrom?: Date;
+    durationFrom?: Date | null;
 
     @Field(() => Date, { nullable: true })
     @Transform(({ value }) => (value ? new Date(value) : null))
     @IsOptional()
     @IsDate()
-    durationTo?: Date;
+    durationTo?: Date | null;
 }
 
 export class CreateFileInput {

--- a/packages/api/cms-api/src/dam/files/dto/file.input.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.input.ts
@@ -58,13 +58,13 @@ export class LicenseInput {
     author?: string;
 
     @Field(() => Date, { nullable: true })
-    @Transform(({ value }) => new Date(value))
+    @Transform(({ value }) => (value === null || value === undefined ? null : new Date(value)))
     @IsOptional()
     @IsDate()
     durationFrom?: Date;
 
     @Field(() => Date, { nullable: true })
-    @Transform(({ value }) => new Date(value))
+    @Transform(({ value }) => (value === null || value === undefined ? null : new Date(value)))
     @IsOptional()
     @IsDate()
     durationTo?: Date;

--- a/packages/api/cms-api/src/dam/files/dto/file.input.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.input.ts
@@ -67,7 +67,7 @@ export class LicenseInput {
     @Transform(({ value }) => (value ? new Date(value) : undefined))
     @IsOptional()
     @IsDate()
-    durationTo?: Date | null;
+    durationTo?: Date;
 }
 
 export class CreateFileInput {

--- a/packages/api/cms-api/src/dam/files/dto/file.input.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.input.ts
@@ -58,13 +58,13 @@ export class LicenseInput {
     author?: string;
 
     @Field(() => Date, { nullable: true })
-    @Transform(({ value }) => (value ? new Date(value) : null))
+    @Transform(({ value }) => (value ? new Date(value) : undefined))
     @IsOptional()
     @IsDate()
     durationFrom?: Date | null;
 
     @Field(() => Date, { nullable: true })
-    @Transform(({ value }) => (value ? new Date(value) : null))
+    @Transform(({ value }) => (value ? new Date(value) : undefined))
     @IsOptional()
     @IsDate()
     durationTo?: Date | null;


### PR DESCRIPTION
## Description

When `durationFrom` or `durationTo` input is null, the `@Transform` decorator invokes `new Date(null)`, resulting in `Thu Jan 01 1970 01:00:00 GMT+0100 (Central European Standard Time)` and causing expired licenses to display incorrectly.