### PR TITLE
try out id's for warning messages

### DIFF
--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -47,6 +47,10 @@ export const pageTreeDocumentTypes = {
 
 const RedirectsPage = createRedirectsPage({ customTargets: { news: NewsLinkBlock }, scopeParts: ["domain"] });
 
+const warningMessages = {
+    "warning.missingHtmlTitle": <FormattedMessage id="warning.missingHtmlTitle" defaultMessage="Missing HTML Title" />,
+};
+
 export const masterMenuData: MasterMenuData = [
     {
         type: "route",
@@ -181,7 +185,7 @@ export const masterMenuData: MasterMenuData = [
                 primary: <FormattedMessage id="menu.warnings" defaultMessage="Warnings" />,
                 route: {
                     path: "/system/warnings",
-                    component: WarningsPage,
+                    render: () => <WarningsPage warningMessages={warningMessages} />,
                 },
                 requiredPermission: "pageTree",
             },

--- a/demo/admin/src/warnings/WarningsGrid.tsx
+++ b/demo/admin/src/warnings/WarningsGrid.tsx
@@ -57,7 +57,11 @@ function WarningsGridToolbar() {
     );
 }
 
-export function WarningsGrid(): React.ReactElement {
+interface Props {
+    warningMessages: Record<string, React.ReactNode>;
+}
+
+export function WarningsGrid({ warningMessages }: Props): React.ReactElement {
     const intl = useIntl();
     const dataGridProps = {
         ...useDataGridRemote({ initialFilter: { items: [{ columnField: "state", operatorValue: "is", value: "open" }] } }),
@@ -110,6 +114,7 @@ export function WarningsGrid(): React.ReactElement {
         {
             field: "message",
             headerName: intl.formatMessage({ id: "warning.message", defaultMessage: "Message" }),
+            renderCell: (params) => (params.value in warningMessages ? warningMessages[params.value as keyof typeof warningMessages] : params.value),
             flex: 1,
         },
         {

--- a/demo/admin/src/warnings/WarningsPage.tsx
+++ b/demo/admin/src/warnings/WarningsPage.tsx
@@ -4,11 +4,15 @@ import { useIntl } from "react-intl";
 
 import { WarningsGrid } from "./WarningsGrid";
 
-export function WarningsPage(): React.ReactElement {
+interface Props {
+    warningMessages: Record<string, React.ReactNode>;
+}
+
+export function WarningsPage({ warningMessages }: Props): React.ReactElement {
     const intl = useIntl();
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "warnings.warnings", defaultMessage: "Warnings" })}>
-            <WarningsGrid />
+            <WarningsGrid warningMessages={warningMessages} />
         </Stack>
     );
 }

--- a/packages/api/cms-api/src/blocks/createSeoBlock.ts
+++ b/packages/api/cms-api/src/blocks/createSeoBlock.ts
@@ -141,7 +141,7 @@ export function createSeoBlock<ImageBlock extends Block = typeof PixelImageBlock
 
         warnings() {
             if (!this.htmlTitle) {
-                return [{ severity: WarningSeverity.low, message: "Missing HTML title" }];
+                return [{ severity: WarningSeverity.low, message: "warning.missingHtmlTitle" }];
             }
             return [];
         }


### PR DESCRIPTION
## Description

Trying out using warning ids instead of warning messages to avoid intl/formatjs in the api

Draft because I'm not sure if this is what we want and because a few adjustments are still missing (renaming from message to messageId, comet error messages do not have to be defined in the project, ...)

## Screenshots/screencasts

No visual changes

## Changeset

Will be in the feature PR