### PR TITLE
Make `AboutModal` responsive

### DIFF
--- a/packages/admin/cms-admin/src/common/header/about/AboutModal.tsx
+++ b/packages/admin/cms-admin/src/common/header/about/AboutModal.tsx
@@ -33,7 +33,7 @@ export function AboutModal({ open, onClose, logo = <CometDigitalExperienceLogo /
                     </DialogTitleContent>
                 </DialogTitle>
                 <DialogContent>
-                    {logo}
+                    <LogoContainer>{logo}</LogoContainer>
                     <VersionContainer>
                         <Typography fontWeight={500}>{`v${version}`}</Typography>
                         {buildInformation?.number && buildInformation.commitHash && (
@@ -89,6 +89,7 @@ const DialogTitleSpace = styled("div")`
 const DialogContent = styled(MuiDialogContent)`
     display: flex;
     align-items: center;
+    text-align: center;
     justify-content: center;
     flex-direction: column;
 `;
@@ -99,4 +100,13 @@ const VersionContainer = styled("div")`
     flex-direction: column;
     margin-top: 40px;
     margin-bottom: 40px;
+`;
+
+const LogoContainer = styled("div")`
+    align-items: center;
+
+    svg {
+        max-width: 100%;
+        height: auto;
+    }
 `;


### PR DESCRIPTION
Added Logo container and text-align for copyright

## Screenshots/screencasts

Before:

https://github.com/user-attachments/assets/e10c627d-82bd-481a-896d-dd0bcbedd24b

After:

https://github.com/user-attachments/assets/7bda1116-32f7-40be-8701-d8d56b6d39be

