### PR TITLE
Adapt size of arrow in `Select` and `Autocomplete` fields

### DIFF
--- a/.changeset/poor-kings-live.md
+++ b/.changeset/poor-kings-live.md
@@ -2,4 +2,4 @@
 "@comet/admin-theme": patch
 ---
 
-Adapt size of arrow in `Select` and `Autocomplete` fields according to Comet DXP design.
+Adapt size of arrow in `Select` and `Autocomplete` fields according to Comet DXP design

--- a/.changeset/poor-kings-live.md
+++ b/.changeset/poor-kings-live.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": patch
+---
+
+Adapt size of arrow in `Select` and `Autocomplete` fields according to Comet DXP design.

--- a/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
@@ -27,6 +27,9 @@ export const getMuiAutocomplete: GetMuiComponentTheme<"MuiAutocomplete"> = (comp
             "&:hover": {
                 backgroundColor: "transparent",
             },
+            "& .MuiSvgIcon-root": {
+                fontSize: "12px",
+            },
         },
     }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/getCommonSelectTheme.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/getCommonSelectTheme.tsx
@@ -28,4 +28,5 @@ export const commonSelectStyleOverrides = {
 export const getCommonIconStyleOverrides = (palette: Palette) => ({
     right: 10,
     color: palette.grey[900],
+    fontSize: 12,
 });


### PR DESCRIPTION
## Description
Change the size of the arrow icon in `Select` and `Autocomplete` fields from 16px to 12px according to the Comet DXP design.

## Screenshots/screencasts



| Before   | After   |
| -------- | ------- |
| <img width="300" alt="Screenshot 2024-12-03 at 09 51 35" src="https://github.com/user-attachments/assets/af52c2d8-a6c5-4aef-a901-7aae5e4c8ca4"> | <img src="https://github.com/user-attachments/assets/5ad2315d-174c-4c9d-9d32-6f84f0ef4b2d" width="300" > |




## Changeset
-   [x] I have verified if my change requires a changeset

## Related tasks and documents
https://vivid-planet.atlassian.net/browse/COM-1266
