### PR TITLE
Fix color of disabled states for radio and checkbox

### DIFF
--- a/.changeset/odd-coins-think.md
+++ b/.changeset/odd-coins-think.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin-theme": patch
+---
+
+Adapt `Radio` and `Checkbox` styling to Comet DXP design
+
+Fix colors of disabled states.

--- a/packages/admin/admin-theme/src/componentsTheme/MuiCheckbox.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiCheckbox.tsx
@@ -41,7 +41,7 @@ export const getMuiCheckbox: GetMuiComponentTheme<"MuiCheckbox"> = (component, {
                     fill: "#fff",
                 },
                 "& .background": {
-                    fill: palette.grey[200],
+                    fill: palette.grey[100],
                 },
             },
             [`&.${checkboxClasses.indeterminate} .${svgIconClasses.root}`]: {

--- a/packages/admin/admin-theme/src/componentsTheme/MuiRadio.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiRadio.tsx
@@ -41,7 +41,7 @@ export const getMuiRadio: GetMuiComponentTheme<"MuiRadio"> = (component, { palet
                     fill: "#fff",
                 },
                 "& .background": {
-                    fill: palette.grey[200],
+                    fill: palette.grey[100],
                 },
             },
         },

--- a/storybook/src/admin/form/Checkbox.stories.tsx
+++ b/storybook/src/admin/form/Checkbox.stories.tsx
@@ -49,40 +49,6 @@ export const Checkbox = () => {
                                     </CardContent>
                                 </Card>
                             </Grid>
-                            <Grid item xs={6}>
-                                <Card variant="outlined">
-                                    <CardContent>
-                                        <FieldContainer label="Checkboxes with secondary color">
-                                            <Field name="uncheckedSecondary" type="checkbox" fullWidth>
-                                                {(props) => (
-                                                    <FormControlLabel
-                                                        label="Unchecked"
-                                                        control={<FinalFormCheckbox {...props} color="secondary" />}
-                                                    />
-                                                )}
-                                            </Field>
-                                            <Field name="checkedSecondary" type="checkbox" fullWidth>
-                                                {(props) => (
-                                                    <FormControlLabel label="Checked" control={<FinalFormCheckbox {...props} color="secondary" />} />
-                                                )}
-                                            </Field>
-                                            <Field name="disabledUncheckedSecondary" type="checkbox" fullWidth disabled>
-                                                {(props) => (
-                                                    <FormControlLabel label="Disabled" control={<FinalFormCheckbox {...props} color="secondary" />} />
-                                                )}
-                                            </Field>
-                                            <Field name="disabledCheckedSecondary" type="checkbox" fullWidth disabled>
-                                                {(props) => (
-                                                    <FormControlLabel
-                                                        label="Disabled & Checked"
-                                                        control={<FinalFormCheckbox {...props} color="secondary" />}
-                                                    />
-                                                )}
-                                            </Field>
-                                        </FieldContainer>
-                                    </CardContent>
-                                </Card>
-                            </Grid>
                         </Grid>
                     </form>
                 )}

--- a/storybook/src/admin/form/Radio.stories.tsx
+++ b/storybook/src/admin/form/Radio.stories.tsx
@@ -43,37 +43,6 @@ export const Radio = () => {
                                     </CardContent>
                                 </Card>
                             </Grid>
-                            <Grid item xs={6}>
-                                <Card variant="outlined">
-                                    <CardContent>
-                                        <FieldContainer label="Radios with secondary color">
-                                            <Field name="foo3" type="radio" value="bar1" fullWidth>
-                                                {(props) => (
-                                                    <FormControlLabel label="Unchecked" control={<FinalFormRadio {...props} color="secondary" />} />
-                                                )}
-                                            </Field>
-                                            <Field name="foo3" type="radio" value="bar2" fullWidth>
-                                                {(props) => (
-                                                    <FormControlLabel label="Checked" control={<FinalFormRadio {...props} color="secondary" />} />
-                                                )}
-                                            </Field>
-                                            <Field name="foo4" type="radio" value="bar1" fullWidth disabled>
-                                                {(props) => (
-                                                    <FormControlLabel label="Disabled" control={<FinalFormRadio {...props} color="secondary" />} />
-                                                )}
-                                            </Field>
-                                            <Field name="foo4" type="radio" value="bar2" fullWidth disabled>
-                                                {(props) => (
-                                                    <FormControlLabel
-                                                        label="Disabled & Checked"
-                                                        control={<FinalFormRadio {...props} color="secondary" />}
-                                                    />
-                                                )}
-                                            </Field>
-                                        </FieldContainer>
-                                    </CardContent>
-                                </Card>
-                            </Grid>
                         </Grid>
                     </form>
                 )}


### PR DESCRIPTION
## Description

- The color of the disabled state of Radios and Checkboxes isn't equal. Fix color according to design.
- There are examples of Radios and Checkboxes using the secondary color option. Those are not in our design and are therefor removed. There should only be primary and standard variants.


## Screenshots/screencasts

<img width="324" alt="Screenshot 2024-11-27 at 14 44 00" src="https://github.com/user-attachments/assets/b2603e6d-6814-4e4a-bbe4-2af32e0be454">


<img width="315" alt="Screenshot 2024-11-27 at 14 44 08" src="https://github.com/user-attachments/assets/1f9d6a4e-3281-4afc-819d-8663a5632254">

-->

## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents
 https://vivid-planet.atlassian.net/browse/COM-1267

Design Links:
https://www.figma.com/design/Swzee5YSEkPVlCXHcyL7mp/COMET-DXP-Library?node-id=241-2527&node-type=frame&t=VqIj7csYbn4gHC7H-0
https://www.figma.com/design/Swzee5YSEkPVlCXHcyL7mp/COMET-DXP-Library?node-id=1227-14461&node-type=canvas&t=l9wlqjAUquQEmzYi-0


