### PR TITLE
Prevent unintended layout shift after initial render of `FieldContainer` 

### DIFF
--- a/.changeset/honest-vans-grow.md
+++ b/.changeset/honest-vans-grow.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Prevent unintended layout shift after the initial render of `FieldContainer` when using the `horizontal` variant

--- a/.changeset/long-trainers-join.md
+++ b/.changeset/long-trainers-join.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Use the `forceVerticalContainerSize` prop on `FieldContainer` to define below which container size the `vertical` styling is applied when using the `horizontal` variant

--- a/.changeset/long-trainers-join.md
+++ b/.changeset/long-trainers-join.md
@@ -2,6 +2,6 @@
 "@comet/admin": minor
 ---
 
-Add a `forceVerticalContainerSize` prop to `FieldContainer` 
+Add a `forceVerticalContainerSize` prop to `FieldContainer`
 
 Use it to define below which container size the `vertical` styling is applied when using the `horizontal` variant.

--- a/.changeset/long-trainers-join.md
+++ b/.changeset/long-trainers-join.md
@@ -2,4 +2,6 @@
 "@comet/admin": minor
 ---
 
-Use the `forceVerticalContainerSize` prop on `FieldContainer` to define below which container size the `vertical` styling is applied when using the `horizontal` variant
+Add a `forceVerticalContainerSize` prop to `FieldContainer` 
+
+Use it to define below which container size the `vertical` styling is applied when using the `horizontal` variant.

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -182,7 +182,7 @@ const InputContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
     componentName: "FormFieldContainer",
     slotName: "inputContainer",
 })(
-    ({ theme, ownerState }) => css`
+    ({ ownerState }) => css`
         ${ownerState.variant === "horizontal" &&
         ownerState.fullWidth &&
         css`

--- a/storybook/src/admin/form/FieldContainer.stories.tsx
+++ b/storybook/src/admin/form/FieldContainer.stories.tsx
@@ -29,13 +29,13 @@ export const FieldContainer = () => {
                         <TextField name="textFieldWithLabelTwo" label="TextField label" variant="horizontal" />
                         <TextField name="testWithoutLabel" variant="horizontal" placeholder="TextField without label" />
                     </FieldSet>
-                    <FieldSet title="VERTICAL (auto-width)">
-                        {/* FieldSet is not made to include non-full-width fields. Adding this `div` removes the flex-behaviour of FieldSet, allowing this example. */}
-                        <div>
-                            <TextField name="textFieldWithLabelOne" label="TextField label" variant="vertical" />
-                            <TextField name="textFieldWithLabelTwo" label="TextField label" variant="vertical" />
-                            <TextField name="testWithoutLabel" variant="vertical" placeholder="TextField without label" />
-                        </div>
+                    <FieldSet
+                        title="VERTICAL (auto-width)"
+                        slotProps={{ children: { sx: { display: "block" } } }} // TODO: Use `FieldSet` here once it supports non-full-width fields (https://vivid-planet.atlassian.net/browse/COM-1430)
+                    >
+                        <TextField name="textFieldWithLabelOne" label="TextField label" variant="vertical" />
+                        <TextField name="textFieldWithLabelTwo" label="TextField label" variant="vertical" />
+                        <TextField name="testWithoutLabel" variant="vertical" placeholder="TextField without label" />
                     </FieldSet>
                 </form>
             )}

--- a/storybook/src/admin/form/FieldContainer.stories.tsx
+++ b/storybook/src/admin/form/FieldContainer.stories.tsx
@@ -1,0 +1,44 @@
+import { FieldSet, TextField } from "@comet/admin";
+import * as React from "react";
+import { Form } from "react-final-form";
+
+export default {
+    title: "@comet/admin/form",
+};
+
+export const FieldContainer = () => {
+    return (
+        <Form
+            onSubmit={() => {
+                // do nothing
+            }}
+            render={({ handleSubmit }) => (
+                <form onSubmit={handleSubmit}>
+                    <FieldSet title="HORIZONTAL (Full-width)">
+                        <TextField name="textFieldWithLabelOne" label="TextField label" variant="horizontal" fullWidth />
+                        <TextField name="textFieldWithLabelTwo" label="TextField label" variant="horizontal" fullWidth />
+                        <TextField name="testWithoutLabel" variant="horizontal" placeholder="TextField without label" fullWidth />
+                    </FieldSet>
+                    <FieldSet title="VERTICAL (Full-width)">
+                        <TextField name="textFieldWithLabelOne" label="TextField label" variant="vertical" fullWidth />
+                        <TextField name="textFieldWithLabelTwo" label="TextField label" variant="vertical" fullWidth />
+                        <TextField name="testWithoutLabel" variant="vertical" placeholder="TextField without label" fullWidth />
+                    </FieldSet>
+                    <FieldSet title="HORIZONTAL (auto-width)">
+                        <TextField name="textFieldWithLabelOne" label="TextField label" variant="horizontal" />
+                        <TextField name="textFieldWithLabelTwo" label="TextField label" variant="horizontal" />
+                        <TextField name="testWithoutLabel" variant="horizontal" placeholder="TextField without label" />
+                    </FieldSet>
+                    <FieldSet title="VERTICAL (auto-width)">
+                        {/* FieldSet is not made to include non-full-width fields. Adding this `div` removes the flex-behaviour of FieldSet, allowing this example. */}
+                        <div>
+                            <TextField name="textFieldWithLabelOne" label="TextField label" variant="vertical" />
+                            <TextField name="textFieldWithLabelTwo" label="TextField label" variant="vertical" />
+                            <TextField name="testWithoutLabel" variant="vertical" placeholder="TextField without label" />
+                        </div>
+                    </FieldSet>
+                </form>
+            )}
+        />
+    );
+};


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description

`FieldContainer` and, therefore, all `Field` components can be set to use the `horizontal` variant to display the label and input next to each other instead of below each other, as in the default `vertical` variant. 

To make fields work better on mobile, we don't apply the styling of the `horizontal` variant until the field has at least `600px` of space available, see https://github.com/vivid-planet/comet/pull/1755.

Previously, this was done using the `useObservedWidth` hook to get the width of the `Root` slot using a ref. 
This caused some issues, as the refs `current` element would sometimes be `null` on the component's initial render and would take the duration of one `ResizeObserver` debounce to be set correctly, causing unintended layout shift, e.g., when switching to a new tab that contains a `FieldContainer`. 

By using CSS container queries, the correct styling can be applied as soon as the element is rendered. 

<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

-->

## Example

<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A dev story in Storybook
-   A unit test

--->

-   [x] I have verified if my change requires an example

## Screenshots/screencasts

| Before   | After   |
| -------- | ------- |
| <video src="https://github.com/user-attachments/assets/fe1ad375-587d-4f9a-9eed-24e79819af78" /> | <video src="https://github.com/user-attachments/assets/fa749daa-c84b-4cbf-b9f5-4a3d803345e5" /> |

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/SVK-424