### PR TITLE
Add additional fields to OneOfBlock type

### DIFF
--- a/.changeset/old-adults-whisper.md
+++ b/.changeset/old-adults-whisper.md
@@ -1,0 +1,6 @@
+---
+"@comet/blocks-api": patch
+"@comet/cms-api": patch
+---
+
+Fix `title` field not added to types in `createLinkBlock`

--- a/packages/api/blocks-api/src/blocks/factories/createOneOfBlock.ts
+++ b/packages/api/blocks-api/src/blocks/factories/createOneOfBlock.ts
@@ -26,10 +26,10 @@ import { BlockFactoryNameOrOptions } from "./types";
 
 type BaseBlockMap = Record<string, Block<BlockDataInterface, BlockInputInterface>>;
 
-interface OneOfBlockDataInterface<BlockMap extends BaseBlockMap> extends BlockDataInterface {
+type OneOfBlockDataInterface<BlockMap extends BaseBlockMap, BlockData = BlockDataInterface> = BlockData & {
     attachedBlocks: SupportedBlocksDataInterfaces<BlockMap>[];
     activeType?: keyof BlockMap;
-}
+};
 
 type SupportedBlocksDataInterfaces<BlockMap extends BaseBlockMap> = {
     [Typename in keyof BlockMap]: BlockDataInterface & {
@@ -38,10 +38,10 @@ type SupportedBlocksDataInterfaces<BlockMap extends BaseBlockMap> = {
     };
 }[keyof BlockMap];
 
-interface OneOfBlockInputInterface<BlockMap extends BaseBlockMap> extends SimpleBlockInputInterface {
+type OneOfBlockInputInterface<BlockMap extends BaseBlockMap, BlockInput = SimpleBlockInputInterface> = BlockInput & {
     attachedBlocks: SupportedBlocksInputInterfaces<BlockMap>[];
     activeType?: keyof BlockMap;
-}
+};
 
 type SupportedBlocksInputInterfaces<BlockMap extends BaseBlockMap> = {
     [Typename in keyof BlockMap]: SimpleBlockInputInterface & {
@@ -250,7 +250,11 @@ export function BaseOneOfBlockInput<BlockMap extends BaseBlockMap>({
     return OneOfBlockInput;
 }
 
-export type OneOfBlock<BlockMap extends BaseBlockMap> = Block<OneOfBlockDataInterface<BlockMap>, OneOfBlockInputInterface<BlockMap>>;
+export type OneOfBlock<
+    BlockMap extends BaseBlockMap,
+    BlockData extends BlockDataInterface = BlockDataInterface,
+    BlockInput extends SimpleBlockInputInterface = SimpleBlockInputInterface,
+> = Block<OneOfBlockDataInterface<BlockMap, BlockData>, OneOfBlockInputInterface<BlockMap, BlockInput>>;
 
 export interface CreateOneOfBlockOptions<BlockMap extends BaseBlockMap> {
     supportedBlocks: BlockMap;
@@ -261,7 +265,11 @@ export interface CreateOneOfBlockOptions<BlockMap extends BaseBlockMap> {
     OneOfBlockInput?: Type<OneOfBlockInputInterface<BlockMap>>;
 }
 
-export function createOneOfBlock<BlockMap extends BaseBlockMap>(
+export function createOneOfBlock<
+    BlockMap extends BaseBlockMap,
+    BlockData extends BlockDataInterface = BlockDataInterface,
+    BlockInput extends SimpleBlockInputInterface = SimpleBlockInputInterface,
+>(
     {
         supportedBlocks,
         allowEmpty = true,
@@ -271,7 +279,7 @@ export function createOneOfBlock<BlockMap extends BaseBlockMap>(
         OneOfBlockInput = BaseOneOfBlockInput({ supportedBlocks, allowEmpty, OneOfBlockData, OneOfBlockItemInput }),
     }: CreateOneOfBlockOptions<BlockMap>,
     nameOrOptions: BlockFactoryNameOrOptions,
-): OneOfBlock<BlockMap> {
+): OneOfBlock<BlockMap, BlockData, BlockInput> {
     class Meta extends AnnotationBlockMeta {
         get fields(): BlockMetaField[] {
             const attachedBlocksField: BlockMetaField = {
@@ -319,5 +327,9 @@ export function createOneOfBlock<BlockMap extends BaseBlockMap>(
         migrate = nameOrOptions.migrate;
     }
 
-    return createBlock(OneOfBlockData, OneOfBlockInput, { name, blockMeta: new Meta(OneOfBlockData), migrate });
+    return createBlock(OneOfBlockData, OneOfBlockInput, {
+        name,
+        blockMeta: new Meta(OneOfBlockData),
+        migrate,
+    }) as unknown as OneOfBlock<BlockMap, BlockData, BlockInput>;
 }

--- a/packages/api/blocks-api/src/blocks/factories/createOneOfBlock.ts
+++ b/packages/api/blocks-api/src/blocks/factories/createOneOfBlock.ts
@@ -26,7 +26,7 @@ import { BlockFactoryNameOrOptions } from "./types";
 
 type BaseBlockMap = Record<string, Block<BlockDataInterface, BlockInputInterface>>;
 
-type OneOfBlockDataInterface<BlockMap extends BaseBlockMap, BlockData = BlockDataInterface> = BlockData & {
+type OneOfBlockDataInterface<BlockMap extends BaseBlockMap, Data extends BlockDataInterface> = Data & {
     attachedBlocks: SupportedBlocksDataInterfaces<BlockMap>[];
     activeType?: keyof BlockMap;
 };
@@ -38,7 +38,11 @@ type SupportedBlocksDataInterfaces<BlockMap extends BaseBlockMap> = {
     };
 }[keyof BlockMap];
 
-type OneOfBlockInputInterface<BlockMap extends BaseBlockMap, BlockInput = SimpleBlockInputInterface> = BlockInput & {
+type OneOfBlockInputInterface<
+    BlockMap extends BaseBlockMap,
+    Data extends BlockDataInterface,
+    Input extends SimpleBlockInputInterface<Data>,
+> = Input & {
     attachedBlocks: SupportedBlocksInputInterfaces<BlockMap>[];
     activeType?: keyof BlockMap;
 };
@@ -91,13 +95,13 @@ export function BaseOneOfBlockItemData<BlockMap extends BaseBlockMap>({
     return OneOfBlockItemData;
 }
 
-export function BaseOneOfBlockData<BlockMap extends BaseBlockMap>({
+export function BaseOneOfBlockData<BlockMap extends BaseBlockMap, Data extends BlockDataInterface = BlockDataInterface>({
     supportedBlocks,
     OneOfBlockItemData,
 }: {
     supportedBlocks: BlockMap;
     OneOfBlockItemData: Type<OneOfBlockItemDataInterface>;
-}): Type<OneOfBlockDataInterface<BlockMap>> {
+}): Type<OneOfBlockDataInterface<BlockMap, Data>> {
     class OneOfBlockData extends BlockData {
         @Transform(({ value }: { value: OneOfBlockItemDataInterface[] }) =>
             value
@@ -111,7 +115,7 @@ export function BaseOneOfBlockData<BlockMap extends BaseBlockMap>({
                 })
                 .map((item) => plainToInstance(OneOfBlockItemData, item)),
         )
-        attachedBlocks: OneOfBlockDataInterface<BlockMap>["attachedBlocks"][number][];
+        attachedBlocks: OneOfBlockDataInterface<BlockMap, Data>["attachedBlocks"][number][];
 
         // index of blocks
         activeType?: string;
@@ -141,7 +145,8 @@ export function BaseOneOfBlockData<BlockMap extends BaseBlockMap>({
         }
     }
 
-    return OneOfBlockData;
+    // Type cast to suppress error: 'OneOfBlockData' is assignable to the constraint of type 'Data', but 'Data' could be instantiated with a different subtype of constraint 'BlockDataInterface'.
+    return OneOfBlockData as unknown as Type<OneOfBlockDataInterface<BlockMap, Data>>;
 }
 
 interface OneOfBlockItemInputInterface extends BlockInput {
@@ -195,7 +200,11 @@ export function BaseOneOfBlockItemInput<BlockMap extends BaseBlockMap>({
     return OneOfBlockItemInput;
 }
 
-export function BaseOneOfBlockInput<BlockMap extends BaseBlockMap>({
+export function BaseOneOfBlockInput<
+    BlockMap extends BaseBlockMap,
+    Data extends BlockDataInterface = BlockDataInterface,
+    Input extends SimpleBlockInputInterface<Data> = SimpleBlockInputInterface<Data>,
+>({
     supportedBlocks,
     allowEmpty,
     OneOfBlockData,
@@ -203,9 +212,9 @@ export function BaseOneOfBlockInput<BlockMap extends BaseBlockMap>({
 }: {
     supportedBlocks: BlockMap;
     allowEmpty?: boolean;
-    OneOfBlockData: Type<OneOfBlockDataInterface<BlockMap>>;
+    OneOfBlockData: Type<OneOfBlockDataInterface<BlockMap, Data>>;
     OneOfBlockItemInput: Type<OneOfBlockItemInputInterface>;
-}): Type<OneOfBlockInputInterface<BlockMap>> {
+}): Type<OneOfBlockInputInterface<BlockMap, Data, Input>> {
     for (const block in supportedBlocks) {
         if (!supportedBlocks[block]) {
             throw new Error(`Supported block '${block}' is undefined. This is most likely due to a circular import`);
@@ -214,7 +223,7 @@ export function BaseOneOfBlockInput<BlockMap extends BaseBlockMap>({
 
     const supportedBlockTypes: Array<keyof BlockMap | null> = Object.keys(supportedBlocks);
 
-    class OneOfBlockInput extends BlockInput {
+    class OneOfBlockInput extends BlockInput<Data> {
         @Transform(({ value }: { value: OneOfBlockItemInputInterface[] }) =>
             value
                 .filter((item) => {
@@ -229,14 +238,14 @@ export function BaseOneOfBlockInput<BlockMap extends BaseBlockMap>({
         )
         @ArrayMinSize(allowEmpty ? 0 : 1)
         @ValidateNested({ each: true })
-        attachedBlocks: OneOfBlockInputInterface<BlockMap>["attachedBlocks"];
+        attachedBlocks: OneOfBlockInputInterface<BlockMap, Data, Input>["attachedBlocks"];
 
         @IsOptional()
         @IsIn(supportedBlockTypes)
         @BlockField({ nullable: allowEmpty })
         activeType?: string;
 
-        transformToBlockData(): OneOfBlockDataInterface<BlockMap> {
+        transformToBlockData(): OneOfBlockDataInterface<BlockMap, Data> {
             const { attachedBlocks, activeType, ...additionalFields } = this;
 
             return plainToInstance(OneOfBlockData, {
@@ -247,28 +256,33 @@ export function BaseOneOfBlockInput<BlockMap extends BaseBlockMap>({
         }
     }
 
-    return OneOfBlockInput;
+    // Type cast to suppress error: 'OneOfBlockInput' is assignable to the constraint of type 'Input', but 'Input' could be instantiated with a different subtype of constraint 'SimpleBlockInputInterface<Data>'.
+    return OneOfBlockInput as unknown as Type<OneOfBlockInputInterface<BlockMap, Data, Input>>;
 }
 
 export type OneOfBlock<
     BlockMap extends BaseBlockMap,
-    BlockData extends BlockDataInterface = BlockDataInterface,
-    BlockInput extends SimpleBlockInputInterface = SimpleBlockInputInterface,
-> = Block<OneOfBlockDataInterface<BlockMap, BlockData>, OneOfBlockInputInterface<BlockMap, BlockInput>>;
+    Data extends BlockDataInterface = BlockDataInterface,
+    Input extends SimpleBlockInputInterface<Data> = SimpleBlockInputInterface<Data>,
+> = Block<OneOfBlockDataInterface<BlockMap, Data>, OneOfBlockInputInterface<BlockMap, Data, Input>>;
 
-export interface CreateOneOfBlockOptions<BlockMap extends BaseBlockMap> {
+export interface CreateOneOfBlockOptions<
+    BlockMap extends BaseBlockMap,
+    Data extends BlockDataInterface = BlockDataInterface,
+    Input extends SimpleBlockInputInterface<Data> = SimpleBlockInputInterface<Data>,
+> {
     supportedBlocks: BlockMap;
     allowEmpty?: boolean;
     OneOfBlockItemData?: Type<OneOfBlockItemDataInterface>;
     OneOfBlockItemInput?: Type<OneOfBlockItemInputInterface>;
-    OneOfBlockData?: Type<OneOfBlockDataInterface<BlockMap>>;
-    OneOfBlockInput?: Type<OneOfBlockInputInterface<BlockMap>>;
+    OneOfBlockData?: Type<OneOfBlockDataInterface<BlockMap, Data>>;
+    OneOfBlockInput?: Type<OneOfBlockInputInterface<BlockMap, Data, Input>>;
 }
 
 export function createOneOfBlock<
     BlockMap extends BaseBlockMap,
-    BlockData extends BlockDataInterface = BlockDataInterface,
-    BlockInput extends SimpleBlockInputInterface = SimpleBlockInputInterface,
+    Data extends BlockDataInterface = BlockDataInterface,
+    Input extends SimpleBlockInputInterface<Data> = SimpleBlockInputInterface<Data>,
 >(
     {
         supportedBlocks,
@@ -277,9 +291,9 @@ export function createOneOfBlock<
         OneOfBlockItemInput = BaseOneOfBlockItemInput({ supportedBlocks, OneOfBlockItemData }),
         OneOfBlockData = BaseOneOfBlockData({ supportedBlocks, OneOfBlockItemData }),
         OneOfBlockInput = BaseOneOfBlockInput({ supportedBlocks, allowEmpty, OneOfBlockData, OneOfBlockItemInput }),
-    }: CreateOneOfBlockOptions<BlockMap>,
+    }: CreateOneOfBlockOptions<BlockMap, Data, Input>,
     nameOrOptions: BlockFactoryNameOrOptions,
-): OneOfBlock<BlockMap, BlockData, BlockInput> {
+): OneOfBlock<BlockMap, Data, Input> {
     class Meta extends AnnotationBlockMeta {
         get fields(): BlockMetaField[] {
             const attachedBlocksField: BlockMetaField = {
@@ -327,9 +341,5 @@ export function createOneOfBlock<
         migrate = nameOrOptions.migrate;
     }
 
-    return createBlock(OneOfBlockData, OneOfBlockInput, {
-        name,
-        blockMeta: new Meta(OneOfBlockData),
-        migrate,
-    }) as unknown as OneOfBlock<BlockMap, BlockData, BlockInput>;
+    return createBlock(OneOfBlockData, OneOfBlockInput, { name, blockMeta: new Meta(OneOfBlockData), migrate });
 }

--- a/packages/api/cms-api/src/blocks/createLinkBlock.test.ts
+++ b/packages/api/cms-api/src/blocks/createLinkBlock.test.ts
@@ -1,0 +1,26 @@
+import { ExternalLinkBlock } from "@comet/blocks-api";
+
+import { InternalLinkBlock } from "../page-tree/blocks/internal-link.block";
+import { createLinkBlock } from "./createLinkBlock";
+
+describe("createLinkBlock", () => {
+    it("should have a title", () => {
+        const LinkBlock = createLinkBlock({
+            supportedBlocks: {
+                internal: InternalLinkBlock,
+                external: ExternalLinkBlock,
+            },
+        });
+
+        expect(
+            LinkBlock.blockInputFactory({
+                attachedBlocks: [],
+                activeType: "internal",
+                // @ts-expect-error fixme
+                title: "Test",
+            })
+                .transformToBlockData()
+                .transformToSave().title,
+        ).toBe("Test");
+    });
+});

--- a/packages/api/cms-api/src/blocks/createLinkBlock.test.ts
+++ b/packages/api/cms-api/src/blocks/createLinkBlock.test.ts
@@ -16,7 +16,6 @@ describe("createLinkBlock", () => {
             LinkBlock.blockInputFactory({
                 attachedBlocks: [],
                 activeType: "internal",
-                // @ts-expect-error fixme
                 title: "Test",
             })
                 .transformToBlockData()

--- a/packages/api/cms-api/src/blocks/createLinkBlock.ts
+++ b/packages/api/cms-api/src/blocks/createLinkBlock.ts
@@ -10,14 +10,13 @@ import {
     BlockInputInterface,
     createOneOfBlock,
     CreateOneOfBlockOptions,
-    OneOfBlock,
 } from "@comet/blocks-api";
 import { IsOptional, IsString } from "class-validator";
 
 function createLinkBlock<BlockMap extends Record<string, Block<BlockDataInterface, BlockInputInterface>>>(
     { supportedBlocks, allowEmpty = false }: CreateOneOfBlockOptions<BlockMap>,
     nameOrOptions: BlockFactoryNameOrOptions = "Link",
-): OneOfBlock<BlockMap> {
+) {
     class LinkBlockItemData extends BaseOneOfBlockItemData({ supportedBlocks }) {}
 
     class LinkBlockItemInput extends BaseOneOfBlockItemInput({ supportedBlocks, OneOfBlockItemData: LinkBlockItemData }) {}
@@ -39,7 +38,10 @@ function createLinkBlock<BlockMap extends Record<string, Block<BlockDataInterfac
         title?: string;
     }
 
-    return createOneOfBlock({ supportedBlocks, allowEmpty, OneOfBlockData: LinkBlockData, OneOfBlockInput: LinkBlockInput }, nameOrOptions);
+    return createOneOfBlock<BlockMap, LinkBlockData, LinkBlockInput>(
+        { supportedBlocks, allowEmpty, OneOfBlockData: LinkBlockData, OneOfBlockInput: LinkBlockInput },
+        nameOrOptions,
+    );
 }
 
 export { createLinkBlock };

--- a/packages/api/cms-api/src/blocks/createLinkBlock.ts
+++ b/packages/api/cms-api/src/blocks/createLinkBlock.ts
@@ -38,10 +38,7 @@ function createLinkBlock<BlockMap extends Record<string, Block<BlockDataInterfac
         title?: string;
     }
 
-    return createOneOfBlock<BlockMap, LinkBlockData, LinkBlockInput>(
-        { supportedBlocks, allowEmpty, OneOfBlockData: LinkBlockData, OneOfBlockInput: LinkBlockInput },
-        nameOrOptions,
-    );
+    return createOneOfBlock({ supportedBlocks, allowEmpty, OneOfBlockData: LinkBlockData, OneOfBlockInput: LinkBlockInput }, nameOrOptions);
 }
 
 export { createLinkBlock };


### PR DESCRIPTION
We added support for additional fields in the OneOfBlock in https://github.com/vivid-planet/comet/pull/1666. However, the additional fields weren't added to the type.

## TODO

- [x] Changeset

## Additional information

First commit adds a test and demonstrates the bug, second commit solves the bug.