### PR TITLE
Adapt chip styling

### DIFF
--- a/.changeset/clever-jobs-invite.md
+++ b/.changeset/clever-jobs-invite.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin-theme": minor
+---
+
+Adapt `Chip` styling to align with Comet DXP design
+
+-   Fix `hover` styling.
+-   Add new styling for <Chip variant="filled" color="info">.

--- a/packages/admin/admin-theme/src/componentsTheme/MuiChip.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiChip.tsx
@@ -1,5 +1,4 @@
 import { Clear } from "@comet/admin-icons";
-import { chipClasses } from "@mui/material";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
@@ -98,17 +97,22 @@ export const getMuiChip: GetMuiComponentTheme<"MuiChip"> = (component, { palette
         },
         filledDefault: {
             backgroundColor: palette.grey["100"],
+            "&.MuiChip-clickable": {
+                "&:hover": {
+                    backgroundColor: palette.grey["200"],
+                },
+            },
+        },
+        filledInfo: {
+            backgroundColor: "#fff",
+            "&.MuiChip-clickable": {
+                "&:hover": {
+                    backgroundColor: palette.grey["50"],
+                },
+            },
         },
         outlinedDefault: {
             borderColor: palette.grey["100"],
-        },
-        clickableColorDefault: {
-            [`&.${chipClasses.filled}:hover`]: {
-                backgroundColor: palette.grey["200"],
-            },
-            [`&.${chipClasses.outlined}:hover`]: {
-                backgroundColor: palette.grey["50"],
-            },
         },
     }),
     defaultProps: {

--- a/storybook/src/admin/mui/Chip.stories.tsx
+++ b/storybook/src/admin/mui/Chip.stories.tsx
@@ -226,6 +226,30 @@ export const _Chip = {
                                     />
                                 </Grid>
                             </Grid>
+                            <Grid container spacing={2} mb={5}>
+                                <Grid item>
+                                    <Chip variant="filled" color="info" label="Normal" />
+                                </Grid>
+                                <Grid item>
+                                    <Chip variant="filled" color="info" clickable label="Clickable" />
+                                </Grid>
+                                <Grid item>
+                                    <Chip variant="filled" color="info" icon={<ChevronDown />} clickable label="With Icon" />
+                                </Grid>
+                                <Grid item>
+                                    <Chip variant="filled" color="info" label="Disabled" disabled />
+                                </Grid>
+                                <Grid item>
+                                    <Chip
+                                        variant="filled"
+                                        color="info"
+                                        label="Deletable"
+                                        onDelete={() => {
+                                            console.log("Delete");
+                                        }}
+                                    />
+                                </Grid>
+                            </Grid>
                         </Box>
                         <Typography variant="h4" gutterBottom>
                             Small size Chips
@@ -367,6 +391,31 @@ export const _Chip = {
                                     <Chip
                                         size="small"
                                         color="warning"
+                                        label="Deletable"
+                                        onDelete={() => {
+                                            console.log("Delete");
+                                        }}
+                                    />
+                                </Grid>
+                            </Grid>
+                            <Grid container spacing={2} mb={5}>
+                                <Grid item>
+                                    <Chip size="small" variant="filled" color="info" label="Normal" />
+                                </Grid>
+                                <Grid item>
+                                    <Chip size="small" variant="filled" color="info" clickable label="Clickable" />
+                                </Grid>
+                                <Grid item>
+                                    <Chip size="small" variant="filled" color="info" icon={<ChevronDown />} clickable label="With Icon" />
+                                </Grid>
+                                <Grid item>
+                                    <Chip size="small" variant="filled" color="info" label="Disabled" disabled />
+                                </Grid>
+                                <Grid item>
+                                    <Chip
+                                        size="small"
+                                        variant="filled"
+                                        color="info"
                                         label="Deletable"
                                         onDelete={() => {
                                             console.log("Delete");


### PR DESCRIPTION
## Description

Hover styling is not consistent with the design in every variant; please implement it as per the design.

- Fix hover styling of all variants
- Add new variant with white background and no boarder (variant="filled" and color="info") and add it to story


## Screenshots/screencasts

<img width="456" alt="Screenshot 2024-12-04 at 15 52 55" src="https://github.com/user-attachments/assets/ee688e4d-3f7d-4e93-94db-ed7f08c1d004">



https://github.com/user-attachments/assets/1758f988-7324-40de-99f1-1007297ba2df



## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents
https://vivid-planet.atlassian.net/browse/COM-1247


