### PR TITLE
Hide scrollbars on preview when using a device view option

### DIFF
--- a/.changeset/fuzzy-mugs-beg.md
+++ b/.changeset/fuzzy-mugs-beg.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": patch
 ---
 
-Remove vertical and horizontal scroll bars from block preview iframe in cms-admin
+Remove vertical and horizontal scroll bars from block preview iframe

--- a/.changeset/fuzzy-mugs-beg.md
+++ b/.changeset/fuzzy-mugs-beg.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": patch
 ---
 
-Remove vertical and horizontal scrollbars from block preview iframe in cms-admin
+Remove vertical and horizontal scroll bars from block preview iframe in cms-admin

--- a/.changeset/fuzzy-mugs-beg.md
+++ b/.changeset/fuzzy-mugs-beg.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Remove vertical and horizontal scrollbars from block preview iframe in cms-admin

--- a/packages/admin/cms-admin/src/preview/common/IFrameViewer.tsx
+++ b/packages/admin/cms-admin/src/preview/common/IFrameViewer.tsx
@@ -109,7 +109,6 @@ const OuterFrame = styled("div", { shouldForwardProp: (prop) => prop !== "device
     width: 100%;
     height: 100%;
     box-sizing: border-box;
-    overflow-y: auto;
     will-change: transform;
 
     ${({ deviceConfig }) =>

--- a/packages/admin/cms-admin/src/preview/common/IFrameViewer.tsx
+++ b/packages/admin/cms-admin/src/preview/common/IFrameViewer.tsx
@@ -120,7 +120,6 @@ const OuterFrame = styled("div", { shouldForwardProp: (prop) => prop !== "device
             width: ${deviceConfig.outerFrame.width}px;
             height: ${deviceConfig.outerFrame.height}px;
             padding: ${deviceConfig.outerFrame.padding};
-            overflow: hidden;
         `}
 `;
 

--- a/packages/admin/cms-admin/src/preview/common/IFrameViewer.tsx
+++ b/packages/admin/cms-admin/src/preview/common/IFrameViewer.tsx
@@ -121,13 +121,14 @@ const OuterFrame = styled("div", { shouldForwardProp: (prop) => prop !== "device
             width: ${deviceConfig.outerFrame.width}px;
             height: ${deviceConfig.outerFrame.height}px;
             padding: ${deviceConfig.outerFrame.padding};
+            overflow: hidden;
         `}
 `;
 
 const IFrame = styled("iframe", { shouldForwardProp: (prop) => prop !== "deviceConfig" })<IFrameProps>`
     display: block;
     border-style: unset;
-    border-width: 1px;
+    border-width: 0px;
     width: 100%;
     height: 100%;
     background-color: ${({ theme }) => theme.palette.common.white};


### PR DESCRIPTION
Hide Vertical and Horizontal Scrollbars on with using device preview options in Admin Panel.

Note: There are two solutions for this problem. Either we hide the scrollbars using overflow: hidden or we change the OuterFrame width and height so that the content fits.

Another Note: Personally I would remove these device outer frames (mobile/tablet/desktop). They are somewhat legacy and don't look that great.


**Before:**


<img width="928" alt="image" src="https://github.com/user-attachments/assets/9984ee95-939b-4d02-a684-63cfcef6d126">
<img width="928" alt="image" src="https://github.com/user-attachments/assets/e1dd1306-c779-4f4e-803b-fd81c22e02d7">
<img width="927" alt="image" src="https://github.com/user-attachments/assets/5e98161b-dee9-48da-9afd-20f0f6257f26">


**After:**


<img width="937" alt="image" src="https://github.com/user-attachments/assets/17e44c20-9504-4f98-8f14-f55d9ec22576">
<img width="930" alt="image" src="https://github.com/user-attachments/assets/f70bf74e-dabf-4e9f-8300-5bb153403e82">
<img width="927" alt="image" src="https://github.com/user-attachments/assets/51425553-8b04-4690-bce9-a78c5defeb39">
