### PR TITLE
Incorporate feedback on pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 
 ## Open TODOs/questions
 
--   [] Add changeset
+-   [ ] Add changeset
 
 ## Further information
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,97 +1,22 @@
-<!--
-PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
-Smaller PRs are easier to review and tend to get merged faster.
-Unrelated changes, refactorings, fixes etc. should be made in separate PRs.
--->
-
 ## Description
 
-<!--
-The description should describe the change you're making.
-It will be used as the commit message for the squashed commit once the PR gets merged.
-Therefore, make sure to keep the description up-to-date as the PR changes.
+## Acceptance criteria
 
-PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
-Reviewers see what you're changing when reviewing the code.
-However, they might not understand your motives as to why you're making the change.
-
-Your description should include:
--   The problem you're facing
--   Your solution to the problem
--   An example usage of your change
--->
-
-<!--
-Everything below this is intended to help ease reviewing this PR.
-Remove all unrelated sections.
--->
-
-## Example
-
-<!--
-Make sure to provide an example of your change if your change includes a new API.
-This can be either:
--   The implementation in Demo
--   A dev story in Storybook
--   A unit test
--->
-
--   [ ] I have verified if my change requires an example
+-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example): <!-- Unit test | Demo | Development story | No example needed --->
+-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
+-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
+-   [ ] I have removed irrelevant sections from the pull request template
 
 ## Screenshots/screencasts
 
-<!--
-When making a visual change, please provide either screenshots or screencasts.
-Hint: For before/after views, you can use a table:
-
 | Before | After |
-| --- | --- |
-| Link | Link |
--->
-
-## Changeset
-
-<!--
-When making a notable change, make sure to add a changeset.
-See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.
-
-TL;DR
-
-Add a changeset when:
--   changing the package's public API (`src/index.ts`)
--   fixing a bug
--   making a visual change
-
-Changeset writing guidelines:
--   Use active voice: "Add new thing" vs. "A new thing is added"
--   First line should be the title: "Add new alert component"
--   Provide additional information in the description
--   Use backticks to highlight code: Add new `Alert` component
--   Use bold formatting for "headlines" in the description: **Example**
--->
-
--   [ ] I have verified if my change requires a changeset
-
-## Related tasks and documents
-
-<!--
-Link to related tasks and documents, for instance, https://vivid-planet.atlassian.net/browse/COM-XXX.
-MAKE SURE THAT EVERYTHING REQUIRED TO UNDERSTAND YOUR CHANGE IS IN THE PR DESCRIPTION.
-Reviewers shouldn't need to review tasks, JIRA conversations etc. to understand what you're doing.
--->
+| ------ | ----- |
+| Link   | Link  |
 
 ## Open TODOs/questions
 
-<!--
--   [ ] Need to validate that this actually works
--   [ ] Merge parent PR
--->
+-   [] Add changeset
 
 ## Further information
 
-<!--
-Further information that helps reviewing the PR, for instance:
--   Alternative solutions you have considered
--   Dependent PRs
--   Links to relevant documentation, blog posts etc.
--->
+-   Task: https://vivid-planet.atlassian.net/browse/COM-XXX

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,6 @@
 -   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example): <!-- Unit test | Demo | Development story | No example needed --->
 -   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
 -   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
--   [ ] I have removed irrelevant sections from the pull request template
 
 ## Screenshots/screencasts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,44 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Pull requests with minor or patch changes should target the [`main`](https://github.com/vivid-planet/comet/tree/main) branch, while major/breaking changes should target the [`next`](https://github.com/vivid-planet/comet/tree/next) branch.
 
-### Changesets
+## Pull requests
+
+> [!WARNING]
+> Please make sure to keep the pull request size at a minium!
+> Smaller pull requests are easier to review and tend to get merged faster.
+> Unrelated changes, refactorings, fixes etc. should be made in follow-up pull requests.
+
+### Description
+
+The description should describe the change you're making.
+It will be used as the commit message for the squashed commit once the pull request gets merged.
+Therefore, make sure to keep the description up-to-date as the pull request changes.
+
+> [!WARNING]
+> Please describe why you're making the change, not what you're changing.
+> Reviewers see what you're changing when reviewing the code.
+> However, they might not understand your motives as to why you're making the change.
+
+Your description should include:
+
+-   The problem you're facing
+-   Your solution to the problem
+-   An example usage of your change
+
+### Example
+
+Make sure to provide an example of your change if your change includes a new API.
+This can be either:
+
+-   A unit test (preferred)
+-   The implementation in Demo
+-   A development story in Storybook
+
+### Screenshots/screencasts
+
+When making a visual change, please provide either screenshots or screencasts.
+
+### Changeset
 
 Changes are documented using [changesets](https://github.com/changesets/changesets). Make sure to [add a changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) when making a notable change.
 
@@ -90,3 +127,19 @@ export function ErrorHandler({ children }: PropsWithChildren) {
 }
 ```
 ````
+
+### Open TODOs/questions
+
+Anything that needs to be done before merging the pull request, for instance, add a changeset.
+
+### Further information
+
+Further information that helps reviewing the pull request, for instance:
+
+-   Alternative solutions you have considered
+-   Related pull requests
+-   Links to relevant tasks, documentation, blog posts etc.
+
+> [!WARNING]
+> Make sure that everything required to understand your change is in the pull request description.
+> Reviewers shouldn't need to review tasks, JIRA conversations etc. to understand what you're doing.


### PR DESCRIPTION
We've introduced an extended pull request template in https://github.com/vivid-planet/comet/pull/2531. Now, after a few months, I've asked colleagues for feedback on the pull request template.

Based on the provided feedback I've made the following changes to the pull request template:
- Remove exhaustive comments, move them to CONTRIBUTING.md
- Merge section "Related tasks and documents" into "Further information"
- Merge section "Example" and "Changeset" into a new section "Acceptance criteria"
- Add a comment to the example task to mention the chosen example
- Highlight tests as the preferred way to add an example