### PR TITLE
Adapt `Alert` styling

### DIFF
--- a/.changeset/fifty-buses-hope.md
+++ b/.changeset/fifty-buses-hope.md
@@ -2,10 +2,10 @@
 "@comet/admin": major
 ---
 
-Fix styling of `Alert` according to Comet DXP design
+Adapt the styling of `Alert` to match the updated Comet design
 
-Remove styling for `text` variant of Buttons used in `Alert`.
-Use `variant="outlined"` instead.
+Remove styling for the `text` variant of buttons used in `Alert`.
+Use buttons with the `outlined` variant instead to adhere to the Comet design guidelines.
 
 ```diff
         <Alert

--- a/.changeset/fifty-buses-hope.md
+++ b/.changeset/fifty-buses-hope.md
@@ -1,0 +1,23 @@
+---
+"@comet/admin": major
+---
+
+Fix styling of `Alert` according to Comet DXP design
+
+Remove styling for `text` variant of Buttons used in `Alert`.
+Use `variant="outlined"` instead.
+
+```diff
+        <Alert
+    // ...
+    action={
+-       <Button variant="text" startIcon={<ArrowRight />}>
+-           Action Text
+-       </Button>
++       <Button variant="outlined" startIcon={<ArrowRight />}>
++           Action Text
++       </Button>
+    }
+    // ...
+>
+```

--- a/.changeset/fifty-buses-hope.md
+++ b/.changeset/fifty-buses-hope.md
@@ -12,8 +12,6 @@ Use buttons with the `outlined` variant instead to adhere to the Comet design gu
     // ...
     action={
 -       <Button variant="text" startIcon={<ArrowRight />}>
--           Action Text
--       </Button>
 +       <Button variant="outlined" startIcon={<ArrowRight />}>
 +           Action Text
 +       </Button>

--- a/.changeset/fifty-buses-hope.md
+++ b/.changeset/fifty-buses-hope.md
@@ -8,14 +8,14 @@ Remove styling for the `text` variant of buttons used in `Alert`.
 Use buttons with the `outlined` variant instead to adhere to the Comet design guidelines.
 
 ```diff
-        <Alert
-    // ...
-    action={
--       <Button variant="text" startIcon={<ArrowRight />}>
-+       <Button variant="outlined" startIcon={<ArrowRight />}>
-+           Action Text
-+       </Button>
-    }
-    // ...
->
+ <Alert
+     // ...
+     action={
+-        <Button variant="text" startIcon={<ArrowRight />}>
++        <Button variant="outlined" startIcon={<ArrowRight />}>
+             Action Text
+         </Button>
+     }
+     // ...
+ >
 ```

--- a/packages/admin/admin/src/alert/Alert.tsx
+++ b/packages/admin/admin/src/alert/Alert.tsx
@@ -1,6 +1,6 @@
 import { Close } from "@comet/admin-icons";
 // eslint-disable-next-line no-restricted-imports
-import { Alert as MuiAlert, alertClasses, AlertTitle, buttonClasses, IconButton, Typography } from "@mui/material";
+import { Alert as MuiAlert, alertClasses, AlertTitle, IconButton, Typography } from "@mui/material";
 import { css, useThemeProps } from "@mui/material/styles";
 import { forwardRef, ReactNode } from "react";
 
@@ -87,10 +87,6 @@ const Root = createComponentSlot(MuiAlert)<AlertClassKey, OwnerState>({
             position: relative;
             align-items: flex-start;
             padding: ${theme.spacing(4, 6, 4, 4)};
-
-            & .${buttonClasses.text} {
-                margin-left: -15px;
-            }
 
             & .${alertClasses.message} {
                 flex-direction: column;

--- a/packages/admin/admin/src/alert/Alert.tsx
+++ b/packages/admin/admin/src/alert/Alert.tsx
@@ -86,7 +86,7 @@ const Root = createComponentSlot(MuiAlert)<AlertClassKey, OwnerState>({
         css`
             position: relative;
             align-items: flex-start;
-            padding: ${theme.spacing(4, 6, "8px", 3)};
+            padding: ${theme.spacing(4, 6, 4, 4)};
 
             & .${buttonClasses.text} {
                 margin-left: -15px;
@@ -102,7 +102,7 @@ const Root = createComponentSlot(MuiAlert)<AlertClassKey, OwnerState>({
         css`
             display: flex;
             align-items: center;
-            padding: ${theme.spacing(2, "12px", 2, 4)};
+            padding: ${theme.spacing(2, 4, 2, 4)};
         `}
     `,
 );
@@ -143,6 +143,11 @@ const CloseIcon = createComponentSlot(IconButton)<AlertClassKey, OwnerState>({
             position: absolute;
             right: 2px;
             top: 2px;
+        `}
+
+        ${ownerState.renderAsSingleRow &&
+        css`
+            padding: 10px;
         `}
     `,
 );

--- a/storybook/src/admin/alert/Alert.stories.tsx
+++ b/storybook/src/admin/alert/Alert.stories.tsx
@@ -20,7 +20,7 @@ export const Alerts = () => {
                             severity="info"
                             title="Title"
                             action={
-                                <Button variant="text" startIcon={<ArrowRight />}>
+                                <Button variant="outlined" startIcon={<ArrowRight />}>
                                     Action Text
                                 </Button>
                             }
@@ -34,7 +34,7 @@ export const Alerts = () => {
                             severity="warning"
                             title="Title"
                             action={
-                                <Button variant="text" startIcon={<ArrowRight />}>
+                                <Button variant="outlined" startIcon={<ArrowRight />}>
                                     Action Text
                                 </Button>
                             }
@@ -50,7 +50,7 @@ export const Alerts = () => {
                             severity="error"
                             title="Title"
                             action={
-                                <Button variant="text" startIcon={<ArrowRight />}>
+                                <Button variant="outlined" startIcon={<ArrowRight />}>
                                     Action Text
                                 </Button>
                             }
@@ -105,7 +105,7 @@ export const Alerts = () => {
                         <Alert
                             severity="success"
                             action={
-                                <Button variant="text" startIcon={<ArrowRight />}>
+                                <Button variant="outlined" startIcon={<ArrowRight />}>
                                     Action Text
                                 </Button>
                             }
@@ -132,7 +132,7 @@ export const Alerts = () => {
                         <Alert
                             severity="warning"
                             action={
-                                <Button variant="text" startIcon={<ArrowRight />}>
+                                <Button variant="outlined" startIcon={<ArrowRight />}>
                                     Action Text
                                 </Button>
                             }


### PR DESCRIPTION
## Description

Style `Alert` according to design. 
Correct usage of Button in Story using variant="outlined" instead of "text"
Remove styling for text variant of Buttons in Alerts. 


## Example

-   [x] I have verified if my change requires an example

## Screenshots/screencasts


When making a visual change, please provide either screenshots or screencasts.
Hint: For before/after views, you can use a table:

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/3a294aae-5961-4d66-8cf0-9ad90c6467de) | ![After](https://github.com/user-attachments/assets/875b4aab-46d3-46ee-b576-609862370321) |




## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents
https://vivid-planet.atlassian.net/browse/COM-1257

## Further information

At the moment there is no design for Alerts in smaller viewports. That's why the Alerts in the story still look broken. 