### PR TITLE
Don't render a tooltip around disabled buttons

### DIFF
--- a/packages/admin/admin/src/rowActions/RowActionsIconItem.tsx
+++ b/packages/admin/admin/src/rowActions/RowActionsIconItem.tsx
@@ -16,13 +16,17 @@ export interface RowActionsIconItemProps extends CommonRowActionItemProps {
 export const RowActionsIconItem = forwardRef<HTMLButtonElement, RowActionsIconItemProps>(
     ({ icon, tooltip, componentsProps = {}, ...restIconButtonProps }, ref) => {
         const { tooltip: tooltipProps, iconButton: iconButtonProps } = componentsProps;
+
+        const combinedIconButtonProps = { ...restIconButtonProps, ...iconButtonProps };
+        const buttonIsDisabled = Boolean(combinedIconButtonProps.disabled);
+
         const button = (
-            <IconButton {...restIconButtonProps} {...iconButtonProps} ref={ref}>
+            <IconButton {...combinedIconButtonProps} ref={ref}>
                 {icon}
             </IconButton>
         );
 
-        if (tooltip) {
+        if (tooltip && !buttonIsDisabled) {
             return (
                 <Tooltip title={tooltip} {...tooltipProps}>
                     {button}


### PR DESCRIPTION
<!--
PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.
-->

## Description

This doesn't change the behavior, as tooltips can't listen to events on disabled elements anyway. 
This prevents the following error in the console:

```
MUI: You are providing a disabled `button` child to the Tooltip component.
A disabled element does not fire events.
Tooltip needs to listen to the child element's events to display the title.
```

<!--
Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.
-->

## Changeset

-   [x] I have verified if my change requires a changeset