### PR TITLE
Add category filter for news

### DIFF
--- a/demo/site/src/app/[domain]/[language]/news/page.tsx
+++ b/demo/site/src/app/[domain]/[language]/news/page.tsx
@@ -1,28 +1,38 @@
+"use server";
+
 import { gql, previewParams } from "@comet/cms-site";
-import { GQLNewsContentScopeInput } from "@src/graphql.generated";
+import { GQLNewsCategory, GQLNewsContentScopeInput } from "@src/graphql.generated";
 import { NewsList } from "@src/news/NewsList";
 import { newsListFragment } from "@src/news/NewsList.fragment";
 import { createGraphQLFetch } from "@src/util/graphQLClient";
 
 import { GQLNewsIndexPageQuery, GQLNewsIndexPageQueryVariables } from "./page.generated";
 
-export default async function NewsIndexPage({ params }: { params: { domain: string; language: string } }) {
-    // TODO support multiple domains, get domain by Host header
-    const { scope, previewData } = (await previewParams()) || { scope: { domain: params.domain, language: params.language }, previewData: undefined };
-    const graphqlFetch = createGraphQLFetch(previewData);
+export default async function NewsIndexPage({ params: { domain, language } }: { params: { domain: string; language: string } }) {
+    const scope = ((await previewParams())?.scope || { domain, language }) as GQLNewsContentScopeInput;
+    const newsList = await fetchNewsList(scope);
+    return <NewsList initialNewsList={newsList} scope={scope} />;
+}
+
+export async function fetchNewsList(scope: GQLNewsContentScopeInput, category?: GQLNewsCategory) {
+    "use server";
+    const graphqlFetch = createGraphQLFetch((await previewParams())?.previewData);
 
     const { newsList } = await graphqlFetch<GQLNewsIndexPageQuery, GQLNewsIndexPageQueryVariables>(
         gql`
-            query NewsIndexPage($scope: NewsContentScopeInput!, $sort: [NewsSort!]!) {
-                newsList(scope: $scope, sort: $sort) {
+            query NewsIndexPage($scope: NewsContentScopeInput!, $sort: [NewsSort!]!, $filter: NewsFilter!) {
+                newsList(scope: $scope, sort: $sort, filter: $filter) {
                     ...NewsList
                 }
             }
 
             ${newsListFragment}
         `,
-        { scope: scope as GQLNewsContentScopeInput, sort: [{ field: "createdAt", direction: "DESC" }] },
+        {
+            scope,
+            sort: [{ field: "createdAt", direction: "DESC" }],
+            filter: { category: { equal: category } },
+        },
     );
-
-    return <NewsList newsList={newsList} />;
+    return newsList;
 }

--- a/demo/site/src/news/NewsList.fragment.ts
+++ b/demo/site/src/news/NewsList.fragment.ts
@@ -11,6 +11,7 @@ export const newsListFragment = gql`
             scope {
                 language
             }
+            category
         }
     }
 `;

--- a/demo/site/src/news/NewsList.tsx
+++ b/demo/site/src/news/NewsList.tsx
@@ -1,19 +1,37 @@
 "use client";
+import { fetchNewsList } from "@src/app/[domain]/[language]/news/page";
 import { DamImageBlock } from "@src/blocks/DamImageBlock";
+import { GQLNewsCategory, GQLNewsContentScopeInput } from "@src/graphql.generated";
 import Link from "next/link";
+import { useState } from "react";
 import styled from "styled-components";
 
 import { GQLNewsListFragment } from "./NewsList.fragment.generated";
 
-export function NewsList({ newsList }: { newsList: GQLNewsListFragment }) {
+export function NewsList({ initialNewsList, scope }: { initialNewsList: GQLNewsListFragment; scope: GQLNewsContentScopeInput }) {
+    const [newsList, setNewsList] = useState(initialNewsList);
+    const categories = [undefined, "Events", "Company", "Awards"] as GQLNewsCategory[];
+
     return (
         <div>
             <h1>News</h1>
+            {categories.map((category) => (
+                <button
+                    key={category}
+                    onClick={async () => {
+                        // To demonstrate server actions we don't filter on the client side
+                        setNewsList(await fetchNewsList(scope, category));
+                    }}
+                >
+                    {category ?? "All"}
+                </button>
+            ))}
             <CardList>
                 {newsList.nodes.map((news) => (
                     <Card key={news.id} href={`/${news.scope.language}/news/${news.slug}`}>
                         <DamImageBlock data={news.image} aspectRatio="4x3" />
                         <h2>{news.title}</h2>
+                        <p>{news.category}</p>
                         {/* <p><FormattedDate value={news.createdAt} /></p> */}
                     </Card>
                 ))}


### PR DESCRIPTION
In the site there are occasions which require a client-side request to the API. To avoid exposing the whole API we can use Next.js Server Actions (instead creating BFFs, which is cumbersome).

This PR demonstrates a category filter for news implemented as a server action.

## Example

https://github.com/user-attachments/assets/0e637bae-ee66-4cac-8349-1b4d433e65d1

## Discussion

- Server Actions are primarily considered as "actions", querying data is possible but not the main use case. Shall we nevertheless showcase a query? An alternative would be a "like"-feature, but this requires a whole new resolver in the api.
- It's not possible to alter the Cache-Control Header, making server actions not suitable for query-requests which are executed regularily with the same parameters from the same client. How can we avoid that devs go this line?