### PR TITLE
Fix alignment of `Alert` icon with the title

### DIFF
--- a/.changeset/nine-rings-check.md
+++ b/.changeset/nine-rings-check.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix alignment of `Alert` Icon with the Title

--- a/.changeset/nine-rings-check.md
+++ b/.changeset/nine-rings-check.md
@@ -2,4 +2,4 @@
 "@comet/admin": patch
 ---
 
-Fix alignment of `Alert` Icon with the Title
+Fix alignment of `Alert` icon with the title

--- a/packages/admin/admin/src/alert/Alert.tsx
+++ b/packages/admin/admin/src/alert/Alert.tsx
@@ -110,7 +110,9 @@ const Root = createComponentSlot(MuiAlert)<AlertClassKey, OwnerState>({
 const Title = createComponentSlot(AlertTitle)<AlertClassKey>({
     componentName: "Alert",
     slotName: "title",
-})();
+})(css`
+    margin-top: 0px;
+`);
 
 const Text = createComponentSlot(Typography)<AlertClassKey>({
     componentName: "Alert",


### PR DESCRIPTION
## Description
Fix Icon alignment in the Alert Component when a Title is set

<!--
Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.
-->

## Example


-   [x] I have verified if my change requires an example

## Screenshots/screencasts
![image](https://github.com/user-attachments/assets/0347e3a3-e7b2-49d0-931d-6f0105c7bebe)

## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1152