### PR TITLE
Fix `BigIntType` usages

### DIFF
--- a/packages/api/cms-api/src/dam/blocks/dam-file-download-link-block-transformer.service.ts
+++ b/packages/api/cms-api/src/dam/blocks/dam-file-download-link-block-transformer.service.ts
@@ -33,7 +33,7 @@ export class DamFileDownloadLinkBlockTransformerService implements BlockTransfor
                 id: file.id,
                 name: file.name,
                 fileUrl: await this.filesService.createFileUrl(file, { previewDamUrls, relativeDamUrls }),
-                size: Number(file.size),
+                size: file.size,
                 scope: file.scope,
             };
         } else if (file && block.openFileType === "Download") {
@@ -41,7 +41,7 @@ export class DamFileDownloadLinkBlockTransformerService implements BlockTransfor
                 id: file.id,
                 name: file.name,
                 fileUrl: await this.filesService.createFileDownloadUrl(file, { previewDamUrls, relativeDamUrls }),
-                size: Number(file.size),
+                size: file.size,
                 scope: file.scope,
             };
         }

--- a/packages/api/cms-api/src/dam/files/entities/file.entity.ts
+++ b/packages/api/cms-api/src/dam/files/entities/file.entity.ts
@@ -67,7 +67,7 @@ export function createFileEntity({ Scope, Folder }: { Scope?: Type<DamScopeInter
         name: string;
 
         @Field(() => Int)
-        @Property({ type: BigIntType })
+        @Property({ type: new BigIntType("number") })
         size: number;
 
         @Field()

--- a/packages/api/cms-api/src/file-uploads/entities/file-upload.entity.ts
+++ b/packages/api/cms-api/src/file-uploads/entities/file-upload.entity.ts
@@ -16,7 +16,7 @@ export class FileUpload extends BaseEntity {
     name: string;
 
     @Field(() => Int)
-    @Property({ type: BigIntType })
+    @Property({ type: new BigIntType("number") })
     size: number;
 
     @Field()


### PR DESCRIPTION
## Description

Previously, our usages of big ints was inconsistent: The GraphQL API uses `Int`, the block meta uses `number`, and columns were incorrectly typed as `number` while MikroORM internally used `string`.

With this change, we now use `number` for the columns. Doing so ensures that the a column defined as big int will always be a number in the API. We decided that we can neglect the mismatch between number and big int since none of our files will ever exceed the limit of number: [Number.MAX_VALUE](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE).

## Changeset

-   [x] I have verified if my change requires a changeset: Internal change, no changeset needed

## Open TODOs/questions

- [x] Merge parent PR https://github.com/vivid-planet/comet/pull/2822
