### PR TITLE
Fix CRUD Generator lint scripts

### DIFF
--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -18,7 +18,7 @@
         "lint:eslint": "eslint --max-warnings 0  --config ./.eslintrc.cli.js --ext .ts,.tsx,.js,.jsx,.json,.md src/ package.json",
         "lint:prettier": "npx prettier --check './**/*.{js,json,md,yml,yaml}'",
         "lint:tsc": "tsc --project .",
-        "lint:generated-files-not-modified": "$npm_execpath admin-generator && git diff --exit-code HEAD --",
+        "lint:generated-files-not-modified": "$npm_execpath admin-generator && git diff --exit-code HEAD -- src/**/generated",
         "start": "run-s intl:compile && run-p gql:types generate-block-types && dotenv -e .env.site-configs -- chokidar --initial -s \"../../packages/admin/*/src/**\" -c \"kill-port $ADMIN_PORT && vite --force\""
     },
     "dependencies": {

--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -16,7 +16,7 @@
         "lint:eslint": "eslint --max-warnings 0  --ext .ts,.tsx,.js,.jsx,.json,.md src/ package.json",
         "lint:prettier": "npx prettier --check './**/*.{js,json,md,yml,yaml}'",
         "lint:tsc": "tsc --project ./tsconfig.lint.json",
-        "lint:generated-files-not-modified": "$npm_execpath api-generator && git diff --exit-code HEAD --",
+        "lint:generated-files-not-modified": "$npm_execpath api-generator && git diff --exit-code HEAD -- src/**/generated",
         "mikro-orm": "mikro-orm",
         "mikro-orm:drop": "mikro-orm schema:drop -r",
         "mikro-orm:migration:generate": "mikro-orm migration:create",


### PR DESCRIPTION
The `lint:generated-files-not-modified` incorrectly failed if any file in the Git repository had changes. We fix this by only checking for files in `src/**/generated`.