### PR TITLE
Storybook: remove React barrel imports

### DIFF
--- a/storybook/.eslintrc.json
+++ b/storybook/.eslintrc.json
@@ -7,7 +7,8 @@
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "no-console": "off",
-        "@comet/no-other-module-relative-import": "off"
+        "@comet/no-other-module-relative-import": "off",
+        "react/react-in-jsx-scope": "off"
     },
     "overrides": [
         {

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -7,7 +7,6 @@ import { createTheme as createMuiTheme, GlobalStyles } from "@mui/material";
 import type { Preview } from "@storybook/react";
 import { Locale as DateFnsLocale } from "date-fns";
 import { de as deLocale, enUS as enLocale } from "date-fns/locale";
-import * as React from "react";
 import { IntlProvider } from "react-intl";
 
 import { worker } from "./mocks/browser";

--- a/storybook/src/admin-date-time/AllDateAndTimePickers.stories.tsx
+++ b/storybook/src/admin-date-time/AllDateAndTimePickers.stories.tsx
@@ -1,6 +1,5 @@
 import { DateField, DateRange, DateRangeField, DateTimeField, TimeField, TimeRange, TimeRangeField } from "@comet/admin-date-time";
 import { Box, Card, CardContent } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin-date-time/DatePicker.stories.tsx
+++ b/storybook/src/admin-date-time/DatePicker.stories.tsx
@@ -1,7 +1,6 @@
 import { Field } from "@comet/admin";
 import { FinalFormDatePicker } from "@comet/admin-date-time";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin-date-time/DateRangePicker.stories.tsx
+++ b/storybook/src/admin-date-time/DateRangePicker.stories.tsx
@@ -1,7 +1,6 @@
 import { Field } from "@comet/admin";
 import { DateRange, FinalFormDateRangePicker } from "@comet/admin-date-time";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin-date-time/DateTimePicker.stories.tsx
+++ b/storybook/src/admin-date-time/DateTimePicker.stories.tsx
@@ -1,7 +1,6 @@
 import { Field } from "@comet/admin";
 import { FinalFormDateTimePicker } from "@comet/admin-date-time";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin-date-time/TimePicker.stories.tsx
+++ b/storybook/src/admin-date-time/TimePicker.stories.tsx
@@ -1,7 +1,6 @@
 import { Field } from "@comet/admin";
 import { FinalFormTimePicker } from "@comet/admin-date-time";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin-date-time/TimeRangePicker.stories.tsx
+++ b/storybook/src/admin-date-time/TimeRangePicker.stories.tsx
@@ -1,7 +1,6 @@
 import { Field } from "@comet/admin";
 import { FinalFormTimeRangePicker, TimeRange } from "@comet/admin-date-time";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin-icons/IconUsage.stories.tsx
+++ b/storybook/src/admin-icons/IconUsage.stories.tsx
@@ -1,6 +1,5 @@
 import { Cookie, Error, ThreeDotSaving } from "@comet/admin-icons";
 import { Card, CardContent, Grid, Typography } from "@mui/material";
-import * as React from "react";
 
 export default {
     title: "@comet/admin-icons",

--- a/storybook/src/admin-react-select/FinalFormReactSelect.stories.tsx
+++ b/storybook/src/admin-react-select/FinalFormReactSelect.stories.tsx
@@ -1,7 +1,6 @@
 import { Field, FinalFormInput, FormSection } from "@comet/admin";
 import { FinalFormReactSelectStaticOptions } from "@comet/admin-react-select";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 const options = [

--- a/storybook/src/admin-react-select/FinalFormReactSelectDialog.stories.tsx
+++ b/storybook/src/admin-react-select/FinalFormReactSelectDialog.stories.tsx
@@ -1,7 +1,6 @@
 import { CancelButton, Field, OkayButton } from "@comet/admin";
 import { FinalFormReactSelectStaticOptions } from "@comet/admin-react-select";
 import { Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 const options = [

--- a/storybook/src/admin-react-select/FinalFormReactSelectDisabledOption.stories.tsx
+++ b/storybook/src/admin-react-select/FinalFormReactSelectDisabledOption.stories.tsx
@@ -1,7 +1,6 @@
 import { Field, FormSection } from "@comet/admin";
 import { FinalFormReactSelectStaticOptions } from "@comet/admin-react-select";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 const options = [

--- a/storybook/src/admin-react-select/ReactSelectDisabledOption.stories.tsx
+++ b/storybook/src/admin-react-select/ReactSelectDisabledOption.stories.tsx
@@ -1,7 +1,6 @@
 import { FormSection } from "@comet/admin";
 import { ReactSelect } from "@comet/admin-react-select";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 
 const options = [
     { value: "chocolate", label: "Chocolate" },

--- a/storybook/src/admin-rte/Field.stories.tsx
+++ b/storybook/src/admin-rte/Field.stories.tsx
@@ -1,7 +1,7 @@
 import { Field, FinalFormInput, FormSection } from "@comet/admin";
 import { createFinalFormRte } from "@comet/admin-rte";
 import { Button, Card, CardContent, Grid } from "@mui/material";
-import * as React from "react";
+import { useReducer, useState } from "react";
 import { Form } from "react-final-form";
 
 const { RteField, RteReadOnly } = createFinalFormRte();
@@ -11,8 +11,8 @@ export default {
 };
 
 export const _Field = () => {
-    const [submittedValue, setSubmittedValue] = React.useState<{ rteContent: any }>({ rteContent: undefined });
-    const [disabled, toggleDisabled] = React.useReducer((s) => !s, false);
+    const [submittedValue, setSubmittedValue] = useState<{ rteContent: any }>({ rteContent: undefined });
+    const [disabled, toggleDisabled] = useReducer((s) => !s, false);
 
     return (
         <Grid container spacing={4} style={{ maxWidth: 800 }}>

--- a/storybook/src/admin-rte/FieldAllOptions.stories.tsx
+++ b/storybook/src/admin-rte/FieldAllOptions.stories.tsx
@@ -1,7 +1,7 @@
 import { Field, FormSection } from "@comet/admin";
 import { createFinalFormRte } from "@comet/admin-rte";
 import { Button, Card, CardContent, Grid } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 
 import { ContentFormat, defaultContent, makeApiOptions, rteOptions } from "./RteAllOptions.stories";
@@ -17,7 +17,7 @@ export default {
 
 export const FieldAllOptions = {
     render: () => {
-        const [submittedValue, setSubmittedValue] = React.useState<{ rteContent: any }>({ rteContent: defaultContent });
+        const [submittedValue, setSubmittedValue] = useState<{ rteContent: any }>({ rteContent: defaultContent });
 
         return (
             <Grid container spacing={4} style={{ maxWidth: 800 }}>

--- a/storybook/src/admin-rte/MaxListLevel.stories.tsx
+++ b/storybook/src/admin-rte/MaxListLevel.stories.tsx
@@ -1,6 +1,6 @@
 import { IRteRef, makeRteApi, Rte } from "@comet/admin-rte";
 import { Box, Card, CardContent } from "@mui/material";
-import * as React from "react";
+import { useRef } from "react";
 
 import { PrintEditorState, useAutoFocus } from "./helper";
 
@@ -128,7 +128,7 @@ export const MaxListLevel = {
         });
 
         // focus the editor to see the cursor immediately
-        const editorRef = React.useRef<IRteRef>();
+        const editorRef = useRef<IRteRef>();
         useAutoFocus(editorRef);
 
         return (

--- a/storybook/src/admin-rte/Rte.stories.tsx
+++ b/storybook/src/admin-rte/Rte.stories.tsx
@@ -1,6 +1,6 @@
 import { IRteRef, makeRteApi, Rte } from "@comet/admin-rte";
 import { Box, Card, CardContent } from "@mui/material";
-import * as React from "react";
+import { useRef } from "react";
 
 import { exampleContent, PrintEditorState, useAutoFocus } from "./helper";
 
@@ -15,7 +15,7 @@ export const RteMinimalConfiguration = {
         const { editorState, setEditorState } = useRteApi({ defaultValue: JSON.stringify(exampleContent) }); // defaultValue is optional
 
         // focus the editor to see the cursor immediately
-        const editorRef = React.useRef<IRteRef>();
+        const editorRef = useRef<IRteRef>();
         useAutoFocus(editorRef);
 
         return (

--- a/storybook/src/admin-rte/RteAllOptions.stories.tsx
+++ b/storybook/src/admin-rte/RteAllOptions.stories.tsx
@@ -1,7 +1,7 @@
 import { IMakeRteApiProps, IRteApiProps, IRteOptions, IRteRef, LinkDecorator, makeRteApi, Rte } from "@comet/admin-rte";
 import { Box, Card, CardContent, Typography } from "@mui/material";
 import { convertFromRaw, convertToRaw } from "draft-js";
-import * as React from "react";
+import { ReactNode, useRef } from "react";
 
 import { exampleContent, PrintEditorState, useAutoFocus } from "./helper";
 
@@ -25,12 +25,12 @@ export const apiOptions: IRteApiProps<ContentFormat> = {
     debounceDelay: 400, // delay when onDebouncedContentChange after editor content changed
 };
 
-const RedCustomHeader: React.FC = ({ children }) => (
+const RedCustomHeader = ({ children }: { children?: ReactNode }) => (
     <Typography variant="h1" style={{ color: "red" }}>
         {children}
     </Typography>
 );
-const GreenCustomHeader: React.FC = ({ children }) => <h2 style={{ color: "green" }}>{children}</h2>;
+const GreenCustomHeader = ({ children }: { children?: ReactNode }) => <h2 style={{ color: "green" }}>{children}</h2>;
 
 export const rteOptions: IRteOptions = {
     supports: [
@@ -112,7 +112,7 @@ export const RteAllOptions = {
         const { editorState, setEditorState } = useRteApi(apiOptions);
 
         // focus the editor to see the cursor immediately
-        const editorRef = React.useRef<IRteRef>();
+        const editorRef = useRef<IRteRef>();
         useAutoFocus(editorRef);
 
         return (

--- a/storybook/src/admin-rte/RteCustom.stories.tsx
+++ b/storybook/src/admin-rte/RteCustom.stories.tsx
@@ -1,6 +1,6 @@
 import { IRteOptions, IRteRef, makeRteApi, Rte } from "@comet/admin-rte";
 import { Box, Card, CardContent, Typography } from "@mui/material";
-import * as React from "react";
+import { useRef } from "react";
 
 import { PrintEditorState, useAutoFocus } from "./helper";
 
@@ -20,7 +20,7 @@ export const RteCustomized = {
         const { editorState, setEditorState } = useRteApi();
 
         // focus the editor to see the cursor immediately
-        const editorRef = React.useRef<IRteRef>();
+        const editorRef = useRef<IRteRef>();
         useAutoFocus(editorRef);
 
         return (

--- a/storybook/src/admin-rte/RteCustomInlineStyles.stories.tsx
+++ b/storybook/src/admin-rte/RteCustomInlineStyles.stories.tsx
@@ -1,7 +1,7 @@
 import { Favorite } from "@comet/admin-icons";
 import { IRteOptions, IRteRef, makeRteApi, Rte } from "@comet/admin-rte";
 import { Box, Card, CardContent } from "@mui/material";
-import * as React from "react";
+import { useRef } from "react";
 
 import { PrintEditorState, useAutoFocus } from "./helper";
 
@@ -29,7 +29,7 @@ export const CustomInlineStyles = {
         const { editorState, setEditorState } = useRteApi();
 
         // focus the editor to see the cursor immediately
-        const editorRef = React.useRef<IRteRef>();
+        const editorRef = useRef<IRteRef>();
         useAutoFocus(editorRef);
 
         return (

--- a/storybook/src/admin-rte/RteDisable.stories.tsx
+++ b/storybook/src/admin-rte/RteDisable.stories.tsx
@@ -1,7 +1,7 @@
 import { Toolbar, ToolbarActions, ToolbarFillSpace } from "@comet/admin";
 import { IRteRef, makeRteApi, Rte } from "@comet/admin-rte";
 import { Box, Button, Card, CardContent } from "@mui/material";
-import * as React from "react";
+import { useReducer, useRef } from "react";
 
 import { exampleContent, PrintEditorState, useAutoFocus } from "./helper";
 
@@ -14,10 +14,10 @@ export default {
 export const RteDisable = {
     render: () => {
         const { editorState, setEditorState } = useRteApi({ defaultValue: JSON.stringify(exampleContent) }); // defaultValue is optional
-        const [disabled, toggleDisabled] = React.useReducer((s) => !s, false);
+        const [disabled, toggleDisabled] = useReducer((s) => !s, false);
 
         // focus the editor to see the cursor immediately
-        const editorRef = React.useRef<IRteRef>();
+        const editorRef = useRef<IRteRef>();
         useAutoFocus(editorRef);
 
         return (

--- a/storybook/src/admin-rte/RteFilterContent.stories.tsx
+++ b/storybook/src/admin-rte/RteFilterContent.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from "@comet/admin-rte";
 import { Box, Card, CardContent, Typography } from "@mui/material";
 import { EditorState, EntityInstance } from "draft-js";
-import * as React from "react";
+import { useRef } from "react";
 
 import { PrintEditorState, useAutoFocus } from "./helper";
 
@@ -41,7 +41,7 @@ export const RteFilterContent = {
         const { editorState, setEditorState } = useRteApi();
 
         // focus the editor to see the cursor immediately
-        const editorRef = React.useRef<IRteRef>();
+        const editorRef = useRef<IRteRef>();
         useAutoFocus(editorRef);
 
         return (

--- a/storybook/src/admin-rte/RteMaxBlocks.stories.tsx
+++ b/storybook/src/admin-rte/RteMaxBlocks.stories.tsx
@@ -1,6 +1,6 @@
 import { IRteOptions, IRteRef, makeRteApi, Rte } from "@comet/admin-rte";
 import { Box, Card, CardContent } from "@mui/material";
-import * as React from "react";
+import { useRef } from "react";
 
 import { PrintEditorState, useAutoFocus } from "./helper";
 
@@ -45,7 +45,7 @@ export const RteMaxBlocksSet = {
         });
 
         // focus the editor to see the cursor immediately
-        const editorRef = React.useRef<IRteRef>();
+        const editorRef = useRef<IRteRef>();
         useAutoFocus(editorRef);
 
         return (

--- a/storybook/src/admin-rte/RteReadOnly.stories.tsx
+++ b/storybook/src/admin-rte/RteReadOnly.stories.tsx
@@ -1,12 +1,12 @@
 import { IRteReadOnlyOptions, makeRteApi, RteReadOnly } from "@comet/admin-rte";
 import { Box, Card, CardContent } from "@mui/material";
-import * as React from "react";
+import { ReactNode } from "react";
 
 import { exampleContent, PrintEditorState } from "./helper";
 
 const [useRteApi] = makeRteApi();
 
-const GreenCustomHeader: React.FC = ({ children }) => <span style={{ color: "green" }}>{children}</span>;
+const GreenCustomHeader = ({ children }: { children?: ReactNode }) => <span style={{ color: "green" }}>{children}</span>;
 
 const rteOptions: IRteReadOnlyOptions = {
     blocktypeMap: {

--- a/storybook/src/admin-rte/RteSortBlockTypes.stories.tsx
+++ b/storybook/src/admin-rte/RteSortBlockTypes.stories.tsx
@@ -1,6 +1,5 @@
 import { IRteOptions, makeRteApi, Rte } from "@comet/admin-rte";
 import { Box, Card, CardContent } from "@mui/material";
-import * as React from "react";
 
 const rteOptions: IRteOptions = {
     blocktypeMap: {

--- a/storybook/src/admin-rte/RteTheming.stories.tsx
+++ b/storybook/src/admin-rte/RteTheming.stories.tsx
@@ -1,6 +1,5 @@
 import { makeRteApi, Rte } from "@comet/admin-rte";
 import { Box, Card, CardContent } from "@mui/material";
-import * as React from "react";
 
 const [useRteApi] = makeRteApi();
 

--- a/storybook/src/admin-rte/SaveAsDraftObject.stories.tsx
+++ b/storybook/src/admin-rte/SaveAsDraftObject.stories.tsx
@@ -1,7 +1,7 @@
 import { IMakeRteApiProps, makeRteApi, OnDebouncedContentChangeFn, Rte } from "@comet/admin-rte";
 import { Box, Card, CardContent } from "@mui/material";
 import { convertFromRaw, convertToRaw, RawDraftContentState } from "draft-js";
-import * as React from "react";
+import { useState } from "react";
 
 import { PrintAnything } from "./helper";
 
@@ -48,7 +48,7 @@ export default {
 
 export const SaveAsRawDraftJsObject = {
     render: () => {
-        const [savableContent, setSavableContent] = React.useState<RawDraftContentState>(defaultValue);
+        const [savableContent, setSavableContent] = useState<RawDraftContentState>(defaultValue);
 
         const handleDebouncedContentChange: OnDebouncedContentChangeFn = (innerEditorState, convertStateToRawContent) => {
             setSavableContent(convertStateToRawContent(innerEditorState));

--- a/storybook/src/admin-rte/SaveAsHtml.stories.tsx
+++ b/storybook/src/admin-rte/SaveAsHtml.stories.tsx
@@ -2,7 +2,7 @@ import { IMakeRteApiProps, makeRteApi, OnDebouncedContentChangeFn, Rte } from "@
 import { Box, Card, CardContent } from "@mui/material";
 import { ContentState, convertFromHTML } from "draft-js";
 import { stateToHTML } from "draft-js-export-html";
-import * as React from "react";
+import { useState } from "react";
 
 import { PrintAnything } from "./helper";
 
@@ -28,7 +28,7 @@ export default {
 
 export const SaveAsHtml = {
     render: () => {
-        const [savableContent, setSavableContent] = React.useState<Html>(defaultValue);
+        const [savableContent, setSavableContent] = useState<Html>(defaultValue);
 
         const handleDebouncedContentChange: OnDebouncedContentChangeFn = (innerEditorState, convertStateToRawContent) => {
             setSavableContent(convertStateToRawContent(innerEditorState));

--- a/storybook/src/admin-rte/SaveAsMD.stories.tsx
+++ b/storybook/src/admin-rte/SaveAsMD.stories.tsx
@@ -2,7 +2,7 @@ import { IMakeRteApiProps, makeRteApi, OnDebouncedContentChangeFn, Rte } from "@
 import { Box, Card, CardContent } from "@mui/material";
 import { stateToMarkdown } from "draft-js-export-markdown";
 import { stateFromMarkdown } from "draft-js-import-markdown";
-import * as React from "react";
+import { useState } from "react";
 
 import { PrintAnything } from "./helper";
 
@@ -31,7 +31,7 @@ export default {
 
 export const SaveAsMd = {
     render: () => {
-        const [savableContent, setSavableContent] = React.useState<Markdown>(defaultValue);
+        const [savableContent, setSavableContent] = useState<Markdown>(defaultValue);
 
         const handleDebouncedContentChange: OnDebouncedContentChangeFn = (innerEditorState, convertStateToRawContent) => {
             setSavableContent(convertStateToRawContent(innerEditorState));

--- a/storybook/src/admin-rte/SynchronizedEditors.stories.tsx
+++ b/storybook/src/admin-rte/SynchronizedEditors.stories.tsx
@@ -1,7 +1,7 @@
 import { IRteRef, makeRteApi, Rte } from "@comet/admin-rte";
 import { Grid, Typography } from "@mui/material";
 import { EditorState } from "draft-js";
-import * as React from "react";
+import { useRef, useState } from "react";
 
 import { PrintEditorState, useAutoFocus } from "./helper";
 
@@ -14,10 +14,10 @@ export default {
 export const SynchronizedRtEs = {
     render: () => {
         const { editorState, setEditorState } = useRteApi();
-        const [activeEditor, setActiveEditor] = React.useState<"left" | "right">("left");
+        const [activeEditor, setActiveEditor] = useState<"left" | "right">("left");
 
         // focus the editor to see the cursor immediately
-        const leftEditorRef = React.useRef<IRteRef>();
+        const leftEditorRef = useRef<IRteRef>();
         useAutoFocus(leftEditorRef);
 
         return (

--- a/storybook/src/admin-rte/ToolbarButtonsSubmitForm.stories.tsx
+++ b/storybook/src/admin-rte/ToolbarButtonsSubmitForm.stories.tsx
@@ -1,6 +1,5 @@
 import { Field } from "@comet/admin";
 import { createFinalFormRte } from "@comet/admin-rte";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 const { RteField } = createFinalFormRte();

--- a/storybook/src/admin-rte/helper.tsx
+++ b/storybook/src/admin-rte/helper.tsx
@@ -2,10 +2,10 @@ import { FormSection } from "@comet/admin";
 import { IRteRef } from "@comet/admin-rte";
 import { Card, CardContent } from "@mui/material";
 import { convertToRaw, EditorState, RawDraftContentState } from "draft-js";
-import * as React from "react";
+import { MutableRefObject, useEffect } from "react";
 
-export function useAutoFocus(editorRef: React.MutableRefObject<IRteRef | undefined>) {
-    React.useEffect(() => {
+export function useAutoFocus(editorRef: MutableRefObject<IRteRef | undefined>) {
+    useEffect(() => {
         if (editorRef && editorRef.current) {
             editorRef.current.focus();
         }

--- a/storybook/src/admin/FieldSet.stories.tsx
+++ b/storybook/src/admin/FieldSet.stories.tsx
@@ -2,7 +2,6 @@ import { FieldSet, Tooltip } from "@comet/admin";
 import { Info } from "@comet/admin-icons";
 import { Chip, Stack, Typography } from "@mui/material";
 import { Box } from "@mui/system";
-import React from "react";
 
 const textContent =
     "FieldSet content. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";

--- a/storybook/src/admin/FullHeightContent.stories.tsx
+++ b/storybook/src/admin/FullHeightContent.stories.tsx
@@ -12,7 +12,6 @@ import {
 import { Add } from "@comet/admin-icons";
 import { ContentScopeIndicator } from "@comet/cms-admin";
 import { Button } from "@mui/material";
-import React from "react";
 
 import { ExampleDataGrid } from "../helpers/ExampleDataGrid";
 import { masterLayoutDecorator, stackRouteDecorator } from "../helpers/storyDecorators";

--- a/storybook/src/admin/Typography.stories.tsx
+++ b/storybook/src/admin/Typography.stories.tsx
@@ -1,5 +1,4 @@
 import { Divider, Grid, Paper, Typography } from "@mui/material";
-import React from "react";
 
 export default {
     title: "@comet/admin/Typography",

--- a/storybook/src/admin/alert/Alert.stories.tsx
+++ b/storybook/src/admin/alert/Alert.stories.tsx
@@ -2,7 +2,6 @@ import { Alert, OkayButton, SaveButton } from "@comet/admin";
 import { ArrowRight } from "@comet/admin-icons";
 import { Button, Card, CardContent, Typography } from "@mui/material";
 import { Stack } from "@mui/system";
-import React from "react";
 
 export default {
     title: "@comet/admin/alert/Alert",

--- a/storybook/src/admin/alert/AlertInSnackbar.stories.tsx
+++ b/storybook/src/admin/alert/AlertInSnackbar.stories.tsx
@@ -1,6 +1,6 @@
 import { Alert } from "@comet/admin";
 import { Button, Snackbar } from "@mui/material";
-import React from "react";
+import { useState } from "react";
 
 export default {
     title: "@comet/admin/alert/Alert",
@@ -8,7 +8,7 @@ export default {
 
 export const AlertInSnackbar = {
     render: () => {
-        const [showSnackbar, setShowSnackbar] = React.useState(false);
+        const [showSnackbar, setShowSnackbar] = useState(false);
         return (
             <>
                 <Button

--- a/storybook/src/admin/clipboard/clipboard.stories.tsx
+++ b/storybook/src/admin/clipboard/clipboard.stories.tsx
@@ -1,6 +1,6 @@
 import { Alert, readClipboardText, writeClipboardText } from "@comet/admin";
 import { Button, Grid } from "@mui/material";
-import React from "react";
+import { useState } from "react";
 
 export default {
     title: "@comet/admin/clipboard",
@@ -8,7 +8,7 @@ export default {
 
 export const ClipboardFallbackSizeLimit = function () {
     const writtenClipboardContent = "a".repeat(1024 * 1024 * 10); // 10MB
-    const [readClipboardContent, setReadClipboardContent] = React.useState<string | undefined>();
+    const [readClipboardContent, setReadClipboardContent] = useState<string | undefined>();
 
     return (
         <Grid container spacing={2}>

--- a/storybook/src/admin/edit-dialog/EditDialogInRouterTabs.stories.tsx
+++ b/storybook/src/admin/edit-dialog/EditDialogInRouterTabs.stories.tsx
@@ -14,7 +14,7 @@ import {
 import { Add } from "@comet/admin-icons";
 import { Button, Typography } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
-import React from "react";
+import { ReactNode, RefObject, useRef } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
@@ -33,10 +33,10 @@ const products = [
 ];
 
 type DialogProps = {
-    dialogApiRef: React.RefObject<IEditDialogApi>;
+    dialogApiRef: RefObject<IEditDialogApi>;
 };
 
-const AddProductDialog: React.FC<DialogProps> = ({ dialogApiRef }) => {
+const AddProductDialog = ({ dialogApiRef }: DialogProps) => {
     const intl = useIntl();
 
     return (
@@ -64,7 +64,7 @@ const AddProductDialog: React.FC<DialogProps> = ({ dialogApiRef }) => {
     );
 };
 
-function Toolbar({ toolbarAction }: { toolbarAction?: React.ReactNode }) {
+function Toolbar({ toolbarAction }: { toolbarAction?: ReactNode }) {
     return (
         <DataGridToolbar>
             <ToolbarFillSpace />
@@ -75,7 +75,7 @@ function Toolbar({ toolbarAction }: { toolbarAction?: React.ReactNode }) {
 
 export const EditDialogInRouterTabs = {
     render: () => {
-        const editDialogApi = React.useRef<IEditDialogApi>(null);
+        const editDialogApi = useRef<IEditDialogApi>(null);
         return (
             <RouterTabs>
                 <RouterTab path="" label="First Tab">

--- a/storybook/src/admin/edit-dialog/EditDialogInRouterTabsWithinStack.stories.tsx
+++ b/storybook/src/admin/edit-dialog/EditDialogInRouterTabsWithinStack.stories.tsx
@@ -24,7 +24,7 @@ import {
 import { Add, Edit } from "@comet/admin-icons";
 import { Button, IconButton, Typography } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
-import React from "react";
+import { ReactNode, RefObject, useRef } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
@@ -67,10 +67,10 @@ const stocks = [
 ];
 
 type DialogProps = {
-    dialogApiRef: React.RefObject<IEditDialogApi>;
+    dialogApiRef: RefObject<IEditDialogApi>;
 };
 
-const AddProductDialog: React.FC<DialogProps> = ({ dialogApiRef }) => {
+const AddProductDialog = ({ dialogApiRef }: DialogProps) => {
     const intl = useIntl();
 
     return (
@@ -98,7 +98,7 @@ const AddProductDialog: React.FC<DialogProps> = ({ dialogApiRef }) => {
     );
 };
 
-const AddStocksDialog: React.FC<DialogProps> = ({ dialogApiRef }) => {
+const AddStocksDialog = ({ dialogApiRef }: DialogProps) => {
     const intl = useIntl();
 
     return (
@@ -126,7 +126,7 @@ const AddStocksDialog: React.FC<DialogProps> = ({ dialogApiRef }) => {
     );
 };
 
-function Toolbar({ toolbarAction }: { toolbarAction?: React.ReactNode }) {
+function Toolbar({ toolbarAction }: { toolbarAction?: ReactNode }) {
     return (
         <DataGridToolbar>
             <ToolbarItem>
@@ -147,9 +147,9 @@ type ProductDetailsProps = {
     productId: string;
 };
 
-export const ProductDetailsPage: React.FC<ProductDetailsProps> = ({ productId }: ProductDetailsProps) => {
+export const ProductDetailsPage = ({ productId }: ProductDetailsProps) => {
     const intl = useIntl();
-    const editDialogApi = React.useRef<IEditDialogApi>(null);
+    const editDialogApi = useRef<IEditDialogApi>(null);
 
     const rows: { id: string; productId: string; amount: string }[] = [];
     stocks.forEach((row) => {
@@ -254,7 +254,7 @@ export const ProductDetailsPage: React.FC<ProductDetailsProps> = ({ productId }:
 export const EditDialogInRouterTabsWithinStack = {
     render: () => {
         const intl = useIntl();
-        const editDialogApi = React.useRef<IEditDialogApi>(null);
+        const editDialogApi = useRef<IEditDialogApi>(null);
 
         return (
             <>

--- a/storybook/src/admin/edit-dialog/EditDialogWithFormInStack.stories.tsx
+++ b/storybook/src/admin/edit-dialog/EditDialogWithFormInStack.stories.tsx
@@ -1,6 +1,6 @@
 import { Field, FinalForm, FinalFormInput, Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch, useEditDialog } from "@comet/admin";
 import { Button } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
@@ -8,7 +8,7 @@ interface RootPageProps {
     counter: number;
 }
 
-const RootPage = ({ counter }: RootPageProps): React.ReactElement => {
+const RootPage = ({ counter }: RootPageProps) => {
     const [EditDialog, selection, editDialogApi, selectionApi] = useEditDialog();
 
     return (
@@ -80,7 +80,7 @@ interface InnerNestedStackProps {
 }
 
 const InnerNestedStack = ({ counter }: InnerNestedStackProps) => {
-    const [nestedCounter, setNestedCounter] = React.useState<number>();
+    const [nestedCounter, setNestedCounter] = useState<number>();
 
     return (
         <StackSwitch initialPage="root">

--- a/storybook/src/admin/edit-dialog/NestedEditDialogInStack.stories.tsx
+++ b/storybook/src/admin/edit-dialog/NestedEditDialogInStack.stories.tsx
@@ -1,7 +1,6 @@
 import { FinalForm, MainContent, Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch, TextField, useEditDialog } from "@comet/admin";
 import { Button, Typography } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
-import React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 

--- a/storybook/src/admin/error-handling/ErrorBoundary.stories.tsx
+++ b/storybook/src/admin/error-handling/ErrorBoundary.stories.tsx
@@ -1,9 +1,8 @@
 import { Alert, ErrorBoundary } from "@comet/admin";
 import { Box, Card, CardContent, Link, Typography } from "@mui/material";
 import { Meta } from "@storybook/react";
-import * as React from "react";
 
-const ViewWithNoError: React.FunctionComponent = () => {
+const ViewWithNoError = () => {
     return (
         <div>
             <Typography>View with No Error</Typography>
@@ -11,7 +10,7 @@ const ViewWithNoError: React.FunctionComponent = () => {
     );
 };
 
-const ViewWithError: React.FunctionComponent = () => {
+const ViewWithError = () => {
     throw new Error("Some error occurred");
     return (
         <div>

--- a/storybook/src/admin/error-handling/RouteWithErrorBoundary.stories.tsx
+++ b/storybook/src/admin/error-handling/RouteWithErrorBoundary.stories.tsx
@@ -1,11 +1,10 @@
 import { Alert, MasterLayout, Menu, MenuItemRouterLink, RouteWithErrorBoundary } from "@comet/admin";
 import { Card, CardContent, Typography } from "@mui/material";
-import * as React from "react";
 import { Redirect, Route, Switch } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
-const ViewWithNoError: React.FunctionComponent = () => {
+const ViewWithNoError = () => {
     return (
         <Card variant="outlined">
             <CardContent>
@@ -21,7 +20,7 @@ const ViewWithNoError: React.FunctionComponent = () => {
     );
 };
 
-const ViewWithError: React.FunctionComponent = () => {
+const ViewWithError = () => {
     throw new Error("Some error occurred");
     return (
         <div>

--- a/storybook/src/admin/fetch-provider/FetchProvider.stories.tsx
+++ b/storybook/src/admin/fetch-provider/FetchProvider.stories.tsx
@@ -1,10 +1,10 @@
 import { createFetch, FetchProvider, useFetch } from "@comet/admin";
-import * as React from "react";
+import { useEffect, useState } from "react";
 
 function ExampleFetch() {
     const fetch = useFetch();
-    const [data, setData] = React.useState<object | null>(null);
-    React.useEffect(() => {
+    const [data, setData] = useState<object | null>(null);
+    useEffect(() => {
         const fetchData = async () => {
             const response = await fetch(`/launches`);
             setData(await response.json());

--- a/storybook/src/admin/form/AllFieldComponents.stories.tsx
+++ b/storybook/src/admin/form/AllFieldComponents.stories.tsx
@@ -19,7 +19,7 @@ import {
 import { ColorField } from "@comet/admin-color-picker";
 import { DateField, DateRangeField, DateTimeField, TimeField, TimeRangeField } from "@comet/admin-date-time";
 import { Box, Button, Link, MenuItem } from "@mui/material";
-import * as React from "react";
+import { useMemo } from "react";
 import { Form } from "react-final-form";
 
 export default {
@@ -50,7 +50,7 @@ export const AllFieldComponents = {
             { value: "vanilla", label: "Vanilla" },
         ];
 
-        const initalValues = React.useMemo(() => ({ multiSelect: [] }), []);
+        const initalValues = useMemo(() => ({ multiSelect: [] }), []);
 
         return (
             <Form

--- a/storybook/src/admin/form/Autocomplete.stories.tsx
+++ b/storybook/src/admin/form/Autocomplete.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FinalFormAutocomplete, FinalFormSelect, useAsyncOptionsProps } from "@comet/admin";
 import { Button } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 interface Option {

--- a/storybook/src/admin/form/Checkbox.stories.tsx
+++ b/storybook/src/admin/form/Checkbox.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FieldContainer, FinalFormCheckbox } from "@comet/admin";
 import { Card, CardContent, FormControlLabel, Grid } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin/form/CustomButtons.stories.tsx
+++ b/storybook/src/admin/form/CustomButtons.stories.tsx
@@ -2,7 +2,6 @@ import { Field, FinalForm, FinalFormInput } from "@comet/admin";
 import { Master } from "@comet/admin-icons";
 import { Box, Button, Card, CardContent } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
 import { useFormState } from "react-final-form";
 
 const StyledButton = styled(Button)`
@@ -20,7 +19,7 @@ const StyledButton = styled(Button)`
     }
 `;
 
-const CustomButtons: React.FC = () => {
+const CustomButtons = () => {
     const { values, pristine, hasValidationErrors, submitting } = useFormState();
 
     return (

--- a/storybook/src/admin/form/DependentAsyncSelects.stories.tsx
+++ b/storybook/src/admin/form/DependentAsyncSelects.stories.tsx
@@ -1,7 +1,6 @@
 import { gql, useApolloClient } from "@apollo/client";
 import { AsyncSelectField, FinalForm, OnChangeField } from "@comet/admin";
 import { Box } from "@mui/material";
-import * as React from "react";
 
 import { apolloStoryDecorator } from "../../apollo-story.decorator";
 import { Manufacturer, Product } from "../../mocks/handlers";

--- a/storybook/src/admin/form/DisableAutoNavigation.stories.tsx
+++ b/storybook/src/admin/form/DisableAutoNavigation.stories.tsx
@@ -14,13 +14,13 @@ import {
 } from "@comet/admin";
 import { Edit } from "@comet/admin-icons";
 import { Box, Card, CardContent, IconButton, Paper, Typography } from "@mui/material";
-import * as React from "react";
+import { useContext } from "react";
 import { Switch } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
-const SampleTable: React.FunctionComponent = () => {
-    const stackApi = React.useContext(StackSwitchApiContext);
+const SampleTable = () => {
+    const stackApi = useContext(StackSwitchApiContext);
 
     return (
         <>
@@ -63,7 +63,7 @@ const SampleTable: React.FunctionComponent = () => {
     );
 };
 
-const SampleForm: React.FunctionComponent = () => {
+const SampleForm = () => {
     const onSubmit = async () => {
         alert("Submit successful");
         return Promise.resolve();

--- a/storybook/src/admin/form/DisabledSubmitIfNotDirty.stories.tsx
+++ b/storybook/src/admin/form/DisabledSubmitIfNotDirty.stories.tsx
@@ -1,5 +1,4 @@
 import { Field, FinalForm, FinalFormInput, FormSection, SaveButton } from "@comet/admin";
-import * as React from "react";
 
 export default {
     title: "stories/form/FinalForm",

--- a/storybook/src/admin/form/FinalFormFileSelect.stories.tsx
+++ b/storybook/src/admin/form/FinalFormFileSelect.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FinalFormFileSelect } from "@comet/admin";
 import { Box, Card, CardContent, Grid, Typography } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 type FormValues = {

--- a/storybook/src/admin/form/FormInStack.stories.tsx
+++ b/storybook/src/admin/form/FormInStack.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from "@comet/admin";
 import { Box, Button, Card, CardContent } from "@mui/material";
 import { SubmissionErrors } from "final-form";
-import * as React from "react";
+import { useContext } from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
@@ -43,7 +43,7 @@ const resolveSubmitErrors = (error: SubmissionErrors) => {
 };
 
 function Page1() {
-    const switchApi = React.useContext(StackSwitchApiContext);
+    const switchApi = useContext(StackSwitchApiContext);
 
     return (
         <>

--- a/storybook/src/admin/form/FormLayouts.stories.tsx
+++ b/storybook/src/admin/form/FormLayouts.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FinalForm, FinalFormInput, FormSection } from "@comet/admin";
 import { Card, CardContent, Grid } from "@mui/material";
-import * as React from "react";
 
 function VerticalFields() {
     return (

--- a/storybook/src/admin/form/Input.stories.tsx
+++ b/storybook/src/admin/form/Input.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FinalFormInput } from "@comet/admin";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin/form/Radio.stories.tsx
+++ b/storybook/src/admin/form/Radio.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FieldContainer, FinalFormRadio } from "@comet/admin";
 import { Card, CardContent, FormControlLabel, Grid } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin/form/RangeInput.stories.tsx
+++ b/storybook/src/admin/form/RangeInput.stories.tsx
@@ -1,7 +1,6 @@
 import { Field, FinalFormRangeInput, Toolbar, ToolbarTitleItem } from "@comet/admin";
 import { Box, Button, Card, CardContent, SliderThumb, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 const Thumb = styled(SliderThumb)`

--- a/storybook/src/admin/form/RouterTabs.stories.tsx
+++ b/storybook/src/admin/form/RouterTabs.stories.tsx
@@ -12,7 +12,6 @@ import {
     ToolbarFillSpace,
 } from "@comet/admin";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 

--- a/storybook/src/admin/form/RouterTabsInForm.stories.tsx
+++ b/storybook/src/admin/form/RouterTabsInForm.stories.tsx
@@ -1,13 +1,13 @@
 import { Field, FinalForm, FinalFormInput, RouterTab, RouterTabs } from "@comet/admin";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Path() {
     const location = useLocation();
-    const [, rerender] = React.useState(0);
-    React.useEffect(() => {
+    const [, rerender] = useState(0);
+    useEffect(() => {
         const timer = setTimeout(() => {
             rerender(new Date().getTime());
         }, 1000);

--- a/storybook/src/admin/form/RouterTabsInFormWithSubroutes.stories.tsx
+++ b/storybook/src/admin/form/RouterTabsInFormWithSubroutes.stories.tsx
@@ -1,14 +1,14 @@
 import { Field, FinalForm, FinalFormInput, RouterTab, RouterTabs, Stack, StackLink, StackPage, StackSwitch } from "@comet/admin";
 import { Button } from "@mui/material";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Path() {
     const location = useLocation();
-    const [, rerender] = React.useState(0);
-    React.useEffect(() => {
+    const [, rerender] = useState(0);
+    useEffect(() => {
         const timer = setTimeout(() => {
             rerender(new Date().getTime());
         }, 1000);

--- a/storybook/src/admin/form/ScrollToErrorField.stories.tsx
+++ b/storybook/src/admin/form/ScrollToErrorField.stories.tsx
@@ -1,6 +1,6 @@
 import { Field, FinalForm, FinalFormInput } from "@comet/admin";
 import { Button, Typography } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 interface FormValues {
     foo: string;
@@ -28,7 +28,7 @@ export const ScrollToErrorField = () => {
         bar: "",
     };
 
-    const [open, setOpen] = React.useState(false);
+    const [open, setOpen] = useState(false);
     return (
         <>
             <Button variant="contained" color="primary" onClick={() => setOpen((s) => !s)}>

--- a/storybook/src/admin/form/Select.stories.tsx
+++ b/storybook/src/admin/form/Select.stories.tsx
@@ -1,7 +1,6 @@
 import { FieldSet, SelectField, SelectFieldOption } from "@comet/admin";
 import { Account } from "@comet/admin-icons";
 import { Box, Checkbox, InputAdornment, ListItemIcon, ListItemText, MenuItem } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin/form/ShowErrorStrategies.stories.tsx
+++ b/storybook/src/admin/form/ShowErrorStrategies.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FinalForm, FinalFormContext, FinalFormInput } from "@comet/admin";
 import { Button, Typography } from "@mui/material";
-import * as React from "react";
 
 interface FormValues {
     foo: string;

--- a/storybook/src/admin/form/SingleTextField.stories.tsx
+++ b/storybook/src/admin/form/SingleTextField.stories.tsx
@@ -1,7 +1,7 @@
 import { FieldContainer } from "@comet/admin";
 import { Search } from "@comet/admin-icons";
 import { Card, CardContent, Checkbox, FormControlLabel, Grid, InputAdornment, InputBase, Typography } from "@mui/material";
-import * as React from "react";
+import { ChangeEvent, useState } from "react";
 
 export default {
     title: "@comet/admin/form",
@@ -9,9 +9,9 @@ export default {
 
 export const SingleTextField = {
     render: () => {
-        const [searchString1, setSearchString1] = React.useState<string>("");
-        const [searchString2, setSearchString2] = React.useState<string>("");
-        const [checkboxValue, setCheckboxValue] = React.useState<boolean>(false);
+        const [searchString1, setSearchString1] = useState<string>("");
+        const [searchString2, setSearchString2] = useState<string>("");
+        const [checkboxValue, setCheckboxValue] = useState<boolean>(false);
 
         return (
             <div style={{ width: 400 }}>
@@ -31,7 +31,7 @@ export const SingleTextField = {
                                                 <Search />
                                             </InputAdornment>
                                         }
-                                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchString1(e.target.value)}
+                                        onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchString1(e.target.value)}
                                         value={searchString1}
                                     />
                                 </FieldContainer>
@@ -52,7 +52,7 @@ export const SingleTextField = {
                                                 <Search />
                                             </InputAdornment>
                                         }
-                                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchString2(e.target.value)}
+                                        onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchString2(e.target.value)}
                                         value={searchString2}
                                     />
                                 </FieldContainer>
@@ -60,7 +60,7 @@ export const SingleTextField = {
                                     control={
                                         <Checkbox
                                             checked={checkboxValue}
-                                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCheckboxValue(e.target.checked)}
+                                            onChange={(e: ChangeEvent<HTMLInputElement>) => setCheckboxValue(e.target.checked)}
                                         />
                                     }
                                     label="Additional Setting"

--- a/storybook/src/admin/form/StackInForm.stories.tsx
+++ b/storybook/src/admin/form/StackInForm.stories.tsx
@@ -1,5 +1,4 @@
 import { Field, FinalForm, FinalFormInput, Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch } from "@comet/admin";
-import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 

--- a/storybook/src/admin/form/SubmitErrors.stories.tsx
+++ b/storybook/src/admin/form/SubmitErrors.stories.tsx
@@ -1,7 +1,6 @@
 import { Field, FinalForm, FinalFormInput, FinalFormSaveCancelButtonsLegacy } from "@comet/admin";
 import { Box, Card, CardContent } from "@mui/material";
 import { SubmissionErrors } from "final-form";
-import * as React from "react";
 
 const onSubmit = ({ foo, bar }: { foo: string; bar: string }) => {
     const errors = [];

--- a/storybook/src/admin/form/Switch.stories.tsx
+++ b/storybook/src/admin/form/Switch.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FinalFormSwitch } from "@comet/admin";
 import { Box, Card, CardContent, Divider, FormControlLabel } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/admin/form/Tabs.stories.tsx
+++ b/storybook/src/admin/form/Tabs.stories.tsx
@@ -1,13 +1,13 @@
 import { Field, FinalForm, FinalFormInput, Tab, Tabs } from "@comet/admin";
 import { Button, Card, CardContent } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 export default {
     title: "@comet/admin/form",
 };
 
 export const _Tabs = () => {
-    const [showExample3, setShowExample3] = React.useState(false);
+    const [showExample3, setShowExample3] = useState(false);
 
     return (
         <>

--- a/storybook/src/admin/form/TwoLevelValidation.stories.tsx
+++ b/storybook/src/admin/form/TwoLevelValidation.stories.tsx
@@ -1,7 +1,6 @@
 import { Field, FinalForm, FinalFormInput } from "@comet/admin";
 import { Card, CardContent, Grid } from "@mui/material";
 import { FieldValidator } from "final-form";
-import * as React from "react";
 
 const validateWarning = (value: number | undefined) => {
     if (value === undefined) {

--- a/storybook/src/admin/form/Typography.stories.tsx
+++ b/storybook/src/admin/form/Typography.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FieldContainer } from "@comet/admin";
 import { Card, CardContent, Divider, Typography } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 import { FormattedDate } from "react-intl";
 

--- a/storybook/src/admin/form/file/FileDropzone.stories.tsx
+++ b/storybook/src/admin/form/file/FileDropzone.stories.tsx
@@ -1,7 +1,7 @@
 import { FileDropzone, FileDropzoneProps } from "@comet/admin";
 import { Card, CardContent, Stack } from "@mui/material";
 import { Meta } from "@storybook/react";
-import React from "react";
+import { useState } from "react";
 
 type FileRejections = Parameters<Required<FileDropzoneProps>["onDropRejected"]>[0];
 
@@ -45,8 +45,8 @@ type Args = {
 
 export const _FileDropzone = {
     render: ({ disabled, multiple, hasError }: Args) => {
-        const [files, setFiles] = React.useState<File[]>([]);
-        const [rejectedFiles, setRejectedFiles] = React.useState<FileRejections>([]);
+        const [files, setFiles] = useState<File[]>([]);
+        const [rejectedFiles, setRejectedFiles] = useState<FileRejections>([]);
 
         return (
             <>

--- a/storybook/src/admin/form/file/FileSelect.stories.tsx
+++ b/storybook/src/admin/form/file/FileSelect.stories.tsx
@@ -1,7 +1,6 @@
 import { FileSelect, FileSelectItem } from "@comet/admin";
 import { Card, CardContent, Stack } from "@mui/material";
 import { Meta } from "@storybook/react";
-import React from "react";
 
 export default {
     title: "@comet/admin/form/File",

--- a/storybook/src/admin/form/file/FileSelectListItem.stories.tsx
+++ b/storybook/src/admin/form/file/FileSelectListItem.stories.tsx
@@ -1,7 +1,6 @@
 import { FileSelectItem, FileSelectListItem } from "@comet/admin";
 import { Card, CardContent, Stack } from "@mui/material";
 import { Meta } from "@storybook/react";
-import React from "react";
 
 const fileSize = 1.8 * 1024 * 1024; // 1.8 MB
 

--- a/storybook/src/admin/form/file/FileSelectMultipleExamples.stories.tsx
+++ b/storybook/src/admin/form/file/FileSelectMultipleExamples.stories.tsx
@@ -1,6 +1,6 @@
 import { FileSelect, FileSelectItem } from "@comet/admin";
 import { Box, Grid, Typography } from "@mui/material";
-import React from "react";
+import { useState } from "react";
 
 type StoryProps = {
     noBackground?: boolean;
@@ -24,8 +24,8 @@ const dummyFileDownload = (file: any) => {
 };
 
 const SingleFileSelectStory = ({ noBackground, hasExistingFiles }: StoryProps) => {
-    const [file, setFile] = React.useState<FileSelectItem | undefined>(hasExistingFiles ? dummyFiles[0] : undefined);
-    const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
+    const [file, setFile] = useState<FileSelectItem | undefined>(hasExistingFiles ? dummyFiles[0] : undefined);
+    const [tooManyFilesSelected, setTooManyFilesSelected] = useState(false);
 
     return (
         <Box padding={4} sx={{ backgroundColor: noBackground ? "transparent" : "white" }}>
@@ -68,8 +68,8 @@ const SingleFileSelectStory = ({ noBackground, hasExistingFiles }: StoryProps) =
 };
 
 const MultipleFileSelectStory = ({ noBackground, hasExistingFiles }: StoryProps) => {
-    const [files, setFiles] = React.useState<FileSelectItem[]>(hasExistingFiles ? dummyFiles : []);
-    const [tooManyFilesSelected, setTooManyFilesSelected] = React.useState(false);
+    const [files, setFiles] = useState<FileSelectItem[]>(hasExistingFiles ? dummyFiles : []);
+    const [tooManyFilesSelected, setTooManyFilesSelected] = useState(false);
     const maxNumberOfFiles = 4;
 
     return (

--- a/storybook/src/admin/helpers/PrettyBytes.stories.tsx
+++ b/storybook/src/admin/helpers/PrettyBytes.stories.tsx
@@ -1,7 +1,6 @@
 import { PrettyBytes } from "@comet/admin";
 import { Card, CardContent, Grid, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
 
 const Content = styled("div")`
     display: grid;

--- a/storybook/src/admin/mui/AppHeader.stories.tsx
+++ b/storybook/src/admin/mui/AppHeader.stories.tsx
@@ -12,7 +12,6 @@ import {
 } from "@comet/admin";
 import { Account, Dashboard, Language, Logout, Preview } from "@comet/admin-icons";
 import { Avatar, Box, Button, Divider, MenuItem, MenuList } from "@mui/material";
-import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 

--- a/storybook/src/admin/mui/Buttons.stories.tsx
+++ b/storybook/src/admin/mui/Buttons.stories.tsx
@@ -17,7 +17,6 @@ import {
     Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
 
 const ButtonsRow = styled("div")`
     display: flex;

--- a/storybook/src/admin/mui/Chip.stories.tsx
+++ b/storybook/src/admin/mui/Chip.stories.tsx
@@ -1,6 +1,5 @@
 import { ChevronDown } from "@comet/admin-icons";
 import { Box, Card, CardContent, Chip, Grid, Stack, Typography } from "@mui/material";
-import * as React from "react";
 
 export default {
     title: "@comet/admin/mui",

--- a/storybook/src/admin/mui/ChipMenu.stories.tsx
+++ b/storybook/src/admin/mui/ChipMenu.stories.tsx
@@ -1,7 +1,6 @@
 import { ChevronDown, Cookie, Domain, Favorite } from "@comet/admin-icons";
 import { Box, Card, CardContent, Chip, ListItemIcon, ListItemText, Menu, MenuItem, Stack, Typography } from "@mui/material";
-import * as React from "react";
-import { useState } from "react";
+import { MouseEvent, useState } from "react";
 
 export default {
     title: "@comet/admin/mui",
@@ -11,7 +10,7 @@ export const ChipMenu = {
     render: () => {
         const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
-        const handleChipClick = (event: React.MouseEvent) => {
+        const handleChipClick = (event: MouseEvent) => {
             setAnchorEl(event.currentTarget);
         };
 

--- a/storybook/src/admin/mui/Dialog.stories.tsx
+++ b/storybook/src/admin/mui/Dialog.stories.tsx
@@ -1,7 +1,6 @@
 import { CancelButton, Dialog, Field, FinalFormCheckbox, FinalFormInput, FinalFormSelect, OkayButton } from "@comet/admin";
 import { Save } from "@comet/admin-icons";
 import { Button, DialogActions, DialogContent, DialogContentText, DialogProps, FormControlLabel, MenuItem } from "@mui/material";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 type DialogSize = Exclude<DialogProps["maxWidth"], false> | "fullWidth";

--- a/storybook/src/admin/mui/Link.stories.tsx
+++ b/storybook/src/admin/mui/Link.stories.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@mui/material";
-import * as React from "react";
 
 export default {
     title: "@comet/admin/mui",

--- a/storybook/src/admin/mui/Menu.stories.tsx
+++ b/storybook/src/admin/mui/Menu.stories.tsx
@@ -14,14 +14,13 @@ import {
 } from "@comet/admin";
 import { CometColor, Dashboard, Settings, Sort } from "@comet/admin-icons";
 import { Card, CardContent, Typography } from "@mui/material";
-import * as React from "react";
 import { Route, Switch } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 const permanentMenuMinWidth = 1024;
 
-const AppMenu: React.FC = () => {
+const AppMenu = () => {
     const windowSize = useWindowSize();
 
     return (
@@ -55,7 +54,7 @@ const AppMenu: React.FC = () => {
     );
 };
 
-const Header: React.FC = () => (
+const Header = () => (
     <AppHeader>
         <AppHeaderMenuButton />
         <CometLogo />

--- a/storybook/src/admin/mui/MenuDynamicVariants.stories.tsx
+++ b/storybook/src/admin/mui/MenuDynamicVariants.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from "@comet/admin";
 import { CometColor, Dashboard, LinkExternal, Settings, Sort } from "@comet/admin-icons";
 import { Card, CardContent, Divider, Typography } from "@mui/material";
-import * as React from "react";
+import { useContext, useEffect } from "react";
 import { matchPath, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
@@ -23,8 +23,8 @@ import { storyRouterDecorator } from "../../story-router.decorator";
 const permanentMenuMinWidth = 1024;
 const pathsToAlwaysUseTemporaryMenu = ["/foo3", "/foo4"];
 
-const AppMenu: React.FC = () => {
-    const { open, toggleOpen } = React.useContext(MenuContext);
+const AppMenu = () => {
+    const { open, toggleOpen } = useContext(MenuContext);
     const windowSize = useWindowSize();
     const location = useLocation();
 
@@ -35,7 +35,7 @@ const AppMenu: React.FC = () => {
     }
 
     // Open menu when changing to permanent variant and close when changing to temporary variant.
-    React.useEffect(() => {
+    useEffect(() => {
         if ((useTemporaryMenu && open) || (!useTemporaryMenu && !open)) {
             toggleOpen();
         }
@@ -67,7 +67,7 @@ const AppMenu: React.FC = () => {
     );
 };
 
-const Header: React.FC = () => (
+const Header = () => (
     <AppHeader>
         <AppHeaderMenuButton />
         <CometLogo />

--- a/storybook/src/admin/react-intl/Intl.stories.tsx
+++ b/storybook/src/admin/react-intl/Intl.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { FormattedDate, FormattedTime } from "react-intl";
 
 export default {

--- a/storybook/src/admin/router/ForcePromptRoute.stories.tsx
+++ b/storybook/src/admin/router/ForcePromptRoute.stories.tsx
@@ -1,5 +1,5 @@
 import { ForcePromptRoute, RouterPrompt } from "@comet/admin";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
@@ -41,8 +41,8 @@ function Story() {
 
 function Path() {
     const location = useLocation();
-    const [, rerender] = React.useState(0);
-    React.useEffect(() => {
+    const [, rerender] = useState(0);
+    useEffect(() => {
         const timer = setTimeout(() => {
             rerender(new Date().getTime());
         }, 1000);

--- a/storybook/src/admin/router/Prompt.stories.tsx
+++ b/storybook/src/admin/router/Prompt.stories.tsx
@@ -1,5 +1,5 @@
 import { RouterPrompt } from "@comet/admin";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
@@ -32,8 +32,8 @@ function Story() {
 
 function Path() {
     const location = useLocation();
-    const [, rerender] = React.useState(0);
-    React.useEffect(() => {
+    const [, rerender] = useState(0);
+    useEffect(() => {
         const timer = setTimeout(() => {
             rerender(new Date().getTime());
         }, 1000);

--- a/storybook/src/admin/router/SubRoute.stories.tsx
+++ b/storybook/src/admin/router/SubRoute.stories.tsx
@@ -1,5 +1,5 @@
 import { SubRoute, SubRouteIndexRoute, useSubRoutePrefix } from "@comet/admin";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation, useRouteMatch } from "react-router";
 import { Link } from "react-router-dom";
 
@@ -69,8 +69,8 @@ function Story() {
 
 function Path() {
     const location = useLocation();
-    const [, rerender] = React.useState(0);
-    React.useEffect(() => {
+    const [, rerender] = useState(0);
+    useEffect(() => {
         const timer = setTimeout(() => {
             rerender(new Date().getTime());
         }, 1000);

--- a/storybook/src/admin/router/SubRouteNestedIndex.stories.tsx
+++ b/storybook/src/admin/router/SubRouteNestedIndex.stories.tsx
@@ -1,5 +1,5 @@
 import { SubRouteIndexRoute, useSubRoutePrefix } from "@comet/admin";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
@@ -37,8 +37,8 @@ function Story() {
 
 function Path() {
     const location = useLocation();
-    const [, rerender] = React.useState(0);
-    React.useEffect(() => {
+    const [, rerender] = useState(0);
+    useEffect(() => {
         const timer = setTimeout(() => {
             rerender(new Date().getTime());
         }, 1000);

--- a/storybook/src/admin/save-boundary/SaveBoundary.stories.tsx
+++ b/storybook/src/admin/save-boundary/SaveBoundary.stories.tsx
@@ -1,5 +1,5 @@
 import { Savable, SaveBoundary, SaveBoundarySaveButton } from "@comet/admin";
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 async function delay(ms: number): Promise<void> {
     return new Promise((resolve) => {
@@ -11,10 +11,10 @@ async function delay(ms: number): Promise<void> {
 
 function DemoForm() {
     console.log("Render DemoForm");
-    const [saving, setSaving] = React.useState(false);
-    const [input, setInput] = React.useState("");
+    const [saving, setSaving] = useState(false);
+    const [input, setInput] = useState("");
 
-    const doSave = React.useCallback(async () => {
+    const doSave = useCallback(async () => {
         setSaving(true);
         await delay(1000);
         setSaving(false);

--- a/storybook/src/admin/snackbar/CustomSnackbar.stories.tsx
+++ b/storybook/src/admin/snackbar/CustomSnackbar.stories.tsx
@@ -1,6 +1,5 @@
 import { SnackbarProvider, useSnackbarApi } from "@comet/admin";
 import { Button, List, ListItem, Snackbar } from "@mui/material";
-import * as React from "react";
 
 let counter = 0;
 

--- a/storybook/src/admin/snackbar/UndoSnackbar.stories.tsx
+++ b/storybook/src/admin/snackbar/UndoSnackbar.stories.tsx
@@ -1,16 +1,16 @@
 import { SnackbarProvider, UndoSnackbar, useSnackbarApi } from "@comet/admin";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
-import * as React from "react";
+import { MouseEvent, useState } from "react";
 
 const UndoSnackbarExample = () => {
-    const [chosenOption, setChosenOption] = React.useState("one");
+    const [chosenOption, setChosenOption] = useState("one");
     const snackbarApi = useSnackbarApi();
 
     const handleUndo = (prevOption: string) => {
         setChosenOption(prevOption);
     };
 
-    const handleChange = (event: React.MouseEvent<HTMLElement>, newOption: string) => {
+    const handleChange = (event: MouseEvent<HTMLElement>, newOption: string) => {
         const prevOption = chosenOption;
         setChosenOption(newOption);
 

--- a/storybook/src/admin/stack/RouterTabsNestedStack.stories.tsx
+++ b/storybook/src/admin/stack/RouterTabsNestedStack.stories.tsx
@@ -1,6 +1,5 @@
 import { RouterTab, RouterTabs, Stack, StackBreadcrumbs, StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
 import { Button } from "@mui/material";
-import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 

--- a/storybook/src/admin/stack/Stack.stories.tsx
+++ b/storybook/src/admin/stack/Stack.stories.tsx
@@ -1,6 +1,5 @@
 import { Stack, StackBreadcrumbs } from "@comet/admin";
 import { Typography } from "@mui/material";
-import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 

--- a/storybook/src/admin/stack/StackBackButton.stories.tsx
+++ b/storybook/src/admin/stack/StackBackButton.stories.tsx
@@ -1,11 +1,11 @@
 import { Stack, StackBackButton, StackBreadcrumbs, StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
-import * as React from "react";
+import { useContext } from "react";
 import { Redirect, Route, Switch } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Page1() {
-    const switchApi = React.useContext(StackSwitchApiContext);
+    const switchApi = useContext(StackSwitchApiContext);
     return (
         <button
             onClick={(e) => {

--- a/storybook/src/admin/stack/StackBreadcrumbs.stories.tsx
+++ b/storybook/src/admin/stack/StackBreadcrumbs.stories.tsx
@@ -1,5 +1,4 @@
 import { BreadcrumbItem, Stack, StackBreadcrumbs, useStackApi } from "@comet/admin";
-import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 

--- a/storybook/src/admin/stack/StackBreadcrumbsTabs.stories.tsx
+++ b/storybook/src/admin/stack/StackBreadcrumbsTabs.stories.tsx
@@ -1,5 +1,4 @@
 import { RouterTab, RouterTabs, Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch } from "@comet/admin";
-import * as React from "react";
 import { useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";

--- a/storybook/src/admin/stack/StackCustomSeparator.stories.tsx
+++ b/storybook/src/admin/stack/StackCustomSeparator.stories.tsx
@@ -1,12 +1,12 @@
 import { Stack, StackBreadcrumbs, StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
 import { CometColor } from "@comet/admin-icons";
-import * as React from "react";
+import { useContext } from "react";
 import { Redirect, Route, Switch } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Page1() {
-    const switchApi = React.useContext(StackSwitchApiContext);
+    const switchApi = useContext(StackSwitchApiContext);
     return (
         <button
             onClick={(e) => {

--- a/storybook/src/admin/stack/StackLink.stories.tsx
+++ b/storybook/src/admin/stack/StackLink.stories.tsx
@@ -1,6 +1,5 @@
 import { Stack, StackLink, StackPage, StackSwitch } from "@comet/admin";
 import { Button, Link } from "@mui/material";
-import * as React from "react";
 import { useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";

--- a/storybook/src/admin/stack/StackNested.stories.tsx
+++ b/storybook/src/admin/stack/StackNested.stories.tsx
@@ -1,11 +1,11 @@
 import { Stack, StackBreadcrumbs, StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
-import * as React from "react";
+import { useContext } from "react";
 import { Redirect, Route, Switch } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Page1() {
-    const switchApi = React.useContext(StackSwitchApiContext);
+    const switchApi = useContext(StackSwitchApiContext);
     return (
         <button
             onClick={(e) => {

--- a/storybook/src/admin/stack/StackNestedOnInitialPage.stories.tsx
+++ b/storybook/src/admin/stack/StackNestedOnInitialPage.stories.tsx
@@ -1,13 +1,13 @@
 import { Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch } from "@comet/admin";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Path() {
     const location = useLocation();
-    const [, rerender] = React.useState(0);
-    React.useEffect(() => {
+    const [, rerender] = useState(0);
+    useEffect(() => {
         const timer = setTimeout(() => {
             rerender(new Date().getTime());
         }, 1000);

--- a/storybook/src/admin/stack/StackNestedOneStack.stories.tsx
+++ b/storybook/src/admin/stack/StackNestedOneStack.stories.tsx
@@ -1,5 +1,5 @@
 import { Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch, SubRoute, useSubRoutePrefix } from "@comet/admin";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
@@ -37,8 +37,8 @@ function Story() {
 
 function Path() {
     const location = useLocation();
-    const [, rerender] = React.useState(0);
-    React.useEffect(() => {
+    const [, rerender] = useState(0);
+    useEffect(() => {
         const timer = setTimeout(() => {
             rerender(new Date().getTime());
         }, 100);

--- a/storybook/src/admin/stack/StackPageTitle.stories.tsx
+++ b/storybook/src/admin/stack/StackPageTitle.stories.tsx
@@ -1,11 +1,11 @@
 import { Stack, StackBreadcrumbs, StackPage, StackPageTitle, useStackSwitch } from "@comet/admin";
-import * as React from "react";
+import { useState } from "react";
 import { Redirect, Route, Switch } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Page2() {
-    const [counter, setCounter] = React.useState(0);
+    const [counter, setCounter] = useState(0);
     const [StackSwitch, api] = useStackSwitch();
     return (
         <div>
@@ -38,7 +38,7 @@ function Page2() {
 }
 
 function Story() {
-    const [counter, setCounter] = React.useState(0);
+    const [counter, setCounter] = useState(0);
     const [StackSwitch, api] = useStackSwitch();
     return (
         <div>

--- a/storybook/src/admin/stack/StackReactNodeTitle.stories.tsx
+++ b/storybook/src/admin/stack/StackReactNodeTitle.stories.tsx
@@ -1,6 +1,5 @@
 import { Stack, StackBreadcrumbs, StackPage, StackPageTitle, useStackSwitch } from "@comet/admin";
 import { Button, Typography } from "@mui/material";
-import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
@@ -31,5 +30,5 @@ export const StackWithReactReactNodeTitle = {
         );
     },
 
-    name: "Stack with React.ReactNode title",
+    name: "Stack with ReactNode title",
 };

--- a/storybook/src/admin/stack/StackRefApi.stories.tsx
+++ b/storybook/src/admin/stack/StackRefApi.stories.tsx
@@ -1,5 +1,4 @@
 import { Stack, StackBreadcrumbs, StackPage, useStackSwitch } from "@comet/admin";
-import * as React from "react";
 import { Redirect, Route, Switch } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";

--- a/storybook/src/admin/stack/StackTableFormQueryAtStack.stories.tsx
+++ b/storybook/src/admin/stack/StackTableFormQueryAtStack.stories.tsx
@@ -21,7 +21,7 @@ import {
 } from "@comet/admin";
 import { Edit } from "@comet/admin-icons";
 import { Grid, IconButton, Typography } from "@mui/material";
-import * as React from "react";
+import { useContext } from "react";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";
 import { storyRouterDecorator } from "../../story-router.decorator";
@@ -65,7 +65,7 @@ interface IExampleTableProps {
     filterApi: IFilterApi<IFilterValues>;
 }
 function ExampleTable(props: IExampleTableProps) {
-    const stackApi = React.useContext(StackSwitchApiContext);
+    const stackApi = useContext(StackSwitchApiContext);
 
     return (
         <>

--- a/storybook/src/admin/stack/StackTableFormQueryInTable.stories.tsx
+++ b/storybook/src/admin/stack/StackTableFormQueryInTable.stories.tsx
@@ -21,7 +21,7 @@ import {
 } from "@comet/admin";
 import { Edit } from "@comet/admin-icons";
 import { Card, CardContent, Grid, IconButton, Typography } from "@mui/material";
-import * as React from "react";
+import { useContext } from "react";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";
 import { storyRouterDecorator } from "../../story-router.decorator";
@@ -70,7 +70,7 @@ function ExampleTable(props: { persistedStateId: string }) {
         }),
     });
 
-    const stackApi = React.useContext(StackSwitchApiContext);
+    const stackApi = useContext(StackSwitchApiContext);
 
     return (
         <TableQuery api={api} loading={loading} error={error}>

--- a/storybook/src/admin/stack/StackUrl.stories.tsx
+++ b/storybook/src/admin/stack/StackUrl.stories.tsx
@@ -1,6 +1,5 @@
 import { Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch } from "@comet/admin";
 import { Link } from "@mui/material";
-import * as React from "react";
 import { useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";

--- a/storybook/src/admin/table/GlobalErrorHandling.stories.tsx
+++ b/storybook/src/admin/table/GlobalErrorHandling.stories.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import { Table, TableQuery, useTableQuery } from "@comet/admin";
-import * as React from "react";
 
 import { apolloSwapiStoryDecorator } from "../../apollo-story.decorator";
 import { errorDialogStoryProviderDecorator } from "../../docs/components/ErrorHandling/ErrorDialog/error-dialog-provider.decorator";

--- a/storybook/src/admin/table/Table.stories.tsx
+++ b/storybook/src/admin/table/Table.stories.tsx
@@ -1,5 +1,4 @@
 import { Table } from "@comet/admin";
-import * as React from "react";
 
 interface IExampleRow {
     id: number;

--- a/storybook/src/admin/table/TableBesidesForm.stories.tsx
+++ b/storybook/src/admin/table/TableBesidesForm.stories.tsx
@@ -1,7 +1,6 @@
 import { gql } from "@apollo/client";
 import { Field, FinalForm, FinalFormInput, ISelectionApi, Selected, SelectionRoute, Table, TableQuery, useTableQuery } from "@comet/admin";
 import { Grid } from "@mui/material";
-import * as React from "react";
 import { Redirect, Route, Switch } from "react-router";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";

--- a/storybook/src/admin/table/TableBesidesFormSelectionHooks.stories.tsx
+++ b/storybook/src/admin/table/TableBesidesFormSelectionHooks.stories.tsx
@@ -1,7 +1,6 @@
 import { gql } from "@apollo/client";
 import { Field, FinalForm, FinalFormInput, ISelectionApi, Selected, Table, TableQuery, useSelectionRoute, useTableQuery } from "@comet/admin";
 import { Grid } from "@mui/material";
-import * as React from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";

--- a/storybook/src/admin/table/TableDndOrder.stories.tsx
+++ b/storybook/src/admin/table/TableDndOrder.stories.tsx
@@ -1,6 +1,5 @@
 import { Stack, StackLink, StackPage, StackSwitch, TableDndOrder, TableLocalChanges } from "@comet/admin";
 import { Button } from "@mui/material";
-import * as React from "react";
 
 import { dndProviderDecorator } from "../../dnd.decorator";
 import { storyRouterDecorator } from "../../story-router.decorator";

--- a/storybook/src/admin/table/TableEditDialogHooks.stories.tsx
+++ b/storybook/src/admin/table/TableEditDialogHooks.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from "@comet/admin";
 import { Add as AddIcon, Edit as EditIcon } from "@comet/admin-icons";
 import { Button, IconButton, Typography } from "@mui/material";
-import * as React from "react";
+import { useMemo, useState } from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
@@ -29,7 +29,7 @@ export const EditDialogHooks = {
             mode: "edit" | "add";
         }
         // Defined in story to be able to call setData, hence using useMemo to avoid multiple rendering
-        const EditForm = React.useMemo(() => {
+        const EditForm = useMemo(() => {
             return (props: IEditFormProps) => (
                 <FinalForm
                     mode={props.mode}
@@ -61,7 +61,7 @@ export const EditDialogHooks = {
             foo: string;
             bar: string;
         }
-        const [data, setData] = React.useState<IExampleRow[]>([
+        const [data, setData] = useState<IExampleRow[]>([
             { id: 1, foo: "blub", bar: "blub" },
             { id: 2, foo: "blub", bar: "blub" },
         ]);

--- a/storybook/src/admin/table/TableExpandedRow.stories.tsx
+++ b/storybook/src/admin/table/TableExpandedRow.stories.tsx
@@ -2,7 +2,7 @@ import { ITableHeadRowProps, ITableRowProps, Table, TableBodyRow, TableColumns, 
 import { AddNoCircle } from "@comet/admin-icons";
 import { IconButton, TableCell } from "@mui/material";
 import TableRow from "@mui/material/TableRow";
-import * as React from "react";
+import { useState } from "react";
 
 interface IRow {
     id: number;
@@ -11,7 +11,7 @@ interface IRow {
 }
 
 function ExpandableTableRow({ rowProps, ...rest }: ITableRowProps<IRow>) {
-    const [isExpanded, setIsExpanded] = React.useState(false);
+    const [isExpanded, setIsExpanded] = useState(false);
     return (
         <>
             <TableBodyRow {...rowProps}>

--- a/storybook/src/admin/table/TableExportAllPages.stories.tsx
+++ b/storybook/src/admin/table/TableExportAllPages.stories.tsx
@@ -14,7 +14,6 @@ import {
     useTableQueryPaging,
 } from "@comet/admin";
 import { Typography } from "@mui/material";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";
 

--- a/storybook/src/admin/table/TableExportDisplayedTableData.stories.tsx
+++ b/storybook/src/admin/table/TableExportDisplayedTableData.stories.tsx
@@ -10,7 +10,6 @@ import {
     useExportDisplayedTableData,
 } from "@comet/admin";
 import { Typography } from "@mui/material";
-import * as React from "react";
 
 interface IExampleRow extends IRow {
     id: number;
@@ -22,7 +21,7 @@ interface IExampleRow extends IRow {
     };
 }
 
-const CustomHeader: React.FunctionComponent = () => {
+const CustomHeader = () => {
     return <div>Custom Header</div>;
 };
 
@@ -83,7 +82,7 @@ export const ExportDisplayedTableData = () => {
                         },
                         {
                             name: "customheader",
-                            header: <CustomHeader>Custom Header</CustomHeader>,
+                            header: <CustomHeader />,
                             headerExcel: "Overrided Excel Export Header", // HTML Nodes / React Nodes (from above header) can not be exported to excel -> use headerExcel to set an exportable column header
                             render: (row) => "Custom Row Content", // if render returns a string -> excel export can export this string
                         },

--- a/storybook/src/admin/table/TableExportVisibility.stories.tsx
+++ b/storybook/src/admin/table/TableExportVisibility.stories.tsx
@@ -11,7 +11,6 @@ import {
     VisibleType,
 } from "@comet/admin";
 import { Typography } from "@mui/material";
-import * as React from "react";
 
 interface IExampleRow extends IRow {
     id: number;

--- a/storybook/src/admin/table/TableExportWithLimit.stories.tsx
+++ b/storybook/src/admin/table/TableExportWithLimit.stories.tsx
@@ -15,7 +15,6 @@ import {
     useTableQueryPaging,
 } from "@comet/admin";
 import { Typography } from "@mui/material";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";
 

--- a/storybook/src/admin/table/TableExportWithLimitFilter.stories.tsx
+++ b/storybook/src/admin/table/TableExportWithLimitFilter.stories.tsx
@@ -20,7 +20,6 @@ import {
     VisibleType,
 } from "@comet/admin";
 import { Typography } from "@mui/material";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";
 

--- a/storybook/src/admin/table/TableFilter.stories.tsx
+++ b/storybook/src/admin/table/TableFilter.stories.tsx
@@ -13,7 +13,6 @@ import {
 } from "@comet/admin";
 import { Typography } from "@mui/material";
 import * as qs from "qs";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";
 

--- a/storybook/src/admin/table/TableFilterClientside.stories.tsx
+++ b/storybook/src/admin/table/TableFilterClientside.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FinalFormInput, MainContent, Table, TableFilterFinalForm, Toolbar, ToolbarItem, useTableQueryFilter } from "@comet/admin";
 import { Typography } from "@mui/material";
-import * as React from "react";
 
 interface IExampleRow {
     id: number;

--- a/storybook/src/admin/table/TableFilterPagingSort.stories.tsx
+++ b/storybook/src/admin/table/TableFilterPagingSort.stories.tsx
@@ -17,7 +17,6 @@ import {
 } from "@comet/admin";
 import { Typography } from "@mui/material";
 import * as qs from "qs";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";
 

--- a/storybook/src/admin/table/TableOffsetLimitPaging.stories.tsx
+++ b/storybook/src/admin/table/TableOffsetLimitPaging.stories.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import { createOffsetLimitPagingAction, MainContent, Table, TableQuery, useTableQuery, useTableQueryPaging } from "@comet/admin";
-import * as React from "react";
 
 import { LaunchesPastResult } from "../../../.storybook/mocks/handlers";
 import { apolloStoryDecorator } from "../../apollo-story.decorator";

--- a/storybook/src/admin/table/TablePaging.stories.tsx
+++ b/storybook/src/admin/table/TablePaging.stories.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import { createPagePagingActions, MainContent, Table, TableQuery, useTableQuery, useTableQueryPaging } from "@comet/admin";
-import * as React from "react";
 
 import { LaunchesPastPagePagingResult } from "../../../.storybook/mocks/handlers";
 import { apolloStoryDecorator } from "../../apollo-story.decorator";

--- a/storybook/src/admin/table/TablePagingClientside.stories.tsx
+++ b/storybook/src/admin/table/TablePagingClientside.stories.tsx
@@ -1,5 +1,4 @@
 import { IPagingInfo, Table, useTableQueryPaging } from "@comet/admin";
-import * as React from "react";
 
 interface IExampleRow {
     id: number;

--- a/storybook/src/admin/table/TableResetFilter.stories.tsx
+++ b/storybook/src/admin/table/TableResetFilter.stories.tsx
@@ -3,7 +3,6 @@ import { Field, Table, TableFilterFinalForm, TableQuery, useTableQuery, useTable
 import { FinalFormReactSelectStaticOptions } from "@comet/admin-react-select";
 import { Grid } from "@mui/material";
 import * as qs from "qs";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";
 

--- a/storybook/src/admin/table/TableResponsive.stories.tsx
+++ b/storybook/src/admin/table/TableResponsive.stories.tsx
@@ -1,6 +1,5 @@
 import { ITableRowProps, Table, TableBodyRow, TableColumns, useWindowSize } from "@comet/admin";
 import { TableCell } from "@mui/material";
-import * as React from "react";
 
 function ExampleTableRow({ columns, row, showSecondRow, rowProps }: ITableRowProps<IExampleRow> & { showSecondRow: boolean }) {
     return (

--- a/storybook/src/admin/table/TableSort.stories.tsx
+++ b/storybook/src/admin/table/TableSort.stories.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import { SortDirection, Table, TableQuery, useTableQuery, useTableQuerySort } from "@comet/admin";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../apollo-rest-story.decorator";
 

--- a/storybook/src/admin/table/TableSortClientside.stories.tsx
+++ b/storybook/src/admin/table/TableSortClientside.stories.tsx
@@ -1,5 +1,4 @@
 import { SortDirection, Table, useTableQuerySort } from "@comet/admin";
-import * as React from "react";
 
 interface IExampleRow {
     id: number;

--- a/storybook/src/admin/table/TableStackEditDialogHooks.stories.tsx
+++ b/storybook/src/admin/table/TableStackEditDialogHooks.stories.tsx
@@ -16,7 +16,6 @@ import {
 } from "@comet/admin";
 import { Add as AddIcon, Edit as EditIcon } from "@comet/admin-icons";
 import { Button, IconButton, Typography } from "@mui/material";
-import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 

--- a/storybook/src/admin/table/filterbar/AllFiltersInFilterbar.stories.tsx
+++ b/storybook/src/admin/table/filterbar/AllFiltersInFilterbar.stories.tsx
@@ -13,13 +13,12 @@ import {
 import { FinalFormReactSelectStaticOptions } from "@comet/admin-react-select";
 import { Box, Divider, FormControlLabel, Typography } from "@mui/material";
 import faker from "faker";
-import * as React from "react";
 
 interface ColorFilterFieldProps {
     colors: string[];
 }
 
-const ColorFilterField: React.FC<ColorFilterFieldProps> = ({ colors }) => {
+const ColorFilterField = ({ colors }: ColorFilterFieldProps) => {
     const options = colors
         .filter((color, index, colorsArray) => colorsArray.indexOf(color) == index) //filter colorsArray to only have unique values as select options
         .map((color) => {

--- a/storybook/src/admin/table/filterbar/CombinedFieldsFilter.stories.tsx
+++ b/storybook/src/admin/table/filterbar/CombinedFieldsFilter.stories.tsx
@@ -10,7 +10,6 @@ import {
 } from "@comet/admin";
 import { Box, Divider, FormControlLabel, Typography } from "@mui/material";
 import faker from "faker";
-import * as React from "react";
 
 interface IFilterValues {
     expressDelivery: boolean;

--- a/storybook/src/admin/table/filterbar/FilterBarButton.stories.tsx
+++ b/storybook/src/admin/table/filterbar/FilterBarButton.stories.tsx
@@ -1,7 +1,6 @@
 import { FilterBarButton } from "@comet/admin";
 import { ChevronDown } from "@comet/admin-icons";
 import { List, ListItem } from "@mui/material";
-import * as React from "react";
 
 function Story() {
     return (

--- a/storybook/src/admin/table/filterbar/RangeInputFieldFilter.stories.tsx
+++ b/storybook/src/admin/table/filterbar/RangeInputFieldFilter.stories.tsx
@@ -1,7 +1,6 @@
 import { Field, FilterBar, FilterBarPopoverFilter, FinalFormRangeInput, Table, TableFilterFinalForm, useTableQueryFilter } from "@comet/admin";
 import { Typography } from "@mui/material";
 import faker from "faker";
-import * as React from "react";
 
 interface IFilterValues {
     horsepower: {

--- a/storybook/src/admin/table/filterbar/TextFilterFieldWithoutPopover.stories.tsx
+++ b/storybook/src/admin/table/filterbar/TextFilterFieldWithoutPopover.stories.tsx
@@ -10,7 +10,6 @@ import {
 } from "@comet/admin";
 import { Box, Typography } from "@mui/material";
 import faker from "faker";
-import * as React from "react";
 
 interface IFilterValues {
     query: string;

--- a/storybook/src/admin/tabs/DynamicTabs.stories.tsx
+++ b/storybook/src/admin/tabs/DynamicTabs.stories.tsx
@@ -1,6 +1,6 @@
 import { RouterTab, RouterTabs, Tab, Tabs } from "@comet/admin";
 import { Button, Typography } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
@@ -50,7 +50,7 @@ export default {
 
 export const DynamicTabsAndRouterTabs = {
     render: () => {
-        const [showFourthTab, setShowFourthTab] = React.useState(false);
+        const [showFourthTab, setShowFourthTab] = useState(false);
 
         return (
             <>

--- a/storybook/src/admin/tabs/RouterTabsInStack.stories.tsx
+++ b/storybook/src/admin/tabs/RouterTabsInStack.stories.tsx
@@ -1,15 +1,15 @@
 import { RouterTab, RouterTabs, Stack, StackPage, StackSwitch } from "@comet/admin";
-import * as React from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 const mountCount: Record<string, number> = {};
 
 function RenderCount(props: { name: string }) {
-    React.useEffect(() => {
+    useEffect(() => {
         mountCount[props.name] = (mountCount[props.name] || 0) + 1;
     }, [props.name]);
-    const renderCount = React.useRef(0);
+    const renderCount = useRef(0);
     renderCount.current++;
     return (
         <div>
@@ -19,8 +19,8 @@ function RenderCount(props: { name: string }) {
 }
 
 function PrintMountCount() {
-    const [, rerender] = React.useState(0);
-    React.useEffect(() => {
+    const [, rerender] = useState(0);
+    useEffect(() => {
         const timer = setInterval(() => {
             rerender(new Date().getTime());
         }, 100);

--- a/storybook/src/admin/tabs/RouterTabsInSubroute.stories.tsx
+++ b/storybook/src/admin/tabs/RouterTabsInSubroute.stories.tsx
@@ -1,5 +1,5 @@
 import { RouterTab, RouterTabs, SubRoute } from "@comet/admin";
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation, useRouteMatch } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
@@ -24,8 +24,8 @@ function Story() {
 
 function Path() {
     const location = useLocation();
-    const [, rerender] = React.useState(0);
-    React.useEffect(() => {
+    const [, rerender] = useState(0);
+    useEffect(() => {
         const timer = setTimeout(() => {
             rerender(new Date().getTime());
         }, 1000);

--- a/storybook/src/admin/theming/ThemableAppHeader.stories.tsx
+++ b/storybook/src/admin/theming/ThemableAppHeader.stories.tsx
@@ -1,6 +1,5 @@
 import { AppHeader, CometLogo, MuiThemeProvider } from "@comet/admin";
 import { createCometTheme } from "@comet/admin-theme";
-import * as React from "react";
 
 export default {
     title: "@comet/admin/theming",

--- a/storybook/src/admin/toolbar/DataGridToolbar.stories.tsx
+++ b/storybook/src/admin/toolbar/DataGridToolbar.stories.tsx
@@ -2,7 +2,6 @@ import { DataGridToolbar, GridFilterButton, StackLink, ToolbarActions, ToolbarFi
 import { Add as AddIcon } from "@comet/admin-icons";
 import { Button } from "@mui/material";
 import { DataGrid, GridToolbarQuickFilter } from "@mui/x-data-grid";
-import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 

--- a/storybook/src/admin/toolbar/Toolbar.stories.tsx
+++ b/storybook/src/admin/toolbar/Toolbar.stories.tsx
@@ -13,11 +13,11 @@ import {
 import { ToolbarActionButton } from "@comet/admin/lib/common/toolbar/actions/ToolbarActionButton";
 import { ArrowRight, Save } from "@comet/admin-icons";
 import { Chip } from "@mui/material";
-import * as React from "react";
+import { ReactNode } from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
-function StackWrapper({ children }: { children: React.ReactNode }) {
+function StackWrapper({ children }: { children: ReactNode }) {
     return (
         <Stack topLevelTitle="Stack Root">
             <StackSwitch initialPage="root">

--- a/storybook/src/admin/tooltip/IconWithTooltip.stories.tsx
+++ b/storybook/src/admin/tooltip/IconWithTooltip.stories.tsx
@@ -1,6 +1,5 @@
 import { Tooltip } from "@comet/admin";
 import { Add } from "@comet/admin-icons";
-import * as React from "react";
 
 export default {
     title: "@comet/admin",

--- a/storybook/src/apollo-rest-story.decorator.tsx
+++ b/storybook/src/apollo-rest-story.decorator.tsx
@@ -1,7 +1,6 @@
 import { ApolloClient, ApolloLink, ApolloProvider, InMemoryCache } from "@apollo/client";
 import { Decorator } from "@storybook/react";
 import { RestLink } from "apollo-link-rest";
-import * as React from "react";
 
 export function apolloRestStoryDecorator(options?: { uri?: string; responseTransformer?: RestLink.ResponseTransformer }): Decorator {
     return (Story) => {

--- a/storybook/src/apollo-story.decorator.tsx
+++ b/storybook/src/apollo-story.decorator.tsx
@@ -1,7 +1,6 @@
 import { ApolloClient, ApolloLink, ApolloProvider, createHttpLink, InMemoryCache } from "@apollo/client";
 import { createErrorDialogApolloLink } from "@comet/admin";
 import { Decorator } from "@storybook/react";
-import * as React from "react";
 
 const createApolloClient = (uri: string) => {
     const link = ApolloLink.from([

--- a/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.stories.tsx
+++ b/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.stories.tsx
@@ -1,7 +1,6 @@
 import { AppHeader, AppHeaderFillSpace, AppHeaderMenuButton, CometLogo, MainContent } from "@comet/admin";
 import { ContentScopeControls, ContentScopeIndicator, ContentScopeProvider, ContentScopeValues, useContentScope } from "@comet/cms-admin";
 import { Typography } from "@mui/material";
-import React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 

--- a/storybook/src/cms-admin/ContentScopeSelect.stories.tsx
+++ b/storybook/src/cms-admin/ContentScopeSelect.stories.tsx
@@ -3,7 +3,7 @@ import { Domain, Language } from "@comet/admin-icons";
 import { ContentScopeSelect, findTextMatches, MarkedMatches } from "@comet/cms-admin";
 import { ListItemIcon, ListItemText } from "@mui/material";
 import { Meta } from "@storybook/react";
-import React, { useState } from "react";
+import { useState } from "react";
 
 export default {
     title: "@comet/cms-admin/Content Scope Select",

--- a/storybook/src/dnd.decorator.tsx
+++ b/storybook/src/dnd.decorator.tsx
@@ -1,5 +1,4 @@
 import { Decorator } from "@storybook/react";
-import * as React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 

--- a/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
+++ b/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
@@ -30,7 +30,7 @@ import {
 import { Add, Edit, Html, Select as SelectIcon } from "@comet/admin-icons";
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, Typography } from "@mui/material";
 import { DataGrid, GridSelectionModel, GridToolbarQuickFilter } from "@mui/x-data-grid";
-import React, { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 
 import { masterLayoutDecorator, stackRouteDecorator } from "../../helpers/storyDecorators";
 import { storyRouterDecorator } from "../../story-router.decorator";

--- a/storybook/src/docs/bestPractices/Overview.mdx
+++ b/storybook/src/docs/bestPractices/Overview.mdx
@@ -10,7 +10,7 @@ tba.
 
 tba.
 
--   `function Dashboard(): React.ReactElement {`
+-   `function Dashboard() {`
 -   file & component structuing:
 -   module (ddd)
 -   naming: products/ProductsForm.tsx

--- a/storybook/src/docs/components/AppHeader/AppHeader.stories.tsx
+++ b/storybook/src/docs/components/AppHeader/AppHeader.stories.tsx
@@ -1,7 +1,7 @@
 import { AppHeader, AppHeaderButton, AppHeaderDropdown, AppHeaderFillSpace, AppHeaderMenuButton, CometLogo } from "@comet/admin";
 import { Account, Language, Logout, Preview, Snips, SwitchUser, Wrench } from "@comet/admin-icons";
 import { Avatar, Box, Button, Divider, MenuItem, MenuList, Typography } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 export default {
     title: "Docs/Components/AppHeader",
@@ -177,7 +177,7 @@ export const CustomButton = {
 
 export const Dropdown = {
     render: () => {
-        const [open, setOpen] = React.useState<boolean>(false);
+        const [open, setOpen] = useState<boolean>(false);
 
         return (
             <>

--- a/storybook/src/docs/components/ClearInputAdornment/ClearInputAdornment.stories.tsx
+++ b/storybook/src/docs/components/ClearInputAdornment/ClearInputAdornment.stories.tsx
@@ -2,7 +2,7 @@ import { ClearInputAdornment, Field, FieldContainer, FinalFormInput, FinalFormSe
 import { FinalFormDatePicker } from "@comet/admin-date-time";
 import { Cut } from "@comet/admin-icons";
 import { Grid, InputBase, MenuItem } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 
 export default {
@@ -11,7 +11,7 @@ export default {
 
 export const Basic = {
     render: () => {
-        const [inputText, setInputText] = React.useState<string>("Lorem ipsum");
+        const [inputText, setInputText] = useState<string>("Lorem ipsum");
 
         return (
             <Grid container spacing={4}>

--- a/storybook/src/docs/components/ClearInputButton/ClearInputButton.stories.tsx
+++ b/storybook/src/docs/components/ClearInputButton/ClearInputButton.stories.tsx
@@ -1,7 +1,7 @@
 import { ClearInputButton } from "@comet/admin";
 import { Cut } from "@comet/admin-icons";
 import { Box, InputAdornment, InputBase, Typography } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 export default {
     title: "Docs/Components/ClearInputButton",
@@ -28,7 +28,7 @@ export const Default = {
 
 export const ClearableInputField = {
     render: () => {
-        const [inputText, setInputText] = React.useState<string>("");
+        const [inputText, setInputText] = useState<string>("");
 
         return (
             <Box display="flex" alignItems="center">

--- a/storybook/src/docs/components/ColorPicker/ColorPicker.stories.tsx
+++ b/storybook/src/docs/components/ColorPicker/ColorPicker.stories.tsx
@@ -2,7 +2,7 @@ import { Field, FieldContainer } from "@comet/admin";
 import { ColorPicker, ColorPickerColorPreviewProps, FinalFormColorPicker } from "@comet/admin-color-picker";
 import { StateFilled, StateRing, Warning } from "@comet/admin-icons";
 import { Grid } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 
 export default {
@@ -11,11 +11,11 @@ export default {
 
 export const Basic = {
     render: () => {
-        const [colorOne, setColorOne] = React.useState<string | undefined>("#00ff00");
-        const [colorTwo, setColorTwo] = React.useState<string | undefined>("rgba(255, 127, 80, 0.75)");
-        const [colorThree, setColorThree] = React.useState<string | undefined>();
-        const [colorFour, setColorFour] = React.useState<string | undefined>();
-        const [colorFive, setColorFive] = React.useState<string | undefined>();
+        const [colorOne, setColorOne] = useState<string | undefined>("#00ff00");
+        const [colorTwo, setColorTwo] = useState<string | undefined>("rgba(255, 127, 80, 0.75)");
+        const [colorThree, setColorThree] = useState<string | undefined>();
+        const [colorFour, setColorFour] = useState<string | undefined>();
+        const [colorFive, setColorFive] = useState<string | undefined>();
 
         return (
             <Grid container spacing={4} sx={{ pb: 2 }}>
@@ -128,18 +128,18 @@ export const FinalForm = {
 
 export const Customized = {
     render: () => {
-        const [colorOne, setColorOne] = React.useState<string | undefined>("#00ff00");
-        const [colorTwo, setColorTwo] = React.useState<string | undefined>();
+        const [colorOne, setColorOne] = useState<string | undefined>("#00ff00");
+        const [colorTwo, setColorTwo] = useState<string | undefined>();
 
-        const CustomColorPreview = ({ color }: ColorPickerColorPreviewProps): React.ReactElement => {
+        const CustomColorPreview = ({ color }: ColorPickerColorPreviewProps) => {
             return <StateFilled htmlColor={color} sx={{ fontSize: 24 }} />;
         };
 
-        const CustomColorEmptyPreview = (): React.ReactElement => {
+        const CustomColorEmptyPreview = () => {
             return <StateRing color="warning" sx={{ fontSize: 24 }} />;
         };
 
-        const CustomColorInvalidPreview = (): React.ReactElement => {
+        const CustomColorInvalidPreview = () => {
             return <Warning color="error" sx={{ fontSize: 24 }} />;
         };
 

--- a/storybook/src/docs/components/ContentOverflow/ContentOverflow.stories.tsx
+++ b/storybook/src/docs/components/ContentOverflow/ContentOverflow.stories.tsx
@@ -2,7 +2,6 @@ import { ContentOverflow, GridColDef } from "@comet/admin";
 import { Box, Link, Paper, Typography, TypographyProps } from "@mui/material";
 import {} from "@mui/system";
 import { DataGrid } from "@mui/x-data-grid";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/ContentOverflow",

--- a/storybook/src/docs/components/CopyToClipboardButton/CopyToClipboardButton.stories.tsx
+++ b/storybook/src/docs/components/CopyToClipboardButton/CopyToClipboardButton.stories.tsx
@@ -1,6 +1,5 @@
 import { CopyToClipboardButton } from "@comet/admin";
 import { Card, CardContent, Grid, Typography, useTheme } from "@mui/material";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/CopyToClipboardButton",

--- a/storybook/src/docs/components/DataGrid/DataGrid.mdx
+++ b/storybook/src/docs/components/DataGrid/DataGrid.mdx
@@ -121,8 +121,8 @@ This component is a button with a context menu, that can also display of the num
 
 The `ActionItem` type has the following properties:
 
--   `label: React.ReactNode`: The label of the action.
--   `icon?: React.ReactNode`: The icon of the action displayed at the start of an action.
+-   `label: ReactNode`: The label of the action.
+-   `icon?: ReactNode`: The icon of the action displayed at the start of an action.
 -   `divider?: boolean`: If true, a divider will be displayed below the action.
 
 <Canvas of={DataGridStories._CrudMoreActionsMenu} />

--- a/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
+++ b/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
@@ -23,8 +23,7 @@ import { Button, Divider, Menu, MenuItem, useTheme } from "@mui/material";
 import Box from "@mui/material/Box";
 import { DataGrid, GridSelectionModel } from "@mui/x-data-grid";
 import { DataGridPro } from "@mui/x-data-grid-pro";
-import * as React from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { apolloStoryDecorator } from "../../../apollo-story.decorator";
 import { exampleColumns, exampleRows } from "../../../helpers/ExampleDataGrid";
@@ -392,8 +391,8 @@ export const UseDataGridExcelExport = {
             },
         ];
 
-        const [showMoreMenu, setShowMoreMenu] = React.useState<boolean>(false);
-        const moreMenuRef = React.useRef<HTMLButtonElement>(null);
+        const [showMoreMenu, setShowMoreMenu] = useState<boolean>(false);
+        const moreMenuRef = useRef<HTMLButtonElement>(null);
 
         const query = gql`
             query LaunchesPast($limit: Int, $offset: Int, $sort: String, $order: String) {

--- a/storybook/src/docs/components/EditDialog/EditDialog.stories.tsx
+++ b/storybook/src/docs/components/EditDialog/EditDialog.stories.tsx
@@ -15,7 +15,7 @@ import {
     useEditDialogApi,
 } from "@comet/admin";
 import { Button, MenuItem, Typography } from "@mui/material";
-import * as React from "react";
+import { useRef, useState, VoidFunctionComponent } from "react";
 import { useLocation } from "react-router";
 import { v4 as uuid } from "uuid";
 
@@ -54,7 +54,7 @@ export const Hook = {
 
 export const Component = {
     render: () => {
-        const editDialogApi = React.useRef<IEditDialogApi>(null);
+        const editDialogApi = useRef<IEditDialogApi>(null);
 
         return (
             <>
@@ -84,7 +84,7 @@ export const Component = {
 
 export const UseEditDialogApi = {
     render: () => {
-        const ChildComponentWithOpenButton: React.VoidFunctionComponent = () => {
+        const ChildComponentWithOpenButton: VoidFunctionComponent = () => {
             const editDialogApi = useEditDialogApi();
 
             return (
@@ -168,7 +168,7 @@ export const WithTable = {
             name: string;
         }
 
-        const [users, setUsers] = React.useState<User[]>([
+        const [users, setUsers] = useState<User[]>([
             { id: "8a31ea9d-d00a-4e37-807b-a69624964ba0", name: "Isabella" },
             { id: "a5baf49a-d53c-4b3f-abd4-80d2b418589d", name: "Theo" },
             { id: "29734826-06b4-491b-ada7-cf1000d95790", name: "Maria" },
@@ -204,7 +204,7 @@ export const WithTable = {
             selectionApi: ISelectionApi;
         }
 
-        const UserForm: React.VoidFunctionComponent<UserFormProps> = ({ selectionApi, id, mode = "add" }) => {
+        const UserForm: VoidFunctionComponent<UserFormProps> = ({ selectionApi, id, mode = "add" }) => {
             const selection = { id, mode };
             const user = selection.mode === "edit" ? users.find((user) => user.id === id) : undefined;
 
@@ -357,7 +357,7 @@ export const SelectionWithComponent = {
         ];
 
         const location = useLocation();
-        const editDialogApi = React.useRef<IEditDialogApi>(null);
+        const editDialogApi = useRef<IEditDialogApi>(null);
 
         return (
             <>

--- a/storybook/src/docs/components/EditDialog/editDialog.decorator.tsx
+++ b/storybook/src/docs/components/EditDialog/editDialog.decorator.tsx
@@ -1,7 +1,6 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { RouterMemoryRouter } from "@comet/admin";
 import { Decorator } from "@storybook/react";
-import * as React from "react";
 
 export function editDialogDecorator(): Decorator {
     return (Story) => {

--- a/storybook/src/docs/components/ErrorHandling/ErrorDialog/ErrorDialog.mdx
+++ b/storybook/src/docs/components/ErrorHandling/ErrorDialog/ErrorDialog.mdx
@@ -13,7 +13,7 @@ Setup is easy, just add the `ErrorDialogHandler` somewhere in your application
 ```
 import { ErrorDialogHandler } from "@comet/admin";
 
-const App: React.FunctionComponent = ({ children }) => {
+const App: FunctionComponent = ({ children }) => {
     return (
         <OtherProvider>
             <ErrorDialogHandler />

--- a/storybook/src/docs/components/ErrorHandling/ErrorDialog/ErrorDialog.stories.tsx
+++ b/storybook/src/docs/components/ErrorHandling/ErrorDialog/ErrorDialog.stories.tsx
@@ -1,7 +1,7 @@
 import { gql, useQuery } from "@apollo/client";
 import { useErrorDialog } from "@comet/admin";
 import { Button, Typography } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 import { apolloSwapiStoryDecorator } from "../../../../apollo-story.decorator";
 import { errorDialogStoryProviderDecorator } from "./error-dialog-provider.decorator";
@@ -40,7 +40,7 @@ export const ManualErrorDialog = {
 export const AutomaticErrorOnGraphqlError = {
     render: () => {
         const Story = () => {
-            const [brokenQuery, setBrokenQuery] = React.useState(false);
+            const [brokenQuery, setBrokenQuery] = useState(false);
             const query = brokenQuery ? "{ allFilms { films { somenotavailablefield } } }" : "{ allFilms { films { title } } }";
             const { data, error } = useQuery(gql`
                 ${query}

--- a/storybook/src/docs/components/ErrorHandling/ErrorDialog/error-dialog-provider.decorator.tsx
+++ b/storybook/src/docs/components/ErrorHandling/ErrorDialog/error-dialog-provider.decorator.tsx
@@ -1,6 +1,5 @@
 import { ErrorDialogHandler } from "@comet/admin";
 import { Decorator } from "@storybook/react";
-import * as React from "react";
 
 export function errorDialogStoryProviderDecorator(): Decorator {
     return (Story) => {

--- a/storybook/src/docs/components/FileDropzone/FileDropzone.stories.tsx
+++ b/storybook/src/docs/components/FileDropzone/FileDropzone.stories.tsx
@@ -1,7 +1,6 @@
 import { FileDropzone } from "@comet/admin";
 import { Card, CardContent, Stack } from "@mui/material";
 import { Meta } from "@storybook/react";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/FileDropzone",

--- a/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
@@ -1,7 +1,6 @@
 import { FileSelect, FileSelectItem } from "@comet/admin";
 import { Card, CardContent } from "@mui/material";
 import { Meta } from "@storybook/react";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/FileSelect",

--- a/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.tsx
+++ b/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.tsx
@@ -1,7 +1,6 @@
 import { FileSelectListItem } from "@comet/admin";
 import { Box, Card, CardContent } from "@mui/material";
 import { Meta } from "@storybook/react";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/FileSelectListItem",

--- a/storybook/src/docs/components/FinalFormRangeInput/FinalFormRangeInput.stories.tsx
+++ b/storybook/src/docs/components/FinalFormRangeInput/FinalFormRangeInput.stories.tsx
@@ -1,7 +1,6 @@
 import { Field, FinalFormRangeInput } from "@comet/admin";
 import { Button } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
 import { Form } from "react-final-form";
 
 export default {

--- a/storybook/src/docs/components/GridCellContent/GridCellContent.stories.tsx
+++ b/storybook/src/docs/components/GridCellContent/GridCellContent.stories.tsx
@@ -2,7 +2,6 @@ import { GridCellContent, GridColDef } from "@comet/admin";
 import { StateFilled } from "@comet/admin-icons";
 import { faker } from "@faker-js/faker";
 import { DataGrid } from "@mui/x-data-grid";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/GridCellContent",

--- a/storybook/src/docs/components/HoverActions/HoverActions.stories.tsx
+++ b/storybook/src/docs/components/HoverActions/HoverActions.stories.tsx
@@ -1,7 +1,6 @@
 import { CopyToClipboardButton, HoverActions, Table } from "@comet/admin";
 import { Download, Maximize } from "@comet/admin-icons";
 import { IconButton } from "@mui/material";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/HoverActions",

--- a/storybook/src/docs/components/Master/Master.stories.tsx
+++ b/storybook/src/docs/components/Master/Master.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from "@comet/admin";
 import { Dashboard, Wrench } from "@comet/admin-icons";
 import { AppBar, Box, Card, CardContent, Drawer, Toolbar as MuiToolbar, Typography } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 export default {
     title: "Docs/Components/Master",
@@ -39,7 +39,7 @@ export const Master = {
         }
 
         function MasterHeader() {
-            const [showDrawer, setShowDrawer] = React.useState<boolean>(false);
+            const [showDrawer, setShowDrawer] = useState<boolean>(false);
             return (
                 <>
                     <AppHeader>

--- a/storybook/src/docs/components/PrettyBytes/PrettyBytes.stories.tsx
+++ b/storybook/src/docs/components/PrettyBytes/PrettyBytes.stories.tsx
@@ -1,5 +1,4 @@
 import { PrettyBytes } from "@comet/admin";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/PrettyBytes",

--- a/storybook/src/docs/components/RowActions/RowActions.stories.tsx
+++ b/storybook/src/docs/components/RowActions/RowActions.stories.tsx
@@ -2,7 +2,6 @@ import { RowActionsItem, RowActionsMenu } from "@comet/admin";
 import { Copy, Delete, Edit, Online, Paste, Settings } from "@comet/admin-icons";
 import { Divider, Paper } from "@mui/material";
 import { Meta } from "@storybook/react";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/RowActions",

--- a/storybook/src/docs/components/Rte/Rte.stories.tsx
+++ b/storybook/src/docs/components/Rte/Rte.stories.tsx
@@ -3,7 +3,6 @@ import { ContentState, convertFromHTML } from "draft-js";
 import { stateToHTML } from "draft-js-export-html";
 import { stateToMarkdown } from "draft-js-export-markdown";
 import { stateFromMarkdown } from "draft-js-import-markdown";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/Rich Text Editor",
@@ -19,7 +18,7 @@ export const Minimal = {
     },
 };
 
-const PrettyJson: React.FC<{ children: string }> = ({ children }) => <pre>{JSON.stringify(JSON.parse(children), null, 2)}</pre>;
+const PrettyJson = ({ children }: { children: string }) => <pre>{JSON.stringify(JSON.parse(children), null, 2)}</pre>;
 
 export const SourceDataDefault = {
     render: () => {

--- a/storybook/src/docs/components/SaveButton/SaveButton.stories.tsx
+++ b/storybook/src/docs/components/SaveButton/SaveButton.stories.tsx
@@ -1,5 +1,5 @@
 import { SaveButton } from "@comet/admin";
-import * as React from "react";
+import { useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 export default {
@@ -8,7 +8,7 @@ export default {
 
 export const Basic = {
     render: () => {
-        const [saving, setSaving] = React.useState(false);
+        const [saving, setSaving] = useState(false);
         return (
             <SaveButton
                 saving={saving}

--- a/storybook/src/docs/components/Selection/Selection.stories.tsx
+++ b/storybook/src/docs/components/Selection/Selection.stories.tsx
@@ -1,7 +1,6 @@
 import { Selection, SelectionRoute, useSelection, useSelectionRoute } from "@comet/admin";
 import { Add } from "@comet/admin-icons";
 import { List, ListItem, ListItemIcon, ListItemText, Paper } from "@mui/material";
-import * as React from "react";
 import { Redirect, Route, useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../../story-router.decorator";

--- a/storybook/src/docs/components/Snackbar/Snackbar.stories.tsx
+++ b/storybook/src/docs/components/Snackbar/Snackbar.stories.tsx
@@ -1,6 +1,6 @@
 import { UndoSnackbar, useSnackbarApi } from "@comet/admin";
 import { Button, List, ListItem, Snackbar, ToggleButton, ToggleButtonGroup } from "@mui/material";
-import * as React from "react";
+import { MouseEvent, useState } from "react";
 
 import { snackbarDecorator } from "./snackbar.decorator";
 
@@ -92,13 +92,13 @@ export const HideSnackbar = {
 
 export const Undo = {
     render: () => {
-        const [chosenOption, setChosenOption] = React.useState<string | undefined>("one");
+        const [chosenOption, setChosenOption] = useState<string | undefined>("one");
         const snackbarApi = useSnackbarApi();
 
         const handleUndo = (prevOption?: string) => {
             setChosenOption(prevOption);
         };
-        const handleChange = (event: React.MouseEvent<HTMLElement>, newOption: any) => {
+        const handleChange = (event: MouseEvent<HTMLElement>, newOption: any) => {
             const prevOption = chosenOption;
             setChosenOption(newOption);
             snackbarApi.showSnackbar(

--- a/storybook/src/docs/components/Snackbar/snackbar.decorator.tsx
+++ b/storybook/src/docs/components/Snackbar/snackbar.decorator.tsx
@@ -1,6 +1,5 @@
 import { SnackbarProvider } from "@comet/admin";
 import { Decorator } from "@storybook/react";
-import * as React from "react";
 
 export function snackbarDecorator(): Decorator {
     return (Story) => {

--- a/storybook/src/docs/components/SplitButton/SplitButton.stories.tsx
+++ b/storybook/src/docs/components/SplitButton/SplitButton.stories.tsx
@@ -1,7 +1,7 @@
 import { SplitButton } from "@comet/admin";
 import { Home } from "@comet/admin-icons";
 import { Button, Typography } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 export default {
     title: "Docs/Components/SplitButton",
@@ -32,7 +32,7 @@ export const Uncontrolled = {
 
 export const Controlled = {
     render: () => {
-        const [selectedIndex, setSelectedIndex] = React.useState(1);
+        const [selectedIndex, setSelectedIndex] = useState(1);
         return (
             <SplitButton
                 variant="contained"

--- a/storybook/src/docs/components/Stack/Stack.stories.tsx
+++ b/storybook/src/docs/components/Stack/Stack.stories.tsx
@@ -15,7 +15,6 @@ import {
 } from "@comet/admin";
 import { ArrowLeft, ArrowRight } from "@comet/admin-icons";
 import { Button, IconButton, Link } from "@mui/material";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../../apollo-rest-story.decorator";
 import { storyRouterDecorator } from "../../../story-router.decorator";

--- a/storybook/src/docs/components/Table/01_Basics.stories.tsx
+++ b/storybook/src/docs/components/Table/01_Basics.stories.tsx
@@ -1,6 +1,6 @@
 import { Table } from "@comet/admin";
 import { Button } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 interface Person {
     id: number;
@@ -149,7 +149,7 @@ export const TableColumnVisibleProp = () => {
         { id: 2, firstname: "Lewis", lastname: "Chan" },
     ];
 
-    const [idVisible, setIdVisible] = React.useState(false);
+    const [idVisible, setIdVisible] = useState(false);
 
     return (
         <>

--- a/storybook/src/docs/components/Table/02_TableQuery.stories.tsx
+++ b/storybook/src/docs/components/Table/02_TableQuery.stories.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import { SortDirection, Table, TableQuery, useTableQuery } from "@comet/admin";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../../apollo-rest-story.decorator";
 

--- a/storybook/src/docs/components/Table/03_Sorting.stories.tsx
+++ b/storybook/src/docs/components/Table/03_Sorting.stories.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import { SortDirection, Table, TableQuery, useTableQuery, useTableQuerySort } from "@comet/admin";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../../apollo-rest-story.decorator";
 

--- a/storybook/src/docs/components/Table/04_Pagination.stories.tsx
+++ b/storybook/src/docs/components/Table/04_Pagination.stories.tsx
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 import { createOffsetLimitPagingAction, Table, TableQuery, useTableQuery, useTableQueryPaging } from "@comet/admin";
-import React from "react";
 
 import { apolloRestStoryDecorator } from "../../../apollo-rest-story.decorator";
 

--- a/storybook/src/docs/components/Table/05_FilterBar.stories.tsx
+++ b/storybook/src/docs/components/Table/05_FilterBar.stories.tsx
@@ -21,13 +21,12 @@ import {
 import { FinalFormReactSelectStaticOptions } from "@comet/admin-react-select";
 import { Link, Typography } from "@mui/material";
 import faker from "faker";
-import * as React from "react";
 
 interface ColorFilterFieldProps {
     colors: string[];
 }
 
-const ColorFilterField: React.FC<ColorFilterFieldProps> = ({ colors }) => {
+const ColorFilterField = ({ colors }: ColorFilterFieldProps) => {
     const options = colors
         .filter((color, index, colorsArray) => colorsArray.indexOf(color) == index) //filter colorsArray to only have unique values as select options
         .map((color) => {

--- a/storybook/src/docs/components/Table/06_ExcelExport.stories.tsx
+++ b/storybook/src/docs/components/Table/06_ExcelExport.stories.tsx
@@ -17,7 +17,6 @@ import {
     VisibleType,
 } from "@comet/admin";
 import { Typography } from "@mui/material";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../../apollo-rest-story.decorator";
 

--- a/storybook/src/docs/components/Table/07_TableDndOrder.stories.tsx
+++ b/storybook/src/docs/components/Table/07_TableDndOrder.stories.tsx
@@ -1,6 +1,5 @@
 import { TableDndOrder, TableLocalChanges } from "@comet/admin";
 import { Button } from "@mui/material";
-import * as React from "react";
 
 import { dndProviderDecorator } from "../../../dnd.decorator";
 

--- a/storybook/src/docs/components/Table/08_SelectionTable.stories.tsx
+++ b/storybook/src/docs/components/Table/08_SelectionTable.stories.tsx
@@ -1,7 +1,6 @@
 import { gql } from "@apollo/client";
 import { Field, FinalForm, FinalFormInput, Selected, Table, TableQuery, useSelectionRoute, useTableQuery } from "@comet/admin";
 import { Grid } from "@mui/material";
-import * as React from "react";
 
 import { apolloRestStoryDecorator } from "../../../apollo-rest-story.decorator";
 import { storyRouterDecorator } from "../../../story-router.decorator";

--- a/storybook/src/docs/components/Tabs/01_Tabs.mdx
+++ b/storybook/src/docs/components/Tabs/01_Tabs.mdx
@@ -87,8 +87,8 @@ The tab content has to be defined separately.
     language="tsx"
     code={dedent`
         // based on https://v4.mui.com/components/tabs/#SimpleTabs.tsx
-        const [value, setValue] = React.useState(0);
-        const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {
+        const [value, setValue] = useState(0);
+        const handleChange = (event: ChangeEvent<{}>, newValue: number) => {
             setValue(newValue);
         };
         return (

--- a/storybook/src/docs/components/Tabs/01_Tabs.stories.tsx
+++ b/storybook/src/docs/components/Tabs/01_Tabs.stories.tsx
@@ -11,7 +11,6 @@ import {
     ToolbarFillSpace,
 } from "@comet/admin";
 import { Card, CardContent } from "@mui/material";
-import * as React from "react";
 
 import { storyRouterDecorator } from "../../../story-router.decorator";
 

--- a/storybook/src/docs/components/Tabs/02_RouterTabs.stories.tsx
+++ b/storybook/src/docs/components/Tabs/02_RouterTabs.stories.tsx
@@ -1,5 +1,4 @@
 import { RouterTab, RouterTabs, Stack, StackBreadcrumbs, StackPage, StackSwitch } from "@comet/admin";
-import * as React from "react";
 import { useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../../story-router.decorator";

--- a/storybook/src/docs/components/Tabs/stories/NestedStackSwitchWithRouterTabs.stories.tsx
+++ b/storybook/src/docs/components/Tabs/stories/NestedStackSwitchWithRouterTabs.stories.tsx
@@ -1,5 +1,4 @@
 import { RouterTab, RouterTabs, Stack, StackBreadcrumbs, StackPage, StackSwitch } from "@comet/admin";
-import * as React from "react";
 import { useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../../../story-router.decorator";

--- a/storybook/src/docs/components/Toolbar/Toolbar.stories.tsx
+++ b/storybook/src/docs/components/Toolbar/Toolbar.stories.tsx
@@ -23,7 +23,7 @@ import {
 } from "@comet/admin";
 import { ChevronLeft, CometColor, Search } from "@comet/admin-icons";
 import { Autocomplete, Button, Grid, IconButton, InputAdornment, InputBase, Typography } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
@@ -550,7 +550,7 @@ export const SearchAutocomplete = () => {
 };
 
 export const Save = () => {
-    const [saving, setSaving] = React.useState(false);
+    const [saving, setSaving] = useState(false);
     return (
         <Toolbar>
             <ToolbarTitleItem>Save Button</ToolbarTitleItem>
@@ -635,7 +635,7 @@ export const _FinalFormSaveButton = () => {
 };
 
 export const SaveSplitButton = () => {
-    const [saving, setSaving] = React.useState(false);
+    const [saving, setSaving] = useState(false);
     return (
         <Toolbar>
             <ToolbarTitleItem>Save Split Button</ToolbarTitleItem>

--- a/storybook/src/docs/components/Toolbar/toolbar.decorator.tsx
+++ b/storybook/src/docs/components/Toolbar/toolbar.decorator.tsx
@@ -1,6 +1,5 @@
 import { Stack, StackPage, StackPageTitle, StackSwitch } from "@comet/admin";
 import { Decorator } from "@storybook/react";
-import * as React from "react";
 
 export function toolbarDecorator(): Decorator {
     return (Story) => {

--- a/storybook/src/docs/components/Tooltip/Tooltip.stories.tsx
+++ b/storybook/src/docs/components/Tooltip/Tooltip.stories.tsx
@@ -1,7 +1,6 @@
 import { Tooltip } from "@comet/admin";
 import { Info } from "@comet/admin-icons";
 import { Grid, IconButton } from "@mui/material";
-import * as React from "react";
 
 export default {
     title: "Docs/Components/Tooltip",

--- a/storybook/src/docs/form/Layout.stories.tsx
+++ b/storybook/src/docs/form/Layout.stories.tsx
@@ -24,7 +24,7 @@ import {
     Typography,
 } from "@mui/material";
 import { styled, StyledEngineProvider } from "@mui/material/styles";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 
 const fooBarOptions = [
@@ -129,7 +129,7 @@ export const FieldsInSidebar = {
 
 export const FieldsInDialog = {
     render: () => {
-        const [showDialog, setShowDialog] = React.useState<boolean>(false);
+        const [showDialog, setShowDialog] = useState<boolean>(false);
 
         return (
             <>

--- a/storybook/src/docs/form/Validation.stories.tsx
+++ b/storybook/src/docs/form/Validation.stories.tsx
@@ -1,6 +1,5 @@
 import { Field, FinalForm, FinalFormInput } from "@comet/admin";
 import { FORM_ERROR } from "final-form";
-import * as React from "react";
 
 export default {
     title: "Docs/Form/Validation",

--- a/storybook/src/docs/form/components/DateAndTimePickers/01_DatePicker.stories.tsx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/01_DatePicker.stories.tsx
@@ -1,7 +1,7 @@
 import { Field, FieldContainer } from "@comet/admin";
 import { DatePicker, FinalFormDatePicker } from "@comet/admin-date-time";
 import { Grid } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 
 export default {
@@ -9,10 +9,10 @@ export default {
 };
 
 export const Basic = () => {
-    const [dateOne, setDateOne] = React.useState<string | undefined>();
-    const [dateTwo, setDateTwo] = React.useState<string | undefined>();
-    const [dateThree, setDateThree] = React.useState<string | undefined>("2024-03-10");
-    const [dateFour, setDateFour] = React.useState<string | undefined>("2024-03-10");
+    const [dateOne, setDateOne] = useState<string | undefined>();
+    const [dateTwo, setDateTwo] = useState<string | undefined>();
+    const [dateThree, setDateThree] = useState<string | undefined>("2024-03-10");
+    const [dateFour, setDateFour] = useState<string | undefined>("2024-03-10");
 
     return (
         <Grid container spacing={4}>

--- a/storybook/src/docs/form/components/DateAndTimePickers/02_TimePicker.stories.tsx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/02_TimePicker.stories.tsx
@@ -1,7 +1,7 @@
 import { Field, FieldContainer } from "@comet/admin";
 import { FinalFormTimePicker, TimePicker } from "@comet/admin-date-time";
 import { Grid } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 
 export default {
@@ -9,10 +9,10 @@ export default {
 };
 
 export const Basic = () => {
-    const [timeOne, setTimeOne] = React.useState<string | undefined>();
-    const [timeTwo, setTimeTwo] = React.useState<string | undefined>();
-    const [timeThree, setTimeThree] = React.useState<string | undefined>();
-    const [timeFour, setTimeFour] = React.useState<string | undefined>("14:30");
+    const [timeOne, setTimeOne] = useState<string | undefined>();
+    const [timeTwo, setTimeTwo] = useState<string | undefined>();
+    const [timeThree, setTimeThree] = useState<string | undefined>();
+    const [timeFour, setTimeFour] = useState<string | undefined>("14:30");
 
     return (
         <Grid container spacing={4}>

--- a/storybook/src/docs/form/components/DateAndTimePickers/03_DateTimePicker.stories.tsx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/03_DateTimePicker.stories.tsx
@@ -1,7 +1,7 @@
 import { Field, FieldContainer } from "@comet/admin";
 import { DateTimePicker, FinalFormDateTimePicker } from "@comet/admin-date-time";
 import { Grid } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 
 export default {
@@ -9,10 +9,10 @@ export default {
 };
 
 export const Basic = () => {
-    const [dateTimeOne, setDateTimeOne] = React.useState<Date | undefined>();
-    const [dateTimeTwo, setDateTimeTwo] = React.useState<Date | undefined>(new Date());
-    const [dateTimeThree, setDateTimeThree] = React.useState<Date | undefined>();
-    const [dateTimeFour, setDateFour] = React.useState<Date | undefined>(new Date());
+    const [dateTimeOne, setDateTimeOne] = useState<Date | undefined>();
+    const [dateTimeTwo, setDateTimeTwo] = useState<Date | undefined>(new Date());
+    const [dateTimeThree, setDateTimeThree] = useState<Date | undefined>();
+    const [dateTimeFour, setDateFour] = useState<Date | undefined>(new Date());
 
     return (
         <Grid container spacing={4}>

--- a/storybook/src/docs/form/components/DateAndTimePickers/04_DateRangePicker.stories.tsx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/04_DateRangePicker.stories.tsx
@@ -1,7 +1,7 @@
 import { Field, FieldContainer } from "@comet/admin";
 import { DateRange, DateRangePicker, FinalFormDateRangePicker } from "@comet/admin-date-time";
 import { Grid } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 
 export default {
@@ -9,9 +9,9 @@ export default {
 };
 
 export const Basic = () => {
-    const [dateOne, setDateOne] = React.useState<DateRange | undefined>();
-    const [dateTwo, setDateTwo] = React.useState<DateRange | undefined>({ start: "2024-03-10", end: "2024-03-16" });
-    const [dateThree, setDateThree] = React.useState<DateRange | undefined>({ start: "2024-03-10", end: "2024-03-16" });
+    const [dateOne, setDateOne] = useState<DateRange | undefined>();
+    const [dateTwo, setDateTwo] = useState<DateRange | undefined>({ start: "2024-03-10", end: "2024-03-16" });
+    const [dateThree, setDateThree] = useState<DateRange | undefined>({ start: "2024-03-10", end: "2024-03-16" });
 
     return (
         <Grid container spacing={4}>

--- a/storybook/src/docs/form/components/DateAndTimePickers/05_TimeRangePicker.stories.tsx
+++ b/storybook/src/docs/form/components/DateAndTimePickers/05_TimeRangePicker.stories.tsx
@@ -1,7 +1,7 @@
 import { Field, FieldContainer } from "@comet/admin";
 import { FinalFormTimeRangePicker, TimeRange, TimeRangePicker } from "@comet/admin-date-time";
 import { Grid } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 import { Form } from "react-final-form";
 
 export default {
@@ -9,8 +9,8 @@ export default {
 };
 
 export const Basic = () => {
-    const [timeRangeOne, setTimeRangeOne] = React.useState<TimeRange | undefined>();
-    const [timeRangeTwo, setTimeRangeTwo] = React.useState<TimeRange | undefined>({ start: "14:00", end: "16:00" });
+    const [timeRangeOne, setTimeRangeOne] = useState<TimeRange | undefined>();
+    const [timeRangeTwo, setTimeRangeTwo] = useState<TimeRange | undefined>({ start: "14:00", end: "16:00" });
 
     return (
         <Grid container spacing={8}>

--- a/storybook/src/docs/form/components/Field.stories.tsx
+++ b/storybook/src/docs/form/components/Field.stories.tsx
@@ -1,5 +1,4 @@
 import { Field, FinalForm, FinalFormInput } from "@comet/admin";
-import * as React from "react";
 
 export default {
     title: "Docs/Form/Components/Field",

--- a/storybook/src/docs/form/components/FieldContainer.stories.tsx
+++ b/storybook/src/docs/form/components/FieldContainer.stories.tsx
@@ -1,7 +1,7 @@
 import { FieldContainer } from "@comet/admin";
 import { Info } from "@comet/admin-icons";
 import { InputBase } from "@mui/material";
-import * as React from "react";
+import { ChangeEvent, useState } from "react";
 
 export default {
     title: "Docs/Form/Components/FieldContainer",
@@ -9,9 +9,9 @@ export default {
 
 export const Basic = {
     render: () => {
-        const [value, setValue] = React.useState<string>("");
+        const [value, setValue] = useState<string>("");
 
-        function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+        function handleChange(e: ChangeEvent<HTMLInputElement>) {
             setValue(e.target.value);
         }
 

--- a/storybook/src/docs/form/components/FinalForm.stories.tsx
+++ b/storybook/src/docs/form/components/FinalForm.stories.tsx
@@ -2,7 +2,7 @@ import { gql, useApolloClient } from "@apollo/client";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { Field, FinalForm, FinalFormInput, FormSection, SaveButton } from "@comet/admin";
 import { useFormApiRef } from "@comet/admin/lib/FinalForm";
-import * as React from "react";
+import { VoidFunctionComponent } from "react";
 
 export default {
     title: "Docs/Form/Components/FinalForm",
@@ -99,7 +99,7 @@ export const SubmitMutationBestPractices = () => {
     interface InnerFormProps {
         id: number;
     }
-    const InnerForm: React.VoidFunctionComponent<InnerFormProps> = ({ id }) => {
+    const InnerForm: VoidFunctionComponent<InnerFormProps> = ({ id }) => {
         const client = useApolloClient();
 
         return (

--- a/storybook/src/docs/form/components/FinalFormFields.stories.tsx
+++ b/storybook/src/docs/form/components/FinalFormFields.stories.tsx
@@ -14,7 +14,7 @@ import {
     FinalFormSwitch,
 } from "@comet/admin";
 import { Button, FormControlLabel } from "@mui/material";
-import * as React from "react";
+import { useMemo } from "react";
 
 interface Option {
     value: string;
@@ -76,7 +76,7 @@ export const _FinalFormAutocomplete = {
             { value: "vanilla", label: "Vanilla" },
         ];
 
-        const initialValues = React.useMemo(
+        const initialValues = useMemo(
             // Why useMemo()?
             // FinalForm reinitializes the form every time initalValues changes. A shallow equality check is used.
             // Therefore, without useMemo() FinalForm would reinitialize on every render.
@@ -149,7 +149,7 @@ export const _FinalFormSelect = {
             { value: "vanilla", label: "Vanilla" },
         ];
 
-        const initialValues = React.useMemo(
+        const initialValues = useMemo(
             // Why useMemo()?
             // see "FinalFormAutocomplete" story
             () => ({

--- a/storybook/src/docs/form/components/FormSection.stories.tsx
+++ b/storybook/src/docs/form/components/FormSection.stories.tsx
@@ -1,5 +1,4 @@
 import { Field, FinalForm, FinalFormInput, FormSection } from "@comet/admin";
-import * as React from "react";
 
 export default {
     title: "Docs/Form/Components/FormSection",

--- a/storybook/src/docs/form/components/NumberField.stories.tsx
+++ b/storybook/src/docs/form/components/NumberField.stories.tsx
@@ -1,5 +1,4 @@
 import { FinalForm, NumberField } from "@comet/admin";
-import * as React from "react";
 
 export default {
     title: "Docs/Form/Components/NumberField",

--- a/storybook/src/docs/helper/clipboard.stories.tsx
+++ b/storybook/src/docs/helper/clipboard.stories.tsx
@@ -1,6 +1,5 @@
 import { readClipboardText, writeClipboardText } from "@comet/admin";
 import { Button } from "@mui/material";
-import * as React from "react";
 
 export default {
     title: "Docs/Helper/Clipboard",

--- a/storybook/src/docs/hooks/useAsyncOptionsProps/useAsyncOptionsProps.stories.tsx
+++ b/storybook/src/docs/hooks/useAsyncOptionsProps/useAsyncOptionsProps.stories.tsx
@@ -1,5 +1,5 @@
 import { Field, FinalFormAutocomplete, FinalFormSelect, useAsyncOptionsProps } from "@comet/admin";
-import * as React from "react";
+import { useMemo } from "react";
 import { Form } from "react-final-form";
 
 export default {
@@ -11,7 +11,7 @@ export const Select = () => {
         value: string;
         label: string;
     }
-    const initialValues = React.useMemo(() => {
+    const initialValues = useMemo(() => {
         return { selectAsync: { value: "strawberry", label: "Strawberry" } };
     }, []);
 

--- a/storybook/src/docs/hooks/useFocusAwarePolling/useFocusAwarePolling.stories.tsx
+++ b/storybook/src/docs/hooks/useFocusAwarePolling/useFocusAwarePolling.stories.tsx
@@ -2,7 +2,7 @@ import { gql, useQuery } from "@apollo/client";
 import { useFocusAwarePolling } from "@comet/admin";
 import { Pause, Play } from "@comet/admin-icons";
 import { Button, Typography } from "@mui/material";
-import * as React from "react";
+import { useState } from "react";
 
 import { apolloStoryDecorator } from "../../../apollo-story.decorator";
 
@@ -59,7 +59,7 @@ export const BasicExample = {
 
 export const WithSkipOption = {
     render: () => {
-        const [paused, setPaused] = React.useState(false);
+        const [paused, setPaused] = useState(false);
 
         const { data, loading, error, refetch, startPolling, stopPolling } = useQuery(
             gql`

--- a/storybook/src/docs/hooks/useStoredState/useStoredState.mdx
+++ b/storybook/src/docs/hooks/useStoredState/useStoredState.mdx
@@ -6,7 +6,7 @@ import * as UseStoredStateStories from "./useStoredState.stories";
 
 # useStoredState()
 
-The `useStoredState()` hook has a similar api like the `React.useState()` hook. The main difference is, that `useStoredState()` saves and loads the state by default to local storage, so the state is persistent over tabs, and browser restarts.
+The `useStoredState()` hook has a similar api like the `useState()` hook. The main difference is, that `useStoredState()` saves and loads the state by default to local storage, so the state is persistent over tabs, and browser restarts.
 
 ### Local Storage
 

--- a/storybook/src/docs/hooks/useStoredState/useStoredState.stories.tsx
+++ b/storybook/src/docs/hooks/useStoredState/useStoredState.stories.tsx
@@ -1,6 +1,5 @@
 import { FormSection, useStoredState } from "@comet/admin";
 import { Button, InputBase } from "@mui/material";
-import * as React from "react";
 
 export default {
     title: "Docs/Hooks/useStoredState",

--- a/storybook/src/docs/icons/AllIcons.stories.tsx
+++ b/storybook/src/docs/icons/AllIcons.stories.tsx
@@ -2,7 +2,7 @@ import { ClearInputAdornment } from "@comet/admin";
 import * as icons from "@comet/admin-icons";
 import { Grid, InputAdornment, InputBase, SvgIconProps, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import * as React from "react";
+import { ComponentType, useState } from "react";
 import { useDebounce } from "use-debounce";
 
 const matchesSearchQuery = (str: string, query: string): boolean => {
@@ -40,12 +40,12 @@ const IconWrapper = styled("div")`
 
 const SearchIcon = icons.Search;
 
-const IconsGrid = ({ searchQuery }: { searchQuery: string }): React.ReactElement => {
+const IconsGrid = ({ searchQuery }: { searchQuery: string }) => {
     return (
         <Grid container spacing={4}>
             {Object.keys(icons).map((key) => {
                 if (key !== "__esModule" && key != null && matchesSearchQuery(key, searchQuery)) {
-                    const Icon = (icons as Record<string, React.ComponentType<SvgIconProps>>)[key];
+                    const Icon = (icons as Record<string, ComponentType<SvgIconProps>>)[key];
 
                     return (
                         <Grid item key={key} xs={12} sm={6} md={4} lg={3}>
@@ -68,7 +68,7 @@ export default {
 };
 
 export const AllIcons = () => {
-    const [searchQuery, setSearchQuery] = React.useState<string>("");
+    const [searchQuery, setSearchQuery] = useState<string>("");
     const [debouncedSearchQuery] = useDebounce(searchQuery.trim().toLowerCase(), 500);
 
     return (

--- a/storybook/src/docs/icons/IconsUsage.stories.tsx
+++ b/storybook/src/docs/icons/IconsUsage.stories.tsx
@@ -1,6 +1,5 @@
 import { Attachment, Cookie, Error, ThreeDotSaving } from "@comet/admin-icons";
 import { Typography } from "@mui/material";
-import * as React from "react";
 
 export default {
     title: "Docs/Icons/Usage",

--- a/storybook/src/helpers/ExampleDataGrid.tsx
+++ b/storybook/src/helpers/ExampleDataGrid.tsx
@@ -1,6 +1,5 @@
 import { GridColDef, usePersistentColumnState } from "@comet/admin";
 import { DataGrid, DataGridProps } from "@mui/x-data-grid";
-import React from "react";
 
 export const exampleRows = [
     { id: 1, lastName: "Snow", firstName: "Jon" },

--- a/storybook/src/helpers/storyDecorators.tsx
+++ b/storybook/src/helpers/storyDecorators.tsx
@@ -1,6 +1,6 @@
 import { AppHeader, AppHeaderMenuButton, MasterLayout, Menu, MenuItemRouterLink, Stack } from "@comet/admin";
 import { Dashboard } from "@comet/admin-icons";
-import React from "react";
+import { ComponentType } from "react";
 import { Route } from "react-router";
 
 export function masterLayoutDecorator() {
@@ -16,7 +16,7 @@ export function masterLayoutDecorator() {
         </Menu>
     );
 
-    return (Story: React.ComponentType) => {
+    return (Story: ComponentType) => {
         return (
             <MasterLayout menuComponent={MasterMenu} headerComponent={MasterHeader}>
                 <Story />
@@ -26,7 +26,7 @@ export function masterLayoutDecorator() {
 }
 
 export function stackRouteDecorator(topLevelTitle = "Example Page") {
-    return (Story: React.ComponentType) => {
+    return (Story: ComponentType) => {
         return (
             <Route
                 render={() => (

--- a/storybook/src/story-router.decorator.tsx
+++ b/storybook/src/story-router.decorator.tsx
@@ -2,10 +2,10 @@ import { RouterMemoryRouter } from "@comet/admin";
 import { action } from "@storybook/addon-actions";
 import { Decorator } from "@storybook/react";
 import { Action, History, UnregisterCallback } from "history";
-import * as React from "react";
+import { PropsWithChildren, ReactNode, useEffect } from "react";
 import { MemoryRouterProps, Route, RouteComponentProps } from "react-router";
 
-const StoryRouter = ({ children, routerProps }: { children: React.ReactNode; routerProps?: MemoryRouterProps }) => {
+const StoryRouter = ({ children, routerProps }: { children: ReactNode; routerProps?: MemoryRouterProps }) => {
     return (
         <RouterMemoryRouter {...routerProps}>
             <Route render={(props) => <HistoryWatcher {...props}>{children}</HistoryWatcher>} />
@@ -13,8 +13,8 @@ const StoryRouter = ({ children, routerProps }: { children: React.ReactNode; rou
     );
 };
 
-function HistoryWatcher({ history, children }: React.PropsWithChildren<RouteComponentProps>) {
-    React.useEffect(() => {
+function HistoryWatcher({ history, children }: PropsWithChildren<RouteComponentProps>) {
+    useEffect(() => {
         const onHistoryChanged: History.LocationListener = (location, historyAction: Action) => {
             const path = location.pathname;
             action(historyAction ? historyAction : (location as any).action)(path);

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -4,7 +4,7 @@
         "declaration": true,
         "skipLibCheck": true,
         "esModuleInterop": true,
-        "jsx": "react",
+        "jsx": "react-jsx",
         "lib": ["DOM", "ES2015", "ES2016", "ES2017", "ES2018", "ES2019", "ESNext.AsyncIterable"],
         "noImplicitAny": true,
         "sourceMap": true,


### PR DESCRIPTION
Use named imports instead of barrel importing React. Doing so will result in less code and better readability. The new [React docs](https://react.dev/) also use named imports and never import React itself.

To avoid conflicts, we temporarily add the eslint rules in the packages on main. The restrict-import rule will be added in the v8 (next) branch in the eslint-config package, then they will be removed there again.
