### PR TITLE
refactor: remove as casts from DamImageBlock

### DIFF
--- a/demo/site/src/common/blocks/DamImageBlock.tsx
+++ b/demo/site/src/common/blocks/DamImageBlock.tsx
@@ -9,11 +9,11 @@ type DamImageProps = Omit<NextImageProps, "src" | "width" | "height" | "alt"> & 
 
 export const DamImageBlock = withPreview(
     ({ data: { block }, aspectRatio, ...imageProps }: PropsWithData<DamImageBlockData> & DamImageProps) => {
-        if (!block) {
+        if (!block || !block.props.damFile) {
             return <PreviewSkeleton type="media" hasContent={false} />;
         }
 
-        if (block.type === "pixelImage" && "cropArea" in block.props) {
+        if (block.type === "pixelImage" && "urlTemplate" in block.props) {
             return <PixelImageBlock data={block.props} aspectRatio={aspectRatio} {...imageProps} />;
         } else if (block.type === "svgImage") {
             return <SvgImageBlock data={block.props} />;

--- a/packages/api/cms-api/src/dam/blocks/pixel-image.block.ts
+++ b/packages/api/cms-api/src/dam/blocks/pixel-image.block.ts
@@ -172,7 +172,7 @@ class Meta extends AnnotationBlockMeta {
             {
                 name: "urlTemplate",
                 kind: BlockMetaFieldKind.String,
-                nullable: false,
+                nullable: true,
             },
         );
         return ret;


### PR DESCRIPTION
## Description

Refactor the DamImageBlock site component to remove the hard casts (`as`) as they are error prone and unsafe.
Simply use typescript to discriminate the union type with a sub-field of `PixelImageBlockData`

## Example

-   [x] I have verified if my change requires an example

## Changeset

-   [x] I have verified if my change requires a changeset

## Related tasks and documents

none