### PR TITLE
Fix scrolling in `EditDialog`

### DIFF
--- a/.changeset/curly-mangos-hug.md
+++ b/.changeset/curly-mangos-hug.md
@@ -2,4 +2,4 @@
 "@comet/admin": patch
 ---
 
-Fix: Prevent scrolling of `DialogTitle` and `DialogActions` in `EditDialog`
+Prevent scrolling of `DialogTitle` and `DialogActions` in `EditDialog`

--- a/.changeset/curly-mangos-hug.md
+++ b/.changeset/curly-mangos-hug.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix: Prevent scrolling of `DialogTitle` and `DialogActions` in `EditDialog`

--- a/packages/admin/admin/src/EditDialog.tsx
+++ b/packages/admin/admin/src/EditDialog.tsx
@@ -142,16 +142,14 @@ const EditDialogInner = ({
     return (
         <SaveBoundary onAfterSave={handleAfterSave}>
             <Dialog open={isOpen} onClose={handleCloseClick} {...componentsProps?.dialog}>
-                <div>
-                    <DialogTitle {...componentsProps?.dialogTitle}>
-                        {typeof title === "string" ? title : selection.mode === "edit" ? title.edit : title.add}
-                    </DialogTitle>
-                    <DialogContent {...componentsProps?.dialogContent}>{children}</DialogContent>
-                    <DialogActions {...componentsProps?.dialogActions}>
-                        <CancelButton onClick={handleCancelClick} />
-                        <SaveBoundarySaveButton disabled={false} />
-                    </DialogActions>
-                </div>
+                <DialogTitle {...componentsProps?.dialogTitle}>
+                    {typeof title === "string" ? title : selection.mode === "edit" ? title.edit : title.add}
+                </DialogTitle>
+                <DialogContent {...componentsProps?.dialogContent}>{children}</DialogContent>
+                <DialogActions {...componentsProps?.dialogActions}>
+                    <CancelButton onClick={handleCancelClick} />
+                    <SaveBoundarySaveButton disabled={false} />
+                </DialogActions>
             </Dialog>
         </SaveBoundary>
     );


### PR DESCRIPTION
## Description

Prevent scrolling of `DialogTitle` and `DialogActions` in `EditDialog` so that the SaveButton is always visible, even if the content of the EditDialog is scrollable.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example): <!-- Unit test | Demo | Development story | No example needed --->
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

https://github.com/user-attachments/assets/ec3f161a-4b30-442e-8f5c-9ed7fb0048c5



## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1403
