### PR TITLE
Hide group title in `CrudMoreActionsMenu` when only one group is present

### DIFF
--- a/.changeset/cyan-shoes-beg.md
+++ b/.changeset/cyan-shoes-beg.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": minor
+---
+
+Update `CrudMoreActionsMenu` Design
+
+-   remove `groupTitle` if only one action group is present

--- a/.changeset/cyan-shoes-beg.md
+++ b/.changeset/cyan-shoes-beg.md
@@ -2,6 +2,4 @@
 "@comet/admin": minor
 ---
 
-Update `CrudMoreActionsMenu` Design
-
--   remove `groupTitle` if only one action group is present
+Hide group title in `CrudMoreActionsMenu` when only one group is present

--- a/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
@@ -50,18 +50,16 @@ interface CrudMoreActionsGroupProps {
 }
 
 function CrudMoreActionsGroup({ groupTitle, children, menuListProps, typographyProps }: PropsWithChildren<CrudMoreActionsGroupProps>) {
-    if (groupTitle) {
-        return (
-            <>
+    return (
+        <>
+            {groupTitle && (
                 <Typography variant="overline" color={(theme) => theme.palette.grey[500]} sx={{ padding: "20px 15px 0 15px" }} {...typographyProps}>
                     {groupTitle}
                 </Typography>
-                <MenuList {...menuListProps}>{children}</MenuList>
-            </>
-        );
-    } else {
-        return <MenuList {...menuListProps}>{children}</MenuList>;
-    }
+            )}
+            <MenuList {...menuListProps}>{children}</MenuList>
+        </>
+    );
 }
 
 const CrudMoreActionsDivider = createComponentSlot(Divider)<CrudMoreActionsMenuClassKey>({

--- a/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
@@ -46,18 +46,29 @@ export interface CrudMoreActionsMenuProps
 interface CrudMoreActionsGroupProps {
     groupTitle: ReactNode;
     menuListProps?: MenuListProps;
+    shouldShowTitle: boolean;
     typographyProps?: ComponentProps<typeof Typography>;
 }
 
-function CrudMoreActionsGroup({ groupTitle, children, menuListProps, typographyProps }: PropsWithChildren<CrudMoreActionsGroupProps>) {
-    return (
-        <>
-            <Typography variant="overline" color={(theme) => theme.palette.grey[500]} sx={{ padding: "20px 15px 0 15px" }} {...typographyProps}>
-                {groupTitle}
-            </Typography>
-            <MenuList {...menuListProps}>{children}</MenuList>
-        </>
-    );
+function CrudMoreActionsGroup({
+    groupTitle,
+    children,
+    menuListProps,
+    typographyProps,
+    shouldShowTitle,
+}: PropsWithChildren<CrudMoreActionsGroupProps>) {
+    if (shouldShowTitle) {
+        return (
+            <>
+                <Typography variant="overline" color={(theme) => theme.palette.grey[500]} sx={{ padding: "20px 15px 0 15px" }} {...typographyProps}>
+                    {groupTitle}
+                </Typography>
+                <MenuList {...menuListProps}>{children}</MenuList>
+            </>
+        );
+    } else {
+        return <MenuList {...menuListProps}>{children}</MenuList>;
+    }
 }
 
 const CrudMoreActionsDivider = createComponentSlot(Divider)<CrudMoreActionsMenuClassKey>({
@@ -137,7 +148,7 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
                 {!!overallActions?.length && (
                     <CrudMoreActionsGroup
                         groupTitle={<FormattedMessage id="comet.crudMoreActions.overallActions" defaultMessage="Overall actions" />}
-                        typographyProps={selectiveActions?.length ? undefined : { sx: { display: "none" } }}
+                        shouldShowTitle={!!selectiveActions?.length}
                         {...groupProps}
                     >
                         {overallActions.map((item, index) => {
@@ -171,7 +182,7 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
                 {!!selectiveActions?.length && (
                     <CrudMoreActionsGroup
                         groupTitle={<FormattedMessage id="comet.crudMoreActions.selectiveActions" defaultMessage="Selective actions" />}
-                        typographyProps={overallActions?.length ? undefined : { sx: { display: "none" } }}
+                        shouldShowTitle={!!overallActions?.length}
                         {...groupProps}
                     >
                         {selectiveActions.map((item, index) => {

--- a/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
@@ -44,20 +44,13 @@ export interface CrudMoreActionsMenuProps
 }
 
 interface CrudMoreActionsGroupProps {
-    groupTitle: ReactNode;
+    groupTitle?: ReactNode;
     menuListProps?: MenuListProps;
-    shouldShowTitle: boolean;
     typographyProps?: ComponentProps<typeof Typography>;
 }
 
-function CrudMoreActionsGroup({
-    groupTitle,
-    children,
-    menuListProps,
-    typographyProps,
-    shouldShowTitle,
-}: PropsWithChildren<CrudMoreActionsGroupProps>) {
-    if (shouldShowTitle) {
+function CrudMoreActionsGroup({ groupTitle, children, menuListProps, typographyProps }: PropsWithChildren<CrudMoreActionsGroupProps>) {
+    if (groupTitle) {
         return (
             <>
                 <Typography variant="overline" color={(theme) => theme.palette.grey[500]} sx={{ padding: "20px 15px 0 15px" }} {...typographyProps}>
@@ -127,6 +120,8 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
     const handleClick = (event: MouseEvent<HTMLButtonElement>) => setAnchorEl(event.currentTarget);
 
     const handleClose = () => setAnchorEl(null);
+    const hasOverallActions = !!overallActions?.length;
+    const hasSelectiveActions = !!selectiveActions?.length;
 
     return (
         <>
@@ -145,10 +140,13 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
                     menuProps?.onClose?.(event, reason);
                 }}
             >
-                {!!overallActions?.length && (
+                {hasOverallActions && (
                     <CrudMoreActionsGroup
-                        groupTitle={<FormattedMessage id="comet.crudMoreActions.overallActions" defaultMessage="Overall actions" />}
-                        shouldShowTitle={!!selectiveActions?.length}
+                        groupTitle={
+                            hasSelectiveActions ? (
+                                <FormattedMessage id="comet.crudMoreActions.overallActions" defaultMessage="Overall actions" />
+                            ) : undefined
+                        }
                         {...groupProps}
                     >
                         {overallActions.map((item, index) => {
@@ -177,12 +175,15 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
                     </CrudMoreActionsGroup>
                 )}
 
-                {!!overallActions?.length && !!selectiveActions?.length && <CrudMoreActionsDivider {...dividerProps} />}
+                {hasOverallActions && hasSelectiveActions && <CrudMoreActionsDivider {...dividerProps} />}
 
-                {!!selectiveActions?.length && (
+                {hasSelectiveActions && (
                     <CrudMoreActionsGroup
-                        groupTitle={<FormattedMessage id="comet.crudMoreActions.selectiveActions" defaultMessage="Selective actions" />}
-                        shouldShowTitle={!!overallActions?.length}
+                        groupTitle={
+                            hasOverallActions ? (
+                                <FormattedMessage id="comet.crudMoreActions.selectiveActions" defaultMessage="Selective actions" />
+                            ) : undefined
+                        }
                         {...groupProps}
                     >
                         {selectiveActions.map((item, index) => {

--- a/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
@@ -120,7 +120,7 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
     return (
         <>
             <MoreActionsButton variant="text" color="inherit" endIcon={<MoreVertical />} {...buttonProps} onClick={handleClick}>
-                <FormattedMessage id="comet.crudMoreActions.title" defaultMessage="More actions" />
+                <FormattedMessage id="comet.crudMoreActions.title" defaultMessage="More" />
                 {!!selectionSize && <MoreActionsSelectedItemsChip size="small" color="primary" {...chipProps} label={selectionSize} />}
             </MoreActionsButton>
             <Menu
@@ -137,6 +137,7 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
                 {!!overallActions?.length && (
                     <CrudMoreActionsGroup
                         groupTitle={<FormattedMessage id="comet.crudMoreActions.overallActions" defaultMessage="Overall actions" />}
+                        typographyProps={selectiveActions?.length ? undefined : { sx: { display: "none" } }}
                         {...groupProps}
                     >
                         {overallActions.map((item, index) => {
@@ -170,6 +171,7 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
                 {!!selectiveActions?.length && (
                     <CrudMoreActionsGroup
                         groupTitle={<FormattedMessage id="comet.crudMoreActions.selectiveActions" defaultMessage="Selective actions" />}
+                        typographyProps={overallActions?.length ? undefined : { sx: { display: "none" } }}
                         {...groupProps}
                     >
                         {selectiveActions.map((item, index) => {


### PR DESCRIPTION
## Description
Update CrudMoreActionsMenu Design to only include Group Titles if multiple groups exist
## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/c1fa0ac9-a7fb-47c7-b8ba-3095b59932b0)  | ![image](https://github.com/user-attachments/assets/37a3fdf1-fecf-45b3-bb37-954d79dbcf08)  |


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1174
