### PR TITLE
Center GridCellContent

### DIFF
--- a/packages/admin/admin/src/dataGrid/GridCellContent.tsx
+++ b/packages/admin/admin/src/dataGrid/GridCellContent.tsx
@@ -60,6 +60,7 @@ const Root = createComponentSlot("div")<GridCellContentClassKey, OwnerState>({
         gap: ${theme.spacing(2)};
         overflow: hidden;
         line-height: 0;
+        height: 100%;
     `,
 );
 


### PR DESCRIPTION
## Description
Fix centering `GridCellContent`

This bug appears only in `next` branch, on `main` branch GridCellContent is centered.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example): <!-- Unit test | Demo | Development story | No example needed --->
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| Link   | ![image](https://github.com/user-attachments/assets/1b81f4f7-877e-49f4-96f4-8a2b98196776)  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1440
