### PR TITLE
Stories: EditDialog behaviour

### DIFF
--- a/storybook/src/admin/edit-dialog/EditDialogInStackWithDetailsPage.stories.tsx
+++ b/storybook/src/admin/edit-dialog/EditDialogInStackWithDetailsPage.stories.tsx
@@ -1,0 +1,110 @@
+import {
+    Field,
+    FinalForm,
+    FinalFormInput,
+    messages,
+    SaveBoundary,
+    Stack,
+    StackBreadcrumbs,
+    StackLink,
+    StackMainContent,
+    StackPage,
+    StackSwitch,
+    StackToolbar,
+    ToolbarFillSpace,
+    ToolbarItem,
+    ToolbarTitleItem,
+    useEditDialog,
+} from "@comet/admin";
+import { Button, Typography } from "@mui/material";
+import { DataGrid } from "@mui/x-data-grid";
+import * as React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { editDialogDecorator } from "../../docs/components/EditDialog/editDialog.decorator";
+
+export default {
+    title: "@comet/admin/edit-dialog",
+    decorators: [editDialogDecorator()],
+};
+
+// TODO Project behaviour not reproducible
+
+export const EditDialogInStackWithDetailsPage = {
+    render: () => {
+        const [EditDialog, , editDialogApi] = useEditDialog();
+
+        const products = [
+            { id: "1", name: "Product 1" },
+            { id: "2", name: "Product 2" },
+            { id: "3", name: "Product 3" },
+            { id: "4", name: "Product 4" },
+            { id: "5", name: "Product 5" },
+        ];
+
+        return (
+            <>
+                <Stack topLevelTitle="Products">
+                    <StackBreadcrumbs />
+                    <StackSwitch initialPage="grid">
+                        <StackPage name="grid">
+                            <StackToolbar>
+                                <ToolbarTitleItem>
+                                    Click on Details to see the details of a DataGrid entry. In a project, the EditDialog gets opened instead. Here,
+                                    the behaviour is correct. Why?
+                                </ToolbarTitleItem>
+                                <ToolbarFillSpace />
+                                <ToolbarItem>
+                                    <Button onClick={() => editDialogApi.openAddDialog()} variant="contained" color="primary">
+                                        <FormattedMessage {...messages.add} />
+                                    </Button>
+                                </ToolbarItem>
+                            </StackToolbar>
+                            <StackMainContent fullHeight disablePadding>
+                                <DataGrid
+                                    columns={[
+                                        { field: "id", headerName: "ID", width: 90 },
+                                        { field: "name", headerName: "Name", flex: 1 },
+                                        {
+                                            field: "actions",
+                                            headerName: "",
+                                            renderCell: ({ row }) => (
+                                                <StackLink pageName="details" payload={row.id}>
+                                                    Details
+                                                </StackLink>
+                                            ),
+                                        },
+                                    ]}
+                                    rows={products}
+                                />
+                            </StackMainContent>
+                        </StackPage>
+                        <StackPage name="details" title="Details of product">
+                            {(productId) => (
+                                <SaveBoundary>
+                                    <StackMainContent fullHeight disablePadding>
+                                        <Typography variant="h6" py={2}>
+                                            Stack selection ID: {productId}
+                                        </Typography>
+                                    </StackMainContent>
+                                </SaveBoundary>
+                            )}
+                        </StackPage>
+                    </StackSwitch>
+                </Stack>
+
+                <EditDialog>
+                    <FinalForm
+                        mode="add"
+                        onSubmit={async ({ name }) => {
+                            window.alert(`Name: ${name}`);
+                        }}
+                    >
+                        <Field label="Name" name="name" component={FinalFormInput} fullWidth autoFocus required />
+                    </FinalForm>
+                </EditDialog>
+            </>
+        );
+    },
+    name: "EditDialog in Stack with details page",
+};

--- a/storybook/src/admin/edit-dialog/EditDialogWithCustomActions.stories.tsx
+++ b/storybook/src/admin/edit-dialog/EditDialogWithCustomActions.stories.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { editDialogDecorator } from "../../docs/components/EditDialog/editDialog.decorator";
 
 export default {
-    title: "Docs/Components/Edit Dialog with custom actions",
+    title: "@comet/admin/edit-dialog",
     decorators: [editDialogDecorator()],
 };
 
@@ -15,7 +15,7 @@ export const EditDialogWithCustomActions = {
 
         return (
             <>
-                <h2>Click on the button to see the dialog with multiple actions</h2>
+                <h2>Click on the button to see the dialog. It should show a third action.</h2>
                 <Toolbar>
                     <ToolbarFillSpace />
                     <ToolbarItem>

--- a/storybook/src/admin/edit-dialog/EditDialogWithCustomActions.stories.tsx
+++ b/storybook/src/admin/edit-dialog/EditDialogWithCustomActions.stories.tsx
@@ -1,0 +1,52 @@
+import { Field, FinalForm, FinalFormInput, OkayButton, Toolbar, ToolbarFillSpace, ToolbarItem, useEditDialog } from "@comet/admin";
+import { Button } from "@mui/material";
+import * as React from "react";
+
+import { editDialogDecorator } from "../../docs/components/EditDialog/editDialog.decorator";
+
+export default {
+    title: "Docs/Components/Edit Dialog with custom actions",
+    decorators: [editDialogDecorator()],
+};
+
+export const EditDialogWithCustomActions = {
+    render: () => {
+        const [EditDialog, , editDialogApi] = useEditDialog();
+
+        return (
+            <>
+                <h2>Click on the button to see the dialog with multiple actions</h2>
+                <Toolbar>
+                    <ToolbarFillSpace />
+                    <ToolbarItem>
+                        <Button onClick={() => editDialogApi.openAddDialog()} variant="contained" color="primary">
+                            Open dialog
+                        </Button>
+                    </ToolbarItem>
+                </Toolbar>
+                <EditDialog
+                    componentsProps={{
+                        dialogActions: {
+                            children: (
+                                // TODO: Custom Button is not shown in dialog
+                                <OkayButton variant="contained" color="primary" onClick={() => window.alert(`Alternate action selected!`)}>
+                                    Alternate action
+                                </OkayButton>
+                            ),
+                        },
+                    }}
+                >
+                    <FinalForm
+                        mode="add"
+                        onSubmit={async ({ name }) => {
+                            window.alert(`Name: ${name}`);
+                        }}
+                    >
+                        <Field label="Name" name="name" component={FinalFormInput} fullWidth autoFocus required />
+                    </FinalForm>
+                </EditDialog>
+            </>
+        );
+    },
+    name: "EditDialog with custom actions",
+};

--- a/storybook/src/admin/edit-dialog/EditDialogWithFormInStack.stories.tsx
+++ b/storybook/src/admin/edit-dialog/EditDialogWithFormInStack.stories.tsx
@@ -111,5 +111,5 @@ export const EditDialogWithFormInStack = {
         );
     },
 
-    name: "Edit Dialog with Form in Stack",
+    name: "EditDialog with Form in Stack",
 };

--- a/storybook/src/admin/edit-dialog/NestedEditDialogInStack.stories.tsx
+++ b/storybook/src/admin/edit-dialog/NestedEditDialogInStack.stories.tsx
@@ -101,4 +101,4 @@ export const NestedEditDialogInStack = function Story() {
     );
 };
 
-NestedEditDialogInStack.storyName = "Nested Edit Dialog in Stack";
+NestedEditDialogInStack.storyName = "Nested EditDialog in Stack";


### PR DESCRIPTION
## Description

This PR shows `EditDIalog`s behaviour in very specific use cases. It should help to identify and resolve these issues.

The added stories:
- When EditDialog is combined with an edit StackPage, the dialog opens above the edit page. The structure is the same as in the original project, but the behaviour cannot yet be reproduced in a story.
- Add custom action buttons to EditDialog: Dialogs often need more than just save and cancel buttons. This does not currently work


## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example): <!-- Unit test | Demo | Development story | No example needed --->
-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| Link   | Link  |

## Open TODOs/questions

-   [ ] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-XXX
