### PR TITLE
Admin Generator (Future): Add support for DateTime fields

### DIFF
--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -70,6 +70,7 @@ export const ProductForm: FormConfig<GQLProduct> = {
                 { type: "block", name: "image", label: "Image", block: { name: "DamImageBlock", import: "@comet/cms-admin" } },
                 { type: "fileUpload", name: "priceList", label: "Price List", maxFileSize: 1024 * 1024 * 4, download: true },
                 { type: "fileUpload", name: "datasheets", label: "Datasheets", multiple: true, maxFileSize: 1024 * 1024 * 4, download: false },
+                { type: "dateTime", name: "lastCheckedAt", label: "Last checked at" },
             ],
         },
     ],

--- a/demo/admin/src/products/future/generated/ProductForm.gql.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.gql.tsx
@@ -36,6 +36,7 @@ export const productFormFragment = gql`
         datasheets {
             ...FinalFormFileUpload
         }
+        lastCheckedAt
     }
     ${finalFormFileUploadFragment}
     ${finalFormFileUploadDownloadableFragment}

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -426,7 +426,6 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                 multiple
                                 maxFileSize={4194304}
                             />
-
                             <DateTimeField
                                 variant="horizontal"
                                 fullWidth

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -21,7 +21,7 @@ import {
     useFormApiRef,
     useStackSwitchApi,
 } from "@comet/admin";
-import { FinalFormDatePicker } from "@comet/admin-date-time";
+import { DateTimeField, FinalFormDatePicker } from "@comet/admin-date-time";
 import { CalendarToday as CalendarTodayIcon, Lock } from "@comet/admin-icons";
 import { BlockState, createFinalFormBlock } from "@comet/blocks-admin";
 import {
@@ -108,6 +108,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                           : undefined,
                       availableSince: data.product.availableSince ? new Date(data.product.availableSince) : undefined,
                       image: rootBlocks.image.input2State(data.product.image),
+                      lastCheckedAt: data.product.lastCheckedAt ? new Date(data.product.lastCheckedAt) : undefined,
                   }
                 : {
                       inStock: false,
@@ -424,6 +425,13 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                 variant="horizontal"
                                 multiple
                                 maxFileSize={4194304}
+                            />
+
+                            <DateTimeField
+                                variant="horizontal"
+                                fullWidth
+                                name="lastCheckedAt"
+                                label={<FormattedMessage id="product.lastCheckedAt" defaultMessage="Last checked at" />}
                             />
                         </FieldSet>
                     </>

--- a/packages/admin/cms-admin/src/generator/future/generateForm.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm.ts
@@ -281,10 +281,9 @@ export function generateForm(
         useStackSwitchApi,
     } from "@comet/admin";
     import { ArrowLeft, Lock } from "@comet/admin-icons";
-    import { FinalFormDatePicker } from "@comet/admin-date-time";
+    import { DateTimeField, FinalFormDatePicker } from "@comet/admin-date-time";
     import { BlockState, createFinalFormBlock } from "@comet/blocks-admin";
     import { queryUpdatedAt, resolveHasSaveConflict, useFormSaveConflict, FileUploadField } from "@comet/cms-admin";
-    import { queryUpdatedAt, resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
     import { FormControlLabel, IconButton, MenuItem, InputAdornment } from "@mui/material";
     import { FormApi } from "final-form";
     import isEqual from "lodash.isequal";

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -313,8 +313,7 @@ export function generateFormField({
             },
         ];
     } else if (config.type == "dateTime") {
-        code = `
-            <DateTimeField
+        code = `<DateTimeField
                 ${required ? "required" : ""}
                 ${config.readOnly ? readOnlyPropsWithLock : ""}
                 variant="horizontal"

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -312,6 +312,34 @@ export function generateFormField({
                 },
             },
         ];
+    } else if (config.type == "dateTime") {
+        code = `
+            <DateTimeField
+                ${required ? "required" : ""}
+                ${config.readOnly ? readOnlyPropsWithLock : ""}
+                variant="horizontal"
+                fullWidth
+                name="${nameWithPrefix}"
+                label={${fieldLabel}}
+                ${config.startAdornment ? `startAdornment={<InputAdornment position="start">${startAdornment.adornmentString}</InputAdornment>}` : ""}
+                ${config.endAdornment ? `endAdornment={<InputAdornment position="end">${endAdornment.adornmentString}</InputAdornment>}` : ""}
+                ${
+                    config.helperText
+                        ? `helperText={<FormattedMessage id=` +
+                          `"${formattedMessageRootId}.${name}.helperText" ` +
+                          `defaultMessage="${config.helperText}" />}`
+                        : ""
+                }
+                ${validateCode}
+            />`;
+        formValuesConfig = [
+            {
+                ...defaultFormValuesConfig,
+                ...{
+                    initializationCode: `${name}: data.${dataRootName}.${nameWithPrefix} ? new Date(data.${dataRootName}.${nameWithPrefix}) : undefined`,
+                },
+            },
+        ];
     } else if (config.type == "block") {
         code = `<Field name="${nameWithPrefix}" isEqual={isEqual} label={${fieldLabel}} variant="horizontal" fullWidth>
             {createFinalFormBlock(rootBlocks.${String(config.name)})}

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -50,7 +50,7 @@ export type FormFieldConfig<T> = (
       }
     | { type: "boolean" }
     | { type: "date" }
-    // TODO | { type: "dateTime"; }
+    | { type: "dateTime" } // TODO add InputBaseFieldConfig once merged (!2645)
     | {
           type: "staticSelect";
           values?: Array<{ value: string; label: string } | string>;


### PR DESCRIPTION
## Description

Support for DateTime fields in forms is added. An example use case: Adding start date and time for an event.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example): <!-- Unit test | Demo | Development story | No example needed --->
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

https://github.com/user-attachments/assets/afde0671-0fa4-4b76-9625-2dede1d47058


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1162
-   Related PR: #2639 
