### PR TITLE
Admin Generator (Future): Add `initialFilter` prop for grids

### DIFF
--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -16,6 +16,9 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
         { field: "inStock", sort: "desc" },
         { field: "price", sort: "asc" },
     ],
+    initialFilter: {
+        items: [{ columnField: "type", operatorValue: "is", value: "Shirt" }],
+    },
     columns: [
         {
             type: "combination",

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -132,6 +132,9 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
                 { field: "inStock", sort: "desc" },
                 { field: "price", sort: "asc" },
             ],
+            initialFilter: {
+                items: [{ columnField: "type", operatorValue: "is", value: "Shirt" }],
+            },
             queryParamsPrefix: "products",
         }),
         ...usePersistentColumnState("ProductsGrid"),

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -511,7 +511,9 @@ export function generateGrid(
               ${
                   config.initialFilter
                       ? `initialFilter:{ ${
-                            config.initialFilter.linkOperator ? `linkOperator: "${config.initialFilter.linkOperator}" as GridLinkOperator,` : ""
+                            config.initialFilter.linkOperator
+                                ? `linkOperator: GridLinkOperator.${config.initialFilter.linkOperator === "or" ? "Or" : "And"},`
+                                : ""
                         }
                       items: [${config.initialFilter.items
                           .map((item) => {

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -498,7 +498,7 @@ export function generateGrid(
     const { gridPropsTypeCode, gridPropsParamsCode } = generateGridPropsCode(props);
     const gridToolbarComponentName = `${gqlTypePlural}GridToolbar`;
     const dataGridRemoteParameters =
-        config.initialSort || config.queryParamsPrefix
+        config.initialSort || config.queryParamsPrefix || config.initialFilter
             ? `{${
                   config.initialSort
                       ? ` initialSort: [${config.initialSort
@@ -506,6 +506,18 @@ export function generateGrid(
                                 return `{field: "${item.field}", sort: "${item.sort}"}`;
                             })
                             .join(",\n")} ], `
+                      : ""
+              }
+              ${
+                  config.initialFilter
+                      ? `initialFilter:{ ${
+                            config.initialFilter.linkOperator ? `linkOperator: "${config.initialFilter.linkOperator}" as GridLinkOperator,` : ""
+                        }
+                      items: [${config.initialFilter.items
+                          .map((item) => {
+                              return `{columnField: "${item.columnField}", operatorValue: "${item.operatorValue}", value: "${item.value}" }`;
+                          })
+                          .join(",\n")} ],},`
                       : ""
               }
               ${config.queryParamsPrefix ? `queryParamsPrefix: "${config.queryParamsPrefix}",` : ""}
@@ -541,7 +553,7 @@ export function generateGrid(
     import { Add as AddIcon, Edit, Info, MoreVertical, Excel } from "@comet/admin-icons";
     import { BlockPreviewContent } from "@comet/blocks-admin";
     import { Alert, Button, Box, IconButton, Typography, useTheme, Menu, MenuItem, ListItemIcon, ListItemText, CircularProgress } from "@mui/material";
-    import { DataGridPro, GridRenderCellParams, GridColumnHeaderTitle, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
+    import { DataGridPro, GridLinkOperator, GridRenderCellParams, GridColumnHeaderTitle, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
     import { useContentScope } from "@src/common/ContentScopeProvider";
     import {
         GQL${gqlTypePlural}GridQuery,

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -3,7 +3,7 @@ import { IconName } from "@comet/admin-icons";
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 import { loadSchema } from "@graphql-tools/load";
 import { IconProps } from "@mui/material";
-import { GridSortDirection } from "@mui/x-data-grid";
+import { GridFilterModel, GridSortDirection } from "@mui/x-data-grid";
 import { promises as fs } from "fs";
 import { glob } from "glob";
 import { introspectionFromSchema } from "graphql";
@@ -153,6 +153,7 @@ export type GridConfig<T extends { __typename?: string }> = {
     copyPaste?: boolean;
     readOnly?: boolean;
     initialSort?: Array<{ field: string; sort: GridSortDirection }>;
+    initialFilter?: Omit<GridFilterModel, "linkOperator"> & { linkOperator?: "and" | "or" };
     filterProp?: boolean;
     toolbar?: boolean;
     toolbarActionProp?: boolean;

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -3,7 +3,7 @@ import { IconName } from "@comet/admin-icons";
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 import { loadSchema } from "@graphql-tools/load";
 import { IconProps } from "@mui/material";
-import { GridFilterModel, GridSortDirection } from "@mui/x-data-grid";
+import { GridFilterItem, GridSortDirection } from "@mui/x-data-grid";
 import { promises as fs } from "fs";
 import { glob } from "glob";
 import { introspectionFromSchema } from "graphql";
@@ -139,6 +139,11 @@ export type GridColumnConfig<T> = (
 
 export type ActionsGridColumnConfig = { type: "actions"; component?: ImportReference } & BaseColumnConfig;
 
+type InitialFilterConfig = {
+    items: GridFilterItem[];
+    linkOperator?: "and" | "or";
+};
+
 export type GridConfig<T extends { __typename?: string }> = {
     type: "grid";
     gqlType: T["__typename"];
@@ -153,7 +158,7 @@ export type GridConfig<T extends { __typename?: string }> = {
     copyPaste?: boolean;
     readOnly?: boolean;
     initialSort?: Array<{ field: string; sort: GridSortDirection }>;
-    initialFilter?: Omit<GridFilterModel, "linkOperator"> & { linkOperator?: "and" | "or" };
+    initialFilter?: InitialFilterConfig;
     filterProp?: boolean;
     toolbar?: boolean;
     toolbarActionProp?: boolean;


### PR DESCRIPTION
## Description

`initialFilter` can be used to preset a filter for a grid. This parallels the functionality of `initialSort`.

The `linkOperator` is optional and defaults to "Or".

Be sure to use MUI grid operator values to ensure correct display in `FilterPanel`.

TODO:
-   [x] Show value of `initialFilter` in `FilterPanel` -> GQL filter operator was used instead of MUI filter operator

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example): <!-- Unit test | Demo | Development story | No example needed --->
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Example

```tsx
export const ProductsGrid: GridConfig<GQLProduct> = {
    {...},
    initialFilter: {
        items: [
            { columnField: "type", operatorValue: "is", value: "Shirt" },
            { columnField: "price", operatorValue: ">=", value: "10" }
        ],
        linkOperator: "and",
    },
    {...},
```

## Screenshots/screencasts

Updated screencast:

https://github.com/user-attachments/assets/1fdd755d-595c-4751-926b-03b9d9757101

The following screencast includes behaviour when using the wrong type of filter operator:

https://github.com/user-attachments/assets/37f7645a-4ecf-46ce-8465-d368de87fbce

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/SVK-505
