### PR TITLE
Fix a Bug resulting in duplicate ContentScopes

### DIFF
--- a/.changeset/breezy-mirrors-rule.md
+++ b/.changeset/breezy-mirrors-rule.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix a Bug that results in duplicate ContentScopes

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -146,7 +146,11 @@ export class UserPermissionsService {
             }
         }
 
-        return contentScopes.map((cs) => sortContentScopeKeysAlphabetically(cs));
+        return contentScopes
+            .map((cs) => JSON.stringify(cs))
+            .filter((value, index, self) => self.indexOf(value) === index)
+            .map((cs) => JSON.parse(cs))
+            .map((cs) => sortContentScopeKeysAlphabetically(cs));
     }
 
     normalizeContentScopes(contentScopes: ContentScope[], availableContentScopes: ContentScope[]): ContentScope[] {


### PR DESCRIPTION
## Description
The getContentScopes method returns duplicate Scopes
- duplicate Scopes are now filtered before returning
## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example): <!-- Unit test | Demo | Development story | No example needed --->
-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1449
