### PR TITLE
Fix `notEqual` operation for enum filter

### DIFF
--- a/.changeset/blue-trains-roll.md
+++ b/.changeset/blue-trains-roll.md
@@ -1,5 +1,5 @@
 ---
-"@comet/cms-api": minor
+"@comet/cms-api": patch
 ---
 
-Fix `notEqual` in EnumFilters
+Fix `notEqual` operation for enum filter

--- a/.changeset/blue-trains-roll.md
+++ b/.changeset/blue-trains-roll.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Fix `notEqual` in EnumFilters

--- a/packages/api/cms-api/src/common/filter/mikro-orm.ts
+++ b/packages/api/cms-api/src/common/filter/mikro-orm.ts
@@ -154,7 +154,7 @@ export function filterToMikroOrmQuery(
         if (filterProperty.equal !== undefined) {
             ret.$eq = filterProperty.equal;
         }
-        if (filterProperty.equal !== undefined) {
+        if (filterProperty.notEqual !== undefined) {
             ret.$ne = filterProperty.notEqual;
         }
         if (filterProperty.isAnyOf !== undefined) {


### PR DESCRIPTION
## Description

`notEqual` in EnumFilters was not working due to a wrong condition in `filterToMikroOrmQuery` function

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example): <!-- Unit test | Demo | Development story | No example needed --->
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Before:

https://github.com/user-attachments/assets/ab4804fb-658a-47b8-9658-1c1b6658b0ea

After:


https://github.com/user-attachments/assets/49d28cea-17be-4863-b85c-117904bdb40d



## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1464
