### PR TITLE
Admin Generator (Future): Make the text of the add-entry button configurable

### DIFF
--- a/demo/admin/src/news/generated/NewsGrid.tsx
+++ b/demo/admin/src/news/generated/NewsGrid.tsx
@@ -88,7 +88,7 @@ function NewsGridToolbar() {
             <ToolbarFillSpace />
             <ToolbarActions>
                 <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-                    <FormattedMessage id="news.newNews" defaultMessage="New News" />
+                    <FormattedMessage id="news.newNewsGridEntry" defaultMessage="New News" />
                 </Button>
             </ToolbarActions>
         </DataGridToolbar>

--- a/demo/admin/src/news/generated/NewsGrid.tsx
+++ b/demo/admin/src/news/generated/NewsGrid.tsx
@@ -88,7 +88,7 @@ function NewsGridToolbar() {
             <ToolbarFillSpace />
             <ToolbarActions>
                 <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-                    <FormattedMessage id="news.newNewsGridEntry" defaultMessage="New News" />
+                    <FormattedMessage id="news.newsGrid.newEntry" defaultMessage="New News" />
                 </Button>
             </ToolbarActions>
         </DataGridToolbar>

--- a/demo/admin/src/products/future/ManufacturersGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ManufacturersGrid.cometGen.ts
@@ -6,6 +6,7 @@ export const ManufacturersGrid: GridConfig<GQLManufacturer> = {
     gqlType: "Manufacturer",
     fragmentName: "ManufacturersGridFuture", // configurable as it must be unique across project
     queryParamsPrefix: "manufacturers",
+    newEntryText: "Add Manufacturer",
     columns: [
         { type: "text", name: "id", headerName: "ID" },
         { type: "text", name: "name", headerName: "Name" },

--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -95,7 +95,7 @@ function ManufacturersGridToolbar() {
             <ToolbarFillSpace />
             <ToolbarActions>
                 <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-                    <FormattedMessage id="manufacturer.newManufacturer" defaultMessage="New Manufacturer" />
+                    <FormattedMessage id="manufacturer.newEntry" defaultMessage="Add Manufacturer" />
                 </Button>
             </ToolbarActions>
         </DataGridToolbar>

--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -95,7 +95,7 @@ function ManufacturersGridToolbar() {
             <ToolbarFillSpace />
             <ToolbarActions>
                 <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-                    <FormattedMessage id="manufacturer.newManufacturersGridFutureEntry" defaultMessage="Add Manufacturer" />
+                    <FormattedMessage id="manufacturer.manufacturersGridFuture.newEntry" defaultMessage="Add Manufacturer" />
                 </Button>
             </ToolbarActions>
         </DataGridToolbar>

--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -95,7 +95,7 @@ function ManufacturersGridToolbar() {
             <ToolbarFillSpace />
             <ToolbarActions>
                 <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-                    <FormattedMessage id="manufacturer.newEntry" defaultMessage="Add Manufacturer" />
+                    <FormattedMessage id="manufacturer.newManufacturersGridFutureEntry" defaultMessage="Add Manufacturer" />
                 </Button>
             </ToolbarActions>
         </DataGridToolbar>

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -88,7 +88,7 @@ function ProductVariantsGridToolbar() {
             <ToolbarFillSpace />
             <ToolbarActions>
                 <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-                    <FormattedMessage id="productVariant.newProductVariant" defaultMessage="New Product Variant" />
+                    <FormattedMessage id="productVariant.newProductVariantsGridFutureEntry" defaultMessage="New Product Variant" />
                 </Button>
             </ToolbarActions>
         </DataGridToolbar>

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -88,7 +88,7 @@ function ProductVariantsGridToolbar() {
             <ToolbarFillSpace />
             <ToolbarActions>
                 <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-                    <FormattedMessage id="productVariant.newProductVariantsGridFutureEntry" defaultMessage="New Product Variant" />
+                    <FormattedMessage id="productVariant.productVariantsGridFuture.newEntry" defaultMessage="New Product Variant" />
                 </Button>
             </ToolbarActions>
         </DataGridToolbar>

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -641,6 +641,7 @@ export function generateGrid(
                   gqlType,
                   excelExport: config.excelExport,
                   newEntryText: config.newEntryText,
+                  fragmentName,
               })
             : ""
     }

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -640,6 +640,7 @@ export function generateGrid(
                   instanceGqlType,
                   gqlType,
                   excelExport: config.excelExport,
+                  newEntryText: config.newEntryText,
               })
             : ""
     }

--- a/packages/admin/cms-admin/src/generator/future/generateGrid/generateGridToolbar.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid/generateGridToolbar.ts
@@ -1,7 +1,7 @@
+import { camelCase } from "change-case";
+
 import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
 import { getFormattedMessageNode } from "../utils/intl";
-
-const lowerCaseFirst = (string: string) => string.charAt(0).toLowerCase() + string.substring(1);
 
 type Options = {
     componentName: string;
@@ -113,7 +113,7 @@ const renderToolbarActions = (
     return `<ToolbarActions>
         <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
             ${getFormattedMessageNode(
-                `${instanceGqlType}.${lowerCaseFirst(fragmentName)}.newEntry`,
+                `${instanceGqlType}.${camelCase(fragmentName)}.newEntry`,
                 newEntryText ?? `New ${camelCaseToHumanReadable(gqlType)}`,
             )}
         </Button>

--- a/packages/admin/cms-admin/src/generator/future/generateGrid/generateGridToolbar.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid/generateGridToolbar.ts
@@ -10,6 +10,7 @@ type Options = {
     allowAdding: boolean;
     instanceGqlType: string;
     gqlType: string;
+    newEntryText: string | undefined;
 };
 
 export const generateGridToolbar = ({
@@ -21,6 +22,7 @@ export const generateGridToolbar = ({
     allowAdding,
     instanceGqlType,
     gqlType,
+    newEntryText,
 }: Options) => {
     const showMoreActionsMenu = excelExport;
 
@@ -31,14 +33,7 @@ export const generateGridToolbar = ({
                 ${hasFilter ? filterItem : ""}
                 <ToolbarFillSpace />
                 ${showMoreActionsMenu ? renderMoreActionsMenu(excelExport) : ""}
-              ${
-                  allowAdding
-                      ? renderToolbarActions(
-                            forwardToolbarAction,
-                            getFormattedMessageNode(`${instanceGqlType}.new${gqlType}`, `New ${camelCaseToHumanReadable(gqlType)}`),
-                        )
-                      : ""
-              }
+              ${allowAdding ? renderToolbarActions(forwardToolbarAction, instanceGqlType, gqlType, newEntryText) : ""}
             </DataGridToolbar>
         );
     }`.replace(/^\s+\n/gm, "");
@@ -100,9 +95,21 @@ const renderMoreActionsMenu = (excelExport: boolean | undefined) => {
     />`;
 };
 
-const renderToolbarActions = (forwardToolbarAction: boolean | undefined, addItemText: string) => {
+const renderToolbarActions = (
+    forwardToolbarAction: boolean | undefined,
+    instanceGqlType: string,
+    gqlType: string,
+    newEntryText: string | undefined,
+) => {
     if (forwardToolbarAction) {
         return `{toolbarAction && <ToolbarActions>{toolbarAction}</ToolbarActions>}`;
+    }
+
+    let addItemText = getFormattedMessageNode(`${instanceGqlType}.new${gqlType}`, `New ${camelCaseToHumanReadable(gqlType)}`);
+
+    if (newEntryText) {
+        // This requires a different message-id to prevent other grids with this type but no custom text from having the same id
+        addItemText = getFormattedMessageNode(`${instanceGqlType}.newEntry`, newEntryText);
     }
 
     return `<ToolbarActions>

--- a/packages/admin/cms-admin/src/generator/future/generateGrid/generateGridToolbar.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid/generateGridToolbar.ts
@@ -11,6 +11,7 @@ type Options = {
     instanceGqlType: string;
     gqlType: string;
     newEntryText: string | undefined;
+    fragmentName: string;
 };
 
 export const generateGridToolbar = ({
@@ -23,6 +24,7 @@ export const generateGridToolbar = ({
     instanceGqlType,
     gqlType,
     newEntryText,
+    fragmentName,
 }: Options) => {
     const showMoreActionsMenu = excelExport;
 
@@ -33,7 +35,7 @@ export const generateGridToolbar = ({
                 ${hasFilter ? filterItem : ""}
                 <ToolbarFillSpace />
                 ${showMoreActionsMenu ? renderMoreActionsMenu(excelExport) : ""}
-              ${allowAdding ? renderToolbarActions(forwardToolbarAction, instanceGqlType, gqlType, newEntryText) : ""}
+              ${allowAdding ? renderToolbarActions(forwardToolbarAction, instanceGqlType, gqlType, newEntryText, fragmentName) : ""}
             </DataGridToolbar>
         );
     }`.replace(/^\s+\n/gm, "");
@@ -100,21 +102,15 @@ const renderToolbarActions = (
     instanceGqlType: string,
     gqlType: string,
     newEntryText: string | undefined,
+    fragmentName: string,
 ) => {
     if (forwardToolbarAction) {
         return `{toolbarAction && <ToolbarActions>{toolbarAction}</ToolbarActions>}`;
     }
 
-    let addItemText = getFormattedMessageNode(`${instanceGqlType}.new${gqlType}`, `New ${camelCaseToHumanReadable(gqlType)}`);
-
-    if (newEntryText) {
-        // This requires a different message-id to prevent other grids with this type but no custom text from having the same id
-        addItemText = getFormattedMessageNode(`${instanceGqlType}.newEntry`, newEntryText);
-    }
-
     return `<ToolbarActions>
         <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-            ${addItemText}
+            ${getFormattedMessageNode(`${instanceGqlType}.new${fragmentName}Entry`, newEntryText ?? `New ${camelCaseToHumanReadable(gqlType)}`)}
         </Button>
     </ToolbarActions>`;
 };

--- a/packages/admin/cms-admin/src/generator/future/generateGrid/generateGridToolbar.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid/generateGridToolbar.ts
@@ -1,6 +1,8 @@
 import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
 import { getFormattedMessageNode } from "../utils/intl";
 
+const lowerCaseFirst = (string: string) => string.charAt(0).toLowerCase() + string.substring(1);
+
 type Options = {
     componentName: string;
     forwardToolbarAction: boolean | undefined;
@@ -110,7 +112,10 @@ const renderToolbarActions = (
 
     return `<ToolbarActions>
         <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-            ${getFormattedMessageNode(`${instanceGqlType}.new${fragmentName}Entry`, newEntryText ?? `New ${camelCaseToHumanReadable(gqlType)}`)}
+            ${getFormattedMessageNode(
+                `${instanceGqlType}.${lowerCaseFirst(fragmentName)}.newEntry`,
+                newEntryText ?? `New ${camelCaseToHumanReadable(gqlType)}`,
+            )}
         </Button>
     </ToolbarActions>`;
 };

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -156,6 +156,7 @@ export type GridConfig<T extends { __typename?: string }> = {
     filterProp?: boolean;
     toolbar?: boolean;
     toolbarActionProp?: boolean;
+    newEntryText?: string;
     rowActionProp?: boolean;
 };
 


### PR DESCRIPTION
## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] **How can we make sure formatted-message IDs are unique?**
Here we set one id for the default/fallback text, and a different one for the custom text. 
This will not work if multiple grids of the same entity have different values for the custom text. 
Should we convert the custom text to `pascalCase` and use that in the ID?

## Further information

https://vivid-planet.atlassian.net/browse/SVK-414
