### PR TITLE
Fix potential CSRF error in createGraphQLFetch

### DIFF
--- a/packages/site/cms-site/src/graphQLFetch/graphQLFetch.ts
+++ b/packages/site/cms-site/src/graphQLFetch/graphQLFetch.ts
@@ -83,7 +83,20 @@ export function createGraphQLFetch(fetch: Fetch, url: string): GraphQLFetch {
             const fetchUrl = new URL(url);
             fetchUrl.searchParams.append("query", query);
             fetchUrl.searchParams.append("variables", JSON.stringify(variables));
-            response = await fetch(fetchUrl, { ...init, headers: { "content-type": "application/json", ...init.headers } });
+            response = await fetch(fetchUrl, {
+                ...init,
+                headers: {
+                    /**
+                     * It's recommended to add the `Apollo-Require-Preflight` header to GET requests, running on an Apollo Server 4.
+                     *
+                     * If this header is missing, Apollo Server 4 will return: This operation has been blocked as a potential Cross-Site Request Forgery (CSRF).
+                     *
+                     * see: https://www.apollographql.com/docs/graphos/routing/security/csrf#enable-csrf-prevention
+                     */
+                    "Apollo-Require-Preflight": "true",
+                    ...init.headers,
+                },
+            });
         } else {
             response = await fetch(url, {
                 method: "POST",

--- a/packages/site/cms-site/src/graphQLFetch/graphQLFetch.ts
+++ b/packages/site/cms-site/src/graphQLFetch/graphQLFetch.ts
@@ -83,7 +83,7 @@ export function createGraphQLFetch(fetch: Fetch, url: string): GraphQLFetch {
             const fetchUrl = new URL(url);
             fetchUrl.searchParams.append("query", query);
             fetchUrl.searchParams.append("variables", JSON.stringify(variables));
-            response = await fetch(fetchUrl, init);
+            response = await fetch(fetchUrl, { ...init, headers: { "content-type": "application/json", ...init.headers } });
         } else {
             response = await fetch(url, {
                 method: "POST",


### PR DESCRIPTION
## Description

Since v4, Apollo Server has a [built-in CSRF protection](https://www.apollographql.com/docs/graphos/routing/security/csrf) that refuses to execute any operation coming from a browser that has not "preflighted" that operation. This can be fixed by adding the `Apollo-Require-Preflight` header for GET-requests.

## Screenshots

**Before**
<img width="1632" alt="Screenshot 2024-12-17 at 09 52 38" src="https://github.com/user-attachments/assets/be67a20d-9c6d-40ce-a593-943728270b13" />

**After**
<img width="1591" alt="Screenshot 2024-12-17 at 09 52 52" src="https://github.com/user-attachments/assets/1776bad5-4f75-4e1d-a351-7696f346b190" />

## Further information

- [Apollo Server docs on CSRF](https://www.apollographql.com/docs/graphos/routing/security/csrf)
