### PR TITLE
Add edit dialog tests in stack tabs and grid

### DIFF
--- a/packages/admin/admin/src/EditDialog.routerTabs.test.tsx
+++ b/packages/admin/admin/src/EditDialog.routerTabs.test.tsx
@@ -86,7 +86,6 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
                                             component={StackLink}
                                             pageName="productEdit"
                                             payload={params.row.id}
-                                            onClick={() => editDialogApi.current?.openEditDialog(params.row.id)}
                                         >
                                             <Edit />
                                         </IconButton>

--- a/packages/admin/admin/src/EditDialog.routerTabs.test.tsx
+++ b/packages/admin/admin/src/EditDialog.routerTabs.test.tsx
@@ -125,7 +125,7 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         );
     }
 
-    it("should navigate to the products page and route when clicking on the products tab", async () => {
+    it("should not open edit dialog when navigating to the products page", async () => {
         const history = createMemoryHistory({
             initialEntries: ["/", "/products"],
             initialIndex: 0,

--- a/packages/admin/admin/src/EditDialog.routerTabs.test.tsx
+++ b/packages/admin/admin/src/EditDialog.routerTabs.test.tsx
@@ -1,0 +1,206 @@
+import { Add, Edit } from "@comet/admin-icons";
+import { Button, IconButton } from "@mui/material";
+import { DataGrid } from "@mui/x-data-grid";
+import { screen, waitFor } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import { ReactNode, RefObject, useRef } from "react";
+import { useIntl } from "react-intl";
+import { Router } from "react-router";
+import { render } from "test-utils";
+
+import { ToolbarActions } from "./common/toolbar/actions/ToolbarActions";
+import { DataGridToolbar } from "./common/toolbar/DataGridToolbar";
+import { ToolbarFillSpace } from "./common/toolbar/fillspace/ToolbarFillSpace";
+import { EditDialog } from "./EditDialog";
+import { IEditDialogApi } from "./EditDialogApiContext";
+import { FinalForm } from "./FinalForm";
+import { TextField } from "./form/fields/TextField";
+import { StackLink } from "./stack/StackLink";
+import { RouterTab, RouterTabs } from "./tabs/RouterTabs";
+
+describe("EditDialog with Stack, Router Tabs and Grid", () => {
+    type DialogProps = {
+        dialogApiRef: RefObject<IEditDialogApi>;
+    };
+
+    const AddProductDialog = ({ dialogApiRef }: DialogProps) => {
+        const intl = useIntl();
+
+        return (
+            <EditDialog
+                ref={dialogApiRef}
+                title={intl.formatMessage({ id: "addProductDialog.title", defaultMessage: "Add a new product" })}
+                componentsProps={{ dialog: { scroll: "paper", fullWidth: true } }}
+            >
+                {() => {
+                    return (
+                        <FinalForm
+                            mode="add"
+                            onSubmit={() => {
+                                // console.log("Submitted!");
+                            }}
+                        >
+                            <TextField name="name" label="Name" fullWidth />
+                        </FinalForm>
+                    );
+                }}
+            </EditDialog>
+        );
+    };
+
+    function Toolbar({ toolbarAction }: { toolbarAction?: ReactNode }) {
+        return (
+            <DataGridToolbar>
+                <ToolbarFillSpace />
+                <ToolbarActions>{toolbarAction}</ToolbarActions>
+            </DataGridToolbar>
+        );
+    }
+
+    function EditDialogInRouterTabs() {
+        const editDialogApi = useRef<IEditDialogApi>(null);
+
+        return (
+            <RouterTabs>
+                <RouterTab label="Customers" path="">
+                    Customers Page
+                </RouterTab>
+                <RouterTab label="Products" path="/products">
+                    <AddProductDialog dialogApiRef={editDialogApi} />
+
+                    <DataGrid
+                        columns={[
+                            { field: "id", headerName: "ID", width: 90 },
+                            {
+                                field: "actions",
+                                headerName: "",
+                                sortable: false,
+                                filterable: false,
+                                align: "right",
+                                width: 86,
+                                renderCell: (params) => {
+                                    return (
+                                        <IconButton
+                                            data-testid="edit.row"
+                                            color="primary"
+                                            component={StackLink}
+                                            pageName="productEdit"
+                                            payload={params.row.id}
+                                            onClick={() => editDialogApi.current?.openEditDialog(params.row.id)}
+                                        >
+                                            <Edit />
+                                        </IconButton>
+                                    );
+                                },
+                            },
+                        ]}
+                        rows={[
+                            { id: "0", productId: "0" },
+                            { id: "1", productId: "0" },
+                            { id: "2", productId: "0" },
+                            { id: "3", productId: "1" },
+                            { id: "4", productId: "1" },
+                            { id: "5", productId: "1" },
+                        ]}
+                        components={{
+                            Toolbar: Toolbar,
+                        }}
+                        componentsProps={{
+                            toolbar: {
+                                toolbarAction: (
+                                    <Button
+                                        startIcon={<Add />}
+                                        onClick={() => editDialogApi.current?.openAddDialog()}
+                                        variant="contained"
+                                        color="primary"
+                                    >
+                                        Add product
+                                    </Button>
+                                ),
+                            },
+                        }}
+                        disableVirtualization
+                    />
+                </RouterTab>
+            </RouterTabs>
+        );
+    }
+
+    it("should navigate to the products page and route when clicking on the products tab", async () => {
+        const history = createMemoryHistory({
+            initialEntries: ["/", "/products"],
+            initialIndex: 0,
+        });
+
+        const rendered = render(
+            <Router history={history}>
+                <EditDialogInRouterTabs />
+            </Router>,
+        );
+
+        expect(history.location.pathname).toBe("/");
+        rendered.getByText("Products").click();
+        expect(screen.getByText("Products")).toBeInTheDocument();
+        expect(history.location.pathname).toBe("/products");
+
+        // Check that the Edit Dialog is not open, there was a bug that was fixed
+        // where the edit dialog was open when navigating to a different tab
+        expect(screen.queryByText("Add a new product")).not.toBeInTheDocument();
+    });
+
+    it("should open product add dialog when clicking on Add product button in grid toolbar", async () => {
+        const history = createMemoryHistory({
+            initialEntries: ["/", "/products"],
+            initialIndex: 0,
+        });
+
+        const rendered = render(
+            <Router history={history}>
+                <EditDialogInRouterTabs />
+            </Router>,
+        );
+
+        rendered.getByText("Products").click();
+        expect(screen.getByText("Products")).toBeInTheDocument();
+
+        expect(rendered.getByText("Add product")).toBeInTheDocument();
+        rendered.getByText("Add product").click();
+        expect(screen.getByText("Add a new product")).toBeInTheDocument();
+    });
+
+    it("should stay on the products page when closing the edit dialog", async () => {
+        const history = createMemoryHistory({
+            initialEntries: ["/", "/products"],
+            initialIndex: 0,
+        });
+
+        const rendered = render(
+            <Router history={history}>
+                <EditDialogInRouterTabs />
+            </Router>,
+        );
+
+        expect(history.location.pathname).toBe("/");
+        expect(screen.getByText("Customers Page")).toBeInTheDocument();
+
+        rendered.getByText("Products").click();
+        expect(rendered.getByText("Add product")).toBeInTheDocument();
+        expect(history.location.pathname).toBe("/products");
+
+        rendered.getByText("Add product").click();
+        expect(screen.getByText("Add a new product")).toBeInTheDocument();
+        expect(history.location.pathname).toBe("/products/add");
+
+        rendered.getByText("Cancel").click();
+
+        // Check that the Edit Dialog is not open and user is still on
+        // the products page, there was a bug where the user was navigated
+        // back to the first tab after closing the edit dialog
+        await waitFor(() => {
+            expect(screen.queryByText("Add a new product")).not.toBeInTheDocument();
+        });
+
+        expect(history.location.pathname).toBe("/products");
+        expect(screen.queryByText("Customers Page")).not.toBeInTheDocument();
+    });
+});

--- a/packages/admin/admin/src/EditDialog.stackRouterTabs.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackRouterTabs.test.tsx
@@ -1,7 +1,7 @@
 import { Add, Edit } from "@comet/admin-icons";
 import { Button, IconButton } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { ReactNode, RefObject, useRef } from "react";
 import { useIntl } from "react-intl";
@@ -66,7 +66,7 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         );
     }
 
-    function StackWithGridAndEditDialog() {
+    function EditDialogInStackTabs() {
         const editDialogApi = useRef<IEditDialogApi>(null);
 
         return (
@@ -158,83 +158,12 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         );
     }
 
-    it("should navigate to the products page and route when clicking on the products tab", async () => {
-        const history = createMemoryHistory();
-
-        const rendered = render(
-            <Router history={history}>
-                <StackWithGridAndEditDialog />
-            </Router>,
-        );
-
-        expect(history.location.pathname).toBe("/");
-        rendered.getByText("Products").click();
-        expect(screen.getByText("Products")).toBeInTheDocument();
-        expect(history.location.pathname).toBe("/index/products");
-
-        // Check that the Edit Dialog is not open, there was a bug that was fixed
-        // where the edit dialog was open when navigating to a different tab
-        expect(screen.queryByText("Add a new product")).not.toBeInTheDocument();
-    });
-
-    it("should stay on the products page when closing the edit dialog", async () => {
-        const history = createMemoryHistory({
-            initialEntries: ["/", "/products"],
-            initialIndex: 0,
-        });
-
-        const rendered = render(
-            <Router history={history}>
-                <StackWithGridAndEditDialog />
-            </Router>,
-        );
-
-        expect(history.location.pathname).toBe("/");
-        expect(screen.getByText("Customers Page")).toBeInTheDocument();
-
-        rendered.getByText("Products").click();
-        expect(rendered.getByText("Add product")).toBeInTheDocument();
-        expect(history.location.pathname).toBe("/index/products");
-
-        rendered.getByText("Add product").click();
-        expect(screen.getByText("Add a new product")).toBeInTheDocument();
-        expect(history.location.pathname).toBe("/index/products/add");
-
-        await waitFor(() => {
-            rendered.getByText("Cancel").click();
-        });
-
-        // Check that the Edit Dialog is not open and user is still on
-        // the products page, there was a bug where the user was navigated
-        // back to the first tab after closing the edit dialog
-        expect(screen.queryByText("Add a new product")).not.toBeInTheDocument();
-        expect(history.location.pathname).toBe("/index/products");
-        expect(screen.queryByText("Customers Page")).not.toBeInTheDocument();
-    });
-
-    it("should open product add dialog when clicking on Add product button in grid toolbar", async () => {
-        const history = createMemoryHistory();
-
-        const rendered = render(
-            <Router history={history}>
-                <StackWithGridAndEditDialog />
-            </Router>,
-        );
-
-        rendered.getByText("Products").click();
-        expect(screen.getByText("Products")).toBeInTheDocument();
-
-        expect(rendered.getByText("Add product")).toBeInTheDocument();
-        rendered.getByText("Add product").click();
-        expect(screen.getByText("Add a new product")).toBeInTheDocument();
-    });
-
     it("should open edit stack page when clicking on edit button in grid", async () => {
         const history = createMemoryHistory();
 
         const rendered = render(
             <Router history={history}>
-                <StackWithGridAndEditDialog />
+                <EditDialogInStackTabs />
             </Router>,
         );
 
@@ -253,7 +182,7 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
 
         const rendered = render(
             <Router history={history}>
-                <StackWithGridAndEditDialog />
+                <EditDialogInStackTabs />
             </Router>,
         );
 

--- a/packages/admin/admin/src/EditDialog.stackRouterTabs.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackRouterTabs.test.tsx
@@ -98,7 +98,6 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
                                                         component={StackLink}
                                                         pageName="productEdit"
                                                         payload={params.row.id}
-                                                        onClick={() => editDialogApi.current?.openEditDialog(params.row.id)}
                                                     >
                                                         <Edit />
                                                     </IconButton>

--- a/packages/admin/admin/src/EditDialog.stackRouterTabs.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackRouterTabs.test.tsx
@@ -157,26 +157,7 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         );
     }
 
-    it("should open edit stack page when clicking on edit button in grid", async () => {
-        const history = createMemoryHistory();
-
-        const rendered = render(
-            <Router history={history}>
-                <EditDialogInStackTabs />
-            </Router>,
-        );
-
-        rendered.getByText("Products").click();
-        expect(screen.getByText("Products")).toBeInTheDocument();
-
-        expect(rendered.getByText("Add product")).toBeInTheDocument();
-        expect(rendered.queryAllByTestId("edit.row")).toHaveLength(6);
-        rendered.queryAllByTestId("edit.row")[5].click();
-        expect(screen.getByText("Product Edit Page")).toBeInTheDocument();
-        expect(history.location.pathname).toBe("/5/productEdit");
-    });
-
-    it("should navigate back to products page when clicking on back button in edit stack page", async () => {
+    it("should not open edit dialog when navigating back to products page", async () => {
         const history = createMemoryHistory();
 
         const rendered = render(
@@ -195,5 +176,10 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         within(rendered.getByTestId("editPage.backButton")).getByRole("button").click();
         expect(screen.getByText("Products")).toBeInTheDocument();
         expect(history.location.pathname).toBe("/index/products");
+
+        // Check that the Edit Dialog is not open, there was a bug that was fixed
+        // where the edit dialog was open when navigating to a page
+        // with an edit dialog component
+        expect(screen.queryByText("Add a new product")).not.toBeInTheDocument();
     });
 });

--- a/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
@@ -73,92 +73,91 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         const editDialogApi = useRef<IEditDialogApi>(null);
 
         return (
-            <>
-                <Stack topLevelTitle="Nested Stack">
-                    <StackSwitch>
-                        <StackPage name="products" title="Products">
-                            <RouterTabs>
-                                <RouterTab label="Customers" path="" forceRender={true}>
-                                    Customers Page
-                                </RouterTab>
-                                <RouterTab label="Products" path="/products" forceRender={true}>
-                                    <DataGrid
-                                        columns={[
-                                            { field: "id", headerName: "ID", width: 90 },
-                                            {
-                                                field: "actions",
-                                                headerName: "",
-                                                sortable: false,
-                                                filterable: false,
-                                                align: "right",
-                                                width: 86,
-                                                renderCell: (params) => {
-                                                    return (
-                                                        <IconButton
-                                                            data-testid="edit.row"
-                                                            color="primary"
-                                                            component={StackLink}
-                                                            pageName="productEdit"
-                                                            payload={params.row.id}
-                                                            onClick={() => editDialogApi.current?.openEditDialog(params.row.id)}
-                                                        >
-                                                            <Edit />
-                                                        </IconButton>
-                                                    );
-                                                },
-                                            },
-                                        ]}
-                                        rows={[
-                                            { id: "0", productId: "0" },
-                                            { id: "1", productId: "0" },
-                                            { id: "2", productId: "0" },
-                                            { id: "3", productId: "1" },
-                                            { id: "4", productId: "1" },
-                                            { id: "5", productId: "1" },
-                                        ]}
-                                        components={{
-                                            Toolbar: Toolbar,
-                                        }}
-                                        componentsProps={{
-                                            toolbar: {
-                                                toolbarAction: (
-                                                    <Button
-                                                        startIcon={<Add />}
-                                                        onClick={() => editDialogApi.current?.openAddDialog()}
-                                                        variant="contained"
+            <Stack topLevelTitle="Nested Stack">
+                <StackSwitch>
+                    <StackPage name="products" title="Products">
+                        <RouterTabs>
+                            <RouterTab label="Customers" path="">
+                                Customers Page
+                            </RouterTab>
+                            <RouterTab label="Products" path="/products">
+                                <AddProductDialog dialogApiRef={editDialogApi} />
+
+                                <DataGrid
+                                    columns={[
+                                        { field: "id", headerName: "ID", width: 90 },
+                                        {
+                                            field: "actions",
+                                            headerName: "",
+                                            sortable: false,
+                                            filterable: false,
+                                            align: "right",
+                                            width: 86,
+                                            renderCell: (params) => {
+                                                return (
+                                                    <IconButton
+                                                        data-testid="edit.row"
                                                         color="primary"
+                                                        component={StackLink}
+                                                        pageName="productEdit"
+                                                        payload={params.row.id}
+                                                        onClick={() => editDialogApi.current?.openEditDialog(params.row.id)}
                                                     >
-                                                        Add product
-                                                    </Button>
-                                                ),
+                                                        <Edit />
+                                                    </IconButton>
+                                                );
                                             },
-                                        }}
-                                        disableVirtualization
-                                    />
-                                </RouterTab>
-                            </RouterTabs>
-                        </StackPage>
-                        <StackPage name="productEdit" title="Product">
-                            {() => (
-                                <MainContent fullHeight disablePadding>
-                                    <SaveBoundary>
-                                        <StackToolbar>
-                                            <ToolbarBackButton />
-                                            <ToolbarAutomaticTitleItem />
-                                            <ToolbarFillSpace />
-                                            <ToolbarActions>
-                                                <SaveBoundarySaveButton />
-                                            </ToolbarActions>
-                                        </StackToolbar>
-                                        <div>Product Edit Page</div>
-                                    </SaveBoundary>
-                                </MainContent>
-                            )}
-                        </StackPage>
-                    </StackSwitch>
-                </Stack>
-                <AddProductDialog dialogApiRef={editDialogApi} />
-            </>
+                                        },
+                                    ]}
+                                    rows={[
+                                        { id: "0", productId: "0" },
+                                        { id: "1", productId: "0" },
+                                        { id: "2", productId: "0" },
+                                        { id: "3", productId: "1" },
+                                        { id: "4", productId: "1" },
+                                        { id: "5", productId: "1" },
+                                    ]}
+                                    components={{
+                                        Toolbar: Toolbar,
+                                    }}
+                                    componentsProps={{
+                                        toolbar: {
+                                            toolbarAction: (
+                                                <Button
+                                                    startIcon={<Add />}
+                                                    onClick={() => editDialogApi.current?.openAddDialog()}
+                                                    variant="contained"
+                                                    color="primary"
+                                                >
+                                                    Add product
+                                                </Button>
+                                            ),
+                                        },
+                                    }}
+                                    disableVirtualization
+                                />
+                            </RouterTab>
+                        </RouterTabs>
+                    </StackPage>
+                    <StackPage name="productEdit" title="Product">
+                        {() => (
+                            <MainContent fullHeight disablePadding>
+                                <SaveBoundary>
+                                    <StackToolbar>
+                                        <ToolbarBackButton />
+                                        <ToolbarAutomaticTitleItem />
+                                        <ToolbarFillSpace />
+                                        <ToolbarActions>
+                                            <SaveBoundarySaveButton />
+                                        </ToolbarActions>
+                                    </StackToolbar>
+                                    <div>Product Edit Page</div>
+                                </SaveBoundary>
+                            </MainContent>
+                        )}
+                    </StackPage>
+                </StackSwitch>
+            </Stack>
         );
     }
 
@@ -182,7 +181,10 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
     });
 
     it("should stay on the products page when closing the edit dialog", async () => {
-        const history = createMemoryHistory();
+        const history = createMemoryHistory({
+            initialEntries: ["/", "/products"],
+            initialIndex: 0,
+        });
 
         const rendered = render(
             <Router history={history}>
@@ -199,18 +201,17 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
 
         rendered.getByText("Add product").click();
         expect(screen.getByText("Add a new product")).toBeInTheDocument();
-        expect(history.location.pathname).toBe("//add");
+        expect(history.location.pathname).toBe("/index/products/add");
 
         await waitFor(() => {
             rendered.getByText("Cancel").click();
         });
 
+        // Check that the Edit Dialog is not open and user is still on
+        // the products page, there was a bug where the user was navigated
+        // back to the first tab after closing the edit dialog
         expect(screen.queryByText("Add a new product")).not.toBeInTheDocument();
-
-        // TODO: this is currently failing. The location path is "/" after clicking cancel. We expect it to still be on the products page route.
-        // expect(history.location.pathname).toBe("/index/products");
-
-        // TODO: this is currently failing. The customer page is visible after clicking cancel. We expect it to still be on the products page.
+        expect(history.location.pathname).toBe("/index/products");
         expect(screen.queryByText("Customers Page")).not.toBeInTheDocument();
     });
 
@@ -222,6 +223,9 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
                 <StackWithGridAndEditDialog />
             </Router>,
         );
+
+        rendered.getByText("Products").click();
+        expect(screen.getByText("Products")).toBeInTheDocument();
 
         expect(rendered.getByText("Add product")).toBeInTheDocument();
         rendered.getByText("Add product").click();
@@ -236,6 +240,9 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
                 <StackWithGridAndEditDialog />
             </Router>,
         );
+
+        rendered.getByText("Products").click();
+        expect(screen.getByText("Products")).toBeInTheDocument();
 
         expect(rendered.getByText("Add product")).toBeInTheDocument();
         expect(rendered.queryAllByTestId("edit.row")).toHaveLength(6);

--- a/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
@@ -59,15 +59,6 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         );
     };
 
-    const rows = [
-        { id: "0", productId: "0", amount: "3" },
-        { id: "1", productId: "0", amount: "6" },
-        { id: "2", productId: "0", amount: "2" },
-        { id: "3", productId: "1", amount: "4" },
-        { id: "4", productId: "1", amount: "5" },
-        { id: "5", productId: "1", amount: "7" },
-    ];
-
     function Toolbar({ toolbarAction }: { toolbarAction?: ReactNode }) {
         return (
             <DataGridToolbar>
@@ -114,7 +105,14 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
                                                 },
                                             },
                                         ]}
-                                        rows={rows}
+                                        rows={[
+                                            { id: "0", productId: "0", amount: "3" },
+                                            { id: "1", productId: "0", amount: "6" },
+                                            { id: "2", productId: "0", amount: "2" },
+                                            { id: "3", productId: "1", amount: "4" },
+                                            { id: "4", productId: "1", amount: "5" },
+                                            { id: "5", productId: "1", amount: "7" },
+                                        ]}
                                         components={{
                                             Toolbar: Toolbar,
                                         }}

--- a/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
@@ -1,5 +1,5 @@
 import { Add, Edit } from "@comet/admin-icons";
-import { Button, createTheme, IconButton } from "@mui/material";
+import { Button, IconButton } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
 import { screen } from "@testing-library/react";
 import { createMemoryHistory } from "history";
@@ -19,7 +19,6 @@ import { EditDialog } from "./EditDialog";
 import { IEditDialogApi } from "./EditDialogApiContext";
 import { FinalForm } from "./FinalForm";
 import { TextField } from "./form/fields/TextField";
-import { MuiThemeProvider } from "./mui/ThemeProvider";
 import { SaveBoundary } from "./saveBoundary/SaveBoundary";
 import { SaveBoundarySaveButton } from "./saveBoundary/SaveBoundarySaveButton";
 import { StackPage } from "./stack/Page";
@@ -167,11 +166,9 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
 
     it("should open add dialog when clicking on Add product button in grid toolbar", async () => {
         const rendered = render(
-            <MuiThemeProvider theme={createTheme()}>
-                <Router history={history}>
-                    <StackWithGridAndEditDialog />
-                </Router>
-            </MuiThemeProvider>,
+            <Router history={history}>
+                <StackWithGridAndEditDialog />
+            </Router>,
         );
 
         expect(rendered.getByText("Add product")).toBeInTheDocument();
@@ -181,11 +178,9 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
 
     it("should open edit stack page when clicking on edit button in grid", async () => {
         const rendered = render(
-            <MuiThemeProvider theme={createTheme()}>
-                <Router history={history}>
-                    <StackWithGridAndEditDialog />
-                </Router>
-            </MuiThemeProvider>,
+            <Router history={history}>
+                <StackWithGridAndEditDialog />
+            </Router>,
         );
 
         expect(rendered.getByText("Add product")).toBeInTheDocument();

--- a/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
@@ -1,0 +1,199 @@
+import { Add, Edit } from "@comet/admin-icons";
+import { Button, createTheme, IconButton } from "@mui/material";
+import { DataGrid } from "@mui/x-data-grid";
+import { screen } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import { ReactNode, RefObject, useRef } from "react";
+import { useIntl } from "react-intl";
+import { Router } from "react-router";
+import { render } from "test-utils";
+
+import { MainContent } from "./common/MainContent";
+import { ToolbarActions } from "./common/toolbar/actions/ToolbarActions";
+import { ToolbarAutomaticTitleItem } from "./common/toolbar/automatictitleitem/ToolbarAutomaticTitleItem";
+import { ToolbarBackButton } from "./common/toolbar/backbutton/ToolbarBackButton";
+import { DataGridToolbar } from "./common/toolbar/DataGridToolbar";
+import { ToolbarFillSpace } from "./common/toolbar/fillspace/ToolbarFillSpace";
+import { StackToolbar } from "./common/toolbar/StackToolbar";
+import { EditDialog } from "./EditDialog";
+import { IEditDialogApi } from "./EditDialogApiContext";
+import { FinalForm } from "./FinalForm";
+import { TextField } from "./form/fields/TextField";
+import { MuiThemeProvider } from "./mui/ThemeProvider";
+import { SaveBoundary } from "./saveBoundary/SaveBoundary";
+import { SaveBoundarySaveButton } from "./saveBoundary/SaveBoundarySaveButton";
+import { StackPage } from "./stack/Page";
+import { Stack } from "./stack/Stack";
+import { StackLink } from "./stack/StackLink";
+import { StackSwitch } from "./stack/Switch";
+import { RouterTab, RouterTabs } from "./tabs/RouterTabs";
+
+describe("EditDialog with Stack, Router Tabs and Grid", () => {
+    const history = createMemoryHistory();
+
+    type DialogProps = {
+        dialogApiRef: RefObject<IEditDialogApi>;
+    };
+
+    const AddProductDialog = ({ dialogApiRef }: DialogProps) => {
+        const intl = useIntl();
+
+        return (
+            <EditDialog
+                ref={dialogApiRef}
+                title={intl.formatMessage({ id: "addProductDialog.title", defaultMessage: "Add a new product" })}
+                componentsProps={{ dialog: { scroll: "paper", fullWidth: true } }}
+            >
+                {() => {
+                    return (
+                        <FinalForm
+                            mode="add"
+                            onSubmit={() => {
+                                // Submit logic
+                            }}
+                            onAfterSubmit={() => {
+                                dialogApiRef.current?.closeDialog();
+                            }}
+                        >
+                            <TextField name="name" label="Name" fullWidth />
+                        </FinalForm>
+                    );
+                }}
+            </EditDialog>
+        );
+    };
+
+    const rows = [
+        { id: "0", productId: "0", amount: "3" },
+        { id: "1", productId: "0", amount: "6" },
+        { id: "2", productId: "0", amount: "2" },
+        { id: "3", productId: "1", amount: "4" },
+        { id: "4", productId: "1", amount: "5" },
+        { id: "5", productId: "1", amount: "7" },
+    ];
+
+    function Toolbar({ toolbarAction }: { toolbarAction?: ReactNode }) {
+        return (
+            <DataGridToolbar>
+                <ToolbarFillSpace />
+                <ToolbarActions>{toolbarAction}</ToolbarActions>
+            </DataGridToolbar>
+        );
+    }
+
+    function StackWithGridAndEditDialog() {
+        const editDialogApi = useRef<IEditDialogApi>(null);
+
+        return (
+            <>
+                <Stack topLevelTitle="Nested Stack">
+                    <StackSwitch>
+                        <StackPage name="products" title="Products">
+                            <RouterTabs>
+                                <RouterTab label="Products" path="" forceRender={true}>
+                                    <DataGrid
+                                        columns={[
+                                            { field: "id", headerName: "ID", width: 90 },
+                                            { field: "amount", headerName: "Amount", flex: 1 },
+                                            {
+                                                field: "actions",
+                                                headerName: "",
+                                                sortable: false,
+                                                filterable: false,
+                                                align: "right",
+                                                width: 86,
+                                                renderCell: (params) => {
+                                                    return (
+                                                        <IconButton
+                                                            data-testid="edit.row"
+                                                            color="primary"
+                                                            component={StackLink}
+                                                            pageName="productEdit"
+                                                            payload={params.row.id}
+                                                            onClick={() => editDialogApi.current?.openEditDialog(params.row.id)}
+                                                        >
+                                                            <Edit />
+                                                        </IconButton>
+                                                    );
+                                                },
+                                            },
+                                        ]}
+                                        rows={rows}
+                                        components={{
+                                            Toolbar: Toolbar,
+                                        }}
+                                        componentsProps={{
+                                            toolbar: {
+                                                toolbarAction: (
+                                                    <Button
+                                                        startIcon={<Add />}
+                                                        onClick={() => editDialogApi.current?.openAddDialog()}
+                                                        variant="contained"
+                                                        color="primary"
+                                                    >
+                                                        Add product
+                                                    </Button>
+                                                ),
+                                            },
+                                        }}
+                                        disableVirtualization
+                                    />
+                                </RouterTab>
+                                <RouterTab label="Customers" path="/customers" forceRender={true}>
+                                    Customers Page
+                                </RouterTab>
+                            </RouterTabs>
+                        </StackPage>
+                        <StackPage name="productEdit" title="Product">
+                            {() => (
+                                <MainContent fullHeight disablePadding>
+                                    <SaveBoundary>
+                                        <StackToolbar>
+                                            <ToolbarBackButton />
+                                            <ToolbarAutomaticTitleItem />
+                                            <ToolbarFillSpace />
+                                            <ToolbarActions>
+                                                <SaveBoundarySaveButton />
+                                            </ToolbarActions>
+                                        </StackToolbar>
+                                        <div>Product Edit Page</div>
+                                    </SaveBoundary>
+                                </MainContent>
+                            )}
+                        </StackPage>
+                    </StackSwitch>
+                </Stack>
+                <AddProductDialog dialogApiRef={editDialogApi} />
+            </>
+        );
+    }
+
+    it("should open add dialog when clicking on Add product button in grid toolbar", async () => {
+        const rendered = render(
+            <MuiThemeProvider theme={createTheme()}>
+                <Router history={history}>
+                    <StackWithGridAndEditDialog />
+                </Router>
+            </MuiThemeProvider>,
+        );
+
+        expect(rendered.getByText("Add product")).toBeInTheDocument();
+        rendered.getByText("Add product").click();
+        expect(screen.getByText("Add a new product")).toBeInTheDocument();
+    });
+
+    it("should open edit stack page when clicking on edit button in grid", async () => {
+        const rendered = render(
+            <MuiThemeProvider theme={createTheme()}>
+                <Router history={history}>
+                    <StackWithGridAndEditDialog />
+                </Router>
+            </MuiThemeProvider>,
+        );
+
+        expect(rendered.getByText("Add product")).toBeInTheDocument();
+        expect(rendered.queryAllByTestId("edit.row")).toHaveLength(6);
+        rendered.queryAllByTestId("edit.row")[5].click();
+        expect(screen.getByText("Product Edit Page")).toBeInTheDocument();
+    });
+});

--- a/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
@@ -1,7 +1,7 @@
 import { Add, Edit } from "@comet/admin-icons";
 import { Button, IconButton } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { ReactNode, RefObject, useRef } from "react";
 import { useIntl } from "react-intl";
@@ -141,7 +141,7 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
                             <MainContent fullHeight disablePadding>
                                 <SaveBoundary>
                                     <StackToolbar>
-                                        <ToolbarBackButton />
+                                        <ToolbarBackButton data-testid="editPage.backButton" />
                                         <ToolbarAutomaticTitleItem />
                                         <ToolbarFillSpace />
                                         <ToolbarActions>
@@ -245,5 +245,27 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         expect(rendered.queryAllByTestId("edit.row")).toHaveLength(6);
         rendered.queryAllByTestId("edit.row")[5].click();
         expect(screen.getByText("Product Edit Page")).toBeInTheDocument();
+        expect(history.location.pathname).toBe("/5/productEdit");
+    });
+
+    it("should navigate back to products page when clicking on back button in edit stack page", async () => {
+        const history = createMemoryHistory();
+
+        const rendered = render(
+            <Router history={history}>
+                <StackWithGridAndEditDialog />
+            </Router>,
+        );
+
+        rendered.getByText("Products").click();
+        expect(screen.getByText("Products")).toBeInTheDocument();
+
+        expect(rendered.queryAllByTestId("edit.row")).toHaveLength(6);
+        rendered.queryAllByTestId("edit.row")[5].click();
+
+        expect(history.location.pathname).toBe("/5/productEdit");
+        within(rendered.getByTestId("editPage.backButton")).getByRole("button").click();
+        expect(screen.getByText("Products")).toBeInTheDocument();
+        expect(history.location.pathname).toBe("/index/products");
     });
 });

--- a/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
@@ -48,9 +48,6 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
                             onSubmit={() => {
                                 // console.log("Submitted!");
                             }}
-                            onAfterSubmit={() => {
-                                dialogApiRef.current?.closeDialog();
-                            }}
                         >
                             <TextField name="name" label="Name" fullWidth />
                         </FinalForm>

--- a/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
@@ -164,6 +164,20 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         );
     }
 
+    it("should navigate to the customers tab when clicking on the customers tab", async () => {
+        const rendered = render(
+            <Router history={history}>
+                <StackWithGridAndEditDialog />
+            </Router>,
+        );
+
+        expect(history.location.pathname).toBe("/");
+        expect(rendered.getByText("Add product")).toBeInTheDocument();
+        rendered.getByText("Customers").click();
+        expect(screen.getByText("Customers Page")).toBeInTheDocument();
+        expect(history.location.pathname).toBe("/index/customers"); // TODO: Find out why this is /index/*
+    });
+
     it("should open add dialog when clicking on Add product button in grid toolbar", async () => {
         const rendered = render(
             <Router history={history}>

--- a/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackTabsAndGrid.test.tsx
@@ -51,9 +51,6 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
                             onSubmit={() => {
                                 // Submit logic
                             }}
-                            onAfterSubmit={() => {
-                                dialogApiRef.current?.closeDialog();
-                            }}
                         >
                             <TextField name="name" label="Name" fullWidth />
                         </FinalForm>


### PR DESCRIPTION
These tests show that the EditDialog behaves correctly when used within a Stack and Router Tabs components.

It also shows that it behaves correctly when opening it through a Data Grid row edit button or an add new button.

It also has a test to check the route when clicking on a tab.