### PR TITLE
RFC: Add basic unit test for future Admin Generator

### DIFF
--- a/packages/admin/cms-admin/src/generator/future/__tests__/grid/queryParamsPrefix.test.ts
+++ b/packages/admin/cms-admin/src/generator/future/__tests__/grid/queryParamsPrefix.test.ts
@@ -1,0 +1,41 @@
+import { buildSchema, introspectionFromSchema } from "graphql";
+
+import { generateGrid } from "../../generateGrid";
+import { GridConfig } from "../../generator";
+
+describe("Admin Generator", () => {
+    describe("Grid", () => {
+        it("should generate correct query params prefix", async () => {
+            const schema = buildSchema(`
+                type Query {
+                    product(id: ID!): Product!
+                    products: [Product!]!
+                }
+
+                type Mutation {
+                    createProduct(title: String!): Product!
+                }
+
+                type Product {
+                    id: ID!
+                    title: String!
+                }
+            `);
+
+            const gqlIntrospection = introspectionFromSchema(schema);
+            const config: GridConfig<{ __typename: "Product" }> = {
+                type: "grid",
+                gqlType: "Product",
+                columns: [],
+                queryParamsPrefix: "testPrefix",
+            };
+
+            const generated = generateGrid(
+                { exportName: "ProductGrid", gqlIntrospection, baseOutputFilename: "ProductGrid", targetDirectory: "src" },
+                config,
+            );
+
+            expect(generated.code).toContain('queryParamsPrefix: "testPrefix"');
+        });
+    });
+});


### PR DESCRIPTION
## Description

Up until now, we implemented all features of the future Admin Generator by implementing it in Demo. This doesn't scale well since we need to "invent" use cases for all features we need in our projects. This PR adds a basic unit test for the Admin Generator. We still need to implement a few helpers (e.g., for building the GraphQL schema), but I believe this could work.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [ ] How do we get the GraphQL schema
