### PR TITLE
SonarQube: Allow duplications between Demo sites

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,5 +4,5 @@ sonar.sources=demo/,docs/,packages/,storybook/
 sonar.tests=packages/
 sonar.test.inclusions=packages/**/__tests__/**,packages/**/*.spec.ts
 sonar.exclusions=packages/**/__tests__/**,packages/**/*.spec.ts,storybook/**/*.stories.tsx,storybook/**/mockServiceWorker.js,storybook/**/mocks/**
-sonar.cpd.exclusions=packages/**/__tests__/**,packages/**/*.spec.ts,storybook/**/*.stories.tsx,storybook/**/mockServiceWorker.js,storybook/**/mocks/**
+sonar.cpd.exclusions=demo/site-pages/**,demo/site/**,packages/**/__tests__/**,packages/**/*.spec.ts,storybook/**/*.stories.tsx,storybook/**/mockServiceWorker.js,storybook/**/mocks/**
 sonar.typescript.tsconfigPaths=demo/*/tsconfig.json,docs/tsconfig.json,packages/*/tsconfig.json,packages/*/*/tsconfig.json,storybook/tsconfig.json


### PR DESCRIPTION
## Description

We have two sites, one for App Router and one for Pages Router. There will be duplications in these two folders.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
