### PR TITLE
Demo Site: Fix Redirect to InternalPage, use absolute path

### DIFF
--- a/demo/site/src/app/[domain]/[language]/[[...path]]/page.tsx
+++ b/demo/site/src/app/[domain]/[language]/[[...path]]/page.tsx
@@ -86,7 +86,7 @@ export default async function Page({ params }: Props) {
                     case "internal": {
                         const internalLink = target.block.props as InternalLinkBlockData;
                         if (internalLink.targetPage) {
-                            destination = `${(internalLink.targetPage.scope as GQLPageTreeNodeScope).language}/${internalLink.targetPage.path}`;
+                            destination = `/${(internalLink.targetPage.scope as GQLPageTreeNodeScope).language}/${internalLink.targetPage.path}`;
                         }
                         break;
                     }


### PR DESCRIPTION
Previously the destination was a relative path appended to the current url (redirect source url), resulting in broken redirects.