### PR TITLE
Set `disableRowSelectionOnClick` for every `DataGrid` using the theme

### DIFF
--- a/.changeset/cyan-ghosts-smoke.md
+++ b/.changeset/cyan-ghosts-smoke.md
@@ -1,0 +1,39 @@
+---
+"@comet/admin-theme": major
+---
+
+Prevent the selection of DataGrid rows by clicking on them
+
+According to the Comet design guidelines, rows should be selected using checkboxes, with the `checkboxSelection` prop, where required.
+
+```tsx
+<DataGrid
+    checkboxSelection
+    onRowSelectionModelChange={(newRowSelectionModel) => {
+        setRowSelectionModel(newRowSelectionModel);
+    }}
+    rowSelectionModel={rowSelectionModel}
+    // ...
+/>
+```
+
+To restore the previous behavior, set the `disableRowSelectionOnClick` prop to `false` in the individual `DataGrid` component or globally, using the theme's `defaultProps`.
+
+```tsx
+<DataGrid
+    disableRowSelectionOnClick
+    // ...
+/>
+```
+
+```tsx
+const theme = createCometTheme({
+    components: {
+        MuiDataGrid: {
+            defaultProps: {
+                disableRowSelectionOnClick: false,
+            },
+        },
+    },
+});
+```

--- a/demo/admin/src/news/blocks/NewsListBlock.tsx
+++ b/demo/admin/src/news/blocks/NewsListBlock.tsx
@@ -66,7 +66,6 @@ export const NewsListBlock: BlockInterface<NewsListBlockData, State, NewsListBlo
                     ]}
                     loading={loading}
                     checkboxSelection
-                    disableRowSelectionOnClick
                     keepNonExistentRowsSelected
                     rowSelectionModel={state.ids}
                     onRowSelectionModelChange={(newSelection) => {

--- a/demo/admin/src/news/generated/NewsGrid.tsx
+++ b/demo/admin/src/news/generated/NewsGrid.tsx
@@ -233,7 +233,6 @@ export function NewsGrid(): React.ReactElement {
         <MainContent fullHeight>
             <DataGridPro
                 {...dataGridProps}
-                disableRowSelectionOnClick
                 rows={rows}
                 rowCount={rowCount}
                 columns={columns}

--- a/demo/admin/src/products/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/ManufacturersGrid.tsx
@@ -176,7 +176,6 @@ export function ManufacturersGrid() {
     return (
         <DataGridPro
             {...dataGridProps}
-            disableRowSelectionOnClick
             rows={rows}
             rowCount={rowCount}
             columns={columns}

--- a/demo/admin/src/products/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/ProductVariantsGrid.tsx
@@ -123,7 +123,6 @@ export function ProductVariantsGrid({ productId }: { productId: string }) {
     return (
         <DataGridPro
             {...dataGridProps}
-            disableRowSelectionOnClick
             rows={rows}
             rowCount={rowCount}
             columns={columns}

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -299,7 +299,6 @@ export function ProductsGrid() {
     return (
         <DataGridPro
             {...dataGridProps}
-            disableRowSelectionOnClick
             rows={rows}
             rowCount={rowCount}
             columns={columns}

--- a/demo/admin/src/products/categories/ProductCategoriesTable.tsx
+++ b/demo/admin/src/products/categories/ProductCategoriesTable.tsx
@@ -116,7 +116,6 @@ function ProductCategoriesTable() {
     return (
         <DataGridPro
             {...dataGridProps}
-            disableRowSelectionOnClick
             rows={rows}
             rowCount={rowCount}
             columns={columns}

--- a/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
@@ -380,7 +380,6 @@ export function ProductsGrid({ toolbarAction, rowAction, actionsColumnWidth = 52
     return (
         <DataGridPro
             {...dataGridProps}
-            disableRowSelectionOnClick
             rows={rows}
             rowCount={rowCount}
             columns={columns}

--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -291,7 +291,6 @@ export function ManufacturersGrid(): React.ReactElement {
     return (
         <DataGridPro
             {...dataGridProps}
-            disableRowSelectionOnClick
             rows={rows}
             rowCount={rowCount}
             columns={columns}

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -181,7 +181,6 @@ export function ProductVariantsGrid({ product }: Props): React.ReactElement {
     return (
         <DataGridPro
             {...dataGridProps}
-            disableRowSelectionOnClick
             rows={rows}
             rowCount={rowCount}
             columns={columns}

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -395,7 +395,6 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
     return (
         <DataGridPro
             {...dataGridProps}
-            disableRowSelectionOnClick
             rows={rows}
             rowCount={rowCount}
             columns={columns}

--- a/demo/admin/src/products/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/generated/ProductsGrid.tsx
@@ -238,7 +238,6 @@ export function ProductsGrid(): React.ReactElement {
         <MainContent fullHeight>
             <DataGridPro
                 {...dataGridProps}
-                disableRowSelectionOnClick
                 rows={rows}
                 rowCount={rowCount}
                 columns={columns}

--- a/demo/admin/src/products/tags/ProductTagTable.tsx
+++ b/demo/admin/src/products/tags/ProductTagTable.tsx
@@ -114,7 +114,6 @@ function ProductTagsTable() {
         <Box sx={{ height: `calc(100vh - var(--comet-admin-master-layout-content-top-spacing))` }}>
             <DataGridPro
                 {...dataGridProps}
-                disableRowSelectionOnClick
                 rows={rows}
                 rowCount={rowCount}
                 columns={columns}

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -22,6 +22,7 @@ import { GetMuiComponentTheme } from "./getComponentsTheme";
 export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, { palette, shadows, spacing }) => ({
     ...component,
     defaultProps: {
+        disableRowSelectionOnClick: true,
         slots: {
             /* @TODO: add FilterPanelAddIcon to display Comet Add Icon once MUI Datagrid is updated to v6 or higher  */
             QuickFilterIcon: Search,

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -562,7 +562,6 @@ const FolderDataGrid = ({
                     getRowClassName={getRowClassName}
                     columns={dataGridColumns}
                     checkboxSelection={!hideMultiselect}
-                    disableRowSelectionOnClick
                     rowSelectionModel={Array.from(damSelectionActionsApi.selectionMap.keys())}
                     onRowSelectionModelChange={handleSelectionModelChange}
                     autoHeight={true}

--- a/packages/admin/cms-admin/src/dashboard/widgets/LatestBuildsDashboardWidget.tsx
+++ b/packages/admin/cms-admin/src/dashboard/widgets/LatestBuildsDashboardWidget.tsx
@@ -42,15 +42,7 @@ export const LatestBuildsDashboardWidget = () => {
 
     return (
         <DashboardWidgetRoot header={<FormattedMessage id="dashboard.latestBuildsWidget.title" defaultMessage="Latest Builds" />}>
-            <DataGrid
-                disableRowSelectionOnClick
-                disableColumnMenu
-                hideFooter
-                autoHeight
-                columns={columns}
-                rows={data?.builds ?? []}
-                loading={loading}
-            />
+            <DataGrid disableColumnMenu hideFooter autoHeight columns={columns} rows={data?.builds ?? []} loading={loading} />
         </DashboardWidgetRoot>
     );
 };

--- a/packages/admin/cms-admin/src/dashboard/widgets/LatestContentUpdatesDashboardWidget.tsx
+++ b/packages/admin/cms-admin/src/dashboard/widgets/LatestContentUpdatesDashboardWidget.tsx
@@ -61,7 +61,7 @@ export const LatestContentUpdatesDashboardWidget = <Row extends MinimalRow>({
             icon={<Reload />}
             header={<FormattedMessage id="dashboard.latestContentUpdatesWidget.title" defaultMessage="Latest Content Updates" />}
         >
-            <DataGrid disableRowSelectionOnClick disableColumnMenu hideFooter autoHeight columns={columns} rows={rows} loading={loading} />
+            <DataGrid disableColumnMenu hideFooter autoHeight columns={columns} rows={rows} loading={loading} />
         </DashboardWidgetRoot>
     );
 };

--- a/packages/admin/cms-admin/src/dependencies/DependencyList.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependencyList.tsx
@@ -195,7 +195,6 @@ export const DependencyList = ({ query, variables }: DependencyListProps) => {
                     },
                 }}
                 rowHeight={60}
-                disableRowSelectionOnClick
                 disableColumnMenu
                 loading={loading && data != null}
                 autoHeight={true}

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -869,7 +869,6 @@ export function generateGrid(
         return (
             <DataGridPro
                 {...dataGridProps}
-                disableRowSelectionOnClick
                 rows={rows}
                 rowCount={rowCount}
                 columns={columns}

--- a/packages/admin/cms-admin/src/generator/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/generateGrid.ts
@@ -422,12 +422,11 @@ export async function writeCrudGrid(
         const rowCount = useBufferedRowCount(data?.${gridQuery}.totalCount);
         if (error) throw error;
         const rows = data?.${gridQuery}.nodes ?? [];
-    
+
         return (
             <MainContent fullHeight>
                 <DataGridPro
                     {...dataGridProps}
-                    disableRowSelectionOnClick
                     rows={rows}
                     rowCount={rowCount}
                     columns={columns}

--- a/packages/admin/cms-admin/src/redirects/RedirectsGrid.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsGrid.tsx
@@ -182,7 +182,6 @@ export function RedirectsGrid({ linkBlock, scope }: Props): JSX.Element {
                 rowCount={rowCount}
                 columns={columns}
                 loading={loading}
-                disableRowSelectionOnClick
                 slots={{ toolbar: RedirectsGridToolbar }}
             />
         </MainContent>

--- a/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
+++ b/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
@@ -350,7 +350,7 @@ export const SingleGridFullHeight = {
                     <ToolbarAutomaticTitleItem />
                 </StackToolbar>
                 <StackMainContent fullHeight>
-                    <DataGrid disableRowSelectionOnClick columns={columns} rows={rows} loading={loading} slots={{ toolbar: GridToolbar }} />
+                    <DataGrid columns={columns} rows={rows} loading={loading} slots={{ toolbar: GridToolbar }} />
                 </StackMainContent>
             </>
         );
@@ -386,14 +386,7 @@ export const SingleGridAutoHeight = {
                     <ToolbarAutomaticTitleItem />
                 </StackToolbar>
                 <StackMainContent>
-                    <DataGrid
-                        disableRowSelectionOnClick
-                        columns={columns}
-                        rows={rows}
-                        loading={loading}
-                        slots={{ toolbar: GridToolbar }}
-                        autoHeight
-                    />
+                    <DataGrid columns={columns} rows={rows} loading={loading} slots={{ toolbar: GridToolbar }} autoHeight />
                 </StackMainContent>
             </>
         );
@@ -468,7 +461,7 @@ export const GridWithFormInADialog = {
                     <ToolbarAutomaticTitleItem />
                 </StackToolbar>
                 <StackMainContent fullHeight>
-                    <DataGrid disableRowSelectionOnClick rows={rows} columns={columns} loading={loading} slots={{ toolbar: GridToolbar }} />
+                    <DataGrid rows={rows} columns={columns} loading={loading} slots={{ toolbar: GridToolbar }} />
                 </StackMainContent>
                 <Dialog open={!!editingId} onClose={() => setEditingId(undefined)}>
                     <SaveBoundary onAfterSave={() => setEditingId(undefined)}>
@@ -566,7 +559,7 @@ export const GridWithFormOnAPage = {
                         <ToolbarAutomaticTitleItem />
                     </StackToolbar>
                     <StackMainContent fullHeight>
-                        <DataGrid disableRowSelectionOnClick rows={rows} columns={columns} loading={loading} slots={{ toolbar: GridToolbar }} />
+                        <DataGrid rows={rows} columns={columns} loading={loading} slots={{ toolbar: GridToolbar }} />
                     </StackMainContent>
                 </StackPage>
                 <StackPage name="add">
@@ -684,7 +677,7 @@ export const NestedGridsAndFormsWithTabs = {
                             <ToolbarAutomaticTitleItem />
                         </StackToolbar>
                         <StackMainContent fullHeight>
-                            <DataGrid disableRowSelectionOnClick rows={rows} columns={columns} loading={loading} slots={{ toolbar: GridToolbar }} />
+                            <DataGrid rows={rows} columns={columns} loading={loading} slots={{ toolbar: GridToolbar }} />
                         </StackMainContent>
                     </StackPage>
                     <StackPage name="edit">
@@ -701,7 +694,7 @@ export const NestedGridsAndFormsWithTabs = {
                                             </RouterTab>
                                             <RouterTab path="/child-items" label="Child items in Grid">
                                                 <FullHeightGridContainer>
-                                                    <DataGrid disableRowSelectionOnClick rows={rows} columns={childGridColumns} loading={loading} />
+                                                    <DataGrid rows={rows} columns={childGridColumns} loading={loading} />
                                                 </FullHeightGridContainer>
                                             </RouterTab>
                                         </RouterTabs>
@@ -809,7 +802,7 @@ export const NestedFormInGridInTabsInGrid = {
                             <ToolbarAutomaticTitleItem />
                         </StackToolbar>
                         <StackMainContent fullHeight>
-                            <DataGrid disableRowSelectionOnClick rows={rows} columns={columns} loading={loading} slots={{ toolbar: GridToolbar }} />
+                            <DataGrid rows={rows} columns={columns} loading={loading} slots={{ toolbar: GridToolbar }} />
                         </StackMainContent>
                     </StackPage>
                     <StackPage name="edit">
@@ -828,7 +821,7 @@ export const NestedFormInGridInTabsInGrid = {
                                                 <StackSwitch>
                                                     <StackPage name="grid">
                                                         <FullHeightGridContainer>
-                                                            <DataGrid disableRowSelectionOnClick rows={rows} columns={columns} loading={loading} />
+                                                            <DataGrid rows={rows} columns={columns} loading={loading} />
                                                         </FullHeightGridContainer>
                                                     </StackPage>
                                                     <StackPage name="edit">
@@ -931,7 +924,6 @@ export const GridWithSelectionAndMoreActionsMenu = {
                 </StackToolbar>
                 <StackMainContent fullHeight>
                     <DataGrid
-                        disableRowSelectionOnClick
                         rows={rows}
                         columns={columns}
                         loading={loading}
@@ -1008,7 +1000,6 @@ export const GridWithSelectionInDialog = {
                 <Dialog open={showDialog} onClose={() => setShowDialog(false)}>
                     <DialogTitle>Selected items</DialogTitle>
                     <DataGrid
-                        disableRowSelectionOnClick
                         rows={rows}
                         columns={columns}
                         loading={loading}

--- a/storybook/src/docs/components/ContentOverflow/ContentOverflow.stories.tsx
+++ b/storybook/src/docs/components/ContentOverflow/ContentOverflow.stories.tsx
@@ -100,7 +100,7 @@ export const InDataGrid = {
             },
         ];
 
-        return <DataGrid autoHeight rows={gridRows} columns={gridColumns} rowHeight={100} disableRowSelectionOnClick />;
+        return <DataGrid autoHeight rows={gridRows} columns={gridColumns} rowHeight={100} />;
     },
     name: "In DataGrid",
 };

--- a/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
+++ b/storybook/src/docs/components/DataGrid/DataGrid.stories.tsx
@@ -545,7 +545,6 @@ export const _CrudMoreActionsMenu = {
                     rows={exampleRows}
                     columns={exampleColumns}
                     checkboxSelection
-                    disableRowSelectionOnClick
                     onRowSelectionModelChange={(newSelectionModel) => {
                         setSelectionModel(newSelectionModel);
                     }}

--- a/storybook/src/docs/components/GridCellContent/GridCellContent.stories.tsx
+++ b/storybook/src/docs/components/GridCellContent/GridCellContent.stories.tsx
@@ -47,7 +47,7 @@ export const Basic = {
             },
         ];
 
-        return <DataGrid autoHeight rows={gridRows} columns={gridColumns} disableRowSelectionOnClick />;
+        return <DataGrid autoHeight rows={gridRows} columns={gridColumns} />;
     },
     name: "GridCellContent",
 };

--- a/storybook/src/helpers/ExampleDataGrid.tsx
+++ b/storybook/src/helpers/ExampleDataGrid.tsx
@@ -28,5 +28,5 @@ export const exampleColumns: GridColDef[] = [
 
 export const ExampleDataGrid = (props: Partial<DataGridProps>) => {
     const dataGridProps = usePersistentColumnState("ResponsiveColumnsStory");
-    return <DataGrid disableRowSelectionOnClick rows={exampleRows} columns={exampleColumns} {...dataGridProps} {...props} />;
+    return <DataGrid rows={exampleRows} columns={exampleColumns} {...dataGridProps} {...props} />;
 };


### PR DESCRIPTION
## Description

MUI's default behavior is to allow selecting a row by clicking on it, independent of the ability to do something with the selection, which could be confusing to the user.

According to the Comet design guidelines, rows should be selected using checkboxes, with the `checkboxSelection` prop, where required.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)