### PR TITLE
Fix input validation for missing child blocks

### DIFF
--- a/.changeset/new-cherries-provide.md
+++ b/.changeset/new-cherries-provide.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-api": patch
+---
+
+Fix input validation for missing child blocks

--- a/packages/api/blocks-api/src/blocks/decorators/child-block-input.test.ts
+++ b/packages/api/blocks-api/src/blocks/decorators/child-block-input.test.ts
@@ -1,0 +1,35 @@
+import { BlockData, BlockDataInterface, BlockInput, createBlock, ExtractBlockData, ExtractBlockInput, inputToData } from "../block";
+import { createRichTextBlock } from "../createRichTextBlock";
+import { ExternalLinkBlock } from "../ExternalLinkBlock";
+import { ChildBlock } from "./child-block";
+import { ChildBlockInput } from "./child-block-input";
+
+const RichTextBlock = createRichTextBlock({ link: ExternalLinkBlock });
+
+class HeadlineBlockData extends BlockData {
+    @ChildBlock(RichTextBlock)
+    headline: ExtractBlockData<typeof RichTextBlock>;
+}
+
+class HeadlineBlockInput extends BlockInput {
+    @ChildBlockInput(RichTextBlock)
+    headline: ExtractBlockInput<typeof RichTextBlock>;
+
+    transformToBlockData(): BlockDataInterface {
+        return inputToData(HeadlineBlockData, this);
+    }
+}
+
+const HeadlineBlock = createBlock(HeadlineBlockData, HeadlineBlockInput, "Headline");
+
+describe("ChildBlockInput", () => {
+    it("should fail if no value is provided", () => {
+        // `@Transform()` allows any value, so we use any here.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const plain: any = {};
+
+        expect(() => {
+            HeadlineBlock.blockInputFactory(plain);
+        }).toThrowError(`Missing child block input for 'headline' (RichText)`);
+    });
+});


### PR DESCRIPTION
## Description

We've noticed that child blocks would pass validation if no value was provided. We fix this by setting the `@Expose()` decorator on the input, as recommended [here](https://github.com/typestack/class-transformer/issues/1599#issuecomment-2094934401).

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
