### PR TITLE
Fix input validation for missing child blocks (v5)

### DIFF
--- a/.changeset/new-cherries-provide.md
+++ b/.changeset/new-cherries-provide.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-api": patch
+---
+
+Fix input validation for missing child blocks

--- a/packages/api/blocks-api/src/blocks/decorators/child-block-input.test.ts
+++ b/packages/api/blocks-api/src/blocks/decorators/child-block-input.test.ts
@@ -1,0 +1,35 @@
+import { BlockData, BlockDataInterface, BlockInput, createBlock, ExtractBlockData, ExtractBlockInput, inputToData } from "../block";
+import { createRichTextBlock } from "../createRichTextBlock";
+import { ExternalLinkBlock } from "../ExternalLinkBlock";
+import { ChildBlock } from "./child-block";
+import { ChildBlockInput } from "./child-block-input";
+
+const RichTextBlock = createRichTextBlock({ link: ExternalLinkBlock });
+
+class HeadlineBlockData extends BlockData {
+    @ChildBlock(RichTextBlock)
+    headline: ExtractBlockData<typeof RichTextBlock>;
+}
+
+class HeadlineBlockInput extends BlockInput {
+    @ChildBlockInput(RichTextBlock)
+    headline: ExtractBlockInput<typeof RichTextBlock>;
+
+    transformToBlockData(): BlockDataInterface {
+        return inputToData(HeadlineBlockData, this);
+    }
+}
+
+const HeadlineBlock = createBlock(HeadlineBlockData, HeadlineBlockInput, "Headline");
+
+describe("ChildBlockInput", () => {
+    it("should fail if no value is provided", () => {
+        // `@Transform()` allows any value, so we use any here.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const plain: any = {};
+
+        expect(() => {
+            HeadlineBlock.blockInputFactory(plain);
+        }).toThrowError(`Missing child block input for 'headline' (RichText)`);
+    });
+});


### PR DESCRIPTION
Backport of https://github.com/vivid-planet/comet/pull/2942 into v5.