### PR TITLE
Validate filename length for uploads to DAM or FileUploads

### DIFF
--- a/.changeset/hip-seahorses-wash.md
+++ b/.changeset/hip-seahorses-wash.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-admin": minor
+"@comet/cms-api": minor
+---
+
+Validate filename length for uploads to DAM or FileUploads
+
+The filename can't exceed 255 characters.

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/fileUploadErrorMessages.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/fileUploadErrorMessages.tsx
@@ -84,3 +84,13 @@ export const SvgContainsJavaScriptError = () => (
         }}
     />
 );
+
+export const FilenameTooLongError = () => (
+    <FormattedMessage
+        id="comet.file.errors.filenameTooLong"
+        defaultMessage="<strong>Filename is too long.</strong> The filename can't exceed 255 characters."
+        values={{
+            strong: formatStrong,
+        }}
+    />
+);

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
@@ -16,6 +16,7 @@ import { NewlyUploadedItem, useFileUploadContext } from "./FileUploadContext";
 import { FileUploadErrorDialog } from "./FileUploadErrorDialog";
 import {
     FileExtensionTypeMismatchError,
+    FilenameTooLongError,
     FileSizeError,
     MaxResolutionError,
     MissingFileExtensionError,
@@ -439,6 +440,8 @@ export const useDamFileUpload = (options: UploadDamFileOptions): FileUploadApi =
                             addValidationError(file, <MissingFileExtensionError />);
                         } else if (message.includes("File type and extension mismatch")) {
                             addValidationError(file, <FileExtensionTypeMismatchError extension={extension} mimetype={file.type} />);
+                        } else if (message.includes("Filename is too long")) {
+                            addValidationError(file, <FilenameTooLongError />);
                         } else {
                             addValidationError(file, <UnknownError />);
                         }

--- a/packages/api/cms-api/src/dam/files/file-validation.service.ts
+++ b/packages/api/cms-api/src/dam/files/file-validation.service.ts
@@ -17,6 +17,11 @@ export class FileValidationService {
     }
 
     validateFileMetadata(file: Pick<FileUploadInput, "fieldname" | "originalname" | "encoding" | "mimetype">): undefined | string {
+        //maximum filename length
+        if (file.originalname.length > 255) {
+            return "Filename is too long";
+        }
+
         //mime type in an accepted mime type
         if (!this.config.acceptedMimeTypes.includes(file.mimetype)) {
             return "Unsupported mime type";


### PR DESCRIPTION
## Description

Validate filename length for uploads to DAM or FileUploads. The filename can't exceed 255 characters.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

<img width="1213" alt="Bildschirmfoto 2024-12-18 um 16 03 40" src="https://github.com/user-attachments/assets/4a4c932b-ef23-4d96-8d82-f6ed9848a84f" />

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/PHSB2C-4346
