### PR TITLE
Delete `@comet/admin-react-select` changeset

### DIFF
--- a/.changeset/nasty-peaches-relax.md
+++ b/.changeset/nasty-peaches-relax.md
@@ -1,5 +1,0 @@
----
-"@comet/admin-react-select": major
----
-
-Remove `@comet/admin-react-select` package


### PR DESCRIPTION
There can't be changesets for packages that no longer exist.
