### PR TITLE
Adjust how tooltips are triggered

### DIFF
--- a/.changeset/good-cobras-pretend.md
+++ b/.changeset/good-cobras-pretend.md
@@ -2,7 +2,10 @@
 "@comet/admin": minor
 ---
 
-Show tooltips on both `hover` and `focus` when using the default `hover` trigger and deprecate the `trigger` prop
+Adjust how tooltips are triggered
 
-This was done to achieve consistent behavior across elements and ensure tooltips are always shown before the user interacts with the underlying element.
-The `trigger` prop will be removed in a future major version, with the combined `hover`/`focus` trigger becoming the only supported behavior.
+This is to achieve a more consistent and user-friendly experience by ensuring tooltips are always shown when the user interacts with the underlying element.
+
+-   When using the default `hover` trigger, tooltips will now be shown on both `hover` and `focus`. Previously, you had to choose between `hover` and `focus`.
+-   The `trigger` prop is deprecated and will be removed in a future major version. The combined `hover`/`focus` trigger will be the only supported behavior.
+-   Tooltips on touch devices will be shown immediately when the user starts interacting with the underlying element.

--- a/.changeset/good-cobras-pretend.md
+++ b/.changeset/good-cobras-pretend.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": minor
+---
+
+Show tooltips on both `hover` and `focus` when using the default `hover` trigger and deprecate the `trigger` prop
+
+This was done to achieve consistent behavior across elements and ensure tooltips are always shown before the user interacts with the underlying element.
+The `trigger` prop will be removed in a future major version, with the combined `hover`/`focus` trigger becoming the only supported behavior.

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -14,7 +14,9 @@ import { cloneElement, ComponentProps, useState } from "react";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 
 export interface TooltipProps extends MuiTooltipProps {
-    // @deprecated Triggers other than the default "hover" will be removed in the future.
+    /**
+     * @deprecated Triggers other than the default "hover" will be removed in the future.
+     */
     trigger?: "hover" | "focus" | "click";
     variant?: Variant;
 }

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -242,7 +242,7 @@ export const Tooltip = (inProps: TooltipProps) => {
             </TooltipRoot>
         </ClickAwayListener>
     ) : (
-        <TooltipRoot disableHoverListener={trigger === "focus"} {...commonTooltipProps}>
+        <TooltipRoot disableHoverListener={trigger === "focus"} enterTouchDelay={0} {...commonTooltipProps}>
             {children}
         </TooltipRoot>
     );

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -242,7 +242,7 @@ export const Tooltip = (inProps: TooltipProps) => {
             </TooltipRoot>
         </ClickAwayListener>
     ) : (
-        <TooltipRoot disableFocusListener={trigger === "hover"} disableHoverListener={trigger === "focus"} {...commonTooltipProps}>
+        <TooltipRoot disableHoverListener={trigger === "focus"} {...commonTooltipProps}>
             {children}
         </TooltipRoot>
     );

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -14,9 +14,11 @@ import { cloneElement, ComponentProps, useState } from "react";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 
 export interface TooltipProps extends MuiTooltipProps {
+    // @deprecated Triggers other than the default "hover" will be removed in the future.
     trigger?: "hover" | "focus" | "click";
     variant?: Variant;
 }
+
 type Variant = "light" | "dark" | "neutral" | "primary" | "error" | "success";
 
 export type TooltipClassKey = "root" | Variant | MuiTooltipClassKey;

--- a/storybook/src/docs/components/Tooltip/Tooltip.mdx
+++ b/storybook/src/docs/components/Tooltip/Tooltip.mdx
@@ -14,10 +14,10 @@ The Comet Admin `Tooltip` extends [Material UI's `Tooltip`](https://mui.com/mate
 
 #### Props
 
-| Name    | Type                                             | Description                                             |
-| :------ | :----------------------------------------------- | :------------------------------------------------------ |
-| trigger | "hover", "focus", "click" (optional)             | Defines the type of event that causes a tooltip to show |
-| variant | "light", "dark", "neutral", "primary" (optional) | Defines the color scheme of a tooltip                   |
+| Name                 | Type                                             | Description                                                                                                                  |
+| :------------------- | :----------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| trigger (deprecated) | "hover", "focus", "click" (optional)             | Defines the type of event that causes a tooltip to show. <br />(_Only the default "hover" will be supported in the future._) |
+| variant              | "light", "dark", "neutral", "primary" (optional) | Defines the color scheme of a tooltip.                                                                                       |
 
 In addition to its own props, the Tooltip component also accepts all props from the Material UI Tooltip component.
 


### PR DESCRIPTION
## Description

This is to achieve a more consistent and user-friendly experience by ensuring tooltips are always shown when the user interacts with the underlying element.

-   When using the default `hover` trigger, tooltips will now be shown on both `hover` and `focus`. Previously, you had to choose between `hover` and `focus`.
-   The `trigger` prop is deprecated and will be removed in a future major version. The combined `hover`/`focus` trigger will be the only supported behavior.
-   Tooltips on touch devices will be shown immediately when the user starts interacting with the underlying element.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset
-   [x] Add PR description

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1474
