### PR TITLE
Demo: Limit max old memory for API and sites

### DIFF
--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -6,7 +6,7 @@
         "api-generator": "rimraf 'src/*/generated' && comet-api-generator generate",
         "prebuild": "rimraf dist",
         "build": "nest build",
-        "console": "dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts",
+        "console": "NODE_OPTIONS='--max-old-space-size=256' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts",
         "console:prod": "node dist/console.js",
         "db:migrate": "$npm_execpath console migrate --",
         "db:migrate:prod": "$npm_execpath console:prod migrate --",
@@ -21,7 +21,7 @@
         "mikro-orm:drop": "mikro-orm schema:drop -r",
         "mikro-orm:migration:generate": "mikro-orm migration:create",
         "start": "$npm_execpath prebuild && dotenv -c -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",
-        "start:dev": "$npm_execpath prebuild && $npm_execpath db:migrate && $npm_execpath console createBlockIndexViews && dotenv -c -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",
+        "start:dev": "$npm_execpath prebuild && $npm_execpath db:migrate && $npm_execpath console createBlockIndexViews && NODE_OPTIONS='--max-old-space-size=512' dotenv -c -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",
         "start:prod": "node dist/main"
     },
     "dependencies": {

--- a/demo/site-pages/package.json
+++ b/demo/site-pages/package.json
@@ -8,7 +8,7 @@
         "build:preBuild:tsc": "tsc --project tsconfig.preBuild.json",
         "build:publicGenerated": "node preBuild/build/preBuild/src/publicGenerator/generate.js",
         "clear:preBuild": "rimraf preBuild/build",
-        "dev": "run-s intl:compile && run-p gql:types generate-block-types && $npm_execpath build:preBuild && NODE_OPTIONS='--inspect=localhost:9230' node server.js",
+        "dev": "run-s intl:compile && run-p gql:types generate-block-types && $npm_execpath build:preBuild && NODE_OPTIONS='--inspect=localhost:9230 --max-old-space-size=512' node server.js",
         "export": "next export",
         "extract:publicGenerated": "node preBuild/build/preBuild/src/publicGenerator/extract.js",
         "generate-block-types": "comet generate-block-types",

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "build": "run-s intl:compile && run-p gql:types generate-block-types && tsc --project tsconfig.server.json && next build",
-        "dev": "run-s intl:compile && run-p gql:types generate-block-types && tsc --project tsconfig.server.json && NODE_OPTIONS='--inspect=localhost:9230' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node dist/server.js",
+        "dev": "run-s intl:compile && run-p gql:types generate-block-types && tsc --project tsconfig.server.json && NODE_OPTIONS='--inspect=localhost:9230 --max-old-space-size=512' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node dist/server.js",
         "export": "next export",
         "generate-block-types": "comet generate-block-types",
         "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",


### PR DESCRIPTION
## Description

We've noticed that some of our applications require a significant amount of memory when deployed. Devs tend to increase the resources in the deployment instead of optimizing the code. To prevent this, we limit the memory during development using [--max-old-space-size](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-mib).

## Further information

The values I've chosen are somewhat arbitrary. I've startet at 256 MB (like in the charts) and doubled the size if I encountered an out-of-memory-error.
