### PR TITLE
Use `ToolbarActionButton` as the base for `GridFilterButton` and `GridColumnsButton`

### DIFF
--- a/.changeset/calm-worms-fetch.md
+++ b/.changeset/calm-worms-fetch.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": minor
+---
+
+Make `GridFilterButton` and `GridColumnsButton` responsive by moving their text to a tooltip on mobile
+
+-   This also makes the button's styles consistent with the standard `Button` component
+-   `GridFilterButton` now supports props to override the default button props

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
@@ -78,7 +78,7 @@ export const ToolbarActionButton = (props: ToolbarActionButtonProps) => {
 
     return useIconButton && icon ? (
         <StyledTooltip title={children} {...tooltipProps}>
-            <StyledIconButton ownerState={ownerState} {...iconButtonProps}>
+            <StyledIconButton ownerState={ownerState} {...restProps} {...iconButtonProps}>
                 {icon}
             </StyledIconButton>
         </StyledTooltip>

--- a/packages/admin/admin/src/dataGrid/GridColumnsButton.tsx
+++ b/packages/admin/admin/src/dataGrid/GridColumnsButton.tsx
@@ -1,23 +1,22 @@
 import { Columns4 } from "@comet/admin-icons";
-import { GridToolbarColumnsButton } from "@mui/x-data-grid";
-import { ComponentProps } from "react";
+import { ButtonProps } from "@mui/material";
+import { GridPreferencePanelsValue, useGridApiContext } from "@mui/x-data-grid";
+import { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 
+import { ToolbarActionButton } from "../common/toolbar/actions/ToolbarActionButton";
 import { messages } from "../messages";
 
-type Props = Omit<ComponentProps<typeof GridToolbarColumnsButton>, "onResize" | "onResizeCapture">;
+export function GridColumnsButton(props: ButtonProps) {
+    const apiRef = useGridApiContext();
 
-export function GridColumnsButton(props: Props) {
+    const handleFilterClick = useCallback(() => {
+        apiRef.current.showPreferences(GridPreferencePanelsValue.columns);
+    }, [apiRef]);
+
     return (
-        <GridToolbarColumnsButton
-            startIcon={<Columns4 />}
-            variant="outlined"
-            color="info"
-            onResize={undefined}
-            onResizeCapture={undefined}
-            {...props}
-        >
+        <ToolbarActionButton startIcon={<Columns4 />} variant="outlined" onClick={handleFilterClick} {...props}>
             <FormattedMessage {...messages.columns} />
-        </GridToolbarColumnsButton>
+        </ToolbarActionButton>
     );
 }

--- a/packages/admin/admin/src/dataGrid/GridFilterButton.tsx
+++ b/packages/admin/admin/src/dataGrid/GridFilterButton.tsx
@@ -1,26 +1,22 @@
 import { Filter } from "@comet/admin-icons";
-import { Button } from "@mui/material";
+import { ButtonProps } from "@mui/material";
 import { useGridApiContext } from "@mui/x-data-grid";
 import { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 
+import { ToolbarActionButton } from "../common/toolbar/actions/ToolbarActionButton";
 import { messages } from "../messages";
 
-export function GridFilterButton() {
+export function GridFilterButton(props: ButtonProps) {
     const apiRef = useGridApiContext();
+
     const handleFilterClick = useCallback(() => {
         apiRef.current.showFilterPanel();
     }, [apiRef]);
+
     return (
-        <Button
-            startIcon={<Filter />}
-            variant="outlined"
-            onClick={handleFilterClick}
-            sx={{
-                borderColor: (theme) => theme.palette.grey[100],
-            }}
-        >
+        <ToolbarActionButton startIcon={<Filter />} variant="outlined" onClick={handleFilterClick} {...props}>
             <FormattedMessage {...messages.filter} />
-        </Button>
+        </ToolbarActionButton>
     );
 }

--- a/storybook/src/admin/toolbar/DataGridToolbar.stories.tsx
+++ b/storybook/src/admin/toolbar/DataGridToolbar.stories.tsx
@@ -1,4 +1,4 @@
-import { DataGridToolbar, GridFilterButton, StackLink, ToolbarActions, ToolbarFillSpace, ToolbarItem } from "@comet/admin";
+import { DataGridToolbar, GridColumnsButton, GridFilterButton, StackLink, ToolbarActions, ToolbarFillSpace, ToolbarItem } from "@comet/admin";
 import { Add as AddIcon } from "@comet/admin-icons";
 import { Button } from "@mui/material";
 import { DataGrid, GridToolbarQuickFilter } from "@mui/x-data-grid";
@@ -36,6 +36,9 @@ export const _DataGridToolbar = {
                             </ToolbarItem>
                             <ToolbarItem>
                                 <GridFilterButton />
+                            </ToolbarItem>
+                            <ToolbarItem>
+                                <GridColumnsButton />
                             </ToolbarItem>
                             <ToolbarFillSpace />
                             <ToolbarActions>


### PR DESCRIPTION
## Description

This makes the buttons responsive by moving their text to a tooltip on mobile. 

This also removes the custom border-color on `GridFilterButton` to match the default button design. 

Changes to the props of `GridFilterButton` are not notable in the changeset as they essentially already extended MUIs `ButtonProps`. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshot desktop

| Before | After |
| ------ | ----- |
| <img width="768" alt="Desktop Before" src="https://github.com/user-attachments/assets/641861e7-d433-4d6f-b2f3-81e24880993f" />   | <img width="768" alt="Desktop Now" src="https://github.com/user-attachments/assets/4bca2fb6-f521-41bd-b014-4f07aa639e04" />  |


## Screenshot mobile (hovering "Columns")

| Before | After |
| ------ | ----- |
| <img width="424" alt="Mobile Before" src="https://github.com/user-attachments/assets/cc952367-68f0-4ce4-8c17-462e45ab505e" />  |  <img width="424" alt="Mobile Now" src="https://github.com/user-attachments/assets/8697fdfc-332f-4162-b96f-7e163d51bc19" /> |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1506
