### PR TITLE
RFC: Combine features of `ToolbarActionButton` and `FeedbackButton` into a single `Button` component

### DIFF
--- a/packages/admin/admin/src/common/buttons/Button.tsx
+++ b/packages/admin/admin/src/common/buttons/Button.tsx
@@ -1,0 +1,77 @@
+import { Breakpoint, Button as MuiButton, ButtonProps as MuiButtonProps, ComponentsOverrides, Theme, useThemeProps } from "@mui/material";
+import { ReactNode } from "react";
+
+import { createComponentSlot } from "../../helpers/createComponentSlot";
+import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
+
+export type ButtonClassKey = "root";
+
+type ButtonThemeProps = ThemedComponentBaseProps<{
+    root: typeof MuiButton;
+}>;
+
+type ResponsiveBehaviorOptions = {
+    breakpoint?: Breakpoint;
+    mobileIcon?: "startIcon" | "endIcon" | ReactNode;
+};
+
+type FeedbackBehaviorOptions = {
+    successMessage?: ReactNode;
+    errorMessage?: ReactNode;
+    loading?: boolean;
+    hasError?: boolean;
+    tooltipDuration?: {
+        success?: number;
+        error?: number;
+    };
+};
+
+/**
+ * TODO:
+ * - Restrice imports from MuiButton
+ * - Consider if we should also use this for IconButtons (and restrict imports from MuiIconButton)
+ */
+
+type CustomButtonProps = {
+    // TODO: Implement responsive behavior
+    // TODO: Should we render an `IconButton` component or style `Button` to work with just an icon?
+    responsiveBehavior?: boolean | ResponsiveBehaviorOptions;
+
+    // TODO: Implement feedback on click behavior
+    // TODO: Figure out if we only need the controlled or uncontrolled version
+    feedbackBehavior?: boolean | FeedbackBehaviorOptions;
+
+    iconMapping?: {
+        loading?: ReactNode;
+    };
+};
+
+export type ButtonProps = CustomButtonProps & ButtonThemeProps & MuiButtonProps;
+
+export const Button = (props: ButtonProps) => {
+    const { slotProps, responsiveBehavior, feedbackBehavior, ...restProps } = useThemeProps({ props, name: "CometAdminButton" });
+
+    return <Root {...restProps} {...slotProps?.root} />;
+};
+
+const Root = createComponentSlot(MuiButton)<ButtonClassKey>({
+    componentName: "Button",
+    slotName: "root",
+})();
+
+declare module "@mui/material/styles" {
+    interface ComponentNameToClassKey {
+        CometAdminButton: ButtonClassKey;
+    }
+
+    interface ComponentsPropsList {
+        CometAdminButton: ButtonProps;
+    }
+
+    interface Components {
+        CometAdminButton?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminButton"];
+        };
+    }
+}

--- a/packages/admin/admin/src/common/buttons/feedback/FeedbackButton.tsx
+++ b/packages/admin/admin/src/common/buttons/feedback/FeedbackButton.tsx
@@ -48,6 +48,9 @@ export interface FeedbackButtonProps
 
 type FeedbackButtonDisplayState = "idle" | "loading" | "success" | "error";
 
+/**
+ * @deprecated Use `Button` from `@comet/admin` instead
+ */
 export function FeedbackButton(inProps: FeedbackButtonProps) {
     const {
         onClick,

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
@@ -7,7 +7,7 @@ import { useWindowSize } from "../../../helpers/useWindowSize";
 
 export type ToolbarActionButtonClassKey = "root" | "tooltip" | "button" | "iconButton" | "text" | "outlined" | "contained";
 
-type ToolbarActionButtonProps = ButtonProps &
+export type ToolbarActionButtonProps = ButtonProps &
     ThemedComponentBaseProps<{
         tooltip: typeof Tooltip;
         iconButton: typeof IconButton;
@@ -65,6 +65,9 @@ const StyledButton = createComponentSlot(Button)<ToolbarActionButtonClassKey, Ow
     },
 })();
 
+/**
+ * @deprecated Use `Button` from `@comet/admin` instead
+ */
 export const ToolbarActionButton = (props: ToolbarActionButtonProps) => {
     const { children, slotProps = {}, ...restProps } = useThemeProps({ props, name: "CometAdminToolbarActionButton" });
     const { iconButton: iconButtonProps, tooltip: tooltipProps, button: buttonProps } = slotProps;

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -10,6 +10,7 @@ export { AppHeaderMenuButton, AppHeaderMenuButtonClassKey, AppHeaderMenuButtonPr
 export { buildCreateRestMutation, buildDeleteRestMutation, buildUpdateRestMutation } from "./buildRestMutation";
 export { readClipboardText } from "./clipboard/readClipboardText";
 export { writeClipboardText } from "./clipboard/writeClipboardText";
+export { Button, ButtonClassKey, ButtonProps } from "./common/buttons/Button";
 export { CancelButton, CancelButtonClassKey, CancelButtonProps } from "./common/buttons/cancel/CancelButton";
 export { ClearInputButton, ClearInputButtonClassKey, ClearInputButtonProps } from "./common/buttons/clearinput/ClearInputButton";
 export { CopyToClipboardButton, CopyToClipboardButtonClassKey, CopyToClipboardButtonProps } from "./common/buttons/CopyToClipboardButton";
@@ -28,6 +29,7 @@ export { FullHeightContent, FullHeightContentClassKey, FullHeightContentProps } 
 export { HoverActions, HoverActionsClassKey, HoverActionsProps } from "./common/HoverActions";
 export { Loading, LoadingProps } from "./common/Loading";
 export { MainContent, MainContentClassKey, MainContentProps, StackMainContent } from "./common/MainContent";
+export { ToolbarActionButton, ToolbarActionButtonClassKey, ToolbarActionButtonProps } from "./common/toolbar/actions/ToolbarActionButton";
 export { ToolbarActions, ToolbarActionsClassKey } from "./common/toolbar/actions/ToolbarActions";
 export {
     ToolbarAutomaticTitleItem,
@@ -74,11 +76,6 @@ export { createFetch, FetchContext, FetchProvider, useFetch } from "./fetchProvi
 export { FileIcon } from "./fileIcons/FileIcon";
 export { FinalForm, FinalFormSubmitEvent, useFormApiRef } from "./FinalForm";
 export { FinalFormSaveButton } from "./FinalFormSaveButton";
-export {
-    FinalFormSaveCancelButtonsLegacy,
-    FinalFormSaveCancelButtonsLegacyClassKey,
-    FinalFormSaveCancelButtonsLegacyProps,
-} from "./FinalFormSaveCancelButtonsLegacy";
 export { FinalFormSaveSplitButton } from "./FinalFormSaveSplitButton";
 export {
     /**

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -10,7 +10,7 @@ export { AppHeaderMenuButton, AppHeaderMenuButtonClassKey, AppHeaderMenuButtonPr
 export { buildCreateRestMutation, buildDeleteRestMutation, buildUpdateRestMutation } from "./buildRestMutation";
 export { readClipboardText } from "./clipboard/readClipboardText";
 export { writeClipboardText } from "./clipboard/writeClipboardText";
-export { Button, ButtonClassKey, ButtonProps } from "./common/buttons/Button";
+export { Button, ButtonClassKey, ButtonFeedbackState, ButtonProps } from "./common/buttons/Button";
 export { CancelButton, CancelButtonClassKey, CancelButtonProps } from "./common/buttons/cancel/CancelButton";
 export { ClearInputButton, ClearInputButtonClassKey, ClearInputButtonProps } from "./common/buttons/clearinput/ClearInputButton";
 export { CopyToClipboardButton, CopyToClipboardButtonClassKey, CopyToClipboardButtonProps } from "./common/buttons/CopyToClipboardButton";

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -76,6 +76,11 @@ export { createFetch, FetchContext, FetchProvider, useFetch } from "./fetchProvi
 export { FileIcon } from "./fileIcons/FileIcon";
 export { FinalForm, FinalFormSubmitEvent, useFormApiRef } from "./FinalForm";
 export { FinalFormSaveButton } from "./FinalFormSaveButton";
+export {
+    FinalFormSaveCancelButtonsLegacy,
+    FinalFormSaveCancelButtonsLegacyClassKey,
+    FinalFormSaveCancelButtonsLegacyProps,
+} from "./FinalFormSaveCancelButtonsLegacy";
 export { FinalFormSaveSplitButton } from "./FinalFormSaveSplitButton";
 export {
     /**

--- a/storybook/src/docs/components/Button/Button.mdx
+++ b/storybook/src/docs/components/Button/Button.mdx
@@ -1,0 +1,17 @@
+import { Canvas, Meta } from "@storybook/addon-docs";
+
+import * as ButtonStories from "./Button.stories";
+
+<Meta of={ButtonStories} />
+
+## All Button Variants
+
+<Canvas of={ButtonStories.AllButtonVariants} />
+
+## Responsive Behavior
+
+<Canvas of={ButtonStories.ResponsiveBehavior} />
+
+## Feedback Behavior
+
+<Canvas of={ButtonStories.FeedbackBehavior} />

--- a/storybook/src/docs/components/Button/Button.stories.tsx
+++ b/storybook/src/docs/components/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import { Button, FeedbackButton, ToolbarActionButton } from "@comet/admin";
-import { Add, ArrowRight } from "@comet/admin-icons";
+import { Add, ArrowRight, Favorite } from "@comet/admin-icons";
 import { Box, Card, CardContent, CardHeader, Chip, Stack, SxProps, Theme } from "@mui/material";
 import { Children, cloneElement, ReactElement, ReactNode } from "react";
 
@@ -261,6 +261,17 @@ export const ResponsiveBehavior = {
                                 responsiveBehavior={{
                                     mobileIcon: <ArrowRight />,
                                 }}
+                                variant="outlined"
+                            >
+                                Button
+                            </Button>
+                            <Button
+                                responsiveBehavior={{
+                                    breakpoint: "md",
+                                    mobileIcon: "endIcon",
+                                }}
+                                startIcon={<ArrowRight />}
+                                endIcon={<Favorite />}
                                 variant="outlined"
                             >
                                 Button

--- a/storybook/src/docs/components/Button/Button.stories.tsx
+++ b/storybook/src/docs/components/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
-import { Button, FeedbackButton, ToolbarActionButton } from "@comet/admin";
+import { Button, ButtonFeedbackState, FeedbackButton, ToolbarActionButton } from "@comet/admin";
 import { Add, ArrowRight, Favorite } from "@comet/admin-icons";
-import { Box, Card, CardContent, CardHeader, Chip, Stack, SxProps, Theme } from "@mui/material";
-import { Children, cloneElement, ReactElement, ReactNode } from "react";
+import { Box, Card, CardContent, CardHeader, Chip, Stack, SxProps, Theme, Typography } from "@mui/material";
+import { Children, cloneElement, ReactElement, ReactNode, useState } from "react";
 
 export default {
     title: "Docs/Components/Button",
@@ -287,12 +287,24 @@ export const ResponsiveBehavior = {
 export const FeedbackBehavior = {
     // TODO
     render: () => {
+        const [firstButtonLoading, setFirstButtonLoading] = useState(false);
+        const [secondButtonLoading, setSecondButtonLoading] = useState(false);
+
+        const [firstButtonHasErrors, setFirstButtonHasErrors] = useState(false);
+        const [secondButtonHasErrors, setSecondButtonHasErrors] = useState(false);
+
+        const [thirdButtonState, setThirdButtonState] = useState<ButtonFeedbackState>("none");
+        const [fourthButtonState, setFourthButtonState] = useState<ButtonFeedbackState>("none");
+
         return (
             <Stack gap={4}>
                 <Card>
                     <CardHeader title="Legacy (FeedbackButton)" />
                     <CardContent>
-                        <GroupOfElements sx={{ alignItems: "center" }}>
+                        <Typography variant="h6" gutterBottom>
+                            Uncontrolled (feedback state depends on the promise)
+                        </Typography>
+                        <Stack direction="row" gap={4} mb={8}>
                             <FeedbackButton
                                 startIcon={<Add />}
                                 onClick={() => {
@@ -309,8 +321,51 @@ export const FeedbackBehavior = {
                             >
                                 This will fail
                             </FeedbackButton>
+                        </Stack>
+                        <Typography variant="h6" gutterBottom>
+                            Controlled (feedback state depends on the props)
+                        </Typography>
+                        <Stack direction="row" gap={4} mb={8}>
                             <FeedbackButton
+                                loading={firstButtonLoading}
+                                hasErrors={firstButtonHasErrors}
                                 startIcon={<Add />}
+                                onClick={() => {
+                                    setFirstButtonLoading(true);
+
+                                    setTimeout(() => {
+                                        setFirstButtonLoading(false);
+                                        setFirstButtonHasErrors(false);
+                                    }, 1000);
+                                }}
+                            >
+                                This will succeed
+                            </FeedbackButton>
+                            <FeedbackButton
+                                loading={secondButtonLoading}
+                                hasErrors={secondButtonHasErrors}
+                                startIcon={<Add />}
+                                onClick={() => {
+                                    setSecondButtonLoading(true);
+
+                                    setTimeout(() => {
+                                        setSecondButtonLoading(false);
+                                        setSecondButtonHasErrors(true);
+
+                                        setTimeout(() => {
+                                            setSecondButtonHasErrors(false);
+                                        }, 1000);
+                                    }, 1000);
+                                }}
+                            >
+                                This will fail
+                            </FeedbackButton>
+                        </Stack>
+                        <Typography variant="h6" gutterBottom>
+                            With custom messages and no icon
+                        </Typography>
+                        <Stack direction="row" gap={4} mb={8}>
+                            <FeedbackButton
                                 onClick={() => {
                                     return new Promise((resolve) => setTimeout(resolve, 500));
                                 }}
@@ -320,7 +375,6 @@ export const FeedbackBehavior = {
                                 Custom message (succeeds)
                             </FeedbackButton>
                             <FeedbackButton
-                                startIcon={<Add />}
                                 onClick={() => {
                                     return new Promise((_, reject) => setTimeout(reject, 500));
                                 }}
@@ -329,15 +383,19 @@ export const FeedbackBehavior = {
                             >
                                 Custom message (fails)
                             </FeedbackButton>
-                        </GroupOfElements>
+                        </Stack>
                     </CardContent>
                 </Card>
                 <Card>
                     <CardHeader title="New (Button)" />
                     <CardContent>
-                        <GroupOfElements sx={{ alignItems: "center" }}>
+                        <Typography variant="h6" gutterBottom>
+                            Uncontrolled (feedback state depends on the promise)
+                        </Typography>
+                        <Stack direction="row" gap={4} mb={8}>
                             <Button
                                 variant="contained"
+                                responsiveBehavior
                                 startIcon={<Add />}
                                 feedbackBehavior
                                 onClick={() => {
@@ -348,6 +406,7 @@ export const FeedbackBehavior = {
                             </Button>
                             <Button
                                 variant="contained"
+                                responsiveBehavior
                                 startIcon={<Add />}
                                 feedbackBehavior
                                 onClick={() => {
@@ -356,9 +415,63 @@ export const FeedbackBehavior = {
                             >
                                 This will fail
                             </Button>
+                        </Stack>
+                        <Typography variant="h6" gutterBottom>
+                            Controlled (feedback state depends on the props)
+                        </Typography>
+                        <Stack direction="row" gap={4} mb={8}>
                             <Button
                                 variant="contained"
+                                responsiveBehavior
                                 startIcon={<Add />}
+                                feedbackBehavior={{
+                                    state: thirdButtonState,
+                                }}
+                                onClick={() => {
+                                    setThirdButtonState("loading");
+
+                                    setTimeout(() => {
+                                        setThirdButtonState("success");
+
+                                        setTimeout(() => {
+                                            setThirdButtonState("none");
+                                        }, 2000);
+                                    }, 1000);
+                                }}
+                            >
+                                This will succeed
+                            </Button>
+                            <Button
+                                variant="contained"
+                                responsiveBehavior
+                                startIcon={<Add />}
+                                feedbackBehavior={{
+                                    state: fourthButtonState,
+                                }}
+                                onClick={() => {
+                                    setFourthButtonState("loading");
+
+                                    setTimeout(() => {
+                                        setFourthButtonState("error");
+
+                                        setTimeout(() => {
+                                            setFourthButtonState("none");
+                                        }, 5000);
+                                    }, 1000);
+                                }}
+                            >
+                                This will fail
+                            </Button>
+                        </Stack>
+                        <Typography variant="h6" gutterBottom>
+                            With custom messages and no icon
+                        </Typography>
+                        <Stack direction="row" gap={4} mb={8}>
+                            <Button
+                                variant="contained"
+                                responsiveBehavior={{
+                                    mobileIcon: <Add />,
+                                }}
                                 feedbackBehavior={{
                                     successMessage: "This worked and has a custom message",
                                     errorMessage: "This failed but at least it has a custom message",
@@ -371,7 +484,9 @@ export const FeedbackBehavior = {
                             </Button>
                             <Button
                                 variant="contained"
-                                startIcon={<Add />}
+                                responsiveBehavior={{
+                                    mobileIcon: <Add />,
+                                }}
                                 feedbackBehavior={{
                                     successMessage: "This worked and has a custom message",
                                     errorMessage: "This failed but at least it has a custom message",
@@ -382,7 +497,7 @@ export const FeedbackBehavior = {
                             >
                                 Custom message (fails)
                             </Button>
-                        </GroupOfElements>
+                        </Stack>
                     </CardContent>
                 </Card>
             </Stack>

--- a/storybook/src/docs/components/Button/Button.stories.tsx
+++ b/storybook/src/docs/components/Button/Button.stories.tsx
@@ -1,0 +1,380 @@
+import { Button, FeedbackButton, ToolbarActionButton } from "@comet/admin";
+import { Add, ArrowRight } from "@comet/admin-icons";
+import { Box, Card, CardContent, CardHeader, Chip, Stack, SxProps, Theme } from "@mui/material";
+import { Children, cloneElement, ReactElement, ReactNode } from "react";
+
+export default {
+    title: "Docs/Components/Button",
+};
+
+const GroupOfElements = ({ children, sx }: { children: ReactNode; sx?: SxProps<Theme> }) => {
+    return (
+        <Stack flexDirection="row" flexWrap="wrap" gap={{ xs: 2, md: 4 }} p={{ xs: 2, md: 4 }} sx={sx}>
+            {Children.map(children, (child: ReactElement) => (
+                <Box sx={{ flex: 1 }}>{cloneElement(child)}</Box>
+            ))}
+        </Stack>
+    );
+};
+
+/**
+ * TODO:
+ * - Fix minWidth of icon-only buttons
+ * - Fix size-increase due to chip
+ * - Fix requiring custom styling
+ */
+export const AllButtonVariants = {
+    render: () => {
+        return (
+            <Card>
+                <CardContent>
+                    <GroupOfElements>
+                        <Button variant="contained">Button</Button>
+                        <Button variant="contained" startIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="contained" endIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="contained" endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button variant="contained" startIcon={<ArrowRight />} endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button
+                            variant="contained"
+                            endIcon={
+                                <>
+                                    <ArrowRight />
+                                    <Chip label={4} />
+                                </>
+                            }
+                        >
+                            Button
+                        </Button>
+                        <Button variant="contained" sx={{ minWidth: 0 }}>
+                            <ArrowRight />
+                        </Button>
+                    </GroupOfElements>
+                    <GroupOfElements>
+                        <Button variant="contained" color="secondary">
+                            Button
+                        </Button>
+                        <Button variant="contained" color="secondary" startIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="contained" color="secondary" endIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="contained" color="secondary" endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button variant="contained" color="secondary" startIcon={<ArrowRight />} endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button
+                            variant="contained"
+                            color="secondary"
+                            endIcon={
+                                <>
+                                    <ArrowRight />
+                                    <Chip label={4} />
+                                </>
+                            }
+                        >
+                            Button
+                        </Button>
+                        <Button variant="contained" color="secondary" sx={{ minWidth: 0 }}>
+                            <ArrowRight />
+                        </Button>
+                    </GroupOfElements>
+                    <GroupOfElements>
+                        <Button variant="outlined">Button</Button>
+                        <Button variant="outlined" startIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="outlined" endIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="outlined" endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button variant="outlined" startIcon={<ArrowRight />} endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button
+                            variant="outlined"
+                            endIcon={
+                                <>
+                                    <ArrowRight />
+                                    <Chip label={4} />
+                                </>
+                            }
+                        >
+                            Button
+                        </Button>
+                        <Button variant="outlined" sx={{ minWidth: 0 }}>
+                            <ArrowRight />
+                        </Button>
+                    </GroupOfElements>
+                    <GroupOfElements>
+                        <Button variant="outlined" color="error">
+                            Button
+                        </Button>
+                        <Button variant="outlined" color="error" startIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="outlined" color="error" endIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="outlined" color="error" endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button variant="outlined" color="error" startIcon={<ArrowRight />} endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button
+                            variant="outlined"
+                            color="error"
+                            endIcon={
+                                <>
+                                    <ArrowRight />
+                                    <Chip label={4} />
+                                </>
+                            }
+                        >
+                            Button
+                        </Button>
+                        <Button variant="outlined" color="error" sx={{ minWidth: 0 }}>
+                            <ArrowRight />
+                        </Button>
+                    </GroupOfElements>
+                    <GroupOfElements>
+                        <Button variant="contained" color="success">
+                            Button
+                        </Button>
+                        <Button variant="contained" color="success" startIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="contained" color="success" endIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="contained" color="success" endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button variant="contained" color="success" startIcon={<ArrowRight />} endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button
+                            variant="contained"
+                            color="success"
+                            endIcon={
+                                <>
+                                    <ArrowRight />
+                                    <Chip label={4} />
+                                </>
+                            }
+                        >
+                            Button
+                        </Button>
+                        <Button variant="contained" color="success" sx={{ minWidth: 0 }}>
+                            <ArrowRight />
+                        </Button>
+                    </GroupOfElements>
+                    <GroupOfElements sx={(theme) => ({ backgroundColor: theme.palette.grey[800] })}>
+                        {/* TODO: Move this color-variant to the theme */}
+                        <Button variant="text" sx={{ color: "white" }}>
+                            Button
+                        </Button>
+                        <Button variant="text" sx={{ color: "white" }} startIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="text" sx={{ color: "white" }} endIcon={<ArrowRight />}>
+                            Button
+                        </Button>
+                        <Button variant="text" sx={{ color: "white" }} endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button variant="text" sx={{ color: "white" }} startIcon={<ArrowRight />} endIcon={<Chip label={4} />}>
+                            Button
+                        </Button>
+                        <Button
+                            variant="text"
+                            sx={{ color: "white" }}
+                            endIcon={
+                                <>
+                                    <ArrowRight />
+                                    <Chip label={4} />
+                                </>
+                            }
+                        >
+                            Button
+                        </Button>
+                        <Button
+                            variant="text"
+                            sx={{
+                                color: "white",
+                                minWidth: 0,
+                            }}
+                        >
+                            <ArrowRight />
+                        </Button>
+                    </GroupOfElements>
+                </CardContent>
+            </Card>
+        );
+    },
+};
+
+export const ResponsiveBehavior = {
+    render: () => {
+        return (
+            <Stack gap={4}>
+                <Card>
+                    <CardHeader title="Legacy (ToolbarActionButton)" />
+                    <CardContent>
+                        <GroupOfElements sx={{ alignItems: "center" }}>
+                            <ToolbarActionButton startIcon={<ArrowRight />} variant="contained">
+                                Button
+                            </ToolbarActionButton>
+                            <ToolbarActionButton endIcon={<ArrowRight />} variant="contained" color="secondary">
+                                Button
+                            </ToolbarActionButton>
+                            <ToolbarActionButton startIcon={<ArrowRight />} variant="outlined">
+                                Button
+                            </ToolbarActionButton>
+                        </GroupOfElements>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader title="New (Button)" />
+                    <CardContent>
+                        <GroupOfElements sx={{ alignItems: "center" }}>
+                            <Button responsiveBehavior startIcon={<ArrowRight />} variant="contained">
+                                Button
+                            </Button>
+                            <Button responsiveBehavior endIcon={<ArrowRight />} variant="contained" color="secondary">
+                                Button
+                            </Button>
+                            <Button
+                                responsiveBehavior={{
+                                    mobileIcon: <ArrowRight />,
+                                }}
+                                variant="outlined"
+                            >
+                                Button
+                            </Button>
+                        </GroupOfElements>
+                    </CardContent>
+                </Card>
+            </Stack>
+        );
+    },
+};
+
+export const FeedbackBehavior = {
+    // TODO
+    render: () => {
+        return (
+            <Stack gap={4}>
+                <Card>
+                    <CardHeader title="Legacy (FeedbackButton)" />
+                    <CardContent>
+                        <GroupOfElements sx={{ alignItems: "center" }}>
+                            <FeedbackButton
+                                startIcon={<Add />}
+                                onClick={() => {
+                                    return new Promise((resolve) => setTimeout(resolve, 500));
+                                }}
+                            >
+                                This will succeed
+                            </FeedbackButton>
+                            <FeedbackButton
+                                startIcon={<Add />}
+                                onClick={() => {
+                                    return new Promise((_, reject) => setTimeout(reject, 500));
+                                }}
+                            >
+                                This will fail
+                            </FeedbackButton>
+                            <FeedbackButton
+                                startIcon={<Add />}
+                                onClick={() => {
+                                    return new Promise((resolve) => setTimeout(resolve, 500));
+                                }}
+                                tooltipErrorMessage="This failed but at least it has a custom message"
+                                tooltipSuccessMessage="This worked and has a custom message"
+                            >
+                                Custom message (succeeds)
+                            </FeedbackButton>
+                            <FeedbackButton
+                                startIcon={<Add />}
+                                onClick={() => {
+                                    return new Promise((_, reject) => setTimeout(reject, 500));
+                                }}
+                                tooltipErrorMessage="This failed but at least it has a custom message"
+                                tooltipSuccessMessage="This worked and has a custom message"
+                            >
+                                Custom message (fails)
+                            </FeedbackButton>
+                        </GroupOfElements>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader title="New (Button)" />
+                    <CardContent>
+                        <GroupOfElements sx={{ alignItems: "center" }}>
+                            <Button
+                                variant="contained"
+                                startIcon={<Add />}
+                                feedbackBehavior
+                                onClick={() => {
+                                    return new Promise((resolve) => setTimeout(resolve, 500));
+                                }}
+                            >
+                                This will succeed
+                            </Button>
+                            <Button
+                                variant="contained"
+                                startIcon={<Add />}
+                                feedbackBehavior
+                                onClick={() => {
+                                    return new Promise((_, reject) => setTimeout(reject, 500));
+                                }}
+                            >
+                                This will fail
+                            </Button>
+                            <Button
+                                variant="contained"
+                                startIcon={<Add />}
+                                feedbackBehavior={{
+                                    successMessage: "This worked and has a custom message",
+                                    errorMessage: "This failed but at least it has a custom message",
+                                }}
+                                onClick={() => {
+                                    return new Promise((resolve) => setTimeout(resolve, 500));
+                                }}
+                            >
+                                Custom message (succeeds)
+                            </Button>
+                            <Button
+                                variant="contained"
+                                startIcon={<Add />}
+                                feedbackBehavior={{
+                                    successMessage: "This worked and has a custom message",
+                                    errorMessage: "This failed but at least it has a custom message",
+                                }}
+                                onClick={() => {
+                                    return new Promise((_, reject) => setTimeout(reject, 500));
+                                }}
+                            >
+                                Custom message (fails)
+                            </Button>
+                        </GroupOfElements>
+                    </CardContent>
+                </Card>
+            </Stack>
+        );
+    },
+};


### PR DESCRIPTION
## Description

## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [ ] Add changeset
-   [ ] Docs
-   [ ] Should the width/height of the responsive icon-button be smaller than the standard button design, as `ToolbarActionButton` currently is?
 -   [ ] Should we restrict imports from `MuiButton`?
 -   [ ] Should we also use this for IconButtons (and restrict imports from `MuiIconButton`)?
 -   [ ] Move FeedbackTooltip and FeedbackLoading to the right side, if only an `endIcon` is set. 
 -   [ ] Position the loading icon correctly, depending on the icons and the responsive behavior.
 -   [ ] Prevent setting no icon (`startIcon`, `endIcon`, `mobileIcon`) when using `responsiveBehavior` (ts-error?)
 -   [ ] Fix this console error: `MUI: You have provided a 'title' prop to the child of <Tooltip />`

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1289
