### PR TITLE
Prevent image uploads from failing if exif data cannot be parsed

### DIFF
--- a/.changeset/smart-humans-report.md
+++ b/.changeset/smart-humans-report.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Prevent image uploads from failing if exif data cannot be parsed

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -630,7 +630,11 @@ export class FilesService {
 
         let exifData: Record<string, string | number | Uint8Array | number[] | Uint16Array> | undefined;
         if (exifrSupportedMimetypes.includes(file.mimetype)) {
-            exifData = await exifr.parse(file.path);
+            try {
+                exifData = await exifr.parse(file.path);
+            } catch {
+                // empty
+            }
         }
 
         return { exifData, contentHash, image };

--- a/project-words.txt
+++ b/project-words.txt
@@ -17,3 +17,4 @@ rgba
 subcomponent
 subpage
 typesafe
+exif


### PR DESCRIPTION
## Description

Previously, image upload would sometimes fail because the exif data couldn't be parsed. 

In my opinion, the exif data is nice-to-have but isn't important enough to justify a failing upload. Thus, I now prevent a hard error if the exif parse fails, instead just leaving the exif data empty.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Before:

<img width="1294" alt="Bildschirmfoto 2024-12-31 um 12 54 51" src="https://github.com/user-attachments/assets/c1da6663-570e-494d-afc8-74ed2bab1c89" />

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1239
