### PR TITLE
Add `image/x-icon` to and remove `video/avi`, `image/psd` and `video/x-m4v` from accepted mimetypes

### DIFF
--- a/.changeset/hot-cheetahs-juggle.md
+++ b/.changeset/hot-cheetahs-juggle.md
@@ -1,0 +1,15 @@
+---
+"@comet/cms-admin": patch
+"@comet/cms-api": patch
+---
+
+Remove `video/avi`, `image/psd` and `video/x-m4v` from default accepted mimetypes
+
+None of this mimetypes had an actual impact:
+
+-   `video/avi` doesn't actually exist
+-   `image/psd` doesn't exist / is non-standard
+-   `video/x-m4v` is a niche format and the mimetype is not widely used (e.g., Google Chrome and MacOS use `video/mp4`
+    instead)
+
+So removing them shouldn't have any noticeable effects.

--- a/.changeset/hungry-ties-relate.md
+++ b/.changeset/hungry-ties-relate.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-admin": patch
+"@comet/cms-api": patch
+---
+
+Add `image/x-icon` to default accepted mimetypes
+
+Previously, only `image/vnd.microsoft.icon` was supported. That could lead to problems uploading .ico files, since
+`image/vnd.microsoft.icon` and `image/x-icon` are valid mimetypes for this format.

--- a/packages/admin/cms-admin/src/dam/config/damDefaultAcceptedMimeTypes.ts
+++ b/packages/admin/cms-admin/src/dam/config/damDefaultAcceptedMimeTypes.ts
@@ -12,8 +12,8 @@ export const damDefaultAcceptedMimeTypes = [
     "image/gif",
     "image/webp",
     "image/tiff",
-    "image/psd",
     "image/vnd.microsoft.icon",
+    "image/x-icon",
     "image/bmp",
     // audio
     "audio/mpeg",
@@ -24,8 +24,6 @@ export const damDefaultAcceptedMimeTypes = [
     "video/mp4",
     "video/quicktime",
     "video/ogg",
-    "video/avi",
-    "video/x-m4v",
     "video/webm",
     // pdf
     "application/pdf",

--- a/packages/api/cms-api/src/dam/common/mimeTypes/dam-default-accepted-mimetypes.ts
+++ b/packages/api/cms-api/src/dam/common/mimeTypes/dam-default-accepted-mimetypes.ts
@@ -12,8 +12,8 @@ export const damDefaultAcceptedMimetypes = [
     "image/gif",
     "image/webp",
     "image/tiff",
-    "image/psd",
     "image/vnd.microsoft.icon",
+    "image/x-icon",
     "image/bmp",
     // audio
     "audio/mpeg",
@@ -24,8 +24,6 @@ export const damDefaultAcceptedMimetypes = [
     "video/mp4",
     "video/quicktime",
     "video/ogg",
-    "video/avi",
-    "video/x-m4v",
     "video/webm",
     // pdf
     "application/pdf",


### PR DESCRIPTION
## Description

- Add `image/x-icon` mimetype

We allow .ico files. There are two valid mimetypes: `image/vnd.microsoft.icon` and `image/x-icon` (see [1](https://github.com/jshttp/mime-db/blob/master/db.json#L7857C4-L7860) and [2](https://github.com/jshttp/mime-db/blob/master/db.json#L7767-L7770)). We only allowed `image/vnd.microsoft.icon` but not `image/x-icon` leading to wrongful rejection of .ico files.

---

- Remove `video/avi` mimetype

This mimetype doesn't even exist. I'm not sure how it ended up in the list. According to [mimedb](https://github.com/jshttp/mime-db/blob/master/db.json#L9081) and [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types#:~:text=.avi,video/x%2Dmsvideo), the correct mimetype for .avi files is `video/x-msvideo`. 

I removed it instead of replacing it with `video/x-msvideo` because apparently it was never actually needed. We can add it if there is demand.

- Remove `image/psd` mimetype

Basically same as above. The actual mimetype is `image/vnd.adobe.photoshop`. Since it was never an issue, I removed the wrong mimetype without substitution.

- Remove `video/x-m4v` mimetype

The problem here is that `video/x-m4v` seems to be the correct mimetype (according to [mime-db](https://github.com/jshttp/mime-db/blob/master/db.json#L9043)). However, Google Chrome and MacOS interpret it as `video/mp4`.

I also decided to remove it completely, as it probably never actually worked and .m4v is a very niche format developed by Apple and not widely used (https://en.wikipedia.org/wiki/M4V).

-> Removing them shouldn't have any noticeable effect and is therefore non-breaking

But we could also handle these file types differently. What do you think?

## Acceptance criteria

-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1239
