### PR TITLE
Fix `defaultProps` of `MuiDataGrid` in `createCometTheme()`

### DIFF
--- a/.changeset/cool-beers-whisper.md
+++ b/.changeset/cool-beers-whisper.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": patch
+---
+
+Fix an issue where setting `defaultProps` of `MuiDataGrid` would override the `defaultProps` defined by `createCometTheme()`

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -24,6 +24,7 @@ import { GetMuiComponentTheme } from "./getComponentsTheme";
 export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, { palette, shadows, spacing }) => ({
     ...component,
     defaultProps: {
+        ...component?.defaultProps,
         components: {
             /* @TODO: add FilterPanelAddIcon to display Comet Add Icon once MUI Datagrid is updated to v6 or higher  */
             QuickFilterIcon: Search,
@@ -39,8 +40,8 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
         },
         localeText: {
             noRowsLabel: GRID_DEFAULT_LOCALE_TEXT.noResultsOverlayLabel,
+            ...component?.defaultProps?.localeText,
         },
-        ...component?.defaultProps,
     },
     styleOverrides: mergeOverrideStyles<"MuiDataGrid">(component?.styleOverrides, {
         root: {


### PR DESCRIPTION
## Description

Fix an issue where setting `defaultProps` of `MuiDataGrid` would override the `defaultProps` defined by `createCometTheme()`.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1506
