### PR TITLE
Add partial match support to `usePreview` helpers `isSelected` and `isHovered`

### DIFF
--- a/.changeset/fast-ties-peel.md
+++ b/.changeset/fast-ties-peel.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-site": minor
+---
+
+Extend the `usePreview`-helpers `isSelected` and `isHovered` with optional partial match support
+
+-   When `exactMatch` is set to `true` (default), the function checks for exact URL matches.
+-   When `exactMatch` is set to `false`, the function checks if the selected route starts with the given URL.

--- a/demo/site/src/common/blocks/AccordionBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionBlock.tsx
@@ -2,27 +2,26 @@ import { isWithPreviewPropsData, PropsWithData, usePreview, withPreview } from "
 import { AccordionBlockData } from "@src/blocks.generated";
 import { AccordionItemBlock } from "@src/common/blocks/AccordionItemBlock";
 import { PageLayout } from "@src/layout/PageLayout";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
 
 type AccordionBlockProps = PropsWithData<AccordionBlockData>;
 
 export const AccordionBlock = withPreview(
     ({ data }: AccordionBlockProps) => {
+        const getOpenByDefaultBlockKeys = useCallback(() => {
+            return data.blocks.filter((block) => block.props.openByDefault).map((block) => block.key);
+        }, [data.blocks]);
+
         const [expandedItems, setExpandedItems] = useState<Set<string>>(() => {
             // Create a Set containing the keys of blocks where openByDefault is set to true
-
-            const defaultExpandedItems = data.blocks.filter((block) => block.props.openByDefault).map((block) => block.key);
-
-            return new Set(defaultExpandedItems);
+            return new Set(getOpenByDefaultBlockKeys());
         });
 
         const { showPreviewSkeletons, isSelected, isHovered } = usePreview();
 
         useEffect(() => {
             if (showPreviewSkeletons) {
-                const getOpenByDefaultBlockKeys = () => data.blocks.filter((block) => block.props.openByDefault).map((block) => block.key);
-
                 const getFocusedBlockKey = () => {
                     const focusedBlock = data.blocks.find((block) => {
                         if (!isWithPreviewPropsData(block)) {
@@ -48,7 +47,7 @@ export const AccordionBlock = withPreview(
                     return expandedItemsInPreview;
                 });
             }
-        }, [showPreviewSkeletons, data.blocks, isSelected, isHovered]);
+        }, [showPreviewSkeletons, data.blocks, isSelected, isHovered, getOpenByDefaultBlockKeys]);
 
         const handleChange = (itemKey: string) => {
             const newExpandedItems = new Set(expandedItems);

--- a/demo/site/src/common/blocks/AccordionBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionBlock.tsx
@@ -31,7 +31,7 @@ export const AccordionBlock = withPreview(
 
                         const url = block.adminMeta?.route;
 
-                        return url && (isSelected(url) || isHovered(url));
+                        return url && (isSelected(url, { exactMatch: false }) || isHovered(url, { exactMatch: false }));
                     });
 
                     return focusedBlock?.key;

--- a/demo/site/src/common/blocks/AccordionBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionBlock.tsx
@@ -50,7 +50,7 @@ export const AccordionBlock = withPreview(
             }
         }, [showPreviewSkeletons, data.blocks, isSelected, isHovered]);
 
-        const handleItemClick = (itemKey: string) => {
+        const handleChange = (itemKey: string) => {
             const newExpandedItems = new Set(expandedItems);
 
             newExpandedItems.has(itemKey) ? newExpandedItems.delete(itemKey) : newExpandedItems.add(itemKey);
@@ -64,7 +64,7 @@ export const AccordionBlock = withPreview(
                     <AccordionItemBlock
                         key={block.key}
                         data={block.props}
-                        onItemClick={() => handleItemClick(block.key)}
+                        onChange={() => handleChange(block.key)}
                         isExpanded={expandedItems.has(block.key)}
                     />
                 ))}

--- a/demo/site/src/common/blocks/AccordionBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionBlock.tsx
@@ -1,18 +1,76 @@
-import { ListBlock, PropsWithData, withPreview } from "@comet/cms-site";
+import { isWithPreviewPropsData, PropsWithData, usePreview, withPreview } from "@comet/cms-site";
 import { AccordionBlockData } from "@src/blocks.generated";
+import { AccordionItemBlock } from "@src/common/blocks/AccordionItemBlock";
 import { PageLayout } from "@src/layout/PageLayout";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
-
-import { AccordionItemBlock } from "./AccordionItemBlock";
 
 type AccordionBlockProps = PropsWithData<AccordionBlockData>;
 
 export const AccordionBlock = withPreview(
-    ({ data }: AccordionBlockProps) => (
-        <Root>
-            <ListBlock data={data} block={(block) => <AccordionItemBlock data={block} />} />
-        </Root>
-    ),
+    ({ data }: AccordionBlockProps) => {
+        const [expandedItems, setExpandedItems] = useState<Set<string>>(() => {
+            // Create a Set containing the keys of blocks where openByDefault is set to true
+
+            const defaultExpandedItems = data.blocks.filter((block) => block.props.openByDefault).map((block) => block.key);
+
+            return new Set(defaultExpandedItems);
+        });
+
+        const { showPreviewSkeletons, isSelected, isHovered } = usePreview();
+
+        useEffect(() => {
+            if (showPreviewSkeletons) {
+                const getOpenByDefaultBlockKeys = () => data.blocks.filter((block) => block.props.openByDefault).map((block) => block.key);
+
+                const getFocusedBlockKey = () => {
+                    const focusedBlock = data.blocks.find((block) => {
+                        if (!isWithPreviewPropsData(block)) {
+                            return false;
+                        }
+
+                        const url = block.adminMeta?.route;
+
+                        return url && (isSelected(url) || isHovered(url));
+                    });
+
+                    return focusedBlock?.key;
+                };
+
+                setExpandedItems(() => {
+                    const expandedItemsInPreview = new Set<string>(getOpenByDefaultBlockKeys());
+                    const focusedBlockKey = getFocusedBlockKey();
+
+                    if (focusedBlockKey) {
+                        expandedItemsInPreview.add(focusedBlockKey);
+                    }
+
+                    return expandedItemsInPreview;
+                });
+            }
+        }, [showPreviewSkeletons, data.blocks, isSelected, isHovered]);
+
+        const handleItemClick = (itemKey: string) => {
+            const newExpandedItems = new Set(expandedItems);
+
+            newExpandedItems.has(itemKey) ? newExpandedItems.delete(itemKey) : newExpandedItems.add(itemKey);
+
+            setExpandedItems(newExpandedItems);
+        };
+
+        return (
+            <Root>
+                {data.blocks.map((block) => (
+                    <AccordionItemBlock
+                        key={block.key}
+                        data={block.props}
+                        onItemClick={() => handleItemClick(block.key)}
+                        isExpanded={expandedItems.has(block.key)}
+                    />
+                ))}
+            </Root>
+        );
+    },
     { label: "Accordion" },
 );
 

--- a/demo/site/src/common/blocks/AccordionBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionBlock.tsx
@@ -36,16 +36,14 @@ export const AccordionBlock = withPreview(
                     return focusedBlock?.key;
                 };
 
-                setExpandedItems(() => {
-                    const expandedItemsInPreview = new Set<string>(getOpenByDefaultBlockKeys());
-                    const focusedBlockKey = getFocusedBlockKey();
+                const expandedItemsInPreview = new Set<string>(getOpenByDefaultBlockKeys());
+                const focusedBlockKey = getFocusedBlockKey();
 
-                    if (focusedBlockKey) {
-                        expandedItemsInPreview.add(focusedBlockKey);
-                    }
+                if (focusedBlockKey) {
+                    expandedItemsInPreview.add(focusedBlockKey);
+                }
 
-                    return expandedItemsInPreview;
-                });
+                setExpandedItems(expandedItemsInPreview);
             }
         }, [showPreviewSkeletons, data.blocks, isSelected, isHovered, getOpenByDefaultBlockKeys]);
 

--- a/demo/site/src/common/blocks/AccordionBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionBlock.tsx
@@ -9,14 +9,14 @@ type AccordionBlockProps = PropsWithData<AccordionBlockData>;
 
 export const AccordionBlock = withPreview(
     ({ data }: AccordionBlockProps) => {
-        const getOpenByDefaultBlockKeys = useMemo(
+        const openByDefaultBlockKeys = useMemo(
             () => data.blocks.filter((block) => block.props.openByDefault).map((block) => block.key),
             [data.blocks],
         );
 
         const [expandedItems, setExpandedItems] = useState<Set<string>>(() => {
             // Create a Set containing the keys of blocks where openByDefault is set to true
-            return new Set(getOpenByDefaultBlockKeys);
+            return new Set(openByDefaultBlockKeys);
         });
 
         const { showPreviewSkeletons, isSelected, isHovered } = usePreview();
@@ -37,7 +37,7 @@ export const AccordionBlock = withPreview(
                     return focusedBlock?.key;
                 };
 
-                const expandedItemsInPreview = new Set<string>(getOpenByDefaultBlockKeys);
+                const expandedItemsInPreview = new Set<string>(openByDefaultBlockKeys);
                 const focusedBlockKey = getFocusedBlockKey();
 
                 if (focusedBlockKey) {
@@ -46,7 +46,7 @@ export const AccordionBlock = withPreview(
 
                 setExpandedItems(expandedItemsInPreview);
             }
-        }, [showPreviewSkeletons, data.blocks, isSelected, isHovered, getOpenByDefaultBlockKeys]);
+        }, [showPreviewSkeletons, data.blocks, isSelected, isHovered, openByDefaultBlockKeys]);
 
         const handleChange = (itemKey: string) => {
             const newExpandedItems = new Set(expandedItems);

--- a/demo/site/src/common/blocks/AccordionBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionBlock.tsx
@@ -2,20 +2,21 @@ import { isWithPreviewPropsData, PropsWithData, usePreview, withPreview } from "
 import { AccordionBlockData } from "@src/blocks.generated";
 import { AccordionItemBlock } from "@src/common/blocks/AccordionItemBlock";
 import { PageLayout } from "@src/layout/PageLayout";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 
 type AccordionBlockProps = PropsWithData<AccordionBlockData>;
 
 export const AccordionBlock = withPreview(
     ({ data }: AccordionBlockProps) => {
-        const getOpenByDefaultBlockKeys = useCallback(() => {
-            return data.blocks.filter((block) => block.props.openByDefault).map((block) => block.key);
-        }, [data.blocks]);
+        const getOpenByDefaultBlockKeys = useMemo(
+            () => data.blocks.filter((block) => block.props.openByDefault).map((block) => block.key),
+            [data.blocks],
+        );
 
         const [expandedItems, setExpandedItems] = useState<Set<string>>(() => {
             // Create a Set containing the keys of blocks where openByDefault is set to true
-            return new Set(getOpenByDefaultBlockKeys());
+            return new Set(getOpenByDefaultBlockKeys);
         });
 
         const { showPreviewSkeletons, isSelected, isHovered } = usePreview();
@@ -36,7 +37,7 @@ export const AccordionBlock = withPreview(
                     return focusedBlock?.key;
                 };
 
-                const expandedItemsInPreview = new Set<string>(getOpenByDefaultBlockKeys());
+                const expandedItemsInPreview = new Set<string>(getOpenByDefaultBlockKeys);
                 const focusedBlockKey = getFocusedBlockKey();
 
                 if (focusedBlockKey) {

--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -26,11 +26,11 @@ const AccordionContentBlock = withPreview(
 
 type AccordionItemBlockProps = PropsWithData<AccordionItemBlockData> & {
     isExpanded: boolean;
-    onItemClick: () => void;
+    onChange: () => void;
 };
 
 export const AccordionItemBlock = withPreview(
-    ({ data: { title, content }, isExpanded, onItemClick }: AccordionItemBlockProps) => {
+    ({ data: { title, content }, isExpanded, onChange }: AccordionItemBlockProps) => {
         const intl = useIntl();
 
         const ariaLabelText = isExpanded
@@ -39,7 +39,7 @@ export const AccordionItemBlock = withPreview(
 
         return (
             <>
-                <TitleWrapper onClick={() => onItemClick()} aria-label={ariaLabelText}>
+                <TitleWrapper onClick={() => onChange()} aria-label={ariaLabelText}>
                     <Typography variant="h350">{title}</Typography>
                     <IconWrapper>
                         <AnimatedChevron href="/assets/icons/chevron-down.svg#chevron-down" $isExpanded={isExpanded} />

--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -1,15 +1,14 @@
 import { BlocksBlock, PropsWithData, SupportedBlocks, withPreview } from "@comet/cms-site";
 import { AccordionContentBlockData, AccordionItemBlockData } from "@src/blocks.generated";
-import { useState } from "react";
+import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
+import { SpaceBlock } from "@src/common/blocks/SpaceBlock";
+import { StandaloneCallToActionListBlock } from "@src/common/blocks/StandaloneCallToActionListBlock";
+import { StandaloneHeadingBlock } from "@src/common/blocks/StandaloneHeadingBlock";
+import { SvgUse } from "@src/common/helpers/SvgUse";
 import { useIntl } from "react-intl";
 import styled, { css } from "styled-components";
 
 import { Typography } from "../components/Typography";
-import { SvgUse } from "../helpers/SvgUse";
-import { RichTextBlock } from "./RichTextBlock";
-import { SpaceBlock } from "./SpaceBlock";
-import { StandaloneCallToActionListBlock } from "./StandaloneCallToActionListBlock";
-import { StandaloneHeadingBlock } from "./StandaloneHeadingBlock";
 
 const supportedBlocks: SupportedBlocks = {
     richtext: (props) => <RichTextBlock data={props} />,
@@ -25,12 +24,14 @@ const AccordionContentBlock = withPreview(
     { label: "Accordion Content" },
 );
 
-type AccordionItemBlockProps = PropsWithData<AccordionItemBlockData>;
+type AccordionItemBlockProps = PropsWithData<AccordionItemBlockData> & {
+    isExpanded: boolean;
+    onItemClick: () => void;
+};
 
 export const AccordionItemBlock = withPreview(
-    ({ data: { title, content, openByDefault } }: AccordionItemBlockProps) => {
+    ({ data: { title, content }, isExpanded, onItemClick }: AccordionItemBlockProps) => {
         const intl = useIntl();
-        const [isExpanded, setIsExpanded] = useState<boolean>(openByDefault);
 
         const ariaLabelText = isExpanded
             ? intl.formatMessage({ id: "accordionBlock.ariaLabel.expanded", defaultMessage: "Collapse accordion item" })
@@ -38,7 +39,7 @@ export const AccordionItemBlock = withPreview(
 
         return (
             <>
-                <TitleWrapper onClick={() => setIsExpanded(!isExpanded)} aria-label={ariaLabelText}>
+                <TitleWrapper onClick={() => onItemClick()} aria-label={ariaLabelText}>
                     <Typography variant="h350">{title}</Typography>
                     <IconWrapper>
                         <AnimatedChevron href="/assets/icons/chevron-down.svg#chevron-down" $isExpanded={isExpanded} />

--- a/packages/site/cms-site/src/preview/usePreview.ts
+++ b/packages/site/cms-site/src/preview/usePreview.ts
@@ -4,8 +4,8 @@ import { useIFrameBridge } from "../iframebridge/useIFrameBridge";
 import { PreviewContext, PreviewContextOptions } from "./PreviewContext";
 
 export interface PreviewHookReturn extends PreviewContextOptions {
-    isSelected: (url: string, options?: { exactMatch?: boolean }) => boolean | undefined;
-    isHovered: (url: string, options?: { exactMatch?: boolean }) => boolean | undefined;
+    isSelected: (url: string, options?: { exactMatch?: boolean }) => boolean;
+    isHovered: (url: string, options?: { exactMatch?: boolean }) => boolean;
 }
 
 export function usePreview(): PreviewHookReturn {
@@ -13,6 +13,10 @@ export function usePreview(): PreviewHookReturn {
     const previewContext = useContext(PreviewContext);
     const isSelected = useCallback(
         (url: string, options?: { exactMatch?: boolean }) => {
+            if (!iFrameBridge.selectedAdminRoute) {
+                return false;
+            }
+
             const exactMatch = options?.exactMatch ?? true;
 
             if (exactMatch) {
@@ -26,6 +30,10 @@ export function usePreview(): PreviewHookReturn {
 
     const isHovered = useCallback(
         (url: string, options?: { exactMatch?: boolean }) => {
+            if (!iFrameBridge.hoveredAdminRoute) {
+                return false;
+            }
+
             const exactMatch = options?.exactMatch ?? true;
 
             if (exactMatch) {

--- a/packages/site/cms-site/src/preview/usePreview.ts
+++ b/packages/site/cms-site/src/preview/usePreview.ts
@@ -4,23 +4,35 @@ import { useIFrameBridge } from "../iframebridge/useIFrameBridge";
 import { PreviewContext, PreviewContextOptions } from "./PreviewContext";
 
 export interface PreviewHookReturn extends PreviewContextOptions {
-    isSelected: (url: string) => boolean;
-    isHovered: (url: string) => boolean;
+    isSelected: (url: string, options?: { exactMatch?: boolean }) => boolean | undefined;
+    isHovered: (url: string, options?: { exactMatch?: boolean }) => boolean | undefined;
 }
 
 export function usePreview(): PreviewHookReturn {
     const iFrameBridge = useIFrameBridge();
     const previewContext = useContext(PreviewContext);
     const isSelected = useCallback(
-        (url: string) => {
-            return url === iFrameBridge.selectedAdminRoute;
+        (url: string, options?: { exactMatch?: boolean }) => {
+            const exactMatch = options?.exactMatch ?? true;
+
+            if (exactMatch) {
+                return url === iFrameBridge.selectedAdminRoute;
+            } else {
+                return iFrameBridge.selectedAdminRoute?.startsWith(url);
+            }
         },
         [iFrameBridge.selectedAdminRoute],
     );
 
     const isHovered = useCallback(
-        (url: string) => {
-            return url === iFrameBridge.hoveredAdminRoute;
+        (url: string, options?: { exactMatch?: boolean }) => {
+            const exactMatch = options?.exactMatch ?? true;
+
+            if (exactMatch) {
+                return url === iFrameBridge.hoveredAdminRoute;
+            } else {
+                return iFrameBridge.hoveredAdminRoute?.startsWith(url);
+            }
         },
         [iFrameBridge.hoveredAdminRoute],
     );


### PR DESCRIPTION
## Description

At the moment the `isSelected` and `isHovered` helpers of the `usePreview()` hook only support the exact comparison of the given URL. This change adds the option to only compare the URL partially by checking if the `adminRoute` starts with the provided URL.

This change is useful for scenarios like displaying child blocks in components such as accordions, where the exact structure of the child block and therefore the admin route to compare might not be known.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| https://github.com/user-attachments/assets/fc6abab1-7b53-4cf4-b571-f7506fdd3ac3 | https://github.com/user-attachments/assets/ab1b00ff-38da-4d31-8900-6bb17a671430 |


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1293
