### PR TITLE
Update `query-string` to v7

### DIFF
--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -38,7 +38,7 @@
         "is-mobile": "^4.0.0",
         "lodash.debounce": "^4.0.8",
         "lodash.isequal": "^4.5.0",
-        "query-string": "^6.8.1",
+        "query-string": "^7.1.3",
         "react-dropzone": "^14.0.0",
         "use-constant": "^1.0.0",
         "uuid": "^9.0.0"

--- a/packages/admin/admin/src/table/paging/createRestPagingActions.ts
+++ b/packages/admin/admin/src/table/paging/createRestPagingActions.ts
@@ -1,4 +1,4 @@
-import * as queryString from "query-string";
+import queryString from "query-string";
 
 import { IPagingApi } from "../useTableQueryPaging";
 import { IPagingInfo } from "./IPagingInfo";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -815,8 +815,8 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0
       query-string:
-        specifier: ^6.8.1
-        version: 6.14.1
+        specifier: ^7.1.3
+        version: 7.1.3
       react-dropzone:
         specifier: ^14.0.0
         version: 14.3.5(react@17.0.2)
@@ -13454,8 +13454,8 @@ packages:
     resolution: {integrity: sha512-25P7wI2UoDbIQsQp50ARkt+5pwPsOq7G/BqvT5xAbapnRoNWMN8/p55H9TXd5MuENiJnm5XICB2H2aDZGwts7w==}
     engines: {node: '>=0.10.21'}
 
-  query-string@6.14.1:
-    resolution: {integrity: sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==}
+  query-string@7.1.3:
+    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
 
   querystring@0.2.0:
@@ -30486,7 +30486,7 @@ snapshots:
 
   quantize@1.0.2: {}
 
-  query-string@6.14.1:
+  query-string@7.1.3:
     dependencies:
       decode-uri-component: 0.2.2
       filter-obj: 1.1.0


### PR DESCRIPTION
## Description

Only has one breaking change that doesn't affect us (see https://github.com/sindresorhus/query-string/releases/tag/v7.0.0)

Note: We can only upgrade to v7 (instead of v9) because `query-string` is pure ESM since v8 (see https://github.com/sindresorhus/query-string/releases/tag/v8.0.0). 

