### PR TITLE
Pass missing props to icon-button to of `ToolbarActionButton` to fix missing `onClick`

### DIFF
--- a/.changeset/nice-bugs-knock.md
+++ b/.changeset/nice-bugs-knock.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix `onClick` and other props not being passed to the icon version of some button components

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
@@ -78,7 +78,7 @@ export const ToolbarActionButton = (props: ToolbarActionButtonProps) => {
 
     return useIconButton && icon ? (
         <StyledTooltip title={children} {...tooltipProps}>
-            <StyledIconButton ownerState={ownerState} {...iconButtonProps}>
+            <StyledIconButton ownerState={ownerState} {...restProps} {...iconButtonProps}>
                 {icon}
             </StyledIconButton>
         </StyledTooltip>


### PR DESCRIPTION
## Description

Props such as `onClick` were only passed to the desktop `Button` and not to the mobile `IconButton`. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1506
