### PR TITLE
Add support for full screen dialogs

### DIFF
--- a/.changeset/four-terms-hope.md
+++ b/.changeset/four-terms-hope.md
@@ -1,0 +1,12 @@
+---
+"@comet/admin-theme": minor
+---
+
+Add support and styling for full screen dialogs using the `fullScreen` prop
+
+```tsx
+<Dialog open fullScreen>
+    <DialogTitle>Dialog Title</DialogTitle>
+    <DialogContent>Dialog content</DialogContent>
+</Dialog>
+```

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialog.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialog.ts
@@ -32,5 +32,10 @@ export const getMuiDialog: GetMuiComponentTheme<"MuiDialog"> = (component, { spa
         paperFullWidth: {
             width: `calc(100% - ${spacing(16)})`,
         },
+        paperFullScreen: {
+            borderRadius: 0,
+            maxWidth: "none",
+            margin: 0,
+        },
     }),
 });

--- a/storybook/src/admin/mui/Dialog.stories.tsx
+++ b/storybook/src/admin/mui/Dialog.stories.tsx
@@ -1,6 +1,6 @@
-import { CancelButton, Dialog, Field, FinalFormCheckbox, FinalFormInput, FinalFormSelect, OkayButton } from "@comet/admin";
+import { CancelButton, CheckboxField, Dialog, OkayButton, SelectField, TextField } from "@comet/admin";
 import { Save } from "@comet/admin-icons";
-import { Button, DialogActions, DialogContent, DialogContentText, DialogProps, FormControlLabel, MenuItem } from "@mui/material";
+import { Button, DialogActions, DialogContent, DialogContentText, DialogProps } from "@mui/material";
 import { Form } from "react-final-form";
 
 type DialogSize = Exclude<DialogProps["maxWidth"], false> | "fullWidth" | "fullScreen";
@@ -75,7 +75,6 @@ export const _Dialog = {
                     render={({ handleSubmit }) => (
                         <form onSubmit={handleSubmit}>
                             <Dialog
-                                scroll="body"
                                 title={selectedDialogTitle}
                                 onClose={selectedDialogOnClose === "callback" ? () => console.log("Dialog closed") : undefined}
                                 open={true}
@@ -110,21 +109,9 @@ function DefaultDialogContent() {
                     Lorem ipsum nullam quis risus eget urna mollis ornare vel eu leo. Nullam id dolor id nibh ultricies vehicula ut id elit. Vivamus
                     sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Curabitur blandit tempus porttitor.
                 </DialogContentText>
-                <Field name="text" label="Textfield" component={FinalFormInput} fullWidth />
-                <Field name="select" label="Select" fullWidth>
-                    {(props) => (
-                        <FinalFormSelect {...props} fullWidth>
-                            {selectOptions.map((option) => (
-                                <MenuItem value={option.value} key={option.value}>
-                                    {option.label}
-                                </MenuItem>
-                            ))}
-                        </FinalFormSelect>
-                    )}
-                </Field>
-                <Field name="checked" type="checkbox" fullWidth>
-                    {(props) => <FormControlLabel label="Checkbox" control={<FinalFormCheckbox {...props} />} />}
-                </Field>
+                <TextField name="text" label="Textfield" fullWidth />
+                <SelectField name="select" label="Select" fullWidth options={selectOptions} />
+                <CheckboxField name="checked" label="Checkbox" fullWidth />
             </DialogContent>
             <DialogActions>
                 <CancelButton />

--- a/storybook/src/admin/mui/Dialog.stories.tsx
+++ b/storybook/src/admin/mui/Dialog.stories.tsx
@@ -3,7 +3,7 @@ import { Save } from "@comet/admin-icons";
 import { Button, DialogActions, DialogContent, DialogContentText, DialogProps, FormControlLabel, MenuItem } from "@mui/material";
 import { Form } from "react-final-form";
 
-type DialogSize = Exclude<DialogProps["maxWidth"], false> | "fullWidth";
+type DialogSize = Exclude<DialogProps["maxWidth"], false> | "fullWidth" | "fullScreen";
 
 type DialogSizeOptions = {
     [label: string]: DialogSize;
@@ -16,6 +16,7 @@ const dialogSizeOptions: DialogSizeOptions = {
     "LG (1280px)": "lg",
     "XL (1920px)": "xl",
     FullWidth: "fullWidth",
+    FullScreen: "fullScreen",
 };
 
 const selectOptions = [
@@ -79,7 +80,8 @@ export const _Dialog = {
                                 onClose={selectedDialogOnClose === "callback" ? () => console.log("Dialog closed") : undefined}
                                 open={true}
                                 fullWidth={selectedDialogSize === "fullWidth"}
-                                maxWidth={selectedDialogSize !== "fullWidth" && selectedDialogSize}
+                                fullScreen={selectedDialogSize === "fullScreen"}
+                                maxWidth={selectedDialogSize !== "fullWidth" && selectedDialogSize !== "fullScreen" && selectedDialogSize}
                             >
                                 <>{selectedDialogSize === "xs" ? <ConfirmationDialogContent /> : <DefaultDialogContent />}</>
                             </Dialog>


### PR DESCRIPTION
## Description

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1024" alt="FullScreen Dialog on Desktop Previously" src="https://github.com/user-attachments/assets/bb9b803f-d23c-495a-98ca-3839e73cd447" /> | <img width="1024" alt="FullScreen Dialog on Desktop Now" src="https://github.com/user-attachments/assets/619e7c4e-5d1a-48b2-b375-2b8ebe458850" /> |
| <img width="375" alt="FullScreen Dialog on Mobile Previously" src="https://github.com/user-attachments/assets/35cddace-af0e-4c32-95e6-7578d2352f0a" /> | <img width="375" alt="FullScreen Dialog on Mobile Now" src="https://github.com/user-attachments/assets/c1e549f6-d60e-405e-a3bd-db010f979aa5" /> |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1175
