### PR TITLE
Draft: Renovate: Ignore packages we don't want to upgrade ATM

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,34 @@
         {
             "matchUpdateTypes": ["major"],
             "labels": ["major", "dependencies"]
+        },
+
+        {
+            "matchPackageNames": ["react-router", "react-router-dom", "@types/react-router", "@types/react-router-dom"],
+            "allowedVersions": "^5.0.0",
+            "cantUpgradeBecause": "> v5 doesn't support Prompts, so we don't want to upgrade atm"
+        },
+        {
+            "matchPackageNames": ["history", "@types/history"],
+            "allowedVersions": "^4.0.0",
+            "cantUpgradeBecause": "react-router v5 has a dependency to history v4"
+        },
+        {
+            "matchPackageNames": ["immutable", "@types/immutable"],
+            "allowedVersions": "^3.7.4",
+            "cantUpgradeBecause": "draft-js only supports v3.7.4"
+        },
+        {
+            "matchPackageNames": ["change-case"],
+            "matchFileNames": ["packages/**"],
+            "allowedVersions": "^4.0.0",
+            "cantUpgradeBecause": "v5 is pure ESM"
+        },
+        {
+            "matchPackageNames": ["query-string"],
+            "matchFileNames": ["packages/**"],
+            "allowedVersions": "^7.0.0",
+            "cantUpgradeBecause": "v8 is pure ESM"
         }
     ],
     "rangeStrategy": "bump",

--- a/renovate.json5
+++ b/renovate.json5
@@ -72,31 +72,31 @@
         },
 
         {
+            // Can't upgrade because: > v5 doesn't support Prompts, so we don't want to upgrade atm
             "matchPackageNames": ["react-router", "react-router-dom", "@types/react-router", "@types/react-router-dom"],
-            "allowedVersions": "^5.0.0",
-            "cantUpgradeBecause": "> v5 doesn't support Prompts, so we don't want to upgrade atm"
+            "allowedVersions": "^5.0.0"
         },
         {
+            // Can't upgrade because: react-router v5 has a dependency to history v4
             "matchPackageNames": ["history", "@types/history"],
-            "allowedVersions": "^4.0.0",
-            "cantUpgradeBecause": "react-router v5 has a dependency to history v4"
+            "allowedVersions": "^4.0.0"
         },
         {
+            // Can't upgrade because: draft-js only supports v3.7.4
             "matchPackageNames": ["immutable", "@types/immutable"],
-            "allowedVersions": "^3.7.4",
-            "cantUpgradeBecause": "draft-js only supports v3.7.4"
+            "allowedVersions": "^3.7.4"
         },
         {
+            // Can't upgrade because: v5 is pure ESM
             "matchPackageNames": ["change-case"],
             "matchFileNames": ["packages/**"],
-            "allowedVersions": "^4.0.0",
-            "cantUpgradeBecause": "v5 is pure ESM"
+            "allowedVersions": "^4.0.0"
         },
         {
-            "matchPackageNames": ["query-string"],
+            // Can't upgrade because: v8 is pure ESM
+            "matchPackageNames": ["query-string"], // test comment
             "matchFileNames": ["packages/**"],
             "allowedVersions": "^7.0.0",
-            "cantUpgradeBecause": "v8 is pure ESM"
         }
     ],
     "rangeStrategy": "bump",

--- a/renovate.json5
+++ b/renovate.json5
@@ -94,7 +94,7 @@
         },
         {
             // Can't upgrade because: v8 is pure ESM
-            "matchPackageNames": ["query-string"], // test comment
+            "matchPackageNames": ["query-string"],
             "matchFileNames": ["packages/**"],
             "allowedVersions": "^7.0.0",
         }


### PR DESCRIPTION
## Description

There are some packages that we can't / don't want to upgrade ATM. I listed them in the renovate config and added the reason why we ignore them so that

- renovate doesn't suggest these updates
- the config serves as a single-source-of-truth for delayed updates

---

Switch to json5 to allow comments (is [supported by renovate](https://docs.renovatebot.com/configuration-options/#ignore-versions-with-negated-regex-syntax:~:text=renovate.json-,renovate.json5,-.github/renovate.json))
