### PR TITLE
Update `chokidar-cli` to v3

### DIFF
--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -77,7 +77,7 @@
         "@types/react-router-dom": "^5.0.0",
         "@types/uuid": "^7.0.0",
         "@vitejs/plugin-react-swc": "^3.6.0",
-        "chokidar-cli": "^2.1.0",
+        "chokidar-cli": "^3.0.0",
         "dotenv-cli": "^4.1.1",
         "eslint": "^8.0.0",
         "eslint-plugin-graphql": "^4.0.0",

--- a/demo/site-pages/package.json
+++ b/demo/site-pages/package.json
@@ -51,7 +51,7 @@
         "@types/node": "^22.0.0",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
-        "chokidar-cli": "^2.1.0",
+        "chokidar-cli": "^3.0.0",
         "eslint": "^8.0.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.0.0",

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -51,7 +51,7 @@
         "@types/node": "^22.0.0",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
-        "chokidar-cli": "^2.1.0",
+        "chokidar-cli": "^3.0.0",
         "eslint": "^8.0.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.0.0",

--- a/packages/admin/blocks-admin/package.json
+++ b/packages/admin/blocks-admin/package.json
@@ -55,7 +55,7 @@
         "@types/react-router": "^5.1.20",
         "@types/react-router-dom": "^5.0.0",
         "@types/uuid": "^8.0.0",
-        "chokidar-cli": "^2.1.0",
+        "chokidar-cli": "^3.0.0",
         "eslint": "^8.0.0",
         "final-form": "^4.20.10",
         "jest": "^29.5.0",

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -109,7 +109,7 @@
         "@types/react-virtualized-auto-sizer": "^1.0.0",
         "@types/react-window": "^1.0.0",
         "@types/uuid": "^9.0.0",
-        "chokidar-cli": "^2.1.0",
+        "chokidar-cli": "^3.0.0",
         "csstype": "^3.1.3",
         "draft-js": "^0.11.7",
         "eslint": "^8.0.0",

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -112,7 +112,7 @@
         "@types/request-ip": "^0.0.41",
         "@types/rimraf": "^3.0.0",
         "@types/uuid": "^9.0.0",
-        "chokidar-cli": "^2.1.0",
+        "chokidar-cli": "^3.0.0",
         "class-validator": "^0.14.1",
         "eslint": "^8.0.0",
         "express": "^4.0.0",

--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -39,7 +39,7 @@
         "@types/jest": "^29.5.0",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
-        "chokidar-cli": "^2.1.0",
+        "chokidar-cli": "^3.0.0",
         "eslint": "^8.0.0",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0(@swc/helpers@0.5.5)(vite@5.1.8(@types/node@22.9.0)(terser@5.36.0))
       chokidar-cli:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.0
+        version: 3.0.0
       dotenv-cli:
         specifier: ^4.1.1
         version: 4.1.1
@@ -516,8 +516,8 @@ importers:
         specifier: ^18.2.22
         version: 18.3.0
       chokidar-cli:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.0
+        version: 3.0.0
       eslint:
         specifier: ^8.0.0
         version: 8.57.1
@@ -607,8 +607,8 @@ importers:
         specifier: ^18.2.22
         version: 18.3.0
       chokidar-cli:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.0
+        version: 3.0.0
       eslint:
         specifier: ^8.0.0
         version: 8.57.1
@@ -1443,8 +1443,8 @@ importers:
         specifier: ^8.0.0
         version: 8.3.4
       chokidar-cli:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.0
+        version: 3.0.0
       eslint:
         specifier: ^8.0.0
         version: 8.57.1
@@ -1714,8 +1714,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.8
       chokidar-cli:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.0
+        version: 3.0.0
       csstype:
         specifier: ^3.1.3
         version: 3.1.3
@@ -2018,8 +2018,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.8
       chokidar-cli:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.0
+        version: 3.0.0
       class-validator:
         specifier: ^0.14.1
         version: 0.14.1
@@ -2237,8 +2237,8 @@ importers:
         specifier: ^18.2.22
         version: 18.3.0
       chokidar-cli:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.0
+        version: 3.0.0
       eslint:
         specifier: ^8.0.0
         version: 8.57.1
@@ -8158,8 +8158,8 @@ packages:
     resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
     engines: {node: '>= 6'}
 
-  chokidar-cli@2.1.0:
-    resolution: {integrity: sha512-6n21AVpW6ywuEPoxJcLXMA2p4T+SLjWsXKny/9yTWFz0kKxESI3eUylpeV97LylING/27T/RVTY0f2/0QaWq9Q==}
+  chokidar-cli@3.0.0:
+    resolution: {integrity: sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==}
     engines: {node: '>= 8.10.0'}
     hasBin: true
 
@@ -24212,7 +24212,7 @@ snapshots:
       parse5: 7.1.2
       parse5-htmlparser2-tree-adapter: 7.0.0
 
-  chokidar-cli@2.1.0:
+  chokidar-cli@3.0.0:
     dependencies:
       chokidar: 3.6.0
       lodash.debounce: 4.0.8


### PR DESCRIPTION
## Description

Breaking changes:

- Drop support for windows
- Drop support for old node versions

-> doesn't affect us

see https://github.com/open-cli-tools/chokidar-cli/releases/tag/v3.0.0
