### PR TITLE
Styling and custom component for `DataGrid` panels

### DIFF
--- a/.changeset/fresh-eggs-think.md
+++ b/.changeset/fresh-eggs-think.md
@@ -1,6 +1,19 @@
+---
+"@comet/admin": minor
+---
+
+Add the `DataGridPanel` component to replace MUIs default Panel used by DataGrid to match the Comet DXP design
+
+It is recommended to add this component to your theme's `defaultProps` of `MuiDataGrid`.
+Additionally it is recommended to set the `localeText` prop to ensure the correct text is displayed in the panels.
+
+_Due to technical limitations, these values can currently not be provided by the default theme from the `@comet/admin-theme` package._
+
+Example theme configuration for `admin/src/theme.ts`:
+
+```ts
 import { DataGridPanel } from "@comet/admin";
 import { createCometTheme } from "@comet/admin-theme";
-import type {} from "@mui/lab/themeAugmentation";
 import type {} from "@mui/x-data-grid/themeAugmentation";
 import { IntlShape } from "react-intl";
 
@@ -11,6 +24,7 @@ export const getTheme = (intl: IntlShape) =>
                 defaultProps: {
                     localeText: {
                         filterPanelColumns: intl.formatMessage({ id: "dataGrid.filterPanelColumns", defaultMessage: "Column" }),
+                        columnsPanelTextFieldLabel: "",
                         columnsPanelTextFieldPlaceholder: intl.formatMessage({
                             id: "dataGrid.columnsPanelTextFieldPlaceholder",
                             defaultMessage: "Find column...",
@@ -23,3 +37,4 @@ export const getTheme = (intl: IntlShape) =>
             },
         },
     });
+```

--- a/.changeset/fresh-eggs-think.md
+++ b/.changeset/fresh-eggs-think.md
@@ -2,12 +2,9 @@
 "@comet/admin": minor
 ---
 
-Add the `DataGridPanel` component to replace MUIs default Panel used by DataGrid to match the Comet DXP design
+Add the `DataGridPanel` component to replace MUIs default `Panel` used by `DataGrid` to match the Comet DXP design
 
 It is recommended to add this component to your theme's `defaultProps` of `MuiDataGrid`.
-Additionally it is recommended to set the `localeText` prop to ensure the correct text is displayed in the panels.
-
-_Due to technical limitations, these values can currently not be provided by the default theme from the `@comet/admin-theme` package._
 
 Example theme configuration for `admin/src/theme.ts`:
 
@@ -15,26 +12,16 @@ Example theme configuration for `admin/src/theme.ts`:
 import { DataGridPanel } from "@comet/admin";
 import { createCometTheme } from "@comet/admin-theme";
 import type {} from "@mui/x-data-grid/themeAugmentation";
-import { IntlShape } from "react-intl";
 
-export const getTheme = (intl: IntlShape) =>
-    createCometTheme({
-        components: {
-            MuiDataGrid: {
-                defaultProps: {
-                    localeText: {
-                        filterPanelColumns: intl.formatMessage({ id: "dataGrid.filterPanelColumns", defaultMessage: "Column" }),
-                        columnsPanelTextFieldLabel: "",
-                        columnsPanelTextFieldPlaceholder: intl.formatMessage({
-                            id: "dataGrid.columnsPanelTextFieldPlaceholder",
-                            defaultMessage: "Find column...",
-                        }),
-                    },
-                    components: {
-                        Panel: DataGridPanel,
-                    },
+export const theme = createCometTheme({
+    components: {
+        MuiDataGrid: {
+            defaultProps: {
+                components: {
+                    Panel: DataGridPanel,
                 },
             },
         },
-    });
+    },
+});
 ```

--- a/.changeset/weak-meals-juggle.md
+++ b/.changeset/weak-meals-juggle.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": minor
+---
+
+Improve the styling of the filter and columns panels of DataGrid

--- a/.changeset/weak-meals-juggle.md
+++ b/.changeset/weak-meals-juggle.md
@@ -2,4 +2,4 @@
 "@comet/admin-theme": minor
 ---
 
-Improve the styling of the filter and columns panels of DataGrid
+Improve the styling of the filter and columns panels of `DataGrid`

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -20,10 +20,10 @@ import { css, Global } from "@emotion/react";
 import { createApolloClient } from "@src/common/apollo/createApolloClient";
 import { ConfigProvider, createConfig } from "@src/config";
 import { ContentScope } from "@src/site-configs";
-import { getTheme } from "@src/theme";
+import { theme } from "@src/theme";
 import { HTML5toTouch } from "rdndmb-html5-to-touch";
 import { DndProvider } from "react-dnd-multi-backend";
-import { FormattedMessage, IntlContext, IntlProvider } from "react-intl";
+import { FormattedMessage, IntlProvider } from "react-intl";
 import { Route, Switch } from "react-router";
 
 import { ContentScopeProvider } from "./common/ContentScopeProvider";
@@ -97,64 +97,60 @@ export function App() {
                                 }}
                             >
                                 <IntlProvider locale="en" messages={getMessages()}>
-                                    <IntlContext.Consumer>
-                                        {(intl) => (
-                                            <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.language}>
-                                                <MuiThemeProvider theme={getTheme(intl)}>
-                                                    <DndProvider options={HTML5toTouch}>
-                                                        <SnackbarProvider>
-                                                            <CmsBlockContextProvider
-                                                                damConfig={{
-                                                                    apiUrl: config.apiUrl,
-                                                                    apiClient,
-                                                                    maxFileSize: config.dam.uploadsMaxFileSize,
-                                                                    maxSrcResolution: config.imgproxy.maxSrcResolution,
-                                                                    allowedImageAspectRatios: config.dam.allowedImageAspectRatios,
-                                                                }}
-                                                                pageTreeCategories={pageTreeCategories}
-                                                                pageTreeDocumentTypes={pageTreeDocumentTypes}
-                                                                additionalPageTreeNodeFragment={additionalPageTreeNodeFieldsFragment}
-                                                            >
-                                                                <ErrorDialogHandler />
-                                                                <CurrentUserProvider>
-                                                                    <RouterBrowserRouter>
-                                                                        <GlobalStyle />
-                                                                        <ContentScopeProvider>
-                                                                            {({ match }) => (
-                                                                                <Switch>
-                                                                                    <Route
-                                                                                        path={`${match.path}/preview`}
-                                                                                        render={(props) => (
-                                                                                            <SitePreview
-                                                                                                resolvePath={(path: string, scope) => {
-                                                                                                    return `/${scope.language}${path}`;
-                                                                                                }}
-                                                                                                {...props}
-                                                                                            />
-                                                                                        )}
+                                    <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.language}>
+                                        <MuiThemeProvider theme={theme}>
+                                            <DndProvider options={HTML5toTouch}>
+                                                <SnackbarProvider>
+                                                    <CmsBlockContextProvider
+                                                        damConfig={{
+                                                            apiUrl: config.apiUrl,
+                                                            apiClient,
+                                                            maxFileSize: config.dam.uploadsMaxFileSize,
+                                                            maxSrcResolution: config.imgproxy.maxSrcResolution,
+                                                            allowedImageAspectRatios: config.dam.allowedImageAspectRatios,
+                                                        }}
+                                                        pageTreeCategories={pageTreeCategories}
+                                                        pageTreeDocumentTypes={pageTreeDocumentTypes}
+                                                        additionalPageTreeNodeFragment={additionalPageTreeNodeFieldsFragment}
+                                                    >
+                                                        <ErrorDialogHandler />
+                                                        <CurrentUserProvider>
+                                                            <RouterBrowserRouter>
+                                                                <GlobalStyle />
+                                                                <ContentScopeProvider>
+                                                                    {({ match }) => (
+                                                                        <Switch>
+                                                                            <Route
+                                                                                path={`${match.path}/preview`}
+                                                                                render={(props) => (
+                                                                                    <SitePreview
+                                                                                        resolvePath={(path: string, scope) => {
+                                                                                            return `/${scope.language}${path}`;
+                                                                                        }}
+                                                                                        {...props}
                                                                                     />
-                                                                                    <Route
-                                                                                        render={() => (
-                                                                                            <MasterLayout
-                                                                                                headerComponent={MasterHeader}
-                                                                                                menuComponent={AppMasterMenu}
-                                                                                            >
-                                                                                                <MasterMenuRoutes menu={masterMenuData} />
-                                                                                            </MasterLayout>
-                                                                                        )}
-                                                                                    />
-                                                                                </Switch>
-                                                                            )}
-                                                                        </ContentScopeProvider>
-                                                                    </RouterBrowserRouter>
-                                                                </CurrentUserProvider>
-                                                            </CmsBlockContextProvider>
-                                                        </SnackbarProvider>
-                                                    </DndProvider>
-                                                </MuiThemeProvider>
-                                            </LocaleProvider>
-                                        )}
-                                    </IntlContext.Consumer>
+                                                                                )}
+                                                                            />
+                                                                            <Route
+                                                                                render={() => (
+                                                                                    <MasterLayout
+                                                                                        headerComponent={MasterHeader}
+                                                                                        menuComponent={AppMasterMenu}
+                                                                                    >
+                                                                                        <MasterMenuRoutes menu={masterMenuData} />
+                                                                                    </MasterLayout>
+                                                                                )}
+                                                                            />
+                                                                        </Switch>
+                                                                    )}
+                                                                </ContentScopeProvider>
+                                                            </RouterBrowserRouter>
+                                                        </CurrentUserProvider>
+                                                    </CmsBlockContextProvider>
+                                                </SnackbarProvider>
+                                            </DndProvider>
+                                        </MuiThemeProvider>
+                                    </LocaleProvider>
                                 </IntlProvider>
                             </DependenciesConfigProvider>
                         </DamConfigProvider>

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -20,10 +20,10 @@ import { css, Global } from "@emotion/react";
 import { createApolloClient } from "@src/common/apollo/createApolloClient";
 import { ConfigProvider, createConfig } from "@src/config";
 import { ContentScope } from "@src/site-configs";
-import { theme } from "@src/theme";
+import { getTheme } from "@src/theme";
 import { HTML5toTouch } from "rdndmb-html5-to-touch";
 import { DndProvider } from "react-dnd-multi-backend";
-import { FormattedMessage, IntlProvider } from "react-intl";
+import { FormattedMessage, IntlContext, IntlProvider } from "react-intl";
 import { Route, Switch } from "react-router";
 
 import { ContentScopeProvider } from "./common/ContentScopeProvider";
@@ -97,60 +97,64 @@ export function App() {
                                 }}
                             >
                                 <IntlProvider locale="en" messages={getMessages()}>
-                                    <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.language}>
-                                        <MuiThemeProvider theme={theme}>
-                                            <DndProvider options={HTML5toTouch}>
-                                                <SnackbarProvider>
-                                                    <CmsBlockContextProvider
-                                                        damConfig={{
-                                                            apiUrl: config.apiUrl,
-                                                            apiClient,
-                                                            maxFileSize: config.dam.uploadsMaxFileSize,
-                                                            maxSrcResolution: config.imgproxy.maxSrcResolution,
-                                                            allowedImageAspectRatios: config.dam.allowedImageAspectRatios,
-                                                        }}
-                                                        pageTreeCategories={pageTreeCategories}
-                                                        pageTreeDocumentTypes={pageTreeDocumentTypes}
-                                                        additionalPageTreeNodeFragment={additionalPageTreeNodeFieldsFragment}
-                                                    >
-                                                        <ErrorDialogHandler />
-                                                        <CurrentUserProvider>
-                                                            <RouterBrowserRouter>
-                                                                <GlobalStyle />
-                                                                <ContentScopeProvider>
-                                                                    {({ match }) => (
-                                                                        <Switch>
-                                                                            <Route
-                                                                                path={`${match.path}/preview`}
-                                                                                render={(props) => (
-                                                                                    <SitePreview
-                                                                                        resolvePath={(path: string, scope) => {
-                                                                                            return `/${scope.language}${path}`;
-                                                                                        }}
-                                                                                        {...props}
+                                    <IntlContext.Consumer>
+                                        {(intl) => (
+                                            <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.language}>
+                                                <MuiThemeProvider theme={getTheme(intl)}>
+                                                    <DndProvider options={HTML5toTouch}>
+                                                        <SnackbarProvider>
+                                                            <CmsBlockContextProvider
+                                                                damConfig={{
+                                                                    apiUrl: config.apiUrl,
+                                                                    apiClient,
+                                                                    maxFileSize: config.dam.uploadsMaxFileSize,
+                                                                    maxSrcResolution: config.imgproxy.maxSrcResolution,
+                                                                    allowedImageAspectRatios: config.dam.allowedImageAspectRatios,
+                                                                }}
+                                                                pageTreeCategories={pageTreeCategories}
+                                                                pageTreeDocumentTypes={pageTreeDocumentTypes}
+                                                                additionalPageTreeNodeFragment={additionalPageTreeNodeFieldsFragment}
+                                                            >
+                                                                <ErrorDialogHandler />
+                                                                <CurrentUserProvider>
+                                                                    <RouterBrowserRouter>
+                                                                        <GlobalStyle />
+                                                                        <ContentScopeProvider>
+                                                                            {({ match }) => (
+                                                                                <Switch>
+                                                                                    <Route
+                                                                                        path={`${match.path}/preview`}
+                                                                                        render={(props) => (
+                                                                                            <SitePreview
+                                                                                                resolvePath={(path: string, scope) => {
+                                                                                                    return `/${scope.language}${path}`;
+                                                                                                }}
+                                                                                                {...props}
+                                                                                            />
+                                                                                        )}
                                                                                     />
-                                                                                )}
-                                                                            />
-                                                                            <Route
-                                                                                render={() => (
-                                                                                    <MasterLayout
-                                                                                        headerComponent={MasterHeader}
-                                                                                        menuComponent={AppMasterMenu}
-                                                                                    >
-                                                                                        <MasterMenuRoutes menu={masterMenuData} />
-                                                                                    </MasterLayout>
-                                                                                )}
-                                                                            />
-                                                                        </Switch>
-                                                                    )}
-                                                                </ContentScopeProvider>
-                                                            </RouterBrowserRouter>
-                                                        </CurrentUserProvider>
-                                                    </CmsBlockContextProvider>
-                                                </SnackbarProvider>
-                                            </DndProvider>
-                                        </MuiThemeProvider>
-                                    </LocaleProvider>
+                                                                                    <Route
+                                                                                        render={() => (
+                                                                                            <MasterLayout
+                                                                                                headerComponent={MasterHeader}
+                                                                                                menuComponent={AppMasterMenu}
+                                                                                            >
+                                                                                                <MasterMenuRoutes menu={masterMenuData} />
+                                                                                            </MasterLayout>
+                                                                                        )}
+                                                                                    />
+                                                                                </Switch>
+                                                                            )}
+                                                                        </ContentScopeProvider>
+                                                                    </RouterBrowserRouter>
+                                                                </CurrentUserProvider>
+                                                            </CmsBlockContextProvider>
+                                                        </SnackbarProvider>
+                                                    </DndProvider>
+                                                </MuiThemeProvider>
+                                            </LocaleProvider>
+                                        )}
+                                    </IntlContext.Consumer>
                                 </IntlProvider>
                             </DependenciesConfigProvider>
                         </DamConfigProvider>

--- a/demo/admin/src/theme.ts
+++ b/demo/admin/src/theme.ts
@@ -2,24 +2,15 @@ import { DataGridPanel } from "@comet/admin";
 import { createCometTheme } from "@comet/admin-theme";
 import type {} from "@mui/lab/themeAugmentation";
 import type {} from "@mui/x-data-grid/themeAugmentation";
-import { IntlShape } from "react-intl";
 
-export const getTheme = (intl: IntlShape) =>
-    createCometTheme({
-        components: {
-            MuiDataGrid: {
-                defaultProps: {
-                    localeText: {
-                        filterPanelColumns: intl.formatMessage({ id: "dataGrid.filterPanelColumns", defaultMessage: "Column" }),
-                        columnsPanelTextFieldPlaceholder: intl.formatMessage({
-                            id: "dataGrid.columnsPanelTextFieldPlaceholder",
-                            defaultMessage: "Find column...",
-                        }),
-                    },
-                    components: {
-                        Panel: DataGridPanel,
-                    },
+export const theme = createCometTheme({
+    components: {
+        MuiDataGrid: {
+            defaultProps: {
+                components: {
+                    Panel: DataGridPanel,
                 },
             },
         },
-    });
+    },
+});

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -1,14 +1,11 @@
 import { ArrowDown, ArrowUp, Check, Clear, Close, Delete, MoreVertical, Search } from "@comet/admin-icons";
 import {
     buttonBaseClasses,
-    buttonClasses,
-    formControlClasses,
     getSwitchUtilityClass,
     iconButtonClasses,
-    inputAdornmentClasses,
     inputBaseClasses,
-    inputClasses,
     inputLabelClasses,
+    nativeSelectClasses,
     svgIconClasses,
     SvgIconProps,
     switchClasses,
@@ -21,15 +18,19 @@ import type {} from "@mui/x-data-grid/themeAugmentation";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, { palette, shadows, spacing }) => ({
+const filtersLeftSectionWidth = 120;
+const filterDeleteIconSize = 32;
+const filterLeftSectionGap = 5;
+const filterOperatorInputWidth = filtersLeftSectionWidth - filterDeleteIconSize - filterLeftSectionGap;
+
+export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, { palette, shadows, spacing, breakpoints }) => ({
     ...component,
     defaultProps: {
         ...component?.defaultProps,
         components: {
-            /* @TODO: add FilterPanelAddIcon to display Comet Add Icon once MUI Datagrid is updated to v6 or higher  */
             QuickFilterIcon: Search,
             QuickFilterClearIcon: Clear,
-            FilterPanelDeleteIcon: Delete,
+            FilterPanelDeleteIcon: (props: SvgIconProps) => <Delete {...props} fontSize="medium" />,
             BooleanCellTrueIcon: Check,
             BooleanCellFalseIcon: Close,
             ColumnSortedAscendingIcon: ArrowUp,
@@ -38,8 +39,16 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             ColumnMenuIcon: (props: SvgIconProps) => <MoreVertical {...props} fontSize="medium" />,
             ...component?.defaultProps?.components,
         },
+        componentsProps: {
+            ...component?.defaultProps?.componentsProps,
+            baseButton: {
+                color: "info",
+                ...component?.defaultProps?.componentsProps?.baseButton,
+            },
+        },
         localeText: {
             noRowsLabel: GRID_DEFAULT_LOCALE_TEXT.noResultsOverlayLabel,
+            columnsPanelTextFieldLabel: "",
             ...component?.defaultProps?.localeText,
         },
     },
@@ -58,8 +67,19 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
                 },
             },
         },
+        panelHeader: {
+            padding: `4px 4px ${spacing(1)} 4px`,
+            borderBottom: `1px solid ${palette.divider}`,
+        },
+        columnsPanel: {
+            padding: 0,
+        },
         columnsPanelRow: {
             marginBottom: spacing(2),
+
+            "&:last-child": {
+                marginBottom: 0,
+            },
 
             [`& .${switchClasses.root}`]: {
                 marginRight: 0,
@@ -113,126 +133,124 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             height: "20px",
             marginRight: "10px",
         },
-        panel: {
-            ["@media (max-width: 900px)"]: {
-                width: "100%",
-                transform: "translate3d(0,0,0)",
-            },
-        },
         panelContent: {
-            padding: spacing(1, 0),
-            [`& .${gridClasses.filterForm}:first-child .${gridClasses.filterFormLinkOperatorInput}`]: {
-                display: "flex",
-            },
-            ["@media (max-width: 900px)"]: {
-                maxHeight: "none",
-                padding: 0,
-            },
+            padding: spacing(4),
+        },
+        paper: {
+            border: `1px solid ${palette.grey[100]}`,
+            boxShadow: shadows[4],
+            borderRadius: 4,
+            maxHeight: "none",
+            flexDirection: "column",
         },
         filterForm: {
-            margin: spacing(5, 4, 0, 4),
-            padding: spacing(2, 1),
-            gap: "5px",
-            borderBottom: `1px solid ${palette.grey[50]}`,
-            ["@media (max-width: 900px)"]: {
-                flexDirection: "row",
-                flexWrap: "wrap",
-                margin: spacing(4, 4, 0, 4),
-                gap: 0,
-                padding: 0,
-                paddingBottom: spacing(5),
-                "&:last-child": {
-                    marginBottom: 0,
-                    paddingBottom: 0,
+            flexDirection: "row",
+            flexWrap: "wrap",
+            padding: 0,
+
+            [`${breakpoints.up("md")}`]: {
+                flexWrap: "nowrap",
+                gap: spacing(1),
+            },
+
+            ["&:not(:last-child)"]: {
+                paddingBottom: spacing(4),
+                marginBottom: spacing(4),
+                borderBottom: `1px solid ${palette.divider}`,
+
+                [`${breakpoints.up("md")}`]: {
+                    paddingBottom: spacing(2),
+                    marginBottom: spacing(2),
+                    borderBottomColor: palette.grey[50],
                 },
             },
-            "&:last-child": {
-                border: "none",
+
+            [`&:first-child .${gridClasses.filterFormLinkOperatorInput}`]: {
+                // The first "Operator"-select is fully hidden by default when there is only one filter.
+                // Setting `display: block` makes sure it takes up it's space as if it were visible to prevent the alignment from breaking.
+                // Even though `display: block` is set now, it's still not visible, due to it's default styling of `visibility: hidden`.
+                display: "block",
             },
-            [`.${formControlClasses.root}`]: {
-                marginRight: 0,
-            },
-            [`.${iconButtonClasses.root}`]: {
-                height: 32,
-                width: 32,
-            },
+
             [`.${inputLabelClasses.root}`]: {
-                transform: "translateY(-22px)",
+                position: "static",
+                transform: "none",
                 fontSize: 14,
-                ["@media (max-width: 900px)"]: {
-                    position: "relative",
-                    transform: "unset",
-                },
+                fontWeight: 600,
             },
-            [`.${inputClasses.root}`]: {
-                marginTop: 0,
-            },
-            [`& .${inputAdornmentClasses.root}`]: {
-                padding: spacing(0, 1, 0, 0),
-            },
-        },
-        filterFormLinkOperatorInput: {
-            ["@media (max-width: 900px)"]: {
-                padding: spacing(2, 1),
-                width: "27.2%",
+
+            [`.${nativeSelectClasses.select}`]: {
+                whiteSpace: "nowrap",
+                textOverflow: "ellipsis",
             },
         },
         filterFormDeleteIcon: {
+            width: filterDeleteIconSize,
+            height: filterDeleteIconSize,
+            marginRight: filterLeftSectionGap,
+            marginTop: "auto",
+            marginBottom: 3,
             justifyContent: "center",
 
-            [`& .${svgIconClasses.root}`]: {
-                width: 16,
-                height: 16,
+            [`${breakpoints.up("md")}`]: {
+                marginRight: 0,
             },
 
-            ["@media (max-width: 900px)"]: {
-                padding: spacing(2, 1),
-                alignItems: "flex-start",
-                justifyContent: "flex-end",
-                width: "11.1%",
+            [`& > .${iconButtonClasses.root}`]: {
+                height: "100%",
             },
         },
-        panelFooter: {
-            borderTop: `1px solid ${palette.grey[100]}`,
-            padding: "7px 0",
-            [`.${buttonClasses.root}`]: {
-                color: palette.primary.main,
-            },
-            ["@media (max-width: 900px)"]: {
-                justifyContent: "center",
-                boxShadow: shadows[4],
+        filterFormLinkOperatorInput: {
+            width: filterOperatorInputWidth,
+            marginRight: 0,
+
+            [`${breakpoints.up("md")}`]: {
+                width: 80,
             },
         },
         filterFormColumnInput: {
-            marginRight: spacing(4),
+            width: `calc(100% - ${filtersLeftSectionWidth}px)`,
+            paddingLeft: spacing(2),
+            boxSizing: "border-box",
 
-            ["@media (max-width: 900px)"]: {
-                padding: spacing(2, 1),
-                width: "61.6%",
+            [`${breakpoints.up("md")}`]: {
+                width: 199,
+                paddingLeft: 0,
             },
         },
         filterFormOperatorInput: {
-            margin: spacing(0, 4, 0, 0),
+            marginTop: spacing(3),
+            flexBasis: filterOperatorInputWidth,
+            flexGrow: 1,
 
-            ["@media (max-width: 900px)"]: {
-                padding: spacing(2, 1),
-                width: "38.3%",
+            [`${breakpoints.up("md")}`]: {
+                marginTop: 0,
+                width: 110,
             },
         },
         filterFormValueInput: {
-            ["@media (max-width: 900px)"]: {
-                padding: spacing(2, 1),
-                width: "61.6%",
+            width: `calc(100% - ${filtersLeftSectionWidth}px)`,
+            paddingLeft: spacing(2),
+            boxSizing: "border-box",
+            marginTop: spacing(3),
+
+            [`${breakpoints.up("md")}`]: {
+                width: 199,
+                paddingLeft: 0,
+                marginTop: 0,
+            },
+
+            "&:empty": {
+                display: "none", // Make space for `filterFormOperatorInput` to expand and take up the full width
+            },
+
+            [`& .${inputBaseClasses.root}`]: {
+                marginTop: 0,
             },
         },
-        paper: {
-            boxShadow: shadows[4],
-            border: `1px solid ${palette.divider}`,
-            borderRadius: "4px",
-            ["@media (max-width: 900px)"]: {
-                height: "100%",
-                maxHeight: "none",
-            },
+        panelFooter: {
+            padding: spacing(2),
+            borderTop: `1px solid ${palette.divider}`,
         },
         // @ts-expect-error This key exists but is missing in the types.
         toolbarQuickFilter: {

--- a/packages/admin/admin/src/dataGrid/DataGridPanel.tsx
+++ b/packages/admin/admin/src/dataGrid/DataGridPanel.tsx
@@ -1,0 +1,409 @@
+import { Add, Check, Close, Reset } from "@comet/admin-icons";
+import { ComponentsOverrides, css, Dialog, DialogContent, Divider, Theme, Typography, useMediaQuery, useTheme, useThemeProps } from "@mui/material";
+import {
+    gridColumnVisibilityModelSelector,
+    gridFilterableColumnDefinitionsSelector,
+    GridFilterItem,
+    gridFilterModelSelector,
+    GridPanel,
+    GridPanelProps,
+    gridPreferencePanelStateSelector,
+    GridPreferencePanelsValue,
+    useGridApiContext,
+    useGridRootProps,
+    useGridSelector,
+} from "@mui/x-data-grid";
+import { ReactNode, useCallback, useMemo } from "react";
+import { FormattedMessage } from "react-intl";
+
+import { Button } from "../common/buttons/Button";
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+
+const panelTypeTitle: Record<GridPreferencePanelsValue, ReactNode> = {
+    [GridPreferencePanelsValue.filters]: <FormattedMessage id="dataGrid.panel.filters" defaultMessage="Filters" />,
+    [GridPreferencePanelsValue.columns]: <FormattedMessage id="dataGrid.panel.columns" defaultMessage="Columns" />,
+};
+
+export type DataGridPanelClassKey =
+    | "desktopGridPanel"
+    | "desktopPanelFooterDivider"
+    | "desktopPanelFooter"
+    | "desktopAddFilterButton"
+    | "mobileDialog"
+    | "mobileDialogHeader"
+    | "mobileDialogTitle"
+    | "mobileDialogCloseButton"
+    | "mobileDialogContent"
+    | "mobileDialogFooter"
+    | "mobileAddFilterButtonWrapper"
+    | "mobileAddFilterButton"
+    | "mobileDialogFooterActions"
+    | "resetFiltersButton"
+    | "resetColumnsButton"
+    | "applyButton";
+
+export type DataGridPanelProps = Pick<GridPanelProps, "open" | "children"> &
+    Omit<
+        ThemedComponentBaseProps<{
+            desktopGridPanel: typeof GridPanel;
+            desktopPanelFooterDivider: typeof Divider;
+            desktopPanelFooter: "div";
+            desktopAddFilterButton: typeof Button;
+            mobileDialog: typeof Dialog;
+            mobileDialogHeader: "div";
+            mobileDialogTitle: typeof Typography;
+            mobileDialogCloseButton: typeof Button;
+            mobileDialogContent: typeof DialogContent;
+            mobileDialogFooter: "div";
+            mobileAddFilterButtonWrapper: "div";
+            mobileAddFilterButton: typeof Button;
+            mobileDialogFooterActions: "div";
+            resetFiltersButton: typeof Button;
+            resetColumnsButton: typeof Button;
+            applyButton: typeof Button;
+        }>,
+        "sx"
+    > & {
+        iconMapping?: {
+            closeDialog?: ReactNode;
+            addFilter?: ReactNode;
+            resetFilters?: ReactNode;
+            resetColumns?: ReactNode;
+            apply?: ReactNode;
+        };
+    };
+
+type OwnerState = {
+    openedPanelValue: GridPreferencePanelsValue | undefined;
+};
+
+const addFilterText = <FormattedMessage id="dataGrid.panel.addFilter" defaultMessage="Add filter" />;
+
+let lastAddedFilterItemId = 0;
+
+export const DataGridPanel = (inProps: DataGridPanelProps) => {
+    const { children, open, slotProps, iconMapping = {} } = useThemeProps({ props: inProps, name: "CometAdminDataGridPanel" });
+    const apiRef = useGridApiContext();
+    const filterModel = useGridSelector(apiRef, gridFilterModelSelector);
+    const filterableColumns = useGridSelector(apiRef, gridFilterableColumnDefinitionsSelector);
+    const { openedPanelValue } = useGridSelector(apiRef, gridPreferencePanelStateSelector);
+    const initialColumnVisibilityModel = useMemo(() => gridColumnVisibilityModelSelector(apiRef), [apiRef]);
+    const rootProps = useGridRootProps();
+
+    const {
+        closeDialog: closeDialogIcon = <Close />,
+        addFilter: addFilterIcon = <Add />,
+        resetFilters: resetFiltersIcon = <Reset />,
+        resetColumns: resetColumnsIcon = <Reset />,
+        apply: applyIcon = <Check />,
+    } = iconMapping;
+
+    const geNewFilterItem = useCallback(() => {
+        const firstColumnWithOperator = filterableColumns.find((colDef) => colDef.filterOperators?.length);
+
+        if (!firstColumnWithOperator?.filterOperators?.length) {
+            return null;
+        }
+
+        return {
+            columnField: firstColumnWithOperator.field,
+            operatorValue: firstColumnWithOperator.filterOperators[0].value,
+            id: lastAddedFilterItemId++,
+        };
+    }, [filterableColumns]);
+
+    const filterItems = useMemo<GridFilterItem[]>(() => {
+        if (filterModel.items.length) {
+            return filterModel.items;
+        }
+
+        const newFilterItem = geNewFilterItem();
+
+        if (newFilterItem) {
+            return [newFilterItem];
+        }
+
+        return [];
+    }, [filterModel.items, geNewFilterItem]);
+
+    const addNewFilter = useCallback(() => {
+        const newFilterItem = geNewFilterItem();
+
+        if (newFilterItem) {
+            apiRef.current.upsertFilterItems([...filterItems, newFilterItem]);
+        }
+    }, [apiRef, filterItems, geNewFilterItem]);
+
+    const resetFilters = useCallback(() => {
+        apiRef.current.setFilterModel({ items: [] });
+    }, [apiRef]);
+
+    const resetColumns = useCallback(() => {
+        apiRef.current.setColumnVisibilityModel(initialColumnVisibilityModel);
+    }, [apiRef, initialColumnVisibilityModel]);
+
+    const closeDialog = useCallback(() => {
+        if (openedPanelValue === GridPreferencePanelsValue.filters) {
+            apiRef.current.hideFilterPanel();
+        } else {
+            apiRef.current.hidePreferences();
+        }
+    }, [apiRef, openedPanelValue]);
+
+    const theme = useTheme();
+    const renderFullScreen = useMediaQuery(theme.breakpoints.down("md"));
+
+    const ownerState: OwnerState = {
+        openedPanelValue,
+    };
+
+    const resetFiltersButton = (
+        <ResetFiltersButton variant="outlined" startIcon={resetFiltersIcon} onClick={resetFilters} {...slotProps?.resetFiltersButton}>
+            <FormattedMessage id="dataGrid.panel.resetFilters" defaultMessage="Reset filters" />
+        </ResetFiltersButton>
+    );
+
+    const resetColumnsButton = (
+        <ResetColumnsButton variant="outlined" startIcon={resetColumnsIcon} onClick={resetColumns} {...slotProps?.resetColumnsButton}>
+            <FormattedMessage id="dataGrid.panel.resetColumns" defaultMessage="Reset columns" />
+        </ResetColumnsButton>
+    );
+
+    const applyButton = (
+        <ApplyButton startIcon={applyIcon} onClick={closeDialog} {...slotProps?.applyButton}>
+            <FormattedMessage id="dataGrid.panel.apply" defaultMessage="Apply" />
+        </ApplyButton>
+    );
+
+    if (renderFullScreen) {
+        return (
+            <MobileDialog open={open} onClose={closeDialog} fullScreen {...slotProps?.mobileDialog}>
+                <MobileDialogHeader {...slotProps?.mobileDialogHeader}>
+                    <MobileDialogTitle {...slotProps?.mobileDialogTitle}>{!!openedPanelValue && panelTypeTitle[openedPanelValue]}</MobileDialogTitle>
+                    <MobileDialogCloseButton {...slotProps?.mobileDialogCloseButton} variant="textDark" onClick={closeDialog}>
+                        {closeDialogIcon}
+                    </MobileDialogCloseButton>
+                </MobileDialogHeader>
+                <MobileDialogContent {...slotProps?.mobileDialogContent}>{children}</MobileDialogContent>
+                <MobileDialogFooter {...slotProps?.mobileDialogFooter}>
+                    {openedPanelValue === GridPreferencePanelsValue.filters && !rootProps.disableMultipleColumnsFiltering && (
+                        <MobileAddFilterButtonWrapper {...slotProps?.mobileAddFilterButtonWrapper}>
+                            <MobileAddFilterButton
+                                variant="textDark"
+                                startIcon={addFilterIcon}
+                                onClick={addNewFilter}
+                                {...slotProps?.mobileAddFilterButton}
+                            >
+                                {addFilterText}
+                            </MobileAddFilterButton>
+                        </MobileAddFilterButtonWrapper>
+                    )}
+                    <MobileDialogFooterActions {...slotProps?.mobileDialogFooterActions}>
+                        {openedPanelValue === GridPreferencePanelsValue.filters && (
+                            <>
+                                {resetFiltersButton}
+                                {applyButton}
+                            </>
+                        )}
+                        {openedPanelValue === GridPreferencePanelsValue.columns && (
+                            <>
+                                {resetColumnsButton}
+                                {applyButton}
+                            </>
+                        )}
+                    </MobileDialogFooterActions>
+                </MobileDialogFooter>
+            </MobileDialog>
+        );
+    }
+
+    return (
+        <DesktopGridPanel
+            onResize={undefined} // TODO: Typing bug - remove after updating to DataGrid 7
+            onResizeCapture={undefined} // TODO: Typing bug - remove after updating to DataGrid 7
+            open={open}
+            ownerState={ownerState}
+            {...slotProps?.desktopGridPanel}
+        >
+            {children}
+            <DesktopPanelFooterDivider {...slotProps?.desktopPanelFooterDivider} />
+            <DesktopPanelFooter {...slotProps?.desktopPanelFooter}>
+                {openedPanelValue === GridPreferencePanelsValue.filters && (
+                    <>
+                        <div>
+                            {!rootProps.disableMultipleColumnsFiltering && (
+                                <DesktopAddFilterButton variant="outlined" startIcon={addFilterIcon} onClick={addNewFilter}>
+                                    {addFilterText}
+                                </DesktopAddFilterButton>
+                            )}
+                        </div>
+                        {resetFiltersButton}
+                    </>
+                )}
+                {openedPanelValue === GridPreferencePanelsValue.columns && (
+                    <>
+                        {resetColumnsButton}
+                        {applyButton}
+                    </>
+                )}
+            </DesktopPanelFooter>
+        </DesktopGridPanel>
+    );
+};
+
+const DesktopGridPanel = createComponentSlot(GridPanel)<DataGridPanelClassKey, OwnerState>({
+    componentName: "DataGridPanel",
+    slotName: "desktopGridPanel",
+})(css`
+    .MuiDataGrid-panelHeader,
+    .MuiDataGrid-panelFooter {
+        // Hide MUIs header and footer so we can add our own with a better structure for styling
+        display: none;
+    }
+`);
+
+const DesktopPanelFooterDivider = createComponentSlot(Divider)<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "desktopPanelFooterDivider",
+})();
+
+const DesktopPanelFooter = createComponentSlot("div")<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "desktopPanelFooter",
+})(
+    ({ theme }) => css`
+        display: flex;
+        justify-content: space-between;
+        padding: ${theme.spacing(4)};
+    `,
+);
+
+const DesktopAddFilterButton = createComponentSlot(Button)<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "desktopAddFilterButton",
+})();
+
+const MobileDialog = createComponentSlot(Dialog)<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "mobileDialog",
+})(css`
+    .MuiDataGrid-panelContent {
+        max-height: none;
+    }
+
+    .MuiDataGrid-panelHeader,
+    .MuiDataGrid-panelFooter {
+        // Hide MUIs header and footer so we can add our own with a better structure for styling
+        display: none;
+    }
+`);
+
+const MobileDialogHeader = createComponentSlot("div")<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "mobileDialogHeader",
+})(
+    ({ theme }) => css`
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: ${theme.spacing(2)};
+        padding-left: ${theme.spacing(4)};
+        box-shadow: ${theme.shadows[4]};
+    `,
+);
+
+const MobileDialogTitle = createComponentSlot(Typography)<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "mobileDialogTitle",
+})();
+
+const MobileDialogCloseButton = createComponentSlot(Button)<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "mobileDialogCloseButton",
+})(css`
+    min-width: 0; // TODO: Should this be done in the theme?
+`);
+
+const MobileDialogContent = createComponentSlot(DialogContent)<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "mobileDialogContent",
+})(
+    ({ theme }) => css`
+        padding: 0;
+        background-color: white;
+
+        ${theme.breakpoints.up("sm")} {
+            padding: 0;
+        }
+    `,
+);
+
+const MobileDialogFooter = createComponentSlot("div")<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "mobileDialogFooter",
+})();
+
+const MobileAddFilterButtonWrapper = createComponentSlot("div")<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "mobileAddFilterButtonWrapper",
+})(
+    ({ theme }) => css`
+        position: relative;
+        display: flex;
+        justify-content: center;
+        padding: ${theme.spacing(2)} ${theme.spacing(4)};
+        box-shadow: ${theme.shadows[4]};
+        border-bottom: 1px solid ${theme.palette.divider};
+    `,
+);
+
+const MobileAddFilterButton = createComponentSlot(Button)<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "mobileAddFilterButton",
+})();
+
+const MobileDialogFooterActions = createComponentSlot("div")<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "mobileDialogFooterActions",
+})(
+    ({ theme }) => css`
+        display: flex;
+        justify-content: space-between;
+        padding: ${theme.spacing(4)};
+        box-shadow: ${theme.shadows[4]};
+    `,
+);
+
+const ResetFiltersButton = createComponentSlot(Button)<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "resetFiltersButton",
+})();
+
+const ResetColumnsButton = createComponentSlot(Button)<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "resetColumnsButton",
+})();
+
+const ApplyButton = createComponentSlot(Button)<DataGridPanelClassKey>({
+    componentName: "DataGridPanel",
+    slotName: "applyButton",
+})();
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminDataGridPanel: DataGridPanelProps;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminDataGridPanel: DataGridPanelClassKey;
+    }
+
+    interface Components {
+        CometAdminDataGridPanel?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminDataGridPanel"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDataGridPanel"];
+        };
+    }
+}

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -49,7 +49,7 @@ export { ContentOverflow, ContentOverflowClassKey, ContentOverflowProps } from "
 export { CrudContextMenu, CrudContextMenuClassKey, CrudContextMenuProps } from "./dataGrid/CrudContextMenu";
 export { CrudMoreActionsMenu, CrudMoreActionsMenuContext, CrudMoreActionsMenuItem, CrudMoreActionsMenuProps } from "./dataGrid/CrudMoreActionsMenu";
 export { CrudVisibility, CrudVisibilityProps } from "./dataGrid/CrudVisibility";
-export { DataGridPanel } from "./dataGrid/DataGridPanel";
+export { DataGridPanel, DataGridPanelClassKey, DataGridPanelProps } from "./dataGrid/DataGridPanel";
 export { ExportApi, useDataGridExcelExport } from "./dataGrid/excelExport/useDataGridExcelExport";
 export { GridCellContent, GridCellContentClassKey, GridCellContentProps } from "./dataGrid/GridCellContent";
 export { GridColDef } from "./dataGrid/GridColDef";

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -49,6 +49,7 @@ export { ContentOverflow, ContentOverflowClassKey, ContentOverflowProps } from "
 export { CrudContextMenu, CrudContextMenuClassKey, CrudContextMenuProps } from "./dataGrid/CrudContextMenu";
 export { CrudMoreActionsMenu, CrudMoreActionsMenuContext, CrudMoreActionsMenuItem, CrudMoreActionsMenuProps } from "./dataGrid/CrudMoreActionsMenu";
 export { CrudVisibility, CrudVisibilityProps } from "./dataGrid/CrudVisibility";
+export { DataGridPanel } from "./dataGrid/DataGridPanel";
 export { ExportApi, useDataGridExcelExport } from "./dataGrid/excelExport/useDataGridExcelExport";
 export { GridCellContent, GridCellContentClassKey, GridCellContentProps } from "./dataGrid/GridCellContent";
 export { GridColDef } from "./dataGrid/GridColDef";

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -4,11 +4,10 @@ import { DataGridPanel, MainContent, MuiThemeProvider } from "@comet/admin";
 import { DateFnsLocaleProvider } from "@comet/admin-date-time";
 import { createCometTheme } from "@comet/admin-theme";
 import { createTheme as createMuiTheme, GlobalStyles } from "@mui/material";
-import type {} from "@mui/x-data-grid/themeAugmentation";
 import type { Preview } from "@storybook/react";
 import { Locale as DateFnsLocale } from "date-fns";
 import { de as deLocale, enUS as enLocale } from "date-fns/locale";
-import { IntlContext, IntlProvider, IntlShape } from "react-intl";
+import { IntlProvider } from "react-intl";
 
 import { worker } from "./mocks/browser";
 import { previewGlobalStyles } from "./preview.styles";
@@ -58,26 +57,6 @@ const messages = {
     },
 };
 
-const getCometTheme = (intl: IntlShape) =>
-    createCometTheme({
-        components: {
-            MuiDataGrid: {
-                defaultProps: {
-                    localeText: {
-                        filterPanelColumns: intl.formatMessage({ id: "dataGrid.filterPanelColumns", defaultMessage: "Column" }),
-                        columnsPanelTextFieldPlaceholder: intl.formatMessage({
-                            id: "dataGrid.columnsPanelTextFieldPlaceholder",
-                            defaultMessage: "Find column...",
-                        }),
-                    },
-                    components: {
-                        Panel: DataGridPanel,
-                    },
-                },
-            },
-        },
-    });
-
 const preview: Preview = {
     argTypes: {
         theme: {
@@ -91,28 +70,38 @@ const preview: Preview = {
     decorators: [
         (Story, context) => {
             const { theme: selectedTheme, locale: selectedLocale } = context.args;
+            const theme =
+                selectedTheme === themeOptions.defaultMui
+                    ? createMuiTheme()
+                    : createCometTheme({
+                          components: {
+                              MuiDataGrid: {
+                                  defaultProps: {
+                                      components: {
+                                          Panel: DataGridPanel,
+                                      },
+                                  },
+                              },
+                          },
+                      });
 
             return (
-                <IntlProvider locale={selectedLocale} messages={messages[selectedLocale] ?? {}}>
-                    <IntlContext.Consumer>
-                        {(intl) => (
-                            <MuiThemeProvider theme={selectedTheme === themeOptions.defaultMui ? createMuiTheme() : getCometTheme(intl)}>
-                                <DateFnsLocaleProvider value={dateFnsLocales[selectedLocale]}>
-                                    <GlobalStyles styles={previewGlobalStyles} />
-                                    <>
-                                        {context.parameters.layout === "padded" ? (
-                                            <MainContent>
-                                                <Story />
-                                            </MainContent>
-                                        ) : (
-                                            <Story />
-                                        )}
-                                    </>
-                                </DateFnsLocaleProvider>
-                            </MuiThemeProvider>
-                        )}
-                    </IntlContext.Consumer>
-                </IntlProvider>
+                <MuiThemeProvider theme={theme}>
+                    <IntlProvider locale={selectedLocale} messages={messages[selectedLocale] ?? {}}>
+                        <DateFnsLocaleProvider value={dateFnsLocales[selectedLocale]}>
+                            <GlobalStyles styles={previewGlobalStyles} />
+                            <>
+                                {context.parameters.layout === "padded" ? (
+                                    <MainContent>
+                                        <Story />
+                                    </MainContent>
+                                ) : (
+                                    <Story />
+                                )}
+                            </>
+                        </DateFnsLocaleProvider>
+                    </IntlProvider>
+                </MuiThemeProvider>
             );
         },
     ],

--- a/storybook/src/admin/toolbar/DataGridToolbar.stories.tsx
+++ b/storybook/src/admin/toolbar/DataGridToolbar.stories.tsx
@@ -1,7 +1,18 @@
-import { DataGridToolbar, FillSpace, GridColumnsButton, GridFilterButton, StackLink, ToolbarActions, ToolbarItem } from "@comet/admin";
+import {
+    Button,
+    DataGridToolbar,
+    FillSpace,
+    GridColumnsButton,
+    GridFilterButton,
+    StackLink,
+    ToolbarActions,
+    ToolbarItem,
+    useDataGridRemote,
+    usePersistentColumnState,
+} from "@comet/admin";
 import { Add as AddIcon } from "@comet/admin-icons";
-import { Button } from "@mui/material";
-import { DataGrid, GridToolbarQuickFilter } from "@mui/x-data-grid";
+import { DataGrid as DataGridCommunity, GridToolbarQuickFilter } from "@mui/x-data-grid";
+import { DataGridPro } from "@mui/x-data-grid-pro";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
@@ -11,50 +22,62 @@ const data = [
     { id: "e60900ec-3c69-4e67-8d78-83a10c7573d3", firstname: "Sophia", lastname: "Williams" },
 ];
 
+const gridOptions = ["Community", "Pro"] as const;
+
 export default {
     title: "@comet/admin/DataGridToolbar",
     decorators: [storyRouterDecorator()],
+    argTypes: {
+        gridVersion: {
+            name: "Data Grid Version",
+            control: "select",
+            options: gridOptions,
+        },
+    },
+    args: { gridVersion: gridOptions[0] },
 };
 
 export const _DataGridToolbar = {
-    render: () => {
+    render: ({ gridVersion }: { gridVersion: (typeof gridOptions)[number] }) => {
+        const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("FooBar") };
+
         const columns = [
             { field: "firstname", headerName: "First Name", width: 150 },
             { field: "lastname", headerName: "Last Name", width: 150 },
         ];
 
+        const Toolbar = () => {
+            return (
+                <DataGridToolbar>
+                    <ToolbarItem>
+                        <GridToolbarQuickFilter />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <GridFilterButton />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <GridColumnsButton />
+                    </ToolbarItem>
+                    <FillSpace />
+                    <ToolbarActions>
+                        <Button responsive startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
+                            Add person
+                        </Button>
+                    </ToolbarActions>
+                </DataGridToolbar>
+            );
+        };
+
+        const DataGrid = gridVersion === "Community" ? DataGridCommunity : DataGridPro;
+
         return (
             <DataGrid
+                {...dataGridProps}
                 autoHeight
                 columns={columns}
                 rows={data}
                 components={{
-                    Toolbar: () => (
-                        <DataGridToolbar>
-                            <ToolbarItem>
-                                <GridToolbarQuickFilter />
-                            </ToolbarItem>
-                            <ToolbarItem>
-                                <GridFilterButton />
-                            </ToolbarItem>
-                            <ToolbarItem>
-                                <GridColumnsButton />
-                            </ToolbarItem>
-                            <FillSpace />
-                            <ToolbarActions>
-                                <Button
-                                    startIcon={<AddIcon />}
-                                    component={StackLink}
-                                    pageName="add"
-                                    payload="add"
-                                    variant="contained"
-                                    color="primary"
-                                >
-                                    Add person
-                                </Button>
-                            </ToolbarActions>
-                        </DataGridToolbar>
-                    ),
+                    Toolbar,
                 }}
             />
         );


### PR DESCRIPTION
## Description

This implements theme-styling of the filter and column panels to more closely match the comet design. 
No changes in the application are needed for this to take effect.

This also implements a custom `DataGridPanel` component which improves on the styling and enables the full-screen/mobile variants of the panels defined by the comet design. 

Due to `@comet/admin-theme` not having a dependency on `@comet/admin` the new component must be added to the applications theme manually. This will be changed in `v8`, as the `@comet/admin-theme` package is being merged into the `@comet/admin` package with https://github.com/vivid-planet/comet/pull/3479 

Example theme: `src/theme.ts`:

```ts
import { DataGridPanel } from "@comet/admin";
import { createCometTheme } from "@comet/admin-theme";
import type {} from "@mui/x-data-grid/themeAugmentation";

export const theme = createCometTheme({
    components: {
        MuiDataGrid: {
            defaultProps: {
                components: {
                    Panel: DataGridPanel,
                },
            },
        },
    },
});
```

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots

### Custom `DataGridPanel` (preferred - needs to be added in the theme)

| Columns Panel | Filters Panel |
| ----- | ----- |
| <img width="1024" alt="Custom ColumnsPanel Desktop" src="https://github.com/user-attachments/assets/b6775034-3e96-4c79-b4fc-2fba008f564a" /> | <img width="1024" alt="Custom FilterPanel Desktop" src="https://github.com/user-attachments/assets/5e86f8b2-5cd5-4db2-8692-0233cffcac59" /> |
| <img width="390" alt="Custom ColumnsPanel Mobile" src="https://github.com/user-attachments/assets/19244356-87ca-4261-ac15-ee953673aeee" /> | <img width="390" alt="Custom FilterPanel Mobile" src="https://github.com/user-attachments/assets/7cb1761f-3925-4a5c-a9a7-676114606212" /> |

### MUIs default GridPanel (works out of the box)

| Columns Panel | Filters Panel |
| ----- | ----- |
| <img width="1024" alt="Default ColumnsPanel Desktop" src="https://github.com/user-attachments/assets/10951729-4b6d-43b7-a224-e358542c8975" /> | <img width="1024" alt="Default FilterPanel Desktop" src="https://github.com/user-attachments/assets/6a0ce965-f633-4847-894b-3785570ee34e" /> |
| <img width="390" alt="Default ColumnsPanel Mobile" src="https://github.com/user-attachments/assets/fc720df3-53b6-4fd7-b146-2f8b3009c1f8" /> | <img width="390" alt="Default FilterPanel Mobile" src="https://github.com/user-attachments/assets/e615029e-71c4-44a5-bf6b-95bea0973985" /> |

### Changed to be made in separate tasks/PRs:

-   Move theme values added to Demo-Admin to `createCometTheme()` – this may require merging the `@comet/admin-theme` into the `@comet/admin` package [COM-1649](https://vivid-planet.atlassian.net/browse/COM-1649)
-   Fix styling of value input when using the "Is any of" operator [COM-1650](https://vivid-planet.atlassian.net/browse/COM-1650)
-   Implement the new columns-panel according to the design [COM-1651](https://vivid-planet.atlassian.net/browse/COM-1651)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1175


[COM-1649]: https://vivid-planet.atlassian.net/browse/COM-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ