### PR TITLE
Add helper `createCompositeBlockSwitchField`

### DIFF
--- a/.changeset/short-singers-trade.md
+++ b/.changeset/short-singers-trade.md
@@ -1,0 +1,7 @@
+---
+"@comet/blocks-admin": minor
+---
+
+Add `createCompositeBlockSwitchField` helper function
+
+To simplify the creation of a switch field block by hiding the verbose definition of `Form`, `Field` and items.

--- a/packages/admin/blocks-admin/src/blocks/helpers/createCompositeBlockSwitchField.tsx
+++ b/packages/admin/blocks-admin/src/blocks/helpers/createCompositeBlockSwitchField.tsx
@@ -1,0 +1,19 @@
+import { SwitchField, SwitchFieldProps } from "@comet/admin";
+
+import { BlocksFinalForm } from "../../form/BlocksFinalForm";
+import { createCompositeSetting } from "./composeBlocks/createCompositeSetting";
+
+interface Options extends Partial<SwitchFieldProps> {
+    defaultValue?: boolean;
+}
+
+export function createCompositeBlockSwitchField({ defaultValue = false, fullWidth = true, ...fieldProps }: Options) {
+    return createCompositeSetting<boolean>({
+        defaultValue,
+        AdminComponent: ({ state, updateState }) => (
+            <BlocksFinalForm<{ value: typeof state }> onSubmit={({ value }) => updateState(value)} initialValues={{ value: state }}>
+                <SwitchField name="value" fullWidth={fullWidth} {...fieldProps} />
+            </BlocksFinalForm>
+        ),
+    });
+}

--- a/packages/admin/blocks-admin/src/index.ts
+++ b/packages/admin/blocks-admin/src/index.ts
@@ -29,6 +29,7 @@ export { createCompositeSetting } from "./blocks/helpers/composeBlocks/createCom
 export { createCompositeSettings } from "./blocks/helpers/composeBlocks/createCompositeSettings";
 export { createBlockSkeleton } from "./blocks/helpers/createBlockSkeleton";
 export { createCompositeBlockSelectField } from "./blocks/helpers/createCompositeBlockSelectField";
+export { createCompositeBlockSwitchField } from "./blocks/helpers/createCompositeBlockSwitchField";
 export { createCompositeBlockTextField } from "./blocks/helpers/createCompositeBlockTextField";
 export { default as decomposeUpdateStateAction } from "./blocks/helpers/decomposeUpdateStateAction";
 export { withAdditionalBlockAttributes } from "./blocks/helpers/withAdditionalBlockAttributes";


### PR DESCRIPTION
## Description

This has a slightly different/improved API compared to those of `createCompositeBlockTextField` and `createCompositeBlockSelectField`. 

Instead of setting the props for the field-component in the `fieldProps` object, we set them directly. 
Also since `fullWidth: true` is used in almost all cases, that is set by default. 

This makes the usage slightly simpler and more compact:

**Existing API**

```ts
block: createCompositeBlockSwitchField({
    fieldProps: {
        label: <FormattedMessage id="example.required" defaultMessage="Required" />,
        fullWidth: true,
    },
}),
```

**New API**

```ts
block: createCompositeBlockSwitchField({
    label: <FormattedMessage id="example.required" defaultMessage="Required" />,
}),
```

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset
-   [x] Should we keep the API of the existing helper functions for consistencs (at least in V7)?
-   [x] Should we use this API in the existing helper function as well (in V8)?
    -   Set props of field-component directly instead of inside a `fieldProps` object
    -   Set `fullWidth` to `true` by default