### PR TITLE
Add new `Button` component to use in favor of MUI's `Button` component

### DIFF
--- a/.changeset/olive-fans-invite.md
+++ b/.changeset/olive-fans-invite.md
@@ -1,0 +1,14 @@
+---
+"@comet/admin": minor
+---
+
+Add new `Button` component to use in favor of MUI's `Button` component
+
+```diff
+-import { Button } from "@mui/material";
++import { Button } from "@comet/admin";
+
+const MyComponent = () => {
+    return <Button onClick={() => console.log("Hello")}>Hello</Button>;
+};
+```

--- a/packages/admin/admin/src/common/buttons/Button.tsx
+++ b/packages/admin/admin/src/common/buttons/Button.tsx
@@ -1,0 +1,38 @@
+import { Button as MuiButton, ButtonProps as MuiButtonProps, ComponentsOverrides, Theme, useThemeProps } from "@mui/material";
+
+import { createComponentSlot } from "../../helpers/createComponentSlot";
+import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
+
+export type ButtonClassKey = "root";
+
+export type ButtonProps = MuiButtonProps &
+    ThemedComponentBaseProps<{
+        root: typeof MuiButton;
+    }>;
+
+export const Button = (inProps: ButtonProps) => {
+    const { slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminButton" });
+    return <Root {...restProps} {...slotProps?.root} />;
+};
+
+const Root = createComponentSlot(MuiButton)<ButtonClassKey>({
+    componentName: "Button",
+    slotName: "root",
+})();
+
+declare module "@mui/material/styles" {
+    interface ComponentNameToClassKey {
+        CometAdminButton: ButtonClassKey;
+    }
+
+    interface ComponentsPropsList {
+        CometAdminButton: ButtonProps;
+    }
+
+    interface Components {
+        CometAdminButton?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminButton"];
+        };
+    }
+}

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -10,6 +10,7 @@ export { AppHeaderMenuButton, AppHeaderMenuButtonClassKey, AppHeaderMenuButtonPr
 export { buildCreateRestMutation, buildDeleteRestMutation, buildUpdateRestMutation } from "./buildRestMutation";
 export { readClipboardText } from "./clipboard/readClipboardText";
 export { writeClipboardText } from "./clipboard/writeClipboardText";
+export { Button, ButtonClassKey, ButtonProps } from "./common/buttons/Button";
 export { CancelButton, CancelButtonClassKey, CancelButtonProps } from "./common/buttons/cancel/CancelButton";
 export { ClearInputButton, ClearInputButtonClassKey, ClearInputButtonProps } from "./common/buttons/clearinput/ClearInputButton";
 export { CopyToClipboardButton, CopyToClipboardButtonClassKey, CopyToClipboardButtonProps } from "./common/buttons/CopyToClipboardButton";


### PR DESCRIPTION
## Description

This is the base for the new `Button` component to replace MUI's component. 
Custom features will be added in separate follow-up PRs into the feature-branch `feature/custom-button`. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset

## Will be done in follow-up PRs into the feature-branch `feature/custom-button`:

-    Implement optional responsive behavior
-    Implement custom variants instead of supporting MUIs variants and colors
-    Replace usages of MUIs `Button`
-    Implement usage inside `FeedbackButton` (V8)
-    Restrict import of MUI's `Button` (V8)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1289
