### PR TITLE
Fix warning of props being forwarded to the DOM

### DIFF
--- a/demo/site/src/common/components/Typography.tsx
+++ b/demo/site/src/common/components/Typography.tsx
@@ -191,11 +191,15 @@ const variantToElementMap: Record<TypographyVariant, "h1" | "h2" | "h3" | "h4" |
     p200: "p",
 };
 
-export const Typography = styled.div.attrs<{
-    as?: unknown;
-    variant?: TypographyVariant;
-    bottomSpacing?: boolean;
-}>((props) => ({ as: props.as ?? variantToElementMap[props.variant ?? "p300"] }))`
+export const Typography = styled.div
+    .withConfig({
+        shouldForwardProp: (prop) => !["variant", "bottomSpacing"].includes(prop),
+    })
+    .attrs<{
+        as?: unknown;
+        variant?: TypographyVariant;
+        bottomSpacing?: boolean;
+    }>((props) => ({ as: props.as ?? variantToElementMap[props.variant ?? "p300"] }))`
     font-family: ${({ theme }) => theme.fontFamily};
     ${({ variant = "p300" }) => typographyVariantStyle[variant]};
     margin-top: 0;


### PR DESCRIPTION
## Description
Fix a bug that caused props of styled components to be passed to the DOM resulting in an error
- using the shouldForwardProp prevents this
## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Related: https://github.com/vivid-planet/comet-starter/pull/596