### PR TITLE
Fix Next links in breadcrumbs

### DIFF
--- a/demo/site/src/common/components/Breadcrumbs.sc.ts
+++ b/demo/site/src/common/components/Breadcrumbs.sc.ts
@@ -5,7 +5,7 @@ export const Container = styled.div`
     grid-column: 2 / 24;
 `;
 
-export const Link = styled.a`
+export const Link = styled.span`
     color: ${({ theme }) => theme.palette.primary.main};
     text-decoration: none;
 

--- a/demo/site/src/common/components/Breadcrumbs.sc.ts
+++ b/demo/site/src/common/components/Breadcrumbs.sc.ts
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import styled from "styled-components";
 
 export const Container = styled.div`
@@ -5,7 +6,7 @@ export const Container = styled.div`
     grid-column: 2 / 24;
 `;
 
-export const Link = styled.span`
+export const StyledLink = styled(Link)`
     color: ${({ theme }) => theme.palette.primary.main};
     text-decoration: none;
 

--- a/demo/site/src/common/components/Breadcrumbs.tsx
+++ b/demo/site/src/common/components/Breadcrumbs.tsx
@@ -13,13 +13,13 @@ const Breadcrumbs = ({ name, path, parentNodes }: GQLBreadcrumbsFragment) => {
                 <sc.Container>
                     {parentNodes.map((parentNode) => (
                         <Fragment key={parentNode.path}>
-                            <Link href={parentNode.path} passHref>
+                            <Link href={parentNode.path} passHref legacyBehavior>
                                 <sc.Link> {parentNode.name}</sc.Link>
                             </Link>
                             <sc.Divider />
                         </Fragment>
                     ))}
-                    <Link href={path} passHref>
+                    <Link href={path} passHref legacyBehavior>
                         <sc.Link> {name}</sc.Link>
                     </Link>
                 </sc.Container>

--- a/demo/site/src/common/components/Breadcrumbs.tsx
+++ b/demo/site/src/common/components/Breadcrumbs.tsx
@@ -1,5 +1,4 @@
 "use client";
-import Link from "next/link";
 import { Fragment } from "react";
 
 import { GQLBreadcrumbsFragment } from "./Breadcrumbs.fragment.generated";
@@ -13,15 +12,13 @@ const Breadcrumbs = ({ name, path, parentNodes }: GQLBreadcrumbsFragment) => {
                 <sc.Container>
                     {parentNodes.map((parentNode) => (
                         <Fragment key={parentNode.path}>
-                            <Link href={parentNode.path}>
-                                <sc.Link> {parentNode.name}</sc.Link>
-                            </Link>
+                            <sc.StyledLink href={parentNode.path}> {parentNode.name}</sc.StyledLink>
+
                             <sc.Divider />
                         </Fragment>
                     ))}
-                    <Link href={path}>
-                        <sc.Link> {name}</sc.Link>
-                    </Link>
+
+                    <sc.StyledLink href={path}> {name}</sc.StyledLink>
                 </sc.Container>
             )}
         </GridRoot>

--- a/demo/site/src/common/components/Breadcrumbs.tsx
+++ b/demo/site/src/common/components/Breadcrumbs.tsx
@@ -13,13 +13,13 @@ const Breadcrumbs = ({ name, path, parentNodes }: GQLBreadcrumbsFragment) => {
                 <sc.Container>
                     {parentNodes.map((parentNode) => (
                         <Fragment key={parentNode.path}>
-                            <Link href={parentNode.path} passHref legacyBehavior>
+                            <Link href={parentNode.path}>
                                 <sc.Link> {parentNode.name}</sc.Link>
                             </Link>
                             <sc.Divider />
                         </Fragment>
                     ))}
-                    <Link href={path} passHref legacyBehavior>
+                    <Link href={path}>
                         <sc.Link> {name}</sc.Link>
                     </Link>
                 </sc.Container>


### PR DESCRIPTION
## Description

currently breadcrumbs are causing in error when rendering because of nesting a tags.


## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="2560" alt="Screenshot 2025-01-13 at 08 10 41" src="https://github.com/user-attachments/assets/2c4a030d-1080-426f-8bb9-b9298fffa9eb" />   <img width="1285" alt="Screenshot 2025-01-13 at 08 10 48" src="https://github.com/user-attachments/assets/89553f4b-b15f-4081-bf24-31c7037cb89d" /> |  <img width="1276" alt="Screenshot 2025-01-13 at 08 12 23" src="https://github.com/user-attachments/assets/a2bb83b7-bb78-4773-81e3-3466e8f37661" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1531
