### PR TITLE
fix: add global styling and responsive space stylings

### DIFF
--- a/demo/site/src/app/GlobalStyle.ts
+++ b/demo/site/src/app/GlobalStyle.ts
@@ -1,0 +1,90 @@
+"use client";
+import { createGlobalStyle } from "styled-components";
+
+export const GlobalStyle = createGlobalStyle`
+    /* Fix a problem with Flexbox to avoid overflows: https://defensivecss.dev/tip/flexbox-min-content-size/ */
+    * {
+        min-width: 0;
+    }
+    
+    html {
+        /* Prevent font size adjustments after orientation changes in mobile devices */
+        text-size-adjust: 100%;
+
+        --header-height: 100px;
+        --full-viewport-height: 100vh;
+
+        @supports (height: 100dvh) {
+            --full-viewport-height: 100dvh;
+        }
+    }
+
+    body {
+        margin: 0;
+
+        /* Improve text rendering with font-smoothing */
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        color: ${({ theme }) => theme.palette.text.primary};
+        
+        /* Make body take the height of the viewport to put footer at the bottom  */
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p {
+        margin: 0;
+    }
+
+    /* Prevent sub and sup elements from affecting the line height in all browsers */
+    sub,
+    sup {
+        font-size: 75%;
+        line-height: 0;
+        position: relative;
+        vertical-align: baseline;
+    }
+
+    sub {
+        bottom: -0.25em;
+    }
+
+    sup {
+        top: -0.5em;
+    }
+
+    button,
+    input,
+    select,
+    textarea {
+        /* Use the application's default font for form elements */
+        font: inherit;
+
+        /* Remove default border-radius that is added by iOS Safari */
+        border-radius: 0;
+    }
+
+    /* Improve media defaults */
+    img,
+    picture,
+    video,
+    canvas,
+    svg {
+        display: block;
+        max-width: 100%;
+    }
+
+    /* Create a root stacking context: https://www.joshwcomeau.com/css/custom-css-reset/#eight-root-stacking-context-9 */
+    /* stylelint-disable selector-id-pattern */
+    #root,
+    #__next {
+        isolation: isolate;
+    }
+`;

--- a/demo/site/src/app/layout.tsx
+++ b/demo/site/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import { CookieApiProvider, useLocalStorageCookieApi, useOneTrustCookieApi as useProductionCookieApi } from "@comet/cms-site";
+import { GlobalStyle } from "@src/app/GlobalStyle";
 import { ErrorHandler } from "@src/util/ErrorHandler";
+import { ResponsiveSpacingStyle } from "@src/util/ResponsiveSpacingStyle";
 import StyledComponentsRegistry from "@src/util/StyledComponentsRegistry";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
@@ -17,6 +19,8 @@ export default function RootLayout({ children }: Readonly<PropsWithChildren>) {
             <body className={inter.className}>
                 <CookieApiProvider api={process.env.NODE_ENV === "development" ? useLocalStorageCookieApi : useProductionCookieApi}>
                     <StyledComponentsRegistry>
+                        <GlobalStyle />
+                        <ResponsiveSpacingStyle />
                         <ErrorHandler>{children}</ErrorHandler>
                     </StyledComponentsRegistry>
                 </CookieApiProvider>

--- a/demo/site/src/util/ResponsiveSpacingStyle.ts
+++ b/demo/site/src/util/ResponsiveSpacingStyle.ts
@@ -1,0 +1,46 @@
+"use client";
+import { createGlobalStyle } from "styled-components";
+
+const ResponsiveSpacingStyle = createGlobalStyle`
+    :root {
+        --spacing-d400: 72px;
+        --spacing-d300: 44px;
+        --spacing-d200: 28px;
+        --spacing-d100: 20px;
+        --spacing-s600: 32px;
+        --spacing-s500: 24px;
+        --spacing-s400: 16px;
+        --spacing-s300: 12px;
+        --spacing-s200: 8px;
+        --spacing-s100: 4px;
+    }
+
+    ${({ theme }) => theme.breakpoints.sm.mediaQuery} {
+        :root {
+            --spacing-d400: 96px;
+            --spacing-d300: 68px;
+            --spacing-d200: 52px;
+            --spacing-d100: 24px;
+        }
+    }
+
+    ${({ theme }) => theme.breakpoints.md.mediaQuery} {
+        :root {
+            --spacing-d400: 120px;
+            --spacing-d300: 84px;
+            --spacing-d200: 64px;
+            --spacing-d100: 32px;
+        }
+    }
+
+    ${({ theme }) => theme.breakpoints.lg.mediaQuery} {
+        :root {
+            --spacing-d400: 172px;
+            --spacing-d300: 100px;
+            --spacing-d200: 72px;
+            --spacing-d100: 48px;
+        }
+    }
+`;
+
+export { ResponsiveSpacingStyle };


### PR DESCRIPTION
## Description

global stylings were not present in demo, and responsive styles did not work, because css variables were not available.

copied global styles and responsive spacing styles from comet-starter.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1392" alt="Screenshot 2025-01-13 at 08 51 45" src="https://github.com/user-attachments/assets/6472599a-e8f7-4716-8fd3-83e3eb4ecf7e" /> | <img width="1392" alt="Screenshot 2025-01-13 at 08 51 53" src="https://github.com/user-attachments/assets/9c9efecf-a571-4cc3-97de-c3643f6ac8d7" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1532
