### PR TITLE
Prevent unresponsive Admin UI of block-preview when rendering an input element in the frontend

### DIFF
--- a/.changeset/metal-waves-add.md
+++ b/.changeset/metal-waves-add.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": patch
+---
+
+Prevent unresponsive Admin UI of block-preview when rendering an input element in the frontend

--- a/packages/site/cms-site/src/iframebridge/IFrameBridge.tsx
+++ b/packages/site/cms-site/src/iframebridge/IFrameBridge.tsx
@@ -121,7 +121,21 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
 
     useEffect(() => {
         if (childrenWrapperRef.current) {
-            const mutationObserver = new MutationObserver(() => {
+            const mutationObserver = new MutationObserver((mutations) => {
+                const mutationsOnlyIncludeNameAndTypeAttributeChangesFromInputElement = mutations.every((mutation) => {
+                    if (mutation.target instanceof HTMLElement && mutation.target.tagName === "INPUT") {
+                        return mutation.attributeName === "name" || mutation.attributeName === "type";
+                    }
+                    return false;
+                });
+
+                if (mutationsOnlyIncludeNameAndTypeAttributeChangesFromInputElement) {
+                    // Recalculating the site/preview elements causes the site content to re-render.
+                    // When the site contains a input element, the `name` and `type` attributes immediately trigger the mutation observer.
+                    // Skipping the recalculation in this case prevents this infinite loop.
+                    return;
+                }
+
                 recalculatePreviewElementsData();
             });
 


### PR DESCRIPTION
## Description

When an input is rendered, it's `name` and `type` attributes change from `null` to their actual value.
This triggers a re-calculation of the preview overlays, due to https://github.com/vivid-planet/comet/pull/2682.
The re-calculation then causes a re-render of the site-content, which causes an infinite loop.

This issue does not seem to occur with other elements, such as `textarea` or `select`.

This fix does not address the root cause of the issue, but it does allow using the `input` element in the frontend, which was practically not possible before. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/SVK-518
-   To reproduce the issue, see https://github.com/vivid-planet/comet/pull/3085
