### PR TITLE
Allow non-full-width fields in `FieldSet`

### DIFF
--- a/.changeset/sharp-dryers-happen.md
+++ b/.changeset/sharp-dryers-happen.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Fix: Remove `display: flex` from `children`-slot of `FieldSet` to allow non-full-width fields

--- a/.changeset/sharp-dryers-happen.md
+++ b/.changeset/sharp-dryers-happen.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin": minor
+"@comet/admin": patch
 ---
 
-Fix: Remove `display: flex` from `children`-slot of `FieldSet` to allow non-full-width fields
+Allow non-full-width fields in `FieldSet`

--- a/packages/admin/admin/src/common/FieldSet.tsx
+++ b/packages/admin/admin/src/common/FieldSet.tsx
@@ -190,8 +190,6 @@ const Children = createComponentSlot(MuiAccordionDetails)<FieldSetClassKey, Owne
     },
 })(
     ({ theme, ownerState }) => css`
-        display: flex;
-        flex-direction: column;
         padding: 20px;
 
         ${!ownerState.hiddenSummary &&

--- a/storybook/src/admin/form/FieldContainer.stories.tsx
+++ b/storybook/src/admin/form/FieldContainer.stories.tsx
@@ -28,10 +28,7 @@ export const FieldContainer = () => {
                         <TextField name="textFieldWithLabelTwo" label="TextField label" variant="horizontal" />
                         <TextField name="testWithoutLabel" variant="horizontal" placeholder="TextField without label" />
                     </FieldSet>
-                    <FieldSet
-                        title="VERTICAL (auto-width)"
-                        slotProps={{ children: { sx: { display: "block" } } }} // TODO: Use `FieldSet` here once it supports non-full-width fields (https://vivid-planet.atlassian.net/browse/COM-1430)
-                    >
+                    <FieldSet title="VERTICAL (auto-width)">
                         <TextField name="textFieldWithLabelOne" label="TextField label" variant="vertical" />
                         <TextField name="textFieldWithLabelTwo" label="TextField label" variant="vertical" />
                         <TextField name="testWithoutLabel" variant="vertical" placeholder="TextField without label" />


### PR DESCRIPTION
## Description

If child Fields are rendered without fullWidth, they won't have the correct width. Remove 'display: flex' to correct this. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before                                                                                         | After                                                                                          |
|----|----|
| ![Screenshot 2025-01-13 at 14 01 02](https://github.com/user-attachments/assets/37ccb584-838b-4dc5-a061-18aa7ac2704c) | ![Screenshot 2025-01-13 at 14 01 02](https://github.com/user-attachments/assets/384ea782-f0a4-4935-a66d-a7837a023492) |



## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1430
