### PR TITLE
Renovate: Remove range strategy configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,13 +69,8 @@
         {
             "matchUpdateTypes": ["major"],
             "labels": ["major", "dependencies"]
-        },
-        {
-            "matchDepTypes": ["peerDependencies"],
-            "rangeStrategy": "widen"
         }
     ],
-    "rangeStrategy": "bump",
     "labels": ["dependencies"],
     "baseBranches": ["next"]
 }


### PR DESCRIPTION
## Description

This is an attempt to prevent Renovate from updating peer dependency ranges.
