### PR TITLE
Renovate: Prevent Renovate from bumping peer dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,10 @@
         {
             "matchUpdateTypes": ["major"],
             "labels": ["major", "dependencies"]
+        },
+        {
+            "matchDepTypes": ["peerDependencies"],
+            "rangeStrategy": "widen"
         }
     ],
     "rangeStrategy": "bump",


### PR DESCRIPTION
## Description

https://github.com/vivid-planet/comet/pull/3077 was incorrectly merged into `next`. It should be merged into `main` instead.
