### PR TITLE
Hide DAM "Dependents" tab based on permission

### DIFF
--- a/.changeset/eighty-cheetahs-burn.md
+++ b/.changeset/eighty-cheetahs-burn.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Hide the "Dependents" tab in the DAM for users without the permission `dependencies`

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -26,6 +26,7 @@ import { useContentScope } from "../../contentScope/Provider";
 import { useDependenciesConfig } from "../../dependencies/DependenciesConfig";
 import { DependencyList } from "../../dependencies/DependencyList";
 import { GQLFocalPoint, GQLImageCropAreaInput, GQLLicenseInput } from "../../graphql.generated";
+import { useUserPermissionCheck } from "../../userPermissions/hooks/currentUser";
 import { useDamConfig } from "../config/useDamConfig";
 import { LicenseValidityTags } from "../DataGrid/tags/LicenseValidityTags";
 import Duplicates from "./Duplicates";
@@ -115,6 +116,7 @@ const EditFileInner = ({ file, id, contentScopeIndicator }: EditFileInnerProps) 
     const intl = useIntl();
     const damConfig = useDamConfig();
     const apolloClient = useApolloClient();
+    const isAllowed = useUserPermissionCheck();
 
     const onSubmit = useCallback(
         async (values: EditFileFormValues) => {
@@ -244,7 +246,7 @@ const EditFileInner = ({ file, id, contentScopeIndicator }: EditFileInnerProps) 
                                 >
                                     <Duplicates fileId={file.id} />
                                 </RouterTab>
-                                {Object.keys(dependencyMap).length > 0 && (
+                                {isAllowed("dependencies") && Object.keys(dependencyMap).length > 0 && (
                                     <RouterTab
                                         key="dependents"
                                         label={intl.formatMessage({ id: "comet.dam.file.dependents", defaultMessage: "Dependents" })}


### PR DESCRIPTION
## Description

Hide the "Dependents" tab in the DAM for users without the permission `dependencies`

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

### Before


https://github.com/user-attachments/assets/a988807c-54f5-4444-ab42-a695eb5d5d5a



### After

<img width="1728" alt="Bildschirmfoto 2025-01-14 um 16 12 13" src="https://github.com/user-attachments/assets/5836abbb-fac5-48be-bb79-118f44dc3cc3" />

