### PR TITLE
Pass `x-preview-dam-urls` and `x-relative-dam-urls` headers to `url` field resolver in `FileImagesResolver`

### DIFF
--- a/.changeset/heavy-drinks-leave.md
+++ b/.changeset/heavy-drinks-leave.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Pass `x-preview-dam-urls` and `x-relative-dam-urls` headers to `url` field resolver in `FileImagesResolver`

--- a/packages/api/cms-api/src/dam/files/file-image.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/file-image.resolver.ts
@@ -1,4 +1,5 @@
-import { Args, Int, Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { IncomingMessage } from "http";
 
 import { RequiredPermission } from "../../user-permissions/decorators/required-permission.decorator";
 import { ImagesService } from "../images/images.service";
@@ -15,10 +16,18 @@ export class FileImagesResolver {
         @Args("width", { type: () => Int }) width: number,
         @Args("height", { type: () => Int }) height: number,
         @Parent() fileImage: DamFileImage,
+        @Context("req") req: IncomingMessage,
     ): Promise<string | undefined> {
         const file = await this.filesService.findOneByImageId(fileImage.id);
+
         if (file) {
-            const urlTemplate = this.imagesService.createUrlTemplate({ file }, {});
+            const urlTemplate = this.imagesService.createUrlTemplate(
+                { file },
+                {
+                    previewDamUrls: Boolean(req.headers["x-preview-dam-urls"]),
+                    relativeDamUrls: Boolean(req.headers["x-relative-dam-urls"]),
+                },
+            );
             return urlTemplate.replace("$resizeWidth", String(width)).replace("$resizeHeight", String(height));
         }
     }


### PR DESCRIPTION
## Description

Pass `x-preview-dam-urls` and `x-relative-dam-urls` headers to `url` field resolver in `FileImagesResolver`. In the DAM, the preview URLs are now used for the thumbnails.

## Acceptance criteria

-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
