### PR TITLE
MUI Dialog mobile styling adaptions

### DIFF
--- a/.changeset/eighty-zebras-rescue.md
+++ b/.changeset/eighty-zebras-rescue.md
@@ -2,4 +2,4 @@
 "@comet/admin-theme": patch
 ---
 
-Adapt styling of 'MuiDialogActions', 'MuiDialogContent', 'MuiDialogTitle' to match the Comet DXP design
+Adapt styling of `DialogActions`, `DialogContent`, and `DialogTitle` to match the Comet DXP design

--- a/.changeset/eighty-zebras-rescue.md
+++ b/.changeset/eighty-zebras-rescue.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": patch
+---
+
+Adapt styling of 'MuiDialogActions', 'MuiDialogContent', 'MuiDialogTitle' to match the Comet DXP design.

--- a/.changeset/eighty-zebras-rescue.md
+++ b/.changeset/eighty-zebras-rescue.md
@@ -2,4 +2,4 @@
 "@comet/admin-theme": patch
 ---
 
-Adapt styling of 'MuiDialogActions', 'MuiDialogContent', 'MuiDialogTitle' to match the Comet DXP design.
+Adapt styling of 'MuiDialogActions', 'MuiDialogContent', 'MuiDialogTitle' to match the Comet DXP design

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogActions.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogActions.ts
@@ -1,16 +1,16 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogActions: GetMuiComponentTheme<"MuiDialogActions"> = (component, { palette, breakpoints }) => ({
+export const getMuiDialogActions: GetMuiComponentTheme<"MuiDialogActions"> = (component, { palette, breakpoints, spacing }) => ({
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiDialogActions">(component?.styleOverrides, {
         root: {
             borderTop: `1px solid ${palette.grey[100]}`,
-            padding: 10,
+            padding: spacing(2),
             justifyContent: "space-between",
 
             [breakpoints.up("sm")]: {
-                padding: 20,
+                padding: spacing(4),
             },
 
             "&>:first-of-type:last-child": {

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogActions.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogActions.ts
@@ -1,13 +1,17 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogActions: GetMuiComponentTheme<"MuiDialogActions"> = (component, { palette }) => ({
+export const getMuiDialogActions: GetMuiComponentTheme<"MuiDialogActions"> = (component, { palette, breakpoints }) => ({
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiDialogActions">(component?.styleOverrides, {
         root: {
             borderTop: `1px solid ${palette.grey[100]}`,
-            padding: 20,
+            padding: 10,
             justifyContent: "space-between",
+
+            [breakpoints.up("sm")]: {
+                padding: 20,
+            },
 
             "&>:first-of-type:last-child": {
                 marginLeft: "auto",

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogContent.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogContent.ts
@@ -3,15 +3,23 @@ import { dialogTitleClasses } from "@mui/material";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogContent: GetMuiComponentTheme<"MuiDialogContent"> = (component, { palette }) => ({
+export const getMuiDialogContent: GetMuiComponentTheme<"MuiDialogContent"> = (component, { palette, breakpoints }) => ({
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiDialogContent">(component?.styleOverrides, {
         root: {
             backgroundColor: palette.grey[50],
-            padding: 40,
+            padding: 10,
 
             [`.${dialogTitleClasses.root} + &`]: {
-                paddingTop: 40,
+                paddingTop: 10,
+            },
+
+            [breakpoints.up("sm")]: {
+                padding: 40,
+
+                [`.${dialogTitleClasses.root} + &`]: {
+                    paddingTop: 40,
+                },
             },
         },
     }),

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogContent.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogContent.ts
@@ -3,22 +3,22 @@ import { dialogTitleClasses } from "@mui/material";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogContent: GetMuiComponentTheme<"MuiDialogContent"> = (component, { palette, breakpoints }) => ({
+export const getMuiDialogContent: GetMuiComponentTheme<"MuiDialogContent"> = (component, { palette, breakpoints, spacing }) => ({
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiDialogContent">(component?.styleOverrides, {
         root: {
             backgroundColor: palette.grey[50],
-            padding: 10,
+            padding: spacing(2),
 
             [`.${dialogTitleClasses.root} + &`]: {
-                paddingTop: 10,
+                paddingTop: spacing(2),
             },
 
             [breakpoints.up("sm")]: {
-                padding: 40,
+                padding: spacing(8),
 
                 [`.${dialogTitleClasses.root} + &`]: {
-                    paddingTop: 40,
+                    paddingTop: spacing(8),
                 },
             },
         },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogTitle.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogTitle.ts
@@ -1,7 +1,7 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (component, { palette, typography }) => ({
+export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (component, { palette, typography, breakpoints }) => ({
     ...component,
     defaultProps: {
         variant: "subtitle1",
@@ -10,7 +10,14 @@ export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (compon
         root: {
             backgroundColor: palette.grey["A200"],
             color: "#ffffff",
-            padding: 20,
+            padding: 10,
+            fontSize: "14px",
+
+            [breakpoints.up("sm")]: {
+                minWidth: 0,
+                fontSize: "16px",
+                padding: 20,
+            },
         },
     }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogTitle.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogTitle.ts
@@ -1,7 +1,7 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (component, { palette, typography, breakpoints }) => ({
+export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (component, { palette, typography, breakpoints, spacing }) => ({
     ...component,
     defaultProps: {
         variant: "subtitle1",
@@ -10,13 +10,13 @@ export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (compon
         root: {
             backgroundColor: palette.grey["A200"],
             color: "#ffffff",
-            padding: 10,
+            padding: spacing(2),
             fontSize: "14px",
 
             [breakpoints.up("sm")]: {
                 minWidth: 0,
                 fontSize: "16px",
-                padding: 20,
+                padding: spacing(4),
             },
         },
     }),


### PR DESCRIPTION
## Description

Adjust the spacings of MuiDialogTitle, MuiDialogContent and MuiDialogActions on mobile according to design

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before                                                                                                         | After                                                                                                          |
|---------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
| <img width="377" alt="Screenshot 2025-01-15 at 08 40 30" src="https://github.com/user-attachments/assets/1031b852-3f0e-4f20-98ce-cafe84b46b54" /> | <img width="377" alt="Screenshot 2025-01-15 at 08 40 42" src="https://github.com/user-attachments/assets/ff8bad87-24b0-4897-84ae-3bc2642ff75a" /> |


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1386
