### PR TITLE
Fix redirects after MikroORM v6 upgrade

### DIFF
--- a/packages/api/cms-api/src/redirects/redirects.resolver.ts
+++ b/packages/api/cms-api/src/redirects/redirects.resolver.ts
@@ -65,7 +65,7 @@ export function createRedirectsResolver({
             const where = this.redirectService.getFindCondition({ query, type, active });
             if (hasNonEmptyScope) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (where as any).scope = scope;
+                (where as any).scope = nonEmptyScopeOrNothing(scope);
             }
 
             const options: FindOptions<RedirectInterface> = {};
@@ -83,7 +83,7 @@ export function createRedirectsResolver({
             const where = this.redirectService.getFindConditionPaginatedRedirects({ search, filter });
             if (hasNonEmptyScope) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (where as any).scope = scope;
+                (where as any).scope = nonEmptyScopeOrNothing(scope);
             }
 
             const options: FindOptions<RedirectInterface> = { offset, limit };
@@ -117,7 +117,7 @@ export function createRedirectsResolver({
         ): Promise<RedirectInterface | null> {
             const where: FilterQuery<RedirectInterface> = { source, sourceType };
             if (hasNonEmptyScope) {
-                where.scope = scope;
+                where.scope = nonEmptyScopeOrNothing(scope);
             }
             const redirect = await this.repository.findOne(where);
             return redirect ?? null;


### PR DESCRIPTION
## Description

Loading the redirects failed with the error `ValidationError: Invalid query for entity 'Redirect', property 'toJSON' does not exist in embeddable 'RedirectScope'`. This is likely due to [changes made to implicit serialization](https://mikro-orm.io/docs/upgrading-v5-to-v6). We fix this by using the `nonEmptyScopeOrNothing` helper, which should be used anyway.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1212
