### PR TITLE
feat: add possiblity to override the category of a block with createListBlock

### DIFF
--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -17,7 +17,7 @@ import { BlockPreviewContent } from "../common/blockRow/BlockPreviewContent";
 import { BlockRow } from "../common/blockRow/BlockRow";
 import { createBlockSkeleton } from "../helpers/createBlockSkeleton";
 import { deduplicateBlockDependencies } from "../helpers/deduplicateBlockDependencies";
-import { BlockDependency, BlockInterface, BlockState, PreviewContent } from "../types";
+import { BlockCategory, BlockDependency, BlockInterface, BlockState, PreviewContent } from "../types";
 import { createUseAdminComponent } from "./listBlock/createUseAdminComponent";
 
 // Using {} instead of Record<string, never> because never and unknown are incompatible.
@@ -83,6 +83,7 @@ interface CreateListBlockOptions<T extends BlockInterface, AdditionalItemFields 
         onMenuClose: () => void;
     }>;
     AdditionalItemContent?: FunctionComponent<{ item: ListBlockItem<T, AdditionalItemFields> }>;
+    overrideCategory?: BlockCategory;
 }
 
 export function createListBlock<T extends BlockInterface, AdditionalItemFields extends Record<string, unknown> = DefaultAdditionalItemFields>({
@@ -97,6 +98,7 @@ export function createListBlock<T extends BlockInterface, AdditionalItemFields e
     additionalItemFields,
     AdditionalItemContextMenuItems,
     AdditionalItemContent,
+    overrideCategory,
 }: CreateListBlockOptions<T, AdditionalItemFields>): BlockInterface<
     ListBlockFragment<AdditionalItemFields>,
     ListBlockState<T, AdditionalItemFields>,
@@ -141,7 +143,7 @@ export function createListBlock<T extends BlockInterface, AdditionalItemFields e
                     : [],
         }),
 
-        category: block.category,
+        category: overrideCategory ?? block.category,
 
         input2State: (input) => {
             return {


### PR DESCRIPTION
Add possiblity to override the category of a block with createListBlock

## Description
Currently it is not possible to set the category of a block that is created with `createListBlock`. We add a parameter `overrideBlockCategory` to do that.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

For example: moving `KeyFactsBlock` from "Text & Content" to "Teaser" is not possible, except by changing the Category of its list item block `KeyFactsItemBlock` which is probably not correct.
![Untitled](https://github.com/user-attachments/assets/90b764f7-f169-47e1-9f72-0ca3df88fe34)

## Open TODOs/questions

-   [ ] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-XXX
