### PR TITLE
Fix rendering a link containing a soft hyphen

### DIFF
--- a/demo/site/src/common/blocks/RichTextBlock.tsx
+++ b/demo/site/src/common/blocks/RichTextBlock.tsx
@@ -2,6 +2,7 @@
 import { hasRichTextBlockContent, PreviewSkeleton, PropsWithData, withPreview } from "@comet/cms-site";
 import { LinkBlockData, RichTextBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { Children, isValidElement } from "react";
 import redraft, { Renderers, TextBlockRenderFn } from "redraft";
 import styled, { css } from "styled-components";
 
@@ -76,7 +77,8 @@ const defaultRichTextRenderers: Renderers = {
     entities: {
         // key is the entity key value from raw
         LINK: (children, data: LinkBlockData, { key }) => {
-            const mergedKey = key + children?.toString();
+            const childrenString = extractTextFromChildren(children);
+            const mergedKey = childrenString + key;
 
             return isValidLink(data) ? (
                 <InlineLink key={mergedKey} data={data}>
@@ -88,6 +90,19 @@ const defaultRichTextRenderers: Renderers = {
         },
     },
 };
+
+function extractTextFromChildren(children: React.ReactNode): string {
+    return Children.toArray(children)
+        .map((child) => {
+            if (typeof child === "string" || typeof child === "number") {
+                return String(child);
+            } else if (isValidElement(child)) {
+                return child.props.children ? extractTextFromChildren(child.props.children) : "";
+            }
+            return "";
+        })
+        .join("");
+}
 
 interface RichTextBlockProps extends PropsWithData<RichTextBlockData> {
     renderers?: Renderers;

--- a/demo/site/src/common/blocks/RichTextBlock.tsx
+++ b/demo/site/src/common/blocks/RichTextBlock.tsx
@@ -75,14 +75,17 @@ const defaultRichTextRenderers: Renderers = {
      */
     entities: {
         // key is the entity key value from raw
-        LINK: (children, data: LinkBlockData, { key }) =>
-            isValidLink(data) ? (
-                <InlineLink key={key} data={data}>
+        LINK: (children, data: LinkBlockData, { key }) => {
+            const mergedKey = key + children?.toString();
+
+            return isValidLink(data) ? (
+                <InlineLink key={mergedKey} data={data}>
                     {children}
                 </InlineLink>
             ) : (
                 <span>{children}</span>
-            ),
+            );
+        },
     },
 };
 


### PR DESCRIPTION
## Description

### Problem

When inserting a soft hyphen (or non-breaking space) into a link, the first link part would be repeated multiple times. 

### Reason

The same key was used for the first and second part. This happens because when inserting a soft hyphen, the block is split into two entityRanges. But both ranges get the same key (0 in this case):

```
{
    "key": "1v4k7",
    "text": "Li­nk 2",
    "type": "paragraph-standard",
    "depth": 0,
    "inlineStyleRanges": [],
    "entityRanges": [
        {
            "offset": 0,
            "length": 2,
            "key": 0
        },
        {
            "offset": 3,
            "length": 4,
            "key": 0
        }
    ],
    "data": {}
}
```

### Solution

I combine the key and the children (converted to a string) to get a unique key. This still has an edge case: when the first and second part of the link is identical (e.g., `Tuk(-)Tuk`). But I guess this is neglectable. 

### Alternative Solution

It should also be possible to fix this issue in the admin. I couldn't find a way to override the keys for the ranges. 

I did find a way to insert the soft hyphen without splitting the entity into two ranges by setting the `entityKey` in `insertText`:

```
const startKey = selection.getStartKey();
const startOffset = selection.getStartOffset();
const blockWithEntity = currentContent.getBlockForKey(startKey);

const entityKey = startOffset > 0 ? blockWithEntity.getEntityAt(startOffset - 1) : blockWithEntity.getEntityAt(startOffset);

const updatedContent = Modifier.insertText(
    currentContent,
    selection,
    String.fromCharCode(SHY_UNICODE_CHAR),
    undefined, 
    entityKey, 
);
```
 However, this caused the `EditorComponent` to not render anymore. I couldn't find the reason for this as the Decorator strategy returns the right range. After some debugging, I decided it's not worth the time.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1728" alt="Bildschirmfoto 2025-01-15 um 22 31 09" src="https://github.com/user-attachments/assets/76f8e9b4-59fc-407b-beb2-bec83ec3e0af" /> | <img width="1728" alt="Bildschirmfoto 2025-01-15 um 22 31 27" src="https://github.com/user-attachments/assets/7f8624c9-069a-43b8-b135-8ac0106f8ae8" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1537
