### PR TITLE
Style spacings in Data Grid depending on density

### DIFF
--- a/.changeset/popular-seals-promise.md
+++ b/.changeset/popular-seals-promise.md
@@ -2,4 +2,4 @@
 "@comet/admin-theme": patch
 ---
 
-Adapt `height` of elements in `MuiDataGrid` depending on the `density`-prop to match the Comet DXP design
+Adapt `height` of elements in `DataGrid` depending on the `density`-prop to match the Comet DXP design

--- a/.changeset/popular-seals-promise.md
+++ b/.changeset/popular-seals-promise.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": patch
+---
+
+Adapt `height` of elements in `MuiDataGrid` depending on the `density`-prop to match the Comet DXP design

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -90,6 +90,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
         },
         footerContainer: ({ ownerState }) => ({
             borderTop: `1px solid ${palette.grey[100]}`,
+            boxSizing: "border-box",
             height: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             minHeight: getDensityHeightValue(ownerState?.density, spacing),
             maxHeight: getDensityHeightValue(ownerState?.density, spacing),

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -76,7 +76,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             minHeight: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             maxHeight: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
         }),
-        cell: {
+        cell: ({ ownerState }) => ({
             borderTop: `1px solid ${palette.grey[100]}`,
             "&:focus": {
                 outline: "none",
@@ -87,7 +87,9 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             [`& .${getDataGridUtilityClass("booleanCell")}`]: {
                 color: palette.grey[900],
             },
-        },
+            height: `${getDensityHeightValue(ownerState?.density, spacing)}`,
+            alignContent: "center",
+        }),
         footerContainer: ({ ownerState }) => ({
             borderTop: `1px solid ${palette.grey[100]}`,
             boxSizing: "border-box",
@@ -95,12 +97,10 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             minHeight: getDensityHeightValue(ownerState?.density, spacing),
             maxHeight: getDensityHeightValue(ownerState?.density, spacing),
 
-            ...(ownerState?.density === "compact" && {
-                "& .MuiTablePagination-root > .MuiToolbar-root": {
-                    height: getDensityHeightValue(ownerState?.density, spacing),
-                    minHeight: getDensityHeightValue(ownerState?.density, spacing),
-                },
-            }),
+            "& .MuiTablePagination-root > .MuiToolbar-root": {
+                height: getDensityHeightValue(ownerState?.density, spacing),
+                minHeight: getDensityHeightValue(ownerState?.density, spacing),
+            },
         }),
 
         iconSeparator: {

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -102,7 +102,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             borderTop: `1px solid ${palette.grey[100]}`,
             ...getDensityStyles(ownerState?.density, spacing),
 
-            ...(ownerState.density === "compact" && {
+            ...(ownerState?.density === "compact" && {
                 "& .MuiTablePagination-root > .MuiToolbar-root": {
                     height: spacing(8),
                     minHeight: spacing(8),

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -13,11 +13,35 @@ import {
     TextField,
     TextFieldProps,
 } from "@mui/material";
+import { Spacing } from "@mui/system";
 import { getDataGridUtilityClass, GRID_DEFAULT_LOCALE_TEXT, gridClasses } from "@mui/x-data-grid";
 import type {} from "@mui/x-data-grid/themeAugmentation";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+const getDensityStyles = (density: string | unknown, spacing: Spacing) => {
+    switch (density) {
+        case "compact":
+            return {
+                minHeight: `${spacing(8)} !important`,
+                maxHeight: `${spacing(8)} !important`,
+                height: `${spacing(8)} !important`,
+            };
+        case "comfortable":
+            return {
+                minHeight: `${spacing(16)} !important`,
+                maxHeight: `${spacing(16)} !important`,
+                height: `${spacing(16)} !important`,
+            };
+        default:
+            return {
+                minHeight: `${spacing(12)} !important`,
+                maxHeight: `${spacing(12)} !important`,
+                height: `${spacing(12)} !important`,
+            };
+    }
+};
 
 export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, { palette, shadows, spacing }) => ({
     ...component,
@@ -46,21 +70,24 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
         root: {
             backgroundColor: "white",
         },
-        columnHeader: {
+        columnHeader: ({ ownerState }) => ({
             "&:focus": {
                 outline: "none",
             },
             "&:focus-within": {
                 outline: "none",
             },
-        },
+            ...getDensityStyles(ownerState?.density, spacing),
+        }),
         pinnedColumns: {
             backgroundColor: "white",
             boxShadow: shadows[2],
         },
+        row: ({ ownerState }) => ({
+            ...getDensityStyles(ownerState?.density, spacing),
+        }),
         cell: {
             borderTop: `1px solid ${palette.grey[100]}`,
-
             "&:focus": {
                 outline: "none",
             },
@@ -71,9 +98,18 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
                 color: palette.grey[900],
             },
         },
-        footerContainer: {
+        footerContainer: ({ ownerState }) => ({
             borderTop: `1px solid ${palette.grey[100]}`,
-        },
+            ...getDensityStyles(ownerState?.density, spacing),
+
+            ...(ownerState.density === "compact" && {
+                "& .MuiTablePagination-root > .MuiToolbar-root": {
+                    height: spacing(8),
+                    minHeight: spacing(8),
+                },
+            }),
+        }),
+
         iconSeparator: {
             backgroundColor: palette.grey[100],
             width: "2px",

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -78,7 +78,6 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
         row: ({ ownerState }) => ({
             height: `${getDensityHeightValue(ownerState?.density, spacing)}`,
             /* !important is required to override inline styles */
-            "--height": `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             minHeight: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             maxHeight: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
         }),

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -20,26 +20,14 @@ import type {} from "@mui/x-data-grid/themeAugmentation";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-const getDensityStyles = (density: string | unknown, spacing: Spacing) => {
+const getDensityHeightValue = (density: string | unknown, spacing: Spacing) => {
     switch (density) {
         case "compact":
-            return {
-                minHeight: `${spacing(8)} !important`,
-                maxHeight: `${spacing(8)} !important`,
-                height: `${spacing(8)} !important`,
-            };
+            return spacing(8);
         case "comfortable":
-            return {
-                minHeight: `${spacing(16)} !important`,
-                maxHeight: `${spacing(16)} !important`,
-                height: `${spacing(16)} !important`,
-            };
+            return spacing(16);
         default:
-            return {
-                minHeight: `${spacing(12)} !important`,
-                maxHeight: `${spacing(12)} !important`,
-                height: `${spacing(12)} !important`,
-            };
+            return spacing(12);
     }
 };
 
@@ -71,20 +59,22 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             backgroundColor: "white",
         },
         columnHeader: ({ ownerState }) => ({
+            height: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             "&:focus": {
                 outline: "none",
             },
             "&:focus-within": {
                 outline: "none",
             },
-            ...getDensityStyles(ownerState?.density, spacing),
         }),
         pinnedColumns: {
             backgroundColor: "white",
             boxShadow: shadows[2],
         },
         row: ({ ownerState }) => ({
-            ...getDensityStyles(ownerState?.density, spacing),
+            height: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
+            minHeight: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
+            maxHeight: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
         }),
         cell: {
             borderTop: `1px solid ${palette.grey[100]}`,
@@ -100,12 +90,14 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
         },
         footerContainer: ({ ownerState }) => ({
             borderTop: `1px solid ${palette.grey[100]}`,
-            ...getDensityStyles(ownerState?.density, spacing),
+            height: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
+            minHeight: getDensityHeightValue(ownerState?.density, spacing),
+            maxHeight: getDensityHeightValue(ownerState?.density, spacing),
 
             ...(ownerState?.density === "compact" && {
                 "& .MuiTablePagination-root > .MuiToolbar-root": {
-                    height: spacing(8),
-                    minHeight: spacing(8),
+                    height: getDensityHeightValue(ownerState?.density, spacing),
+                    minHeight: getDensityHeightValue(ownerState?.density, spacing),
                 },
             }),
         }),

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -76,8 +76,9 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             boxShadow: shadows[2],
         },
         row: ({ ownerState }) => ({
+            height: `${getDensityHeightValue(ownerState?.density, spacing)}`,
             /* !important is required to override inline styles */
-            height: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
+            "--height": `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             minHeight: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             maxHeight: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
         }),

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -68,6 +68,9 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
                 outline: "none",
             },
         }),
+        columnHeaderTitleContainer: ({ ownerState }) => ({
+            height: `${getDensityHeightValue(ownerState?.density, spacing)}`,
+        }),
         pinnedColumns: {
             backgroundColor: "white",
             boxShadow: shadows[2],

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -99,8 +99,6 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
         footerContainer: ({ ownerState }) => ({
             borderTop: `1px solid ${palette.grey[100]}`,
             boxSizing: "border-box",
-            /* !important is required to override inline styles */
-            height: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             minHeight: getDensityHeightValue(ownerState?.density, spacing),
             maxHeight: getDensityHeightValue(ownerState?.density, spacing),
 

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -59,6 +59,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             backgroundColor: "white",
         },
         columnHeader: ({ ownerState }) => ({
+            /* !important is required to override inline styles */
             height: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             "&:focus": {
                 outline: "none",
@@ -72,6 +73,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             boxShadow: shadows[2],
         },
         row: ({ ownerState }) => ({
+            /* !important is required to override inline styles */
             height: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             minHeight: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             maxHeight: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
@@ -93,6 +95,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
         footerContainer: ({ ownerState }) => ({
             borderTop: `1px solid ${palette.grey[100]}`,
             boxSizing: "border-box",
+            /* !important is required to override inline styles */
             height: `${getDensityHeightValue(ownerState?.density, spacing)} !important`,
             minHeight: getDensityHeightValue(ownerState?.density, spacing),
             maxHeight: getDensityHeightValue(ownerState?.density, spacing),


### PR DESCRIPTION
## Description
Adjust the height of the elements of DataGrids (rows, column header, footer) to suit the design, depending on the set density (“standard”, “compact”, “comfortable").


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1034" alt="Screenshot 2025-01-16 at 10 42 48" src="https://github.com/user-attachments/assets/ec77eff8-ebc8-4146-b07e-8909ac4b5bec" /> | <img width="1036" alt="Screenshot 2025-01-16 at 10 38 58" src="https://github.com/user-attachments/assets/0f50ce53-499a-4860-9c05-e55dba569c3f" /> |
| <img width="1040" alt="Screenshot 2025-01-16 at 10 42 39" src="https://github.com/user-attachments/assets/35a5e07f-8bcb-429d-b9b4-7e552cd334cf" /> | <img width="1020" alt="Screenshot 2025-01-16 at 10 08 00" src="https://github.com/user-attachments/assets/21302199-5760-4143-9b06-b0132e631ada" /> |
| <img width="1055" alt="Screenshot 2025-01-16 at 10 42 32" src="https://github.com/user-attachments/assets/ea96ce88-5ddf-4a61-8251-8f3f76831af7" /> | <img width="1028" alt="Screenshot 2025-01-16 at 10 07 53" src="https://github.com/user-attachments/assets/3c08747e-758b-45dd-99e9-feb0b2cfafd1" /> |


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1503
