### PR TITLE
Pass `x-preview-dam-urls` header to `url` field resolver in `FileImagesResolver` (v6)

### DIFF
--- a/.changeset/heavy-drinks-leave.md
+++ b/.changeset/heavy-drinks-leave.md
@@ -2,4 +2,4 @@
 "@comet/cms-api": patch
 ---
 
-Pass `x-preview-dam-urls` and `x-relative-dam-urls` headers to `url` field resolver in `FileImagesResolver`
+Pass `x-preview-dam-urls` header to `url` field resolver in `FileImagesResolver`

--- a/.changeset/heavy-drinks-leave.md
+++ b/.changeset/heavy-drinks-leave.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Pass `x-preview-dam-urls` and `x-relative-dam-urls` headers to `url` field resolver in `FileImagesResolver`

--- a/packages/api/cms-api/src/dam/files/file-image.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/file-image.resolver.ts
@@ -1,4 +1,5 @@
-import { Args, Int, Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { Args, Context, Int, Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { IncomingMessage } from "http";
 
 import { RequiredPermission } from "../../user-permissions/decorators/required-permission.decorator";
 import { ImagesService } from "../images/images.service";
@@ -15,10 +16,12 @@ export class FileImagesResolver {
         @Args("width", { type: () => Int }) width: number,
         @Args("height", { type: () => Int }) height: number,
         @Parent() fileImage: DamFileImage,
+        @Context("req") req: IncomingMessage,
     ): Promise<string | undefined> {
         const file = await this.filesService.findOneByImageId(fileImage.id);
+
         if (file) {
-            const urlTemplate = this.imagesService.createUrlTemplate({ file });
+            const urlTemplate = this.imagesService.createUrlTemplate({ file }, Boolean(req.headers["x-preview-dam-urls"]));
             return urlTemplate.replace("$resizeWidth", String(width)).replace("$resizeHeight", String(height));
         }
     }


### PR DESCRIPTION
Backport of https://github.com/vivid-planet/comet/pull/3128 

(only passes `x-preview-dam-urls` because `x-relative-dam-urls` was newly introduced in v7)