### PR TITLE
Renovate: widen Node updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -67,6 +67,11 @@
             "matchPackageNames": ["/^lodash.*/", "/^@types/lodash.*/"]
         },
         {
+            "groupName": "node",
+            "matchPackageNames": ["node"],
+            "rangeStrategy": "widen"
+        },
+        {
             "matchUpdateTypes": ["major"],
             "labels": ["major", "dependencies"]
         },


### PR DESCRIPTION
We do this to prevent Renovate from updating the .nvmrc.