### PR TITLE
Export `useDamScope` hook

### DIFF
--- a/.changeset/mean-pears-tie.md
+++ b/.changeset/mean-pears-tie.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Export `useDamScope` hook
+
+This allows accessing the DAM scope in the application. This might be necessary when developing integrations with a third-party DAM.

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -54,6 +54,7 @@ export { DamConfigProvider } from "./dam/config/DamConfigProvider";
 export { damDefaultAcceptedMimeTypes } from "./dam/config/damDefaultAcceptedMimeTypes";
 export { useDamAcceptedMimeTypes } from "./dam/config/useDamAcceptedMimeTypes";
 export { useDamConfig } from "./dam/config/useDamConfig";
+export { useDamScope } from "./dam/config/useDamScope";
 export { useCurrentDamFolder } from "./dam/CurrentDamFolderProvider";
 export { DamPage } from "./dam/DamPage";
 export type { FileWithDamUploadMetadata } from "./dam/DataGrid/fileUpload/useDamFileUpload";


### PR DESCRIPTION
## Description

This allows accessing the DAM scope in the application. This might be necessary when developing integrations with a third-party DAM.

## Acceptance criteria

-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)


Note: I didn't add an example because the main use case for now is using it for a third-party DAM integration that loads the chosen image(s) on the server-side. We only have a client-side example in Demo. I deemed implementing a second, server-side example too much effort to justify for a simple export. Let me know if you see this differently.
