### PR TITLE
Forward `ref` in `Button`

### DIFF
--- a/packages/admin/admin/src/common/buttons/Button.tsx
+++ b/packages/admin/admin/src/common/buttons/Button.tsx
@@ -9,7 +9,7 @@ import {
     useTheme,
     useThemeProps,
 } from "@mui/material";
-import { ReactNode } from "react";
+import { forwardRef, ReactNode } from "react";
 
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
@@ -62,7 +62,7 @@ const getMobileIconNode = ({ mobileIcon, startIcon, endIcon }: Pick<ButtonProps,
     return mobileIcon;
 };
 
-export const Button = (inProps: ButtonProps) => {
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>((inProps, ref) => {
     const {
         slotProps,
         variant = "primary",
@@ -94,6 +94,7 @@ export const Button = (inProps: ButtonProps) => {
         ...restProps,
         ownerState,
         ...slotProps?.root,
+        ref,
     };
 
     if (ownerState.usingResponsiveBehavior) {
@@ -111,7 +112,7 @@ export const Button = (inProps: ButtonProps) => {
             {children}
         </Root>
     );
-};
+});
 
 const Root = createComponentSlot(MuiButton)<ButtonClassKey, OwnerState>({
     componentName: "Button",


### PR DESCRIPTION
## Description

Forwarding the `ref` is required in some cases, e.g., when attaching a `Menu` to the `Button` that opens it like the ["More actions" button in the DataGrid excel export story](https://storybook.comet-dxp.com/?path=/story/docs-components-datagrid--use-data-grid-excel-export)

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1289
