### PR TITLE
Allow setting the `component` prop in `Button`

### DIFF
--- a/packages/admin/admin/src/common/buttons/Button.tsx
+++ b/packages/admin/admin/src/common/buttons/Button.tsx
@@ -9,7 +9,8 @@ import {
     useTheme,
     useThemeProps,
 } from "@mui/material";
-import { forwardRef, ReactNode } from "react";
+import { OverridableComponent, OverridableTypeMap } from "@mui/material/OverridableComponent";
+import { ElementType, ForwardedRef, forwardRef, ReactNode } from "react";
 
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
@@ -20,7 +21,7 @@ type Slot = "root" | "mobileTooltip";
 type ComponentState = Variant | "usingResponsiveBehavior";
 export type ButtonClassKey = Slot | ComponentState;
 
-export type ButtonProps = Omit<MuiButtonProps, "variant" | "color"> &
+export type ButtonProps<C extends ElementType = "button"> = Omit<MuiButtonProps<C>, "variant" | "color"> &
     ThemedComponentBaseProps<{
         root: typeof MuiButton;
         mobileTooltip: typeof Tooltip;
@@ -30,6 +31,11 @@ export type ButtonProps = Omit<MuiButtonProps, "variant" | "color"> &
         mobileIcon?: "auto" | "startIcon" | "endIcon" | ReactNode;
         mobileBreakpoint?: Breakpoint;
     };
+
+interface ButtonTypeMap<C extends ElementType = "button"> extends OverridableTypeMap {
+    props: ButtonProps<C>;
+    defaultComponent: C;
+}
 
 type OwnerState = {
     variant: Variant;
@@ -62,7 +68,7 @@ const getMobileIconNode = ({ mobileIcon, startIcon, endIcon }: Pick<ButtonProps,
     return mobileIcon;
 };
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>((inProps, ref) => {
+export const Button = forwardRef(<C extends ElementType = "button">(inProps: ButtonProps<C>, ref: ForwardedRef<any>) => {
     const {
         slotProps,
         variant = "primary",
@@ -112,7 +118,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>((inProps, ref) 
             {children}
         </Root>
     );
-});
+}) as OverridableComponent<ButtonTypeMap>;
 
 const Root = createComponentSlot(MuiButton)<ButtonClassKey, OwnerState>({
     componentName: "Button",


### PR DESCRIPTION
## Description

This allows setting the underlying that will be rendered by the `Button` component. 
When set, the props of the passed in `component` will also be allowed on the `Button` directly. 
This is the same behavior as supported by MUIs `Button`. 

E.g., when using a `StackLink` the props `pageName` and `payload` will be supported. 

```tsx
<Button component={StackLink} pageName="page" payload="test" />
```

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## TODO

-   [x] Merge parent PR https://github.com/vivid-planet/comet/pull/3209

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1289
