### PR TITLE
Admin Generator (Future): Make buttons in generated grids responsive (first option)

### DIFF
--- a/.changeset/good-ads-begin.md
+++ b/.changeset/good-ads-begin.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Apply the theme's `defaultProps` to the `CrudMoreActionsMenu` component when defined

--- a/.changeset/orange-kangaroos-greet.md
+++ b/.changeset/orange-kangaroos-greet.md
@@ -1,0 +1,19 @@
+---
+"@comet/admin": minor
+---
+
+Support applying props directly to `CrudMoreActionsMenu` to apply them to its `Button` component
+
+For example, the component can be set to be responsive by applying the `responsive` prop from `Button`:
+
+```tsx
+<CrudMoreActionsMenu
+    responsive
+    overallActions={
+        // ...
+    }
+    selectiveActions={
+        // ...
+    }
+/>
+```

--- a/demo/admin/src/news/generated/NewsGrid.tsx
+++ b/demo/admin/src/news/generated/NewsGrid.tsx
@@ -2,6 +2,7 @@
 // You may choose to use this file as scaffold by moving this file out of generated folder and removing this comment.
 import { gql, useApolloClient, useQuery } from "@apollo/client";
 import {
+    Button,
     CrudContextMenu,
     dataGridDateColumn,
     DataGridToolbar,
@@ -22,7 +23,7 @@ import {
 import { Add as AddIcon, Edit as EditIcon } from "@comet/admin-icons";
 import { BlockPreviewContent } from "@comet/blocks-admin";
 import { DamImageBlock } from "@comet/cms-admin";
-import { Button, IconButton } from "@mui/material";
+import { IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import { useContentScope } from "@src/common/ContentScopeProvider";
 import * as React from "react";
@@ -87,7 +88,7 @@ function NewsGridToolbar() {
             </ToolbarItem>
             <ToolbarFillSpace />
             <ToolbarActions>
-                <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
+                <Button responsive startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
                     <FormattedMessage id="news.newNews" defaultMessage="New News" />
                 </Button>
             </ToolbarActions>

--- a/demo/admin/src/products/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/ManufacturersGrid.tsx
@@ -41,7 +41,7 @@ function ManufacturersGridToolbar() {
             </ToolbarItem>
             <FillSpace />
             <ToolbarItem>
-                <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
+                <Button responsive startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
                     <FormattedMessage id="manufacturers.newManufacturer" defaultMessage="New Manufacturer" />
                 </Button>
             </ToolbarItem>

--- a/demo/admin/src/products/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/ProductVariantsGrid.tsx
@@ -37,12 +37,12 @@ function ProductVariantsGridToolbar() {
             <ToolbarItem>
                 <GridToolbarQuickFilter />
             </ToolbarItem>
-            <FillSpace />
             <ToolbarItem>
                 <GridFilterButton />
             </ToolbarItem>
+            <FillSpace />
             <ToolbarItem>
-                <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
+                <Button responsive startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
                     <FormattedMessage id="products.newVariant" defaultMessage="New Variant" />
                 </Button>
             </ToolbarItem>

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -57,7 +57,7 @@ function ProductsGridToolbar() {
             </ToolbarItem>
             <FillSpace />
             <ToolbarItem>
-                <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
+                <Button responsive startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
                     <FormattedMessage id="products.newProduct" defaultMessage="New Product" />
                 </Button>
             </ToolbarItem>

--- a/demo/admin/src/products/future/ProductsPage.tsx
+++ b/demo/admin/src/products/future/ProductsPage.tsx
@@ -47,7 +47,7 @@ export function ProductsPage() {
                     <StackMainContent fullHeight>
                         <ProductsGrid
                             toolbarAction={
-                                <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
+                                <Button responsive startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
                                     <FormattedMessage id="product.newProduct" defaultMessage="New Product" />
                                 </Button>
                             }

--- a/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/CombinationFieldsTestProductsGrid.tsx
@@ -81,7 +81,7 @@ function ProductsGridToolbar({ toolbarAction }: { toolbarAction?: React.ReactNod
                 <GridFilterButton />
             </ToolbarItem>
             <ToolbarFillSpace />
-            {toolbarAction && <ToolbarActions>{toolbarAction}</ToolbarActions>}
+            <ToolbarActions>{toolbarAction}</ToolbarActions>
         </DataGridToolbar>
     );
 }

--- a/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/future/generated/ManufacturersGrid.tsx
@@ -2,6 +2,7 @@
 // You may choose to use this file as scaffold by moving this file out of generated folder and removing this comment.
 import { gql, useApolloClient, useQuery } from "@apollo/client";
 import {
+    Button,
     CrudContextMenu,
     DataGridToolbar,
     filterByFragment,
@@ -19,7 +20,7 @@ import {
     usePersistentColumnState,
 } from "@comet/admin";
 import { Add as AddIcon, Edit as EditIcon, Info } from "@comet/admin-icons";
-import { Button, IconButton } from "@mui/material";
+import { IconButton } from "@mui/material";
 import { DataGridPro, GridColumnHeaderTitle, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -94,7 +95,7 @@ function ManufacturersGridToolbar() {
             </ToolbarItem>
             <ToolbarFillSpace />
             <ToolbarActions>
-                <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
+                <Button responsive startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
                     <FormattedMessage id="manufacturer.newManufacturer" defaultMessage="New Manufacturer" />
                 </Button>
             </ToolbarActions>

--- a/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductVariantsGrid.tsx
@@ -2,6 +2,7 @@
 // You may choose to use this file as scaffold by moving this file out of generated folder and removing this comment.
 import { gql, useApolloClient, useQuery } from "@apollo/client";
 import {
+    Button,
     CrudContextMenu,
     dataGridDateColumn,
     DataGridToolbar,
@@ -20,7 +21,7 @@ import {
 } from "@comet/admin";
 import { Add as AddIcon, Edit as EditIcon } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
-import { Button, IconButton } from "@mui/material";
+import { IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -87,7 +88,7 @@ function ProductVariantsGridToolbar() {
             </ToolbarItem>
             <ToolbarFillSpace />
             <ToolbarActions>
-                <Button startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
+                <Button responsive startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
                     <FormattedMessage id="productVariant.newProductVariant" defaultMessage="New Product Variant" />
                 </Button>
             </ToolbarActions>

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -100,17 +100,20 @@ function ProductsGridToolbar({ toolbarAction, exportApi }: { toolbarAction?: Rea
                 <GridFilterButton />
             </ToolbarItem>
             <ToolbarFillSpace />
-            <CrudMoreActionsMenu
-                overallActions={[
-                    {
-                        label: <FormattedMessage {...messages.downloadAsExcel} />,
-                        icon: exportApi.loading ? <CircularProgress size={20} /> : <Excel />,
-                        onClick: () => exportApi.exportGrid(),
-                        disabled: exportApi.loading,
-                    },
-                ]}
-            />
-            {toolbarAction && <ToolbarActions>{toolbarAction}</ToolbarActions>}
+            <ToolbarActions>
+                <CrudMoreActionsMenu
+                    responsive
+                    overallActions={[
+                        {
+                            label: <FormattedMessage {...messages.downloadAsExcel} />,
+                            icon: exportApi.loading ? <CircularProgress size={20} /> : <Excel />,
+                            onClick: () => exportApi.exportGrid(),
+                            disabled: exportApi.loading,
+                        },
+                    ]}
+                />
+                {toolbarAction}
+            </ToolbarActions>
         </DataGridToolbar>
     );
 }

--- a/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
@@ -1,6 +1,5 @@
 import { MoreVertical } from "@comet/admin-icons";
 import {
-    Button,
     Chip,
     ComponentsOverrides,
     css,
@@ -13,11 +12,13 @@ import {
     MenuListProps,
     Theme,
     Typography,
+    useThemeProps,
 } from "@mui/material";
 import { Maybe } from "graphql/jsutils/Maybe";
 import { ComponentProps, MouseEvent, PropsWithChildren, ReactNode, useState } from "react";
 import { FormattedMessage } from "react-intl";
 
+import { Button, ButtonProps } from "../common/buttons/Button";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
@@ -30,14 +31,15 @@ export interface ActionItem extends ComponentProps<typeof MenuItem> {
 }
 
 export interface CrudMoreActionsMenuProps
-    extends ThemedComponentBaseProps<{
-        menu: typeof Menu;
-        menuItem: typeof MenuItem;
-        button: typeof Button;
-        group: typeof CrudMoreActionsGroup;
-        divider: typeof CrudMoreActionsDivider;
-        chip: typeof Chip;
-    }> {
+    extends Omit<ButtonProps, "slotProps">,
+        ThemedComponentBaseProps<{
+            menu: typeof Menu;
+            menuItem: typeof MenuItem;
+            button: typeof Button;
+            group: typeof CrudMoreActionsGroup;
+            divider: typeof CrudMoreActionsDivider;
+            chip: typeof Chip;
+        }> {
     selectionSize?: number;
     overallActions?: Maybe<ActionItem>[];
     selectiveActions?: Maybe<ActionItem>[];
@@ -88,11 +90,7 @@ const MoreActionsSelectedItemsChip = createComponentSlot(Chip)<CrudMoreActionsMe
 const MoreActionsButton = createComponentSlot(Button)<CrudMoreActionsMenuClassKey>({
     componentName: "CrudMoreActions",
     slotName: "button",
-})(
-    css`
-        margin: 0 10px;
-    `,
-);
+})();
 
 const MoreActionsMenuItem = createComponentSlot(MenuItem)<CrudMoreActionsMenuClassKey>({
     componentName: "CrudMoreActions",
@@ -104,14 +102,11 @@ const MoreActionsMenuItem = createComponentSlot(MenuItem)<CrudMoreActionsMenuCla
     `,
 );
 
-export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveActions, selectionSize }: CrudMoreActionsMenuProps) {
-    const {
-        menu: menuProps,
-        button: buttonProps,
-        group: groupProps,
-        divider: dividerProps,
-        chip: chipProps,
-    } = slotProps ?? { menu: {}, button: {}, group: {}, divider: {}, chip: {} };
+export function CrudMoreActionsMenu(inProps: CrudMoreActionsMenuProps) {
+    const { slotProps, overallActions, selectiveActions, selectionSize, ...restProps } = useThemeProps({
+        props: inProps,
+        name: "CometAdminCrudMoreActionsMenu",
+    });
 
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
@@ -123,19 +118,19 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
 
     return (
         <>
-            <MoreActionsButton variant="text" color="inherit" endIcon={<MoreVertical />} {...buttonProps} onClick={handleClick}>
+            <MoreActionsButton variant="textDark" endIcon={<MoreVertical />} {...slotProps?.button} {...restProps} onClick={handleClick}>
                 <FormattedMessage id="comet.crudMoreActions.title" defaultMessage="More" />
-                {!!selectionSize && <MoreActionsSelectedItemsChip size="small" color="primary" {...chipProps} label={selectionSize} />}
+                {!!selectionSize && <MoreActionsSelectedItemsChip size="small" color="primary" {...slotProps?.chip} label={selectionSize} />}
             </MoreActionsButton>
             <Menu
                 keepMounted={false}
                 PaperProps={{ sx: { minWidth: 220, borderRadius: "4px" } }}
                 open={Boolean(anchorEl)}
                 anchorEl={anchorEl}
-                {...menuProps}
+                {...slotProps?.menu}
                 onClose={(event, reason) => {
                     handleClose();
-                    menuProps?.onClose?.(event, reason);
+                    slotProps?.menu?.onClose?.(event, reason);
                 }}
             >
                 {hasOverallActions && (
@@ -145,7 +140,7 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
                                 <FormattedMessage id="comet.crudMoreActions.overallActions" defaultMessage="Overall actions" />
                             ) : undefined
                         }
-                        {...groupProps}
+                        {...slotProps?.group}
                     >
                         {overallActions.map((item, index) => {
                             if (!item) return null;
@@ -166,14 +161,14 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
                                         {!!icon && <ListItemIcon sx={{ minWidth: "unset !important" }}>{icon}</ListItemIcon>}
                                         <ListItemText primary={label} />
                                     </MoreActionsMenuItem>
-                                    {!!divider && <CrudMoreActionsDivider {...dividerProps} />}
+                                    {!!divider && <CrudMoreActionsDivider {...slotProps?.divider} />}
                                 </div>
                             );
                         })}
                     </CrudMoreActionsGroup>
                 )}
 
-                {hasOverallActions && hasSelectiveActions && <CrudMoreActionsDivider {...dividerProps} />}
+                {hasOverallActions && hasSelectiveActions && <CrudMoreActionsDivider {...slotProps?.divider} />}
 
                 {hasSelectiveActions && (
                     <CrudMoreActionsGroup
@@ -182,7 +177,7 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
                                 <FormattedMessage id="comet.crudMoreActions.selectiveActions" defaultMessage="Selective actions" />
                             ) : undefined
                         }
-                        {...groupProps}
+                        {...slotProps?.group}
                     >
                         {selectiveActions.map((item, index) => {
                             if (!item) return;
@@ -203,10 +198,10 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
                                         {!!icon && <ListItemIcon sx={{ minWidth: "unset !important" }}>{icon}</ListItemIcon>}
                                         <ListItemText primary={label} />
                                         {!!selectionSize && (
-                                            <MoreActionsSelectedItemsChip size="small" color="primary" {...chipProps} label={selectionSize} />
+                                            <MoreActionsSelectedItemsChip size="small" color="primary" {...slotProps?.chip} label={selectionSize} />
                                         )}
                                     </MoreActionsMenuItem>
-                                    {!!divider && <CrudMoreActionsDivider {...dividerProps} />}
+                                    {!!divider && <CrudMoreActionsDivider {...slotProps?.divider} />}
                                 </div>
                             );
                         })}

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -528,6 +528,7 @@ export function generateGrid(
 
     const code = `import { gql, useApolloClient, useQuery } from "@apollo/client";
     import {
+        Button,
         CrudContextMenu,
         CrudMoreActionsMenu,
         DataGridToolbar,
@@ -554,7 +555,7 @@ export function generateGrid(
     } from "@comet/admin";
     import { Add as AddIcon, Edit, Info, MoreVertical, Excel } from "@comet/admin-icons";
     import { BlockPreviewContent } from "@comet/blocks-admin";
-    import { Alert, Button, Box, IconButton, Typography, useTheme, Menu, MenuItem, ListItemIcon, ListItemText, CircularProgress } from "@mui/material";
+    import { Alert, Box, IconButton, Typography, useTheme, Menu, MenuItem, ListItemIcon, ListItemText, CircularProgress } from "@mui/material";
     import { DataGridPro, GridLinkOperator, GridRenderCellParams, GridColumnHeaderTitle, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
     import { useContentScope } from "@src/common/ContentScopeProvider";
     import {


### PR DESCRIPTION
## Description

The buttons inside the toolbar action are now responsive to improve support on mobile devices. 
`CrudMoreActionsMenu` is now rendered inside the `ToolbarActions` to adhere to the design guidelines. 

`CrudMoreActionsMenu` now uses the new `Button` component internally to support the responsive behavior. 
It was also slightly refactored/adjusted to be more consistent with other admin component and fix an issue where the `defaultProps` from the theme would be ignored. 

Potential alternative: https://github.com/vivid-planet/comet/pull/3236

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="500" alt="Future Products Grid Before" src="https://github.com/user-attachments/assets/bc247fc5-ecdd-4fdd-96f7-bd1ab33c2a05" />   | <img width="500" alt="Future Products Grid After" src="https://github.com/user-attachments/assets/b7244b37-4357-46d6-8e8b-a03329e8d0f1" />  |

## Open TODOs/questions

-   [x] Add changeset
-   [ ] Merge parent PR https://github.com/vivid-planet/comet/pull/3205

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1289
