### PR TITLE
Optimize `GridToolbarQuickFilter` (the search input above the `DataGrid`)

### DIFF
--- a/.changeset/angry-poems-lay.md
+++ b/.changeset/angry-poems-lay.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Make the width of `GridToolbarQuickFilter` responsive when used inside `DataGridToolbar`

--- a/.changeset/witty-garlics-flow.md
+++ b/.changeset/witty-garlics-flow.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin-theme": minor
+"@comet/admin-theme": patch
 ---
 
 Prevent the input value of `GridToolbarQuickFilter` from being truncated too early

--- a/.changeset/witty-garlics-flow.md
+++ b/.changeset/witty-garlics-flow.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": minor
+---
+
+Prevent the input value of `GridToolbarQuickFilter` from being truncated too early

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -46,6 +46,17 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
     styleOverrides: mergeOverrideStyles<"MuiDataGrid">(component?.styleOverrides, {
         root: {
             backgroundColor: "white",
+
+            "& [class*='MuiDataGrid-toolbarQuickFilter']": {
+                [`& > .${inputBaseClasses.root} .${inputBaseClasses.input}`]: {
+                    paddingRight: 0, // Removes unnecessary spacing to the clear button that already has enough spacing
+                    textOverflow: "ellipsis",
+                },
+
+                [`& > .${inputBaseClasses.root} .${inputBaseClasses.input}[value=''] + .${iconButtonClasses.root}`]: {
+                    display: "none", // Prevents the disabled clear-button from overlaying the input value
+                },
+            },
         },
         columnsPanelRow: {
             marginBottom: spacing(2),

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -24,6 +24,18 @@ const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey, OwnerState>({
     },
 })(
     ({ ownerState, theme }) => css`
+        [class*="MuiDataGrid-toolbarQuickFilter"] {
+            width: 120px;
+
+            ${theme.breakpoints.up("sm")} {
+                width: 150px;
+            }
+
+            ${theme.breakpoints.up("md")} {
+                width: "auto";
+            }
+        }
+
         ${ownerState.density === "comfortable" &&
         css`
             min-height: 80px;


### PR DESCRIPTION
## Description

Make the width of `GridToolbarQuickFilter` responsive when used inside `DataGridToolbar`. 
And prevent the input value of `GridToolbarQuickFilter` from being truncated too early.
 
## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="340" alt="DataGrid Mobile Before" src="https://github.com/user-attachments/assets/a83a1a23-a451-45b1-a597-75c38e332870" />   | <img width="340" alt="DataGrid Mobile After" src="https://github.com/user-attachments/assets/ae946661-d71b-4956-9856-0b6267ce2546" />  |
| <img width="640" alt="DataGrid Medium Before" src="https://github.com/user-attachments/assets/a2166d44-7ed0-4f0e-aa38-151037bfe319" />   | <img width="640" alt="DataGrid Medium After" src="https://github.com/user-attachments/assets/c2e4673a-3858-4ce2-aa8e-05b73f6d319a" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1507
