### PR TITLE
Adjust the spacings inside `Toolbar` and `DataGridToolbar`

### DIFF
--- a/.changeset/rude-moons-help.md
+++ b/.changeset/rude-moons-help.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Adjust the spacings inside `Toolbar` and `DataGridToolbar` to match the Comet design

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -52,8 +52,18 @@ const TopBar = createComponentSlot("div")<ToolbarClassKey>({
         display: flex;
         align-items: center;
         gap: ${theme.spacing(2)};
-        padding-left: ${theme.spacing(4)};
-        padding-right: ${theme.spacing(4)};
+        padding-left: ${theme.spacing(2)};
+        padding-right: ${theme.spacing(2)};
+
+        ${theme.breakpoints.up("sm")} {
+            padding-left: ${theme.spacing(2)};
+            padding-right: ${theme.spacing(2)};
+        }
+
+        ${theme.breakpoints.up("md")} {
+            padding-left: ${theme.spacing(4)};
+            padding-right: ${theme.spacing(4)};
+        }
     `,
 );
 
@@ -73,11 +83,18 @@ const BottomBar = createComponentSlot(MuiToolbar)<ToolbarClassKey>({
         border-top: solid 1px ${theme.palette.grey["50"]};
         box-sizing: border-box;
         min-height: 60px;
-        padding: 0 5px;
+        padding-left: ${theme.spacing(2)};
+        padding-right: ${theme.spacing(2)};
 
         ${theme.breakpoints.up("sm")} {
             min-height: 60px;
-            padding: 0 10px;
+            padding-left: ${theme.spacing(2)};
+            padding-right: ${theme.spacing(2)};
+        }
+
+        ${theme.breakpoints.up("md")} {
+            padding-left: ${theme.spacing(4)};
+            padding-right: ${theme.spacing(4)};
         }
 
         // necessary to override strange MUI default styling

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActions.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActions.tsx
@@ -15,10 +15,6 @@ const Root = createComponentSlot("div")<ToolbarActionsClassKey>({
         display: flex;
         align-items: center;
         gap: ${theme.spacing(2)};
-
-        ${theme.breakpoints.up("md")} {
-            gap: ${theme.spacing(4)};
-        }
     `,
 );
 

--- a/packages/admin/admin/src/common/toolbar/item/ToolbarItem.tsx
+++ b/packages/admin/admin/src/common/toolbar/item/ToolbarItem.tsx
@@ -15,11 +15,7 @@ const Root = createComponentSlot("div")<ToolbarItemClassKey>({
         display: flex;
         justify-items: center;
         align-items: center;
-        padding: 0 ${theme.spacing(1)};
-
-        ${theme.breakpoints.up("sm")} {
-            padding: 0 ${theme.spacing(1)};
-        }
+        padding-right: ${theme.spacing(2)};
     `,
 );
 

--- a/packages/admin/cms-admin/src/pages/pageSearch/PageSearch.tsx
+++ b/packages/admin/cms-admin/src/pages/pageSearch/PageSearch.tsx
@@ -1,5 +1,3 @@
-import { styled } from "@mui/material/styles";
-
 import { SearchInput } from "../../common/SearchInput";
 import { PageSearchApi } from "./usePageSearch";
 
@@ -11,24 +9,13 @@ interface PageSearchProps {
 
 export function PageSearch({ query, onQueryChange, pageSearchApi }: PageSearchProps) {
     return (
-        <Root>
-            <SearchInput
-                query={query}
-                onQueryChange={onQueryChange}
-                currentMatch={pageSearchApi.currentMatch}
-                totalMatches={pageSearchApi.totalMatches}
-                jumpToPreviousMatch={pageSearchApi.jumpToPreviousMatch}
-                jumpToNextMatch={pageSearchApi.jumpToNextMatch}
-            />
-        </Root>
+        <SearchInput
+            query={query}
+            onQueryChange={onQueryChange}
+            currentMatch={pageSearchApi.currentMatch}
+            totalMatches={pageSearchApi.totalMatches}
+            jumpToPreviousMatch={pageSearchApi.jumpToPreviousMatch}
+            jumpToNextMatch={pageSearchApi.jumpToNextMatch}
+        />
     );
 }
-
-const Root = styled("div")`
-    display: flex;
-    flex: 1;
-    justify-content: center;
-    align-items: center;
-    margin-left: 10px;
-    margin-right: 10px;
-`;

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -10,6 +10,7 @@ import {
     StackSwitch,
     Toolbar,
     ToolbarActions,
+    ToolbarItem,
     useEditDialog,
     useFocusAwarePolling,
     useStoredState,
@@ -138,11 +139,15 @@ export function PagesPage({
                 <StackSwitch>
                     <StackPage name="table">
                         <Toolbar scopeIndicator={renderContentScopeIndicator(scope)}>
-                            <PageSearch query={query} onQueryChange={setQuery} pageSearchApi={pageSearchApi} />
-                            <FormControlLabel
-                                control={<Switch checked={showArchive} color="primary" onChange={handleArchiveToggleClick} />}
-                                label={<FormattedMessage id="comet.pages.pages.archivedItems" defaultMessage="Archived items" />}
-                            />
+                            <ToolbarItem sx={{ flexGrow: 1 }}>
+                                <PageSearch query={query} onQueryChange={setQuery} pageSearchApi={pageSearchApi} />
+                            </ToolbarItem>
+                            <ToolbarItem>
+                                <FormControlLabel
+                                    control={<Switch checked={showArchive} color="primary" onChange={handleArchiveToggleClick} />}
+                                    label={<FormattedMessage id="comet.pages.pages.archivedItems" defaultMessage="Archived items" />}
+                                />
+                            </ToolbarItem>
                             <ToolbarActions>
                                 <Button
                                     variant="contained"

--- a/storybook/src/docs/components/Toolbar/Toolbar.stories.tsx
+++ b/storybook/src/docs/components/Toolbar/Toolbar.stories.tsx
@@ -22,7 +22,7 @@ import {
     useStackSwitchApi,
 } from "@comet/admin";
 import { ChevronLeft, CometColor, Search } from "@comet/admin-icons";
-import { Autocomplete, Button, Grid, IconButton, InputAdornment, InputBase, Typography } from "@mui/material";
+import { Autocomplete, Button, IconButton, InputAdornment, InputBase, Typography } from "@mui/material";
 import { useState } from "react";
 import { Form } from "react-final-form";
 import { FormattedMessage } from "react-intl";
@@ -70,30 +70,26 @@ export const Breadcrumbs = () => {
             <ToolbarActions>
                 <StackSwitchApiContext.Consumer>
                     {(stackSwitchApi) => (
-                        <Grid container spacing={4}>
-                            <Grid item>
-                                <Button
-                                    color="primary"
-                                    variant="contained"
-                                    onClick={() => {
-                                        stackSwitchApi.activatePage("page-1", "details");
-                                    }}
-                                >
-                                    1
-                                </Button>
-                            </Grid>
-                            <Grid item>
-                                <Button
-                                    color="primary"
-                                    variant="contained"
-                                    onClick={() => {
-                                        stackSwitchApi.activatePage("page-2", "details");
-                                    }}
-                                >
-                                    2
-                                </Button>
-                            </Grid>
-                        </Grid>
+                        <>
+                            <Button
+                                color="primary"
+                                variant="contained"
+                                onClick={() => {
+                                    stackSwitchApi.activatePage("page-1", "details");
+                                }}
+                            >
+                                1
+                            </Button>
+                            <Button
+                                color="primary"
+                                variant="contained"
+                                onClick={() => {
+                                    stackSwitchApi.activatePage("page-2", "details");
+                                }}
+                            >
+                                2
+                            </Button>
+                        </>
                     )}
                 </StackSwitchApiContext.Consumer>
             </ToolbarActions>
@@ -131,9 +127,9 @@ export const FillSpaceLeft = {
         return (
             <Toolbar>
                 <FillSpace />
-                <ToolbarItem>
+                <ToolbarActions>
                     <Typography>Item</Typography>
-                </ToolbarItem>
+                </ToolbarActions>
             </Toolbar>
         );
     },
@@ -184,30 +180,24 @@ export const FillSpaceMiddle2 = {
                 </ToolbarItem>
                 <FillSpace />
                 <ToolbarActions>
-                    <Grid container spacing={4}>
-                        <Grid item>
-                            <Button
-                                color="primary"
-                                variant="contained"
-                                onClick={() => {
-                                    alert("clicked Action 1");
-                                }}
-                            >
-                                Action 1
-                            </Button>
-                        </Grid>
-                        <Grid item>
-                            <Button
-                                color="secondary"
-                                variant="contained"
-                                onClick={() => {
-                                    alert("clicked Action 2");
-                                }}
-                            >
-                                Action 2
-                            </Button>
-                        </Grid>
-                    </Grid>
+                    <Button
+                        color="primary"
+                        variant="contained"
+                        onClick={() => {
+                            alert("clicked Action 1");
+                        }}
+                    >
+                        Action 1
+                    </Button>
+                    <Button
+                        color="secondary"
+                        variant="contained"
+                        onClick={() => {
+                            alert("clicked Action 2");
+                        }}
+                    >
+                        Action 2
+                    </Button>
                 </ToolbarActions>
                 <FillSpace />
                 <ToolbarItem>
@@ -288,30 +278,24 @@ export const ToolbarActionsTwoActions = {
                 <ToolbarAutomaticTitleItem />
                 <FillSpace />
                 <ToolbarActions>
-                    <Grid container spacing={4}>
-                        <Grid item>
-                            <Button
-                                color="primary"
-                                variant="contained"
-                                onClick={() => {
-                                    alert("clicked Action 1");
-                                }}
-                            >
-                                Action 1
-                            </Button>
-                        </Grid>
-                        <Grid item>
-                            <Button
-                                color="secondary"
-                                variant="contained"
-                                onClick={() => {
-                                    alert("clicked Action 2");
-                                }}
-                            >
-                                Action 2
-                            </Button>
-                        </Grid>
-                    </Grid>
+                    <Button
+                        color="primary"
+                        variant="contained"
+                        onClick={() => {
+                            alert("clicked Action 1");
+                        }}
+                    >
+                        Action 1
+                    </Button>
+                    <Button
+                        color="secondary"
+                        variant="contained"
+                        onClick={() => {
+                            alert("clicked Action 2");
+                        }}
+                    >
+                        Action 2
+                    </Button>
                 </ToolbarActions>
             </Toolbar>
         );


### PR DESCRIPTION
## Description

This is to match the comet design and remove inconsistent spacings. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="400" alt="GridToolbar Mobile Before" src="https://github.com/user-attachments/assets/68447397-84c1-472f-ae75-e7f93b3ed0f1" />   | <img width="400" alt="GridToolbar Mobile After" src="https://github.com/user-attachments/assets/ccec576c-0733-4dbe-95ce-fb752c068da0" />  |
| <img width="798" alt="Toolbar Desktop Before" src="https://github.com/user-attachments/assets/8d86778f-485a-4a6d-a292-cd0bfe32a19a" />   | <img width="798" alt="Toolbar Desktop After" src="https://github.com/user-attachments/assets/d061c075-cd3a-4f69-b387-ca35b0cf9fc4" />  |
| <img width="375" alt="Toolbar and GridToolbar Mobile Before" src="https://github.com/user-attachments/assets/56baa598-a7fd-40ea-910a-078cdf76c393" />   | <img width="375" alt="Toolbar and GridToolbar Mobile After" src="https://github.com/user-attachments/assets/e9cd967d-2610-4f4c-9c88-818f0ea4b2f4" />  |
| <img width="950" alt="Toolbar and GridToolbar Desktop Before" src="https://github.com/user-attachments/assets/a8dcada3-c039-4e6f-b8bf-bfc8d4cb10f8" />   | <img width="950" alt="Toolbar and GridToolbar Desktop After" src="https://github.com/user-attachments/assets/e27fc411-d4db-4fac-b651-9fcbc08ecd83" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1507
