### PR TITLE
New Lint rule to restrict process env usage

### DIFF
--- a/.changeset/lovely-buttons-drive.md
+++ b/.changeset/lovely-buttons-drive.md
@@ -1,0 +1,5 @@
+---
+"@comet/eslint-config": minor
+---
+
+Add new custom eslint rule to restrict the usage of process.env

--- a/packages/eslint-config/nextjs.js
+++ b/packages/eslint-config/nextjs.js
@@ -24,7 +24,7 @@ module.exports = {
             {
                 selector:
                     "MemberExpression[type=MemberExpression][object.type=MemberExpression][object.object.type=Identifier][object.object.name=process][object.property.type=Identifier][object.property.name=env][property.type=Identifier][property.name=/^NEXT_PUBLIC/]",
-                message: "Avoid using NEXT_PUBLIC_ environment variables",
+                message: "Avoid using NEXT_PUBLIC_ environment variables. Use SiteConfig or a custom Context instead",
             },
         ],
     },
@@ -37,7 +37,8 @@ module.exports = {
                     {
                         selector:
                             "MemberExpression[type=MemberExpression][object.type=MemberExpression][object.object.type=Identifier][object.object.name=process][object.property.type=Identifier][object.property.name=env][property.type=Identifier][property.name!=NODE_ENV]",
-                        message: "Environment variables other than NODE_ENV are not allowed in next.config.js",
+                        message:
+                            "Environment variables other than NODE_ENV are not allowed in next.config.js. Use SiteConfig or a custom Context instead",
                     },
                 ],
             },
@@ -50,7 +51,7 @@ module.exports = {
                     {
                         selector:
                             "MemberExpression[type=MemberExpression][object.type=MemberExpression][object.object.type=Identifier][object.object.name=process][object.property.type=Identifier][object.property.name=env][property.type=Identifier]",
-                        message: "Environment variables are not allowed in loaders",
+                        message: "Environment variables are not allowed in loaders. Use SiteConfig or a custom Context instead",
                     },
                 ],
             },

--- a/packages/eslint-config/nextjs.js
+++ b/packages/eslint-config/nextjs.js
@@ -36,8 +36,21 @@ module.exports = {
                     "error",
                     {
                         selector:
-                            "MemberExpression[type=MemberExpression][object.type=MemberExpression][object.object.type=Identifier][object.object.name=process][object.property.type=Identifier][object.property.name=env][property.type=Identifier][property.name=NODE_ENV]",
-                        message: "Avoid using environment variables other than NODE_ENV",
+                            "MemberExpression[type=MemberExpression][object.type=MemberExpression][object.object.type=Identifier][object.object.name=process][object.property.type=Identifier][object.property.name=env][property.type=Identifier][property.name!=NODE_ENV]",
+                        message: "Environment variables other than NODE_ENV are not allowed in next.config.js",
+                    },
+                ],
+            },
+        },
+        {
+            files: ["*.loader.ts"],
+            rules: {
+                "no-restricted-syntax": [
+                    "error",
+                    {
+                        selector:
+                            "MemberExpression[type=MemberExpression][object.type=MemberExpression][object.object.type=Identifier][object.object.name=process][object.property.type=Identifier][object.property.name=env][property.type=Identifier]",
+                        message: "Environment variables are not allowed in loaders",
                     },
                 ],
             },

--- a/packages/eslint-config/nextjs.js
+++ b/packages/eslint-config/nextjs.js
@@ -19,5 +19,28 @@ module.exports = {
                 ],
             },
         ],
+        "no-restricted-syntax": [
+            "error",
+            {
+                selector:
+                    "MemberExpression[type=MemberExpression][object.type=MemberExpression][object.object.type=Identifier][object.object.name=process][object.property.type=Identifier][object.property.name=env][property.type=Identifier][property.name=/^NEXT_PUBLIC/]",
+                message: "Avoid using NEXT_PUBLIC_ environment variables",
+            },
+        ],
     },
+    overrides: [
+        {
+            files: ["next.config.js"],
+            rules: {
+                "no-restricted-syntax": [
+                    "error",
+                    {
+                        selector:
+                            "MemberExpression[type=MemberExpression][object.type=MemberExpression][object.object.type=Identifier][object.object.name=process][object.property.type=Identifier][object.property.name=env][property.type=Identifier][property.name=NODE_ENV]",
+                        message: "Avoid using environment variables other than NODE_ENV",
+                    },
+                ],
+            },
+        },
+    ],
 };


### PR DESCRIPTION
## Description

Added new eslint rules to restrict usage of process.env
- Restrict using NEXT_PUBLIC_ variables
- Restrict using other env variables than NODE_ENV in next.config.js
- Restrict using process.env in *.loader.ts files

## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1290
