### PR TITLE
Fix Renovate config validation workflow

### DIFF
--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -32,7 +32,6 @@ jobs:
               with:
                   node-version: 22
                   registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
 
             - name: Validate renovate config
               run: npx --yes --package renovate -- renovate-config-validator


### PR DESCRIPTION
Remove the cache option when setting up Node, since we don't perform an install step.
