### PR TITLE
Example of rendering a custom component inside the product form

### DIFF
--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -39,6 +39,7 @@ import { useMemo } from "react";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { FutureProductNotice } from "./helpers/FutureProductNotice";
 import {
     GQLProductCategoriesSelectQuery,
     GQLProductCategoriesSelectQueryVariables,
@@ -209,6 +210,7 @@ export function ProductForm({ id, width }: FormProps) {
                         name="availableSince"
                         label={<FormattedMessage id="product.availableSince" defaultMessage="Available Since" />}
                     />
+                    <FutureProductNotice />
                     <AsyncSelectField
                         name="manufacturerCountry"
                         loadOptions={async () => {

--- a/demo/admin/src/products/helpers/FutureProductNotice.tsx
+++ b/demo/admin/src/products/helpers/FutureProductNotice.tsx
@@ -1,0 +1,27 @@
+import { Alert } from "@comet/admin";
+import { useField } from "react-final-form";
+import { FormattedMessage } from "react-intl";
+
+export const FutureProductNotice = () => {
+    const availableSinceField = useField("availableSince");
+    const dateValue = availableSinceField.input.value ? new Date(availableSinceField.input.value) : null;
+    const today = new Date();
+    const willBeAvailableInTheFuture = dateValue && dateValue > today;
+
+    if (willBeAvailableInTheFuture) {
+        return (
+            <Alert
+                severity="warning"
+                sx={{ mb: 4 }}
+                title={
+                    <FormattedMessage
+                        id="product.futureProductNotice"
+                        defaultMessage="This product will not be visible to the public until the selected date."
+                    />
+                }
+            />
+        );
+    }
+
+    return null;
+};


### PR DESCRIPTION
## Description

Sometimes it will be necessary to render custom, non-common content inside a generated form. 
This is an example of what the future admin generator could generate, see https://github.com/vivid-planet/comet/pull/3235 for the generator implementation.  

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

<img width="756" alt="image" src="https://github.com/user-attachments/assets/0af87873-6c0c-40b4-a0a7-1c93c9f998a1" />

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/SVK-637
