### PR TITLE
Update Jest config in `@comet/blocks-admin` to support react-dnd ESM module

### DIFF
--- a/packages/admin/blocks-admin/jest.config.ts
+++ b/packages/admin/blocks-admin/jest.config.ts
@@ -4,192 +4,37 @@
  */
 
 export default {
-    // All imported modules in your tests should be mocked automatically
-    // automock: false,
-
-    // Stop running tests after `n` failures
-    // bail: 0,
-
-    // The directory where Jest should store its cached dependency information
-    // cacheDirectory: "/private/var/folders/9v/pgcggckn1t5g2b5qhrnpsyxc0000gn/T/jest_dx",
-
-    // Automatically clear mock calls and instances between every test
-    // clearMocks: false,
-
-    // Indicates whether the coverage information should be collected while executing the test
-    // collectCoverage: false,
-
-    // An array of glob patterns indicating a set of files for which coverage information should be collected
-    // collectCoverageFrom: undefined,
-
-    // The directory where Jest should output its coverage files
-    // coverageDirectory: undefined,
-
-    // An array of regexp pattern strings used to skip coverage collection
-    // coveragePathIgnorePatterns: [
-    //   "/node_modules/"
-    // ],
-
     // Indicates which provider should be used to instrument code for coverage
     coverageProvider: "v8",
-
-    // A list of reporter names that Jest uses when writing coverage reports
-    // coverageReporters: [
-    //   "json",
-    //   "text",
-    //   "lcov",
-    //   "clover"
-    // ],
-
-    // An object that configures minimum threshold enforcement for coverage results
-    // coverageThreshold: undefined,
-
-    // A path to a custom dependency extractor
-    // dependencyExtractor: undefined,
-
-    // Make calling deprecated APIs throw helpful error messages
-    // errorOnDeprecated: false,
-
-    // Force coverage collection from ignored files using an array of glob patterns
-    // forceCoverageMatch: [],
-
-    // A path to a module which exports an async function that is triggered once before all test suites
-    // globalSetup: undefined,
-
-    // A path to a module which exports an async function that is triggered once after all test suites
-    // globalTeardown: undefined,
-
-    // A set of global variables that need to be available in all test environments
-    globals: {
-        "ts-jest": {
-            tsconfig: "tsconfig.test.json",
-        },
-    },
-
-    // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-    // maxWorkers: "50%",
-
-    // An array of directory names to be searched recursively up from the requiring module's location
-    // moduleDirectories: [
-    //   "node_modules"
-    // ],
-
-    // An array of file extensions your modules use
-    // moduleFileExtensions: [
-    //   "js",
-    //   "json",
-    //   "jsx",
-    //   "ts",
-    //   "tsx",
-    //   "node"
-    // ],
-
-    // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-    // moduleNameMapper: {},
-
-    // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-    // modulePathIgnorePatterns: [],
-
-    // Activates notifications for test results
-    // notify: false,
-
-    // An enum that specifies notification mode. Requires { notify: true }
-    // notifyMode: "failure-change",
 
     // A preset that is used as a base for Jest's configuration
     preset: "ts-jest",
 
-    // Run tests from one or more projects
-    // projects: undefined,
-
     // Use this configuration option to add custom reporters to Jest
     reporters: ["default", "jest-junit"],
 
-    // Automatically reset mock state between every test
-    // resetMocks: false,
-
-    // Reset the module registry before running each individual test
-    // resetModules: false,
-
-    // A path to a custom resolver
-    // resolver: undefined,
-
-    // Automatically restore mock state between every test
-    // restoreMocks: false,
-
     // The root directory that Jest should scan for tests and modules within
-    rootDir: "./src",
-
-    // A list of paths to directories that Jest should use to search for files in
-    // roots: [
-    //   "<rootDir>"
-    // ],
-
-    // Allows you to use a custom runner instead of Jest's default test runner
-    // runner: "jest-runner",
-
-    // The paths to modules that run some code to configure or set up the testing environment before each test
-    // setupFiles: [],
-
-    // A list of paths to modules that run some code to configure or set up the testing framework before each test
-    // setupFilesAfterEnv: [],
-
-    // The number of seconds after which a test is considered as slow and reported as such in the results.
-    // slowTestThreshold: 5,
-
-    // A list of paths to snapshot serializer modules Jest should use for snapshot testing
-    // snapshotSerializers: [],
+    rootDir: "./",
 
     // The test environment that will be used for testing
     testEnvironment: "jest-environment-jsdom",
 
-    // Options that will be passed to the testEnvironment
-    // testEnvironmentOptions: {},
-
-    // Adds a location field to test results
-    // testLocationInResults: false,
-
-    // The glob patterns Jest uses to detect test files
-    // testMatch: [
-    //   "**/__tests__/**/*.[jt]s?(x)",
-    //   "**/?(*.)+(spec|test).[tj]s?(x)"
-    // ],
-
     // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-    // testPathIgnorePatterns: [
-    //   "/node_modules/"
-    // ],
-
-    // The regexp pattern or array of patterns that Jest uses to detect test files
-    // testRegex: [],
-
-    // This option allows the use of a custom results processor
-    // testResultsProcessor: undefined,
-
-    // This option allows use of a custom test runner
-    // testRunner: "jasmine2",
-
-    // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
-    // testURL: "http://localhost",
-
-    // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
-    // timers: "real",
+    testPathIgnorePatterns: ["/node_modules/"],
 
     // A map from regular expressions to paths to transformers
-    // transform: {},
-
+    transform: {
+        "^.+\\.(ts|tsx)$": "ts-jest",
+    },
     // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
     // transformIgnorePatterns: ["<rootDir>/node_modules/(?!(@mui)/)"],
+    //transformIgnorePatterns: ["<rootDir>/node_modules/(?!@react-dnd|react-dnd|core-dnd|@react-dnd|dnd-core|react-dnd-html5-backend)"],
+    transformIgnorePatterns: ["node_modules/(?!(react-dnd|dnd-core|react-dnd-html5-backend)/)"],
 
-    // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-    // unmockedModulePathPatterns: undefined,
-
-    // Indicates whether each individual test should be reported during the run
-    // verbose: undefined,
-
-    // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-    // watchPathIgnorePatterns: [],
-
-    // Whether to use watchman for file crawling
-    // watchman: true,
+    moduleNameMapper: {
+        "^react-dnd$": "<rootDir>/testing/stub-file.ts",
+        // "^react-dnd$": "react-dnd/dist/cjs",
+        // "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs",
+        // "^dnd-core$": "dnd-core/dist/cjs",
+    },
 };

--- a/packages/admin/blocks-admin/jest.config.ts
+++ b/packages/admin/blocks-admin/jest.config.ts
@@ -22,19 +22,7 @@ export default {
     // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
     testPathIgnorePatterns: ["/node_modules/"],
 
-    // A map from regular expressions to paths to transformers
-    transform: {
-        "^.+\\.(ts|tsx)$": "ts-jest",
-    },
-    // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-    // transformIgnorePatterns: ["<rootDir>/node_modules/(?!(@mui)/)"],
-    //transformIgnorePatterns: ["<rootDir>/node_modules/(?!@react-dnd|react-dnd|core-dnd|@react-dnd|dnd-core|react-dnd-html5-backend)"],
-    transformIgnorePatterns: ["node_modules/(?!(react-dnd|dnd-core|react-dnd-html5-backend)/)"],
-
     moduleNameMapper: {
         "^react-dnd$": "<rootDir>/testing/stub-file.ts",
-        // "^react-dnd$": "react-dnd/dist/cjs",
-        // "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs",
-        // "^dnd-core$": "dnd-core/dist/cjs",
     },
 };

--- a/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/composeBlocks.spec.tsx
+++ b/packages/admin/blocks-admin/src/blocks/helpers/composeBlocks/composeBlocks.spec.tsx
@@ -6,10 +6,6 @@ import { createCompositeSetting } from "./createCompositeSetting";
 import { createCompositeSettings } from "./createCompositeSettings";
 import { AdminComponentPropsMap, CompositeBlocksConfig, DataMapState } from "./types";
 
-jest.mock("react-dnd", () => {
-    return;
-});
-
 // TODO: youtube block moved, space block deprecated, update tests
 
 describe("composeBlocks", () => {

--- a/packages/admin/blocks-admin/testing/stub-file.ts
+++ b/packages/admin/blocks-admin/testing/stub-file.ts
@@ -1,0 +1,4 @@
+// This is a stub file for testing purposes. It it used in the jest.config.ts (moduleNameMapper) in order to mock certain file types, or modules that are in ESM format
+// Documentation of the use of stub files in jest's moduleNameMapper can be found here: https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring
+
+export default "";

--- a/packages/admin/blocks-admin/tsconfig.test.json
+++ b/packages/admin/blocks-admin/tsconfig.test.json
@@ -1,6 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "target": "ES6"
-    }
-}


### PR DESCRIPTION
## Description

Update jest config in admin/blocks-admin to support react-dnd ESM module

When writing certain tests, react-dnd is loaded, however as it is packaged as an ESM module jest cannot resolve it.

```
    Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    /home/philippe/Development/comet/comet/node_modules/.pnpm/react-dnd@16.0.1_@types+node@22.9.0_@types+react@17.0.53_react@17.0.2/node_modules/react-dnd/dist/index.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){export * from './core/index.js';
                                                                                      ^^^^^^

    SyntaxError: Unexpected token 'export'

      11 | var _TableRow = _interopRequireDefault(require("@mui/material/TableRow"));
      12 | var _react = require("react");
    > 13 | var _reactDnd = require("react-dnd");
```

This PR updates the jest config using a mock file to load instead of modules in question.

This PR also gets rid of the deprecated tsconfig.test.json file which caused the following warning:
```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

Task: https://vivid-planet.atlassian.net/browse/COM-1554
