### PR TITLE
chore: rename all headline block definitions to heading in demo

### DIFF
--- a/demo/admin/src/common/blocks/HeadingBlock.tsx
+++ b/demo/admin/src/common/blocks/HeadingBlock.tsx
@@ -14,7 +14,7 @@ const EyebrowRichTextBlock = createRichTextBlock({
     minHeight: 0,
 });
 
-const HeadlineRichTextBlock = createRichTextBlock({
+const HeadingRichTextBlock = createRichTextBlock({
     link: LinkBlock,
     rte: {
         maxBlocks: 1,
@@ -66,20 +66,20 @@ export const HeadingBlock = createCompositeBlock(
                 block: EyebrowRichTextBlock,
                 title: <FormattedMessage id="headingBlock.eyebrow" defaultMessage="Eyebrow" />,
             },
-            headline: {
-                block: HeadlineRichTextBlock,
-                title: <FormattedMessage id="headingBlock.title" defaultMessage="Headline" />,
+            heading: {
+                block: HeadingRichTextBlock,
+                title: <FormattedMessage id="headingBlock.title" defaultMessage="Heading" />,
             },
             htmlTag: {
                 block: createCompositeBlockSelectField<HeadingBlockData["htmlTag"]>({
                     defaultValue: "H2",
                     options: [
-                        { value: "H1", label: <FormattedMessage id="headingBlock.headline1" defaultMessage="Headline 1" /> },
-                        { value: "H2", label: <FormattedMessage id="headingBlock.headline2" defaultMessage="Headline 2" /> },
-                        { value: "H3", label: <FormattedMessage id="headingBlock.headline3" defaultMessage="Headline 3" /> },
-                        { value: "H4", label: <FormattedMessage id="headingBlock.headline4" defaultMessage="Headline 4" /> },
-                        { value: "H5", label: <FormattedMessage id="headingBlock.headline5" defaultMessage="Headline 5" /> },
-                        { value: "H6", label: <FormattedMessage id="headingBlock.headline6" defaultMessage="Headline 6" /> },
+                        { value: "H1", label: <FormattedMessage id="headingBlock.heading1" defaultMessage="Heading 1" /> },
+                        { value: "H2", label: <FormattedMessage id="headingBlock.heading2" defaultMessage="Heading 2" /> },
+                        { value: "H3", label: <FormattedMessage id="headingBlock.heading3" defaultMessage="Heading 3" /> },
+                        { value: "H4", label: <FormattedMessage id="headingBlock.heading4" defaultMessage="Heading 4" /> },
+                        { value: "H5", label: <FormattedMessage id="headingBlock.heading5" defaultMessage="Heading 5" /> },
+                        { value: "H6", label: <FormattedMessage id="headingBlock.heading6" defaultMessage="Heading 6" /> },
                     ],
                     label: <FormattedMessage id="headingBlock.htmlTag" defaultMessage="HTML tag" />,
                     fullWidth: true,

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -1093,7 +1093,7 @@
                 "nullable": false
             },
             {
-                "name": "headline",
+                "name": "heading",
                 "kind": "Block",
                 "block": "RichText",
                 "nullable": false
@@ -1120,7 +1120,7 @@
                 "nullable": false
             },
             {
-                "name": "headline",
+                "name": "heading",
                 "kind": "Block",
                 "block": "RichText",
                 "nullable": false

--- a/demo/api/src/common/blocks/heading.block.ts
+++ b/demo/api/src/common/blocks/heading.block.ts
@@ -13,7 +13,7 @@ import { IsEnum } from "class-validator";
 
 import { RichTextBlock } from "./rich-text.block";
 
-enum HeadlineTag {
+export enum HeadingTag {
     H1 = "H1",
     H2 = "H2",
     H3 = "H3",
@@ -27,10 +27,10 @@ class HeadingBlockData extends BlockData {
     eyebrow: BlockDataInterface;
 
     @ChildBlock(RichTextBlock)
-    headline: BlockDataInterface;
+    heading: BlockDataInterface;
 
-    @BlockField({ type: "enum", enum: HeadlineTag })
-    htmlTag: HeadlineTag;
+    @BlockField({ type: "enum", enum: HeadingTag })
+    htmlTag: HeadingTag;
 }
 
 class HeadingBlockInput extends BlockInput {
@@ -38,11 +38,11 @@ class HeadingBlockInput extends BlockInput {
     eyebrow: ExtractBlockInput<typeof RichTextBlock>;
 
     @ChildBlockInput(RichTextBlock)
-    headline: ExtractBlockInput<typeof RichTextBlock>;
+    heading: ExtractBlockInput<typeof RichTextBlock>;
 
-    @IsEnum(HeadlineTag)
-    @BlockField({ type: "enum", enum: HeadlineTag })
-    htmlTag: HeadlineTag;
+    @IsEnum(HeadingTag)
+    @BlockField({ type: "enum", enum: HeadingTag })
+    htmlTag: HeadingTag;
 
     transformToBlockData(): HeadingBlockData {
         return inputToData(HeadingBlockData, this);

--- a/demo/site-pages/src/common/blocks/HeadingBlock.tsx
+++ b/demo/site-pages/src/common/blocks/HeadingBlock.tsx
@@ -10,7 +10,7 @@ const eyebrowRenderers: Renderers = {
     inline: defaultRichTextInlineStyleMap,
 };
 
-const getHeadlineRenderers = (htmlTag: keyof HTMLElementTagNameMap): Renderers => ({
+const getHeadingRenderers = (htmlTag: keyof HTMLElementTagNameMap): Renderers => ({
     inline: defaultRichTextInlineStyleMap,
     blocks: {
         "header-one": createTextBlockRenderFn({ variant: "h600", as: htmlTag, bottomSpacing: true }),
@@ -22,7 +22,7 @@ const getHeadlineRenderers = (htmlTag: keyof HTMLElementTagNameMap): Renderers =
     },
 });
 
-const headlineTagMap: Record<HeadingBlockData["htmlTag"], keyof HTMLElementTagNameMap> = {
+const headingTagMap: Record<HeadingBlockData["htmlTag"], keyof HTMLElementTagNameMap> = {
     H1: "h1",
     H2: "h2",
     H3: "h3",
@@ -34,8 +34,8 @@ const headlineTagMap: Record<HeadingBlockData["htmlTag"], keyof HTMLElementTagNa
 type HeadingBlockProps = PropsWithData<HeadingBlockData>;
 
 export const HeadingBlock = withPreview(
-    ({ data: { eyebrow, headline, htmlTag } }: HeadingBlockProps) => {
-        const headlineTag = headlineTagMap[htmlTag];
+    ({ data: { eyebrow, heading, htmlTag } }: HeadingBlockProps) => {
+        const headingTag = headingTagMap[htmlTag];
 
         return (
             <>
@@ -45,14 +45,14 @@ export const HeadingBlock = withPreview(
                     </Typography>
                 )}
                 <PreviewSkeleton
-                    hasContent={hasRichTextBlockContent(headline)}
+                    hasContent={hasRichTextBlockContent(heading)}
                     title={
-                        <HeadlineSkeleton variant="h550" as="span">
-                            Headline
-                        </HeadlineSkeleton>
+                        <HeadingSkeleton variant="h550" as="span">
+                            Heading
+                        </HeadingSkeleton>
                     }
                 >
-                    <RichTextBlock data={headline} renderers={getHeadlineRenderers(headlineTag)} />
+                    <RichTextBlock data={heading} renderers={getHeadingRenderers(headingTag)} />
                 </PreviewSkeleton>
             </>
         );
@@ -60,6 +60,6 @@ export const HeadingBlock = withPreview(
     { label: "Heading" },
 );
 
-const HeadlineSkeleton = styled(Typography)`
+const HeadingSkeleton = styled(Typography)`
     color: inherit;
 `;

--- a/demo/site/src/common/blocks/HeadingBlock.tsx
+++ b/demo/site/src/common/blocks/HeadingBlock.tsx
@@ -11,7 +11,7 @@ const eyebrowRenderers: Renderers = {
     inline: defaultRichTextInlineStyleMap,
 };
 
-const getHeadlineRenderers = (htmlTag: keyof HTMLElementTagNameMap): Renderers => ({
+const getHeadingRenderers = (htmlTag: keyof HTMLElementTagNameMap): Renderers => ({
     inline: defaultRichTextInlineStyleMap,
     blocks: {
         "header-one": createTextBlockRenderFn({ variant: "h600", as: htmlTag, bottomSpacing: true }),
@@ -23,7 +23,7 @@ const getHeadlineRenderers = (htmlTag: keyof HTMLElementTagNameMap): Renderers =
     },
 });
 
-const headlineTagMap: Record<HeadingBlockData["htmlTag"], keyof HTMLElementTagNameMap> = {
+const headingTagMap: Record<HeadingBlockData["htmlTag"], keyof HTMLElementTagNameMap> = {
     H1: "h1",
     H2: "h2",
     H3: "h3",
@@ -35,8 +35,8 @@ const headlineTagMap: Record<HeadingBlockData["htmlTag"], keyof HTMLElementTagNa
 type HeadingBlockProps = PropsWithData<HeadingBlockData>;
 
 export const HeadingBlock = withPreview(
-    ({ data: { eyebrow, headline, htmlTag } }: HeadingBlockProps) => {
-        const headlineTag = headlineTagMap[htmlTag];
+    ({ data: { eyebrow, heading, htmlTag } }: HeadingBlockProps) => {
+        const headingTag = headingTagMap[htmlTag];
 
         return (
             <>
@@ -46,14 +46,14 @@ export const HeadingBlock = withPreview(
                     </Typography>
                 )}
                 <PreviewSkeleton
-                    hasContent={hasRichTextBlockContent(headline)}
+                    hasContent={hasRichTextBlockContent(heading)}
                     title={
-                        <HeadlineSkeleton variant="h550" as="span">
-                            Headline
-                        </HeadlineSkeleton>
+                        <HeadingSkeleton variant="h550" as="span">
+                            Heading
+                        </HeadingSkeleton>
                     }
                 >
-                    <RichTextBlock data={headline} renderers={getHeadlineRenderers(headlineTag)} />
+                    <RichTextBlock data={heading} renderers={getHeadingRenderers(headingTag)} />
                 </PreviewSkeleton>
             </>
         );
@@ -61,6 +61,6 @@ export const HeadingBlock = withPreview(
     { label: "Heading" },
 );
 
-const HeadlineSkeleton = styled(Typography)`
+const HeadingSkeleton = styled(Typography)`
     color: inherit;
 `;


### PR DESCRIPTION
## Description

There were some leftover `headline` naming that were not renamed when headline was changed to heading in Demo.
