### PR TITLE
Add import restriction for MUI's `Dialog`

### DIFF
--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -293,6 +293,13 @@ Example:
 ></Tooltip>
 ```
 
+### Import `Dialog` from `@comet/admin` package
+
+```diff
+- import { Dialog } from "@mui/material";
++ import { Dialog } from "@comet/admin";
+```
+
 ### Update MUI - X Packages
 
 In `package.json` update the version of the MUI X packages to `^7.22.3`.

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -49,6 +49,11 @@ module.exports = {
                         message: "Please use Alert from @comet/admin instead",
                     },
                     {
+                        name: "@mui/material",
+                        importNames: ["Dialog"],
+                        message: "Please use Dialog from @comet/admin instead",
+                    },
+                    {
                         name: "@mui/x-data-grid",
                         importNames: ["GridColDef"],
                         message: "Please use GridColDef from @comet/admin instead",


### PR DESCRIPTION
<!--

PLEASE MAKE SURE TO KEEP THE PR SIZE AT A MINIMUM!
Smaller PRs are easier to review and tend to get merged faster.
Unrelated changes, refactorings, fixes etc. should be made in separate PRs.

--->

## Description
Add eslint rule to use Dialog from comet instead of MUI

-   [x] I have verified if my change requires a changeset

## Related tasks and documents
https://vivid-planet.atlassian.net/browse/COM-1045

Depends on: 
- https://github.com/vivid-planet/comet/pull/2609
<!--

Link to related tasks and documents, for instance, https://vivid-planet.atlassian.net/browse/COM-XXX.

MAKE SURE THAT EVERYTHING REQUIRED TO UNDERSTAND YOUR CHANGE IS IN THE PR DESCRIPTION.
Reviewers shouldn't need to review tasks, JIRA conversations etc. to understand what you're doing.

-->

## Open TODOs/questions

-   [x] Merge PR https://github.com/vivid-planet/comet/pull/2609
-   [x] Upgrade Script: https://github.com/vivid-planet/comet-upgrade/pull/53


