### PR TITLE
Add `override` parameter to all block factories in `@comet/blocks-admin`

### DIFF
--- a/.changeset/polite-chairs-join.md
+++ b/.changeset/polite-chairs-join.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": minor
+---
+
+Add an `override` argument to all "createBlock" functions to follow `createCompositeBlock`'s pattern

--- a/.changeset/polite-chairs-join.md
+++ b/.changeset/polite-chairs-join.md
@@ -2,4 +2,4 @@
 "@comet/blocks-admin": minor
 ---
 
-Add an `override` argument to all "createBlock" functions to follow `createCompositeBlock`'s pattern
+Add an `override` argument to all block factories to follow `createCompositeBlock`'s pattern

--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.test.tsx
@@ -18,13 +18,15 @@ describe("createBlocksBlock", () => {
         resolveDependencyPath: () => "",
     };
 
+    const TestBlock2 = TestBlock;
+
     it("should override block's values", () => {
         const nameOverride = "override name";
         const block = createBlocksBlock(
             {
                 name: "testBlocksBlock",
                 displayName: "Test List Block",
-                supportedBlocks: { TestBlock },
+                supportedBlocks: { TestBlock, TestBlock2 },
             },
             (block) => {
                 block.name = nameOverride;

--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.test.tsx
@@ -1,0 +1,36 @@
+import { BlockCategory } from "../types";
+import { createBlocksBlock } from "./createBlocksBlock";
+
+describe("createBlocksBlock", () => {
+    const TestBlock = {
+        category: BlockCategory.TextAndContent,
+        name: "title",
+        displayName: "Title",
+        AdminComponent: () => null,
+        defaultValues: () => ({}),
+        createPreviewState: () => ({}),
+        input2State: () => ({}),
+        isValid: () => true,
+        output2State: () => Promise.resolve({}),
+        previewContent: () => [],
+        state2Output: () => ({}),
+        replaceDependenciesInOutput: () => ({}),
+        resolveDependencyPath: () => "",
+    };
+
+    it("should override block's values", () => {
+        const nameOverride = "override name";
+        const block = createBlocksBlock(
+            {
+                name: "testBlocksBlock",
+                displayName: "Test List Block",
+                supportedBlocks: { TestBlock },
+            },
+            (block) => {
+                block.name = nameOverride;
+                return block;
+            },
+        );
+        expect(block.name).toBe(nameOverride);
+    });
+});

--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.test.tsx
@@ -1,21 +1,14 @@
+import { createBlockSkeleton } from "../helpers/createBlockSkeleton";
 import { BlockCategory } from "../types";
 import { createBlocksBlock } from "./createBlocksBlock";
 
 describe("createBlocksBlock", () => {
     const TestBlock = {
+        ...createBlockSkeleton(),
         category: BlockCategory.TextAndContent,
         name: "title",
         displayName: "Title",
-        AdminComponent: () => null,
         defaultValues: () => ({}),
-        createPreviewState: () => ({}),
-        input2State: () => ({}),
-        isValid: () => true,
-        output2State: () => Promise.resolve({}),
-        previewContent: () => [],
-        state2Output: () => ({}),
-        replaceDependenciesInOutput: () => ({}),
-        resolveDependencyPath: () => "",
     };
 
     const TestBlock2 = TestBlock;

--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
@@ -104,19 +104,24 @@ interface CreateBlocksBlockOptions<AdditionalItemFields extends Record<string, u
     AdditionalItemContent?: FunctionComponent<{ item: BlocksBlockItem<BlockInterface, AdditionalItemFields> }>;
 }
 
-export function createBlocksBlock<AdditionalItemFields extends Record<string, unknown> = DefaultAdditionalItemFields>({
-    supportedBlocks,
-    name,
-    displayName = <FormattedMessage id="comet.blocks.blocks.name" defaultMessage="Blocks" />,
-    maxVisibleBlocks,
-    additionalItemFields,
-    AdditionalItemContextMenuItems,
-    AdditionalItemContent,
-}: CreateBlocksBlockOptions<AdditionalItemFields>): BlockInterface<
-    BlocksBlockFragment<AdditionalItemFields>,
-    BlocksBlockState<AdditionalItemFields>,
-    BlocksBlockOutput<AdditionalItemFields>
-> {
+export function createBlocksBlock<AdditionalItemFields extends Record<string, unknown> = DefaultAdditionalItemFields>(
+    {
+        supportedBlocks,
+        name,
+        displayName = <FormattedMessage id="comet.blocks.blocks.name" defaultMessage="Blocks" />,
+        maxVisibleBlocks,
+        additionalItemFields,
+        AdditionalItemContextMenuItems,
+        AdditionalItemContent,
+    }: CreateBlocksBlockOptions<AdditionalItemFields>,
+    override?: (
+        block: BlockInterface<
+            BlocksBlockFragment<AdditionalItemFields>,
+            BlocksBlockState<AdditionalItemFields>,
+            BlocksBlockOutput<AdditionalItemFields>
+        >,
+    ) => BlockInterface<BlocksBlockFragment<AdditionalItemFields>, BlocksBlockState<AdditionalItemFields>, BlocksBlockOutput<AdditionalItemFields>>,
+): BlockInterface<BlocksBlockFragment<AdditionalItemFields>, BlocksBlockState<AdditionalItemFields>, BlocksBlockOutput<AdditionalItemFields>> {
     if (Object.keys(supportedBlocks).length === 0) {
         throw new Error("Blocks block with no supported block is not allowed. Please specify at least two supported blocks.");
     }
@@ -864,6 +869,11 @@ export function createBlocksBlock<AdditionalItemFields extends Record<string, un
             return `${blockItem.key}/blocks/${childPath}`;
         },
     };
+
+    if (override) {
+        return override(BlocksBlock);
+    }
+
     return BlocksBlock;
 }
 

--- a/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.test.tsx
@@ -1,21 +1,14 @@
+import { createBlockSkeleton } from "../helpers/createBlockSkeleton";
 import { BlockCategory } from "../types";
 import { createColumnsBlock } from "./createColumnsBlock";
 
 describe("createColumnsBlock", () => {
     const TestBlock = {
+        ...createBlockSkeleton(),
         category: BlockCategory.TextAndContent,
         name: "title",
         displayName: "Title",
-        AdminComponent: () => null,
         defaultValues: () => ({}),
-        createPreviewState: () => ({}),
-        input2State: () => ({}),
-        isValid: () => true,
-        output2State: () => Promise.resolve({}),
-        previewContent: () => [],
-        state2Output: () => ({}),
-        replaceDependenciesInOutput: () => ({}),
-        resolveDependencyPath: () => "",
     };
 
     it("should override block's values", () => {

--- a/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.test.tsx
@@ -1,0 +1,37 @@
+import { BlockCategory } from "../types";
+import { createColumnsBlock } from "./createColumnsBlock";
+
+describe("createColumnsBlock", () => {
+    const TestBlock = {
+        category: BlockCategory.TextAndContent,
+        name: "title",
+        displayName: "Title",
+        AdminComponent: () => null,
+        defaultValues: () => ({}),
+        createPreviewState: () => ({}),
+        input2State: () => ({}),
+        isValid: () => true,
+        output2State: () => Promise.resolve({}),
+        previewContent: () => [],
+        state2Output: () => ({}),
+        replaceDependenciesInOutput: () => ({}),
+        resolveDependencyPath: () => "",
+    };
+
+    it("should override block's values", () => {
+        const nameOverride = "override name";
+        const block = createColumnsBlock(
+            {
+                name: "testColumnsBlock",
+                displayName: "Test List Block",
+                contentBlock: TestBlock,
+                layouts: [{ name: "test", columns: 1, label: "Test", preview: <div /> }],
+            },
+            (block) => {
+                block.name = nameOverride;
+                return block;
+            },
+        );
+        expect(block.name).toBe(nameOverride);
+    });
+});

--- a/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
@@ -59,13 +59,12 @@ interface CreateColumnsBlockOptions<T extends BlockInterface> {
     layouts: ColumnsBlockLayout[];
 }
 
-export function createColumnsBlock<T extends BlockInterface>({
-    name,
-    displayName,
-    category = BlockCategory.Layout,
-    contentBlock,
-    layouts,
-}: CreateColumnsBlockOptions<T>): BlockInterface<ColumnsBlockFragment<T>, ColumnsBlockState<T>, ColumnsBlockFragment<T>> {
+export function createColumnsBlock<T extends BlockInterface>(
+    { name, displayName, category = BlockCategory.Layout, contentBlock, layouts }: CreateColumnsBlockOptions<T>,
+    override?: (
+        block: BlockInterface<ColumnsBlockFragment<T>, ColumnsBlockState<T>, ColumnsBlockFragment<T>>,
+    ) => BlockInterface<ColumnsBlockFragment<T>, ColumnsBlockState<T>, ColumnsBlockFragment<T>>,
+): BlockInterface<ColumnsBlockFragment<T>, ColumnsBlockState<T>, ColumnsBlockFragment<T>> {
     if (layouts.length === 0) {
         throw new Error(`Number of layouts must be greater than 0!`);
     }
@@ -466,6 +465,10 @@ export function createColumnsBlock<T extends BlockInterface>({
             return `${blockItem.key}/edit/${childPath}`;
         },
     };
+
+    if (override) {
+        return override(ColumnsBlock);
+    }
 
     return ColumnsBlock;
 }

--- a/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.test.tsx
@@ -1,0 +1,20 @@
+import { createCompositeBlock } from "./createCompositeBlock";
+
+describe("createCompositeBlock", () => {
+    it("should override block's values", () => {
+        const nameOverride = "override name";
+        const block = createCompositeBlock(
+            {
+                name: "testCompositeBlock",
+                displayName: "Test List Block",
+                blocks: {},
+                layouts: [{ name: "test", columns: 1, label: "Test", preview: <div /> }],
+            },
+            (block) => {
+                block.name = nameOverride;
+                return block;
+            },
+        );
+        expect(block.name).toBe(nameOverride);
+    });
+});

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.test.tsx
@@ -18,35 +18,6 @@ describe("createListBlock", () => {
         resolveDependencyPath: () => "",
     };
 
-    it("should use category from factory options", () => {
-        const block = createListBlock({
-            name: "testListBlock",
-            displayName: "Test List Block",
-            itemName: "item",
-            itemsName: "items",
-            category: BlockCategory.Layout,
-            minVisibleBlocks: 1,
-            maxVisibleBlocks: 3,
-            createDefaultListEntry: true,
-            block: TestListItemBlock,
-        });
-        expect(block.category).toBe(BlockCategory.Layout);
-    });
-
-    it("should fallback to item's category when none is provided", () => {
-        const block = createListBlock({
-            name: "testListBlock",
-            displayName: "Test List Block",
-            itemName: "item",
-            itemsName: "items",
-            minVisibleBlocks: 1,
-            maxVisibleBlocks: 3,
-            createDefaultListEntry: true,
-            block: TestListItemBlock,
-        });
-        expect(block.category).toBe(BlockCategory.TextAndContent);
-    });
-
     it("should override block's values", () => {
         const nameOverride = "override name";
         const block = createListBlock(

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.test.tsx
@@ -1,21 +1,14 @@
+import { createBlockSkeleton } from "../helpers/createBlockSkeleton";
 import { BlockCategory } from "../types";
 import { createListBlock } from "./createListBlock";
 
 describe("createListBlock", () => {
     const TestListItemBlock = {
+        ...createBlockSkeleton(),
         category: BlockCategory.TextAndContent,
         name: "title",
         displayName: "Title",
-        AdminComponent: () => null,
         defaultValues: () => ({}),
-        createPreviewState: () => ({}),
-        input2State: () => ({}),
-        isValid: () => true,
-        output2State: () => Promise.resolve({}),
-        previewContent: () => [],
-        state2Output: () => ({}),
-        replaceDependenciesInOutput: () => ({}),
-        resolveDependencyPath: () => "",
     };
 
     it("should override block's values", () => {

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.test.tsx
@@ -1,0 +1,70 @@
+import { BlockCategory } from "../types";
+import { createListBlock } from "./createListBlock";
+
+describe("createListBlock", () => {
+    const TestListItemBlock = {
+        category: BlockCategory.TextAndContent,
+        name: "title",
+        displayName: "Title",
+        AdminComponent: () => null,
+        defaultValues: () => ({}),
+        createPreviewState: () => ({}),
+        input2State: () => ({}),
+        isValid: () => true,
+        output2State: () => Promise.resolve({}),
+        previewContent: () => [],
+        state2Output: () => ({}),
+        replaceDependenciesInOutput: () => ({}),
+        resolveDependencyPath: () => "",
+    };
+
+    it("should use category from factory options", () => {
+        const block = createListBlock({
+            name: "testListBlock",
+            displayName: "Test List Block",
+            itemName: "item",
+            itemsName: "items",
+            category: BlockCategory.Layout,
+            minVisibleBlocks: 1,
+            maxVisibleBlocks: 3,
+            createDefaultListEntry: true,
+            block: TestListItemBlock,
+        });
+        expect(block.category).toBe(BlockCategory.Layout);
+    });
+
+    it("should fallback to item's category when none is provided", () => {
+        const block = createListBlock({
+            name: "testListBlock",
+            displayName: "Test List Block",
+            itemName: "item",
+            itemsName: "items",
+            minVisibleBlocks: 1,
+            maxVisibleBlocks: 3,
+            createDefaultListEntry: true,
+            block: TestListItemBlock,
+        });
+        expect(block.category).toBe(BlockCategory.TextAndContent);
+    });
+
+    it("should override block's values", () => {
+        const nameOverride = "override name";
+        const block = createListBlock(
+            {
+                name: "testListBlock",
+                displayName: "Test List Block",
+                itemName: "item",
+                itemsName: "items",
+                minVisibleBlocks: 1,
+                maxVisibleBlocks: 3,
+                createDefaultListEntry: true,
+                block: TestListItemBlock,
+            },
+            (block) => {
+                block.name = nameOverride;
+                return block;
+            },
+        );
+        expect(block.name).toBe(nameOverride);
+    });
+});

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -85,23 +85,29 @@ interface CreateListBlockOptions<T extends BlockInterface, AdditionalItemFields 
     AdditionalItemContent?: FunctionComponent<{ item: ListBlockItem<T, AdditionalItemFields> }>;
 }
 
-export function createListBlock<T extends BlockInterface, AdditionalItemFields extends Record<string, unknown> = DefaultAdditionalItemFields>({
-    name,
-    block,
-    displayName = <FormattedMessage id="comet.blocks.listBlock.name" defaultMessage="List" />,
-    itemName = <FormattedMessage id="comet.blocks.listBlock.itemName" defaultMessage="block" />,
-    itemsName = <FormattedMessage id="comet.blocks.listBlock.itemsName" defaultMessage="blocks" />,
-    minVisibleBlocks,
-    maxVisibleBlocks,
-    createDefaultListEntry,
-    additionalItemFields,
-    AdditionalItemContextMenuItems,
-    AdditionalItemContent,
-}: CreateListBlockOptions<T, AdditionalItemFields>): BlockInterface<
-    ListBlockFragment<AdditionalItemFields>,
-    ListBlockState<T, AdditionalItemFields>,
-    ListBlockOutput<AdditionalItemFields>
-> {
+export function createListBlock<T extends BlockInterface, AdditionalItemFields extends Record<string, unknown> = DefaultAdditionalItemFields>(
+    {
+        name,
+        block,
+        displayName = <FormattedMessage id="comet.blocks.listBlock.name" defaultMessage="List" />,
+        itemName = <FormattedMessage id="comet.blocks.listBlock.itemName" defaultMessage="block" />,
+        itemsName = <FormattedMessage id="comet.blocks.listBlock.itemsName" defaultMessage="blocks" />,
+        minVisibleBlocks,
+        maxVisibleBlocks,
+        createDefaultListEntry,
+        additionalItemFields,
+        AdditionalItemContextMenuItems,
+        AdditionalItemContent,
+        category,
+    }: CreateListBlockOptions<T, AdditionalItemFields>,
+    override?: (
+        block: BlockInterface<
+            ListBlockFragment<AdditionalItemFields>,
+            ListBlockState<T, AdditionalItemFields>,
+            ListBlockOutput<AdditionalItemFields>
+        >,
+    ) => BlockInterface<ListBlockFragment<AdditionalItemFields>, ListBlockState<T, AdditionalItemFields>, ListBlockOutput<AdditionalItemFields>>,
+): BlockInterface<ListBlockFragment<AdditionalItemFields>, ListBlockState<T, AdditionalItemFields>, ListBlockOutput<AdditionalItemFields>> {
     const useAdminComponent = createUseAdminComponent({ block, maxVisibleBlocks, additionalItemFields });
     if (minVisibleBlocks && maxVisibleBlocks && minVisibleBlocks > maxVisibleBlocks)
         throw new Error(
@@ -530,6 +536,9 @@ export function createListBlock<T extends BlockInterface, AdditionalItemFields e
             return `${blockItem.key}/edit/${childPath}`;
         },
     };
+    if (override) {
+        return override(BlockListBlock);
+    }
     return BlockListBlock;
 }
 

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -98,7 +98,6 @@ export function createListBlock<T extends BlockInterface, AdditionalItemFields e
         additionalItemFields,
         AdditionalItemContextMenuItems,
         AdditionalItemContent,
-        category,
     }: CreateListBlockOptions<T, AdditionalItemFields>,
     override?: (
         block: BlockInterface<

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.test.tsx
@@ -1,21 +1,14 @@
+import { createBlockSkeleton } from "../helpers/createBlockSkeleton";
 import { BlockCategory } from "../types";
 import { createOneOfBlock } from "./createOneOfBlock";
 
 describe("createOneOfBlock", () => {
     const TestBlock = {
+        ...createBlockSkeleton(),
         category: BlockCategory.TextAndContent,
         name: "title",
         displayName: "Title",
-        AdminComponent: () => null,
         defaultValues: () => ({}),
-        createPreviewState: () => ({}),
-        input2State: () => ({}),
-        isValid: () => true,
-        output2State: () => Promise.resolve({}),
-        previewContent: () => [],
-        state2Output: () => ({}),
-        replaceDependenciesInOutput: () => ({}),
-        resolveDependencyPath: () => "",
     };
 
     it("should override block's values", () => {

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.test.tsx
@@ -1,0 +1,36 @@
+import { BlockCategory } from "../types";
+import { createOneOfBlock } from "./createOneOfBlock";
+
+describe("createOneOfBlock", () => {
+    const TestBlock = {
+        category: BlockCategory.TextAndContent,
+        name: "title",
+        displayName: "Title",
+        AdminComponent: () => null,
+        defaultValues: () => ({}),
+        createPreviewState: () => ({}),
+        input2State: () => ({}),
+        isValid: () => true,
+        output2State: () => Promise.resolve({}),
+        previewContent: () => [],
+        state2Output: () => ({}),
+        replaceDependenciesInOutput: () => ({}),
+        resolveDependencyPath: () => "",
+    };
+
+    it("should override block's values", () => {
+        const nameOverride = "override name";
+        const block = createOneOfBlock(
+            {
+                name: "testBlocksBlock",
+                displayName: "Test List Block",
+                supportedBlocks: { TestContentBlock: TestBlock },
+            },
+            (block) => {
+                block.name = nameOverride;
+                return block;
+            },
+        );
+        expect(block.name).toBe(nameOverride);
+    });
+});

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -67,14 +67,19 @@ export interface CreateOneOfBlockOptions<T extends boolean> {
     allowEmpty?: T;
 }
 
-export const createOneOfBlock = <T extends boolean = boolean>({
-    supportedBlocks,
-    name,
-    displayName = "Switch",
-    category = BlockCategory.Other,
-    variant = "select",
-    allowEmpty: passedAllowEmpty,
-}: CreateOneOfBlockOptions<T>): BlockInterface<OneOfBlockFragment, OneOfBlockState, OneOfBlockOutput<T>, OneOfBlockPreviewState> => {
+export const createOneOfBlock = <T extends boolean = boolean>(
+    {
+        supportedBlocks,
+        name,
+        displayName = "Switch",
+        category = BlockCategory.Other,
+        variant = "select",
+        allowEmpty: passedAllowEmpty,
+    }: CreateOneOfBlockOptions<T>,
+    override?: (
+        block: BlockInterface<OneOfBlockFragment, OneOfBlockState, OneOfBlockOutput<T>, OneOfBlockPreviewState>,
+    ) => BlockInterface<OneOfBlockFragment, OneOfBlockState, OneOfBlockOutput<T>, OneOfBlockPreviewState>,
+): BlockInterface<OneOfBlockFragment, OneOfBlockState, OneOfBlockOutput<T>, OneOfBlockPreviewState> => {
     // allowEmpty can't have a default type because it's typed by a generic
     const allowEmpty = (passedAllowEmpty ?? true) satisfies boolean;
 
@@ -441,6 +446,9 @@ export const createOneOfBlock = <T extends boolean = boolean>({
             }
         },
     };
+    if (override) {
+        return override(OneOfBlock);
+    }
     return OneOfBlock;
 };
 

--- a/packages/admin/blocks-admin/src/blocks/factories/createOptionalBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOptionalBlock.test.tsx
@@ -1,3 +1,4 @@
+import { createBlockSkeleton } from "../helpers/createBlockSkeleton";
 import { BlockCategory } from "../types";
 import { createOptionalBlock } from "./createOptionalBlock";
 
@@ -6,19 +7,11 @@ describe("createOptionalBlock", () => {
         const nameOverride = "override name";
         const block = createOptionalBlock(
             {
+                ...createBlockSkeleton(),
                 name: "testBlocksBlock",
                 displayName: "Test List Block",
                 category: BlockCategory.Layout,
-                AdminComponent: () => null,
                 defaultValues: () => ({}),
-                createPreviewState: () => ({}),
-                input2State: () => ({}),
-                isValid: () => true,
-                output2State: () => Promise.resolve({}),
-                previewContent: () => [],
-                state2Output: () => ({}),
-                replaceDependenciesInOutput: () => ({}),
-                resolveDependencyPath: () => "",
             },
             {},
             (block) => {

--- a/packages/admin/blocks-admin/src/blocks/factories/createOptionalBlock.test.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOptionalBlock.test.tsx
@@ -1,0 +1,31 @@
+import { BlockCategory } from "../types";
+import { createOptionalBlock } from "./createOptionalBlock";
+
+describe("createOptionalBlock", () => {
+    it("should override block's values", () => {
+        const nameOverride = "override name";
+        const block = createOptionalBlock(
+            {
+                name: "testBlocksBlock",
+                displayName: "Test List Block",
+                category: BlockCategory.Layout,
+                AdminComponent: () => null,
+                defaultValues: () => ({}),
+                createPreviewState: () => ({}),
+                input2State: () => ({}),
+                isValid: () => true,
+                output2State: () => Promise.resolve({}),
+                previewContent: () => [],
+                state2Output: () => ({}),
+                replaceDependenciesInOutput: () => ({}),
+                resolveDependencyPath: () => "",
+            },
+            {},
+            (block) => {
+                block.name = nameOverride;
+                return block;
+            },
+        );
+        expect(block.name).toBe(nameOverride);
+    });
+});

--- a/packages/admin/blocks-admin/src/blocks/factories/createOptionalBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOptionalBlock.tsx
@@ -31,6 +31,9 @@ export interface OptionalBlockOutput<DecoratedBlock extends BlockInterface> {
 export function createOptionalBlock<T extends BlockInterface>(
     decoratedBlock: T,
     options?: { title?: ReactNode; name?: string },
+    override?: (
+        block: BlockInterface<OptionalBlockDecoratorFragment<T>, OptionalBlockState<T>, OptionalBlockOutput<T>>,
+    ) => BlockInterface<OptionalBlockDecoratorFragment<T>, OptionalBlockState<T>, OptionalBlockOutput<T>>,
 ): BlockInterface<OptionalBlockDecoratorFragment<T>, OptionalBlockState<T>, OptionalBlockOutput<T>> {
     const OptionalBlock: BlockInterface<OptionalBlockDecoratorFragment<T>, OptionalBlockState<T>, OptionalBlockOutput<T>> = {
         ...createBlockSkeleton(),
@@ -170,5 +173,10 @@ export function createOptionalBlock<T extends BlockInterface>(
             return block && visible ? decoratedBlock.previewContent(block, ctx) : [];
         },
     };
+
+    if (override) {
+        return override(OptionalBlock);
+    }
+
     return OptionalBlock;
 }


### PR DESCRIPTION
## Description

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1554
