### PR TITLE
Demo: Add custom more actions to handmade products grid

### DIFF
--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -28,7 +28,14 @@ import {
 import { Add as AddIcon, Disabled, Edit, Excel, Online, StateFilled as StateFilledIcon } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { CircularProgress, IconButton, useTheme } from "@mui/material";
-import { DataGridPro, GridFilterInputSingleSelect, GridFilterInputValue, GridSelectionModel, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
+import {
+    DataGridPro,
+    GridFilterInputSingleSelect,
+    GridFilterInputValue,
+    GridSelectionModel,
+    GridToolbarQuickFilter,
+    useGridApiContext,
+} from "@mui/x-data-grid-pro";
 import gql from "graphql-tag";
 import { useState } from "react";
 import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
@@ -52,6 +59,7 @@ import { ProductsGridPreviewAction } from "./ProductsGridPreviewAction";
 function ProductsGridToolbar({ exportApi, selectionModel }: { exportApi: ExportApi; selectionModel: GridSelectionModel }) {
     const client = useApolloClient();
     const theme = useTheme();
+    const apiRef = useGridApiContext();
 
     return (
         <DataGridToolbar>
@@ -91,6 +99,7 @@ function ProductsGridToolbar({ exportApi, selectionModel }: { exportApi: ExportA
                                     });
                                 }
                             },
+                            disabled: selectionModel.every((id) => apiRef.current.getRow(id)?.status === "Published"),
                         },
                         {
                             label: "Unpublish",
@@ -107,6 +116,7 @@ function ProductsGridToolbar({ exportApi, selectionModel }: { exportApi: ExportA
                                     });
                                 }
                             },
+                            disabled: selectionModel.every((id) => apiRef.current.getRow(id)?.status === "Unpublished"),
                         },
                     ]}
                     selectionSize={selectionModel.length}

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -390,6 +390,7 @@ export function ProductsGrid() {
                 toolbar: { exportApi, selectionModel },
             }}
             checkboxSelection
+            keepNonExistentRowsSelected
             selectionModel={selectionModel}
             onSelectionModelChange={(selectionModel) => {
                 setSelectionModel(selectionModel);

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -33,6 +33,7 @@ import gql from "graphql-tag";
 import { useState } from "react";
 import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
 
+import { PublishAllProducts } from "./helpers/PublishAllProducts";
 import { ManufacturerFilterOperator } from "./ManufacturerFilter";
 import {
     GQLCreateProductMutation,
@@ -74,6 +75,7 @@ function ProductsGridToolbar({ exportApi, selectionModel }: { exportApi: ExportA
                             onClick: () => exportApi.exportGrid(),
                             disabled: exportApi.loading,
                         },
+                        <PublishAllProducts key="publish" />,
                     ]}
                     selectiveActions={[
                         {

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -28,14 +28,7 @@ import {
 import { Add as AddIcon, Disabled, Edit, Excel, Online, StateFilled as StateFilledIcon } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { CircularProgress, IconButton, useTheme } from "@mui/material";
-import {
-    DataGridPro,
-    GridFilterInputSingleSelect,
-    GridFilterInputValue,
-    GridSelectionModel,
-    GridToolbarQuickFilter,
-    useGridApiContext,
-} from "@mui/x-data-grid-pro";
+import { DataGridPro, GridFilterInputSingleSelect, GridFilterInputValue, GridSelectionModel, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
 import gql from "graphql-tag";
 import { useState } from "react";
 import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
@@ -59,7 +52,6 @@ import { ProductsGridPreviewAction } from "./ProductsGridPreviewAction";
 function ProductsGridToolbar({ exportApi, selectionModel }: { exportApi: ExportApi; selectionModel: GridSelectionModel }) {
     const client = useApolloClient();
     const theme = useTheme();
-    const apiRef = useGridApiContext();
 
     return (
         <DataGridToolbar>
@@ -99,7 +91,6 @@ function ProductsGridToolbar({ exportApi, selectionModel }: { exportApi: ExportA
                                     });
                                 }
                             },
-                            disabled: selectionModel.every((id) => apiRef.current.getRow(id)?.status === "Published"),
                         },
                         {
                             label: "Unpublish",
@@ -116,7 +107,6 @@ function ProductsGridToolbar({ exportApi, selectionModel }: { exportApi: ExportA
                                     });
                                 }
                             },
-                            disabled: selectionModel.every((id) => apiRef.current.getRow(id)?.status === "Unpublished"),
                         },
                     ]}
                     selectionSize={selectionModel.length}

--- a/demo/admin/src/products/helpers/PublishAllProducts.tsx
+++ b/demo/admin/src/products/helpers/PublishAllProducts.tsx
@@ -1,7 +1,7 @@
 import { gql, useApolloClient } from "@apollo/client";
-import { Button, CancelButton, CrudMoreActionsMenuContext } from "@comet/admin";
+import { Button, CancelButton, CrudMoreActionsMenuContext, Dialog } from "@comet/admin";
 import { Online } from "@comet/admin-icons";
-import { Dialog, DialogActions, DialogContent, DialogTitle, ListItemIcon, MenuItem } from "@mui/material";
+import { DialogActions, DialogContent, ListItemIcon, MenuItem } from "@mui/material";
 import { useContext, useState } from "react";
 
 import { GQLPublishAllProductsMutation, GQLPublishAllProductsMutationVariables } from "./PublishAllProducts.generated";
@@ -42,8 +42,7 @@ export function PublishAllProducts() {
                 </ListItemIcon>
                 Publish all...
             </MenuItem>
-            <Dialog open={open} onClose={handleClose}>
-                <DialogTitle>Publish all products?</DialogTitle>
+            <Dialog open={open} onClose={handleClose} title="Publish all products?">
                 <DialogContent>You are about to publish all products.</DialogContent>
                 <DialogActions>
                     <CancelButton onClick={handleClose}>Cancel</CancelButton>

--- a/demo/admin/src/products/helpers/PublishAllProducts.tsx
+++ b/demo/admin/src/products/helpers/PublishAllProducts.tsx
@@ -45,7 +45,7 @@ export function PublishAllProducts() {
             <Dialog open={open} onClose={handleClose} title="Publish all products?">
                 <DialogContent>You are about to publish all products.</DialogContent>
                 <DialogActions>
-                    <CancelButton onClick={handleClose}>Cancel</CancelButton>
+                    <CancelButton onClick={handleClose} />
                     <Button onClick={handlePublishAll} startIcon={<Online />} variant="success">
                         Publish
                     </Button>

--- a/demo/admin/src/products/helpers/PublishAllProducts.tsx
+++ b/demo/admin/src/products/helpers/PublishAllProducts.tsx
@@ -1,0 +1,57 @@
+import { gql, useApolloClient } from "@apollo/client";
+import { CancelButton, CrudMoreActionsMenuContext } from "@comet/admin";
+import { Online } from "@comet/admin-icons";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, ListItemIcon, MenuItem } from "@mui/material";
+import { useContext, useState } from "react";
+
+import { GQLPublishAllProductsMutation, GQLPublishAllProductsMutationVariables } from "./PublishAllProducts.generated";
+
+export function PublishAllProducts() {
+    const [open, setOpen] = useState(false);
+    const client = useApolloClient();
+    const { closeMenu } = useContext(CrudMoreActionsMenuContext);
+
+    const handlePublishAll = async () => {
+        await client.mutate<GQLPublishAllProductsMutation, GQLPublishAllProductsMutationVariables>({
+            mutation: gql`
+                mutation PublishAllProducts {
+                    publishAllProducts
+                }
+            `,
+        });
+
+        client.cache.evict({ fieldName: "products" });
+
+        handleClose();
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+        closeMenu();
+    };
+
+    return (
+        <>
+            <MenuItem
+                onClick={() => {
+                    setOpen(true);
+                }}
+            >
+                <ListItemIcon>
+                    <Online color="success" />
+                </ListItemIcon>
+                Publish all...
+            </MenuItem>
+            <Dialog open={open} onClose={handleClose}>
+                <DialogTitle>Publish all products?</DialogTitle>
+                <DialogContent>You are about to publish all products.</DialogContent>
+                <DialogActions>
+                    <CancelButton onClick={handleClose}>Cancel</CancelButton>
+                    <Button onClick={handlePublishAll} startIcon={<Online />} color="success" variant="contained">
+                        Publish
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    );
+}

--- a/demo/admin/src/products/helpers/PublishAllProducts.tsx
+++ b/demo/admin/src/products/helpers/PublishAllProducts.tsx
@@ -1,7 +1,7 @@
 import { gql, useApolloClient } from "@apollo/client";
-import { CancelButton, CrudMoreActionsMenuContext } from "@comet/admin";
+import { Button, CancelButton, CrudMoreActionsMenuContext } from "@comet/admin";
 import { Online } from "@comet/admin-icons";
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, ListItemIcon, MenuItem } from "@mui/material";
+import { Dialog, DialogActions, DialogContent, DialogTitle, ListItemIcon, MenuItem } from "@mui/material";
 import { useContext, useState } from "react";
 
 import { GQLPublishAllProductsMutation, GQLPublishAllProductsMutationVariables } from "./PublishAllProducts.generated";
@@ -47,7 +47,7 @@ export function PublishAllProducts() {
                 <DialogContent>You are about to publish all products.</DialogContent>
                 <DialogActions>
                     <CancelButton onClick={handleClose}>Cancel</CancelButton>
-                    <Button onClick={handlePublishAll} startIcon={<Online />} color="success" variant="contained">
+                    <Button onClick={handlePublishAll} startIcon={<Online />} variant="success">
                         Publish
                     </Button>
                 </DialogActions>

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -1239,6 +1239,7 @@ type Mutation {
   createManufacturer(input: ManufacturerInput!): Manufacturer!
   updateManufacturer(id: ID!, input: ManufacturerUpdateInput!): Manufacturer!
   deleteManufacturer(id: ID!): Boolean!
+  publishAllProducts: Boolean!
 }
 
 input UserPermissionInput {

--- a/demo/api/src/products/custom-product.resolver.ts
+++ b/demo/api/src/products/custom-product.resolver.ts
@@ -1,0 +1,18 @@
+import { RequiredPermission } from "@comet/cms-api";
+import { InjectRepository } from "@mikro-orm/nestjs";
+import { EntityRepository } from "@mikro-orm/postgresql";
+import { Mutation, Resolver } from "@nestjs/graphql";
+
+import { Product, ProductStatus } from "./entities/product.entity";
+
+@Resolver(() => Product)
+@RequiredPermission(["products"], { skipScopeCheck: true })
+export class CustomProductResolver {
+    constructor(@InjectRepository(Product) private readonly repository: EntityRepository<Product>) {}
+
+    @Mutation(() => Boolean)
+    async publishAllProducts(): Promise<boolean> {
+        await this.repository.nativeUpdate({ status: { $ne: ProductStatus.Published } }, { status: ProductStatus.Published });
+        return true;
+    }
+}

--- a/demo/api/src/products/products.module.ts
+++ b/demo/api/src/products/products.module.ts
@@ -3,6 +3,7 @@ import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { Module } from "@nestjs/common";
 import { ProductVariantsService } from "@src/products/generated/product-variants.service";
 
+import { CustomProductResolver } from "./custom-product.resolver";
 import { Manufacturer } from "./entities/manufacturer.entity";
 import { ManufacturerCountry } from "./entities/manufacturer-country.entity";
 import { Product } from "./entities/product.entity";
@@ -46,6 +47,7 @@ import { ProductVariantResolver } from "./generated/product-variant.resolver";
         ManufacturerResolver,
         ManufacturerCountryResolver,
         ProductToTagResolver,
+        CustomProductResolver,
     ],
     exports: [],
 })


### PR DESCRIPTION
## Description

We need custom actions in the more actions menu in the Admin Generator. This PR is a first step into this direction by implementing custom actions in the handmade products grids. The selective actions allow publishing/unpublishing products. The overall action allows publishing all products.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

https://github.com/user-attachments/assets/46c99d75-e68f-447c-9799-1cce9be1e975

https://github.com/user-attachments/assets/b7ee5026-9bc0-4073-9574-fc8808394918

## Open TODOs/questions

-   [x] Decide if `CrudMoreActionsMenu` should allow overriding the selection size for single items (e.g., set 0 if an action can't be done)
- [x] Decide if selection should be cleared after action
- [x] Find an example for an overall action
- [x] Merge parent PR https://github.com/vivid-planet/comet/pull/3261
- [x] Merge parent PR https://github.com/vivid-planet/comet/pull/3275

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/SVK-517