### PR TITLE
Fix `minHeight` styling in `createRichTextBlock`

### DIFF
--- a/.changeset/witty-onions-check.md
+++ b/.changeset/witty-onions-check.md
@@ -2,4 +2,4 @@
 "@comet/admin-rte": patch
 ---
 
-`minHeight` in `createRichTextBlock` takes a number value to set the `minHeight` of the draft editor content correctly
+Set correct editor height when using the `minHeight` option

--- a/.changeset/witty-onions-check.md
+++ b/.changeset/witty-onions-check.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-rte": patch
+---
+
+`minHeight` in `createRichTextBlock` takes a number value to set the `minHeight` of the draft editor content correctly

--- a/packages/admin/admin-rte/src/core/Rte.tsx
+++ b/packages/admin/admin-rte/src/core/Rte.tsx
@@ -376,7 +376,7 @@ const Editor = createComponentSlot("div")<RteClassKey, OwnerState>({
 
             ${ownerState.minHeight !== undefined &&
             css`
-                min-height: ${ownerState.minHeight};
+                min-height: ${`${ownerState.minHeight}px`};
             `}
 
             padding: 20px;


### PR DESCRIPTION
## Description

`createRichTextBlock` accepts a number value for `minHeight`, which is used for styling in the RTE. CSS needs a string value including the unit. 

The minHeight variable is now used in a string including 'px' in CSS, so that the minHeight value is applied correctly.


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Tested by passing `minHeight: 500` to `createRichTextBlock`

| Before                                                                                                           | After                                                                                                           |
|------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
| ![Screenshot 2025-01-23 at 11 56 16](https://github.com/user-attachments/assets/b66c77f8-37ae-4a28-aac4-7b6199e73f54) | ![Screenshot 2025-01-23 at 11 55 47](https://github.com/user-attachments/assets/c8c5e3df-7cf5-45db-9794-f80571afc86a) |


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1522

