### PR TITLE
Export `FileUploadInput`

### DIFF
--- a/.changeset/friendly-seas-yawn.md
+++ b/.changeset/friendly-seas-yawn.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Export `FileUploadInput`

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -89,7 +89,7 @@ export { DamConfig } from "./dam/dam.config";
 export { DAM_CONFIG, IMGPROXY_CONFIG } from "./dam/dam.constants";
 export { DamModule } from "./dam/dam.module";
 export { CreateFileInput, ImageFileInput, UpdateFileInput } from "./dam/files/dto/file.input";
-export { FileUploadInterface } from "./dam/files/dto/file-upload.input";
+export { FileUploadInput, FileUploadInterface } from "./dam/files/dto/file-upload.input";
 export { CreateFolderInput, UpdateFolderInput } from "./dam/files/dto/folder.input";
 export { createFileEntity, FileInterface } from "./dam/files/entities/file.entity";
 export { DamFileImage } from "./dam/files/entities/file-image.entity";


### PR DESCRIPTION
Exports `FileUploadInput`

Currently only the deprecated `FileUploadInterface` is exported. But not the new `FileUploadInput`