### PR TITLE
Override the `Cache-Control` header with `no-cache` for error responses

### DIFF
--- a/demo/build-and-run-site.sh
+++ b/demo/build-and-run-site.sh
@@ -1,0 +1,24 @@
+# Execute this script via `npm run build-and-run-site`
+#
+# This script builds the site like in the CI and starts it.
+#
+# Reasons why you want to do this:
+# - Check if it builds without warnings
+# - Check if there are suggestions from next build
+# - Check if it behaves in the same way like the dev-server
+# - Check caching behaviour, e.g. Cache-Control header (which is always no-cache in dev-server)
+
+#!/usr/bin/env bash
+
+echo "[1/2] Build site..."
+cd site
+rm -f .env .env.local .env.site-configs
+rm -rf .next
+NODE_ENV=production npm run build
+ln -sf ../../.env ./
+ln -sf ../../.env.local ./
+ln -sf ../.env.site-configs ./
+echo ""
+
+echo "[2/2] Start site..."
+npx dotenv -e .env.secrets -e .env.site-configs -- npm run serve

--- a/demo/site-pages/package.json
+++ b/demo/site-pages/package.json
@@ -40,7 +40,7 @@
         "graphql": "^15.0.0",
         "graphql-request": "^3.0.0",
         "graphql-tag": "^2.12.6",
-        "next": "^14.2.22",
+        "next": "^14.2.24",
         "pure-react-carousel": "^1.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/demo/site/next.config.mjs
+++ b/demo/site/next.config.mjs
@@ -33,7 +33,8 @@ const nextConfig = {
         return {
             afterFiles: [
                 {
-                    source: "/:path(_next|assets)/:file*",
+                    // Show a 404 instead of trying to render page for paths starting with /_next/ or /assets/ as they don't get rewritten in DomainRewriteMiddleware and cause errors in ...path page
+                    source: "/:prefix(_next|assets)/:path*",
                     destination: "/404",
                 },
             ],

--- a/demo/site/next.config.mjs
+++ b/demo/site/next.config.mjs
@@ -29,6 +29,16 @@ const nextConfig = {
     },
     cacheHandler: process.env.REDIS_ENABLED === "true" ? import.meta.resolve("./dist/cache-handler.js").replace("file://", "") : undefined,
     cacheMaxMemorySize: process.env.REDIS_ENABLED === "true" ? 0 : undefined, // disable default in-memory caching
+    rewrites: () => {
+        return {
+            afterFiles: [
+                {
+                    source: "/_next/:path*",
+                    destination: "/404",
+                },
+            ],
+        };
+    },
 };
 
 export default withBundleAnalyzer(nextConfig);

--- a/demo/site/next.config.mjs
+++ b/demo/site/next.config.mjs
@@ -33,7 +33,7 @@ const nextConfig = {
         return {
             afterFiles: [
                 {
-                    source: "/_next/:path*",
+                    source: "/:path(_next|assets)/:file*",
                     destination: "/404",
                 },
             ],

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -40,7 +40,7 @@
         "graphql-tag": "^2.12.6",
         "ioredis": "^5.4.1",
         "lru-cache": "^11.0.1",
-        "next": "^14.2.12",
+        "next": "^14.2.24",
         "pure-react-carousel": "^1.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/demo/site/server.ts
+++ b/demo/site/server.ts
@@ -53,6 +53,15 @@ app.prepare().then(() => {
                 };
             }
 
+            const originalWriteHead = res.writeHead;
+            res.writeHead = function (statusCode: number, ...args: unknown[]) {
+                if (statusCode >= 400) {
+                    // prevent caching of error responses
+                    res.setHeader("Cache-Control", "private, no-cache, no-store, max-age=0, must-revalidate");
+                }
+                return originalWriteHead.apply(this, [statusCode, ...args]);
+            };
+
             await handle(req, res, parsedUrl);
         } catch (err) {
             console.error("Error occurred handling", req.url, err);

--- a/demo/site/server.ts
+++ b/demo/site/server.ts
@@ -55,6 +55,7 @@ app.prepare().then(() => {
 
             const originalWriteHead = res.writeHead;
             res.writeHead = function (statusCode: number, ...args: unknown[]) {
+                // since writeHead is a callback function, it's called after handle() -> we get the actual response statusCode
                 if (statusCode >= 400) {
                     // prevent caching of error responses
                     res.setHeader("Cache-Control", "private, no-cache, no-store, max-age=0, must-revalidate");

--- a/demo/site/src/app/not-found.tsx
+++ b/demo/site/src/app/not-found.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-export default async function NotFound404(): Promise<JSX.Element> {
+export default function NotFound404() {
     return (
         <html lang="en">
             <body>

--- a/demo/site/src/app/not-found.tsx
+++ b/demo/site/src/app/not-found.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default async function NotFound404(): Promise<JSX.Element> {
+    return (
+        <html lang="en">
+            <body>
+                <p>Page not found.</p>
+                <Link href="/">Return Home</Link>
+            </body>
+        </html>
+    );
+}

--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -47,7 +47,7 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "jest-junit": "^15.0.0",
-        "next": "^14.2.22",
+        "next": "^14.2.24",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.0.0",
         "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2779,8 +2779,8 @@ importers:
         specifier: ^15.0.0
         version: 15.0.0
       next:
-        specifier: ^14.2.22
-        version: 14.2.22(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^14.2.24
+        version: 14.2.24(@babel/core@7.22.11)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -12438,13 +12438,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@next/env@14.2.22:
-    resolution: {integrity: sha512-EQ6y1QeNQglNmNIXvwP/Bb+lf7n9WtgcWvtoFsHquVLCJUuxRs+6SfZ5EK0/EqkkLex4RrDySvKgKNN7PXip7Q==}
-    dev: true
-
   /@next/env@14.2.24:
     resolution: {integrity: sha512-LAm0Is2KHTNT6IT16lxT+suD0u+VVfYNQqM+EJTKuFRRuY2z+zj01kueWXPCxbMBDt0B5vONYzabHGUNbZYAhA==}
-    dev: false
 
   /@next/eslint-plugin-next@14.2.5:
     resolution: {integrity: sha512-LY3btOpPh+OTIpviNojDpUdIbHW9j0JBYBjsIp8IxtDFfYFyORvw3yNq6N231FVqQA7n7lwaf7xHbVJlA1ED7g==}
@@ -12452,31 +12447,12 @@ packages:
       glob: 10.3.10
     dev: false
 
-  /@next/swc-darwin-arm64@14.2.22:
-    resolution: {integrity: sha512-HUaLiehovgnqY4TMBZJ3pDaOsTE1spIXeR10pWgdQVPYqDGQmHJBj3h3V6yC0uuo/RoY2GC0YBFRkOX3dI9WVQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@next/swc-darwin-arm64@14.2.24:
     resolution: {integrity: sha512-7Tdi13aojnAZGpapVU6meVSpNzgrFwZ8joDcNS8cJVNuP3zqqrLqeory9Xec5TJZR/stsGJdfwo8KeyloT3+rQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-darwin-x64@14.2.22:
-    resolution: {integrity: sha512-ApVDANousaAGrosWvxoGdLT0uvLBUC+srqOcpXuyfglA40cP2LBFaGmBjhgpxYk5z4xmunzqQvcIgXawTzo2uQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@next/swc-darwin-x64@14.2.24:
@@ -12485,16 +12461,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-arm64-gnu@14.2.22:
-    resolution: {integrity: sha512-3O2J99Bk9aM+d4CGn9eEayJXHuH9QLx0BctvWyuUGtJ3/mH6lkfAPRI4FidmHMBQBB4UcvLMfNf8vF0NZT7iKw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@next/swc-linux-arm64-gnu@14.2.24:
@@ -12503,16 +12469,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-arm64-musl@14.2.22:
-    resolution: {integrity: sha512-H/hqfRz75yy60y5Eg7DxYfbmHMjv60Dsa6IWHzpJSz4MRkZNy5eDnEW9wyts9bkxwbOVZNPHeb3NkqanP+nGPg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@next/swc-linux-arm64-musl@14.2.24:
@@ -12521,16 +12477,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-x64-gnu@14.2.22:
-    resolution: {integrity: sha512-LckLwlCLcGR1hlI5eiJymR8zSHPsuruuwaZ3H2uudr25+Dpzo6cRFjp/3OR5UYJt8LSwlXv9mmY4oI2QynwpqQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@next/swc-linux-x64-gnu@14.2.24:
@@ -12539,16 +12485,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-x64-musl@14.2.22:
-    resolution: {integrity: sha512-qGUutzmh0PoFU0fCSu0XYpOfT7ydBZgDfcETIeft46abPqP+dmePhwRGLhFKwZWxNWQCPprH26TjaTxM0Nv8mw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@next/swc-linux-x64-musl@14.2.24:
@@ -12557,16 +12493,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-win32-arm64-msvc@14.2.22:
-    resolution: {integrity: sha512-K6MwucMWmIvMb9GlvT0haYsfIPxfQD8yXqxwFy4uLFMeXIb2TcVYQimxkaFZv86I7sn1NOZnpOaVk5eaxThGIw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@next/swc-win32-arm64-msvc@14.2.24:
@@ -12575,16 +12501,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-win32-ia32-msvc@14.2.22:
-    resolution: {integrity: sha512-5IhDDTPEbzPR31ZzqHe90LnNe7BlJUZvC4sA1thPJV6oN5WmtWjZ0bOYfNsyZx00FJt7gggNs6SrsX0UEIcIpA==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@next/swc-win32-ia32-msvc@14.2.24:
@@ -12593,16 +12509,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-win32-x64-msvc@14.2.22:
-    resolution: {integrity: sha512-nvRaB1PyG4scn9/qNzlkwEwLzuoPH3Gjp7Q/pLuwUgOTt1oPMlnCI3A3rgkt+eZnU71emOiEv/mR201HoURPGg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@next/swc-win32-x64-msvc@14.2.24:
@@ -12611,7 +12517,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3:
@@ -12739,7 +12644,6 @@ packages:
   /@opentelemetry/api@1.9.0:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
-    dev: false
 
   /@opentelemetry/auto-instrumentations-node@0.50.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-LqoSiWrOM4Cnr395frDHL4R/o5c2fuqqrqW8sZwhxvkasImmVlyL66YMPHllM2O5xVj2nP2ANUKHZSd293meZA==}
@@ -27767,50 +27671,6 @@ packages:
     resolution: {integrity: sha512-+I10J3wKNoKddNxn0CNpoZ3eTZuqxjNM3b1GImVx22+ePI+Y15P8g/j3WsbP0fhzzrFzrtjOAoq5NCCucswXOQ==}
     dev: false
 
-  /next@14.2.22(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-Ps2caobQ9hlEhscLPiPm3J3SYhfwfpMqzsoCMZGWxt9jBRK9hoBZj2A37i8joKhsyth2EuVKDVJCTF5/H4iEDw==}
-    engines: {node: '>=18.17.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
-      '@types/react': ^18.0.0
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@playwright/test':
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 14.2.22
-      '@swc/helpers': 0.5.5
-      '@types/react': 18.3.18
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001680
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.22.11)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.22
-      '@next/swc-darwin-x64': 14.2.22
-      '@next/swc-linux-arm64-gnu': 14.2.22
-      '@next/swc-linux-arm64-musl': 14.2.22
-      '@next/swc-linux-x64-gnu': 14.2.22
-      '@next/swc-linux-x64-musl': 14.2.22
-      '@next/swc-win32-arm64-msvc': 14.2.22
-      '@next/swc-win32-ia32-msvc': 14.2.22
-      '@next/swc-win32-x64-msvc': 14.2.22
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: true
-
   /next@14.2.24(@babel/core@7.22.11)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-En8VEexSJ0Py2FfVnRRh8gtERwDRaJGNvsvad47ShkC2Yi8AXQPXEA2vKoDJlGFSj5WE5SyF21zNi4M5gyi+SQ==}
     engines: {node: '>=18.17.0'}
@@ -27854,7 +27714,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    dev: false
 
   /next@14.2.24(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-En8VEexSJ0Py2FfVnRRh8gtERwDRaJGNvsvad47ShkC2Yi8AXQPXEA2vKoDJlGFSj5WE5SyF21zNi4M5gyi+SQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -713,8 +713,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.2
       next:
-        specifier: ^14.2.12
-        version: 14.2.22(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^14.2.24
+        version: 14.2.24(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
       pure-react-carousel:
         specifier: ^1.0.0
         version: 1.30.1(react-dom@18.3.1)(react@18.3.1)
@@ -870,8 +870,8 @@ importers:
         specifier: ^2.12.6
         version: 2.12.6(graphql@15.8.0)
       next:
-        specifier: ^14.2.22
-        version: 14.2.22(@babel/core@7.22.11)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^14.2.24
+        version: 14.2.24(@babel/core@7.22.11)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
       pure-react-carousel:
         specifier: ^1.0.0
         version: 1.30.1(react-dom@18.3.1)(react@18.3.1)
@@ -2780,7 +2780,7 @@ importers:
         version: 15.0.0
       next:
         specifier: ^14.2.22
-        version: 14.2.22(@babel/core@7.22.11)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+        version: 14.2.22(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -12440,6 +12440,11 @@ packages:
 
   /@next/env@14.2.22:
     resolution: {integrity: sha512-EQ6y1QeNQglNmNIXvwP/Bb+lf7n9WtgcWvtoFsHquVLCJUuxRs+6SfZ5EK0/EqkkLex4RrDySvKgKNN7PXip7Q==}
+    dev: true
+
+  /@next/env@14.2.24:
+    resolution: {integrity: sha512-LAm0Is2KHTNT6IT16lxT+suD0u+VVfYNQqM+EJTKuFRRuY2z+zj01kueWXPCxbMBDt0B5vONYzabHGUNbZYAhA==}
+    dev: false
 
   /@next/eslint-plugin-next@14.2.5:
     resolution: {integrity: sha512-LY3btOpPh+OTIpviNojDpUdIbHW9j0JBYBjsIp8IxtDFfYFyORvw3yNq6N231FVqQA7n7lwaf7xHbVJlA1ED7g==}
@@ -12453,6 +12458,16 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-darwin-arm64@14.2.24:
+    resolution: {integrity: sha512-7Tdi13aojnAZGpapVU6meVSpNzgrFwZ8joDcNS8cJVNuP3zqqrLqeory9Xec5TJZR/stsGJdfwo8KeyloT3+rQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-darwin-x64@14.2.22:
@@ -12461,6 +12476,16 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-darwin-x64@14.2.24:
+    resolution: {integrity: sha512-lXR2WQqUtu69l5JMdTwSvQUkdqAhEWOqJEYUQ21QczQsAlNOW2kWZCucA6b3EXmPbcvmHB1kSZDua/713d52xg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-arm64-gnu@14.2.22:
@@ -12469,6 +12494,16 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-linux-arm64-gnu@14.2.24:
+    resolution: {integrity: sha512-nxvJgWOpSNmzidYvvGDfXwxkijb6hL9+cjZx1PVG6urr2h2jUqBALkKjT7kpfurRWicK6hFOvarmaWsINT1hnA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-arm64-musl@14.2.22:
@@ -12477,6 +12512,16 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-linux-arm64-musl@14.2.24:
+    resolution: {integrity: sha512-PaBgOPhqa4Abxa3y/P92F3kklNPsiFjcjldQGT7kFmiY5nuFn8ClBEoX8GIpqU1ODP2y8P6hio6vTomx2Vy0UQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-x64-gnu@14.2.22:
@@ -12485,6 +12530,16 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-linux-x64-gnu@14.2.24:
+    resolution: {integrity: sha512-vEbyadiRI7GOr94hd2AB15LFVgcJZQWu7Cdi9cWjCMeCiUsHWA0U5BkGPuoYRnTxTn0HacuMb9NeAmStfBCLoQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-x64-musl@14.2.22:
@@ -12493,6 +12548,16 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-linux-x64-musl@14.2.24:
+    resolution: {integrity: sha512-df0FC9ptaYsd8nQCINCzFtDWtko8PNRTAU0/+d7hy47E0oC17tI54U/0NdGk7l/76jz1J377dvRjmt6IUdkpzQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-win32-arm64-msvc@14.2.22:
@@ -12501,6 +12566,16 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-win32-arm64-msvc@14.2.24:
+    resolution: {integrity: sha512-ZEntbLjeYAJ286eAqbxpZHhDFYpYjArotQ+/TW9j7UROh0DUmX7wYDGtsTPpfCV8V+UoqHBPU7q9D4nDNH014Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-win32-ia32-msvc@14.2.22:
@@ -12509,6 +12584,16 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-win32-ia32-msvc@14.2.24:
+    resolution: {integrity: sha512-9KuS+XUXM3T6v7leeWU0erpJ6NsFIwiTFD5nzNg8J5uo/DMIPvCp3L1Ao5HjbHX0gkWPB1VrKoo/Il4F0cGK2Q==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-win32-x64-msvc@14.2.22:
@@ -12517,6 +12602,16 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-win32-x64-msvc@14.2.24:
+    resolution: {integrity: sha512-cXcJ2+x0fXQ2CntaE00d7uUH+u1Bfp/E0HsNQH79YiLaZE5Rbm7dZzyAYccn3uICM7mw+DxoMqEfGXZtF4Fgaw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3:
@@ -12644,6 +12739,7 @@ packages:
   /@opentelemetry/api@1.9.0:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+    dev: false
 
   /@opentelemetry/auto-instrumentations-node@0.50.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-LqoSiWrOM4Cnr395frDHL4R/o5c2fuqqrqW8sZwhxvkasImmVlyL66YMPHllM2O5xVj2nP2ANUKHZSd293meZA==}
@@ -27671,7 +27767,7 @@ packages:
     resolution: {integrity: sha512-+I10J3wKNoKddNxn0CNpoZ3eTZuqxjNM3b1GImVx22+ePI+Y15P8g/j3WsbP0fhzzrFzrtjOAoq5NCCucswXOQ==}
     dev: false
 
-  /next@14.2.22(@babel/core@7.22.11)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
+  /next@14.2.22(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Ps2caobQ9hlEhscLPiPm3J3SYhfwfpMqzsoCMZGWxt9jBRK9hoBZj2A37i8joKhsyth2EuVKDVJCTF5/H4iEDw==}
     engines: {node: '>=18.17.0'}
     hasBin: true
@@ -27691,7 +27787,6 @@ packages:
         optional: true
     dependencies:
       '@next/env': 14.2.22
-      '@opentelemetry/api': 1.9.0
       '@swc/helpers': 0.5.5
       '@types/react': 18.3.18
       busboy: 1.6.0
@@ -27714,9 +27809,10 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    dev: true
 
-  /next@14.2.22(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-Ps2caobQ9hlEhscLPiPm3J3SYhfwfpMqzsoCMZGWxt9jBRK9hoBZj2A37i8joKhsyth2EuVKDVJCTF5/H4iEDw==}
+  /next@14.2.24(@babel/core@7.22.11)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-En8VEexSJ0Py2FfVnRRh8gtERwDRaJGNvsvad47ShkC2Yi8AXQPXEA2vKoDJlGFSj5WE5SyF21zNi4M5gyi+SQ==}
     engines: {node: '>=18.17.0'}
     hasBin: true
     peerDependencies:
@@ -27734,7 +27830,52 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 14.2.22
+      '@next/env': 14.2.24
+      '@opentelemetry/api': 1.9.0
+      '@swc/helpers': 0.5.5
+      '@types/react': 18.3.18
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001680
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.22.11)(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.24
+      '@next/swc-darwin-x64': 14.2.24
+      '@next/swc-linux-arm64-gnu': 14.2.24
+      '@next/swc-linux-arm64-musl': 14.2.24
+      '@next/swc-linux-x64-gnu': 14.2.24
+      '@next/swc-linux-x64-musl': 14.2.24
+      '@next/swc-win32-arm64-msvc': 14.2.24
+      '@next/swc-win32-ia32-msvc': 14.2.24
+      '@next/swc-win32-x64-msvc': 14.2.24
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: false
+
+  /next@14.2.24(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-En8VEexSJ0Py2FfVnRRh8gtERwDRaJGNvsvad47ShkC2Yi8AXQPXEA2vKoDJlGFSj5WE5SyF21zNi4M5gyi+SQ==}
+    engines: {node: '>=18.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      '@types/react': ^18.0.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 14.2.24
       '@opentelemetry/api': 1.9.0
       '@swc/helpers': 0.5.5
       '@types/react': 18.3.18
@@ -27746,15 +27887,15 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.1(@babel/core@7.26.0)(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.22
-      '@next/swc-darwin-x64': 14.2.22
-      '@next/swc-linux-arm64-gnu': 14.2.22
-      '@next/swc-linux-arm64-musl': 14.2.22
-      '@next/swc-linux-x64-gnu': 14.2.22
-      '@next/swc-linux-x64-musl': 14.2.22
-      '@next/swc-win32-arm64-msvc': 14.2.22
-      '@next/swc-win32-ia32-msvc': 14.2.22
-      '@next/swc-win32-x64-msvc': 14.2.22
+      '@next/swc-darwin-arm64': 14.2.24
+      '@next/swc-darwin-x64': 14.2.24
+      '@next/swc-linux-arm64-gnu': 14.2.24
+      '@next/swc-linux-arm64-musl': 14.2.24
+      '@next/swc-linux-x64-gnu': 14.2.24
+      '@next/swc-linux-x64-musl': 14.2.24
+      '@next/swc-win32-arm64-msvc': 14.2.24
+      '@next/swc-win32-ia32-msvc': 14.2.24
+      '@next/swc-win32-x64-msvc': 14.2.24
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros


### PR DESCRIPTION
# Description

- Add `build-and-run-site.sh` to Demo
- Update next to newest version (to make sure the caching behavior didn't change in the meantime)
- Redirect non-existing `/_next` URLs to 404
- Add fallback 404 page in root (/app)
- Override `Cache-Control` header for 4xx and 5xx responses

---

## Original Problem in client project

We repeatedly faced problems with broken sites after deploying to production. The reason was that a 404 response was returned for JS files under the /_next/static route, e.g.

<img width="672" alt="Bildschirmfoto 2025-01-24 um 22 04 30 2" src="https://github.com/user-attachments/assets/dcbe60c1-be36-48fc-98c3-62ddadf0fff8" />

To make it worse, this 404 response had the Cache-Control header `max-age=14400, s-maxage=31536000, stale-while-revalidate`, meaning the CDN cached it for a year -> the site was broken forever

### Likely reason

The /_next/static files are created during the build, so they should always be there. So it's probably got something to do with pod replacement during zero-downtime-deployment:

Before deployment there are two site pods "site_old_1" and "site_old_2". During deployment, the files are built and `main-app-7441d622c71610a.js` is created. Once the build is done, "site_old_1" is replaced by "site_new_1". 

Now there's a short period of time where "site_new_1" and "site_old_2" run together. If the load balancer routes a request for `main-app-7441d622c71610a.js` to "site_old_2", the request 404s. This 404 is cached by the CDN -> the site is broken forever.

## Problem in Demo

In Demo, the response was different to our client project (because of starter changes in the meantime). The response was a 500 that wasn't cached:

<img width="468" alt="Bildschirmfoto 2025-02-18 um 20 59 53" src="https://github.com/user-attachments/assets/0a37f24b-e627-45d1-a8ff-2a848cb0005f" />

This 500 occurred because Next routed the request to our page in `/[domain]/[language]/[[...path]]`. There, `_next` was interpreted as the domain and obviously no site config for this domain could be found causing the error:

<img width="920" alt="Bildschirmfoto 2025-02-14 um 11 23 27 2" src="https://github.com/user-attachments/assets/8b0168ad-f95f-44e2-b4e4-2deea9bac44a" />

Though the 500 response has the correct cache headers, it's still suboptimal. Firstly, because the site config error always shows in the CLI and Sentry. Secondly, because if a file doesn't exist, the semantically correct response is 404.

### Why is `http://localhost:3000/_next/static/nonexistent-file.js` routed to the page?

The path matching in next works in these 8 steps:

> 1. headers from next.config.js
> 2. redirects from next.config.js
> 3. Middleware (rewrites, redirects, etc.)
> 4. beforeFiles (rewrites) from next.config.js
> 5. Filesystem routes (public/, _next/static/, pages/, app/, etc.)
> 6. afterFiles (rewrites) from next.config.js
> 7. Dynamic Routes (/blog/[slug])
> 8. fallback (rewrites) from next.config.js
> https://nextjs.org/docs/app/building-your-application/routing/middleware#matching-paths

For `/_next` URLs we skip the middleware (step 3), otherwise an error would occur there. If `/_next/static/nonexistent-file.js` would exist, it would match in step 5. However, since it doesn't exist, path matching continues to step 7 -> the request ends up in `/[domain]/[language]/[[...path]]/page.tsx` and causes an error there.

## Solution

### Returning a 404 instead of 500

Normally, `/_next/static` URLs should match in step 5. However, non-existing `/_next/static` URLs end up in step 7 in our setup.

However, there is step 6 inbetween: `6. afterFiles (rewrites) from next.config.js`. We now use that to rewrite non-existing `/_next/static` URLs to `/404` -> a 404 is returned instead of a 500

### Returning the correct cache header

However, the 404 response here has no `Cache-Control` header:

<img width="654" alt="Bildschirmfoto 2025-02-14 um 15 22 42" src="https://github.com/user-attachments/assets/510e03b2-eb6c-4b15-b4d9-c53fc9a493ca" />

See issue https://github.com/vercel/next.js/issues/76168

Sending no `Cache-Control` header at all can lead to unexpected behavior, so we must override it:

In `server.ts` I override the `res.writeHead` function. If the response statusCode is 4.x.x or 5.x.x, I replace the Cache-Control header with `private, no-cache, no-store, max-age=0, must-revalidate`. This prevents the CDN from caching it.

Now:

<img width="708" alt="Bildschirmfoto 2025-02-14 um 15 02 16" src="https://github.com/user-attachments/assets/e772f43f-7392-4d60-9426-18e8503b7a6a" />

Note: If a user visits the page at a unfortunate time during deployment, the site might still break. But just for this one user.

### Alternative solutions

- Override the Cache-Control header in the CDN (for 4.x.x and 5.x.x status codes)

---

Task: https://vivid-planet.atlassian.net/browse/COM-1615

--- 

Starter PR: https://github.com/vivid-planet/comet-starter/pull/692