### PR TITLE
Prevent router prompt when using a block with subroutes in a form

### DIFF
--- a/.changeset/cool-masks-punch.md
+++ b/.changeset/cool-masks-punch.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": minor
+---
+
+Add `disableForcePromptRoute` option to `StackSwitch`
+
+This can be useful when a navigation in a switch shouldn't trigger a prompt, e.g., when navigating inside a block.

--- a/.changeset/sour-dodos-count.md
+++ b/.changeset/sour-dodos-count.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Prevent router prompt when using a block with subroutes in a form

--- a/packages/admin/admin/src/stack/Switch.tsx
+++ b/packages/admin/admin/src/stack/Switch.tsx
@@ -13,7 +13,7 @@ import {
     useRef,
     useState,
 } from "react";
-import { matchPath, RouteComponentProps, useHistory, useLocation, useRouteMatch } from "react-router";
+import { matchPath, Route, RouteComponentProps, useHistory, useLocation, useRouteMatch } from "react-router";
 import { v4 as uuid } from "uuid";
 
 import { ForcePromptRoute } from "../router/ForcePromptRoute";
@@ -26,6 +26,7 @@ interface IProps {
     initialPage?: string;
     title?: ReactNode;
     children: Array<ReactElement<IStackPageProps>>;
+    disableForcePromptRoute?: boolean;
 }
 
 export const StackSwitchApiContext = createContext<IStackSwitchApi>({
@@ -196,13 +197,14 @@ const StackSwitchInner: RefForwardingComponent<IStackSwitchApi, IProps & IHookPr
                 if (matchPath(location.pathname, { path })) {
                     routeMatched = true;
                 }
+                const RouteComponent = props.disableForcePromptRoute ? Route : ForcePromptRoute;
                 return (
-                    <ForcePromptRoute path={path}>
+                    <RouteComponent path={path}>
                         {(routeProps: RouteComponentProps<IRouteParams>) => {
                             if (!routeProps.match) return null;
                             return renderRoute(page, routeProps);
                         }}
-                    </ForcePromptRoute>
+                    </RouteComponent>
                 );
             })}
             {!routeMatched && (

--- a/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createBlocksBlock.tsx
@@ -560,7 +560,7 @@ export function createBlocksBlock<AdditionalItemFields extends Record<string, un
 
             return (
                 <>
-                    <StackSwitch>
+                    <StackSwitch disableForcePromptRoute>
                         <StackPage name="main">
                             <StackSwitchApiContext.Consumer>
                                 {(stackApi) => {

--- a/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createColumnsBlock.tsx
@@ -237,7 +237,7 @@ export function createColumnsBlock<T extends BlockInterface>({
 
             return (
                 <>
-                    <StackSwitch initialPage="list">
+                    <StackSwitch initialPage="list" disableForcePromptRoute>
                         <StackPage name="list">
                             <BlocksFinalForm<{ layout: ColumnsBlockLayout; columns: number }>
                                 onSubmit={({ layout, columns }) => {

--- a/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx
@@ -247,7 +247,7 @@ export const createCompositeBlock = <Options extends CreateCompositeBlockOptions
             };
 
             return (
-                <StackSwitch>
+                <StackSwitch disableForcePromptRoute>
                     {[
                         <StackPage name="initial" key="initial">
                             {Object.entries(groups).map(([groupKey, group]) => {

--- a/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createListBlock.tsx
@@ -277,7 +277,7 @@ export function createListBlock<T extends BlockInterface, AdditionalItemFields e
 
             return (
                 <SelectPreviewComponent>
-                    <StackSwitch>
+                    <StackSwitch disableForcePromptRoute>
                         <StackPage name="table">
                             <StackSwitchApiContext.Consumer>
                                 {(stackApi) => {

--- a/storybook/src/blocks-admin/BlockInFinalForm.stories.tsx
+++ b/storybook/src/blocks-admin/BlockInFinalForm.stories.tsx
@@ -1,0 +1,39 @@
+import { Field, FinalForm, SaveBoundary } from "@comet/admin";
+import { AdminComponentRoot, createFinalFormBlock, createListBlock } from "@comet/blocks-admin";
+import { ExternalLinkBlock } from "@comet/cms-admin";
+
+import { dndProviderDecorator } from "../dnd.decorator";
+import { snackbarDecorator } from "../docs/components/Snackbar/snackbar.decorator";
+import { storyRouterDecorator } from "../story-router.decorator";
+
+export default {
+    decorators: [snackbarDecorator(), storyRouterDecorator(), dndProviderDecorator()],
+};
+
+export const BlockInFinalFormWithSaveBoundary = () => {
+    const LinkListBlock = createListBlock({ name: "LinkList", block: ExternalLinkBlock });
+    const FinalFormLinkListBlock = createFinalFormBlock(LinkListBlock);
+
+    return (
+        <SaveBoundary>
+            <FinalForm mode="edit" onSubmit={() => {}} initialValues={{ links: LinkListBlock.defaultValues() }}>
+                <AdminComponentRoot>
+                    <Field name="links" component={FinalFormLinkListBlock} fullWidth />
+                </AdminComponentRoot>
+            </FinalForm>
+        </SaveBoundary>
+    );
+};
+
+export const BlockInFinalFormWithoutSaveBoundary = () => {
+    const LinkListBlock = createListBlock({ name: "LinkList", block: ExternalLinkBlock });
+    const FinalFormLinkListBlock = createFinalFormBlock(LinkListBlock);
+
+    return (
+        <FinalForm mode="edit" onSubmit={() => {}} initialValues={{ links: LinkListBlock.defaultValues() }}>
+            <AdminComponentRoot>
+                <Field name="links" component={FinalFormLinkListBlock} fullWidth />
+            </AdminComponentRoot>
+        </FinalForm>
+    );
+};


### PR DESCRIPTION
## Description

In https://github.com/vivid-planet/comet/pull/1955 we introduced the concept of a `ForcePromptRoute` to force a prompt when navigating into a nested stack. However, this behavior isn't desired when using a block with subroutes (e.g., a BlocksBlock) in a form. We fix this by adding a `disableForcePromptRoute` option to `StackSwitch` to disable the behavior for stacks used in blocks.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1380
