### PR TITLE
Reduce `MainContent` padding on mobile

### DIFF
--- a/.changeset/famous-wolves-shake.md
+++ b/.changeset/famous-wolves-shake.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Reduce `MainContent` padding on mobile

--- a/packages/admin/admin/src/common/MainContent.tsx
+++ b/packages/admin/admin/src/common/MainContent.tsx
@@ -27,7 +27,11 @@ const Root = createComponentSlot("main")<MainContentClassKey, OwnerState>({
     ({ theme, ownerState }) => css`
         position: relative;
         z-index: 5;
-        padding: ${theme.spacing(4)};
+        padding: ${theme.spacing(2)};
+
+        ${theme.breakpoints.up("md")} {
+            padding: ${theme.spacing(4)};
+        }
 
         ${ownerState.fullHeight &&
         css`
@@ -37,16 +41,28 @@ const Root = createComponentSlot("main")<MainContentClassKey, OwnerState>({
         ${ownerState.disablePaddingTop &&
         css`
             padding-top: 0;
+
+            ${theme.breakpoints.up("md")} {
+                padding: 0;
+            }
         `}
 
         ${ownerState.disablePaddingBottom &&
         css`
             padding-bottom: 0;
+
+            ${theme.breakpoints.up("md")} {
+                padding: 0;
+            }
         `}
 
         ${ownerState.disablePadding &&
         css`
             padding: 0;
+
+            ${theme.breakpoints.up("md")} {
+                padding: 0;
+            }
         `}
     `,
 );

--- a/packages/admin/admin/src/common/MainContent.tsx
+++ b/packages/admin/admin/src/common/MainContent.tsx
@@ -43,7 +43,7 @@ const Root = createComponentSlot("main")<MainContentClassKey, OwnerState>({
             padding-top: 0;
 
             ${theme.breakpoints.up("md")} {
-                padding: 0;
+                padding-top: 0;
             }
         `}
 
@@ -52,7 +52,7 @@ const Root = createComponentSlot("main")<MainContentClassKey, OwnerState>({
             padding-bottom: 0;
 
             ${theme.breakpoints.up("md")} {
-                padding: 0;
+                padding-bottom: 0;
             }
         `}
 


### PR DESCRIPTION
## Description

This is to match the updated Comet Design.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
