### PR TITLE
Future Admin Generator PoC: parse config using ts-morph to support in…

### DIFF
--- a/demo/admin/src/products/future/ProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductForm.cometGen.ts
@@ -1,4 +1,4 @@
-import { future_FormConfig as FormConfig } from "@comet/cms-admin";
+import { DamImageBlock, future_FormConfig as FormConfig } from "@comet/cms-admin";
 import { GQLProduct } from "@src/graphql.generated";
 
 export const ProductForm: FormConfig<GQLProduct> = {
@@ -18,7 +18,8 @@ export const ProductForm: FormConfig<GQLProduct> = {
                     name: "title",
                     label: "Titel", // default is generated from name (camelCaseToHumanReadable)
                     required: true, // default is inferred from gql schema
-                    validate: { name: "validateTitle", import: "./validateTitle" },
+                    //validate: { name: "validateTitle", import: "./validateTitle" },
+                    validate: (value: string) => (value.length < 3 ? "Title must be at least 3 characters long" : undefined),
                 },
                 { type: "text", name: "slug" },
                 { type: "date", name: "createdAt", label: "Created", readOnly: true },
@@ -69,7 +70,7 @@ export const ProductForm: FormConfig<GQLProduct> = {
                 { type: "boolean", name: "inStock" },
                 { type: "date", name: "availableSince", startAdornment: { icon: "CalendarToday" } },
                 { type: "component", component: { name: "FutureProductNotice", import: "../../helpers/FutureProductNotice" } },
-                { type: "block", name: "image", label: "Image", block: { name: "DamImageBlock", import: "@comet/cms-admin" } },
+                { type: "block", name: "image", label: "Image", block: DamImageBlock },
                 { type: "fileUpload", name: "priceList", label: "Price List", maxFileSize: 1024 * 1024 * 4, download: true },
                 { type: "fileUpload", name: "datasheets", label: "Datasheets", multiple: true, maxFileSize: 1024 * 1024 * 4, download: false },
                 { type: "dateTime", name: "lastCheckedAt", label: "Last checked at" },

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -41,7 +41,6 @@ import { FormSpy } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
 import { FutureProductNotice } from "../../helpers/FutureProductNotice";
-import { validateTitle } from "../validateTitle";
 import {
     GQLManufacturersSelectQuery,
     GQLManufacturersSelectQueryVariables,
@@ -212,7 +211,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                 fullWidth
                                 name="title"
                                 label={<FormattedMessage id="product.title" defaultMessage="Titel" />}
-                                validate={validateTitle}
+                                validate={(value: string) => (value.length < 3 ? "Title must be at least 3 characters long" : undefined)}
                             />
 
                             <TextField
@@ -422,14 +421,14 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                 name="priceList"
                                 label={<FormattedMessage id="product.priceList" defaultMessage="Price List" />}
                                 variant="horizontal"
-                                maxFileSize={4194304}
+                                maxFileSize={1024 * 1024 * 4}
                             />
                             <FileUploadField
                                 name="datasheets"
                                 label={<FormattedMessage id="product.datasheets" defaultMessage="Datasheets" />}
                                 variant="horizontal"
                                 multiple
-                                maxFileSize={4194304}
+                                maxFileSize={1024 * 1024 * 4}
                             />
                             <DateTimeField
                                 variant="horizontal"

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -77,6 +77,7 @@
         "rimraf": "^3.0.0",
         "slugify": "^1.0.0",
         "split.js": "^1.6.4",
+        "ts-morph": "^16.0.0",
         "use-debounce": "^6.0.0",
         "uuid": "^9.0.0"
     },

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormField.ts
@@ -131,16 +131,20 @@ export function generateFormField({
 
     let validateCode = "";
     if (config.validate) {
-        let importPath = config.validate.import;
-        if (importPath.startsWith("./")) {
-            //go one level up as generated files are in generated subfolder
-            importPath = `.${importPath}`;
+        if ("import" in config.validate) {
+            let importPath = config.validate.import;
+            if (importPath.startsWith("./")) {
+                //go one level up as generated files are in generated subfolder
+                importPath = `.${importPath}`;
+            }
+            imports.push({
+                name: config.validate.name,
+                importPath,
+            });
+            validateCode = `validate={${config.validate.name}}`;
+        } else if ("code" in config.validate) {
+            validateCode = `validate={${config.validate.code}}`;
         }
-        imports.push({
-            name: config.validate.name,
-            importPath,
-        });
-        validateCode = `validate={${config.validate.name}}`;
     }
 
     const fieldLabel = `<FormattedMessage id="${formattedMessageRootId}.${name}" defaultMessage="${label}" />`;

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -1,5 +1,6 @@
 import { GridColDef } from "@comet/admin";
 import { IconName } from "@comet/admin-icons";
+import { BlockInterface } from "@comet/blocks-admin";
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 import { loadSchema } from "@graphql-tools/load";
 import { IconProps } from "@mui/material";
@@ -15,6 +16,7 @@ import { generateGrid } from "./generateGrid";
 import { GridCombinationColumnConfig } from "./generateGrid/combinationColumn";
 import { UsableFields } from "./generateGrid/usableFields";
 import { ColumnVisibleOption } from "./utils/columnVisibility";
+import { exportedDeclarationToJson, morphTsSource } from "./utils/tsMorphHelper";
 import { writeGenerated } from "./utils/writeGenerated";
 
 export type ImportReference = {
@@ -69,7 +71,7 @@ export type FormFieldConfig<T> = (
           labelField?: string;
           filterField?: { name: string; gqlName?: string };
       } & Omit<InputBaseFieldConfig, "endAdornment">)
-    | { type: "block"; block: ImportReference }
+    | { type: "block"; block: ImportReference | BlockInterface }
     | SingleFileFormFieldConfig
     | MultiFileFormFieldConfig
 ) & {
@@ -77,7 +79,7 @@ export type FormFieldConfig<T> = (
     label?: string;
     required?: boolean;
     virtual?: boolean;
-    validate?: ImportReference;
+    validate?: ImportReference | ((value: unknown) => string | undefined);
     helperText?: string;
     readOnly?: boolean;
 };
@@ -188,8 +190,18 @@ export async function runFutureGenerate(filePattern = "src/**/*.cometGen.ts") {
         let gqlDocumentsOutputCode = "";
         const targetDirectory = `${dirname(file)}/generated`;
         const baseOutputFilename = basename(file).replace(/\.cometGen\.ts$/, "");
-        const configs = await import(`${process.cwd()}/${file.replace(/\.ts$/, "")}`);
-        //const configs = await import(`${process.cwd()}/${file}`);
+        //const configs = await import(`${process.cwd()}/${file.replace(/\.ts$/, "")}`);
+        const configs: Record<string, GeneratorConfig> = {}; //TODO GeneratorConfig is not fully correct
+        const tsMorph = morphTsSource(file);
+        for (const [name, declarations] of Array.from(tsMorph.getExportedDeclarations().entries())) {
+            console.log(name);
+            if (declarations.length != 1) {
+                throw new Error(`Expected exactly one declaration for ${name}`);
+            }
+            const config = exportedDeclarationToJson(declarations[0]);
+            console.dir(config, { depth: 10 });
+            configs[name] = config;
+        }
 
         const codeOuputFilename = `${targetDirectory}/${basename(file.replace(/\.cometGen\.ts$/, ""))}.tsx`;
         await fs.rm(codeOuputFilename, { force: true });
@@ -197,7 +209,7 @@ export async function runFutureGenerate(filePattern = "src/**/*.cometGen.ts") {
         console.log(`generating ${file}`);
 
         for (const exportName in configs) {
-            const config = configs[exportName] as GeneratorConfig;
+            const config = configs[exportName];
             let generated: GeneratorReturn;
             if (config.type == "form") {
                 generated = generateForm({ exportName, gqlIntrospection, baseOutputFilename, targetDirectory }, config);

--- a/packages/admin/cms-admin/src/generator/future/utils/tsMorphHelper.ts
+++ b/packages/admin/cms-admin/src/generator/future/utils/tsMorphHelper.ts
@@ -1,0 +1,98 @@
+import {
+    ArrayLiteralExpression,
+    ExportedDeclarations,
+    Expression,
+    Identifier,
+    NumericLiteral,
+    ObjectLiteralExpression,
+    Project,
+    PropertyAssignment,
+    StringLiternal,
+    SyntaxKind,
+    VariableDeclaration,
+} from "ts-morph";
+
+const project = new Project({
+    tsConfigFilePath: "tsconfig.json",
+    skipAddingFilesFromTsConfig: true,
+});
+export function morphTsSource(path: string) {
+    let tsSource = project.getSourceFile(path);
+    if (!tsSource) tsSource = project.addSourceFileAtPath(path);
+    return tsSource;
+}
+
+function astExpressionToJson(node: Expression) {
+    if (node.getKind() == SyntaxKind.ObjectLiteralExpression) {
+        const ret = {} as Record<string, unknown>;
+        for (const property of (node as ObjectLiteralExpression).getProperties()) {
+            if (property.getKind() == SyntaxKind.PropertyAssignment) {
+                const propertyAssignment = property as PropertyAssignment;
+                const propertyAssignmentInitializer = propertyAssignment.getInitializer();
+                if (propertyAssignmentInitializer) {
+                    ret[propertyAssignment.getName()] = astExpressionToJson(propertyAssignmentInitializer);
+                } else {
+                    throw new Error(`Initializer is required for propertyAssignment '${propertyAssignment.getName()}'`);
+                }
+            } else {
+                throw new Error(`Unsupported ObjectLiteralExpression property Kind ${property.getKindName()}`);
+            }
+        }
+        return ret;
+    } else if (node.getKind() == SyntaxKind.StringLiteral) {
+        return (node as StringLiternal).getLiteralValue();
+    } else if (node.getKind() == SyntaxKind.NumericLiteral) {
+        return (node as NumericLiteral).getLiteralValue();
+    } else if (node.getKind() == SyntaxKind.FalseKeyword) {
+        return false;
+    } else if (node.getKind() == SyntaxKind.TrueKeyword) {
+        return true;
+    } else if (node.getKind() == SyntaxKind.BinaryExpression) {
+        //what is this?
+        return node.getText();
+    } else if (node.getKind() == SyntaxKind.ArrowFunction) {
+        return {
+            code: node.getText(),
+        };
+    } else if (node.getKind() == SyntaxKind.ArrayLiteralExpression) {
+        const ret = [] as Array<unknown>;
+        for (const element of (node as ArrayLiteralExpression).getElements()) {
+            ret.push(astExpressionToJson(element));
+        }
+        return ret;
+    } else if (node.getKind() == SyntaxKind.Identifier) {
+        for (const referencedSymbol of (node as Identifier).findReferences()) {
+            for (const reference of referencedSymbol.getReferences()) {
+                const referenceNode = reference.getNode();
+                const importDeclaration = referenceNode.getFirstAncestorByKind(SyntaxKind.ImportDeclaration);
+                if (importDeclaration) {
+                    for (const namedImport of importDeclaration.getNamedImports()) {
+                        if ((namedImport.getAliasNode() || namedImport.getNameNode())?.getText() == referenceNode.getText()) {
+                            return {
+                                name: namedImport.getNameNode().getText(),
+                                import: importDeclaration.getModuleSpecifierValue(),
+                            };
+                        }
+                    }
+                }
+            }
+        }
+        throw new Error(`Unsupported identifier, only imports are supported`);
+    } else {
+        throw new Error(`Unsupported expression Kind ${node.getKindName()}`);
+    }
+}
+
+export function exportedDeclarationToJson(node: ExportedDeclarations) {
+    if (node.getKind() == SyntaxKind.VariableDeclaration) {
+        const variableDeclaration = node as VariableDeclaration;
+        const initializer = variableDeclaration.getInitializer();
+        if (initializer) {
+            return astExpressionToJson(initializer);
+        } else {
+            throw new Error(`Initializer is required for variableDeclaration '${variableDeclaration.getName()}'`);
+        }
+    } else {
+        throw new Error(`Unsupported declaration kind '${node.getKindName()}'`);
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2055,6 +2055,9 @@ importers:
       split.js:
         specifier: ^1.6.4
         version: 1.6.5
+      ts-morph:
+        specifier: ^16.0.0
+        version: 16.0.0
       use-debounce:
         specifier: ^6.0.0
         version: 6.0.1(react@17.0.2)
@@ -15510,7 +15513,7 @@ packages:
   /@ts-morph/common@0.17.0:
     resolution: {integrity: sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==}
     dependencies:
-      fast-glob: 3.2.12
+      fast-glob: 3.3.2
       minimatch: 5.1.6
       mkdirp: 1.0.4
       path-browserify: 1.0.1
@@ -18281,7 +18284,7 @@ packages:
     engines: {node: '>=8'}
     requiresBuild: true
     dependencies:
-      fill-range: 7.0.1
+      fill-range: 7.1.1
 
   /braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -22334,7 +22337,7 @@ packages:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
 
   /fast-json-parse@1.0.3:
     resolution: {integrity: sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==}
@@ -22557,13 +22560,6 @@ packages:
       merge-descriptors: 1.0.1
     dev: false
 
-  /fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
-    engines: {node: '>=8'}
-    requiresBuild: true
-    dependencies:
-      to-regex-range: 5.0.1
-
   /fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -22687,7 +22683,7 @@ packages:
   /find-yarn-workspace-root2@1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
     dependencies:
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pkg-dir: 4.2.0
     dev: false
 
@@ -23295,7 +23291,7 @@ packages:
       '@types/glob': 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.2
       glob: 7.2.3
       ignore: 5.2.4
       merge2: 1.4.1
@@ -23308,7 +23304,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.2
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -23330,7 +23326,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.2
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
@@ -25320,7 +25316,7 @@ packages:
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pretty-format: 29.5.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -33791,7 +33787,7 @@ packages:
   /urlpattern-polyfill@6.0.2:
     resolution: {integrity: sha512-5vZjFlH9ofROmuWmXM9yj2wljYKgWstGwe8YTyiqM7hVum/g9LyCizPZtb3UqsuppVwety9QJmfc42VggLpTgg==}
     dependencies:
-      braces: 3.0.2
+      braces: 3.0.3
     dev: true
 
   /use-composed-ref@1.3.0(react@17.0.2):


### PR DESCRIPTION
## The Problem

Currently the .cometGen.ts config files are evaluated as code. This has one major drawback: we can't parse inline code, as it will be executed, or, if it's a function definition, we don't know if it's inline or imported.

## The Proposed Solution

Instead we parse the config file using ts-morph and iterate the resulting AST to get a json structure similar to before, but with the flexibility to parse for imports or inline functions.

### Example, inline function (validate)

config with inline function:
```
                {
                    type: "text",
                    name: "title",
                    label: "Titel", // default is generated from name (camelCaseToHumanReadable)
                    required: true, // default is inferred from gql schema
                    validate: (value: string) => (value.length < 3 ? "Title must be at least 3 characters long" : undefined),
                },
```

generated code:
```
                            <TextField
                                required
                                variant="horizontal"
                                fullWidth
                                name="title"
                                label={<FormattedMessage id="product.title" defaultMessage="Titel" />}
                                validate={(value: string) => (value.length < 3 ? "Title must be at least 3 characters long" : undefined)}
                            />
```

### Example, imported block
```
import { DamImageBlock } from "@comet/cms-admin";
// ...
{ type: "block", name: "image", label: "Image", block: DamImageBlock },
```

## Disadvantages

Any other "a bit" advanced definition of config is not supported, as the config is not evaluated anymore. This includes any factories, helpers etc. Problem is that we can't use typescript to forbid them.

For example, the following is NOT supported anymore:

```
const typeValues = [{ value: "Cap", label: "great Cap" }, "Shirt", "Tie"];

export const ProductsGrid: GridConfig<GQLProduct> = {
    type: "grid",
    gqlType: "Product",
   ///...
    columns: [
        {
            type: "combination",
            name: "overview",
            headerName: "Overview",
            minWidth: 200,
            primaryText: "title",
            secondaryText: {
                type: "formattedMessage",
                message: "{price} • {type} • {category} • {inStock}",
                    type: {
                        type: "staticSelect",
                        field: "type",
                        values: typeValues, //<< this identifier references a value defined in this file. NOT supported anymore.
                        emptyValue: "No type",
                    },
```

## TODO
- [ ] implement missing json conversion parts
- [ ] allow usage of tsx, for example to use `<FormattedMessage` in validate
- [ ] use new way everywhere where we have imports
- [ ] typing of code-generation-runtime vs. config-definition is incorrect
