### PR TITLE
Fix type of `icon` props in RTE

### DIFF
--- a/packages/admin/admin-rte/src/core/Controls/ControlButton.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/ControlButton.tsx
@@ -2,7 +2,7 @@ import { createComponentSlot, ThemedComponentBaseProps } from "@comet/admin";
 import { ComponentsOverrides } from "@mui/material";
 import { css, Theme, useThemeProps } from "@mui/material/styles";
 import { SvgIconProps } from "@mui/material/SvgIcon";
-import { MouseEvent, PropsWithChildren } from "react";
+import { ForwardRefExoticComponent, MouseEvent, PropsWithChildren, RefAttributes } from "react";
 
 import getRteTheme from "../utils/getRteTheme";
 
@@ -73,10 +73,10 @@ export interface IProps
     disabled?: boolean;
     selected?: boolean;
     onButtonClick?: (e: MouseEvent) => void;
-    icon?: (props: SvgIconProps) => JSX.Element | null;
+    icon?: ForwardRefExoticComponent<Omit<SvgIconProps, "ref"> & RefAttributes<SVGSVGElement>>;
 
     /** @deprecated use icon instead */
-    Icon?: (props: SvgIconProps) => JSX.Element | null;
+    Icon?: ForwardRefExoticComponent<Omit<SvgIconProps, "ref"> & RefAttributes<SVGSVGElement>>;
 }
 
 export function ControlButton(inProps: PropsWithChildren<IProps>) {

--- a/packages/admin/admin-rte/src/core/types.ts
+++ b/packages/admin/admin-rte/src/core/types.ts
@@ -1,6 +1,6 @@
 import { SvgIconProps } from "@mui/material/SvgIcon";
 import { DraftInlineStyleType, Editor, EditorState } from "draft-js";
-import { ComponentType, CSSProperties, MouseEvent, ReactNode, RefObject } from "react";
+import { ComponentType, CSSProperties, ForwardRefExoticComponent, MouseEvent, ReactNode, RefAttributes, RefObject } from "react";
 
 import { IRteOptions, SupportedThings } from "./Rte";
 
@@ -15,7 +15,7 @@ export interface IBlocktypeConfig {
     renderConfig?: DraftBlockRenderConfig; // visual appearance of the blocktype
     label?: string | ReactNode; // displayed in the dropdown
     group?: "dropdown" | "button"; // displays the element in the dropdown or as button
-    icon?: (props: SvgIconProps) => JSX.Element | null;
+    icon?: ForwardRefExoticComponent<Omit<SvgIconProps, "ref"> & RefAttributes<SVGSVGElement>>;
     supportedBy?: SupportedThings; // blocktype is active when this "supported thing" is active
 }
 
@@ -29,11 +29,11 @@ export interface IFeatureConfig<T extends string = string> {
     disabled?: boolean;
     selected?: boolean;
     onButtonClick?: (e: MouseEvent) => void;
-    icon?: (props: SvgIconProps) => JSX.Element | null;
+    icon?: ForwardRefExoticComponent<Omit<SvgIconProps, "ref"> & RefAttributes<SVGSVGElement>>;
     tooltipText?: ReactNode;
 
     /** @deprecated use icon instead */
-    Icon?: (props: SvgIconProps) => JSX.Element | null;
+    Icon?: ForwardRefExoticComponent<Omit<SvgIconProps, "ref"> & RefAttributes<SVGSVGElement>>;
 }
 
 type CustomInlineStyleType = "SUP" | "SUB" | string;
@@ -70,7 +70,7 @@ export interface ICustomBlockTypeMap_Deprecated {
 export interface CustomInlineStyles {
     [name: string]: {
         label: ReactNode;
-        icon?: (props: SvgIconProps) => JSX.Element | null;
+        icon?: ForwardRefExoticComponent<Omit<SvgIconProps, "ref"> & RefAttributes<SVGSVGElement>>;
         tooltipText?: ReactNode;
         style: CSSProperties;
     };


### PR DESCRIPTION
## Description

Regression introduced with https://github.com/vivid-planet/comet/pull/3231.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example): [story](https://github.com/vivid-planet/comet/blob/next/storybook/src/admin-rte/RteCustomInlineStyles.stories.tsx#L13)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset): part of https://github.com/vivid-planet/comet/pull/3231
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1134
- Initial discussion: https://github.com/vivid-planet/comet/pull/3230#discussion_r1933401680
