### PR TITLE
Present 404 when domain lookup not successful

### DIFF
--- a/demo/site/src/middleware/redirectToMainHost.ts
+++ b/demo/site/src/middleware/redirectToMainHost.ts
@@ -20,7 +20,7 @@ export function withRedirectToMainHostMiddleware(middleware: CustomMiddleware) {
                 return NextResponse.redirect(redirectSiteConfig.url);
             }
 
-            throw new Error(`Cannot get siteConfig for host ${host}`);
+            return NextResponse.next({ status: 404 });
         }
         return middleware(request);
     };


### PR DESCRIPTION
Currently we throw an error when the domain lookup in the site is not successful. But not all domains have to be served, so returning a 404 is the preferred way instead of presenting an error screen (and logging the error).

This PR does not implement `app/not-found.tsx`, so the default 404 screen will be shown:
![image](https://github.com/user-attachments/assets/f3aa4545-2cb6-4a5d-9c8c-4d1241414b73)
