### PR TITLE
Admin Generator (Future): Add support for custom components in more actions menu

### DIFF
--- a/demo/admin/src/products/future/ProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.ts
@@ -11,6 +11,14 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
     toolbarActionProp: true,
     rowActionProp: true,
     excelExport: true,
+    moreActions: {
+        overallActions: [
+            {
+                name: "publish",
+                component: { name: "PublishAllProducts", import: "../../helpers/PublishAllProducts" },
+            },
+        ],
+    },
     queryParamsPrefix: "products",
     initialSort: [
         { field: "inStock", sort: "desc" },

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -33,6 +33,7 @@ import { GQLProductFilter } from "@src/graphql.generated";
 import * as React from "react";
 import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
 
+import { PublishAllProducts } from "../../helpers/PublishAllProducts";
 import { ProductsGridPreviewAction } from "../../ProductsGridPreviewAction";
 import { ManufacturerFilterOperators } from "../ManufacturerFilter";
 import {
@@ -114,6 +115,7 @@ function ProductsGridToolbar({ toolbarAction, exportApi }: { toolbarAction?: Rea
                             onClick: () => exportApi.exportGrid(),
                             disabled: exportApi.loading,
                         },
+                        <PublishAllProducts key="publish" />,
                     ]}
                 />
                 {toolbarAction}

--- a/packages/admin/cms-admin/src/generator/future/generateGrid.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid.ts
@@ -526,6 +526,13 @@ export function generateGrid(
               }`
             : "";
 
+    config.moreActions?.overallActions?.forEach((action) => {
+        imports.push({
+            name: action.component.name,
+            importPath: action.component.import,
+        });
+    });
+
     const code = `import { gql, useApolloClient, useQuery } from "@apollo/client";
     import {
         Button,
@@ -657,6 +664,7 @@ export function generateGrid(
                   excelExport: config.excelExport,
                   newEntryText: config.newEntryText,
                   fragmentName,
+                  moreActions: config.moreActions,
               })
             : ""
     }

--- a/packages/admin/cms-admin/src/generator/future/generateGrid/generateGridToolbar.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateGrid/generateGridToolbar.ts
@@ -1,5 +1,6 @@
 import { camelCase } from "change-case";
 
+import { ImportReference } from "../generator";
 import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
 import { getFormattedMessageNode } from "../utils/intl";
 
@@ -14,6 +15,7 @@ type Options = {
     gqlType: string;
     newEntryText: string | undefined;
     fragmentName: string;
+    moreActions?: MoreActions;
 };
 
 export const generateGridToolbar = ({
@@ -27,6 +29,7 @@ export const generateGridToolbar = ({
     gqlType,
     newEntryText,
     fragmentName,
+    moreActions,
 }: Options) => {
     return `function ${componentName}(${getGridToolbarProps(!!forwardToolbarAction, !!excelExport)}) {
         return (
@@ -42,6 +45,7 @@ export const generateGridToolbar = ({
                     ),
                     excelExport,
                     allowAdding,
+                    moreActions,
                 })}
             </DataGridToolbar>
         );
@@ -87,15 +91,21 @@ const filterItem = `<ToolbarItem>
     <GridFilterButton />
 </ToolbarItem>`;
 
+export type MoreActions = {
+    overallActions?: [{ name: string; component: ImportReference }];
+};
+
 type RenderToolbarActionsOptions = {
     forwardToolbarAction: boolean | undefined;
     addItemText: string;
     excelExport: boolean | undefined;
     allowAdding: boolean | undefined;
+    moreActions?: MoreActions;
 };
 
-const renderToolbarActions = ({ forwardToolbarAction, addItemText, excelExport, allowAdding }: RenderToolbarActionsOptions) => {
-    const showMoreActionsMenu = excelExport;
+const renderToolbarActions = ({ forwardToolbarAction, addItemText, excelExport, allowAdding, moreActions }: RenderToolbarActionsOptions) => {
+    const hasCustomMoreActions = moreActions?.overallActions && moreActions.overallActions.length > 0;
+    const showMoreActionsMenu = excelExport || hasCustomMoreActions;
 
     if (!showMoreActionsMenu && !allowAdding) {
         return "";
@@ -115,9 +125,10 @@ const renderToolbarActions = ({ forwardToolbarAction, addItemText, excelExport, 
                         icon: exportApi.loading ? <CircularProgress size={20} /> : <Excel />,
                         onClick: () => exportApi.exportGrid(),
                         disabled: exportApi.loading,
-                    }`
+                    },`
                     : ""
             }
+            ${moreActions?.overallActions?.map(({ name, component }) => `<${component.name} key="${name}" />,`) ?? ""}
         ]}
     />`;
 

--- a/packages/admin/cms-admin/src/generator/future/generator.ts
+++ b/packages/admin/cms-admin/src/generator/future/generator.ts
@@ -13,6 +13,7 @@ import { FinalFormFileUploadProps } from "../../form/file/FinalFormFileUpload";
 import { generateForm } from "./generateForm";
 import { generateGrid } from "./generateGrid";
 import { GridCombinationColumnConfig } from "./generateGrid/combinationColumn";
+import { MoreActions } from "./generateGrid/generateGridToolbar";
 import { UsableFields } from "./generateGrid/usableFields";
 import { ColumnVisibleOption } from "./utils/columnVisibility";
 import { writeGenerated } from "./utils/writeGenerated";
@@ -169,6 +170,7 @@ export type GridConfig<T extends { __typename?: string }> = {
     toolbarActionProp?: boolean;
     newEntryText?: string;
     rowActionProp?: boolean;
+    moreActions?: MoreActions;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description

This implements the first part (custom component) of #3259 in the Admin Generator. The second part (custom click handlers) will be implemented in a follow-up PR once we have decided how we want to continue with #3297.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [ ] How to define the order of Excel export in the menu

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/SVK-517
