### PR TITLE
Admin Generator: add `fullWidth` to the toggle field of `optionalNested` fields to not lose `fullWidth` for the nested fields

### DIFF
--- a/.changeset/gold-paws-deny.md
+++ b/.changeset/gold-paws-deny.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+add fullWidth to toggle form field of optionalNested form fields to not loose width for the nested fields

--- a/.changeset/gold-paws-deny.md
+++ b/.changeset/gold-paws-deny.md
@@ -1,5 +1,0 @@
----
-"@comet/cms-admin": patch
----
-
-add fullWidth to toggle form field of optionalNested form fields to not loose width for the nested fields

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -313,7 +313,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                                     />
                                 )}
                             </Field>
-                            <Field name="dimensionsEnabled" subscription={{ value: true }}>
+                            <Field name="dimensionsEnabled" fullWidth subscription={{ value: true }}>
                                 {({ input: { value } }) =>
                                     value ? (
                                         <>

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
@@ -173,7 +173,7 @@ export function generateFormLayout({
                         />
                     )}
                 </Field>
-                 <Field name="${String(config.name)}Enabled" subscription={{ value: true }}>
+                 <Field name="${String(config.name)}Enabled" fullWidth subscription={{ value: true }}>
                     {({ input: { value } }) =>
                         value ? (
                             <>


### PR DESCRIPTION
## Description

Nested Fields in optional Section of Form lost their width. Added fullWidth prop to toggle field to resolve width of nested fields.

## Acceptance criteria

-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  <img width="798" alt="Screenshot 2025-01-30 at 10 40 58" src="https://github.com/user-attachments/assets/53117a03-4ee0-4166-8fb8-86e56efa84f2" />   |  <img width="779" alt="Screenshot 2025-01-30 at 10 41 13" src="https://github.com/user-attachments/assets/f77b395d-a686-4997-9b09-25cb6a46ebe8" />  |
