### PR TITLE
Send 404 on missing _rsc-Parameter

### DIFF
--- a/demo/site/server.ts
+++ b/demo/site/server.ts
@@ -53,7 +53,8 @@ app.prepare().then(() => {
                 };
             }
 
-            if (req.headers["rsc"] !== undefined || req.headers["next-router-prefetch"] !== undefined) {
+            if (req.headers["rsc"] !== undefined) {
+                // for Rsc requests make sure a _rsc query param exists, to avoid CDN (that ignores Vary header) caching rsc response for a non-rsc request
                 if (req.url && new URL(req.url, `http://${req.headers.host}`).searchParams.get("_rsc") === null) {
                     res.statusCode = 404;
                     res.end();


### PR DESCRIPTION
A basis for Discussion purely based on my obervations. This is more a workaround than a solution and might break things.

Problem is that Next.js sends different content for either of these request headers:
- RSC
- Next-Router-Prefetch

Normally these requests are accompanied with a `_rsc` query param (with a hash as value), but the param is not mandatory. To avoid CDN caching Next.js sets the response header `Vary` with the value `RSC, Next-Router-State-Tree, Next-Router-Prefetch, Accept-Encoding` (same for both mentioned headers!).

This PR allows only sending the header when also a _rsc query param is sent. This avoids wrong caching in CDNs which don't respect the `Vary` header (e.g. Cloudflare).

Tested with Next.js 14.2.22.

Reference: https://github.com/vercel/next.js/issues/65335#issuecomment-2121343642
