### PR TITLE
Demo: Use middleware for status

### DIFF
--- a/demo/site/src/app/[domain]/api/status/route.tsx
+++ b/demo/site/src/app/[domain]/api/status/route.tsx
@@ -1,7 +1,0 @@
-export const dynamic = "force-dynamic";
-
-export async function GET() {
-    return new Response("OK", {
-        status: 200,
-    });
-}

--- a/demo/site/src/middleware.ts
+++ b/demo/site/src/middleware.ts
@@ -7,8 +7,10 @@ import { withPredefinedPagesMiddleware } from "./middleware/predefinedPages";
 import { withPreviewMiddleware } from "./middleware/preview";
 import { withRedirectToMainHostMiddleware } from "./middleware/redirectToMainHost";
 import { withSitePreviewMiddleware } from "./middleware/sitePreview";
+import { withStatusMiddleware } from "./middleware/status";
 
 export default chain([
+    withStatusMiddleware,
     withSitePreviewMiddleware,
     withRedirectToMainHostMiddleware,
     withAdminRedirectMiddleware,

--- a/demo/site/src/middleware/status.ts
+++ b/demo/site/src/middleware/status.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { CustomMiddleware } from "./chain";
+
+export function withStatusMiddleware(middleware: CustomMiddleware) {
+    return async (request: NextRequest) => {
+        if (request.nextUrl.pathname === "/api/status") {
+            return NextResponse.json({ status: "OK" });
+        }
+        return middleware(request);
+    };
+}


### PR DESCRIPTION
We recently moved the `/api/status` handler from `app` to `app/[domain]` (https://github.com/vivid-planet/comet/pull/3086). This has the unwanted side effect that the page only works if the [domain lookup is successful](https://github.com/vivid-planet/comet/blob/main/demo/site/src/middleware/domainRewrite.ts#L10). However, this is not the case for the [liveness probe](https://github.com/vivid-planet/comet-charts/blob/main/charts/comet-site-v1/templates/deployment.yaml#L150-L163) which uses an internal cluster url.

Instead of moving back to `app` I decided for a (hopefully) more stable middleware version.

There is one caveat, the middleware version returns a json instead just a string. This might be considered as breaking (but does work with the monitoring in our company which just checks if the content contains the "OK" keyword).