### PR TITLE
Fix edit dialog tests

### DIFF
--- a/packages/admin/admin/src/EditDialog.routerTabs.test.tsx
+++ b/packages/admin/admin/src/EditDialog.routerTabs.test.tsx
@@ -151,7 +151,7 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         expect(screen.queryByText("Add a new product")).not.toBeInTheDocument();
     });
 
-    it.skip("should open product add dialog when clicking on Add product button in grid toolbar", async () => {
+    it("should open product add dialog when clicking on Add product button in grid toolbar", async () => {
         const history = createMemoryHistory({
             initialEntries: ["/", "/products"],
             initialIndex: 0,
@@ -164,14 +164,18 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         );
 
         rendered.getByText("Products").click();
-        expect(screen.getByText("Products")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText("Products")).toBeInTheDocument();
+        });
 
         expect(rendered.getByText("Add product")).toBeInTheDocument();
         rendered.getByText("Add product").click();
-        expect(screen.getByText("Add a new product")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText("Add a new product")).toBeInTheDocument();
+        });
     });
 
-    it.skip("should stay on the products page when closing the edit dialog", async () => {
+    it("should stay on the products page when closing the edit dialog", async () => {
         const history = createMemoryHistory({
             initialEntries: ["/", "/products"],
             initialIndex: 0,
@@ -187,11 +191,15 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         expect(screen.getByText("Customers Page")).toBeInTheDocument();
 
         rendered.getByText("Products").click();
-        expect(rendered.getByText("Add product")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(rendered.getByText("Add product")).toBeInTheDocument();
+        });
         expect(history.location.pathname).toBe("/products");
 
         rendered.getByText("Add product").click();
-        expect(screen.getByText("Add a new product")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText("Add a new product")).toBeInTheDocument();
+        });
         expect(history.location.pathname).toBe("/products/add");
 
         rendered.getByText("Cancel").click();

--- a/packages/admin/admin/src/EditDialog.stackRouterTabs.test.tsx
+++ b/packages/admin/admin/src/EditDialog.stackRouterTabs.test.tsx
@@ -1,7 +1,7 @@
 import { Add, Edit } from "@comet/admin-icons";
 import { Button, IconButton } from "@mui/material";
 import { DataGrid, GridSlotsComponent } from "@mui/x-data-grid";
-import { screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { ReactNode, RefObject, useRef } from "react";
 import { useIntl } from "react-intl";
@@ -76,7 +76,7 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         return (
             <Stack topLevelTitle="Nested Stack">
                 <StackSwitch>
-                    <StackPage name="products" title="Products">
+                    <StackPage name="products">
                         <RouterTabs>
                             <RouterTab label="Customers" path="">
                                 Customers Page
@@ -161,7 +161,7 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         );
     }
 
-    it.skip("should not open edit dialog when navigating back to products page", async () => {
+    it("should not open edit dialog when navigating back to products page", async () => {
         const history = createMemoryHistory();
 
         const rendered = render(
@@ -171,14 +171,20 @@ describe("EditDialog with Stack, Router Tabs and Grid", () => {
         );
 
         rendered.getByText("Products").click();
-        expect(screen.getByText("Products")).toBeInTheDocument();
 
-        expect(rendered.queryAllByTestId("edit.row")).toHaveLength(6);
+        await waitFor(() => {
+            expect(rendered.queryAllByTestId("edit.row")).toHaveLength(6);
+        });
         rendered.queryAllByTestId("edit.row")[5].click();
 
         expect(history.location.pathname).toBe("/5/productEdit");
+        await waitFor(() => {
+            expect(rendered.getByTestId("editPage.backButton")).toBeInTheDocument();
+        });
         within(rendered.getByTestId("editPage.backButton")).getByRole("button").click();
-        expect(screen.getByText("Products")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText("Products")).toBeInTheDocument();
+        });
         expect(history.location.pathname).toBe("/index/products");
 
         // Check that the Edit Dialog is not open, there was a bug that was fixed


### PR DESCRIPTION
## Description

The tests added in https://github.com/vivid-planet/comet/pull/2936 didn't work after merging main into next. This is probably related to the newer Testing Library version in next. I've fixed the tests by adding multiple `waitFor` statements.

