### PR TITLE
Use Data Grid density for `DataGridToolbar`'s density

### DIFF
--- a/.changeset/large-moons-kiss.md
+++ b/.changeset/large-moons-kiss.md
@@ -4,4 +4,4 @@
 
 Deprecate `density` prop of `DataGridToolbar`
 
-The usage of the `density` prop in `DataGridToolbar` is now deprecated as DataGrid now controls the styling of DataGridToolbar based on its density setting.
+The density setting of the surrounding Data Grid now controls the styling of the toolbar.

--- a/.changeset/large-moons-kiss.md
+++ b/.changeset/large-moons-kiss.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": minor
+---
+
+Deprecate `density` prop of `DataGridToolbar`
+
+The usage of the `density` prop in `DataGridToolbar` is now deprecated as DataGrid now controls the styling of DataGridToolbar based on its density setting.

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -58,7 +58,7 @@ export const DataGridToolbar = (inProps: DataGridToolbarProps) => {
     const { density = "standard", slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminDataGridToolbar" });
 
     const apiRef = useGridApiContext();
-    const gridDensity = apiRef.current?.state?.density.value || "standard";
+    const gridDensity = apiRef.current?.state?.density.value;
 
     const ownerState: OwnerState = {
         density: gridDensity || density,

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -1,19 +1,23 @@
 import { ComponentsOverrides } from "@mui/material";
 import { css, Theme, useThemeProps } from "@mui/material/styles";
+import { useGridApiContext } from "@mui/x-data-grid";
 
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { Toolbar, ToolbarProps } from "./Toolbar";
 
-export type DataGridToolbarClassKey = "root" | "standard" | "comfortable";
+export type DataGridToolbarClassKey = "root" | "standard" | "comfortable" | "compact";
 
-export type DataGridToolbarProps = { density?: "standard" | "comfortable" } & Omit<ToolbarProps, "slotProps" | "scopeIndicator" | "hideTopBar"> &
+export type DataGridToolbarProps = { density?: "standard" | "comfortable" | "compact" } & Omit<
+    ToolbarProps,
+    "slotProps" | "scopeIndicator" | "hideTopBar"
+> &
     ThemedComponentBaseProps<{
         root: typeof Toolbar;
     }>;
 
 type OwnerState = {
-    density: "standard" | "comfortable";
+    density: "standard" | "comfortable" | "compact";
 };
 
 const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey, OwnerState>({
@@ -55,8 +59,11 @@ const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey, OwnerState>({
 export const DataGridToolbar = (inProps: DataGridToolbarProps) => {
     const { density = "standard", slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminDataGridToolbar" });
 
+    const apiRef = useGridApiContext();
+    const gridDensity = apiRef.current?.state?.density.value || "standard";
+
     const ownerState: OwnerState = {
-        density,
+        density: gridDensity || density,
     };
 
     return <Root ownerState={ownerState} hideTopBar {...slotProps?.root} {...restProps} />;

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -8,13 +8,11 @@ import { Toolbar, ToolbarProps } from "./Toolbar";
 
 export type DataGridToolbarClassKey = "root" | "standard" | "comfortable" | "compact";
 
-export type DataGridToolbarProps = { density?: "standard" | "comfortable" | "compact" } & Omit<
-    ToolbarProps,
-    "slotProps" | "scopeIndicator" | "hideTopBar"
-> &
-    ThemedComponentBaseProps<{
-        root: typeof Toolbar;
-    }>;
+export type DataGridToolbarProps = {
+    /** @deprecated The `density` prop is deprecated. The density is now used from the DataGrid. */
+    density?: "standard" | "comfortable" | "compact";
+} & Omit<ToolbarProps, "slotProps" | "scopeIndicator" | "hideTopBar"> &
+    ThemedComponentBaseProps<{ root: typeof Toolbar }>;
 
 type OwnerState = {
     density: "standard" | "comfortable" | "compact";

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -55,13 +55,13 @@ const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey, OwnerState>({
 );
 
 export const DataGridToolbar = (inProps: DataGridToolbarProps) => {
-    const { density = "standard", slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminDataGridToolbar" });
+    const { density, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminDataGridToolbar" });
 
     const apiRef = useGridApiContext();
     const gridDensity = apiRef.current?.state?.density.value;
 
     const ownerState: OwnerState = {
-        density: gridDensity || density,
+        density: density || gridDensity,
     };
 
     return <Root ownerState={ownerState} hideTopBar {...slotProps?.root} {...restProps} />;


### PR DESCRIPTION
## Description

At the moment it is necessary to pass the density prop twice: once to the DataGrid and once to the DataGridToolbar. 
The DataGridToolbar should not get the prop anymore, but instead use the density of the DataGrid.

- Get density in DataGridToolbar from 'useGridApiContext'
- Set height depending on the density value
- Set density prop to deprecated

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Standard:
![Screenshot 2025-02-04 at 09 47 21](https://github.com/user-attachments/assets/4a3bba44-6545-42c3-a8d4-9d72c87ad7b1)

Compact: 
![Screenshot 2025-02-04 at 09 47 49](https://github.com/user-attachments/assets/b7a3b3b7-1c1d-4de0-acd0-f6e43785a9a0)


Comfortable:
![Screenshot 2025-02-04 at 09 47 37](https://github.com/user-attachments/assets/4d683e8d-7f8a-4248-adee-07826dfc948f)


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1504
