### PR TITLE
Demo: Set correct (boolean) value of `inStock` in Handmade ProductsGrid

### DIFF
--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -228,7 +228,7 @@ export function ProductsGrid() {
             type: "singleSelect",
             valueOptions: [
                 {
-                    value: "true",
+                    value: true,
                     label: intl.formatMessage({ id: "product.inStock.true.primary", defaultMessage: "In stock" }),
                     cellContent: (
                         <GridCellContent
@@ -238,7 +238,7 @@ export function ProductsGrid() {
                     ),
                 },
                 {
-                    value: "false",
+                    value: false,
                     label: intl.formatMessage({ id: "product.inStock.false.primary", defaultMessage: "Out of stock" }),
                     cellContent: (
                         <GridCellContent


### PR DESCRIPTION
## Description

With the string-values the item was never rendered correctly and filtering/sorting was not possible. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots

| Before | Now |
| --- | --- |
|<img width="726" alt="InStock Before" src="https://github.com/user-attachments/assets/2d69b5ae-fe6b-4dd4-ab15-035693c9b1f0" />|<img width="726" alt="InStock Now" src="https://github.com/user-attachments/assets/c5bfcf07-9022-4ff3-ba1d-d5948ab2aa4b" />|

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1461