### PR TITLE
Set alt attribute to empty string as default in `SvgImageBlock`

### DIFF
--- a/.changeset/shiny-mangos-report.md
+++ b/.changeset/shiny-mangos-report.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": patch
+---
+
+Set alt attribute to empty string as default in `SvgImageBlock`

--- a/packages/site/cms-site/src/blocks/SvgImageBlock.tsx
+++ b/packages/site/cms-site/src/blocks/SvgImageBlock.tsx
@@ -19,7 +19,7 @@ export const SvgImageBlock = withPreview(
                 src={damFile.fileUrl}
                 width={width === "auto" ? undefined : width}
                 height={height === "auto" ? undefined : height}
-                alt={damFile.altText}
+                alt={damFile.altText ?? ""}
             />
         );
     },


### PR DESCRIPTION
## Description

Set alt attribute to empty string as default in `SvgImageBlock`

### Reason

Screen readers skip images with empty alt attributes but they read the file name if there is no alt tag at all. To avoid this confusing output, we add an empty alt attribute as default.

We already did this in the PixelImageBlock (see https://github.com/vivid-planet/comet/blob/e0dea4c990f3b54405789e1316fa93ada2faddd0/packages/site/cms-site/src/blocks/PixelImageBlock.tsx#L64)