### PR TITLE
Don't render `DialogContent` around `DataGrid`

### DIFF
--- a/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
+++ b/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
@@ -958,7 +958,11 @@ export const GridWithSelectionInDialog = {
                         <Typography variant="h4">No items selected :(</Typography>
                     )}
                 </StackMainContent>
-                <EditDialog onAfterSave={() => editDialogApi.closeDialog()} title="Selected items">
+                <EditDialog
+                    onAfterSave={() => editDialogApi.closeDialog()}
+                    title="Selected items"
+                    componentsProps={{ dialogContent: { sx: { display: "contents" } } }}
+                >
                     <DataGrid
                         disableSelectionOnClick
                         rows={rows}

--- a/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
+++ b/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
@@ -961,6 +961,7 @@ export const GridWithSelectionInDialog = {
                 <EditDialog
                     onAfterSave={() => editDialogApi.closeDialog()}
                     title="Selected items"
+                    // TODO: Remove dialogContent styling once DialogContent is no longer rendered inside EditDialog (https://vivid-planet.atlassian.net/browse/COM-1606)
                     componentsProps={{ dialogContent: { sx: { display: "contents" } } }}
                 >
                     <DataGrid


### PR DESCRIPTION
## Description

`DataGrid` should not have a spacing around it when rendered inside a `Dialog` according to the Comet design guidelines.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1024" alt="Grid in Dialog with DialogContent" src="https://github.com/user-attachments/assets/48ae3afc-e64a-4255-b13f-82d925849c9e" />   | <img width="1024" alt="Grid in Dialog without DialogContent" src="https://github.com/user-attachments/assets/a72f0c84-f7f7-441b-8690-f362f22598d1" />  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1606
