### PR TITLE
Add language redirect middleware

### DIFF
--- a/demo/site/src/app/[domain]/[language]/layout.tsx
+++ b/demo/site/src/app/[domain]/[language]/layout.tsx
@@ -1,14 +1,9 @@
 import { IntlProvider } from "@src/util/IntlProvider";
 import { loadMessages } from "@src/util/loadMessages";
 import { setNotFoundContext } from "@src/util/NotFoundContext";
-import { getSiteConfigForDomain } from "@src/util/siteConfig";
 import { PropsWithChildren } from "react";
 
 export default async function Page({ children, params: { domain, language } }: PropsWithChildren<{ params: { domain: string; language: string } }>) {
-    const siteConfig = getSiteConfigForDomain(domain);
-    if (!siteConfig.scope.languages.includes(language)) {
-        language = "en";
-    }
     setNotFoundContext({ domain, language });
 
     const messages = await loadMessages(language);

--- a/demo/site/src/app/[domain]/page.tsx
+++ b/demo/site/src/app/[domain]/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default async function Page() {
-    redirect("/en");
-}

--- a/demo/site/src/middleware.ts
+++ b/demo/site/src/middleware.ts
@@ -3,6 +3,7 @@ import { chain } from "./middleware/chain";
 import { withCspHeadersMiddleware } from "./middleware/cspHeaders";
 import { withDamRewriteMiddleware } from "./middleware/damRewrite";
 import { withDomainRewriteMiddleware } from "./middleware/domainRewrite";
+import { withLanguageRedirectMiddleware } from "./middleware/languageRedirect";
 import { withPredefinedPagesMiddleware } from "./middleware/predefinedPages";
 import { withPreviewMiddleware } from "./middleware/preview";
 import { withRedirectToMainHostMiddleware } from "./middleware/redirectToMainHost";
@@ -18,6 +19,7 @@ export default chain([
     withCspHeadersMiddleware, // order matters: after redirects (that don't need csp headers), before everything else that needs csp headers
     withPreviewMiddleware,
     withPredefinedPagesMiddleware,
+    withLanguageRedirectMiddleware,
     withDomainRewriteMiddleware, // must be last (rewrites all urls)
 ]);
 

--- a/demo/site/src/middleware/languageRedirect.ts
+++ b/demo/site/src/middleware/languageRedirect.ts
@@ -1,0 +1,19 @@
+import { getHostByHeaders, getSiteConfigForHost } from "@src/util/siteConfig";
+import { NextRequest, NextResponse } from "next/server";
+
+import { CustomMiddleware } from "./chain";
+
+export function withLanguageRedirectMiddleware(middleware: CustomMiddleware) {
+    return async (request: NextRequest) => {
+        const headers = request.headers;
+        const host = getHostByHeaders(headers);
+        const siteConfig = await getSiteConfigForHost(host);
+
+        const language = request.nextUrl.pathname.split("/")[1];
+        if (siteConfig && !siteConfig.scope.languages.includes(language)) {
+            return NextResponse.redirect(`${siteConfig.url}/en`);
+        }
+
+        return middleware(request);
+    };
+}


### PR DESCRIPTION
We currently set the language manually to "en" when the first path part does not match. This has disadvantages:
- leads to duplicate content
- needs to be implemented everytime the language param is used (e.g. in nested layouts)
- may lead to unexpected behaviour I didn't think of yet

I'm suggesting here a middleware which simply redirects to `/en`.