### PR TITLE
Demo Site: Fix error when language not found

### DIFF
--- a/demo/site/src/app/[domain]/[language]/[[...path]]/layout.tsx
+++ b/demo/site/src/app/[domain]/[language]/[[...path]]/layout.tsx
@@ -12,6 +12,10 @@ interface LayoutProps {
 }
 
 export default async function Layout({ children, params: { domain, language } }: PropsWithChildren<LayoutProps>) {
+    const siteConfig = getSiteConfigForDomain(domain);
+    if (!siteConfig.scope.languages.includes(language)) {
+        language = "en";
+    }
     const { previewData } = (await previewParams()) || { previewData: undefined };
     const graphqlFetch = createGraphQLFetch(previewData);
 


### PR DESCRIPTION
We have to do the same here like in the layout above. The reason is that we have to make sure that the layout is rendered even when the language is not supported. The page then either finds a redirect or presents a 404.