### PR TITLE
Style page tree search input

### DIFF
--- a/.changeset/young-coats-tie.md
+++ b/.changeset/young-coats-tie.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": patch
 ---
 
-Adapt styling of the search input icons in `PageSearch` to match the Comet DXP design
+Adapt styling of the page tree search input to match the Comet DXP design

--- a/.changeset/young-coats-tie.md
+++ b/.changeset/young-coats-tie.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Adapt styling of the search input icons in `PageSearch` to match the Comet DXP design

--- a/packages/admin/cms-admin/src/common/SearchInput.tsx
+++ b/packages/admin/cms-admin/src/common/SearchInput.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, ChevronUp, Clear, Search } from "@comet/admin-icons";
+import styled from "@emotion/styled";
 import { IconButton, InputAdornment, InputBase, Typography } from "@mui/material";
 import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from "react";
 import { useHotkeys, useIsHotkeyPressed } from "react-hotkeys-hook";
@@ -92,22 +93,27 @@ export const SearchInput = ({
             }
             endAdornment={
                 internalQuery ? (
-                    <InputAdornment position="end">
-                        <Typography>
+                    <StyledInputAdornment position="end">
+                        <Typography variant="body2">
                             {currentMatch !== undefined && totalMatches !== undefined ? `${currentMatch + 1}/${totalMatches}` : "..."}
                         </Typography>
-                        <IconButton onClick={jumpToPreviousMatch} disabled={!jumpToPreviousMatch} size="large">
-                            <ChevronUp />
+                        <IconButton onClick={jumpToPreviousMatch} disabled={!jumpToPreviousMatch} size="medium">
+                            <ChevronUp color="secondary" />
                         </IconButton>
-                        <IconButton onClick={jumpToNextMatch} disabled={!jumpToNextMatch} size="large">
-                            <ChevronDown />
+                        <IconButton onClick={jumpToNextMatch} disabled={!jumpToNextMatch} size="medium">
+                            <ChevronDown color="secondary" />
                         </IconButton>
-                        <IconButton onClick={handleClearClick} size="large">
+                        <IconButton onClick={handleClearClick} size="medium">
                             <Clear />
                         </IconButton>
-                    </InputAdornment>
+                    </StyledInputAdornment>
                 ) : null
             }
         />
     );
 };
+
+const StyledInputAdornment = styled(InputAdornment)`
+    align-self: center;
+    height: 32px;
+`;

--- a/packages/admin/cms-admin/src/common/SearchInput.tsx
+++ b/packages/admin/cms-admin/src/common/SearchInput.tsx
@@ -93,7 +93,7 @@ export const SearchInput = ({
             endAdornment={
                 internalQuery ? (
                     <InputAdornment position="end">
-                        <Typography variant="body2" sx={{ marginRight: "10px" }}>
+                        <Typography variant="body2" sx={{ marginRight: 2 }}>
                             {currentMatch !== undefined && totalMatches !== undefined ? `${currentMatch + 1}/${totalMatches}` : "..."}
                         </Typography>
                         <IconButton onClick={jumpToPreviousMatch} disabled={!jumpToPreviousMatch} size="medium">

--- a/packages/admin/cms-admin/src/common/SearchInput.tsx
+++ b/packages/admin/cms-admin/src/common/SearchInput.tsx
@@ -1,5 +1,4 @@
 import { ChevronDown, ChevronUp, Clear, Search } from "@comet/admin-icons";
-import styled from "@emotion/styled";
 import { IconButton, InputAdornment, InputBase, Typography } from "@mui/material";
 import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from "react";
 import { useHotkeys, useIsHotkeyPressed } from "react-hotkeys-hook";
@@ -93,7 +92,7 @@ export const SearchInput = ({
             }
             endAdornment={
                 internalQuery ? (
-                    <StyledInputAdornment position="end">
+                    <InputAdornment position="end">
                         <Typography variant="body2">
                             {currentMatch !== undefined && totalMatches !== undefined ? `${currentMatch + 1}/${totalMatches}` : "..."}
                         </Typography>
@@ -106,14 +105,9 @@ export const SearchInput = ({
                         <IconButton onClick={handleClearClick} size="medium">
                             <Clear />
                         </IconButton>
-                    </StyledInputAdornment>
+                    </InputAdornment>
                 ) : null
             }
         />
     );
 };
-
-const StyledInputAdornment = styled(InputAdornment)`
-    align-self: center;
-    height: 32px;
-`;

--- a/packages/admin/cms-admin/src/common/SearchInput.tsx
+++ b/packages/admin/cms-admin/src/common/SearchInput.tsx
@@ -96,11 +96,11 @@ export const SearchInput = ({
                         <Typography variant="body2" sx={{ marginRight: 2 }}>
                             {currentMatch !== undefined && totalMatches !== undefined ? `${currentMatch + 1}/${totalMatches}` : "..."}
                         </Typography>
-                        <IconButton onClick={jumpToPreviousMatch} disabled={!jumpToPreviousMatch} size="medium">
-                            <ChevronUp color="secondary" />
+                        <IconButton onClick={jumpToPreviousMatch} disabled={!jumpToPreviousMatch} size="medium" color="secondary">
+                            <ChevronUp />
                         </IconButton>
-                        <IconButton onClick={jumpToNextMatch} disabled={!jumpToNextMatch} size="medium">
-                            <ChevronDown color="secondary" />
+                        <IconButton onClick={jumpToNextMatch} disabled={!jumpToNextMatch} size="medium" color="secondary">
+                            <ChevronDown />
                         </IconButton>
                         <IconButton onClick={handleClearClick} size="medium">
                             <Clear />

--- a/packages/admin/cms-admin/src/common/SearchInput.tsx
+++ b/packages/admin/cms-admin/src/common/SearchInput.tsx
@@ -93,7 +93,7 @@ export const SearchInput = ({
             endAdornment={
                 internalQuery ? (
                     <InputAdornment position="end">
-                        <Typography variant="body2">
+                        <Typography variant="body2" sx={{ marginRight: "10px" }}>
                             {currentMatch !== undefined && totalMatches !== undefined ? `${currentMatch + 1}/${totalMatches}` : "..."}
                         </Typography>
                         <IconButton onClick={jumpToPreviousMatch} disabled={!jumpToPreviousMatch} size="medium">


### PR DESCRIPTION
## Description

Style items on the right side of the search input field (colors, spacings, font) according to design.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="572" alt="Screenshot 2025-02-11 at 12 26 59" src="https://github.com/user-attachments/assets/9020eabf-9d80-4bb5-bde4-f9d19da1f48f" /> | <img width="570" alt="Screenshot 2025-02-11 at 12 26 37" src="https://github.com/user-attachments/assets/dea9bce6-03f1-4b67-af31-b5aceb78295d" />
  

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1389
