### PR TITLE
Admin Generator: Fix `initiallyExpanded` prop not set if `false`

### DIFF
--- a/.changeset/five-timers-rule.md
+++ b/.changeset/five-timers-rule.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": major
+---
+
+Admin Generator - Form: fix initiallyExpanded not set correctly

--- a/.changeset/five-timers-rule.md
+++ b/.changeset/five-timers-rule.md
@@ -1,5 +1,0 @@
----
-"@comet/cms-admin": major
----
-
-Admin Generator - Form: fix initiallyExpanded not set correctly

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -190,7 +190,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
                     {saveConflict.dialogs}
                     <>
                         <FieldSet
-                            initiallyExpanded
+                            initiallyExpanded={true}
                             title={<FormattedMessage id="product.mainData.title" defaultMessage="Main Data" />}
                             supportText={
                                 mode === "edit" && (

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
@@ -70,7 +70,6 @@ export function generateFormLayout({
         code = `
         <FieldSet
             ${config.collapsible === undefined || config.collapsible ? `collapsible` : ``}
-            
             ${config.initiallyExpanded != null ? `initiallyExpanded={${config.initiallyExpanded}}` : ``}
             title={<FormattedMessage id="${formattedMessageRootId}.${config.name}.title" defaultMessage="${title}" />}
             ${

--- a/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
+++ b/packages/admin/cms-admin/src/generator/future/generateForm/generateFormLayout.ts
@@ -70,7 +70,8 @@ export function generateFormLayout({
         code = `
         <FieldSet
             ${config.collapsible === undefined || config.collapsible ? `collapsible` : ``}
-            ${config.initiallyExpanded ? `initiallyExpanded` : ``}
+            
+            ${config.initiallyExpanded != null ? `initiallyExpanded={${config.initiallyExpanded}}` : ``}
             title={<FormattedMessage id="${formattedMessageRootId}.${config.name}.title" defaultMessage="${title}" />}
             ${
                 config.supportText


### PR DESCRIPTION
## Description
fix Form Generator. If `initiallyExpanded` is set to `false`, the initiallyExpanded prop did not get set on the `Fieldset` Component. This is wrong, because internally the `Fieldset` Component has a default value assigned to `initiallyExpanded` of `true`


### Sample Code:

```
export const ProductForm: FormConfig<GQLProduct> = {
    type: "form",
    gqlType: "Product",
    fragmentName: "ProductFormDetails", // configurable as it must be unique across project
    fields: [
        {
            type: "fieldSet",
            name: "mainData",
            collapsible: true,
            initiallyExpanded: true,
            fields: [
                {
                    type: "text",
                    name: "title",
                },
            ],
        },
        {
            type: "fieldSet",
            name: "additionalData",
            collapsible: true,
            initiallyExpanded: false,
            fields: [
                {
                    type: "boolean",
                    name: "inStock",
                },
            ],
        },
    ],
};
```

### Problem

![image](https://github.com/user-attachments/assets/c6e97066-5376-4e6e-9165-3ea6485dcfc6)




### Screenshots

| Before | After |
| ------ | ----- |
|  <img width="982" alt="Screenshot 2025-02-11 at 17 30 25" src="https://github.com/user-attachments/assets/c7eae69a-760a-4eb8-8382-39d3194144ea" /> |  <img width="1728" alt="Screenshot 2025-02-11 at 17 13 37" src="https://github.com/user-attachments/assets/25223ae9-a446-4a0a-8171-3792308f1285" />
|


------ 

Task: https://vivid-planet.atlassian.net/browse/COM-1630