### PR TITLE
Style dashboard header on mobile

### DIFF
--- a/.changeset/sharp-trains-taste.md
+++ b/.changeset/sharp-trains-taste.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Adapt styling of the dashboard header to match the Comet DXP design

--- a/packages/admin/cms-admin/src/dashboard/DashboardHeader.tsx
+++ b/packages/admin/cms-admin/src/dashboard/DashboardHeader.tsx
@@ -45,13 +45,25 @@ const Root = styled("div")<RootProps>`
                 background-image: url(${backgroundImageUrl["2x"]});
             }
         `}
+
+    ${({ theme }) => theme.breakpoints.down("sm")} {
+        height: 230px;
+    }
 `;
 
 const Greeting = styled(Typography)`
     position: absolute;
-    left: ${({ theme }) => theme.spacing(8)};
-    bottom: ${({ theme }) => theme.spacing(8)};
-    font-size: 55px;
-    line-height: 64px;
-    font-weight: 200;
+    left: ${({ theme }) => theme.spacing(4)};
+    bottom: ${({ theme }) => theme.spacing(2.4)};
+    font-size: 30px;
+    line-height: 38px;
+    font-weight: 160;
+
+    ${({ theme }) => theme.breakpoints.up("sm")} {
+        left: ${({ theme }) => theme.spacing(8)};
+        bottom: ${({ theme }) => theme.spacing(8)};
+        font-size: 55px;
+        line-height: 64px;
+        font-weight: 200;
+    }
 `;

--- a/packages/admin/cms-admin/src/dashboard/DashboardHeader.tsx
+++ b/packages/admin/cms-admin/src/dashboard/DashboardHeader.tsx
@@ -54,7 +54,7 @@ const Root = styled("div")<RootProps>`
 const Greeting = styled(Typography)`
     position: absolute;
     left: ${({ theme }) => theme.spacing(4)};
-    bottom: ${({ theme }) => theme.spacing(2.4)};
+    bottom: 12px;
     font-size: 30px;
     line-height: 38px;
     font-weight: 160;

--- a/packages/admin/cms-admin/src/dashboard/DashboardHeader.tsx
+++ b/packages/admin/cms-admin/src/dashboard/DashboardHeader.tsx
@@ -30,7 +30,7 @@ type RootProps = {
 
 const Root = styled("div")<RootProps>`
     position: relative;
-    height: 300px;
+    height: 230px;
     color: ${({ textColor }) => (textColor === "light" ? "white" : textColor === "dark" ? "black" : "inherit")};
     background-color: ${({ theme }) => theme.palette.grey[700]};
 
@@ -46,8 +46,8 @@ const Root = styled("div")<RootProps>`
             }
         `}
 
-    ${({ theme }) => theme.breakpoints.down("sm")} {
-        height: 230px;
+    ${({ theme }) => theme.breakpoints.up("sm")} {
+        height: 300px;
     }
 `;
 

--- a/packages/admin/cms-admin/src/dashboard/DateTime.tsx
+++ b/packages/admin/cms-admin/src/dashboard/DateTime.tsx
@@ -29,7 +29,7 @@ export const DateTime = () => {
 
 const Root = styled("div")`
     position: absolute;
-    top: ${({ theme }) => theme.spacing(3.2)};
+    top: 16px;
     right: ${({ theme }) => theme.spacing(4)};
     text-align: right;
 

--- a/packages/admin/cms-admin/src/dashboard/DateTime.tsx
+++ b/packages/admin/cms-admin/src/dashboard/DateTime.tsx
@@ -29,18 +29,34 @@ export const DateTime = () => {
 
 const Root = styled("div")`
     position: absolute;
-    top: ${({ theme }) => theme.spacing(4)};
-    right: ${({ theme }) => theme.spacing(8)};
-    font-weight: 200;
+    top: ${({ theme }) => theme.spacing(3.2)};
+    right: ${({ theme }) => theme.spacing(4)};
     text-align: right;
+
+    ${({ theme }) => theme.breakpoints.up("sm")} {
+        top: ${({ theme }) => theme.spacing(4)};
+        right: ${({ theme }) => theme.spacing(8)};
+    }
 `;
 
 const DateContainer = styled("div")`
-    font-size: 33px;
-    line-height: 39px;
+    font-size: 24px;
+    line-height: 28px;
+    font-weight: 150;
+
+    ${({ theme }) => theme.breakpoints.up("sm")} {
+        font-size: 33px;
+        line-height: 39px;
+    }
 `;
 
 const TimeContainer = styled("div")`
-    font-size: 55px;
-    line-height: 64px;
+    font-size: 36px;
+    line-height: 42px;
+    font-weight: 170;
+
+    ${({ theme }) => theme.breakpoints.up("sm")} {
+        font-size: 55px;
+        line-height: 64px;
+    }
 `;


### PR DESCRIPTION
## Description

Adapt spacings and typography of the dashboard header to match the design.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1091" alt="Screenshot 2025-02-12 at 09 44 03" src="https://github.com/user-attachments/assets/2b6f61d6-43cb-4612-b4f6-ef47672dd9ab" /> | <img width="1860" alt="Screenshot 2025-02-12 at 09 42 16" src="https://github.com/user-attachments/assets/4128a4cc-51b3-471c-b6e0-72927d796f94" /> |
| <img width="378" alt="Screenshot 2025-02-12 at 09 43 52" src="https://github.com/user-attachments/assets/85b0c5ba-3e3e-4ffc-8e1f-c040e693c8db" /> | <img width="376" alt="Screenshot 2025-02-12 at 09 42 41" src="https://github.com/user-attachments/assets/d99f9caa-a7ea-4fd0-8165-85993672748c" />

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1387
