### PR TITLE
Fix block types generation watch mode

### DIFF
--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -7,7 +7,7 @@
         "build": "run-s intl:compile && run-p gql:types generate-block-types && NODE_ENV=production vite build",
         "preview": "npm run build && vite preview",
         "generate-block-types": "comet generate-block-types --inputs",
-        "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"npm run generate-block-types\"",
+        "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"npm run generate-block-types\"",
         "gql:types": "graphql-codegen",
         "gql:watch": "graphql-codegen --watch",
         "intl:compile": "run-p intl:compile:comet intl:compile:comet-demo",

--- a/demo/site-pages/package.json
+++ b/demo/site-pages/package.json
@@ -12,7 +12,7 @@
         "export": "next export",
         "extract:publicGenerated": "node preBuild/build/preBuild/src/publicGenerator/extract.js",
         "generate-block-types": "comet generate-block-types",
-        "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",
+        "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"$npm_execpath generate-block-types\"",
         "gql:types": "graphql-codegen",
         "gql:watch": "graphql-codegen --watch",
         "intl:extract": "formatjs extract \"src/**/*.ts*\" --ignore **/*.d.ts --out-file lang-extracted/en.json --format simple",

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -7,7 +7,7 @@
         "dev": "run-s intl:compile && run-p gql:types generate-block-types && tsc --project tsconfig.server.json && NODE_OPTIONS='--inspect=localhost:9230 --max-old-space-size=512' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node dist/server.js",
         "export": "next export",
         "generate-block-types": "comet generate-block-types",
-        "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",
+        "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"$npm_execpath generate-block-types\"",
         "gql:types": "graphql-codegen",
         "gql:watch": "graphql-codegen --watch",
         "intl:compile": "formatjs compile-folder --format simple --ast lang/comet-demo-lang/site lang-compiled/",

--- a/docs/docs/4-guides/1-how-to-build-a-custom-client/index.md
+++ b/docs/docs/4-guides/1-how-to-build-a-custom-client/index.md
@@ -407,7 +407,7 @@ The Comet API creates this `block-meta.json` and this file gets symlinked to the
 {
     "scripts": {
         "generate-block-types": "comet generate-block-types",
-        "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"npm run generate-block-types\""
+        "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"npm run generate-block-types\""
     }
 }
 ```

--- a/packages/admin/blocks-admin/package.json
+++ b/packages/admin/blocks-admin/package.json
@@ -18,7 +18,7 @@
         "build:types": "tsc --project ./tsconfig.build.json --emitDeclarationOnly",
         "clean": "rimraf lib",
         "generate-block-types": "comet generate-block-types --inputs",
-        "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",
+        "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"$npm_execpath generate-block-types\"",
         "lint": "$npm_execpath generate-block-types && run-p lint:prettier lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0 src/ package.json",
         "lint:prettier": "npx prettier --check './**/*.{js,json,md,yml,yaml}'",

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -21,7 +21,7 @@
         "build:types": "tsc --project ./tsconfig.build.json --emitDeclarationOnly",
         "clean": "rimraf lib 'src/**/*.generated.ts'",
         "generate-block-types": "comet generate-block-types --inputs",
-        "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",
+        "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"$npm_execpath generate-block-types\"",
         "generate-graphql-types": "graphql-codegen",
         "generate-graphql-types:watch": "$npm_execpath generate-graphql-types --watch",
         "lint": "run-p generate-graphql-types generate-block-types && run-p lint:prettier lint:eslint lint:tsc",

--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -17,7 +17,7 @@
         "clean": "rimraf lib 'src/**/*.generated.ts'",
         "dev": "$npm_execpath generate-block-types && tsc --watch --preserveWatchOutput --project tsconfig.build.json",
         "generate-block-types": "comet generate-block-types",
-        "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"$npm_execpath generate-block-types\"",
+        "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"$npm_execpath generate-block-types\"",
         "lint": "$npm_execpath generate-block-types && run-p lint:prettier lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0 --ext .ts,.tsx,.js,.jsx,.json,.md src/ package.json",
         "lint:prettier": "npx prettier --check './**/*.{js,json,md,yml,yaml}'",


### PR DESCRIPTION
## Description

Noticed this while trying to improve hot-reloading of Comet packages in the Demo Admin: The syntax `**/block-meta.json` for chokidar incorrectly caused block types generation for any change in the package's folder, including changes in node_modules/. I've removed the incorrect `**/` since we only need to generate block types if the block-meta.json file changes.