### PR TITLE
Demo Admin: improve hot-reloading on change in admin package

### DIFF
--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -20,7 +20,7 @@
         "lint:tsc": "tsc --project .",
         "lint:generated-files-not-modified": "$npm_execpath admin-generator && git diff --exit-code HEAD -- src/**/generated",
         "serve": "node server",
-        "start": "run-s intl:compile && run-p gql:types generate-block-types && dotenv -e .env.site-configs -- chokidar --initial -s \"../../packages/admin/*/src/**\" -c \"kill-port $ADMIN_PORT && vite --force\""
+        "start": "run-s intl:compile && run-p gql:types generate-block-types && dotenv -e .env.site-configs -- vite"
     },
     "dependencies": {
         "@apollo/client": "^3.7.0",
@@ -123,7 +123,6 @@
         "dotenv-cli": "^4.0.0",
         "eslint": "^8.0.0",
         "eslint-plugin-graphql": "^4.0.0",
-        "kill-port": "^2.0.1",
         "npm-run-all": "^4.1.5",
         "pascal-case": "^3.0.0",
         "prettier": "^2.0.0",

--- a/demo/admin/vite.config.mts
+++ b/demo/admin/vite.config.mts
@@ -1,9 +1,37 @@
 import react from "@vitejs/plugin-react-swc";
 import { resolve } from "path";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import { createHtmlPlugin } from "vite-plugin-html";
 
 import { environment as envVarsToLoad } from "./src/environment";
+
+const adminPackagesPathRegex = /\/packages\/admin\/.*\/src\//;
+
+/**
+ * Plugin to watch for changes in admin packages and restart the dev server to force the optimizer to re-bundle.
+ * Inspired by https://prosopo.io/articles/using-vite-to-rebuild-local-dependencies-in-an-npm-workspace/.
+ */
+const adminPackagesHotReloadPlugin: Plugin = {
+    name: "admin-packages-hot-reload",
+    buildStart() {
+        this.addWatchFile("../../packages/admin/admin/src");
+        this.addWatchFile("../../packages/admin/admin-color-picker/src");
+        this.addWatchFile("../../packages/admin/admin-date-time/src");
+        this.addWatchFile("../../packages/admin/admin-icons/src");
+        this.addWatchFile("../../packages/admin/admin-react-select/src");
+        this.addWatchFile("../../packages/admin/admin-rte/src");
+        this.addWatchFile("../../packages/admin/admin-theme/src");
+        this.addWatchFile("../../packages/admin/blocks-admin/src");
+        this.addWatchFile("../../packages/admin/cms-admin/src");
+    },
+    async handleHotUpdate({ file, server }) {
+        const isChangeInAdminPackage = adminPackagesPathRegex.test(file);
+
+        if (isChangeInAdminPackage) {
+            await server.restart(true);
+        }
+    },
+};
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -45,6 +73,7 @@ export default defineConfig(({ mode }) => {
                     },
                 },
             }),
+            adminPackagesHotReloadPlugin,
         ],
         server: {
             host: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,9 +357,6 @@ importers:
       eslint-plugin-graphql:
         specifier: ^4.0.0
         version: 4.0.0(@types/node@22.9.0)(graphql@15.8.0)(typescript@4.9.4)
-      kill-port:
-        specifier: ^2.0.1
-        version: 2.0.1
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -4392,7 +4389,7 @@ packages:
       '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -8995,7 +8992,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       espree: 9.5.2
       globals: 13.19.0
       ignore: 5.2.4
@@ -10756,7 +10753,7 @@ packages:
       '@types/json-stable-stringify': 1.0.34
       '@types/jsonwebtoken': 9.0.1
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       dotenv: 16.4.5
       graphql: 15.8.0
       graphql-request: 5.1.0(graphql@15.8.0)
@@ -11194,7 +11191,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -20303,6 +20300,17 @@ packages:
       ms: 2.1.3
     dev: false
 
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+
   /debug@4.3.4(supports-color@9.3.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -21900,7 +21908,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -23187,10 +23195,6 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
     dev: false
-
-  /get-them-args@1.3.2:
-    resolution: {integrity: sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==}
-    dev: true
 
   /get-tsconfig@4.3.0:
     resolution: {integrity: sha512-YCcF28IqSay3fqpIu5y3Krg/utCBHBeoflkZyHj/QcqI2nrLPC3ZegS9CmIo+hJb8K7aiGsuUl7PwWVjNG2HQQ==}
@@ -25947,14 +25951,6 @@ packages:
   /khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
     dev: false
-
-  /kill-port@2.0.1:
-    resolution: {integrity: sha512-e0SVOV5jFo0mx8r7bS29maVWp17qGqLBZ5ricNSajON6//kmb7qqqNnml4twNE8Dtj97UQD+gNFOaipS/q1zzQ==}
-    hasBin: true
-    dependencies:
-      get-them-args: 1.3.2
-      shell-exec: 1.0.2
-    dev: true
 
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -31805,10 +31801,6 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  /shell-exec@1.0.2:
-    resolution: {integrity: sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==}
-    dev: true
 
   /shell-quote@1.7.4:
     resolution: {integrity: sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==}


### PR DESCRIPTION
## Description

In https://github.com/vivid-planet/comet/pull/1838 we introduced a hacky way to support hot-reloading the Vite dev server when a change in an admin package happens by killing the dev server and starting again. This solution proved to be insufficient since the dev server wasn't correctly shutdown all the time, resulting in multiple abandoned Node.js processes.

This introduces a better solution inspired by [this article](https://prosopo.io/articles/using-vite-to-rebuild-local-dependencies-in-an-npm-workspace/). We add a custom Vite plugin that watches for file changes in the admin packages folders and then restarts the dev server. The `force` option is set to `true` to force the optimizer to re-bundle.

## Open TODOs/questions

-   [x] Merge parent PR https://github.com/vivid-planet/comet/pull/3413

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-831
- Inspiration: https://prosopo.io/articles/using-vite-to-rebuild-local-dependencies-in-an-npm-workspace/
