### PR TITLE
Fix spacing for `ListItemIcon` and `ListItemAvatar`

### DIFF
--- a/.changeset/little-comics-look.md
+++ b/.changeset/little-comics-look.md
@@ -1,6 +1,5 @@
 ---
 "@comet/admin-theme": patch
-"@comet/cms-admin": patch
 ---
 
 Fix spacing for `ListItemIcon` and `ListItemAvatar` to align with Comet DXP design

--- a/.changeset/little-comics-look.md
+++ b/.changeset/little-comics-look.md
@@ -1,0 +1,6 @@
+---
+"@comet/admin-theme": patch
+"@comet/cms-admin": patch
+---
+
+Fix spacing for `ListItemIcon` and `ListItemAvatar` to align with Comet DXP design

--- a/packages/admin/admin-theme/src/componentsTheme/MuiListItem.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiListItem.ts
@@ -1,7 +1,7 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiListItem: GetMuiComponentTheme<"MuiListItem"> = (component) => ({
+export const getMuiListItem: GetMuiComponentTheme<"MuiListItem"> = (component, { spacing }) => ({
     ...component,
     defaultProps: {
         dense: true,
@@ -9,7 +9,7 @@ export const getMuiListItem: GetMuiComponentTheme<"MuiListItem"> = (component) =
     },
     styleOverrides: mergeOverrideStyles<"MuiListItem">(component?.styleOverrides, {
         root: {
-            gap: "10px",
+            gap: spacing(2),
         },
     }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiListItemAvatar.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiListItemAvatar.tsx
@@ -1,15 +1,15 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiListItemAvatar: GetMuiComponentTheme<"MuiListItemAvatar"> = (component) => ({
+export const getMuiListItemAvatar: GetMuiComponentTheme<"MuiListItemAvatar"> = (component, { spacing }) => ({
     ...component,
     defaultProps: {
         dense: true,
         ...component?.defaultProps,
     },
-    styleOverrides: mergeOverrideStyles<"MuiListItem">(component?.styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiListItemAvatar">(component?.styleOverrides, {
         root: {
-            gap: "10px",
+            gap: spacing(2),
         },
     }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiListItemAvatar.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiListItemAvatar.tsx
@@ -3,10 +3,6 @@ import { GetMuiComponentTheme } from "./getComponentsTheme";
 
 export const getMuiListItemAvatar: GetMuiComponentTheme<"MuiListItemAvatar"> = (component, { spacing }) => ({
     ...component,
-    defaultProps: {
-        dense: true,
-        ...component?.defaultProps,
-    },
     styleOverrides: mergeOverrideStyles<"MuiListItemAvatar">(component?.styleOverrides, {
         root: {
             gap: spacing(2),

--- a/packages/admin/admin-theme/src/componentsTheme/MuiListItemAvatar.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiListItemAvatar.tsx
@@ -5,7 +5,7 @@ export const getMuiListItemAvatar: GetMuiComponentTheme<"MuiListItemAvatar"> = (
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiListItemAvatar">(component?.styleOverrides, {
         root: {
-            gap: spacing(2),
+            minWidth: 0,
         },
     }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiListItemAvatar.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiListItemAvatar.tsx
@@ -1,7 +1,7 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiListItem: GetMuiComponentTheme<"MuiListItem"> = (component) => ({
+export const getMuiListItemAvatar: GetMuiComponentTheme<"MuiListItemAvatar"> = (component) => ({
     ...component,
     defaultProps: {
         dense: true,

--- a/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
@@ -35,6 +35,7 @@ import { getMuiInputBase } from "./MuiInputBase";
 import { getMuiLinearProgress } from "./MuiLinearProgress";
 import { getMuiLink } from "./MuiLink";
 import { getMuiListItem } from "./MuiListItem";
+import { getMuiListItemAvatar } from "./MuiListItemAvatar";
 import { getMuiListItemIcon } from "./MuiListItemIcon";
 import { getMuiMenu } from "./MuiMenu";
 import { getMuiNativeSelect } from "./MuiNativeSelect";
@@ -101,6 +102,7 @@ export const getComponentsTheme = (components: Components, themeData: ThemeData)
     MuiLink: getMuiLink(components.MuiLink, themeData),
     MuiListItem: getMuiListItem(components.MuiListItem, themeData),
     MuiListItemIcon: getMuiListItemIcon(components.MuiListItemIcon, themeData),
+    MuiListItemAvatar: getMuiListItemAvatar(components.MuiListItemAvatar, themeData),
     MuiMenu: getMuiMenu(components.MuiMenu, themeData),
     MuiNativeSelect: getMuiNativeSelect(components.MuiNativeSelect, themeData),
     MuiPaper: getMuiPaper(components.MuiPaper, themeData),

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
@@ -101,7 +101,7 @@ export function ContentScopeSelect<Value extends ContentScopeInterface = Content
 
             return (
                 <>
-                    <ListItemIcon sx={{ minWidth: "none" }}>
+                    <ListItemIcon>
                         <Domain />
                     </ListItemIcon>
                     <ListItemText


### PR DESCRIPTION
## Description

Refactoring the Menu styling (https://github.com/vivid-planet/comet/pull/3346) caused bugs in the styling of ListItemIcons. Add a gap to match the design. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="355" alt="Screenshot 2025-02-12 at 12 38 45" src="https://github.com/user-attachments/assets/3ee7cca9-de96-4034-a7e8-37ffb379f4e1" /> | <img width="350" alt="Screenshot 2025-02-18 at 09 47 48" src="https://github.com/user-attachments/assets/5afc9af4-9375-4cc5-8efb-34359e6b320a" /> |
| <img width="380" alt="Screenshot 2025-02-12 at 12 38 53" src="https://github.com/user-attachments/assets/b3ad40d8-01c8-4082-af0e-0aaaaf8557a2" /> | <img width="324" alt="Screenshot 2025-02-18 at 09 47 10" src="https://github.com/user-attachments/assets/fd154a49-ea3b-4a45-a853-ffd4c0df2215" /> |






## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1094
