### PR TITLE
Use first available content scope for user as default value

### DIFF
--- a/demo/admin/src/common/ContentScopeProvider.tsx
+++ b/demo/admin/src/common/ContentScopeProvider.tsx
@@ -32,8 +32,16 @@ export const ContentScopeProvider = ({ children }: Pick<ContentScopeProviderProp
         language: { value: contentScope.language, label: contentScope.language.toUpperCase() },
     }));
 
+    if (!user.allowedContentScopes[0]) {
+        throw new Error("User does not have access to any scopes.");
+    }
+    const defaultValue = {
+        domain: user.allowedContentScopes[0].domain,
+        language: user.allowedContentScopes[0].language,
+    };
+
     return (
-        <ContentScopeProviderLibrary<ContentScope> values={values} defaultValue={{ domain: "main", language: "en" }}>
+        <ContentScopeProviderLibrary<ContentScope> values={values} defaultValue={defaultValue}>
             {children}
         </ContentScopeProviderLibrary>
     );


### PR DESCRIPTION
## Description

When a user does not have the defaultScope as permission, only a white page is rendered. This PR redirects the user to the first scope they have access to.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts


https://github.com/user-attachments/assets/634462ff-22e4-4e4d-82e1-6bca0d2c85a1



When the user has no scopes assigned:
Before:
![Screenshot 2025-02-12 at 15 20 35](https://github.com/user-attachments/assets/a922e092-71d9-47f2-b6af-fe13515b20b0)

After:
![Screenshot 2025-02-12 at 15 20 19](https://github.com/user-attachments/assets/b1f221f6-b867-41f7-8495-8eaa208db77a)

Still a white page for the user but that is another topic.

## Open TODOs/questions

-   [x] Add changeset: I don't think a changeset is required here. Please let me know if I'm mistaken.

## Further information

-   Task: There is no task for this, it was noticed in a project and that's why I'm adding it to the demo.
