### PR TITLE
Demo Site: Improve redirecting to main host

### DIFF
--- a/demo/site/src/middleware/redirectToMainHost.ts
+++ b/demo/site/src/middleware/redirectToMainHost.ts
@@ -1,8 +1,25 @@
+import type { PublicSiteConfig } from "@src/site-configs";
 import { getHostByHeaders, getSiteConfigForHost, getSiteConfigs } from "@src/util/siteConfig";
 import { NextRequest, NextResponse } from "next/server";
 
 import { CustomMiddleware } from "./chain";
 
+const normalizeDomain = (host: string) => (host.startsWith("www.") ? host.substring(4) : host);
+
+const matchesHostWithAdditionalDomain = (siteConfig: PublicSiteConfig, host: string) => {
+    if (normalizeDomain(siteConfig.domains.main) === normalizeDomain(host)) return true; // non-www redirect
+    if (siteConfig.domains.additional?.map(normalizeDomain).includes(normalizeDomain(host))) return true;
+    return false;
+};
+
+const matchesHostWithPattern = (siteConfig: PublicSiteConfig, host: string) => {
+    if (!siteConfig.domains.pattern) return false;
+    return host.match(new RegExp(siteConfig.domains.pattern)) !== null;
+};
+
+/**
+ * When http host isn't siteConfig.domains.main (instead .pattern or .additional match), redirect to main host.
+ */
 export function withRedirectToMainHostMiddleware(middleware: CustomMiddleware) {
     return async (request: NextRequest) => {
         const headers = request.headers;
@@ -11,16 +28,14 @@ export function withRedirectToMainHostMiddleware(middleware: CustomMiddleware) {
 
         if (!siteConfig) {
             // Redirect to Main Host
-            const redirectSiteConfig = getSiteConfigs().find(
-                (siteConfig) =>
-                    siteConfig.domains.additional?.includes(host) ||
-                    (siteConfig.domains.pattern && host.match(new RegExp(siteConfig.domains.pattern))),
-            );
+            const redirectSiteConfig =
+                getSiteConfigs().find((siteConfig) => matchesHostWithAdditionalDomain(siteConfig, host)) ||
+                getSiteConfigs().find((siteConfig) => matchesHostWithPattern(siteConfig, host));
             if (redirectSiteConfig) {
-                return NextResponse.redirect(redirectSiteConfig.url);
+                return NextResponse.redirect(redirectSiteConfig.url + request.nextUrl.pathname + request.nextUrl.search, { status: 301 });
             }
 
-            return NextResponse.next({ status: 404 });
+            return NextResponse.json({ error: `Cannot resolve domain: ${host}` }, { status: 404 });
         }
         return middleware(request);
     };

--- a/demo/site/src/middleware/redirectToMainHost.ts
+++ b/demo/site/src/middleware/redirectToMainHost.ts
@@ -14,7 +14,7 @@ const matchesHostWithAdditionalDomain = (siteConfig: PublicSiteConfig, host: str
 
 const matchesHostWithPattern = (siteConfig: PublicSiteConfig, host: string) => {
     if (!siteConfig.domains.pattern) return false;
-    return host.match(new RegExp(siteConfig.domains.pattern)) !== null;
+    return new RegExp(siteConfig.domains.pattern).test(host);
 };
 
 /**


### PR DESCRIPTION
- Show error message when domain not found (https://github.com/vivid-planet/comet-starter/pull/705)
- Redirect from non-www to www-domain without the need of a pattern
- Keep path and query params when redirecting