### PR TITLE
Add comment for omitted `alt`-prop

### DIFF
--- a/.changeset/sixty-radios-switch.md
+++ b/.changeset/sixty-radios-switch.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": minor
+---
+
+Add comment explaining why we omit the `alt`-prop in `PixelImageBlock`

--- a/demo/site-pages/src/common/blocks/DamImageBlock.tsx
+++ b/demo/site-pages/src/common/blocks/DamImageBlock.tsx
@@ -4,6 +4,10 @@ import { ImageProps as NextImageProps } from "next/image";
 
 type DamImageProps = Omit<NextImageProps, "src" | "width" | "height" | "alt"> & {
     aspectRatio: string | "inherit";
+    /**
+     * Do not set an `alt` attribute. The alt text is set in the DAM.
+     */
+    alt?: never;
 };
 
 export const DamImageBlock = withPreview(

--- a/demo/site/src/common/blocks/DamImageBlock.tsx
+++ b/demo/site/src/common/blocks/DamImageBlock.tsx
@@ -5,6 +5,10 @@ import { ImageProps as NextImageProps } from "next/image";
 
 type DamImageProps = Omit<NextImageProps, "src" | "width" | "height" | "alt"> & {
     aspectRatio: string | "inherit";
+    /**
+     * Do not set an `alt` attribute. The alt text is set in the DAM.
+     */
+    alt?: never;
 };
 
 export const DamImageBlock = withPreview(

--- a/packages/site/cms-site/src/blocks/PixelImageBlock.tsx
+++ b/packages/site/cms-site/src/blocks/PixelImageBlock.tsx
@@ -11,6 +11,10 @@ import { PropsWithData } from "./PropsWithData";
 
 interface PixelImageBlockProps extends PropsWithData<PixelImageBlockData>, Omit<ImageProps, "src" | "width" | "height" | "alt"> {
     aspectRatio: string | number | "inherit";
+    /**
+     * Do not set an `alt` attribute. The alt text is set in the DAM.
+     */
+    alt?: never;
 }
 
 export const PixelImageBlock = withPreview(


### PR DESCRIPTION
## Description

In a recent discussion the question arose why we omit the `alt`-prop from `next/image` in `DamImageBlock`. We do this because the alt text should be set by the user in the DAM, not the dev. I've added a non-assignable `alt?: never` prop with a JSDoc explaining this for devs while implementing. What do you think?