### PR TITLE
Demo Site: Add handler for revalidateTag

### DIFF
--- a/demo/site/cache-handler.ts
+++ b/demo/site/cache-handler.ts
@@ -164,4 +164,9 @@ export default class CacheHandler {
         }
         fallbackCache.set(key, value, { size: stringData.length });
     }
+
+    async revalidateTag(tags: string | string[]): Promise<void> {
+        if (tags.length === 0) return;
+        console.warn("CacheHandler.revalidateTag", tags);
+    }
 }


### PR DESCRIPTION
Since it happens that the handler is called with empty arguments only warn on non empty tags. 