### PR TITLE
Add language support for content generation

### DIFF
--- a/.changeset/little-avocados-nail.md
+++ b/.changeset/little-avocados-nail.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Allow passing a language to `generateAltText` and `generateImageTitle`

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -19,6 +19,7 @@ import {
 import { css, Global } from "@emotion/react";
 import { createApolloClient } from "@src/common/apollo/createApolloClient";
 import { ConfigProvider, createConfig } from "@src/config";
+import { ContentScope } from "@src/site-configs";
 import { theme } from "@src/theme";
 import { HTML5toTouch } from "rdndmb-html5-to-touch";
 import { DndProvider } from "react-dnd-multi-backend";
@@ -96,7 +97,7 @@ export function App() {
                                 }}
                             >
                                 <IntlProvider locale="en" messages={getMessages()}>
-                                    <LocaleProvider resolveLocaleForScope={(scope) => scope.domain}>
+                                    <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.language}>
                                         <MuiThemeProvider theme={theme}>
                                             <DndProvider options={HTML5toTouch}>
                                                 <SnackbarProvider>

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -155,13 +155,6 @@ enum KubernetesJobStatus {
   failed
 }
 
-type SeoTags {
-  htmlTitle: String!
-  metaDescription: String!
-  openGraphTitle: String!
-  openGraphDescription: String!
-}
-
 type KubernetesCronJob {
   id: ID!
   name: String!
@@ -1221,9 +1214,6 @@ type Mutation {
   updateDamFolder(id: ID!, input: UpdateDamFolderInput!): DamFolder!
   moveDamFolders(folderIds: [ID!]!, targetFolderId: ID, scope: DamScopeInput!): [DamFolder!]!
   deleteDamFolder(id: ID!): Boolean!
-  generateImageTitle(fileId: String!, language: String): String!
-  generateAltText(fileId: String!, language: String): String!
-  generateSeoTags(content: String!, language: String!): SeoTags!
   createNews(scope: NewsContentScopeInput!, input: NewsInput!): News!
   updateNews(id: ID!, input: NewsUpdateInput!): News!
   deleteNews(id: ID!): Boolean!

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -155,6 +155,13 @@ enum KubernetesJobStatus {
   failed
 }
 
+type SeoTags {
+  htmlTitle: String!
+  metaDescription: String!
+  openGraphTitle: String!
+  openGraphDescription: String!
+}
+
 type KubernetesCronJob {
   id: ID!
   name: String!
@@ -1214,6 +1221,9 @@ type Mutation {
   updateDamFolder(id: ID!, input: UpdateDamFolderInput!): DamFolder!
   moveDamFolders(folderIds: [ID!]!, targetFolderId: ID, scope: DamScopeInput!): [DamFolder!]!
   deleteDamFolder(id: ID!): Boolean!
+  generateImageTitle(fileId: String!, language: String): String!
+  generateAltText(fileId: String!, language: String): String!
+  generateSeoTags(content: String!, language: String!): SeoTags!
   createNews(scope: NewsContentScopeInput!, input: NewsInput!): News!
   updateNews(id: ID!, input: NewsUpdateInput!): News!
   deleteNews(id: ID!): Boolean!

--- a/demo/api/src/content-generation/content-generation.service.ts
+++ b/demo/api/src/content-generation/content-generation.service.ts
@@ -5,15 +5,15 @@ import { Injectable } from "@nestjs/common";
 export class ContentGenerationService implements ContentGenerationServiceInterface {
     constructor(private readonly openAiContentGenerationService: AzureOpenAiContentGenerationService) {}
 
-    async generateAltText(fileId: string) {
-        return this.openAiContentGenerationService.generateAltText(fileId);
+    async generateAltText(fileId: string, options?: { language: string }) {
+        return this.openAiContentGenerationService.generateAltText(fileId, options);
     }
 
-    async generateImageTitle(fileId: string) {
-        return this.openAiContentGenerationService.generateImageTitle(fileId);
+    async generateImageTitle(fileId: string, options?: { language: string }) {
+        return this.openAiContentGenerationService.generateImageTitle(fileId, options);
     }
 
-    async generateSeoTags(content: string) {
-        return this.openAiContentGenerationService.generateSeoTags(content);
+    async generateSeoTags(content: string, options: { language: string }) {
+        return this.openAiContentGenerationService.generateSeoTags(content, options);
     }
 }

--- a/docs/docs/3-features-modules/4-content-generation/index.md
+++ b/docs/docs/3-features-modules/4-content-generation/index.md
@@ -63,11 +63,11 @@ To enable this feature, perform the following steps:
 ```ts
 @Injectable()
 export class ContentGenerationService implements ContentGenerationServiceInterface {
-    async generateAltText(fileId: string) {
+    async generateAltText(fileId: string, options?: { language: string }) {
         // ...
     }
 
-    async generateImageTitle(fileId: string) {
+    async generateImageTitle(fileId: string, options?: { language: string }) {
         // ...
     }
 }
@@ -84,12 +84,12 @@ export class ContentGenerationService implements ContentGenerationServiceInterfa
         private readonly openAiContentGenerationService: AzureOpenAiContentGenerationService,
     ) {}
 
-    async generateAltText(fileId: string) {
-        return this.openAiContentGenerationService.generateAltText(fileId);
+    async generateAltText(fileId: string, options?: { language: string }) {
+        return this.openAiContentGenerationService.generateAltText(fileId, options);
     }
 
-    async generateImageTitle(fileId: string) {
-        return this.openAiContentGenerationService.generateAltText(fileId);
+    async generateImageTitle(fileId: string, options?: { language: string }) {
+        return this.openAiContentGenerationService.generateImageTitle(fileId, options);
     }
 }
 ```
@@ -118,7 +118,7 @@ To enable this feature, perform the following steps:
 ```ts
 @Injectable()
 export class ContentGenerationService implements ContentGenerationServiceInterface {
-    async generateSeoTags(content: string) {
+    async generateSeoTags(content: string, options: { language: string }) {
         // ...
     }
 }
@@ -135,8 +135,8 @@ export class ContentGenerationService implements ContentGenerationServiceInterfa
         private readonly openAiContentGenerationService: AzureOpenAiContentGenerationService,
     ) {}
 
-    async generateSeoTags(content: string) {
-        return this.openAiContentGenerationService.generateSeoTags(content);
+    async generateSeoTags(content: string, options: { language: string }) {
+        return this.openAiContentGenerationService.generateSeoTags(content, options);
     }
 }
 ```

--- a/packages/admin/cms-admin/src/blocks/seo/useSeoTagGeneration.test.tsx
+++ b/packages/admin/cms-admin/src/blocks/seo/useSeoTagGeneration.test.tsx
@@ -10,6 +10,19 @@ jest.mock("../../documents/ContentGenerationConfigContext", () => {
         useContentGenerationConfig: jest.fn(),
     };
 });
+
+jest.mock("../../contentScope/Provider", () => {
+    return {
+        useContentScope: jest.fn(),
+    };
+});
+
+jest.mock("../../locale/useLocale", () => {
+    return {
+        useLocale: jest.fn(),
+    };
+});
+
 jest.mock("@comet/admin", () => {
     return {
         useErrorDialog: jest.fn(),

--- a/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.gql.ts
+++ b/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.gql.ts
@@ -1,13 +1,13 @@
 import { gql } from "@apollo/client";
 
 export const generateAltTextMutation = gql`
-    mutation GenerateAltText($fileId: String!) {
-        generateAltText(fileId: $fileId)
+    mutation GenerateAltText($fileId: String!, $language: String!) {
+        generateAltText(fileId: $fileId, language: $language)
     }
 `;
 
 export const generateImageTitleMutation = gql`
-    mutation GenerateImageTitle($fileId: String!) {
-        generateImageTitle(fileId: $fileId)
+    mutation GenerateImageTitle($fileId: String!, $language: String!) {
+        generateImageTitle(fileId: $fileId, language: $language)
     }
 `;

--- a/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
@@ -8,6 +8,8 @@ import { useCallback } from "react";
 import { useForm } from "react-final-form";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { useContentScope } from "../../contentScope/Provider";
+import { useLocale } from "../../locale/useLocale";
 import { useDamConfig } from "../config/useDamConfig";
 import { useDamScope } from "../config/useDamScope";
 import { slugifyFilename } from "../helpers/slugifyFilename";
@@ -42,6 +44,9 @@ export const FileSettingsFields = ({ file }: SettingsFormProps) => {
     const damConfig = useDamConfig();
     const formApi = useForm();
     const { contentGeneration } = useDamConfig();
+    const contentScope = useContentScope();
+    const locale = useLocale(contentScope);
+
     const damIsFilenameOccupied = useCallback(
         async (filename: string): Promise<boolean> => {
             const { data } = await apollo.query<GQLDamIsFilenameOccupiedQuery, GQLDamIsFilenameOccupiedQueryVariables>({
@@ -139,7 +144,7 @@ export const FileSettingsFields = ({ file }: SettingsFormProps) => {
                             <IconButton
                                 color="primary"
                                 onClick={async () => {
-                                    const { data } = await generateAltText({ variables: { fileId: file.id } });
+                                    const { data } = await generateAltText({ variables: { fileId: file.id, language: locale } });
                                     formApi.change("altText", data?.generateAltText);
                                 }}
                             >
@@ -162,7 +167,7 @@ export const FileSettingsFields = ({ file }: SettingsFormProps) => {
                             <IconButton
                                 color="primary"
                                 onClick={async () => {
-                                    const { data } = await generateImageTitle({ variables: { fileId: file.id } });
+                                    const { data } = await generateImageTitle({ variables: { fileId: file.id, language: locale } });
                                     formApi.change("title", data?.generateImageTitle);
                                 }}
                             >

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -559,9 +559,9 @@ type Mutation {
   userPermissionsDeletePermission(id: ID!): Boolean!
   userPermissionsUpdateOverrideContentScopes(input: UserPermissionOverrideContentScopesInput!): UserPermission!
   userPermissionsUpdateContentScopes(userId: String!, input: UserContentScopesInput!): Boolean!
-  generateAltText(fileId: String!): String!
-  generateImageTitle(fileId: String!): String!
-  generateSeoTags(content: String!): SeoTags!
+  generateAltText(fileId: String!, language: String): String!
+  generateImageTitle(fileId: String!, language: String): String!
+  generateSeoTags(content: String!, language: String!): SeoTags!
 }
 
 input CreateBuildsInput {

--- a/packages/api/cms-api/src/content-generation/azure-open-ai/azure-open-ai-content-generation.service.ts
+++ b/packages/api/cms-api/src/content-generation/azure-open-ai/azure-open-ai-content-generation.service.ts
@@ -53,7 +53,8 @@ export class AzureOpenAiContentGenerationService implements ContentGenerationSer
         });
     }
 
-    async generateAltText(fileId: string): Promise<string> {
+    async generateAltText(fileId: string, options?: { language: string }): Promise<string> {
+        const language = options?.language ?? "en";
         const config = this.getConfigForMethod("generateAltText");
 
         const file = await this.filesService.findOneById(fileId);
@@ -66,8 +67,7 @@ export class AzureOpenAiContentGenerationService implements ContentGenerationSer
         const prompt: Array<ChatCompletionMessageParam> = [
             {
                 role: "system",
-                content:
-                    "You are an expert in writing alternative text for HTML images. The user will provide you with an image and your job is to provide an alternative text for this image. This text should help visually impaired users understand the content of the image. Keep yourself to a short description, ideally 3 sentences or less. Don't put the text in quotation marks.",
+                content: `You are an expert in writing alternative text for HTML images. The user will provide you with an image and your job is to provide an alternative text for this image. This text should help visually impaired users understand the content of the image. Keep yourself to a short description, ideally 3 sentences or less. Don't put the text in quotation marks. Answer in the language "${language}".`,
             },
             {
                 role: "user",
@@ -82,11 +82,13 @@ export class AzureOpenAiContentGenerationService implements ContentGenerationSer
                 ],
             },
         ];
+
         const result = await client.chat.completions.create({ messages: prompt, model: "", max_tokens: 300 });
         return result.choices[0].message?.content ?? "";
     }
 
-    async generateImageTitle(fileId: string): Promise<string> {
+    async generateImageTitle(fileId: string, options?: { language: string }): Promise<string> {
+        const language = options?.language ?? "en";
         const config = this.getConfigForMethod("generateImageTitle");
 
         const file = await this.filesService.findOneById(fileId);
@@ -99,8 +101,7 @@ export class AzureOpenAiContentGenerationService implements ContentGenerationSer
         const prompt: Array<ChatCompletionMessageParam> = [
             {
                 role: "system",
-                content:
-                    "The user will provide you with an image. Write a short text that can be displayed in the HTML title attribute of this image. Do not put the title inside quotation marks",
+                content: `The user will provide you with an image. Write a short text that can be displayed in the HTML title attribute of this image. Do not put the title inside quotation marks. Answer in the language "${language}".`,
             },
             {
                 role: "user",
@@ -119,7 +120,7 @@ export class AzureOpenAiContentGenerationService implements ContentGenerationSer
         return result.choices[0].message?.content ?? "";
     }
 
-    async generateSeoTags(content: string): Promise<SeoTags> {
+    async generateSeoTags(content: string, { language }: { language: string }): Promise<SeoTags> {
         const config = this.getConfigForMethod("generateSeoTags");
 
         const client = this.createClient(config);
@@ -136,7 +137,7 @@ export class AzureOpenAiContentGenerationService implements ContentGenerationSer
                         "openGraphDescription": "",
                     }
                     
-                    Only answer in valid JSON. Don't put the JSON in quotation marks or markdown. Don't include any placeholders.
+                    Only answer in valid JSON. Don't put the JSON in quotation marks or markdown. Don't include any placeholders. Answer in the language "${language}".
                     `,
             },
             {

--- a/packages/api/cms-api/src/content-generation/content-generation-service.interface.ts
+++ b/packages/api/cms-api/src/content-generation/content-generation-service.interface.ts
@@ -2,9 +2,9 @@ import { Field, ObjectType } from "@nestjs/graphql";
 import { IsString } from "class-validator";
 
 export interface ContentGenerationServiceInterface {
-    generateAltText?(fileId: string): Promise<string>;
-    generateImageTitle?(fileId: string): Promise<string>;
-    generateSeoTags?(content: string): Promise<SeoTags>;
+    generateAltText?(fileId: string, options?: { language: string }): Promise<string>;
+    generateImageTitle?(fileId: string, options?: { language: string }): Promise<string>;
+    generateSeoTags?(content: string, options: { language: string }): Promise<SeoTags>;
 }
 
 @ObjectType()

--- a/packages/api/cms-api/src/content-generation/generate-alt-text.resolver.ts
+++ b/packages/api/cms-api/src/content-generation/generate-alt-text.resolver.ts
@@ -8,7 +8,7 @@ import { CONTENT_GENERATION_SERVICE } from "./content-generation.constants";
 import { ContentGenerationServiceInterface } from "./content-generation-service.interface";
 
 @ArgsType()
-export class GenerateAltTextArgs {
+class GenerateAltTextArgs {
     @IsUUID()
     @Field(() => String)
     fileId: string;

--- a/packages/api/cms-api/src/content-generation/generate-alt-text.resolver.ts
+++ b/packages/api/cms-api/src/content-generation/generate-alt-text.resolver.ts
@@ -11,8 +11,11 @@ export class GenerateAltTextResolver {
 
     @RequiredPermission(["dam"], { skipScopeCheck: true })
     @Mutation(() => String)
-    async generateAltText(@Args("fileId", { type: () => String }) fileId: string): Promise<string> {
-        const altText = await this.contentGenerationService.generateAltText?.(fileId);
+    async generateAltText(
+        @Args("fileId", { type: () => String }) fileId: string,
+        @Args("language", { type: () => String, nullable: true }) language?: string,
+    ): Promise<string> {
+        const altText = await this.contentGenerationService.generateAltText?.(fileId, { language: language ?? "en" });
         if (!altText) throw new Error("Alt text generation failed or is not supported");
         return altText;
     }

--- a/packages/api/cms-api/src/content-generation/generate-alt-text.resolver.ts
+++ b/packages/api/cms-api/src/content-generation/generate-alt-text.resolver.ts
@@ -1,9 +1,23 @@
 import { Inject } from "@nestjs/common";
-import { Args, Mutation, Resolver } from "@nestjs/graphql";
+import { Args, ArgsType, Field, Mutation, Resolver } from "@nestjs/graphql";
+import { IsLocale, IsUUID } from "class-validator";
 
+import { IsUndefinable } from "../common/validators/is-undefinable";
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { CONTENT_GENERATION_SERVICE } from "./content-generation.constants";
 import { ContentGenerationServiceInterface } from "./content-generation-service.interface";
+
+@ArgsType()
+export class GenerateAltTextArgs {
+    @IsUUID()
+    @Field(() => String)
+    fileId: string;
+
+    @IsUndefinable()
+    @IsLocale()
+    @Field(() => String, { nullable: true })
+    language?: string;
+}
 
 @Resolver()
 export class GenerateAltTextResolver {
@@ -11,10 +25,7 @@ export class GenerateAltTextResolver {
 
     @RequiredPermission(["dam"], { skipScopeCheck: true })
     @Mutation(() => String)
-    async generateAltText(
-        @Args("fileId", { type: () => String }) fileId: string,
-        @Args("language", { type: () => String, nullable: true }) language?: string,
-    ): Promise<string> {
+    async generateAltText(@Args() { fileId, language }: GenerateAltTextArgs): Promise<string> {
         const altText = await this.contentGenerationService.generateAltText?.(fileId, { language: language ?? "en" });
         if (!altText) throw new Error("Alt text generation failed or is not supported");
         return altText;

--- a/packages/api/cms-api/src/content-generation/generate-image-title.resolver.ts
+++ b/packages/api/cms-api/src/content-generation/generate-image-title.resolver.ts
@@ -11,8 +11,11 @@ export class GenerateImageTitleResolver {
 
     @RequiredPermission(["dam"], { skipScopeCheck: true })
     @Mutation(() => String)
-    async generateImageTitle(@Args("fileId", { type: () => String }) fileId: string): Promise<string> {
-        const imageTitle = await this.contentGenerationService.generateImageTitle?.(fileId);
+    async generateImageTitle(
+        @Args("fileId", { type: () => String }) fileId: string,
+        @Args("language", { type: () => String, nullable: true }) language?: string,
+    ): Promise<string> {
+        const imageTitle = await this.contentGenerationService.generateImageTitle?.(fileId, { language: language ?? "en" });
         if (!imageTitle) throw new Error("Image title generation failed or is not supported");
         return imageTitle;
     }

--- a/packages/api/cms-api/src/content-generation/generate-image-title.resolver.ts
+++ b/packages/api/cms-api/src/content-generation/generate-image-title.resolver.ts
@@ -8,7 +8,7 @@ import { CONTENT_GENERATION_SERVICE } from "./content-generation.constants";
 import { ContentGenerationServiceInterface } from "./content-generation-service.interface";
 
 @ArgsType()
-export class GenerateImageTitleArgs {
+class GenerateImageTitleArgs {
     @IsUUID()
     @Field(() => String)
     fileId: string;

--- a/packages/api/cms-api/src/content-generation/generate-image-title.resolver.ts
+++ b/packages/api/cms-api/src/content-generation/generate-image-title.resolver.ts
@@ -1,9 +1,23 @@
 import { Inject } from "@nestjs/common";
-import { Args, Mutation, Resolver } from "@nestjs/graphql";
+import { Args, ArgsType, Field, Mutation, Resolver } from "@nestjs/graphql";
+import { IsLocale, IsUUID } from "class-validator";
 
+import { IsUndefinable } from "../common/validators/is-undefinable";
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { CONTENT_GENERATION_SERVICE } from "./content-generation.constants";
 import { ContentGenerationServiceInterface } from "./content-generation-service.interface";
+
+@ArgsType()
+export class GenerateImageTitleArgs {
+    @IsUUID()
+    @Field(() => String)
+    fileId: string;
+
+    @IsUndefinable()
+    @IsLocale()
+    @Field(() => String, { nullable: true })
+    language?: string;
+}
 
 @Resolver()
 export class GenerateImageTitleResolver {
@@ -11,10 +25,7 @@ export class GenerateImageTitleResolver {
 
     @RequiredPermission(["dam"], { skipScopeCheck: true })
     @Mutation(() => String)
-    async generateImageTitle(
-        @Args("fileId", { type: () => String }) fileId: string,
-        @Args("language", { type: () => String, nullable: true }) language?: string,
-    ): Promise<string> {
+    async generateImageTitle(@Args() { fileId, language }: GenerateImageTitleArgs): Promise<string> {
         const imageTitle = await this.contentGenerationService.generateImageTitle?.(fileId, { language: language ?? "en" });
         if (!imageTitle) throw new Error("Image title generation failed or is not supported");
         return imageTitle;

--- a/packages/api/cms-api/src/content-generation/generate-seo-tags.resolver.ts
+++ b/packages/api/cms-api/src/content-generation/generate-seo-tags.resolver.ts
@@ -1,9 +1,21 @@
 import { Inject } from "@nestjs/common";
-import { Args, Mutation, Resolver } from "@nestjs/graphql";
+import { Args, ArgsType, Field, Mutation, Resolver } from "@nestjs/graphql";
+import { IsLocale, IsString } from "class-validator";
 
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { CONTENT_GENERATION_SERVICE } from "./content-generation.constants";
 import { ContentGenerationServiceInterface, SeoTags } from "./content-generation-service.interface";
+
+@ArgsType()
+export class GenerateSeoTagsArgs {
+    @IsString()
+    @Field(() => String)
+    content: string;
+
+    @IsLocale()
+    @Field(() => String)
+    language: string;
+}
 
 @Resolver()
 export class GenerateSeoTagsResolver {
@@ -11,10 +23,7 @@ export class GenerateSeoTagsResolver {
 
     @RequiredPermission(["pageTree"], { skipScopeCheck: true })
     @Mutation(() => SeoTags)
-    async generateSeoTags(
-        @Args("content", { type: () => String }) content: string,
-        @Args("language", { type: () => String }) language: string,
-    ): Promise<SeoTags> {
+    async generateSeoTags(@Args() { content, language }: GenerateSeoTagsArgs): Promise<SeoTags> {
         const seoTags = await this.contentGenerationService.generateSeoTags?.(content, { language });
         if (!seoTags) throw new Error("SEO tag generation failed or is not supported");
         return seoTags;

--- a/packages/api/cms-api/src/content-generation/generate-seo-tags.resolver.ts
+++ b/packages/api/cms-api/src/content-generation/generate-seo-tags.resolver.ts
@@ -7,7 +7,7 @@ import { CONTENT_GENERATION_SERVICE } from "./content-generation.constants";
 import { ContentGenerationServiceInterface, SeoTags } from "./content-generation-service.interface";
 
 @ArgsType()
-export class GenerateSeoTagsArgs {
+class GenerateSeoTagsArgs {
     @IsString()
     @Field(() => String)
     content: string;

--- a/packages/api/cms-api/src/content-generation/generate-seo-tags.resolver.ts
+++ b/packages/api/cms-api/src/content-generation/generate-seo-tags.resolver.ts
@@ -11,8 +11,11 @@ export class GenerateSeoTagsResolver {
 
     @RequiredPermission(["pageTree"], { skipScopeCheck: true })
     @Mutation(() => SeoTags)
-    async generateSeoTags(@Args("content", { type: () => String }) content: string): Promise<SeoTags> {
-        const seoTags = await this.contentGenerationService.generateSeoTags?.(content);
+    async generateSeoTags(
+        @Args("content", { type: () => String }) content: string,
+        @Args("language", { type: () => String }) language: string,
+    ): Promise<SeoTags> {
+        const seoTags = await this.contentGenerationService.generateSeoTags?.(content, { language });
         if (!seoTags) throw new Error("SEO tag generation failed or is not supported");
         return seoTags;
     }


### PR DESCRIPTION
## Description

- Fix usage of `LocaleProvider` in Demo
- Allow passing a language to `generateAltText`, `generateImageTitle` and `generateSeoTags`

Note:  I made the language optional for `generateAltText` and `generateImageTitle` because these methods already existed -> would be a breaking change. For `generateSeoTags` it's required. I want to merge this change to `next` ASAP and make it required for all methods.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts


https://github.com/user-attachments/assets/db66d946-1be5-4d85-9591-b208fe207151

Note: I used the same English text for English and German to show that the generation language doesn't depend on the content language but the scope

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1622
