### PR TITLE
Add changeset for SEO tag generation

### DIFF
--- a/.changeset/proud-panthers-buy.md
+++ b/.changeset/proud-panthers-buy.md
@@ -1,0 +1,17 @@
+---
+"@comet/blocks-admin": minor
+"@comet/admin-rte": minor
+"@comet/cms-admin": minor
+"@comet/cms-api": minor
+---
+
+Add content generation capabilities to `createSeoBlock`
+
+The SeoBlock (when created using the `createSeoBlock` factory) now supports automatic generation of
+
+-   HTML title
+-   Meta description
+-   OpenGraph title
+-   OpenGraph description
+
+For instructions on how to enable this feature see https://docs.comet-dxp.com/docs/features-modules/content-generation/

--- a/.changeset/proud-panthers-buy.md
+++ b/.changeset/proud-panthers-buy.md
@@ -7,11 +7,11 @@
 
 Add content generation capabilities to `createSeoBlock`
 
-The SeoBlock (when created using the `createSeoBlock` factory) now supports automatic generation of
+The SEO block (when created using the `createSeoBlock` factory) now supports automatic generation of:
 
 -   HTML title
 -   Meta description
--   OpenGraph title
--   OpenGraph description
+-   Open Graph title
+-   Open Graph description
 
-For instructions on how to enable this feature see https://docs.comet-dxp.com/docs/features-modules/content-generation/
+See the [docs](https://docs.comet-dxp.com/docs/features-modules/content-generation/) for instructions on enabling this feature.


### PR DESCRIPTION
## Description

Add content generation capabilities to `createSeoBlock`

The SEO block (when created using the `createSeoBlock` factory) now supports automatic generation of:

-   HTML title
-   Meta description
-   Open Graph title
-   Open Graph description

See the [docs](https://docs.comet-dxp.com/docs/features-modules/content-generation/) for instructions on enabling this feature.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-899
