### PR TITLE
Scope-specific blocks: local filter function

### DIFF
--- a/demo/admin/src/documents/pages/blocks/PageContentBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/PageContentBlock.tsx
@@ -21,30 +21,31 @@ import { FullWidthImageBlock } from "./FullWidthImageBlock";
 import { KeyFactsBlock } from "./KeyFactsBlock";
 import { TeaserBlock } from "./TeaserBlock";
 
+const supportedBlocks = {
+    accordion: AccordionBlock,
+    anchor: AnchorBlock,
+    billboardTeaser: BillboardTeaserBlock,
+    space: SpaceBlock,
+    teaser: TeaserBlock,
+    richtext: RichTextBlock,
+    heading: StandaloneHeadingBlock,
+    columns: ColumnsBlock,
+    callToActionList: StandaloneCallToActionListBlock,
+    keyFacts: KeyFactsBlock,
+    media: StandaloneMediaBlock,
+    contentGroup: ContentGroupBlock,
+    mediaGallery: MediaGalleryBlock,
+    image: DamImageBlock,
+    newsDetail: NewsDetailBlock,
+    newsList: NewsListBlock,
+    layout: LayoutBlock,
+    textImage: TextImageBlock,
+    fullWidthImage: FullWidthImageBlock,
+};
+
 export const PageContentBlock = createBlocksBlock({
     name: "PageContent",
-    supportedBlocks: {
-        accordion: AccordionBlock,
-        anchor: AnchorBlock,
-        billboardTeaser: BillboardTeaserBlock,
-        space: SpaceBlock,
-        teaser: TeaserBlock,
-        richtext: RichTextBlock,
-        heading: StandaloneHeadingBlock,
-        columns: ColumnsBlock,
-        callToActionList: StandaloneCallToActionListBlock,
-        keyFacts: KeyFactsBlock,
-        media: StandaloneMediaBlock,
-        contentGroup: ContentGroupBlock,
-        mediaGallery: MediaGalleryBlock,
-
-        image: DamImageBlock,
-        newsDetail: NewsDetailBlock,
-        newsList: NewsListBlock,
-        layout: LayoutBlock,
-        textImage: TextImageBlock,
-        fullWidthImage: FullWidthImageBlock,
-    },
+    supportedBlocks,
     additionalItemFields: {
         ...userGroupAdditionalItemFields,
     },
@@ -53,5 +54,13 @@ export const PageContentBlock = createBlocksBlock({
     },
     AdditionalItemContent: ({ item }) => {
         return <UserGroupChip item={item} />;
+    },
+    filterBlocksForScope: (scope) => {
+        if (scope.domain === "main") {
+            return supportedBlocks;
+        } else {
+            const { newsDetail, newsList, ...filteredBlocks } = supportedBlocks;
+            return filteredBlocks;
+        }
     },
 });


### PR DESCRIPTION
## Description

We want to support scope-specific blocks in the Admin.
This PR introduces a filter function for the BlocksBlock.

**Advantages**
- Can be different for every block

**Disadvantages**
- Needs to be implemented for every block

Note: It would be possible to change `supportedBlocks` to `Record<string, BlockInterface> | (scope) => Record<string, BlockInterface>`, removing the additional function. However, since this requires a lot of effort, I'd like to decide on which approach to use first.

## Open TODOs/questions

- [x] Decide between this PR and https://github.com/vivid-planet/comet/pull/3463
- [ ] Add changeset


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-692
