### PR TITLE
Add on save creating and resolving warnings

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -1616,12 +1616,22 @@ input WarningInput {
   message: String!
   type: String!
   severity: WarningSeverity!
+  dependencyInfo: WarningDependencyInfoInput!
   status: WarningStatus! = open
+}
+
+input WarningDependencyInfoInput {
+  rootEntityName: String!
+  rootColumnName: String!
+  rootPrimaryKey: String!
+  targetId: String!
+  jsonPath: String!
 }
 
 input WarningUpdateInput {
   message: String
   type: String
   severity: WarningSeverity
+  dependencyInfo: WarningDependencyInfoInput
   status: WarningStatus
 }

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -1616,11 +1616,11 @@ input WarningInput {
   message: String!
   type: String!
   severity: WarningSeverity!
-  dependencyInfo: WarningDependencyInfoInput!
+  sourceInfo: WarningSourceInfoInput!
   status: WarningStatus! = open
 }
 
-input WarningDependencyInfoInput {
+input WarningSourceInfoInput {
   rootEntityName: String!
   rootColumnName: String!
   rootPrimaryKey: String!
@@ -1632,6 +1632,6 @@ input WarningUpdateInput {
   message: String
   type: String
   severity: WarningSeverity
-  dependencyInfo: WarningDependencyInfoInput
+  sourceInfo: WarningSourceInfoInput
   status: WarningStatus
 }

--- a/demo/api/src/db/migrations/Migration20250218090446.ts
+++ b/demo/api/src/db/migrations/Migration20250218090446.ts
@@ -3,6 +3,6 @@ import { Migration } from '@mikro-orm/migrations';
 export class Migration20250218090446 extends Migration {
 
   async up(): Promise<void> {
-    this.addSql('alter table "Warning" add column "dependencyInfo" jsonb not null;');
+    this.addSql('alter table "Warning" add column "sourceInfo" jsonb not null;');
   }
 }

--- a/demo/api/src/db/migrations/Migration20250218090446.ts
+++ b/demo/api/src/db/migrations/Migration20250218090446.ts
@@ -1,0 +1,8 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20250218090446 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "Warning" add column "dependencyInfo" jsonb not null;');
+  }
+}

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -6,7 +6,6 @@ import {
     EntityInfo,
     RootBlock,
     RootBlockDataScalar,
-    RootBlockEntity,
     RootBlockType,
 } from "@comet/cms-api";
 import { BaseEntity, Collection, Embeddable, Embedded, Entity, Enum, OneToMany, OptionalProps, PrimaryKey, Property } from "@mikro-orm/postgresql";
@@ -48,7 +47,6 @@ export class NewsContentScope {
 }
 
 @EntityInfo<News>((news) => ({ name: news.title, secondaryInformation: news.slug }))
-@RootBlockEntity()
 @ObjectType()
 @Entity()
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/` })

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -6,6 +6,7 @@ import {
     EntityInfo,
     RootBlock,
     RootBlockDataScalar,
+    RootBlockEntity,
     RootBlockType,
 } from "@comet/cms-api";
 import { BaseEntity, Collection, Embeddable, Embedded, Entity, Enum, OneToMany, OptionalProps, PrimaryKey, Property } from "@mikro-orm/postgresql";
@@ -47,6 +48,7 @@ export class NewsContentScope {
 }
 
 @EntityInfo<News>((news) => ({ name: news.title, secondaryInformation: news.slug }))
+@RootBlockEntity()
 @ObjectType()
 @Entity()
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/` })

--- a/demo/api/src/warnings/dto/warning-dependency-info.ts
+++ b/demo/api/src/warnings/dto/warning-dependency-info.ts
@@ -2,8 +2,8 @@ import { Property } from "@mikro-orm/core";
 import { Field, InputType, ObjectType } from "@nestjs/graphql";
 
 @ObjectType()
-@InputType("WarningDependencyInfoInput")
-export class WarningDependencyInfo {
+@InputType("WarningSourceInfoInput")
+export class WarningSourceInfo {
     @Property()
     @Field()
     rootEntityName: string;

--- a/demo/api/src/warnings/dto/warning-dependency-info.ts
+++ b/demo/api/src/warnings/dto/warning-dependency-info.ts
@@ -1,0 +1,26 @@
+import { Property } from "@mikro-orm/core";
+import { Field, InputType, ObjectType } from "@nestjs/graphql";
+
+@ObjectType()
+@InputType("WarningDependencyInfoInput")
+export class WarningDependencyInfo {
+    @Property()
+    @Field()
+    rootEntityName: string;
+
+    @Property()
+    @Field()
+    rootColumnName: string;
+
+    @Property()
+    @Field()
+    rootPrimaryKey: string;
+
+    @Property()
+    @Field()
+    targetId: string;
+
+    @Property()
+    @Field()
+    jsonPath: string;
+}

--- a/demo/api/src/warnings/entities/warning.entity.ts
+++ b/demo/api/src/warnings/entities/warning.entity.ts
@@ -3,7 +3,7 @@ import { BaseEntity, Entity, Enum, OptionalProps, PrimaryKey, Property } from "@
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
 
-import { WarningDependencyInfo } from "../dto/warning-dependency-info";
+import { WarningSourceInfo } from "../dto/warning-dependency-info";
 import { WarningSeverity } from "./warning-severity.enum";
 import { WarningStatus } from "./warning-status.enum";
 
@@ -41,7 +41,7 @@ export class Warning extends BaseEntity {
 
     @Property({ type: "jsonb" })
     @CrudField()
-    dependencyInfo: WarningDependencyInfo;
+    sourceInfo: WarningSourceInfo;
 
     @Enum({ items: () => WarningStatus })
     @Field(() => WarningStatus)

--- a/demo/api/src/warnings/entities/warning.entity.ts
+++ b/demo/api/src/warnings/entities/warning.entity.ts
@@ -1,14 +1,14 @@
-import { CrudField, CrudGenerator, RootBlockEntity } from "@comet/cms-api";
+import { CrudField, CrudGenerator } from "@comet/cms-api";
 import { BaseEntity, Entity, Enum, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
 
+import { WarningDependencyInfo } from "../dto/warning-dependency-info";
 import { WarningSeverity } from "./warning-severity.enum";
 import { WarningStatus } from "./warning-status.enum";
 
 @ObjectType()
 @Entity()
-@RootBlockEntity<Warning>()
 @CrudGenerator({ targetDirectory: `${__dirname}/../generated/`, requiredPermission: ["warnings"] })
 export class Warning extends BaseEntity {
     [OptionalProps]?: "createdAt" | "updatedAt" | "status";
@@ -39,7 +39,9 @@ export class Warning extends BaseEntity {
     @Field(() => WarningSeverity)
     severity: WarningSeverity;
 
-    // TODO: add blockInfos with COM-958
+    @Property({ type: "jsonb" })
+    @CrudField()
+    dependencyInfo: WarningDependencyInfo;
 
     @Enum({ items: () => WarningStatus })
     @Field(() => WarningStatus)

--- a/demo/api/src/warnings/generated/dto/warning.input.ts
+++ b/demo/api/src/warnings/generated/dto/warning.input.ts
@@ -5,7 +5,7 @@ import { Field, InputType } from "@nestjs/graphql";
 import { Type } from "class-transformer";
 import { IsEnum, IsNotEmpty, IsString, ValidateNested } from "class-validator";
 
-import { WarningDependencyInfo } from "../../dto/warning-dependency-info";
+import { WarningSourceInfo } from "../../dto/warning-dependency-info";
 import { WarningSeverity } from "../../entities/warning-severity.enum";
 import { WarningStatus } from "../../entities/warning-status.enum";
 
@@ -28,9 +28,9 @@ export class WarningInput {
 
     @IsNotEmpty()
     @ValidateNested()
-    @Type(() => WarningDependencyInfo)
-    @Field(() => WarningDependencyInfo)
-    dependencyInfo: WarningDependencyInfo;
+    @Type(() => WarningSourceInfo)
+    @Field(() => WarningSourceInfo)
+    sourceInfo: WarningSourceInfo;
 
     @IsNotEmpty()
     @IsEnum(WarningStatus)

--- a/demo/api/src/warnings/generated/dto/warning.input.ts
+++ b/demo/api/src/warnings/generated/dto/warning.input.ts
@@ -2,8 +2,10 @@
 // You may choose to use this file as scaffold by moving this file out of generated folder and removing this comment.
 import { PartialType } from "@comet/cms-api";
 import { Field, InputType } from "@nestjs/graphql";
-import { IsEnum, IsNotEmpty, IsString } from "class-validator";
+import { Type } from "class-transformer";
+import { IsEnum, IsNotEmpty, IsString, ValidateNested } from "class-validator";
 
+import { WarningDependencyInfo } from "../../dto/warning-dependency-info";
 import { WarningSeverity } from "../../entities/warning-severity.enum";
 import { WarningStatus } from "../../entities/warning-status.enum";
 
@@ -23,6 +25,12 @@ export class WarningInput {
     @IsEnum(WarningSeverity)
     @Field(() => WarningSeverity)
     severity: WarningSeverity;
+
+    @IsNotEmpty()
+    @ValidateNested()
+    @Type(() => WarningDependencyInfo)
+    @Field(() => WarningDependencyInfo)
+    dependencyInfo: WarningDependencyInfo;
 
     @IsNotEmpty()
     @IsEnum(WarningStatus)

--- a/demo/api/src/warnings/warning-checker.command.ts
+++ b/demo/api/src/warnings/warning-checker.command.ts
@@ -74,7 +74,7 @@ export class WarningCheckerCommand extends CommandRunner {
                                 for (const warning of warnings) {
                                     this.warningService.saveWarning({
                                         warning,
-                                        dependencyInfo: {
+                                        sourceInfo: {
                                             rootEntityName: tableName,
                                             rootColumnName: column,
                                             rootPrimaryKey: data.primaryKey,

--- a/demo/api/src/warnings/warning-checker.command.ts
+++ b/demo/api/src/warnings/warning-checker.command.ts
@@ -60,8 +60,7 @@ export class WarningCheckerCommand extends CommandRunner {
                 rootBlocks = (await queryBuilder.getResult()) as RootBlockData[];
                 for (const { column, block } of rootBlockData) {
                     for (const rootBlock of rootBlocks) {
-                        if (typeof rootBlock[column] === "string") continue;
-                        const blockData = rootBlock[column];
+                        const blockData = rootBlock[column] as BlockData;
 
                         const flatBlocks = new FlatBlocks(blockData, {
                             name: block.name,

--- a/demo/api/src/warnings/warning-event-subscriber.ts
+++ b/demo/api/src/warnings/warning-event-subscriber.ts
@@ -1,0 +1,66 @@
+import { FlatBlocks } from "@comet/cms-api";
+import { EntityName, EventArgs, EventSubscriber } from "@mikro-orm/core";
+import { EntityClass, EntityManager, MikroORM } from "@mikro-orm/postgresql";
+import { Injectable } from "@nestjs/common";
+import { WarningService } from "@src/warnings/warning.service";
+
+@Injectable()
+export class WarningEventSubscriber implements EventSubscriber {
+    constructor(
+        readonly entityManager: EntityManager,
+        private readonly orm: MikroORM,
+        private readonly warningService: WarningService,
+    ) {
+        entityManager.getEventManager().registerSubscriber(this);
+    }
+
+    getSubscribedEntities(): EntityName<unknown>[] {
+        const rootBlockEntities: EntityName<unknown>[] = [];
+
+        const entities = this.orm.config.get("entities") as EntityClass<unknown>[];
+        for (const entity of entities) {
+            const rootBlockEntityOptions = Reflect.getMetadata(`data:rootBlockEntityOptions`, entity);
+
+            if (rootBlockEntityOptions) {
+                rootBlockEntities.push(entity);
+            }
+        }
+        return rootBlockEntities;
+    }
+
+    async afterUpdate(args: EventArgs<unknown>): Promise<void> {
+        return this.handleUpdateAndCreate(args);
+    }
+
+    async afterCreate(args: EventArgs<unknown>): Promise<void> {
+        return this.handleUpdateAndCreate(args);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private async handleUpdateAndCreate(args: EventArgs<any>): Promise<void> {
+        const entity = args.meta.class;
+
+        if (entity) {
+            const keys = Reflect.getMetadata(`keys:rootBlock`, entity.prototype) || [];
+            for (const key of keys) {
+                const block = Reflect.getMetadata(`data:rootBlock`, entity.prototype, key);
+
+                const flatBlocks = new FlatBlocks(args.entity[key], {
+                    name: block.name,
+                    visible: true,
+                    rootPath: "root",
+                });
+                for (const node of flatBlocks.depthFirst()) {
+                    const warnings = node.block.warnings();
+                    await this.warningService.updateWarningsForBlock(warnings, {
+                        rootEntityName: entity.name,
+                        rootColumnName: key,
+                        targetId: args.entity.id,
+                        rootPrimaryKey: args.meta.primaryKeys[0],
+                        jsonPath: node.pathToString(),
+                    });
+                }
+            }
+        }
+    }
+}

--- a/demo/api/src/warnings/warning.module.ts
+++ b/demo/api/src/warnings/warning.module.ts
@@ -3,10 +3,13 @@ import { Module } from "@nestjs/common";
 
 import { Warning } from "./entities/warning.entity";
 import { WarningResolver } from "./generated/warning.resolver";
+import { WarningService } from "./warning.service";
 import { WarningCheckerCommand } from "./warning-checker.command";
+import { WarningEventSubscriber } from "./warning-event-subscriber";
 
 @Module({
     imports: [MikroOrmModule.forFeature([Warning])],
-    providers: [WarningResolver, WarningCheckerCommand],
+    providers: [WarningResolver, WarningCheckerCommand, WarningService, WarningEventSubscriber],
+    exports: [WarningService],
 })
 export class WarningsModule {}

--- a/demo/api/src/warnings/warning.service.ts
+++ b/demo/api/src/warnings/warning.service.ts
@@ -1,0 +1,52 @@
+import { BlockWarning } from "@comet/cms-api";
+import { MikroORM } from "@mikro-orm/core";
+import { EntityManager } from "@mikro-orm/postgresql";
+import { Injectable } from "@nestjs/common";
+import { v5 } from "uuid";
+
+import { WarningDependencyInfo } from "./dto/warning-dependency-info";
+import { Warning } from "./entities/warning.entity";
+import { WarningSeverity } from "./entities/warning-severity.enum";
+
+@Injectable()
+export class WarningService {
+    constructor(
+        private readonly orm: MikroORM,
+        private readonly entityManager: EntityManager,
+    ) {}
+
+    public async saveWarning({ warning, dependencyInfo }: { warning: BlockWarning; dependencyInfo: WarningDependencyInfo }): Promise<void> {
+        const type = "Block";
+        const staticNamespace = "4e099212-0341-4bc8-8f4a-1f31c7a639ae";
+        const id = v5(`${dependencyInfo.rootEntityName}${dependencyInfo.targetId};${warning.message}`, staticNamespace);
+
+        await this.entityManager.upsert(
+            Warning,
+            {
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                id,
+                type,
+                message: warning.message,
+                severity: WarningSeverity[warning.severity as keyof typeof WarningSeverity],
+                dependencyInfo,
+            },
+            { onConflictExcludeFields: ["createdAt"] },
+        );
+    }
+
+    public async updateWarningsForBlock(warnings: BlockWarning[], dependencyInfo: WarningDependencyInfo): Promise<void> {
+        const startDate = new Date();
+        for (const warning of warnings) {
+            await this.saveWarning({
+                warning,
+                dependencyInfo,
+            });
+        }
+        this.deleteOutdatedWarnings(startDate, dependencyInfo);
+    }
+
+    public async deleteOutdatedWarnings(date: Date, dependencyInfo: WarningDependencyInfo): Promise<void> {
+        await this.entityManager.nativeDelete(Warning, { type: "Block", updatedAt: { $lt: date }, dependencyInfo });
+    }
+}

--- a/demo/api/src/warnings/warning.service.ts
+++ b/demo/api/src/warnings/warning.service.ts
@@ -4,7 +4,7 @@ import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
 import { v5 } from "uuid";
 
-import { WarningDependencyInfo } from "./dto/warning-dependency-info";
+import { WarningSourceInfo } from "./dto/warning-dependency-info";
 import { Warning } from "./entities/warning.entity";
 import { WarningSeverity } from "./entities/warning-severity.enum";
 
@@ -15,10 +15,10 @@ export class WarningService {
         private readonly entityManager: EntityManager,
     ) {}
 
-    public async saveWarning({ warning, dependencyInfo }: { warning: BlockWarning; dependencyInfo: WarningDependencyInfo }): Promise<void> {
+    public async saveWarning({ warning, sourceInfo }: { warning: BlockWarning; sourceInfo: WarningSourceInfo }): Promise<void> {
         const type = "Block";
         const staticNamespace = "4e099212-0341-4bc8-8f4a-1f31c7a639ae";
-        const id = v5(`${dependencyInfo.rootEntityName}${dependencyInfo.targetId};${warning.message}`, staticNamespace);
+        const id = v5(`${sourceInfo.rootEntityName}${sourceInfo.targetId};${warning.message}`, staticNamespace);
 
         await this.entityManager.upsert(
             Warning,
@@ -29,24 +29,24 @@ export class WarningService {
                 type,
                 message: warning.message,
                 severity: WarningSeverity[warning.severity as keyof typeof WarningSeverity],
-                dependencyInfo,
+                sourceInfo,
             },
             { onConflictExcludeFields: ["createdAt"] },
         );
     }
 
-    public async updateWarningsForBlock(warnings: BlockWarning[], dependencyInfo: WarningDependencyInfo): Promise<void> {
+    public async updateWarningsForBlock(warnings: BlockWarning[], sourceInfo: WarningSourceInfo): Promise<void> {
         const startDate = new Date();
         for (const warning of warnings) {
             await this.saveWarning({
                 warning,
-                dependencyInfo,
+                sourceInfo,
             });
         }
-        this.deleteOutdatedWarnings(startDate, dependencyInfo);
+        this.deleteOutdatedWarnings(startDate, sourceInfo);
     }
 
-    public async deleteOutdatedWarnings(date: Date, dependencyInfo: WarningDependencyInfo): Promise<void> {
-        await this.entityManager.nativeDelete(Warning, { type: "Block", updatedAt: { $lt: date }, dependencyInfo });
+    public async deleteOutdatedWarnings(date: Date, sourceInfo: WarningSourceInfo): Promise<void> {
+        await this.entityManager.nativeDelete(Warning, { type: "Block", updatedAt: { $lt: date }, sourceInfo });
     }
 }


### PR DESCRIPTION
## Description
When saving, it updates block warnings immediately

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts


https://github.com/user-attachments/assets/ac02ad1b-979c-4dd7-94a1-563f0398dc8c



## Open TODOs/questions

-   [ ] I deleted a Page and it still throws warnings. That is because the Page still exists in the database, but, it is not connected to a PageTreeNode anymore. Do you have any ideas how I could solve this? Maybe I should check with an extra query if the "PageTreeNodeDocument" is attached to a PageTreeNode and is active? And I'm not sure how I could find out if the Entity is a "PageTreeNodeDocument" yet (using EntityInfo?). I can also fix this error in another PR and we discuss this problem in the next meeting.
- [x] Merge parent PR https://github.com/vivid-planet/comet/pull/3460

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-956
