### PR TITLE
Fix opacity on `VideoPreviewImage` to only affect the background color

### DIFF
--- a/.changeset/clean-rivers-give.md
+++ b/.changeset/clean-rivers-give.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": major
+---
+
+Fix opacity on VideoPreviewImage to only affect Background Color

--- a/.changeset/clean-rivers-give.md
+++ b/.changeset/clean-rivers-give.md
@@ -2,4 +2,4 @@
 "@comet/cms-site": major
 ---
 
-Fix opacity on VideoPreviewImage to only affect Background Color
+Fix opacity on `VideoPreviewImage` to only affect the background color

--- a/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
+++ b/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
@@ -42,7 +42,7 @@ const IconWrapper = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: rgba(0 0 0 50%);
+    background-color: rgba(0, 0, 0, 0.5);
     appearance: none;
     border: none;
     padding: 0;

--- a/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
+++ b/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
@@ -42,7 +42,7 @@ const IconWrapper = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: rgba(0 0 0 / 50%);
     appearance: none;
     border: none;
     padding: 0;

--- a/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
+++ b/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
@@ -42,8 +42,7 @@ const IconWrapper = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: black;
-    opacity: 0.5;
+    background-color: rgba(0 0 0 50%);
     appearance: none;
     border: none;
     padding: 0;

--- a/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
+++ b/packages/site/cms-site/src/blocks/helpers/VideoPreviewImage.tsx
@@ -35,10 +35,7 @@ const Root = styled.div<{ $fill?: boolean }>`
 
 const IconWrapper = styled.button`
     position: absolute;
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
+    inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Description

VideoPreviewImage opacity should only affect the background color and not the children for example the play icon.

## Acceptance criteria

-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
