### PR TITLE
Set fallback values for user created via ID token

### DIFF
--- a/.changeset/metal-bees-fix.md
+++ b/.changeset/metal-bees-fix.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Add fallback values for users created by ID-Token

--- a/.changeset/metal-bees-fix.md
+++ b/.changeset/metal-bees-fix.md
@@ -2,4 +2,4 @@
 "@comet/cms-api": patch
 ---
 
-Add fallback values for users created by ID-Token
+Add fallback values for users created via ID token

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -69,8 +69,8 @@ export class UserPermissionsService {
         if (!idToken.sub) throw new Error("JwtPayload does not contain sub.");
         return {
             id: idToken.sub,
-            name: idToken.name,
-            email: idToken.email,
+            name: idToken.name || "Unknown User",
+            email: idToken.email || "",
         };
     }
 


### PR DESCRIPTION
Since we can't assume that name and email are included in the ID-Token we provide fallback values.
