### PR TITLE
Prevent internal `sx` of `Button` from being overridden

### DIFF
--- a/.changeset/smooth-ravens-cry.md
+++ b/.changeset/smooth-ravens-cry.md
@@ -2,4 +2,4 @@
 "@comet/admin": patch
 ---
 
-Preserve the default Button color when using the `sx` prop with the `textLight` or `textDark` variant
+Preserve the default `Button` color when using the `sx` prop with the `textLight` or `textDark` variant

--- a/.changeset/smooth-ravens-cry.md
+++ b/.changeset/smooth-ravens-cry.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Preserve the default Button color when using the `sx` prop with the `textLight` or `textDark` variant

--- a/packages/admin/admin/src/common/buttons/Button.tsx
+++ b/packages/admin/admin/src/common/buttons/Button.tsx
@@ -71,6 +71,7 @@ const getMobileIconNode = ({ mobileIcon, startIcon, endIcon }: Pick<ButtonProps,
 export const Button = forwardRef(<C extends ElementType = "button">(inProps: ButtonProps<C>, ref: ForwardedRef<any>) => {
     const {
         slotProps,
+        sx,
         variant = "primary",
         responsive,
         mobileIcon = "auto",
@@ -97,6 +98,10 @@ export const Button = forwardRef(<C extends ElementType = "button">(inProps: But
 
     const commonButtonProps = {
         ...variantToMuiProps[variant],
+        sx: {
+            ...variantToMuiProps[variant].sx,
+            ...sx,
+        },
         ...restProps,
         ownerState,
         ...slotProps?.root,


### PR DESCRIPTION
## Description

Previously, when passing an `sx` prop to a `Button`, that `sx` prop would fully replace the `sx` prop defined by the button internally, in `variantToMuiProps`.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)