### PR TITLE
Docs: Extend Brevo Migration Guide

### DIFF
--- a/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
+++ b/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
@@ -120,10 +120,10 @@ Instead define them in the `BrevoConfigProvider` once:
 ```diff
 //...
   input2State: (values?: AdditionalFormConfigInputProps) => {
--       email: string;
--       redirectionUrl: string;
-        attributes: //...
-    };
+-     email: string;
+-     redirectionUrl: string;
+      attributes: //...
+  };
 //...
 ```
 

--- a/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
+++ b/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
@@ -70,11 +70,11 @@ Environment variables containing Brevo configuration information can be removed 
 
 A custom database migration must be created in the project to add individual `scope` columns to `BrevoConfig`.
 
-```
+```ts
 //...
- this.addSql(
-            `alter table "BrevoConfig" add column "scope_domain" text not null, add column "scope_language" text not null;`,
-            );
+this.addSql(
+    `alter table "BrevoConfig" add column "scope_domain" text not null, add column "scope_language" text not null;`,
+);
 //...
 ```
 

--- a/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
+++ b/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
@@ -78,12 +78,14 @@ A custom database migration must be created in the project to add individual `sc
 //...
 ```
 
-### Remove `allowedRedirectionUrl` from the Brevo module configuration
+### Remove environment variables from the Brevo module configuration
 
 ```diff
 BrevoModule.register({
     brevo: {
--       allowedRedirectionUrl: config.brevo.allowedRedirectionUrl,
+-       allowedRedirectUrl: config.brevo.allowedRedirectUrl,
+-       sender: { name: config.brevo.sender.name, email: config.brevo.sender.email },
+-       doubleOptInTemplateId: config.brevo.doubleOptInTemplateId,
         //...
     },
     //..

--- a/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
+++ b/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
@@ -66,6 +66,18 @@ Environment variables containing Brevo configuration information can be removed 
 -   BREVO_DOUBLE_OPT_IN_TEMPLATE_ID
 -   BREVO_ALLOWED_REDIRECT_URL
 
+### Add `scope` to `BrevoConfig`
+
+A custom database migration must be created in the project to add individual `scope` columns to `BrevoConfig`.
+
+```
+//...
+ this.addSql(
+            `alter table "BrevoConfig" add column "scope_domain" text not null, add column "scope_language" text not null;`,
+            );
+//...
+```
+
 ### Remove `allowedRedirectionUrl` from the Brevo module configuration
 
 ```diff

--- a/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
+++ b/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
@@ -88,7 +88,7 @@ BrevoModule.register({
 -       doubleOptInTemplateId: config.brevo.doubleOptInTemplateId,
         //...
     },
-    //..
+    //...
 })
 ```
 
@@ -113,6 +113,18 @@ Instead define them in the `BrevoConfigProvider` once:
 >
     {children}
 </BrevoConfigProvider>
+```
+
+### Remove `email` and `allowedRedirectUrl` from `brevoContactsPageAttributesConfig`
+
+```diff
+//...
+  input2State: (values?: AdditionalFormConfigInputProps) => {
+-       email: string;
+-       redirectionUrl: string;
+        attributes: //...
+    };
+//...
 ```
 
 ## Site


### PR DESCRIPTION
## Description

Add missing information in Brevo Migration Guide:

- add scope to BrevoConfig table (https://github.com/vivid-planet/comet-brevo-module/pull/279)
- add variables that need to be removed from the brevo module config
- remove variables from brevoContactsPageAttributesConfig
