### PR TITLE
Prevent unintended horizontal scrolling in preview overlay

### DIFF
--- a/.changeset/short-needles-wave.md
+++ b/.changeset/short-needles-wave.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-site": patch
+---
+
+Prevent unintended horizontal scrolling in the admin's block preview
+
+This previously occurred when blocks were rendered outside of the viewport width, such as elements of a slider.

--- a/packages/site/cms-site/src/iframebridge/IFrameBridge.tsx
+++ b/packages/site/cms-site/src/iframebridge/IFrameBridge.tsx
@@ -97,9 +97,6 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
                 const positioning = getCombinedPositioningOfElements(childNodes);
 
                 const isRenderedOutsideOfViewportWidth = positioning.left > childrenWrapperWidth;
-                const spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport = positioning.left + positioning.width - childrenWrapperWidth;
-                const tooWideForPreviewViewportByPixels =
-                    spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport > 0 ? spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport : 0;
 
                 if (isRenderedOutsideOfViewportWidth) {
                     // TODO: Simply return `null` here after updating to typescript 5+
@@ -114,6 +111,10 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
                         },
                     };
                 }
+
+                const spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport = positioning.left + positioning.width - childrenWrapperWidth;
+                const tooWideForPreviewViewportByPixels =
+                    spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport > 0 ? spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport : 0;
 
                 return {
                     adminRoute: previewElement.adminRoute,

--- a/packages/site/cms-site/src/iframebridge/IFrameBridge.tsx
+++ b/packages/site/cms-site/src/iframebridge/IFrameBridge.tsx
@@ -84,12 +84,36 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
     const [previewElementsData, setPreviewElementsData] = useState<OverlayElementData[]>([]);
 
     const childrenWrapperRef = useRef<HTMLDivElement>(null);
+    const childrenWrapperWidth = childrenWrapperRef.current?.offsetWidth;
 
     const recalculatePreviewElementsData = useCallback(() => {
+        if (!childrenWrapperWidth) {
+            return;
+        }
+
         const newPreviewElementsData = previewElements
             .map((previewElement) => {
                 const childNodes = getRecursiveChildrenOfPreviewElement(previewElement.element);
                 const positioning = getCombinedPositioningOfElements(childNodes);
+
+                const isRenderedOutsideOfViewportWidth = positioning.left > childrenWrapperWidth;
+                const spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport = positioning.left + positioning.width - childrenWrapperWidth;
+                const tooWideForPreviewViewportByPixels =
+                    spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport > 0 ? spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport : 0;
+
+                if (isRenderedOutsideOfViewportWidth) {
+                    // TODO: Simply return `null` here after updating to typescript 5+
+                    return {
+                        adminRoute: previewElement.adminRoute,
+                        label: previewElement.label,
+                        position: {
+                            top: positioning.top,
+                            left: positioning.left,
+                            width: 0,
+                            height: positioning.height,
+                        },
+                    };
+                }
 
                 return {
                     adminRoute: previewElement.adminRoute,
@@ -97,11 +121,12 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
                     position: {
                         top: positioning.top,
                         left: positioning.left,
-                        width: positioning.width,
+                        width: positioning.width - tooWideForPreviewViewportByPixels,
                         height: positioning.height,
                     },
                 };
             })
+            .filter((elementData) => elementData.position.width !== 0) // TODO: Filter out null after updating to typescript 5+ instead of filtering `width !== 0`
             .sort((previousElementData, nextElementData) => {
                 const previousSize = previousElementData.position.width * previousElementData.position.height;
                 const nextSize = nextElementData.position.width * nextElementData.position.height;
@@ -127,7 +152,7 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
 
             return newPreviewElementsData;
         });
-    }, [previewElements]);
+    }, [previewElements, childrenWrapperWidth]);
 
     useEffect(() => {
         if (childrenWrapperRef.current) {


### PR DESCRIPTION
## Description

This previously occurred when blocks were rendered outside of the viewport width, such as elements of a slider. 
The issue was reproduced using the `MediaGallery` block in the demo. 

This is now fixed by:
- not rendering preview-elements at all if they are fully outside of the viewport
- limiting the width of elements that would otherwise overflow outside of the viewport

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/cb72d1ec-a38d-4170-a3ba-e79c3d5b4229" />   | <video src="https://github.com/user-attachments/assets/7dbde801-8819-4084-8817-198e9a06a59f" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/PHSB2C-5220
