### PR TITLE
Format numbers in `DataGrid` pagination depending on the current locale

### DIFF
--- a/.changeset/pink-keys-drop.md
+++ b/.changeset/pink-keys-drop.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Format numbers in `DataGrid` pagination depending on the current locale

--- a/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
@@ -13,8 +13,9 @@ import {
     type TextFieldProps,
 } from "@mui/material";
 import { type Spacing } from "@mui/system";
-import { getDataGridUtilityClass, GRID_DEFAULT_LOCALE_TEXT, gridClasses } from "@mui/x-data-grid";
+import { getDataGridUtilityClass, gridClasses } from "@mui/x-data-grid";
 import type {} from "@mui/x-data-grid/themeAugmentation";
+import { FormattedMessage, FormattedNumber } from "react-intl";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { type GetMuiComponentTheme } from "./getComponentsTheme";
@@ -60,8 +61,21 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             },
         },
         localeText: {
-            noRowsLabel: GRID_DEFAULT_LOCALE_TEXT.noResultsOverlayLabel,
-            columnsPanelTextFieldLabel: "",
+            MuiTablePagination: {
+                labelDisplayedRows: ({ from, to, count }) => (
+                    <FormattedMessage
+                        id="dataGrid.pagination.labelDisplayedRows"
+                        defaultMessage="{from}–{to} of {formattedCount} {count, plural, one {item} other {items}}"
+                        values={{
+                            from: <FormattedNumber value={from} />,
+                            to: <FormattedNumber value={to} />,
+                            formattedCount: <FormattedNumber value={count} />,
+                            count,
+                        }}
+                    />
+                ),
+                ...component?.defaultProps?.localeText?.MuiTablePagination,
+            },
             ...component?.defaultProps?.localeText,
         },
     },


### PR DESCRIPTION
## Description

The numbers in the `DataGrid` footers pagination should show thousand separators. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="720" alt="DataGrid Previously" src="https://github.com/user-attachments/assets/4f1e4c1f-78c2-47b3-9452-ea15e951609e" />   | <img width="720" alt="DataGrid Now" src="https://github.com/user-attachments/assets/3a841469-1104-4745-b51a-3378416c4c3a" />  |

## Open TODOs/questions

-   [x] Add changeset
-   [x] Merge parent https://github.com/vivid-planet/comet/pull/3479

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1587
