### PR TITLE
Demo API: Remove `mikro-orm:*` scripts

### DIFF
--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -18,8 +18,6 @@
         "lint:tsc": "tsc --project ./tsconfig.lint.json",
         "lint:generated-files-not-modified": "$npm_execpath api-generator && git diff --exit-code HEAD -- src/**/generated",
         "mikro-orm": "mikro-orm",
-        "mikro-orm:drop": "mikro-orm schema:drop -r",
-        "mikro-orm:migration:generate": "mikro-orm migration:create",
         "start": "$npm_execpath prebuild && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",
         "start:dev": "run-p dev:*",
         "dev:nest": "$npm_execpath prebuild && $npm_execpath db:migrate && $npm_execpath console createBlockIndexViews && NODE_OPTIONS='--max-old-space-size=512' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",

--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -17,7 +17,6 @@
         "lint:prettier": "npx prettier --check './**/*.{js,json,md,yml,yaml}'",
         "lint:tsc": "tsc --project ./tsconfig.lint.json",
         "lint:generated-files-not-modified": "$npm_execpath api-generator && git diff --exit-code HEAD -- src/**/generated",
-        "mikro-orm": "mikro-orm",
         "start": "$npm_execpath prebuild && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",
         "start:dev": "run-p dev:*",
         "dev:nest": "$npm_execpath prebuild && $npm_execpath db:migrate && $npm_execpath console createBlockIndexViews && NODE_OPTIONS='--max-old-space-size=512' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",


### PR DESCRIPTION
This removes the `mikro-orm`, `mikro-orm:drop` and `mikro-orm:migration:generate` from api/package.json scripts.

As alternative simply use the mikro-orm script:
- `npx mikro-orm --help`
- `npx mikro-orm schema:drop --run`
- `npx mikro-orm migration:create`

Why remove?
- `mikro-orm:migration:generate`'s naming is still coming from type-orm I suppose
- why should abritary commands get it's own script?

Why keep?
- those two are the commonly used commands
- devs are used to it
