### PR TITLE
Fix block preview not rendering before user interaction

### DIFF
--- a/.changeset/tender-boats-yell.md
+++ b/.changeset/tender-boats-yell.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": patch
+---
+
+Update `useBlockPreviewFetch` to use state instead of ref for graphQLFetch. This change ensures the block preview renders without needing to hover.

--- a/.changeset/tender-boats-yell.md
+++ b/.changeset/tender-boats-yell.md
@@ -2,4 +2,4 @@
 "@comet/cms-site": patch
 ---
 
-Update `useBlockPreviewFetch` to use state instead of ref for graphQLFetch. This change ensures the block preview renders without needing to hover.
+Fix block preview not rendering before user interaction

--- a/packages/site/cms-site/src/iframebridge/useBlockPreviewFetch.tsx
+++ b/packages/site/cms-site/src/iframebridge/useBlockPreviewFetch.tsx
@@ -22,6 +22,7 @@ export function useBlockPreviewFetch(apiUrl?: string | undefined) {
 
     useEffect(() => {
         if (graphQLApiUrl) {
+            // We need to use an updater function here because createBlockPreviewFetch's return value would otherwise be incorrectly treated as an updater function.
             setGraphQLFetch(() => createBlockPreviewFetch(graphQLApiUrl, !showOnlyVisible));
         }
     }, [showOnlyVisible, graphQLApiUrl]);

--- a/packages/site/cms-site/src/iframebridge/useBlockPreviewFetch.tsx
+++ b/packages/site/cms-site/src/iframebridge/useBlockPreviewFetch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 
 import { createFetchInMemoryCache } from "../graphQLFetch/fetchInMemoryCache";
 import { convertPreviewDataToHeaders, createFetchWithDefaults, createGraphQLFetch, GraphQLFetch } from "../graphQLFetch/graphQLFetch";
@@ -16,16 +16,18 @@ export function useBlockPreviewFetch(apiUrl: string): { fetch: Fetch; graphQLFet
 export function useBlockPreviewFetch(apiUrl?: string | undefined): { fetch: Fetch; graphQLFetch?: GraphQLFetch };
 export function useBlockPreviewFetch(apiUrl?: string | undefined) {
     const { showOnlyVisible, graphQLApiUrl } = useIFrameBridge();
+    const [graphQLFetch, setGraphQLFetch] = useState<GraphQLFetch | undefined>(() =>
+        apiUrl ? createBlockPreviewFetch(apiUrl, !showOnlyVisible) : undefined,
+    );
 
-    const graphQLFetchRef = useRef(apiUrl ? createBlockPreviewFetch(apiUrl, !showOnlyVisible) : undefined);
     useEffect(() => {
         if (graphQLApiUrl) {
-            graphQLFetchRef.current = createBlockPreviewFetch(graphQLApiUrl, !showOnlyVisible);
+            setGraphQLFetch(() => createBlockPreviewFetch(graphQLApiUrl, !showOnlyVisible));
         }
     }, [showOnlyVisible, graphQLApiUrl]);
 
     return {
-        graphQLFetch: graphQLFetchRef.current,
+        graphQLFetch,
         fetch: cachingFetch,
     };
 }


### PR DESCRIPTION
## Description

Update `useBlockPreviewFetch` to use state instead of ref for graphQLFetch. This change ensures the block preview renders without needing to hover.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/29337eda-227d-45fe-a1c9-9202db4ed267"/>|<video src="https://github.com/user-attachments/assets/f5098e23-93a9-4641-800e-c396e1752b5c"/>|

## Open TODOs/questions

-   [x] Add changeset

