### PR TITLE
Protect images in the site preview

### DIFF
--- a/.changeset/mean-kiwis-tease.md
+++ b/.changeset/mean-kiwis-tease.md
@@ -3,7 +3,7 @@
 "@comet/cms-api": major
 ---
 
-Protect images in site preview
+Protect images in the site preview
 
-The image urls in the site preview are now generated as preview-urls. Authorization is handled
-via the new `createSitePreviewAuthService` which validates the cookie of the site preview.
+The image URLs in the site preview are now generated as preview URLs.
+Authorization is handled via the new `createSitePreviewAuthService`, which validates the site preview cookie.

--- a/.changeset/mean-kiwis-tease.md
+++ b/.changeset/mean-kiwis-tease.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-site": major
+"@comet/cms-api": major
+---
+
+Protect images in site preview
+
+The image urls in the site preview are now generated as preview-urls. Authorization is handled
+via the new `createSitePreviewAuthService` which validates the cookie of the site preview.

--- a/demo/api/src/auth/auth.module.ts
+++ b/demo/api/src/auth/auth.module.ts
@@ -4,6 +4,7 @@ import {
     createAuthResolver,
     createBasicAuthService,
     createJwtAuthService,
+    createSitePreviewAuthService,
     createStaticUserAuthService,
 } from "@comet/cms-api";
 import { DynamicModule, Module } from "@nestjs/common";
@@ -29,6 +30,7 @@ export class AuthModule {
                         password: config.auth.systemUserPassword,
                     }),
                     createJwtAuthService({ verifyOptions: { secret: "secret" } }), // for testing purposes, send header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyIiwiaWF0IjoxNTE2MjM5MDIyfQ.fG9j2rVOgunoya_njgn9w1t8muFlrpE9ffJ9i8sJYsQ"
+                    createSitePreviewAuthService({ sitePreviewSecret: config.sitePreviewSecret }),
                     createStaticUserAuthService({ staticUser: staticUsers[0] }),
                 ),
                 createAuthResolver(),

--- a/demo/site/src/util/graphQLClient.ts
+++ b/demo/site/src/util/graphQLClient.ts
@@ -29,6 +29,7 @@ export function createGraphQLFetch() {
             },
             headers: {
                 authorization: `Basic ${Buffer.from(`system-user:${process.env.BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
+                "x-relative-dam-urls": "1",
                 ...convertPreviewDataToHeaders(previewData),
             },
         }),

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -507,6 +507,7 @@ Rename the `strategy`-factories and wrap them in `...createAuthGuardProviders()`
 +   ...createAuthGuardProviders(
 +       createBasicAuthService({ ... }),
 +       createJwtAuthService({ ... }),
++       createSitePreviewAuthService({ ... }),
 +       createStaticUserAuthService({ ... }),
 +   ),
 ```

--- a/packages/api/cms-api/src/auth/services/site-preview.auth-service.spec.ts
+++ b/packages/api/cms-api/src/auth/services/site-preview.auth-service.spec.ts
@@ -1,0 +1,47 @@
+import { SignJWT } from "jose";
+
+import { SKIP_AUTH_SERVICE } from "../util/auth-service.interface";
+import { createSitePreviewAuthService, type SitePreviewAuthServiceConfig } from "./site-preview.auth-service";
+
+describe("createSitePreviewAuthService", () => {
+    const instantianteService = (config: SitePreviewAuthServiceConfig) => new (createSitePreviewAuthService(config))();
+    const mockRequest = (cookieValue: string) => jest.fn().mockReturnValue({ cookies: { __comet_preview: cookieValue } })();
+    const authenticationError = expect.objectContaining({ authenticationError: expect.any(String) });
+
+    it("throws Error on empty secret", async () => {
+        const service = instantianteService({ sitePreviewSecret: "" });
+        await expect(() => service.authenticateUser(mockRequest(""))).rejects.toThrow("secret must not be empty");
+    });
+
+    it("returns SKIP_AUTH_SERVICE on empty cookie ", async () => {
+        const service = instantianteService({ sitePreviewSecret: "secret" });
+        expect(await service.authenticateUser(mockRequest(""))).toBe(SKIP_AUTH_SERVICE);
+    });
+
+    it("returns authenticationError expired jwt", async () => {
+        const service = instantianteService({ sitePreviewSecret: "secret" });
+        const jwt = await new SignJWT({ userId: "1" })
+            .setProtectedHeader({ alg: "HS256" })
+            .setExpirationTime("-1 day")
+            .sign(new TextEncoder().encode("secret"));
+        expect(await service.authenticateUser(mockRequest(jwt))).toStrictEqual(authenticationError);
+    });
+
+    it("returns authenticationError on wrong secret", async () => {
+        const service = instantianteService({ sitePreviewSecret: "secret" });
+        const jwt = await new SignJWT({ user: "1" }).setProtectedHeader({ alg: "HS256" }).sign(new TextEncoder().encode("wrongSecret"));
+        expect(await service.authenticateUser(mockRequest(jwt))).toStrictEqual(authenticationError);
+    });
+
+    it("returns authenticationError on wrong payload", async () => {
+        const service = instantianteService({ sitePreviewSecret: "secret" });
+        const jwt = await new SignJWT({ user: "1" }).setProtectedHeader({ alg: "HS256" }).sign(new TextEncoder().encode("secret"));
+        expect(await service.authenticateUser(mockRequest(jwt))).toStrictEqual(authenticationError);
+    });
+
+    it("returns userId on correct site-preview-jwt", async () => {
+        const service = instantianteService({ sitePreviewSecret: "secret" });
+        const jwt = await new SignJWT({ userId: "1" }).setProtectedHeader({ alg: "HS256" }).sign(new TextEncoder().encode("secret"));
+        expect(await service.authenticateUser(mockRequest(jwt))).toStrictEqual({ userId: "1" });
+    });
+});

--- a/packages/api/cms-api/src/auth/services/site-preview.auth-service.ts
+++ b/packages/api/cms-api/src/auth/services/site-preview.auth-service.ts
@@ -12,7 +12,7 @@ export function createSitePreviewAuthService({ sitePreviewSecret }: SitePreviewA
     @Injectable()
     class SitePreviewAuthService implements AuthServiceInterface {
         async authenticateUser(request: Request): Promise<AuthenticateUserResult> {
-            if (typeof sitePreviewSecret !== "string" || sitePreviewSecret.length === 0) {
+            if (!sitePreviewSecret) {
                 throw new Error("secret must not be empty");
             }
 

--- a/packages/api/cms-api/src/auth/services/site-preview.auth-service.ts
+++ b/packages/api/cms-api/src/auth/services/site-preview.auth-service.ts
@@ -1,0 +1,45 @@
+import { Injectable, Type } from "@nestjs/common";
+import { Request } from "express";
+import { errors, jwtVerify } from "jose";
+
+import { AuthenticateUserResult, AuthServiceInterface, SKIP_AUTH_SERVICE } from "../util/auth-service.interface";
+
+export interface SitePreviewAuthServiceConfig {
+    sitePreviewSecret: string;
+}
+
+export function createSitePreviewAuthService({ sitePreviewSecret }: SitePreviewAuthServiceConfig): Type<AuthServiceInterface> {
+    @Injectable()
+    class SitePreviewAuthService implements AuthServiceInterface {
+        async authenticateUser(request: Request): Promise<AuthenticateUserResult> {
+            if (typeof sitePreviewSecret !== "string" || sitePreviewSecret.length === 0) {
+                throw new Error("secret must not be empty");
+            }
+
+            const cookieValue = request.cookies["__comet_preview"];
+            if (!cookieValue) return SKIP_AUTH_SERVICE;
+
+            try {
+                const {
+                    payload: { userId },
+                } = await jwtVerify<{ userId: string }>(cookieValue, new TextEncoder().encode(sitePreviewSecret));
+                if (typeof userId !== "string") {
+                    return {
+                        authenticationError: "SitePreviewAuthService: token does not contain userId.",
+                    };
+                }
+                return {
+                    userId,
+                };
+            } catch (e) {
+                if (e instanceof errors.JOSEError) {
+                    return {
+                        authenticationError: (e as Error).message,
+                    };
+                }
+                throw e;
+            }
+        }
+    }
+    return SitePreviewAuthService;
+}

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -7,6 +7,7 @@ export { CometAuthGuard } from "./auth/guards/comet.guard";
 export { createAuthResolver } from "./auth/resolver/auth.resolver";
 export { createBasicAuthService } from "./auth/services/basic.auth-service";
 export { createJwtAuthService } from "./auth/services/jwt.auth-service";
+export { createSitePreviewAuthService } from "./auth/services/site-preview.auth-service";
 export { createStaticUserAuthService } from "./auth/services/static-authed-user.auth-service";
 export { createAuthGuardProviders } from "./auth/util/auth-guard.providers";
 export { AuthServiceInterface } from "./auth/util/auth-service.interface";

--- a/packages/api/cms-api/src/page-tree/site-preview.resolver.ts
+++ b/packages/api/cms-api/src/page-tree/site-preview.resolver.ts
@@ -3,7 +3,9 @@ import { Args, Query, Resolver } from "@nestjs/graphql";
 import { GraphQLJSONObject } from "graphql-scalars";
 import { SignJWT } from "jose";
 
+import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
+import { CurrentUser } from "../user-permissions/dto/current-user";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
 import { SITE_PREVIEW_CONFIG } from "./page-tree.constants";
 
@@ -21,8 +23,10 @@ export class SitePreviewResolver {
         @Args("scope", { type: () => GraphQLJSONObject }) scope: ContentScope,
         @Args("path") path: string,
         @Args("includeInvisible") includeInvisible: boolean,
+        @GetCurrentUser() user: CurrentUser,
     ): Promise<string> {
         return new SignJWT({
+            userId: user.id,
             scope,
             path,
             previewData: {

--- a/packages/site/cms-site/src/graphQLFetch/graphQLFetch.ts
+++ b/packages/site/cms-site/src/graphQLFetch/graphQLFetch.ts
@@ -20,6 +20,7 @@ export function convertPreviewDataToHeaders(previewData?: SitePreviewData) {
     // authentication is required when this header is used
     if (includeInvisibleContentHeaderEntries.length > 0) {
         headers["x-include-invisible-content"] = includeInvisibleContentHeaderEntries.join(",");
+        headers["x-preview-dam-urls"] = "1";
     }
     return headers;
 }

--- a/packages/site/cms-site/src/sitePreview/SitePreviewUtils.ts
+++ b/packages/site/cms-site/src/sitePreview/SitePreviewUtils.ts
@@ -7,6 +7,7 @@ export type SitePreviewData = {
     includeInvisible: boolean;
 };
 export type SitePreviewParams = {
+    userId: string;
     scope: Scope;
     path: string;
     previewData?: SitePreviewData;

--- a/packages/site/cms-site/src/sitePreview/appRouter/sitePreviewRoute.ts
+++ b/packages/site/cms-site/src/sitePreview/appRouter/sitePreviewRoute.ts
@@ -20,6 +20,7 @@ export async function sitePreviewRoute(request: NextRequest) {
     }
 
     const cookieJwt = await new SignJWT({
+        userId: data.userId,
         scope: data.scope,
         path: data.path,
         previewData: data.previewData,


### PR DESCRIPTION
Sets the x-preview-dam-urls in the site-preview which results in image-urls to be validated via the CometAuthGuard.

Since the images are called from the site domain - which is not protected by the AuthProxy - we need to validate the `__comet_preview` cookie which we set to activate the preview. This is achieved by adding `createSitePreviewAuthService`