### PR TITLE
Remove remaining references to `@comet/admin-theme`

### DIFF
--- a/.changeset/cyan-ghosts-smoke.md
+++ b/.changeset/cyan-ghosts-smoke.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin-theme": major
+"@comet/admin": major
 ---
 
 Prevent the selection of DataGrid rows by clicking on them

--- a/.changeset/nice-masks-invite.md
+++ b/.changeset/nice-masks-invite.md
@@ -1,5 +1,4 @@
 ---
-"@comet/admin-theme": major
 "@comet/cms-admin": major
 "@comet/admin": major
 ---

--- a/.changeset/perfect-mangos-greet.md
+++ b/.changeset/perfect-mangos-greet.md
@@ -2,7 +2,6 @@
 "@comet/admin-color-picker": major
 "@comet/admin-date-time": major
 "@comet/admin-icons": major
-"@comet/admin-theme": major
 "@comet/admin-rte": major
 "@comet/cms-admin": major
 "@comet/admin": major

--- a/.changeset/popular-seals-promise.md
+++ b/.changeset/popular-seals-promise.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin-theme": patch
+"@comet/admin": patch
 ---
 
 Adapt `height` of elements in `DataGrid` depending on the `density`-prop to match the Comet DXP design

--- a/.changeset/shiny-ads-fix.md
+++ b/.changeset/shiny-ads-fix.md
@@ -1,5 +1,4 @@
 ---
-"@comet/admin-theme": major
 "@comet/cms-admin": major
 "@comet/admin": major
 ---

--- a/.changeset/soft-horses-ring.md
+++ b/.changeset/soft-horses-ring.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin-theme": major
+"@comet/admin": major
 ---
 
 Remove custom `secondary` color styling from `Checkbox` and `Radio`

--- a/.changeset/thirty-moles-invite.md
+++ b/.changeset/thirty-moles-invite.md
@@ -4,7 +4,6 @@
 "@comet/admin-date-time": minor
 "@comet/admin-icons": minor
 "@comet/admin-rte": minor
-"@comet/admin-theme": minor
 "@comet/admin": minor
 "@comet/cms-admin": minor
 ---

--- a/docs/docs/1-getting-started/3-packages-tools.md
+++ b/docs/docs/1-getting-started/3-packages-tools.md
@@ -37,8 +37,6 @@ Components for use in forms generally have an accompanying component, optimized 
 
 Navigation and routing are managed by [react-router](https://reactrouter.com/).
 
-#### @comet/admin-theme
-
 Using the `createCometTheme` function, you can create a theme that contains all the default styling for your admin. Custom options and styles can be added the same way as with MUI's [createTheme](https://mui.com/material-ui/customization/theming/#api) function. The resulting theme can simply be used with MUI's [ThemeProvider](https://mui.com/material-ui/customization/theming/#theme-provider).
 
 #### @comet/admin-icons


### PR DESCRIPTION
## Description

The canary release failed due to references to the removed package in changesets: https://github.com/vivid-planet/comet/actions/runs/13561313504/job/37904828625