### PR TITLE
Allow `use` tag in SVG again

### DIFF
--- a/.changeset/good-terms-hide.md
+++ b/.changeset/good-terms-hide.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-api": patch
+---
+
+Allow `use` tag in SVG again
+
+`use` can be used to define paths once in a SVG and then integrating them multiple times via anchor links: `<use xlink:href="#path-id" />`. This should not be prohibited.
+
+It's still not possible to use `use` to reference external files, since we still prohibit `href` and `xlink:href` attributes starting with `http://`, `https://` and `javascript:`.

--- a/packages/api/cms-api/src/dam/files/files.utils.ts
+++ b/packages/api/cms-api/src/dam/files/files.utils.ts
@@ -52,7 +52,6 @@ type SvgNode =
 const disallowedSvgTags = [
     "script", // can lead to XSS
     "foreignObject", // can embed non-SVG content
-    "use", // can load external resources
     "image", // can load external resources
     "animate", // can modify attributes; resource exhaustion
     "animateMotion", // can modify attributes; resource exhaustion


### PR DESCRIPTION
## Description

Allow `use` tag in SVG again

`use` can be used to define paths once in a SVG and then integrating them multiple times via anchor links: `<use xlink:href="#path-id" />`. This should not be prohibited.

Banning `use` caused problems for one of our clients when uploading SVGs because they use the pattern described above.

It's still not possible to use `use` to reference external files, since we still prohibit `href` and `xlink:href` attributes starting with `http://`, `https://` and `javascript:`.

---

Also fix a typing problem that lead to a type error in useDamFileUpload. This caused no error message to show up in the Admin when uploading a bad SVG. Instead, the upload progress bar was shown forever.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Before:

https://github.com/user-attachments/assets/56945275-32b0-41a3-b63c-fe13d84b4d20

Now:

https://github.com/user-attachments/assets/b0fd8a4a-689e-452b-876b-debfcf872fdd


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/PHSB2C-5794
