### PR TITLE
File Uploads: Add option to disable the GraphQL field resolvers

### DIFF
--- a/.changeset/perfect-apricots-wait.md
+++ b/.changeset/perfect-apricots-wait.md
@@ -11,7 +11,7 @@ FileUploadsModule.register({
     /* ... */
     download: {
         /* ... */
-        resolver: false,
+        createFieldResolvers: false,
     },
 });
 ```

--- a/.changeset/perfect-apricots-wait.md
+++ b/.changeset/perfect-apricots-wait.md
@@ -1,0 +1,17 @@
+---
+"@comet/cms-api": minor
+---
+
+File Uploads: Add option to disable the GraphQL field resolvers
+
+Use this when using file uploads without GraphQL.
+
+```ts
+FileUploadsModule.register({
+    /* ... */
+    download: {
+        /* ... */
+        resolver: false,
+    },
+});
+```

--- a/packages/api/cms-api/src/file-uploads/file-uploads.config.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.config.ts
@@ -14,6 +14,6 @@ export interface FileUploadsConfig {
          *
          * @default true
          */
-        resolver?: boolean;
+        createFieldResolvers?: boolean;
     };
 }

--- a/packages/api/cms-api/src/file-uploads/file-uploads.config.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.config.ts
@@ -8,5 +8,12 @@ export interface FileUploadsConfig {
     download?: {
         public?: boolean;
         secret: string;
+        /**
+         * Allows disabling the `downloadUrl` and `imageUrl` field resolvers.
+         * Use this when using file uploads without GraphQL.
+         *
+         * @default true
+         */
+        resolver?: boolean;
     };
 }

--- a/packages/api/cms-api/src/file-uploads/file-uploads.module.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.module.ts
@@ -39,7 +39,7 @@ export class FileUploadsModule {
             const FileUploadsDownloadController = createFileUploadsDownloadController({ public: options.download.public ?? false });
             controllers.push(FileUploadsDownloadController);
 
-            const shouldAddResolver = options.download.resolver ?? true;
+            const shouldAddResolver = options.download.createFieldResolvers ?? true;
 
             if (shouldAddResolver) {
                 providers.push(FileUploadsResolver);

--- a/packages/api/cms-api/src/file-uploads/file-uploads.module.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.module.ts
@@ -38,7 +38,12 @@ export class FileUploadsModule {
 
             const FileUploadsDownloadController = createFileUploadsDownloadController({ public: options.download.public ?? false });
             controllers.push(FileUploadsDownloadController);
-            providers.push(FileUploadsResolver);
+
+            const shouldAddResolver = options.download.resolver ?? true;
+
+            if (shouldAddResolver) {
+                providers.push(FileUploadsResolver);
+            }
         }
 
         return {


### PR DESCRIPTION
## Description

Noticed this in a customer project that uses file uploads only with REST. The API doesn't start if `FileUpload` isn't used anywhere in the application.

```ts
FileUploadsModule.register({
    /* ... */
    download: {
        /* ... */
        createFieldResolvers: false,
    },
});
```