### PR TITLE
Fix `@kubernetes/client-node` peer dependency

### DIFF
--- a/.changeset/heavy-poems-post.md
+++ b/.changeset/heavy-poems-post.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": major
+---
+
+Bump `@kubernetes/client-node` peer dependency to v1
+
+To upgrade, install `@kubernetes/client-node` v1.0.0 or later.

--- a/.cspellignore
+++ b/.cspellignore
@@ -9,6 +9,7 @@ exceljs
 exif
 GraphQLJSONObject
 imgproxy
+kubernetes
 libvips
 Logische
 Mikro

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -373,6 +373,33 @@ None of the other breaking changes in `@sentry/node` should affect us. If you st
 
 </details>
 
+#### ✅ `@kubernetes/client-node`
+
+The `@kubernetes/client-node` peer dependency has been bumped to v1.
+
+<details>
+
+<summary>Handled by @comet/upgrade</summary>
+
+:::note Handled by following upgrade script
+
+```sh
+npx @comet/upgrade v8/update-kubernetes-client-node.ts
+```
+
+:::
+
+```diff title=api/package.json
+{
+    "dependencies": {
+-       "@kubernetes/client-node": "^0.18.0",
++       "@kubernetes/client-node": "^1.0.0",
+    }
+}
+```
+
+</details>
+
 #### ✅ Vite / SWC
 
 <details>

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -111,7 +111,7 @@
         "typescript": "^5.7.3"
     },
     "peerDependencies": {
-        "@kubernetes/client-node": ">=0.18.0",
+        "@kubernetes/client-node": "^1.0.0",
         "@mikro-orm/core": "^6.0.0",
         "@mikro-orm/migrations": "^6.0.0",
         "@mikro-orm/nestjs": "^6.0.0",


### PR DESCRIPTION
## Description

`@comet/cms-api` only supports `@kubernetes/client-node` v1 or later due to API changes.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1903
- Upgrade script: https://github.com/vivid-planet/comet-upgrade/pull/90
