### PR TITLE
Allow manual trigger of main-into-next-pr workflow

### DIFF
--- a/.github/workflows/main-into-next-pr.yml
+++ b/.github/workflows/main-into-next-pr.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - main
+    workflow_dispatch:
 jobs:
     main-into-next:
         name: Create "Merge main into next" PR


### PR DESCRIPTION
## Description

Can be handy when `next` is newer than the "Merge main into next"-PR but there are no new changes in `main`.
