### PR TITLE
Remove ts-node as peer dependency from `@comet/api-generator` and `@comet/cli`

### DIFF
--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -82,7 +82,6 @@
         "eslint": "^9.20.1",
         "npm-run-all2": "^5.0.2",
         "prettier": "^3.5.2",
-        "ts-node": "^10.9.2",
         "typescript": "^5.7.3",
         "vite": "^5.4.14",
         "vite-plugin-html": "^3.2.2"

--- a/demo/site-pages/package.json
+++ b/demo/site-pages/package.json
@@ -39,8 +39,7 @@
         "redraft": "^0.10.2",
         "sitemap": "^8.0.0",
         "styled-components": "^6.1.15",
-        "swiper": "^11.2.4",
-        "ts-node": "^10.9.2"
+        "swiper": "^11.2.4"
     },
     "devDependencies": {
         "@babel/core": "^7.26.9",

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -39,8 +39,7 @@
         "react-intl": "^6.8.9",
         "redraft": "^0.10.2",
         "styled-components": "^6.1.15",
-        "swiper": "^11.2.4",
-        "ts-node": "^10.9.2"
+        "swiper": "^11.2.4"
     },
     "devDependencies": {
         "@babel/core": "^7.26.9",

--- a/packages/api/api-generator/package.json
+++ b/packages/api/api-generator/package.json
@@ -31,7 +31,8 @@
         "@comet/cms-api": "workspace:*",
         "commander": "^9.5.0",
         "pluralize": "^8.0.0",
-        "ts-morph": "^25.0.1"
+        "ts-morph": "^25.0.1",
+        "ts-node": "^10.9.2"
     },
     "devDependencies": {
         "@comet/eslint-config": "workspace:*",
@@ -49,15 +50,13 @@
         "reflect-metadata": "^0.2.2",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
-        "ts-node": "^10.9.2",
         "typescript": "^5.7.3",
         "uuid": "^11.0.5"
     },
     "peerDependencies": {
         "@mikro-orm/cli": "^6.0.0",
         "@nestjs/graphql": "^13.0.0",
-        "class-validator": "^0.14.0",
-        "ts-node": "^10.9.1"
+        "class-validator": "^0.14.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,8 @@
     },
     "dependencies": {
         "commander": "^9.5.0",
-        "prettier": "^3.5.2"
+        "prettier": "^3.5.2",
+        "ts-node": "^10.9.2"
     },
     "devDependencies": {
         "@comet/eslint-config": "workspace:^7.14.0",
@@ -35,11 +36,7 @@
         "eslint": "^9.20.1",
         "npm-run-all2": "^5.0.2",
         "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
         "typescript": "^5.7.3"
-    },
-    "peerDependencies": {
-        "ts-node": "^10.9.1"
     },
     "publishConfig": {
         "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1621,6 +1621,9 @@ importers:
       ts-morph:
         specifier: ^25.0.1
         version: 25.0.1
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.10.11(@swc/helpers@0.5.5))(@types/node@22.13.5)(typescript@5.7.3)
     devDependencies:
       '@comet/eslint-config':
         specifier: workspace:*
@@ -1667,9 +1670,6 @@ importers:
       ts-jest:
         specifier: ^29.2.5
         version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.10.11(@swc/helpers@0.5.5))(@types/node@22.13.5)(typescript@5.7.3)))(typescript@5.7.3)
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.10.11(@swc/helpers@0.5.5))(@types/node@22.13.5)(typescript@5.7.3)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -1929,6 +1929,9 @@ importers:
       prettier:
         specifier: ^3.5.2
         version: 3.5.2
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.10.11(@swc/helpers@0.5.5))(@types/node@22.13.5)(typescript@5.7.3)
     devDependencies:
       '@comet/eslint-config':
         specifier: workspace:^7.14.0
@@ -1945,9 +1948,6 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.10.11(@swc/helpers@0.5.5))(@types/node@22.13.5)(typescript@5.7.3)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,9 +231,6 @@ importers:
       prettier:
         specifier: ^3.5.2
         version: 3.5.2
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.10.11(@swc/helpers@0.5.5))(@types/node@22.13.5)(typescript@5.7.3)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -487,9 +484,6 @@ importers:
       swiper:
         specifier: ^11.2.4
         version: 11.2.4
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.10.11(@swc/helpers@0.5.5))(@types/node@22.13.5)(typescript@5.7.3)
     devDependencies:
       '@babel/core':
         specifier: ^7.26.9
@@ -593,9 +587,6 @@ importers:
       swiper:
         specifier: ^11.2.4
         version: 11.2.4
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.10.11(@swc/helpers@0.5.5))(@types/node@22.13.5)(typescript@5.7.3)
     devDependencies:
       '@babel/core':
         specifier: ^7.26.9


### PR DESCRIPTION
## Description
Remove ts-node as peer dependency from @comet/cli and @comet/api-generator package.

related to: https://github.com/vivid-planet/comet/pull/3504#discussion_r1973607841