### PR TITLE
Don't show a trash-icon on the "Confirm" button of `ConfirmPageActionDialog`

### DIFF
--- a/.changeset/thin-cooks-bow.md
+++ b/.changeset/thin-cooks-bow.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Set the correct icon for the button to confirm page actions

--- a/packages/admin/cms-admin/src/pages/pagesPage/ConfirmPageActionDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/ConfirmPageActionDialog.tsx
@@ -1,6 +1,5 @@
-import { CancelButton } from "@comet/admin";
-import { Delete } from "@comet/admin-icons";
-import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
+import { CancelButton, OkayButton } from "@comet/admin";
+import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
 import { ComponentType } from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -69,17 +68,14 @@ export const ConfirmPageActionDialog = ({ open, onCloseDialog, action, selectedP
             </DialogContent>
             <DialogActions>
                 <CancelButton onClick={() => onCloseDialog(false)} />
-                <Button
-                    variant="contained"
-                    color="primary"
+                <OkayButton
                     onClick={() => {
                         onCloseDialog(true);
                     }}
                     autoFocus={true}
-                    startIcon={<Delete />}
                 >
                     <FormattedMessage id="comet.pages.confirmDialog.confirm" defaultMessage="Confirm" />
-                </Button>
+                </OkayButton>
             </DialogActions>
         </Dialog>
     );


### PR DESCRIPTION
## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="704" alt="ConfirmPageActionDialog Previously" src="https://github.com/user-attachments/assets/1c7be959-11f3-4de1-99ef-213b9cb0affc" />   | <img width="704" alt="ConfirmPageActionDialog Now" src="https://github.com/user-attachments/assets/5f1d4fcc-6228-488b-a38f-ad4982719428" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1244
