### PR TITLE
Demo Site: Handle RSC-issues

### DIFF
--- a/demo/site/server.ts
+++ b/demo/site/server.ts
@@ -53,8 +53,17 @@ app.prepare().then(() => {
                 };
             }
 
+            // For Rsc requests: don't cache the response if the _rsc query param is missing
+            const rscParamMissing = !!req.headers["rsc"] && !new URLSearchParams(parsedUrl.search || "").has("_rsc");
+
             const originalWriteHead = res.writeHead;
             res.writeHead = function (statusCode: number, ...args: unknown[]) {
+                // since writeHead is a callback function, it's called after handle() -> we get the actual response statusCode
+                if (statusCode >= 400 || rscParamMissing) {
+                    // prevent caching of error responses
+                    res.setHeader("Cache-Control", "private, no-cache, no-store, max-age=0, must-revalidate");
+                }
+
                 // For redirects: append _rsc query param to redirect location if set in the original request
                 const rsc = new URLSearchParams(parsedUrl.search || "").get("_rsc");
                 const location = res.getHeader("location")?.toString() || "";
@@ -65,15 +74,6 @@ app.prepare().then(() => {
                         redirectSearchParams.set("_rsc", rsc);
                         res.setHeader("location", `${redirectUrl.pathname}?${redirectSearchParams.toString()}`);
                     }
-                }
-
-                // For Rsc requests: don't cache the response if the _rsc query param is missing
-                const rscParamMissing = !!req.headers["rsc"] && !new URLSearchParams(parsedUrl.search || "").has("_rsc");
-
-                // since writeHead is a callback function, it's called after handle() -> we get the actual response statusCode
-                if (statusCode >= 400 || rscParamMissing) {
-                    // prevent caching of error responses
-                    res.setHeader("Cache-Control", "private, no-cache, no-store, max-age=0, must-revalidate");
                 }
 
                 return originalWriteHead.apply(this, [statusCode, ...args]);


### PR DESCRIPTION
Next.js supports different responses on the _same_ URL depending on the presence of a `RSC` header. To avoid CDNs using the same cache selector for those requests, Next.js uses the [Vary Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary).

However, there are CDNs which don't support the `Vary` header. For this reason Next.JS appends a `_rsc` query parameter, even though it does not internally use it. This behaviour leads to problems:

- When making local redirects in the middleware, we can't pass the `_rsc` parameter because it's not accessible (stripped by Next.js). On the other hand the browser preserves the `RSC` header when redirecting, resulting in a request which presents the `RSC` header but no `_rsc` parameter.
-> We fix this by adding the `_rsc` parameter in the `location` header through inspecting the response.
- If it happens that a `RSC` header is present but not `_rsc` parameter we need to avoid caching in the CDN.
  -> We present the appropriate `Cache-Control` header