### PR TITLE
Add Node 22 as supported engine to all packages

### DIFF
--- a/.changeset/gold-windows-fetch.md
+++ b/.changeset/gold-windows-fetch.md
@@ -1,0 +1,21 @@
+---
+"@comet/admin-babel-preset": major
+"@comet/admin-color-picker": major
+"@comet/admin-date-time": major
+"@comet/admin-generator": major
+"@comet/admin-icons": major
+"@comet/api-generator": major
+"@comet/admin-rte": major
+"@comet/cms-admin": major
+"@comet/eslint-config": major
+"@comet/eslint-plugin": major
+"@comet/cms-site": major
+"@comet/admin": major
+"@comet/cms-api": major
+"@comet/cli": major
+---
+
+Require Node v22
+
+The minimum required Node version is now v22.0.0.
+See the migration guide for instructions on how to upgrade your project.

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -33,10 +33,15 @@ It automatically installs the new versions of all `@comet` libraries, runs an ES
 + 22
 ```
 
+```diff title=package.json
+- "@types/node": "^20.0.0",
++ "@types/node": "^22.0.0",
+```
+
 :::note Codemod available
 
 ```sh
-npx @comet/upgrade v8/replace-node-with-v22-in-nvmrc.ts
+npx @comet/upgrade v8/replace-node-with-v22-locally.ts
 ```
 
 :::

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -22,6 +22,50 @@ It automatically installs the new versions of all `@comet` libraries, runs an ES
 
 </details>
 
+## General
+
+### Upgrade Node to v22
+
+#### In development:
+
+```diff title=.nvmrc
+- 20
++ 22
+```
+
+:::note Codemod available
+
+```sh
+npx @comet/upgrade v8/replace-node-with-v22-in-nvmrc.ts
+```
+
+:::
+
+#### In pipeline and deployment:
+
+Make sure you use Node 22 in your CI files.
+When using Gitlab CI, check all files in the .gitlab-ci folders.
+Make sure to extend the correct jobs and replace all images and base images.
+
+```diff
+- extends: .lint-npm-node20
++ extends: .lint-npm-node22
+
+- BASE_IMAGE: "ubi/s2i-ubi9-nodejs20-minimal"
++ BASE_IMAGE: "ubi/s2i-ubi9-nodejs22-minimal"
+
+- image: eu.gcr.io/vivid-planet/utils/ubi9-nodejs20-minimal:master
++ image: eu.gcr.io/vivid-planet/utils/ubi9-nodejs22-minimal:master
+```
+
+:::note Codemod available
+
+```sh
+npx @comet/upgrade v8/replace-node-with-v22-in-gitlab-ci-files.ts
+```
+
+:::
+
 ## API
 
 ### Upgrade peer dependencies

--- a/packages/admin/admin-babel-preset/package.json
+++ b/packages/admin/admin-babel-preset/package.json
@@ -28,6 +28,6 @@
         "registry": "https://registry.npmjs.org"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     }
 }

--- a/packages/admin/admin-babel-preset/package.json
+++ b/packages/admin/admin-babel-preset/package.json
@@ -26,5 +26,8 @@
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"
+    },
+    "engines": {
+        "node": "^22.0.0"
     }
 }

--- a/packages/admin/admin-color-picker/package.json
+++ b/packages/admin/admin-color-picker/package.json
@@ -60,7 +60,7 @@
         "react-intl": "^5.0.0 || ^6.0.0"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/admin/admin-color-picker/package.json
+++ b/packages/admin/admin-color-picker/package.json
@@ -59,6 +59,9 @@
         "react-final-form": "^6.3.1",
         "react-intl": "^5.0.0 || ^6.0.0"
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/admin/admin-date-time/package.json
+++ b/packages/admin/admin-date-time/package.json
@@ -60,7 +60,7 @@
         "react-intl": "^5.0.0 || ^6.0.0"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/admin/admin-date-time/package.json
+++ b/packages/admin/admin-date-time/package.json
@@ -59,6 +59,9 @@
         "react-final-form": "^6.3.1",
         "react-intl": "^5.0.0 || ^6.0.0"
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/admin/admin-generator/package.json
+++ b/packages/admin/admin-generator/package.json
@@ -61,7 +61,7 @@
         "typescript": "^4.9.5"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/admin/admin-generator/package.json
+++ b/packages/admin/admin-generator/package.json
@@ -60,6 +60,9 @@
         "ts-jest": "^29.2.5",
         "typescript": "^4.9.5"
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/admin/admin-icons/package.json
+++ b/packages/admin/admin-icons/package.json
@@ -54,7 +54,7 @@
         "react-dom": "^17.0.0 || ^18.0.0"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/admin/admin-icons/package.json
+++ b/packages/admin/admin-icons/package.json
@@ -53,6 +53,9 @@
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/admin/admin-rte/package.json
+++ b/packages/admin/admin-rte/package.json
@@ -71,7 +71,7 @@
         "react-intl": "^5.0.0 || ^6.0.0"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/admin/admin-rte/package.json
+++ b/packages/admin/admin-rte/package.json
@@ -70,6 +70,9 @@
         "react-final-form": "^6.3.1",
         "react-intl": "^5.0.0 || ^6.0.0"
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -118,7 +118,7 @@
         }
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -117,6 +117,9 @@
             "optional": true
         }
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -137,7 +137,7 @@
         "react-router-dom": "^5.0.0"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -136,6 +136,9 @@
         "react-router": "^5.0.0",
         "react-router-dom": "^5.0.0"
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/api/api-generator/package.json
+++ b/packages/api/api-generator/package.json
@@ -59,7 +59,7 @@
         "class-validator": "^0.14.0"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/api/api-generator/package.json
+++ b/packages/api/api-generator/package.json
@@ -58,6 +58,9 @@
         "@nestjs/graphql": "^13.0.0",
         "class-validator": "^0.14.0"
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -138,7 +138,7 @@
         }
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -137,6 +137,9 @@
             "optional": true
         }
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
         "typescript": "^5.7.3"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,9 @@
         "rimraf": "^6.0.1",
         "typescript": "^5.7.3"
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -60,7 +60,7 @@
         }
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -59,6 +59,9 @@
             "optional": true
         }
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -37,7 +37,7 @@
         "prettier": ">=3"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -36,6 +36,9 @@
         "eslint": ">=9",
         "prettier": ">=3"
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"

--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -62,7 +62,7 @@
         "styled-components": "^6.0.0"
     },
     "engines": {
-        "node": "^22.0.0"
+        "node": ">=22.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -61,6 +61,9 @@
         "react-dom": "^18.0.0",
         "styled-components": "^6.0.0"
     },
+    "engines": {
+        "node": "^22.0.0"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
## Description

Adds Node 22 as the supported Node version to all packages. This will cause a warning when installing the package on an older Node version.

---

Upgrade Scripts: https://github.com/vivid-planet/comet-upgrade/pull/67