### PR TITLE
Add possibility to define warning messages in admin to allow translations

### DIFF
--- a/demo/admin/src/warnings/WarningsGrid.tsx
+++ b/demo/admin/src/warnings/WarningsGrid.tsx
@@ -16,7 +16,8 @@ import { WarningSolid } from "@comet/admin-icons";
 import { Chip } from "@mui/material";
 import { DataGrid, GridToolbarQuickFilter } from "@mui/x-data-grid";
 import { type GQLWarningSeverity } from "@src/graphql.generated";
-import { FormattedMessage, type MessageDescriptor, useIntl } from "react-intl";
+import { type ReactNode } from "react";
+import { useIntl } from "react-intl";
 
 import { warningMessages as cometWarningMessages } from "./warningMessages";
 import { type GQLWarningsGridQuery, type GQLWarningsGridQueryVariables, type GQLWarningsListFragment } from "./WarningsGrid.generated";
@@ -59,7 +60,7 @@ function WarningsGridToolbar() {
 }
 
 interface WarningsGridProps {
-    warningMessages?: Record<string, MessageDescriptor>;
+    warningMessages?: Record<string, ReactNode>;
 }
 
 export function WarningsGrid({ warningMessages: projectWarningMessages }: WarningsGridProps) {
@@ -116,7 +117,7 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
                 const warning = warningMessages[params.value as keyof typeof warningMessages];
 
                 if (warning) {
-                    return <FormattedMessage {...warning} />;
+                    return warning;
                 } else {
                     console.error(`Missing warning message for "${params.value}". Custom warning messages can be passed to WarningsPage component.`);
                     return params.value;

--- a/demo/admin/src/warnings/WarningsGrid.tsx
+++ b/demo/admin/src/warnings/WarningsGrid.tsx
@@ -16,8 +16,9 @@ import { WarningSolid } from "@comet/admin-icons";
 import { Chip } from "@mui/material";
 import { DataGrid, GridToolbarQuickFilter } from "@mui/x-data-grid";
 import { type GQLWarningSeverity } from "@src/graphql.generated";
-import { useIntl } from "react-intl";
+import { FormattedMessage, type MessageDescriptor, useIntl } from "react-intl";
 
+import { warningMessages as cometWarningMessages } from "./warningMessages";
 import { type GQLWarningsGridQuery, type GQLWarningsGridQueryVariables, type GQLWarningsListFragment } from "./WarningsGrid.generated";
 
 const warningsFragment = gql`
@@ -57,7 +58,11 @@ function WarningsGridToolbar() {
     );
 }
 
-export function WarningsGrid() {
+interface WarningsGridProps {
+    warningMessages?: Record<string, MessageDescriptor>;
+}
+
+export function WarningsGrid({ warningMessages: projectWarningMessages }: WarningsGridProps) {
     const intl = useIntl();
     const dataGridProps = {
         ...useDataGridRemote({ initialFilter: { items: [{ field: "state", operator: "is", value: "open" }] } }),
@@ -106,6 +111,17 @@ export function WarningsGrid() {
             field: "message",
             headerName: intl.formatMessage({ id: "warning.message", defaultMessage: "Message" }),
             flex: 1,
+            renderCell: (params) => {
+                const warningMessages = { ...cometWarningMessages, ...projectWarningMessages };
+                const warning = warningMessages[params.value as keyof typeof warningMessages];
+
+                if (warning) {
+                    return <FormattedMessage {...warning} />;
+                } else {
+                    console.error(`Missing warning message for "${params.value}". Custom warning messages can be passed to WarningsPage component.`);
+                    return params.value;
+                }
+            },
         },
         {
             field: "status",

--- a/demo/admin/src/warnings/WarningsGrid.tsx
+++ b/demo/admin/src/warnings/WarningsGrid.tsx
@@ -68,6 +68,7 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
         ...useDataGridRemote({ initialFilter: { items: [{ field: "state", operator: "is", value: "open" }] } }),
         ...usePersistentColumnState("WarningsGrid"),
     };
+    const warningMessages = { ...cometWarningMessages, ...projectWarningMessages };
 
     const columns: GridColDef<GQLWarningsListFragment>[] = [
         {
@@ -112,7 +113,6 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
             headerName: intl.formatMessage({ id: "warning.message", defaultMessage: "Message" }),
             flex: 1,
             renderCell: (params) => {
-                const warningMessages = { ...cometWarningMessages, ...projectWarningMessages };
                 const warning = warningMessages[params.value as keyof typeof warningMessages];
 
                 if (warning) {

--- a/demo/admin/src/warnings/WarningsPage.tsx
+++ b/demo/admin/src/warnings/WarningsPage.tsx
@@ -1,10 +1,11 @@
 import { Stack } from "@comet/admin";
-import { type MessageDescriptor, useIntl } from "react-intl";
+import { type ReactNode } from "react";
+import { useIntl } from "react-intl";
 
 import { WarningsGrid } from "./WarningsGrid";
 
 interface WarningsPageProps {
-    warningMessages?: Record<string, MessageDescriptor>;
+    warningMessages?: Record<string, ReactNode>;
 }
 
 export function WarningsPage({ warningMessages }: WarningsPageProps) {

--- a/demo/admin/src/warnings/WarningsPage.tsx
+++ b/demo/admin/src/warnings/WarningsPage.tsx
@@ -1,13 +1,17 @@
 import { Stack } from "@comet/admin";
-import { useIntl } from "react-intl";
+import { type MessageDescriptor, useIntl } from "react-intl";
 
 import { WarningsGrid } from "./WarningsGrid";
 
-export function WarningsPage() {
+interface WarningsPageProps {
+    warningMessages?: Record<string, MessageDescriptor>;
+}
+
+export function WarningsPage({ warningMessages }: WarningsPageProps) {
     const intl = useIntl();
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "warnings.warnings", defaultMessage: "Warnings" })}>
-            <WarningsGrid />
+            <WarningsGrid warningMessages={warningMessages} />
         </Stack>
     );
 }

--- a/demo/admin/src/warnings/warningMessages.ts
+++ b/demo/admin/src/warnings/warningMessages.ts
@@ -1,5 +1,0 @@
-import { defineMessages } from "react-intl";
-
-export const warningMessages = defineMessages({
-    missingHtmlTitle: { id: "comet.warnings.missingHtmlTitle", defaultMessage: "Missing HTML Title" },
-});

--- a/demo/admin/src/warnings/warningMessages.ts
+++ b/demo/admin/src/warnings/warningMessages.ts
@@ -1,0 +1,5 @@
+import { defineMessages } from "react-intl";
+
+export const warningMessages = defineMessages({
+    missingHtmlTitle: { id: "comet.warnings.missingHtmlTitle", defaultMessage: "Missing HTML Title" },
+});

--- a/demo/admin/src/warnings/warningMessages.tsx
+++ b/demo/admin/src/warnings/warningMessages.tsx
@@ -1,0 +1,5 @@
+import { FormattedMessage } from "react-intl";
+
+export const warningMessages = {
+    missingHtmlTitle: <FormattedMessage id="comet.warnings.missingHtmlTitle" defaultMessage="Missing HTML Title" />,
+};

--- a/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
+++ b/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
@@ -140,7 +140,7 @@ export function createSeoBlock<ImageBlock extends Block = typeof PixelImageBlock
         warnings() {
             if (!this.htmlTitle) {
                 const severity: WarningSeverity = "low";
-                return [{ severity, message: "Missing HTML title" }];
+                return [{ severity, message: "missingHtmlTitle" }];
             }
             return [];
         }


### PR DESCRIPTION
## Description
Add possibility to define warning messages in admin to allow translations. It should be possible to translate warnings, therefore I added a warningsMessages.ts file which should be in the library in the future and the possibility to add custom warningMessages in the project.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts


https://github.com/user-attachments/assets/0b664ca6-a7c2-4c0e-8abc-26e7558e6c21



## Open TODOs/questions

-   [x] Is better Validation needed? Should it be allowed to just define any string ?

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-921
