### PR TITLE
Adapt `FieldSet` styling

### DIFF
--- a/.changeset/tough-cherries-provide.md
+++ b/.changeset/tough-cherries-provide.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Adapt styling of `FieldSet` to align with Comet DXP design

--- a/packages/admin/admin/src/common/FieldSet.tsx
+++ b/packages/admin/admin/src/common/FieldSet.tsx
@@ -43,6 +43,7 @@ export type FieldSetClassKey =
 type OwnerState = {
     disablePadding: boolean;
     hiddenSummary: boolean;
+    collapsible: boolean;
 };
 
 export const FieldSet = (inProps: PropsWithChildren<FieldSetProps>) => {
@@ -66,6 +67,7 @@ export const FieldSet = (inProps: PropsWithChildren<FieldSetProps>) => {
     const ownerState: OwnerState = {
         disablePadding,
         hiddenSummary: !title,
+        collapsible,
     };
 
     return (
@@ -83,7 +85,7 @@ export const FieldSet = (inProps: PropsWithChildren<FieldSetProps>) => {
             {...restProps}
         >
             {!ownerState.hiddenSummary && (
-                <Summary expandIcon={collapsible && <ChevronRight />} {...slotProps?.summary}>
+                <Summary expandIcon={collapsible ? <ChevronRight /> : undefined} ownerState={ownerState} {...slotProps?.summary}>
                     <HeaderColumn {...slotProps?.headerColumn}>
                         <Title {...slotProps?.title}>{title}</Title>
                         <SupportText {...slotProps?.supportText}>{supportText}</SupportText>
@@ -107,15 +109,20 @@ const Root = createComponentSlot(MuiAccordion)<FieldSetClassKey, OwnerState>({
     },
 })();
 
-const Summary = createComponentSlot(MuiAccordionSummary)<FieldSetClassKey>({
+const Summary = createComponentSlot(MuiAccordionSummary)<FieldSetClassKey, OwnerState>({
     componentName: "FieldSet",
     slotName: "summary",
 })(
-    ({ theme }) => css`
+    ({ theme, ownerState }) => css`
         display: flex;
         flex-direction: row-reverse;
         padding: 0 10px;
         height: 80px;
+
+        ${!ownerState.collapsible &&
+        css`
+            cursor: default !important;
+        `}
 
         ${theme.breakpoints.up("sm")} {
             padding: 0 20px;

--- a/packages/admin/admin/src/common/FieldSet.tsx
+++ b/packages/admin/admin/src/common/FieldSet.tsx
@@ -117,7 +117,7 @@ const Summary = createComponentSlot(MuiAccordionSummary)<FieldSetClassKey, Owner
         display: flex;
         flex-direction: row-reverse;
         padding: 0 10px;
-        height: 80px;
+        height: 60px;
 
         ${!ownerState.collapsible &&
         css`
@@ -126,6 +126,7 @@ const Summary = createComponentSlot(MuiAccordionSummary)<FieldSetClassKey, Owner
 
         ${theme.breakpoints.up("sm")} {
             padding: 0 20px;
+            height: 80px;
         }
     `,
 );


### PR DESCRIPTION
## Description

- Correct mobile spacing
- Set cursor to default, when Fieldset is not collapsible

## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| 
![Screenshot 2025-02-28 at 12 24 11](https://github.com/user-attachments/assets/8317c0a5-998f-401e-b15b-4a2fcf76f085) | 
![Screenshot 2025-02-28 at 12 23 55](https://github.com/user-attachments/assets/007618d5-2ffd-418d-b57f-fa037bda435d)
  |

## Open TODOs/questions

-   [ ] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-XXX
