### PR TITLE
Demo: Add support for DAM files to link document type

### DIFF
--- a/demo/site/src/documents/links/Link.tsx
+++ b/demo/site/src/documents/links/Link.tsx
@@ -1,5 +1,5 @@
 import { gql } from "@comet/cms-site";
-import { ExternalLinkBlockData, InternalLinkBlockData } from "@src/blocks.generated";
+import { DamFileDownloadLinkBlockData, ExternalLinkBlockData, InternalLinkBlockData } from "@src/blocks.generated";
 import { GQLPageTreeNodeScopeInput } from "@src/graphql.generated";
 import { createGraphQLFetch } from "@src/util/graphQLClient";
 import { notFound, redirect } from "next/navigation";
@@ -43,6 +43,13 @@ export async function Link({ pageTreeNodeId }: Props): Promise<JSX.Element> {
 
         if (content.block?.type === "external") {
             const link = (content.block.props as ExternalLinkBlockData).targetUrl;
+            if (link) {
+                redirect(link);
+            }
+        }
+
+        if (content.block?.type === "damFileDownload") {
+            const link = (content.block.props as DamFileDownloadLinkBlockData).file?.fileUrl.replace("/download", "");
             if (link) {
                 redirect(link);
             }

--- a/demo/site/src/documents/links/Link.tsx
+++ b/demo/site/src/documents/links/Link.tsx
@@ -49,8 +49,7 @@ export async function Link({ pageTreeNodeId }: Props): Promise<JSX.Element> {
         }
 
         if (content.block?.type === "damFileDownload") {
-            const fileUrl = (content.block.props as DamFileDownloadLinkBlockData).file?.fileUrl.replace("/download", "");
-            const link = fileUrl?.includes("/dam/") ? fileUrl.substring(fileUrl.indexOf("/dam/")) : fileUrl;
+            const link = (content.block.props as DamFileDownloadLinkBlockData).file?.fileUrl.replace("/download", "");
             if (link) {
                 redirect(link);
             }

--- a/demo/site/src/documents/links/Link.tsx
+++ b/demo/site/src/documents/links/Link.tsx
@@ -49,7 +49,8 @@ export async function Link({ pageTreeNodeId }: Props): Promise<JSX.Element> {
         }
 
         if (content.block?.type === "damFileDownload") {
-            const link = (content.block.props as DamFileDownloadLinkBlockData).file?.fileUrl.replace("/download", "");
+            const fileUrl = (content.block.props as DamFileDownloadLinkBlockData).file?.fileUrl.replace("/download", "");
+            const link = fileUrl?.includes("/dam/") ? fileUrl.substring(fileUrl.indexOf("/dam/")) : fileUrl;
             if (link) {
                 redirect(link);
             }

--- a/demo/site/src/util/graphQLClient.ts
+++ b/demo/site/src/util/graphQLClient.ts
@@ -28,6 +28,7 @@ export function createGraphQLFetch() {
                 revalidate: 7.5 * 60,
             },
             headers: {
+                "x-relative-dam-urls": "1",
                 authorization: `Basic ${Buffer.from(`vivid:${process.env.API_PASSWORD}`).toString("base64")}`,
                 ...convertPreviewDataToHeaders(previewData),
             },


### PR DESCRIPTION
## Description

If the damFileDownload link is opened directly, it should redirect to the asset regardless of the selection ('as a download' or 'in a new tab').

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

![image](https://github.com/user-attachments/assets/06afc97b-ba30-401f-a9a3-3ee04a2ee488)


https://github.com/user-attachments/assets/3e0d189a-eddf-4ba6-8c9e-b1a2fd3931a1

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1639
