### PR TITLE
Export `UserPermissionsService` and `CurrentUserPermission`

### DIFF
--- a/.changeset/silly-buses-do.md
+++ b/.changeset/silly-buses-do.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-api": minor
+---
+
+Export `UserPermissionsService` from `@comet/cms-api`
+
+This allows the usage of `getPermissionsAndContentScopes` if projects want to get all rule based
+and admin based permissions for specific users.

--- a/.changeset/silly-buses-do.md
+++ b/.changeset/silly-buses-do.md
@@ -2,7 +2,6 @@
 "@comet/cms-api": minor
 ---
 
-Export `UserPermissionsService` from `@comet/cms-api`
+Export `UserPermissionsService` and `CurrentUserPermission`
 
-This allows the usage of `getPermissionsAndContentScopes` if projects want to get all rule based
-and admin based permissions for specific users.
+This allows the usage of `getPermissionsAndContentScopes` if projects want to get all rule-based and admin-based permissions for specific users.

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -172,10 +172,12 @@ export { RequiredPermission } from "./user-permissions/decorators/required-permi
 export { DisablePermissionCheck } from "./user-permissions/decorators/required-permission.decorator";
 export { ScopedEntity, ScopedEntityMeta } from "./user-permissions/decorators/scoped-entity.decorator";
 export { CurrentUser } from "./user-permissions/dto/current-user";
+export { CurrentUserPermission } from "./user-permissions/dto/current-user";
 export { FindUsersArgs } from "./user-permissions/dto/paginated-user-list";
 export { ContentScope } from "./user-permissions/interfaces/content-scope.interface";
 export { User } from "./user-permissions/interfaces/user";
 export { UserPermissionsModule } from "./user-permissions/user-permissions.module";
+export { UserPermissionsService } from "./user-permissions/user-permissions.service";
 export {
     AccessControlServiceInterface,
     ContentScopesForUser,

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -177,7 +177,7 @@ export { FindUsersArgs } from "./user-permissions/dto/paginated-user-list";
 export { ContentScope } from "./user-permissions/interfaces/content-scope.interface";
 export { User } from "./user-permissions/interfaces/user";
 export { UserPermissionsModule } from "./user-permissions/user-permissions.module";
-export { UserPermissionsService } from "./user-permissions/user-permissions.service";
+export { UserPermissionsPublicService as UserPermissionsService } from "./user-permissions/user-permissions.public.service";
 export {
     AccessControlServiceInterface,
     ContentScopesForUser,

--- a/packages/api/cms-api/src/user-permissions/user-permissions.module.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.module.ts
@@ -11,6 +11,7 @@ import { UserResolver } from "./user.resolver";
 import { UserContentScopesResolver } from "./user-content-scopes.resolver";
 import { UserPermissionResolver } from "./user-permission.resolver";
 import { ACCESS_CONTROL_SERVICE, USER_PERMISSIONS_OPTIONS, USER_PERMISSIONS_USER_SERVICE } from "./user-permissions.constants";
+import { UserPermissionsPublicService } from "./user-permissions.public.service";
 import { UserPermissionsService } from "./user-permissions.service";
 import {
     UserPermissionsAsyncOptions,
@@ -24,6 +25,7 @@ import {
     imports: [MikroOrmModule.forFeature([UserPermission, UserContentScopes]), DiscoveryModule],
     providers: [
         UserPermissionsService,
+        UserPermissionsPublicService,
         UserResolver,
         UserPermissionResolver,
         UserContentScopesResolver,
@@ -33,7 +35,7 @@ import {
             useClass: UserPermissionsGuard,
         },
     ],
-    exports: [ContentScopeService, ACCESS_CONTROL_SERVICE, UserPermissionsService],
+    exports: [ContentScopeService, ACCESS_CONTROL_SERVICE, UserPermissionsService, UserPermissionsPublicService],
 })
 export class UserPermissionsModule {
     static forRoot(options: UserPermissionsModuleSyncOptions): DynamicModule {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.public.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.public.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from "@nestjs/common";
+
+import { User } from "./interfaces/user";
+import { UserPermissionsService } from "./user-permissions.service";
+
+@Injectable()
+export class UserPermissionsPublicService {
+    constructor(private readonly service: UserPermissionsService) {}
+
+    async getAvailableContentScopes() {
+        return this.service.getAvailableContentScopes();
+    }
+
+    async getAvailablePermissions() {
+        return this.service.getAvailablePermissions();
+    }
+
+    async getPermissionsAndContentScopes(user: User) {
+        return this.service.getPermissionsAndContentScopes(user);
+    }
+}


### PR DESCRIPTION
This allows the usage of `getPermissionsAndContentScopes` if projects want to get all rule-based and admin-based permissions for specific users.