### PR TITLE
Readd @comet/eslint-plugin dependency to @comet/eslint-config

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -29,6 +29,7 @@
     },
     "dependencies": {
         "@calm/eslint-plugin-react-intl": "^1.4.1",
+        "@comet/eslint-plugin": "workspace:^8.0.0-beta.0",
         "@eslint/js": "^9.21.0",
         "@next/eslint-plugin-next": "^15.2.0",
         "eslint-config-next": "^15.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2021,6 +2021,9 @@ importers:
       '@calm/eslint-plugin-react-intl':
         specifier: ^1.4.1
         version: 1.4.1
+      '@comet/eslint-plugin':
+        specifier: workspace:^8.0.0-beta.0
+        version: link:../eslint-plugin
       '@eslint/js':
         specifier: ^9.21.0
         version: 9.21.0


### PR DESCRIPTION
## Description

This dependency was removed (probably) mistakenly in https://github.com/vivid-planet/comet/pull/3230/files#diff-b398e019411e81059801ebf7fe19f6ebcad0bc316fd5c0449d8acdbee9d6d5deL18

This causes this error:

<img width="917" alt="Bildschirmfoto 2025-03-03 um 11 31 28" src="https://github.com/user-attachments/assets/24eeb87d-f5f5-462e-bb4e-bbd313994073" />
