### PR TITLE
Unify GraphQL operation names

### DIFF
--- a/demo/admin/src/dashboard/LatestContentUpdates.tsx
+++ b/demo/admin/src/dashboard/LatestContentUpdates.tsx
@@ -8,7 +8,7 @@ import { type GQLLatestContentUpdatesQuery } from "./LatestContentUpdates.genera
 
 export const LatestContentUpdates = () => {
     const contentScope = useContentScope();
-    const { data, loading, error } = useQuery<GQLLatestContentUpdatesQuery, GQLLatestContentUpdatesQueryVariables>(LATEST_CONTENT_UPDATES_QUERY, {
+    const { data, loading, error } = useQuery<GQLLatestContentUpdatesQuery, GQLLatestContentUpdatesQueryVariables>(latestContentUpdatesQuery, {
         variables: {
             scope: contentScope.scope,
         },
@@ -26,7 +26,7 @@ export const LatestContentUpdates = () => {
     return <LatestContentUpdatesDashboardWidget rows={rows} loading={loading} />;
 };
 
-const LATEST_CONTENT_UPDATES_QUERY = gql`
+const latestContentUpdatesQuery = gql`
     query LatestContentUpdates($scope: PageTreeNodeScopeInput!) {
         paginatedPageTreeNodes(offset: 0, limit: 5, scope: $scope, sort: [{ field: updatedAt, direction: DESC }]) {
             nodes {

--- a/demo/admin/src/mainMenu/MainMenu.tsx
+++ b/demo/admin/src/mainMenu/MainMenu.tsx
@@ -5,7 +5,7 @@ import { useIntl } from "react-intl";
 import EditMainMenuItem, { editMainMenuItemFragment, type GQLEditMainMenuItemFragment } from "./components/EditMainMenuItem";
 import MainMenuItems from "./components/MainMenuItems";
 
-const MAIN_MENU_ITEM_QUERY = gql`
+const mainMenuItemQuery = gql`
     query MainMenuItem($id: ID!) {
         mainMenuItem(pageTreeNodeId: $id) {
             ...EditMainMenuItem
@@ -29,7 +29,7 @@ const MainMenu = () => {
                         <Selected<GQLEditMainMenuItemFragment>
                             selectionMode="edit"
                             selectedId={selectedId}
-                            query={MAIN_MENU_ITEM_QUERY}
+                            query={mainMenuItemQuery}
                             dataAccessor="mainMenuItem"
                         >
                             {(item) => (item === undefined ? <Loading behavior="fillPageHeight" /> : <EditMainMenuItem item={item} />)}

--- a/packages/admin/cms-admin/src/dashboard/widgets/LatestBuildsDashboardWidget.tsx
+++ b/packages/admin/cms-admin/src/dashboard/widgets/LatestBuildsDashboardWidget.tsx
@@ -10,7 +10,7 @@ import { DashboardWidgetRoot } from "./DashboardWidgetRoot";
 import { type GQLLatestBuildsQuery, type GQLLatestBuildsQueryVariables } from "./LatestBuildsDashboardWidget.generated";
 
 export const LatestBuildsDashboardWidget = () => {
-    const { data, loading, error } = useQuery<GQLLatestBuildsQuery, GQLLatestBuildsQueryVariables>(LATEST_BUILDS);
+    const { data, loading, error } = useQuery<GQLLatestBuildsQuery, GQLLatestBuildsQueryVariables>(latestBuildsQuery);
 
     const intl = useIntl();
 
@@ -53,7 +53,7 @@ const disableFieldOptions = {
     hideable: false,
 };
 
-const LATEST_BUILDS = gql`
+const latestBuildsQuery = gql`
     query LatestBuilds {
         builds(limit: 5) {
             id

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
@@ -46,7 +46,7 @@ interface PageTreeProps {
 
 type PageTreeRefApi = { scrollToItem: List["scrollToItem"] };
 
-const MOVE_PAGE_TREE_NODES_BY_POS = gql`
+const movePageTreeNodesByPositionMutation = gql`
     mutation MovePageTreeNodesByPos($ids: [ID!]!, $input: MovePageTreeNodesByPosInput!) {
         movePageTreeNodesByPos(ids: $ids, input: $input) {
             id
@@ -58,7 +58,7 @@ const MOVE_PAGE_TREE_NODES_BY_POS = gql`
     }
 `;
 
-const MOVE_PAGE_TREE_NODES_BY_NEIGHBOURS = gql`
+const movePageTreeNodesByNeighboursMutation = gql`
     mutation MovePageTreeNodesByNeighbour($ids: [ID!]!, $input: MovePageTreeNodesByNeighbourInput!) {
         movePageTreeNodesByNeighbour(ids: $ids, input: $input) {
             id
@@ -70,7 +70,7 @@ const MOVE_PAGE_TREE_NODES_BY_NEIGHBOURS = gql`
     }
 `;
 
-const RESET_SLUG = gql`
+const restSlugMutation = gql`
     mutation ResetSlug($id: ID!, $slug: String!) {
         updatePageTreeNodeSlug(id: $id, slug: $slug) {
             id
@@ -79,7 +79,7 @@ const RESET_SLUG = gql`
     }
 `;
 
-const PAGES_CACHE_QUERY = gql`
+const pagesCacheQuery = gql`
     query PagesCache($contentScope: PageTreeNodeScopeInput!, $category: String!) {
         pages: pageTreeNodeList(scope: $contentScope, category: $category) {
             id
@@ -157,7 +157,7 @@ const PageTree: ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = (
         // @TODO: handle path collisions when moving pages
         async ({ ids, parentId, position }: { ids: string[]; parentId: string | null; position: number }) => {
             await client.mutate({
-                mutation: MOVE_PAGE_TREE_NODES_BY_POS,
+                mutation: movePageTreeNodesByPositionMutation,
                 variables: {
                     ids: ids,
                     input: {
@@ -204,7 +204,7 @@ const PageTree: ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = (
                     }
 
                     const pagesQueryData = proxy.readQuery<GQLPagesCacheQuery, GQLPagesCacheQueryVariables>({
-                        query: PAGES_CACHE_QUERY,
+                        query: pagesCacheQuery,
                         variables: {
                             contentScope: scope,
                             category,
@@ -223,7 +223,7 @@ const PageTree: ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = (
 
                         return updatedPageData;
                     });
-                    proxy.writeQuery({ query: PAGES_CACHE_QUERY, data: { pages: updatedPages } });
+                    proxy.writeQuery({ query: pagesCacheQuery, data: { pages: updatedPages } });
                 },
             });
         },
@@ -233,7 +233,7 @@ const PageTree: ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = (
     const moveByNeighbourRequest = useCallback(
         async ({ ids, parentId, afterId, beforeId }: { ids: string[]; parentId: string | null; afterId: string | null; beforeId: string | null }) => {
             await client.mutate({
-                mutation: MOVE_PAGE_TREE_NODES_BY_NEIGHBOURS,
+                mutation: movePageTreeNodesByNeighboursMutation,
                 variables: {
                     ids: ids,
                     input: {
@@ -294,7 +294,7 @@ const PageTree: ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = (
                                 });
 
                                 await client.mutate<GQLResetSlugMutation, GQLResetSlugMutationVariables>({
-                                    mutation: RESET_SLUG,
+                                    mutation: restSlugMutation,
                                     variables: {
                                         id: pageToUndo.id,
                                         slug: pageToUndo.slug,

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
@@ -70,7 +70,7 @@ const movePageTreeNodesByNeighboursMutation = gql`
     }
 `;
 
-const restSlugMutation = gql`
+const resetSlugMutation = gql`
     mutation ResetSlug($id: ID!, $slug: String!) {
         updatePageTreeNodeSlug(id: $id, slug: $slug) {
             id
@@ -294,7 +294,7 @@ const PageTree: ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = (
                                 });
 
                                 await client.mutate<GQLResetSlugMutation, GQLResetSlugMutationVariables>({
-                                    mutation: restSlugMutation,
+                                    mutation: resetSlugMutation,
                                     variables: {
                                         id: pageToUndo.id,
                                         slug: pageToUndo.slug,


### PR DESCRIPTION
## Description
Unify operation variable names, so all are `camelCase` and not mixed between `camelCase` and `UPPER_CASE`. Also, add the operation type as postfix.