### PR TITLE
Demo Admin: Reuse display names in standalone blocks

### DIFF
--- a/demo/admin/src/common/blocks/StandaloneCallToActionListBlock.tsx
+++ b/demo/admin/src/common/blocks/StandaloneCallToActionListBlock.tsx
@@ -6,7 +6,7 @@ import { FormattedMessage } from "react-intl";
 export const StandaloneCallToActionListBlock = createCompositeBlock(
     {
         name: "StandaloneCallToActionList",
-        displayName: <FormattedMessage id="standaloneCallToActionList.displayName" defaultMessage="CallToActionList" />,
+        displayName: CallToActionListBlock.displayName,
         blocks: {
             callToActionList: {
                 block: CallToActionListBlock,

--- a/demo/admin/src/common/blocks/StandaloneHeadingBlock.tsx
+++ b/demo/admin/src/common/blocks/StandaloneHeadingBlock.tsx
@@ -7,7 +7,7 @@ import { FormattedMessage } from "react-intl";
 export const StandaloneHeadingBlock = createCompositeBlock(
     {
         name: "StandaloneHeading",
-        displayName: <FormattedMessage id="standaloneHeading.displayName" defaultMessage="Heading" />,
+        displayName: HeadingBlock.displayName,
         blocks: {
             heading: {
                 block: HeadingBlock,

--- a/demo/admin/src/common/blocks/StandaloneMediaBlock.tsx
+++ b/demo/admin/src/common/blocks/StandaloneMediaBlock.tsx
@@ -7,7 +7,7 @@ import { FormattedMessage } from "react-intl";
 export const StandaloneMediaBlock = createCompositeBlock(
     {
         name: "Media",
-        displayName: <FormattedMessage id="standaloneMedia.displayName" defaultMessage="Media" />,
+        displayName: MediaBlock.displayName,
         blocks: {
             media: {
                 block: MediaBlock,


### PR DESCRIPTION
## Description

Doing so fixes inconsistencies between standalone and normal blocks.
