### PR TITLE
Adapt and correct usage of MUI's `Link`

### DIFF
--- a/.changeset/cold-dots-buy.md
+++ b/.changeset/cold-dots-buy.md
@@ -3,3 +3,5 @@
 ---
 
 Adapt styling of `MuiLink` according to design of Comet DXP
+
+Use `MuiLink` only for links in continuous text or as stand-alone text-links. Replace all other usages with better fitting components (e.g. `RouterLink`, `StackLink`, or `Button`)

--- a/.changeset/cold-dots-buy.md
+++ b/.changeset/cold-dots-buy.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": minor
+---
+
+Adapt styling of `MuiLink` according to design of Comet DXP

--- a/.changeset/cold-dots-buy.md
+++ b/.changeset/cold-dots-buy.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin-theme": minor
+"@comet/admin": minor
 ---
 
 Adapt styling of `MuiLink` according to design of Comet DXP

--- a/.changeset/cold-dots-buy.md
+++ b/.changeset/cold-dots-buy.md
@@ -2,6 +2,6 @@
 "@comet/admin": minor
 ---
 
-Adapt styling of `MuiLink` according to design of Comet DXP
+Adapt styling of MUI's `Link` according to the Comet DXP design
 
-Use `MuiLink` only for links in continuous text or as stand-alone text-links. Replace all other usages with better fitting components (e.g. `RouterLink`, `StackLink`, or `Button`)
+Use `Link` only for links in continuous text or as standalone text links. Replace all other usages with better fitting components (e.g., `RouterLink`, `StackLink`, or `Button`).

--- a/packages/admin/admin/src/stack/breadcrumbs/BreadcrumbsEntry.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/BreadcrumbsEntry.tsx
@@ -1,13 +1,14 @@
 import { LevelUp } from "@comet/admin-icons";
-import { IconButton as MuiIconButton, Link as MuiLink, Typography } from "@mui/material";
+import { IconButton as MuiIconButton, type Link as MuiLink, Typography } from "@mui/material";
 import { css } from "@mui/material/styles";
+import { Link as RouterLink } from "react-router-dom";
 
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { type BreadcrumbItem } from "../Stack";
 import { BreadcrumbLink } from "./BreadcrumbLink";
 import { BackButtonSeparator, type StackBreadcrumbsClassKey, type StackBreadcrumbsProps } from "./StackBreadcrumbs";
 
-const Link = createComponentSlot(MuiLink)<StackBreadcrumbsClassKey>({
+const Link = createComponentSlot(RouterLink)<StackBreadcrumbsClassKey>({
     componentName: "StackBreadcrumbs",
     slotName: "link",
 })(

--- a/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
@@ -1,8 +1,8 @@
 import { ChevronRight } from "@comet/admin-icons";
-import { type Link } from "@mui/material";
 import { type ComponentsOverrides, css, type Theme, useTheme, useThemeProps } from "@mui/material/styles";
 import type Typography from "@mui/material/Typography";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type Link } from "react-router-dom";
 
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";

--- a/packages/admin/admin/src/theme/componentsTheme/MuiLink.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiLink.ts
@@ -9,7 +9,7 @@ export const getMuiLink: GetMuiComponentTheme<"MuiLink"> = (component, { palette
     },
     styleOverrides: mergeOverrideStyles<"MuiLink">(component?.styleOverrides, {
         root: {
-            color: palette.grey[600],
+            color: palette.primary.main,
             fontWeight: 250,
             fontSize: 16,
             lineHeight: "16px",

--- a/packages/admin/cms-admin/src/dam/DataGrid/label/DamItemLabelColumn.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/label/DamItemLabelColumn.tsx
@@ -1,5 +1,5 @@
 import { type IFilterApi, StackLink } from "@comet/admin";
-import { Box, Link } from "@mui/material";
+import { Box } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { type ReactNode, useEffect, useRef } from "react";
 import { type FileRejection, useDropzone } from "react-dropzone";
@@ -27,6 +27,13 @@ const DamItemLabelWrapper = styled(Box, { shouldForwardProp: (prop) => prop !== 
 
     border: ${({ theme, isHovered }) => (isHovered ? `solid 1px ${theme.palette.primary.main}` : "none")};
     background-color: ${({ isHovered }) => (isHovered ? "rgba(41, 182, 246, 0.1)" : "transparent")};
+`;
+
+const StyledStackLink = styled(StackLink)`
+    width: 100%;
+    height: 100%;
+    text-decoration: none;
+    color: ${({ theme }) => theme.palette.grey[900]};
 `;
 
 export interface RenderDamLabelOptions {
@@ -104,19 +111,13 @@ export const DamItemLabelColumn = ({
             {renderDamLabel ? (
                 renderDamLabel(item, { matches: matches.get(item.id), filterApi, showLicenseWarnings: damConfig.enableLicenseFeature })
             ) : (
-                <Link
-                    underline="none"
-                    component={StackLink}
+                <StyledStackLink
                     pageName={isFile(item) ? "edit" : "folder"}
                     payload={item.id}
                     onClick={() => {
                         if (isFolder(item)) {
                             filterApi.formApi.change("searchText", undefined);
                         }
-                    }}
-                    sx={{
-                        width: "100%",
-                        height: "100%",
                     }}
                 >
                     <DamItemLabel
@@ -125,7 +126,7 @@ export const DamItemLabelColumn = ({
                         matches={matches.get(item.id)}
                         showLicenseWarnings={damConfig.enableLicenseFeature}
                     />
-                </Link>
+                </StyledStackLink>
             )}
         </DamItemLabelWrapper>
     );

--- a/packages/admin/cms-admin/src/dam/FileForm/Duplicates.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/Duplicates.tsx
@@ -1,16 +1,7 @@
 import { gql, useQuery } from "@apollo/client";
 import { Alert, FormSection, useStackApi } from "@comet/admin";
 import { BallTriangle as BallTriangleIcon, Link as LinkIcon, OpenNewTab as OpenNewTabIcon, Reload as ReloadIcon } from "@comet/admin-icons";
-import {
-    Button,
-    IconButton,
-    Link,
-    List as MuiList,
-    ListItem,
-    ListItemIcon as MuiListItemIcon,
-    ListItemSecondaryAction,
-    ListItemText,
-} from "@mui/material";
+import { Button, IconButton, List as MuiList, ListItem, ListItemIcon as MuiListItemIcon, ListItemSecondaryAction, ListItemText } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { FormattedMessage } from "react-intl";
 
@@ -79,10 +70,10 @@ const Duplicates = ({ fileId }: { fileId: string }) => {
                                 <ListItemText primary={file.name} secondary={`/${folderPath.join("/")}`} />
                             </ListItemTextWrapper>
                             <ListItemSecondaryAction>
-                                <IconButton component={Link} underline="none" href={href} size="large">
+                                <IconButton href={href} size="large">
                                     <LinkIcon />
                                 </IconButton>
-                                <IconButton component={Link} underline="none" href={href} target="_blank" size="large">
+                                <IconButton href={href} target="_blank" size="large">
                                     <OpenNewTabIcon />
                                 </IconButton>
                             </ListItemSecondaryAction>

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -86,11 +86,7 @@ const EditFile = ({ id, contentScopeIndicator }: EditFormProps) => {
                             id="comet.dam.file.failedToLoad"
                             defaultMessage="Failed to load file. <link>Go to Assets</link>"
                             values={{
-                                link: (chunks) => (
-                                    <RouterLink to={`${scopeMatch.url}/assets`}>
-                                        {chunks}
-                                    </RouterLink>
-                                ),
+                                link: (chunks) => <RouterLink to={`${scopeMatch.url}/assets`}>{chunks}</RouterLink>,
                             }}
                         />
                     </Typography>

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -14,7 +14,7 @@ import {
     ToolbarItem,
     ToolbarTitleItem,
 } from "@comet/admin";
-import { Card, CardContent, Link, Typography } from "@mui/material";
+import { Card, CardContent, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import isEqual from "lodash.isequal";
 import { type ReactNode, useCallback } from "react";
@@ -87,9 +87,9 @@ const EditFile = ({ id, contentScopeIndicator }: EditFormProps) => {
                             defaultMessage="Failed to load file. <link>Go to Assets</link>"
                             values={{
                                 link: (chunks) => (
-                                    <Link to={`${scopeMatch.url}/assets`} component={RouterLink}>
+                                    <RouterLink style={{ outline: "5px solid green" }} to={`${scopeMatch.url}/assets`}>
                                         {chunks}
-                                    </Link>
+                                    </RouterLink>
                                 ),
                             }}
                         />

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -87,7 +87,7 @@ const EditFile = ({ id, contentScopeIndicator }: EditFormProps) => {
                             defaultMessage="Failed to load file. <link>Go to Assets</link>"
                             values={{
                                 link: (chunks) => (
-                                    <RouterLink style={{ outline: "5px solid green" }} to={`${scopeMatch.url}/assets`}>
+                                    <RouterLink to={`${scopeMatch.url}/assets`}>
                                         {chunks}
                                     </RouterLink>
                                 ),

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -1,4 +1,4 @@
-import { greyPalette, StackLink, SubRoute } from "@comet/admin";
+import { StackLink, SubRoute } from "@comet/admin";
 import { Close } from "@comet/admin-icons";
 import {
     Button,

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -76,12 +76,6 @@ const renderDamLabel = (
         <StyledStackLink
             pageName="folder"
             payload={row.id}
-            style={{
-                width: "100%",
-                height: "100%",
-                textDecoration: "none",
-                color: `${greyPalette[900]}`,
-            }}
             onClick={() => {
                 filterApi.formApi.change("searchText", undefined);
             }}

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -1,4 +1,4 @@
-import { StackLink, SubRoute } from "@comet/admin";
+import { greyPalette, StackLink, SubRoute } from "@comet/admin";
 import { Close } from "@comet/admin-icons";
 import {
     Button,
@@ -6,7 +6,6 @@ import {
     Dialog,
     DialogTitle,
     IconButton,
-    Link,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { type SyntheticEvent } from "react";
@@ -57,6 +56,13 @@ const TableRowButton = styled(Button)`
     }
 `;
 
+const StyledStackLink = styled(StackLink)`
+    width: 100%;
+    height: 100%;
+    text-decoration: none;
+    color: ${({ theme }) => theme.palette.grey[900]};
+`;
+
 const renderDamLabel = (
     row: GQLDamFileTableFragment | GQLDamFolderTableFragment,
     onChooseFile: (fileId: string) => void,
@@ -67,21 +73,21 @@ const renderDamLabel = (
             <DamItemLabel asset={row} matches={matches} showLicenseWarnings={showLicenseWarnings} />
         </TableRowButton>
     ) : (
-        <Link
-            underline="none"
-            component={StackLink}
+        <StyledStackLink
             pageName="folder"
             payload={row.id}
-            sx={{
+            style={{
                 width: "100%",
                 height: "100%",
+                textDecoration: "none",
+                color: `${greyPalette[900]}`,
             }}
             onClick={() => {
                 filterApi.formApi.change("searchText", undefined);
             }}
         >
             <DamItemLabel asset={row} matches={matches} />
-        </Link>
+        </StyledStackLink>
     );
 };
 

--- a/storybook/src/admin/stack/StackLink.stories.tsx
+++ b/storybook/src/admin/stack/StackLink.stories.tsx
@@ -1,5 +1,4 @@
 import { Button, Stack, StackLink, StackPage, StackSwitch } from "@comet/admin";
-import { Link } from "@mui/material";
 import { useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
@@ -20,9 +19,9 @@ export const _StackLink = {
                     <StackSwitch>
                         <StackPage name="page1">
                             <h3>Page 1</h3>
-                            <Link component={StackLink} pageName="page2" payload="test">
+                            <StackLink pageName="page2" payload="test">
                                 link based on StackLink
-                            </Link>
+                            </StackLink>
                         </StackPage>
                         <StackPage name="page2">
                             <h3>Page 2</h3>

--- a/storybook/src/admin/stack/StackUrl.stories.tsx
+++ b/storybook/src/admin/stack/StackUrl.stories.tsx
@@ -1,5 +1,4 @@
 import { Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch } from "@comet/admin";
-import { Link } from "@mui/material";
 import { useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
@@ -21,32 +20,32 @@ export const StackUrl = {
                     <StackSwitch>
                         <StackPage name="page1">
                             <h3>Page 1</h3>
-                            <Link component={StackLink} pageName="page2" payload="test">
+                            <StackLink pageName="page2" payload="test">
                                 go to page 2
-                            </Link>
+                            </StackLink>
                         </StackPage>
                         <StackPage name="page2">
                             <h3>Page 2</h3>
                             <p>
-                                <Link component={StackLink} pageName="page1" payload="test">
+                                <StackLink pageName="page1" payload="test">
                                     go to page 1
-                                </Link>
+                                </StackLink>
                             </p>
                             <StackSwitch>
                                 <StackPage name="page2-1">
                                     <h3>Page 2-1</h3>
                                     <p>
-                                        <Link component={StackLink} pageName="page2-2" payload="test">
+                                        <StackLink pageName="page2-2" payload="test">
                                             go to page 2-2
-                                        </Link>
+                                        </StackLink>
                                     </p>
                                 </StackPage>
                                 <StackPage name="page2-2">
                                     <h3>Page 2-2</h3>
                                     <p>
-                                        <Link component={StackLink} pageName="page2-1" payload="test">
+                                        <StackLink pageName="page2-1" payload="test">
                                             go to page 2-1
-                                        </Link>
+                                        </StackLink>
                                     </p>
                                 </StackPage>
                             </StackSwitch>

--- a/storybook/src/docs/components/Stack/Stack.stories.tsx
+++ b/storybook/src/docs/components/Stack/Stack.stories.tsx
@@ -15,7 +15,7 @@ import {
     useStackSwitchApi,
 } from "@comet/admin";
 import { ArrowLeft, ArrowRight } from "@comet/admin-icons";
-import { IconButton, Link } from "@mui/material";
+import { IconButton } from "@mui/material";
 
 import { apolloRestStoryDecorator } from "../../../apollo-rest-story.decorator";
 import { storyRouterDecorator } from "../../../story-router.decorator";
@@ -312,15 +312,15 @@ export const StackLinkMuiLink = {
                 <StackSwitch>
                     <StackPage name="page1">
                         <h3>Page 1</h3>
-                        <Link component={StackLink} pageName="page2" payload="test">
+                        <StackLink pageName="page2" payload="test">
                             StackLink-based MuiLink to page2
-                        </Link>
+                        </StackLink>
                     </StackPage>
                     <StackPage name="page2">
                         <h3>Page 2</h3>
-                        <Link component={StackLink} pageName="page1" payload="test">
+                        <StackLink pageName="page1" payload="test">
                             StackLink-based MuiLink to page1
-                        </Link>
+                        </StackLink>
                     </StackPage>
                 </StackSwitch>
             </Stack>

--- a/storybook/src/docs/components/Table/05_FilterBar.stories.tsx
+++ b/storybook/src/docs/components/Table/05_FilterBar.stories.tsx
@@ -20,7 +20,7 @@ import {
     useTableQueryFilter,
 } from "@comet/admin";
 import { faker } from "@faker-js/faker";
-import { Link, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 
 interface ColorFilterFieldProps {
     colors: string[];
@@ -216,9 +216,9 @@ export const TableWithFilterbarAndPersistedState = {
                                 name: "detail",
                                 render: ({ id }) => {
                                     return (
-                                        <Link component={StackLink} pageName="detail" payload={String(id)}>
+                                        <StackLink pageName="detail" payload={String(id)}>
                                             Show Details
-                                        </Link>
+                                        </StackLink>
                                     );
                                 },
                             },


### PR DESCRIPTION
## Description

- Adapt Link Styling according to design 
- Remove MuiLinks from components, that should not use the MuiLink (all Links that are not simple links in text or stand-alone Text-links) and replace them with components that fit better.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="199" alt="Screenshot 2025-03-05 at 15 08 37" src="https://github.com/user-attachments/assets/b84a2c5e-85dc-498b-8ff1-a00f5896f3e2" /> | <img width="251" alt="Screenshot 2025-03-05 at 15 08 48" src="https://github.com/user-attachments/assets/e175f3d0-b123-441e-aed2-b12662282698" />

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1653
