### PR TITLE
Add support for `isAnyOf` filter to missing types

### DIFF
--- a/.changeset/warm-pumas-explain.md
+++ b/.changeset/warm-pumas-explain.md
@@ -2,4 +2,4 @@
 "@comet/cms-api": minor
 ---
 
-Added support for `isAnyOf` filter for the types `String`, `Number`, `ManyToMany` and `OneToMany`.
+Add `isAnyOf` filter to `StringFilter`, `NumberFilter`, `OneToManyFilter`, and `ManyToManyFilter`

--- a/.changeset/warm-pumas-explain.md
+++ b/.changeset/warm-pumas-explain.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Added support for `isAnyOf` filter for the types `String`, `Number`, `ManyToMany` and `OneToMany`.

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -834,6 +834,7 @@ input StringFilter {
   endsWith: String
   equal: String
   notEqual: String
+  isAnyOf: [String!]
 }
 
 input UserPermissionsUserSort {
@@ -962,6 +963,7 @@ input NewsCategoryEnumFilter {
 input OneToManyFilter {
   contains: ID
   search: String
+  isAnyOf: [ID!]
 }
 
 input NewsSort {
@@ -1028,6 +1030,7 @@ input NumberFilter {
   lowerThanEqual: Float
   greaterThanEqual: Float
   notEqual: Float
+  isAnyOf: [Float!]
 }
 
 input DateFilter {
@@ -1048,6 +1051,7 @@ input ManyToOneFilter {
 input ManyToManyFilter {
   contains: ID
   search: String
+  isAnyOf: [ID!]
 }
 
 input ProductSort {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -412,6 +412,7 @@ input StringFilter {
   endsWith: String
   equal: String
   notEqual: String
+  isAnyOf: [String!]
 }
 
 input BooleanFilter {

--- a/packages/api/cms-api/src/common/filter/many-to-many.filter.ts
+++ b/packages/api/cms-api/src/common/filter/many-to-many.filter.ts
@@ -12,4 +12,9 @@ export class ManyToManyFilter {
     @IsOptional()
     @IsString()
     search?: string;
+
+    @Field(() => [ID], { nullable: true })
+    @IsOptional()
+    @IsUUID(undefined, { each: true })
+    isAnyOf?: string[];
 }

--- a/packages/api/cms-api/src/common/filter/mikro-orm.ts
+++ b/packages/api/cms-api/src/common/filter/mikro-orm.ts
@@ -22,6 +22,9 @@ export function filterToMikroOrmQuery(
         | DateTimeFilter
         | DateFilter
         | BooleanFilter
+        | ManyToOneFilter
+        | OneToManyFilter
+        | ManyToManyFilter
         | EnumFilterInterface<unknown>
         | EnumsFilterInterface<unknown>,
     propertyName: string,
@@ -56,6 +59,9 @@ export function filterToMikroOrmQuery(
         if (filterProperty.notEqual !== undefined) {
             ret.$ne = filterProperty.notEqual;
         }
+        if (filterProperty.isAnyOf !== undefined) {
+            ret.$in = filterProperty.isAnyOf;
+        }
     } else if (filterProperty instanceof NumberFilter) {
         if (filterProperty.equal !== undefined) {
             ret.$eq = filterProperty.equal;
@@ -74,6 +80,9 @@ export function filterToMikroOrmQuery(
         }
         if (filterProperty.notEqual !== undefined) {
             ret.$ne = filterProperty.notEqual;
+        }
+        if (filterProperty.isAnyOf !== undefined) {
+            ret.$in = filterProperty.isAnyOf;
         }
     } else if (filterProperty instanceof DateTimeFilter || filterProperty instanceof DateFilter) {
         if (filterProperty.equal !== undefined) {
@@ -129,6 +138,9 @@ export function filterToMikroOrmQuery(
             }
             ret.$and = searchToMikroOrmQuery(filterProperty.search, prop.targetMeta).$and;
         }
+        if (filterProperty.isAnyOf !== undefined) {
+            ret.$in = filterProperty.isAnyOf;
+        }
     } else if (filterProperty instanceof ManyToManyFilter) {
         if (filterProperty.contains !== undefined) {
             ret.id = {
@@ -149,6 +161,9 @@ export function filterToMikroOrmQuery(
                 throw new Error("targetMeta is not defined");
             }
             ret.$and = searchToMikroOrmQuery(filterProperty.search, prop.targetMeta).$and;
+        }
+        if (filterProperty.isAnyOf !== undefined) {
+            ret.$in = filterProperty.isAnyOf;
         }
     } else if (isEnumFilter(filterProperty)) {
         if (filterProperty.equal !== undefined) {

--- a/packages/api/cms-api/src/common/filter/number.filter.ts
+++ b/packages/api/cms-api/src/common/filter/number.filter.ts
@@ -32,4 +32,9 @@ export class NumberFilter {
     @IsOptional()
     @IsNumber()
     notEqual?: number;
+
+    @Field(() => [Number], { nullable: true })
+    @IsOptional()
+    @IsNumber(undefined, { each: true })
+    isAnyOf?: number[];
 }

--- a/packages/api/cms-api/src/common/filter/one-to-many.filter.ts
+++ b/packages/api/cms-api/src/common/filter/one-to-many.filter.ts
@@ -12,4 +12,9 @@ export class OneToManyFilter {
     @IsOptional()
     @IsString()
     search?: string;
+
+    @Field(() => [ID], { nullable: true })
+    @IsOptional()
+    @IsUUID(undefined, { each: true })
+    isAnyOf?: string[];
 }

--- a/packages/api/cms-api/src/common/filter/string.filter.ts
+++ b/packages/api/cms-api/src/common/filter/string.filter.ts
@@ -27,4 +27,9 @@ export class StringFilter {
     @IsOptional()
     @IsString()
     notEqual?: string;
+
+    @Field(() => [String], { nullable: true })
+    @IsOptional()
+    @IsString({ each: true })
+    isAnyOf?: string[];
 }


### PR DESCRIPTION
## Description

The 'isAnyOf' filter was not yet supported for String, Number, ManyToMany and OneToMany types.
That has been added in this PR.

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1616
