### PR TITLE
Add logger to migrate command

### DIFF
--- a/demo/api/src/db/migrate.command.ts
+++ b/demo/api/src/db/migrate.command.ts
@@ -27,7 +27,7 @@ export class MigrateCommand extends CommandRunner {
             const connection = em.getConnection();
             // we can't use MikroORM's migrations table as lock object, because it does not exist on first run, so we bring our own lock object
             await connection.execute(
-                `CREATE TABLE IF NOT EXISTS "migrations_lock" ("id" int NOT NULL, PRIMARY KEY ("id"))`,
+                `CREATE TABLE IF NOT EXISTS "MigrationsLock" ("id" int NOT NULL, PRIMARY KEY ("id"))`,
                 undefined,
                 undefined,
                 em.getTransactionContext(),
@@ -40,7 +40,7 @@ export class MigrateCommand extends CommandRunner {
                     // we lock in exclusive mode, so any other transactions fails immediately (NOWAIT)
                     // lock gets automatically released on commit or rollback
                     await connection.execute(
-                        `LOCK TABLE "migrations_lock" IN EXCLUSIVE MODE NOWAIT`,
+                        `LOCK TABLE "MigrationsLock" IN EXCLUSIVE MODE NOWAIT`,
                         undefined,
                         undefined,
                         em.getTransactionContext(),
@@ -49,10 +49,10 @@ export class MigrateCommand extends CommandRunner {
                 } catch (error) {
                     await em.rollback();
                     this.logger.warn(error);
-                    this.logger.warn(`Cannot acquire lock for table migrations_lock (try ${++lockTries})`);
+                    this.logger.warn(`Cannot acquire lock for table MigrationsLock (try ${++lockTries})`);
                     if (lockTries > 3600) {
                         this.logger.error(`Giving up...`);
-                        throw new Error("Could not acquire lock for table migrations_lock");
+                        throw new Error("Could not acquire lock for table MigrationsLock");
                     }
                     await this.sleep(1);
                     await em.begin(em.getTransactionContext());

--- a/demo/api/src/db/migrate.command.ts
+++ b/demo/api/src/db/migrate.command.ts
@@ -1,8 +1,11 @@
 import { MikroORM } from "@mikro-orm/postgresql";
+import { Logger } from "@nestjs/common";
 import { Command, CommandRunner } from "nest-commander";
 
 @Command({ name: "migrate", description: "Runs all migrations" })
 export class MigrateCommand extends CommandRunner {
+    private readonly logger = new Logger(MigrateCommand.name);
+
     constructor(private readonly orm: MikroORM) {
         super();
     }
@@ -14,7 +17,7 @@ export class MigrateCommand extends CommandRunner {
     }
 
     async run(): Promise<void> {
-        console.log("Running migrations...");
+        this.logger.log("Running migrations...");
         const em = this.orm.em.fork();
 
         try {
@@ -31,10 +34,10 @@ export class MigrateCommand extends CommandRunner {
             );
 
             let lockTries = 0;
-            let lockAquired = false;
-            while (!lockAquired) {
+            let lockAcquired = false;
+            while (!lockAcquired) {
                 try {
-                    // we lock in exclusive mode, so any other transactions fails immediatly (NOWAIT)
+                    // we lock in exclusive mode, so any other transactions fails immediately (NOWAIT)
                     // lock gets automatically released on commit or rollback
                     await connection.execute(
                         `LOCK TABLE "migrations_lock" IN EXCLUSIVE MODE NOWAIT`,
@@ -42,14 +45,14 @@ export class MigrateCommand extends CommandRunner {
                         undefined,
                         em.getTransactionContext(),
                     );
-                    lockAquired = true;
+                    lockAcquired = true;
                 } catch (error) {
                     await em.rollback();
-                    console.warn(error);
-                    console.warn(`Cannot aquire lock for table migrations_lock (try ${++lockTries})`);
+                    this.logger.warn(error);
+                    this.logger.warn(`Cannot acquire lock for table migrations_lock (try ${++lockTries})`);
                     if (lockTries > 3600) {
-                        console.error(`Giving up...`);
-                        throw new Error("Could not aquire lock for table migrations_locks");
+                        this.logger.error(`Giving up...`);
+                        throw new Error("Could not acquire lock for table migrations_lock");
                     }
                     await this.sleep(1);
                     await em.begin(em.getTransactionContext());
@@ -61,14 +64,14 @@ export class MigrateCommand extends CommandRunner {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } as any); // https://mikro-orm.io/docs/migrations/#providing-transaction-context
 
-            console.log(`Executed migrations. Trying to commit...`);
+            this.logger.log(`Executed migrations. Trying to commit...`);
             await em.commit();
-            console.log("Migrations successfully committed");
+            this.logger.log("Migrations successfully committed");
         } catch (error) {
-            console.error(error);
+            this.logger.error(error);
             await em.rollback();
 
-            // we need to fail with non-zero exit-code, so migrations will be retried by kubernetes with exponantial back-off
+            // we need to fail with non-zero exit-code, so migrations will be retried by kubernetes with exponential back-off
             process.exit(-1);
         }
     }


### PR DESCRIPTION
## Description

- Add logger to MigrateCommand
- Rename migrations_lock to MigrationsLock

This makes the script in Demo identical to Starter: https://github.com/vivid-planet/comet-starter/blob/3486f4ae7a47072b6c74d1d3060c8f9af7da11bd/api/src/db/migrate.command.ts

