### PR TITLE
Handle scope in warnings

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -221,6 +221,7 @@ type Warning {
   severity: WarningSeverity!
   sourceInfo: WarningSourceInfo!
   status: WarningStatus!
+  scope: JSONObject
 }
 
 enum WarningSeverity {
@@ -1233,6 +1234,7 @@ input WarningFilter {
   type: StringFilter
   severity: WarningSeverityEnumFilter
   status: WarningStatusEnumFilter
+  scope: ScopeFilter
   and: [WarningFilter!]
   or: [WarningFilter!]
 }
@@ -1247,6 +1249,12 @@ input WarningStatusEnumFilter {
   isAnyOf: [WarningStatus!]
   equal: WarningStatus
   notEqual: WarningStatus
+}
+
+input ScopeFilter {
+  isAnyOf: [JSONObject!]
+  equal: JSONObject
+  notEqual: JSONObject
 }
 
 input WarningSort {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -865,7 +865,7 @@ type Query {
   manufacturerCountry(id: ID!): ManufacturerCountry!
   manufacturerCountries(offset: Int! = 0, limit: Int! = 25, search: String, filter: ManufacturerCountryFilter): PaginatedManufacturerCountries!
   warning(id: ID!): Warning!
-  warnings(offset: Int! = 0, limit: Int! = 25, status: [WarningStatus!]! = [open], search: String, filter: WarningFilter, sort: [WarningSort!]): PaginatedWarnings!
+  warnings(offset: Int! = 0, limit: Int! = 25, status: [WarningStatus!]! = [open], search: String, scopes: [JSONObject!]!, filter: WarningFilter, sort: [WarningSort!]): PaginatedWarnings!
 }
 
 input UserPermissionsUserFilter {

--- a/demo/api/src/db/migrations/Migration20250311143752.ts
+++ b/demo/api/src/db/migrations/Migration20250311143752.ts
@@ -1,0 +1,9 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20250311143752 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "Warning" add column "scope" jsonb null;`);
+  }
+
+}

--- a/packages/admin/cms-admin/src/contentScope/Provider.tsx
+++ b/packages/admin/cms-admin/src/contentScope/Provider.tsx
@@ -45,6 +45,7 @@ export type UseContentScopeApi<S extends ContentScopeInterface = ContentScopeInt
     setRedirectPathAfterChange: Dispatch<SetStateAction<string | undefined>>;
     supported: boolean;
     values: ContentScopeValues<S>;
+    createUrl: (scope: ContentScopeInterface) => string;
 };
 
 export type ContentScopeValues<S extends ContentScopeInterface = ContentScopeInterface> = Array<{
@@ -127,6 +128,7 @@ export function useContentScope<S extends ContentScopeInterface = ContentScopeIn
         setRedirectPathAfterChange: context.setRedirectPathAfterChange,
         supported: Object.keys(scope).length > 0,
         values: context.values as ContentScopeValues<S>, // @TODO:
+        createUrl: context.location.createUrl,
     };
 }
 

--- a/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
@@ -209,17 +209,7 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
                         id: row.sourceInfo.targetId,
                     });
 
-                    // Check current scope, check if it is the same as row.scope but allow that a key is missing in row.scope
-                    // because when for example scope { domain: "main" } is passed to createUrl, it defaults to language "en" and would result to a unnecessary scope switch
-                    let switchToAnotherScope = false;
-                    for (const key in contentScope.scope) {
-                        if (row.scope[key] && contentScope.scope[key] !== row.scope[key]) {
-                            switchToAnotherScope = true;
-                            break;
-                        }
-                    }
-
-                    const scopeUrl = row.scope && switchToAnotherScope ? createUrl(row.scope) : contentScope.match.url;
+                    const scopeUrl = row.scope ? createUrl({ ...contentScope.scope, ...row.scope }) : contentScope.match.url;
                     return scopeUrl + path;
                 };
 

--- a/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
@@ -208,7 +208,18 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
                         apolloClient,
                         id: row.sourceInfo.targetId,
                     });
-                    const scopeUrl = row.scope ? createUrl(row.scope) : contentScope.match.url;
+
+                    // Check current scope, check if it is the same as row.scope but allow that a key is missing in row.scope
+                    // because when for example scope { domain: "main" } is passed to createUrl, it defaults to language "en" and would result to a unnecessary scope switch
+                    let switchToAnotherScope = false;
+                    for (const key in contentScope.scope) {
+                        if (row.scope[key] && contentScope.scope[key] !== row.scope[key]) {
+                            switchToAnotherScope = true;
+                            break;
+                        }
+                    }
+
+                    const scopeUrl = row.scope && switchToAnotherScope ? createUrl(row.scope) : contentScope.match.url;
                     return scopeUrl + path;
                 };
 

--- a/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
@@ -88,13 +88,6 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
     const { values } = useContentScope();
 
     const scopeValueOptions = values.map((item) => {
-        const keys = Object.keys(item);
-        const firstKey = keys[0];
-        const secondKey = keys[1];
-
-        const firstValue = item[firstKey].value;
-        const secondLabel = item[secondKey].label;
-
         const scope = Object.fromEntries(
             Object.entries(item).map(([key, value]) => {
                 if (typeof value === "object" && value !== null) {
@@ -104,9 +97,13 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
             }),
         );
 
+        const objectValues = Object.values(scope);
+        // Format the values: first value stays as is, values after get " / " added
+        const formattedValues = objectValues.map((val, index) => (index === 0 ? val : ` / ${val}`));
+
         return {
             value: JSON.stringify(scope),
-            label: `${firstValue} / ${secondLabel}`,
+            label: formattedValues.join(""),
         };
     });
 

--- a/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
@@ -208,7 +208,7 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
                         apolloClient,
                         id: row.sourceInfo.targetId,
                     });
-                    const scopeUrl = row.scope ? createUrl(row.scope) : contentScope.match;
+                    const scopeUrl = row.scope ? createUrl(row.scope) : contentScope.match.url;
                     return scopeUrl + path;
                 };
 

--- a/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
@@ -5,6 +5,7 @@ import {
     type GridColDef,
     GridFilterButton,
     MainContent,
+    messages,
     muiGridFilterToGql,
     muiGridSortToGql,
     ToolbarItem,
@@ -178,7 +179,7 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
                     return formattedValues;
                 }
 
-                return value ? capitalCase(value) : undefined;
+                return intl.formatMessage(messages.globalContentScope);
             },
         },
         {

--- a/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
@@ -85,7 +85,7 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
     const entityDependencyMap = useDependenciesConfig();
     const apolloClient = useApolloClient();
     const contentScope = useContentScope();
-    const { values: scopeValues } = useContentScope();
+    const { values: scopeValues, createUrl } = useContentScope();
 
     const scopes = scopeValues.map((item) => Object.fromEntries(Object.entries(item).map(([key, value]) => [key, value.value])));
     const scopeValueOptions = scopeValues.map((item) => {
@@ -208,8 +208,8 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
                         apolloClient,
                         id: row.sourceInfo.targetId,
                     });
-                    // TODO: adapt contentScope.match to allow content scope switches
-                    return contentScope.match.url + path;
+                    const scopeUrl = row.scope ? createUrl(row.scope) : contentScope.match;
+                    return scopeUrl + path;
                 };
 
                 return (

--- a/packages/admin/cms-admin/src/warnings/WarningsPage.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsPage.tsx
@@ -1,7 +1,8 @@
-import { Stack } from "@comet/admin";
+import { Stack, StackToolbar } from "@comet/admin";
 import { type ReactNode } from "react";
 import { useIntl } from "react-intl";
 
+import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
 import { WarningsGrid } from "./WarningsGrid";
 
 interface WarningsPageProps {
@@ -12,6 +13,7 @@ export function WarningsPage({ warningMessages }: WarningsPageProps) {
     const intl = useIntl();
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "warnings.warnings", defaultMessage: "Warnings" })}>
+            <StackToolbar scopeIndicator={<ContentScopeIndicator global />} />
             <WarningsGrid warningMessages={warningMessages} />
         </Stack>
     );

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -431,7 +431,7 @@ type Query {
   azureAiTranslate(input: AzureAiTranslationInput!): String!
   sitePreviewJwt(scope: JSONObject!, path: String!, includeInvisible: Boolean!): String!
   warning(id: ID!): Warning!
-  warnings(offset: Int! = 0, limit: Int! = 25, status: [WarningStatus!]! = [open], search: String, filter: WarningFilter, sort: [WarningSort!]): PaginatedWarnings!
+  warnings(offset: Int! = 0, limit: Int! = 25, status: [WarningStatus!]! = [open], search: String, scopes: [JSONObject!]!, filter: WarningFilter, sort: [WarningSort!]): PaginatedWarnings!
 }
 
 input RedirectScopeInput {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -217,6 +217,7 @@ type Warning {
   severity: WarningSeverity!
   sourceInfo: WarningSourceInfo!
   status: WarningStatus!
+  scope: JSONObject
 }
 
 enum WarningSeverity {
@@ -571,6 +572,7 @@ input WarningFilter {
   type: StringFilter
   severity: WarningSeverityEnumFilter
   status: WarningStatusEnumFilter
+  scope: ScopeFilter
   and: [WarningFilter!]
   or: [WarningFilter!]
 }
@@ -585,6 +587,12 @@ input WarningStatusEnumFilter {
   isAnyOf: [WarningStatus!]
   equal: WarningStatus
   notEqual: WarningStatus
+}
+
+input ScopeFilter {
+  isAnyOf: [JSONObject!]
+  equal: JSONObject
+  notEqual: JSONObject
 }
 
 input WarningSort {

--- a/packages/api/cms-api/src/dam/files/file-warning.service.ts
+++ b/packages/api/cms-api/src/dam/files/file-warning.service.ts
@@ -50,7 +50,7 @@ export class FileWarningService implements CreateWarningsServiceInterface<FileIn
 
             for (const file of files) {
                 const warnings = await this.createWarnings(file);
-                yield { warnings, targetId: file.id };
+                yield { warnings, targetId: file.id, scope: file.scope };
             }
             offset += limit;
         } while (files.length > 0);

--- a/packages/api/cms-api/src/warnings/decorators/create-warnings.decorator.ts
+++ b/packages/api/cms-api/src/warnings/decorators/create-warnings.decorator.ts
@@ -1,11 +1,13 @@
 import { type AnyEntity } from "@mikro-orm/postgresql";
 import { type CustomDecorator, SetMetadata, type Type } from "@nestjs/common";
 
+import { type ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
 import { type WarningData } from "../dto/warning-data";
 
 interface BulkCreateWarningData {
     warnings: WarningData[];
     targetId: string;
+    scope?: ContentScope;
 }
 
 export type CreateWarningsFunction<Entity extends AnyEntity = AnyEntity> = (item: Entity) => Promise<WarningData[]>;

--- a/packages/api/cms-api/src/warnings/dto/warning.filter.ts
+++ b/packages/api/cms-api/src/warnings/dto/warning.filter.ts
@@ -1,6 +1,8 @@
 import { Field, InputType } from "@nestjs/graphql";
 import { Type } from "class-transformer";
 import { IsOptional, ValidateNested } from "class-validator";
+import { GraphQLJSONObject } from "graphql-scalars";
+import { ContentScope } from "src/user-permissions/interfaces/content-scope.interface";
 
 import { DateTimeFilter } from "../../common/filter/date-time.filter";
 import { createEnumFilter } from "../../common/filter/enum.filter.factory";
@@ -12,6 +14,21 @@ import { WarningStatus } from "../entities/warning-status.enum";
 class WarningSeverityEnumFilter extends createEnumFilter(WarningSeverity) {}
 @InputType()
 class WarningStatusEnumFilter extends createEnumFilter(WarningStatus) {}
+
+@InputType({ isAbstract: true })
+class ScopeFilter {
+    @Field(() => [GraphQLJSONObject], { nullable: true })
+    @IsOptional()
+    isAnyOf?: ContentScope[];
+
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @IsOptional()
+    equal?: ContentScope;
+
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @IsOptional()
+    notEqual?: ContentScope;
+}
 
 @InputType()
 export class WarningFilter {
@@ -50,6 +67,10 @@ export class WarningFilter {
     @IsOptional()
     @Type(() => WarningStatusEnumFilter)
     status?: WarningStatusEnumFilter;
+
+    @Field(() => ScopeFilter, { nullable: true })
+    @IsOptional()
+    scope?: ScopeFilter;
 
     @Field(() => [WarningFilter], { nullable: true })
     @Type(() => WarningFilter)

--- a/packages/api/cms-api/src/warnings/dto/warnings.args.ts
+++ b/packages/api/cms-api/src/warnings/dto/warnings.args.ts
@@ -1,8 +1,10 @@
 import { ArgsType, Field } from "@nestjs/graphql";
 import { Type } from "class-transformer";
 import { IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
+import { GraphQLJSONObject } from "graphql-scalars";
 
 import { OffsetBasedPaginationArgs } from "../../common/pagination/offset-based.args";
+import { ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
 import { WarningStatus } from "../entities/warning-status.enum";
 import { WarningFilter } from "./warning.filter";
 import { WarningSort } from "./warning.sort";
@@ -17,6 +19,10 @@ export class WarningsArgs extends OffsetBasedPaginationArgs {
     @IsOptional()
     @IsString()
     search?: string;
+
+    @Field(() => [GraphQLJSONObject])
+    @IsOptional()
+    scopes: ContentScope[];
 
     @Field(() => WarningFilter, { nullable: true })
     @ValidateNested()

--- a/packages/api/cms-api/src/warnings/entities/warning.entity.ts
+++ b/packages/api/cms-api/src/warnings/entities/warning.entity.ts
@@ -1,7 +1,9 @@
 import { BaseEntity, Entity, Enum, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
+import { GraphQLJSONObject } from "graphql-scalars";
 import { v4 as uuid } from "uuid";
 
+import { ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
 import { WarningSourceInfo } from "../dto/warning-source-info";
 import { WarningSeverity } from "./warning-severity.enum";
 import { WarningStatus } from "./warning-status.enum";
@@ -42,4 +44,8 @@ export class Warning extends BaseEntity {
     @Enum({ items: () => WarningStatus })
     @Field(() => WarningStatus)
     status: WarningStatus = WarningStatus.open;
+
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @Property({ type: "jsonb", nullable: true })
+    scope?: ContentScope;
 }

--- a/packages/api/cms-api/src/warnings/warning-checker.command.ts
+++ b/packages/api/cms-api/src/warnings/warning-checker.command.ts
@@ -147,7 +147,7 @@ export class WarningCheckerCommand extends CommandRunner {
 
                     if (service.bulkCreateWarnings) {
                         const warningGenerator = service.bulkCreateWarnings();
-                        for await (const { warnings, targetId } of warningGenerator) {
+                        for await (const { warnings, targetId, scope } of warningGenerator) {
                             for (const warning of warnings) {
                                 await this.warningService.saveWarnings({
                                     warnings: await service.createWarnings(warning),
@@ -157,6 +157,7 @@ export class WarningCheckerCommand extends CommandRunner {
                                         rootPrimaryKey: entityMetadata.primaryKeys[0],
                                         targetId,
                                     },
+                                    scope,
                                 });
                             }
                         }
@@ -211,6 +212,7 @@ export class WarningCheckerCommand extends CommandRunner {
                         rootPrimaryKey,
                         targetId: row[rootPrimaryKey],
                     },
+                    scope: row.scope,
                 });
             }
         } while (rows.length > 0);

--- a/packages/api/cms-api/src/warnings/warning-checker.command.ts
+++ b/packages/api/cms-api/src/warnings/warning-checker.command.ts
@@ -8,6 +8,8 @@ import { Command, CommandRunner } from "nest-commander";
 import { Block, BlockData, BlockWarning, BlockWarningsServiceInterface } from "../blocks/block";
 import { FlatBlocks } from "../blocks/flat-blocks/flat-blocks";
 import { DiscoverService } from "../dependencies/discover.service";
+import { ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
+import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
 import { CreateWarningsFunction, CreateWarningsMeta, CreateWarningsServiceInterface } from "./decorators/create-warnings.decorator";
 import { Warning } from "./entities/warning.entity";
 import { WarningService } from "./warning.service";
@@ -16,6 +18,7 @@ interface RootBlockEntityData {
     primaryKey: string;
     tableName: string;
     className: string;
+    hasScope: boolean;
     rootBlockData: Array<{ block: Block; column: string }>;
 }
 
@@ -47,14 +50,17 @@ export class WarningCheckerCommand extends CommandRunner {
 
         // TODO: (in the next PRs) Check if data itself is valid in the database. (Maybe some data was put into database and is not correct or a migration was done wrong)
         for (const data of this.groupRootBlockDataByEntity()) {
-            const { tableName, className, rootBlockData } = data;
+            const { tableName, className, rootBlockData, hasScope } = data;
 
             const queryBuilderLimit = 100;
             const baseQueryBuilder = this.entityManager.createQueryBuilder(className);
-            baseQueryBuilder
-                .select([`${data.primaryKey} as id`, ...rootBlockData.map(({ column }) => column)])
-                .from(tableName)
-                .limit(queryBuilderLimit);
+
+            const selectFields = [`${data.primaryKey} as id`, ...rootBlockData.map(({ column }) => column)];
+            if (hasScope) {
+                selectFields.push("scope");
+            }
+
+            baseQueryBuilder.select(selectFields).from(tableName).limit(queryBuilderLimit);
             let rootBlocks: RootBlockData[] = [];
             let offset = 0;
 
@@ -62,9 +68,26 @@ export class WarningCheckerCommand extends CommandRunner {
                 const queryBuilder = baseQueryBuilder.clone();
                 queryBuilder.offset(offset);
                 rootBlocks = (await queryBuilder.getResult()) as RootBlockData[];
+
                 for (const { column, block } of rootBlockData) {
                     for (const rootBlock of rootBlocks) {
+                        let scope: ContentScope | undefined = hasScope ? rootBlock["scope"] : undefined;
                         const blockData = rootBlock[column] as BlockData;
+
+                        if (!scope) {
+                            const entity = this.orm.getMetadata().get(className).class;
+                            const scoped = this.reflector.getAllAndOverride<ScopedEntityMeta>("scopedEntity", [entity]);
+
+                            if (scoped) {
+                                const service = this.moduleRef.get(scoped, { strict: false });
+                                const scopedEntityScope = await service.getEntityScope(rootBlock);
+                                if (Array.isArray(scopedEntityScope)) {
+                                    throw new Error("Multiple scopes are not supported for warnings");
+                                } else {
+                                    scope = scopedEntityScope;
+                                }
+                            }
+                        }
 
                         const flatBlocks = new FlatBlocks(blockData, {
                             name: block.name,
@@ -87,6 +110,7 @@ export class WarningCheckerCommand extends CommandRunner {
                             this.warningService.saveWarnings({
                                 warnings,
                                 type: "Block",
+                                scope,
                                 sourceInfo: {
                                     rootEntityName: tableName,
                                     rootColumnName: column,
@@ -209,7 +233,7 @@ export class WarningCheckerCommand extends CommandRunner {
         const rootBlockEntityData = new Map<string, RootBlockEntityData>();
 
         for (const {
-            metadata: { tableName, className, primaryKeys },
+            metadata: { tableName, className, primaryKeys, definedProperties },
             block,
             column,
         } of this.discoverService.discoverRootBlocks()) {
@@ -219,6 +243,7 @@ export class WarningCheckerCommand extends CommandRunner {
                 rootBlockEntityData.set(key, {
                     tableName,
                     className,
+                    hasScope: "scope" in definedProperties,
                     rootBlockData: [],
                     primaryKey: primaryKeys[0],
                 });

--- a/packages/api/cms-api/src/warnings/warning.resolver.ts
+++ b/packages/api/cms-api/src/warnings/warning.resolver.ts
@@ -1,6 +1,5 @@
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository, FindOptions } from "@mikro-orm/postgresql";
-import { UnauthorizedException } from "@nestjs/common";
 import { Args, ID, Query, Resolver } from "@nestjs/graphql";
 import isEqual from "lodash.isequal";
 
@@ -39,7 +38,7 @@ export class WarningResolver {
 
         for (const scope of scopes) {
             if (!allowedScopesForUser?.find((allowedScope) => isEqual(allowedScope, scope))) {
-                throw new UnauthorizedException("Scopes were passed that the user does not have permission to");
+                throw new Error("Scopes were passed that the user does not have permission to");
             }
         }
 

--- a/packages/api/cms-api/src/warnings/warning.resolver.ts
+++ b/packages/api/cms-api/src/warnings/warning.resolver.ts
@@ -1,5 +1,6 @@
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository, FindOptions } from "@mikro-orm/postgresql";
+import { UnauthorizedException } from "@nestjs/common";
 import { Args, ID, Query, Resolver } from "@nestjs/graphql";
 import isEqual from "lodash.isequal";
 
@@ -38,7 +39,7 @@ export class WarningResolver {
 
         for (const scope of scopes) {
             if (!allowedScopesForUser?.find((allowedScope) => isEqual(allowedScope, scope))) {
-                throw new Error("Scopes were passed that the user does not have permission to");
+                throw new UnauthorizedException("Scopes were passed that the user does not have permission to");
             }
         }
 

--- a/packages/api/cms-api/src/warnings/warning.resolver.ts
+++ b/packages/api/cms-api/src/warnings/warning.resolver.ts
@@ -72,18 +72,17 @@ export class WarningResolver {
         }
         const allowedScopes = scopes.concat(additionalScopes);
 
+        where.$or = [{ scope: { $in: allowedScopes } }, { scope: { $eq: null } }];
         if (scope) {
-            where.scope = { $in: allowedScopes };
+            where.$and = where.$and || [];
             if (scope?.equal) {
                 const scopeEqual = scope.equal;
-                where.$or = [{ scope: { $eq: scopeEqual } }];
+                where.$and.push({ scope: { $eq: scopeEqual } });
             } else if (scope.notEqual) {
-                where.$or = [{ scope: { $ne: scope.notEqual } }];
+                where.$and.push({ scope: { $ne: scope.notEqual } });
             } else if (scope.isAnyOf) {
-                where.$or = [{ scope: { $in: scope.isAnyOf } }];
+                where.$and.push({ scope: { $in: scope.isAnyOf } });
             }
-        } else {
-            where.$or = [{ scope: { $in: allowedScopes } }, { scope: { $eq: null } }];
         }
 
         const options: FindOptions<Warning> = { offset, limit };

--- a/packages/api/cms-api/src/warnings/warning.resolver.ts
+++ b/packages/api/cms-api/src/warnings/warning.resolver.ts
@@ -1,10 +1,13 @@
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository, FindOptions } from "@mikro-orm/postgresql";
+import { UnauthorizedException } from "@nestjs/common";
 import { Args, ID, Query, Resolver } from "@nestjs/graphql";
 
+import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
 import { gqlArgsToMikroOrmQuery } from "../common/filter/mikro-orm";
 import { AffectedEntity } from "../user-permissions/decorators/affected-entity.decorator";
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
+import { CurrentUser } from "../user-permissions/dto/current-user";
 import { PaginatedWarnings } from "./dto/paginated-warnings";
 import { WarningsArgs } from "./dto/warnings.args";
 import { Warning } from "./entities/warning.entity";
@@ -25,9 +28,52 @@ export class WarningResolver {
     }
 
     @Query(() => PaginatedWarnings)
-    async warnings(@Args() { status, search, filter, sort, offset, limit }: WarningsArgs): Promise<PaginatedWarnings> {
-        const where = gqlArgsToMikroOrmQuery({ search, filter }, this.repository);
+    async warnings(
+        @Args() { status, search, filter, sort, offset, limit }: WarningsArgs,
+        @GetCurrentUser() user: CurrentUser,
+    ): Promise<PaginatedWarnings> {
+        // TODO: Discuss, should this part be in admin or api? (niko mentioned that it is unusual to have an API request that delivers different data based on the user)
+        const scopes = user.permissions.find(({ permission }) => permission === "warnings")?.contentScopes;
+        if (!scopes) {
+            throw new UnauthorizedException("User does not have the necessary permissions to view warnings");
+        }
+
+        const standardFilter = filter;
+        const scope = filter?.and?.find((item) => item.scope !== undefined)?.scope;
+
+        if (filter?.and) {
+            filter.and = filter.and.filter((item) => item.scope === undefined);
+        }
+
+        const where = gqlArgsToMikroOrmQuery({ search, filter: standardFilter }, this.repository);
         where.status = { $in: status };
+
+        if (scope) {
+            if (scope?.equal) {
+                const scopeEqual = scope.equal;
+                if (!scopes.find((scope) => JSON.stringify(scope) === JSON.stringify(scopeEqual))) {
+                    throw new UnauthorizedException("User does not have the necessary permissions to view warnings");
+                }
+
+                where.$or = [{ scope: { $eq: scopeEqual } }];
+            } else if (scope.notEqual) {
+                const scopeNotEqual = scope.notEqual;
+
+                where.$or = [{ scope: { $in: scopes.filter((scope) => JSON.stringify(scope) !== JSON.stringify(scopeNotEqual)) } }];
+            } else if (scope.isAnyOf) {
+                for (const scopeItem of scope.isAnyOf) {
+                    if (!scopes.find((scope) => JSON.stringify(scope) === JSON.stringify(scopeItem))) {
+                        throw new UnauthorizedException("User does not have the necessary permissions to view warnings");
+                    }
+                }
+
+                where.$or = [{ scope: { $in: scope.isAnyOf } }];
+            }
+        } else {
+            where.$or = [{ scope: { $in: scopes } }, { scope: { $eq: null } }];
+        }
+
+        // TODO: Adaptions for datagrid pro, currently it works only for $and filters
 
         const options: FindOptions<Warning> = { offset, limit };
 

--- a/packages/api/cms-api/src/warnings/warning.service.ts
+++ b/packages/api/cms-api/src/warnings/warning.service.ts
@@ -2,6 +2,7 @@ import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
 import { v5 } from "uuid";
 
+import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
 import { WarningData } from "./dto/warning-data";
 import { WarningSourceInfo } from "./dto/warning-source-info";
 import { Warning } from "./entities/warning.entity";
@@ -10,7 +11,17 @@ import { Warning } from "./entities/warning.entity";
 export class WarningService {
     constructor(private readonly entityManager: EntityManager) {}
 
-    private async saveWarning({ warning, type, sourceInfo }: { warning: WarningData; type: string; sourceInfo: WarningSourceInfo }): Promise<void> {
+    private async saveWarning({
+        warning,
+        type,
+        sourceInfo,
+        scope,
+    }: {
+        warning: WarningData;
+        type: string;
+        sourceInfo: WarningSourceInfo;
+        scope?: ContentScope;
+    }): Promise<void> {
         const staticNamespace = "4e099212-0341-4bc8-8f4a-1f31c7a639ae";
         const id = v5(`${sourceInfo.rootEntityName}${sourceInfo.targetId};${warning.message}`, staticNamespace);
 
@@ -24,6 +35,7 @@ export class WarningService {
                 message: warning.message,
                 severity: warning.severity,
                 sourceInfo,
+                scope,
             },
             { onConflictExcludeFields: ["createdAt"] },
         );
@@ -33,16 +45,19 @@ export class WarningService {
         warnings,
         type,
         sourceInfo,
+        scope,
     }: {
         warnings: WarningData[];
         type: string;
         sourceInfo: WarningSourceInfo;
+        scope?: ContentScope;
     }): Promise<void> {
         for (const warning of warnings) {
             await this.saveWarning({
                 warning,
                 type,
                 sourceInfo,
+                scope,
             });
         }
     }


### PR DESCRIPTION
## Description
This PR adds scope to the warnings. The scope is saved as 1 field as json. The WarningGrid is global and shows all warnings of all scopes (that the user has permissions to). Then the user can filter the scopes. It is also possible to have no scope in a warning (e.g. Dam without scope)

## Screenshots/screencasts
![Screenshot 2025-03-19 at 11 03 56](https://github.com/user-attachments/assets/dc779e7c-5a23-49d6-b0e2-b433154cd0a6)


https://github.com/user-attachments/assets/4ddcf772-679e-48fc-b3b4-0015de7b5a64




## Open TODOs/questions

-   [x] Niko mentioned that it is unusual that a request returns different results for different users, but otherwise the params are the same. Currently I do this in the warnings.resolver.ts in the warnings query --> implemented, scopes are sent in request now
-  [x] Test Warnings with DAM (without scope) and see if everything works fine with it
-  [x] Implement jumping to another scope in Warnings Grid --> 753d057c9b9f4dd89389216723a266eb14f27440


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-955
