### PR TITLE
Improve the block preview of redirect targets

### DIFF
--- a/.changeset/lucky-nails-think.md
+++ b/.changeset/lucky-nails-think.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": minor
+---
+
+createOneOfBlock: Add support for dynamic display names of child blocks

--- a/.changeset/sweet-cups-sit.md
+++ b/.changeset/sweet-cups-sit.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-admin": minor
+---
+
+Improve the block preview of redirect targets
+
+Display the redirect target in the first line.
+Move additional information (type, path) to the second line.

--- a/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createOneOfBlock.tsx
@@ -437,10 +437,10 @@ export const createOneOfBlock = <T extends boolean = boolean>(
         },
 
         dynamicDisplayName: (state) => {
-            const { block } = getActiveBlock(state);
+            const { block, state: blockState } = getActiveBlock(state);
 
             if (block != null) {
-                return block.displayName;
+                return block.dynamicDisplayName?.(blockState.props) ?? block.displayName;
             } else {
                 return displayName;
             }

--- a/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
+++ b/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
@@ -15,6 +15,18 @@ interface RedirectsPageProps {
     redirectPathAfterChange?: string;
 }
 
+const RedirectsInternalLinkBlock: typeof InternalLinkBlock = {
+    ...InternalLinkBlock,
+    previewContent: (state) => (state.targetPage ? [{ type: "text", content: state.targetPage.path }] : []),
+    dynamicDisplayName: (state) => state.targetPage?.name ?? InternalLinkBlock.displayName,
+};
+
+const RedirectsExternalLinkBlock: typeof ExternalLinkBlock = {
+    ...ExternalLinkBlock,
+    previewContent: (state) => (state.targetUrl ? [{ type: "text", content: ExternalLinkBlock.displayName }] : []),
+    dynamicDisplayName: (state) => state.targetUrl ?? ExternalLinkBlock.displayName,
+};
+
 interface CreateRedirectsPageOptions {
     customTargets?: Record<string, BlockInterface>;
     scopeParts?: string[];
@@ -22,7 +34,7 @@ interface CreateRedirectsPageOptions {
 
 function createRedirectsPage({ customTargets, scopeParts = [] }: CreateRedirectsPageOptions = {}): ComponentType<RedirectsPageProps> {
     const linkBlock = createOneOfBlock({
-        supportedBlocks: { internal: InternalLinkBlock, external: ExternalLinkBlock, ...customTargets },
+        supportedBlocks: { internal: RedirectsInternalLinkBlock, external: RedirectsExternalLinkBlock, ...customTargets },
         name: "RedirectsLink",
         displayName: <FormattedMessage id="comet.blocks.link" defaultMessage="Link" />,
         allowEmpty: false,


### PR DESCRIPTION
## Description

Display the redirect target in the first line. Move additional information (type, path) to the second line.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1229" alt="before" src="https://github.com/user-attachments/assets/3f17492e-5870-4e50-a37e-0b4da033d655" /> | <img width="1229" alt="after" src="https://github.com/user-attachments/assets/10706b47-6a92-4cf8-99ea-2ee4de3b2658" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1204
