### PR TITLE
Demo Site: Fix predefinedPages middleware rewrite

### DIFF
--- a/demo/site/src/middleware/predefinedPages.ts
+++ b/demo/site/src/middleware/predefinedPages.ts
@@ -96,7 +96,7 @@ export function withPredefinedPagesMiddleware(middleware: CustomMiddleware) {
         const predefinedPageRewrite = await getPredefinedPageRewrite(siteConfig.scope.domain, pathname);
 
         if (predefinedPageRewrite) {
-            return NextResponse.rewrite(new URL(predefinedPageRewrite, request.url));
+            request.nextUrl.pathname = predefinedPageRewrite; //don't use NextResponse.rewrite, as domainRewrite middleware does this (and uses the modified pathname)
         }
 
         return middleware(request);


### PR DESCRIPTION
predefinedPages middleware rewrite didn't include the visibility and domain params, and it shouldn't have to care about them.

instead of returning (and breaking the middleware chain) modify the request url, so domainRewrite middleware can do the usual rewrite.