### PR TITLE
API Generator: Exit without an error code when no entities are found

### DIFF
--- a/.changeset/lemon-buses-occur.md
+++ b/.changeset/lemon-buses-occur.md
@@ -2,4 +2,4 @@
 "@comet/api-generator": patch
 ---
 
-The API generator now exits without an error code when no entities are found.
+Exit without an error code when no entities are found

--- a/.changeset/lemon-buses-occur.md
+++ b/.changeset/lemon-buses-occur.md
@@ -1,0 +1,5 @@
+---
+"@comet/api-generator": patch
+---
+
+The API generator now exits without an error code when no entities are found.

--- a/packages/api/api-generator/package.json
+++ b/packages/api/api-generator/package.json
@@ -37,6 +37,7 @@
     "devDependencies": {
         "@comet/eslint-config": "workspace:*",
         "@mikro-orm/cli": "^6.4.9",
+        "@mikro-orm/core": "^6.4.9",
         "@mikro-orm/postgresql": "^6.4.9",
         "@nestjs/graphql": "^13.0.3",
         "@types/jest": "^29.5.14",

--- a/packages/api/api-generator/src/commands/generate/generate-command.ts
+++ b/packages/api/api-generator/src/commands/generate/generate-command.ts
@@ -1,5 +1,6 @@
 import { type CrudGeneratorOptions, type CrudSingleGeneratorOptions } from "@comet/cms-api";
 import { CLIHelper } from "@mikro-orm/cli";
+import { type MikroORM } from "@mikro-orm/core";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { Command } from "commander";
 
@@ -8,9 +9,14 @@ import { generateCrudSingle } from "./generateCrudSingle/generate-crud-single";
 import { writeGeneratedFiles } from "./utils/write-generated-files";
 
 export const generateCommand = new Command("generate").action(async (options) => {
+    let orm: MikroORM | null = null;
     try {
-        const orm = await CLIHelper.getORM(undefined, undefined, { dbName: "generator" });
+        orm = await CLIHelper.getORM(undefined, undefined, { dbName: "generator" });
+    } catch (e) {
+        console.warn(e);
+    }
 
+    if (orm != null) {
         const entities = orm.em.getMetadata().getAll();
         LazyMetadataStorage.load();
 
@@ -37,8 +43,7 @@ export const generateCommand = new Command("generate").action(async (options) =>
                 }
             }
         }
+
         await orm.close(true);
-    } catch (e) {
-        console.warn(e);
     }
 });

--- a/packages/api/api-generator/src/commands/generate/generate-command.ts
+++ b/packages/api/api-generator/src/commands/generate/generate-command.ts
@@ -8,39 +8,37 @@ import { generateCrudSingle } from "./generateCrudSingle/generate-crud-single";
 import { writeGeneratedFiles } from "./utils/write-generated-files";
 
 export const generateCommand = new Command("generate").action(async (options) => {
-    const orm = await CLIHelper.getORM(undefined, undefined, {
-        dbName: "generator",
-        discovery: {
-            warnWhenNoEntities: false,
-        },
-    });
+    try {
+        const orm = await CLIHelper.getORM(undefined, undefined, { dbName: "generator" });
 
-    const entities = orm.em.getMetadata().getAll();
-    LazyMetadataStorage.load();
+        const entities = orm.em.getMetadata().getAll();
+        LazyMetadataStorage.load();
 
-    if (Object.keys(entities).length === 0) {
-        console.warn(`No entities found for the generated command.`);
-    }
-    for (const name in entities) {
-        const entity = entities[name];
-        if (!entity.class) {
-            // Ignore e.g. relation entities that don't have a class
-            continue;
-        }
-        {
-            const generatorOptions = Reflect.getMetadata(`data:crudGeneratorOptions`, entity.class) as CrudGeneratorOptions | undefined;
-            if (generatorOptions) {
-                const files = await generateCrud(generatorOptions, entity);
-                await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
+        for (const name in entities) {
+            const entity = entities[name];
+            if (!entity.class) {
+                // Ignore e.g. relation entities that don't have a class
+                continue;
+            }
+            {
+                const generatorOptions = Reflect.getMetadata(`data:crudGeneratorOptions`, entity.class) as CrudGeneratorOptions | undefined;
+                if (generatorOptions) {
+                    const files = await generateCrud(generatorOptions, entity);
+                    await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
+                }
+            }
+            {
+                const generatorOptions = Reflect.getMetadata(`data:crudSingleGeneratorOptions`, entity.class) as
+                    | CrudSingleGeneratorOptions
+                    | undefined;
+                if (generatorOptions) {
+                    const files = await generateCrudSingle(generatorOptions, entity);
+                    await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
+                }
             }
         }
-        {
-            const generatorOptions = Reflect.getMetadata(`data:crudSingleGeneratorOptions`, entity.class) as CrudSingleGeneratorOptions | undefined;
-            if (generatorOptions) {
-                const files = await generateCrudSingle(generatorOptions, entity);
-                await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
-            }
-        }
+        await orm.close(true);
+    } catch (e) {
+        console.warn(e);
     }
-    await orm.close(true);
 });

--- a/packages/api/api-generator/src/commands/generate/generate-command.ts
+++ b/packages/api/api-generator/src/commands/generate/generate-command.ts
@@ -8,37 +8,39 @@ import { generateCrudSingle } from "./generateCrudSingle/generate-crud-single";
 import { writeGeneratedFiles } from "./utils/write-generated-files";
 
 export const generateCommand = new Command("generate").action(async (options) => {
-    try {
-        const orm = await CLIHelper.getORM(undefined, undefined, { dbName: "generator" });
+    const orm = await CLIHelper.getORM(undefined, undefined, {
+        dbName: "generator",
+        discovery: {
+            warnWhenNoEntities: false,
+        },
+    });
 
-        const entities = orm.em.getMetadata().getAll();
-        LazyMetadataStorage.load();
+    const entities = orm.em.getMetadata().getAll();
+    LazyMetadataStorage.load();
 
-        for (const name in entities) {
-            const entity = entities[name];
-            if (!entity.class) {
-                // Ignore e.g. relation entities that don't have a class
-                continue;
-            }
-            {
-                const generatorOptions = Reflect.getMetadata(`data:crudGeneratorOptions`, entity.class) as CrudGeneratorOptions | undefined;
-                if (generatorOptions) {
-                    const files = await generateCrud(generatorOptions, entity);
-                    await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
-                }
-            }
-            {
-                const generatorOptions = Reflect.getMetadata(`data:crudSingleGeneratorOptions`, entity.class) as
-                    | CrudSingleGeneratorOptions
-                    | undefined;
-                if (generatorOptions) {
-                    const files = await generateCrudSingle(generatorOptions, entity);
-                    await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
-                }
+    if (Object.keys(entities).length === 0) {
+        console.warn(`No entities found for the generated command.`);
+    }
+    for (const name in entities) {
+        const entity = entities[name];
+        if (!entity.class) {
+            // Ignore e.g. relation entities that don't have a class
+            continue;
+        }
+        {
+            const generatorOptions = Reflect.getMetadata(`data:crudGeneratorOptions`, entity.class) as CrudGeneratorOptions | undefined;
+            if (generatorOptions) {
+                const files = await generateCrud(generatorOptions, entity);
+                await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
             }
         }
-        await orm.close(true);
-    } catch (e) {
-        console.warn(e);
+        {
+            const generatorOptions = Reflect.getMetadata(`data:crudSingleGeneratorOptions`, entity.class) as CrudSingleGeneratorOptions | undefined;
+            if (generatorOptions) {
+                const files = await generateCrudSingle(generatorOptions, entity);
+                await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
+            }
+        }
     }
+    await orm.close(true);
 });

--- a/packages/api/api-generator/src/commands/generate/generate-command.ts
+++ b/packages/api/api-generator/src/commands/generate/generate-command.ts
@@ -8,32 +8,37 @@ import { generateCrudSingle } from "./generateCrudSingle/generate-crud-single";
 import { writeGeneratedFiles } from "./utils/write-generated-files";
 
 export const generateCommand = new Command("generate").action(async (options) => {
-    const orm = await CLIHelper.getORM(undefined, undefined, { dbName: "generator" });
+    try {
+        const orm = await CLIHelper.getORM(undefined, undefined, { dbName: "generator" });
 
-    const entities = orm.em.getMetadata().getAll();
-    LazyMetadataStorage.load();
+        const entities = orm.em.getMetadata().getAll();
+        LazyMetadataStorage.load();
 
-    for (const name in entities) {
-        const entity = entities[name];
-        if (!entity.class) {
-            // Ignore e.g. relation entities that don't have a class
-            continue;
-        }
-        {
-            const generatorOptions = Reflect.getMetadata(`data:crudGeneratorOptions`, entity.class) as CrudGeneratorOptions | undefined;
-            if (generatorOptions) {
-                const files = await generateCrud(generatorOptions, entity);
-                await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
+        for (const name in entities) {
+            const entity = entities[name];
+            if (!entity.class) {
+                // Ignore e.g. relation entities that don't have a class
+                continue;
+            }
+            {
+                const generatorOptions = Reflect.getMetadata(`data:crudGeneratorOptions`, entity.class) as CrudGeneratorOptions | undefined;
+                if (generatorOptions) {
+                    const files = await generateCrud(generatorOptions, entity);
+                    await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
+                }
+            }
+            {
+                const generatorOptions = Reflect.getMetadata(`data:crudSingleGeneratorOptions`, entity.class) as
+                    | CrudSingleGeneratorOptions
+                    | undefined;
+                if (generatorOptions) {
+                    const files = await generateCrudSingle(generatorOptions, entity);
+                    await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
+                }
             }
         }
-        {
-            const generatorOptions = Reflect.getMetadata(`data:crudSingleGeneratorOptions`, entity.class) as CrudSingleGeneratorOptions | undefined;
-            if (generatorOptions) {
-                const files = await generateCrudSingle(generatorOptions, entity);
-                await writeGeneratedFiles(files, { targetDirectory: generatorOptions.targetDirectory });
-            }
-        }
+        await orm.close(true);
+    } catch (e) {
+        console.warn(e);
     }
-
-    await orm.close(true);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1707,6 +1707,9 @@ importers:
       '@mikro-orm/cli':
         specifier: ^6.4.9
         version: 6.4.9
+      '@mikro-orm/core':
+        specifier: ^6.4.9
+        version: 6.4.9
       '@mikro-orm/postgresql':
         specifier: ^6.4.9
         version: 6.4.9(@mikro-orm/core@6.4.9)


### PR DESCRIPTION
## Description

`api-generator` fails with exit code `1` when no entities are in the project.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|<img width="1727" alt="Screenshot 2025-03-12 at 13 37 51" src="https://github.com/user-attachments/assets/b7b00b36-0a7c-40e6-803f-1b5d763f7e35" />  | <img width="1722" alt="Screenshot 2025-03-12 at 13 38 22" src="https://github.com/user-attachments/assets/c7ab921a-579c-42e9-95eb-391f3bb1b527" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1711
