### PR TITLE
Update content security headers

### DIFF
--- a/demo/admin/server/index.js
+++ b/demo/admin/server/index.js
@@ -15,24 +15,42 @@ indexFile = indexFile.replace(/\$([A-Z_]+)/g, (match, p1) => {
 });
 
 app.use(compression());
+
+app.disable("x-powered-by"); // Disable the X-Powered-By header as it is not needed and can be used to infer the server technology
+
 app.use(
     helmet({
         contentSecurityPolicy: {
             directives: {
-                "script-src": ["'self'", "'unsafe-inline'"],
-                "img-src": ["'self'", "https:", "data:"],
-                "default-src": ["'self'", "https:"],
-                "media-src": ["'self'", "https:"],
-                "style-src": ["'self'", "https:", "'unsafe-inline'"],
-                "font-src": ["'self'", "https:", "data:"],
+                "default-src": ["'none'"], // Don't allow any content to be loaded if not explicitly allowed
+                "script-src": [process.env.NODE_ENV === "development" ? "'self' 'unsafe-eval'" : "'self'"], // Unsafe eval is needed for the preview in local development
+                "script-src-elem": ["'self'", "'unsafe-inline'"],
+                "style-src-elem": ["'self'", "'unsafe-inline'", process.env.PREVIEW_URL],
+                "style-src-attr": ["'unsafe-inline'"],
+                "font-src": ["'self'", "data:"],
+                "connect-src": ["'self'"],
+                "img-src": ["'self'", "data:"],
+                "frame-src": [process.env.PREVIEW_URL],
+                upgradeInsecureRequests: process.env.NODE_ENV === "development" ? undefined : [], // Upgrade all requests to HTTPS on production
             },
+            useDefaults: false, // Avoid default values for not explicitly set directives
         },
-        xXssProtection: false,
+        xFrameOptions: false, // Disable deprecated X-Frame-Options header
+        crossOriginResourcePolicy: "same-origin", // Do not allow cross-origin requests to access the response
+        crossOriginEmbedderPolicy: false, // Disable Cross-Origin-Embedder-Policy as it is not needed (value=no-corp)
+        crossOriginOpenerPolicy: true, // Enable Cross-Origin-Opener-Policy (value=same-origin)
         strictTransportSecurity: {
-            maxAge: 63072000,
+            // Enable Strict-Transport-Security
+            maxAge: 63072000, // 2 years (recommended when subdomains are included)
             includeSubDomains: true,
-            preload: true,
+            preload: true, // Enable preload list (recommended if subdomains are included)
         },
+        referrerPolicy: {
+            policy: "no-referrer", // No referrer information needs to be sent
+        },
+        xContentTypeOptions: true, // Enable X-Content-Type-Options (value=nosniff)
+        xDnsPrefetchControl: false, // Disable this non-standard header as recommended by MDN
+        xPermittedCrossDomainPolicies: true, // Enable X-Permitted-Cross-Domain-Policies (value=none)
     }),
 );
 

--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -66,7 +66,7 @@
         "graphql": "^15.0.0",
         "graphql-scalars": "^1.23.0",
         "hasha": "^5.0.0",
-        "helmet": "^4.6.0",
+        "helmet": "^7.2.0",
         "image-size": "^0.9.0",
         "mime": "^2.0.0",
         "multer": "^1.0.0",

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -80,6 +80,8 @@ export class AppModule {
                         context: ({ req }: { req: Request }) => ({ ...req }),
                         cors: {
                             credentials: true,
+                            methods: ["GET", "POST"],
+                            maxAge: 600,
                             origin: config.corsAllowedOrigins.map((val: string) => new RegExp(val)),
                         },
                         buildSchemaOptions: {

--- a/demo/api/src/main.ts
+++ b/demo/api/src/main.ts
@@ -35,6 +35,8 @@ async function bootstrap(): Promise<void> {
 
     app.enableCors({
         credentials: true,
+        methods: ["GET", "POST"],
+        maxAge: 600,
         origin: config.corsAllowedOrigins.map((val: string) => new RegExp(val)),
     });
 
@@ -48,15 +50,33 @@ async function bootstrap(): Promise<void> {
         }),
     );
 
+    app.disable("x-powered-by");
+
     app.use(
         helmet({
             contentSecurityPolicy: {
-                useDefaults: false,
                 directives: {
-                    "default-src": helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc,
-                    // locally: allow localhost in frame-ancestors to enable including files from the API in iframes in admin
-                    "frame-ancestors": `'self' ${process.env.NODE_ENV === "development" ? config.adminUrl : ""}`,
+                    "default-src": ["'none'"],
                 },
+                useDefaults: false, // Disable default directives
+            },
+            xFrameOptions: false, // Disable non-standard header
+            strictTransportSecurity: {
+                // Enable HSTS
+                maxAge: 63072000, // 2 years (recommended when subdomains are included)
+                includeSubDomains: true,
+                preload: true,
+            },
+            referrerPolicy: {
+                policy: "no-referrer", // No referrer information is sent along with requests
+            },
+            xContentTypeOptions: true, // value="nosniff" (prevent MIME sniffing)
+            xDnsPrefetchControl: false, // Disable non-standard header
+            xDownloadOptions: true, // value="noopen" (prevent IE from executing downloads in the context of the site)
+            xPermittedCrossDomainPolicies: true, // value="none" (prevent the browser from MIME sniffing)
+            originAgentCluster: true, // value=?1
+            crossOriginResourcePolicy: {
+                policy: "same-site", // This allows the resource to be shared with the same site (all subdomains/ports are included)
             },
         }),
     );

--- a/demo/site/next-env.d.ts
+++ b/demo/site/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/demo/site/next.config.mjs
+++ b/demo/site/next.config.mjs
@@ -27,6 +27,47 @@ const nextConfig = {
     experimental: {
         optimizePackageImports: ["@comet/cms-site"],
     },
+    poweredByHeader: false,
+    // https://nextjs.org/docs/advanced-features/security-headers (Content-Security-Policy and CORS are set in middleware/cspHeaders.ts)
+    headers: async () => [
+        {
+            source: "/:path*",
+            headers: [
+                {
+                    key: "Strict-Transport-Security", // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+                    value: "max-age=63072000; includeSubDomains; preload", // 2 years (recommended when subdomains are included)
+                },
+                {
+                    key: "Cross-Origin-Opener-Policy", // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
+                    value: "same-origin", // Only allow the same origin to open the page in a browsing context
+                },
+                {
+                    key: "Cross-Origin-Embedder-Policy",
+                    // This value should be set to 'require-corp' as soon as iframe credentialless is supported by all browsers
+                    // https://developer.mozilla.org/en-US/docs/Web/Security/IFrame_credentialless
+                    // https://caniuse.com/mdn-html_elements_iframe_credentialless
+                    value: "unsafe-none",
+                },
+                {
+                    key: "Cross-Origin-Resource-Policy", // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy
+                    value: "same-site", // Do not allow cross-origin requests to access the response
+                },
+                {
+                    key: "Permissions-Policy", // https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy
+                    value: "",
+                },
+                {
+                    key: "X-Content-Type-Options", // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+                    value: "nosniff", // Prevent MIME sniffing
+                },
+                {
+                    // This should be changed when using web analytics tools. For example, use "strict-origin-when-cross-origin" for Google Analytics
+                    key: "Referrer-Policy", // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+                    value: "same-origin", // Only use referer on own domain.
+                },
+            ],
+        },
+    ],
     cacheHandler: process.env.REDIS_ENABLED === "true" ? import.meta.resolve("./dist/cache-handler.js").replace("file://", "") : undefined,
     cacheMaxMemorySize: process.env.REDIS_ENABLED === "true" ? 0 : undefined, // disable default in-memory caching
     rewrites: () => {

--- a/demo/site/src/middleware/cspHeaders.ts
+++ b/demo/site/src/middleware/cspHeaders.ts
@@ -2,33 +2,40 @@ import { NextRequest } from "next/server";
 
 import { CustomMiddleware } from "./chain";
 
+type ContentSecurityPolicyDirective = {
+    directive: string;
+    values: string[];
+};
+
+const contentSecurityPolicyDirectives: ContentSecurityPolicyDirective[] = [
+    { directive: "default-src", values: ["'none'"] }, // Restrict any content not explicitly allowed
+    { directive: "style-src-elem", values: ["'self'", "'unsafe-inline'"] },
+    { directive: "script-src-elem", values: ["'self'", "'unsafe-inline'"] },
+    { directive: "img-src", values: ["'self'", "data:", process.env.API_URL?.replace("/api", "") ?? ""] },
+    { directive: "style-src-attr", values: ["'unsafe-inline'"] },
+    { directive: "font-src", values: ["'self'", "data:"] },
+    { directive: "frame-ancestors", values: [process.env.ADMIN_URL ?? "https:"] },
+    { directive: "frame-src", values: ["https://www.youtube-nocookie.com/", "https://player.vimeo.com/"] },
+];
+
+if (process.env.NODE_ENV === "development") {
+    contentSecurityPolicyDirectives.push({ directive: "connect-src", values: ["ws:", process.env.API_URL ?? "localhost:"] }); // API URL is needed to lead news feed in local development
+    contentSecurityPolicyDirectives.push({ directive: "script-src", values: ["'unsafe-eval'"] });
+} else {
+    contentSecurityPolicyDirectives.push({ directive: "upgrade-insecure-requests", values: [] });
+}
+
+const contentSecurityPolicy = contentSecurityPolicyDirectives.map((directive) => `${directive.directive} ${directive.values.join(" ")}`).join("; ");
+
 export function withCspHeadersMiddleware(middleware: CustomMiddleware) {
     return async (request: NextRequest) => {
         const response = await middleware(request);
-        response.headers.set(
-            "Content-Security-Policy",
-            `
-                    default-src 'self';
-                    form-action 'self'; 
-                    object-src 'none';
-                    img-src 'self' https: data:${process.env.NODE_ENV === "development" ? " http:" : ""};
-                    media-src 'self' https: data:${process.env.NODE_ENV === "development" ? " http:" : ""};
-                    style-src 'self' 'unsafe-inline'; 
-                    font-src 'self' https: data:;
-                    script-src 'self' 'unsafe-inline' https:${process.env.NODE_ENV === "development" ? " 'unsafe-eval'" : ""};
-                    connect-src 'self' https:${process.env.NODE_ENV === "development" ? " http:" : ""};
-                    frame-ancestors ${process.env.ADMIN_URL ?? "none"};
-                    upgrade-insecure-requests; 
-                    block-all-mixed-content;
-                    frame-src 'self' https://*.youtube.com https://*.youtube-nocookie.com;
-                `
-                .replace(/\s{2,}/g, " ")
-                .trim(),
-        );
+
+        response.headers.set("Content-Security-Policy", contentSecurityPolicy);
+
         if (process.env.ADMIN_URL) {
             response.headers.set("Access-Control-Allow-Origin", process.env.ADMIN_URL);
         }
-
         return response;
     };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,8 +520,8 @@ importers:
         specifier: ^5.0.0
         version: 5.2.2
       helmet:
-        specifier: ^4.6.0
-        version: 4.6.0
+        specifier: ^7.2.0
+        version: 7.2.0
       image-size:
         specifier: ^0.9.0
         version: 0.9.7
@@ -23868,11 +23868,6 @@ packages:
   /headers-utils@3.0.2:
     resolution: {integrity: sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==}
     dev: true
-
-  /helmet@4.6.0:
-    resolution: {integrity: sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==}
-    engines: {node: '>=10.0.0'}
-    dev: false
 
   /helmet@7.2.0:
     resolution: {integrity: sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==}


### PR DESCRIPTION
## This PR updates the HTTP-Headers

- Update helmet to 7.2.0 in API
- Coherent CORS-Policy (Cross-Origin-Ressource-Sharing) for the API -> to Admin & Site
- Coherent CORP/COEP (Cross-Origin-Ressource/Embedder-Policy) for API, Admin & Site
- Strict COOP (Cross-Origin-Opener-Policy) for API, Admin & Site
- Removal of deprecated, redundant, or prohibited headers
- CSP (Content Security Policy) that enforces the JEA (just enough access) principle 


This PR implements the "Just-Enough-Access" (JEA) security strategy, ensuring that only necessary privileges are granted while restricting all others. The PR includes a coherent CORS policy so that resources can only be shared within the microservices. Additionally, CORP/COEP have been enforced to control resource access and embedding to authorized origins only. Several Content Security Policy (CSP) errors have been resolved & unnecessary privileges have been removed - Admin has slightly more flexibility than the Site. 