### PR TITLE
Add /api prefix to Demo API

### DIFF
--- a/.env
+++ b/.env
@@ -39,8 +39,8 @@ IMGPROXY_USE_S3=false
 
 # api
 API_PORT=4000
-API_URL=http://${DEV_DOMAIN:-localhost}:$API_PORT
-API_URL_INTERNAL=http://localhost:$API_PORT
+API_URL=http://${DEV_DOMAIN:-localhost}:$API_PORT/api
+API_URL_INTERNAL=http://localhost:$API_PORT/api
 CORS_ALLOWED_ORIGINS="^http:\/\/localhost:\d+,.*\.dev\.vivid-planet\.cloud,^http://192.168.\d+.\d+:80[0-9]{2}"
 BASIC_AUTH_SYSTEM_USER_PASSWORD=password
 

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -82,6 +82,7 @@ export class AppModule {
                             credentials: true,
                             origin: config.corsAllowedOrigins.map((val: string) => new RegExp(val)),
                         },
+                        useGlobalPrefix: true,
                         buildSchemaOptions: {
                             fieldMiddleware: [BlocksTransformerMiddlewareFactory.create(moduleRef)],
                         },

--- a/demo/api/src/main.ts
+++ b/demo/api/src/main.ts
@@ -33,6 +33,7 @@ async function bootstrap(): Promise<void> {
     //     https://github.com/typestack/class-validator#using-service-container.
     useContainer(app.select(appModule), { fallbackOnErrors: true });
 
+    app.setGlobalPrefix("api");
     app.enableCors({
         credentials: true,
         origin: config.corsAllowedOrigins.map((val: string) => new RegExp(val)),


### PR DESCRIPTION
## Description

The Demo API didn't use the /api prefix yet. The API was still under `http://localhost:4000/graphql`. I now added the /api prefix to make it `http://localhost:4000/api/graphql`

