### PR TITLE
Demo: Proxy API requests through Admin Domain

### DIFF
--- a/.env
+++ b/.env
@@ -39,7 +39,7 @@ IMGPROXY_USE_S3=false
 
 # api
 API_PORT=4000
-API_URL=http://${DEV_DOMAIN:-localhost}:$API_PORT/api
+API_URL=$ADMIN_URL/api
 API_URL_INTERNAL=http://localhost:$API_PORT/api
 CORS_ALLOWED_ORIGINS="^http:\/\/localhost:\d+,.*\.dev\.vivid-planet\.cloud,^http://192.168.\d+.\d+:80[0-9]{2}"
 BASIC_AUTH_SYSTEM_USER_PASSWORD=password

--- a/demo/admin/src/config.tsx
+++ b/demo/admin/src/config.tsx
@@ -19,7 +19,7 @@ export function createConfig() {
     }
     return {
         ...cometConfig,
-        apiUrl: process.env.NODE_ENV === "development" ? `${environmentVariables.ADMIN_URL}/api` : environmentVariables.API_URL,
+        apiUrl: environmentVariables.API_URL,
         adminUrl: environmentVariables.ADMIN_URL,
         sitesConfig: JSON.parse(atob(environmentVariables.PUBLIC_SITE_CONFIGS)) as PublicSiteConfig[],
         buildDate: environmentVariables.BUILD_DATE,

--- a/demo/admin/vite.config.mts
+++ b/demo/admin/vite.config.mts
@@ -80,7 +80,7 @@ export default defineConfig(({ mode }) => {
             port: Number(process.env.ADMIN_PORT),
             proxy: {
                 "/api": {
-                    target: new URL(process.env.API_URL).origin,
+                    target: new URL(process.env.API_URL_INTERNAL).origin,
                     changeOrigin: true,
                     secure: false,
                 },


### PR DESCRIPTION
## Description

Requests from Admin to API are now proxied through the Admin domain locally using Vite server proxy. 

## Why?

In our deployed setup, requests to Admin and requests from Admin to the API are proxied through our Auth proxy to ensure that the user is logged in. The Auth Proxy runs under the Admin Domain. Meaning, API requests go to the Admin Domain and are proxied to the API. This lead to a gap between the local dev setup (API requests go directly to the API domain) and the deployed setup (API requests go to the Admin domain). This sometimes lead to problems when configuring CSP or testing file URLs.

The change in this PR helps harmonize the local and the deployed setup to better avoid such mistakes (though since Admin and API run under localhost, it probably won't prevent all problems). 

---

I tested this and GraphQL requests and file/image/video requests worked. I couldn't find problems

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
