### PR TITLE
Fixtures: Use `transformToBlockData` instead of `blockDataFactory`

### DIFF
--- a/demo/api/src/db/fixtures/generators/document-generator.service.ts
+++ b/demo/api/src/db/fixtures/generators/document-generator.service.ts
@@ -65,9 +65,11 @@ export class DocumentGeneratorService {
         await this.entityManager.persistAndFlush(
             this.pagesRepository.create({
                 id,
-                content: PageContentBlock.blockDataFactory(await this.pageContentBlockFixtureService.generateBlockInput(blockCategory)),
-                seo: SeoBlock.blockDataFactory(await this.seoBlockFixtureService.generateBlockInput()),
-                stage: StageBlock.blockDataFactory(await this.stageBlockFixtureService.generateBlockInput()),
+                content: PageContentBlock.blockInputFactory(
+                    await this.pageContentBlockFixtureService.generateBlockInput(blockCategory),
+                ).transformToBlockData(),
+                seo: SeoBlock.blockInputFactory(await this.seoBlockFixtureService.generateBlockInput()).transformToBlockData(),
+                stage: StageBlock.blockInputFactory(await this.stageBlockFixtureService.generateBlockInput()).transformToBlockData(),
             }),
         );
 

--- a/demo/api/src/db/fixtures/generators/page-content-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/page-content-block-fixture.service.ts
@@ -1,4 +1,4 @@
-import { ExtractBlockInput, ExtractBlockInputFactoryProps } from "@comet/blocks-api";
+import { ExtractBlockInputFactoryProps } from "@comet/blocks-api";
 import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { PageContentBlock } from "@src/documents/pages/blocks/page-content.block";
@@ -50,7 +50,7 @@ export class PageContentBlockFixtureService {
         private readonly sliderBlockFixtureService: SliderBlockFixtureService,
     ) {}
 
-    async generateBlockInput(blockCategory?: BlockCategory): Promise<ExtractBlockInput<typeof PageContentBlock>> {
+    async generateBlockInput(blockCategory?: BlockCategory): Promise<ExtractBlockInputFactoryProps<typeof PageContentBlock>> {
         const blocks: ExtractBlockInputFactoryProps<typeof PageContentBlock>["blocks"] = [];
 
         type SupportedBlocks = (typeof blocks)[number]["type"];
@@ -94,6 +94,6 @@ export class PageContentBlockFixtureService {
             });
         }
 
-        return PageContentBlock.blockInputFactory({ blocks });
+        return { blocks };
     }
 }


### PR DESCRIPTION
## Description

### Problem

The fixtures used `blockDataFactory` to create the block data. This can cause problems when a block has migrations that change it's structure because `blockDataFactory` executes all block migrations.

### Solution

Use `blockInputFactory` and `transformToBlockData` instead because they don't execute the migrations.
