### PR TITLE
Docs: Extend Brevo Migration Guide

### DIFF
--- a/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
+++ b/docs/docs/3-features-modules/9-brevo-module/migration-guide/migration-from-brevo-v2-to-v3.md
@@ -115,6 +115,20 @@ Instead define them in the `BrevoConfigProvider` once:
 </BrevoConfigProvider>
 ```
 
+### Add Brevo test contacts page to admin interface
+
+Create `BrevoTestContactsPage` with `createBrevoTestContactsPage` from `@comet/brevo-admin` and add it to your project's `MasterMenu`:
+
+```tsx
+const BrevoTestContactsPage = createBrevoTestContactsPage({
+    scopeParts: ["domain", "language"],
+    additionalAttributesFragment: brevoContactConfig.additionalAttributesFragment,
+    additionalGridFields: brevoContactConfig.additionalGridFields,
+    additionalFormFields: brevoContactConfig.additionalFormFields,
+    input2State: brevoContactConfig.input2State,
+});
+```
+
 ### Remove `email` and `allowedRedirectUrl` from `brevoContactsPageAttributesConfig`
 
 ```diff


### PR DESCRIPTION
## Description
Extend Brevo Migration Guide with missing `createBrevoTestContactsPage`

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
