### PR TITLE
Use type alias for warning severity

### DIFF
--- a/packages/api/cms-api/src/blocks/block.ts
+++ b/packages/api/cms-api/src/blocks/block.ts
@@ -1,6 +1,5 @@
 import { type Type } from "@nestjs/common";
 import { type ClassConstructor, instanceToPlain, plainToInstance } from "class-transformer";
-import { type WarningSeverity as WarningSeverityEnum } from "src/warnings/entities/warning-severity.enum";
 
 import { AnnotationBlockMeta, getBlockFieldData, getFieldKeys } from "./decorators/field";
 import { strictBlockDataFactoryDecorator } from "./helpers/strictBlockDataFactoryDecorator";
@@ -58,11 +57,9 @@ export declare type BlockIndexItem = {
 } & BlockIndexData;
 export declare type BlockIndex = Array<BlockIndexItem>;
 
-export type WarningSeverity = `${WarningSeverityEnum}`;
-
 export interface BlockWarning {
     message: string;
-    severity: WarningSeverity;
+    severity: "critical" | "high" | "low";
 }
 
 export interface BlockDataInterface {

--- a/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
+++ b/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
@@ -15,7 +15,6 @@ import {
     ExtractBlockInput,
     SimpleBlockInputInterface,
     TraversableTransformBlockResponse,
-    WarningSeverity,
 } from "../block";
 import { ChildBlock } from "../decorators/child-block";
 import { ChildBlockInput } from "../decorators/child-block-input";
@@ -139,8 +138,7 @@ export function createSeoBlock<ImageBlock extends Block = typeof PixelImageBlock
 
         warnings() {
             if (!this.htmlTitle) {
-                const severity: WarningSeverity = "low";
-                return [{ severity, message: "missingHtmlTitle" }];
+                return [{ severity: "low" as const, message: "missingHtmlTitle" }];
             }
             return [];
         }

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -49,7 +49,6 @@ export {
     transformToBlockSave,
     TraversableTransformBlockResponse,
     TraversableTransformBlockResponseArray,
-    WarningSeverity,
 } from "./blocks/block";
 export { BlocksModule } from "./blocks/blocks.module";
 export { getBlocksMeta } from "./blocks/blocks-meta";

--- a/packages/api/cms-api/src/warnings/entities/warning.entity.ts
+++ b/packages/api/cms-api/src/warnings/entities/warning.entity.ts
@@ -33,7 +33,7 @@ export class Warning extends BaseEntity {
 
     @Enum({ items: () => WarningSeverity })
     @Field(() => WarningSeverity)
-    severity: WarningSeverity;
+    severity: "critical" | "high" | "low";
 
     @Property({ type: "jsonb" })
     sourceInfo: WarningSourceInfo;

--- a/packages/api/cms-api/src/warnings/warning.service.ts
+++ b/packages/api/cms-api/src/warnings/warning.service.ts
@@ -6,7 +6,6 @@ import { v5 } from "uuid";
 import { BlockWarning } from "../blocks/block";
 import { WarningSourceInfo } from "./dto/warning-source-info";
 import { Warning } from "./entities/warning.entity";
-import { WarningSeverity } from "./entities/warning-severity.enum";
 
 @Injectable()
 export class WarningService {
@@ -28,7 +27,7 @@ export class WarningService {
                 id,
                 type,
                 message: warning.message,
-                severity: WarningSeverity[warning.severity as keyof typeof WarningSeverity],
+                severity: warning.severity,
                 sourceInfo,
             },
             { onConflictExcludeFields: ["createdAt"] },


### PR DESCRIPTION
## Description

Addresses concerns raised by @raphaelblum in https://github.com/vivid-planet/comet/pull/3654 by using a type alias for the TypeScript-API

## Open TODOs/questions

-   [x] Decide which approach to use

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-955
