### PR TITLE
Only use enums for warning severity

### DIFF
--- a/packages/api/cms-api/src/blocks/block.ts
+++ b/packages/api/cms-api/src/blocks/block.ts
@@ -1,7 +1,7 @@
 import { type Type } from "@nestjs/common";
 import { type ClassConstructor, instanceToPlain, plainToInstance } from "class-transformer";
-import { type WarningSeverity as WarningSeverityEnum } from "src/warnings/entities/warning-severity.enum";
 
+import { type WarningSeverity } from "../warnings/entities/warning-severity.enum";
 import { AnnotationBlockMeta, getBlockFieldData, getFieldKeys } from "./decorators/field";
 import { strictBlockDataFactoryDecorator } from "./helpers/strictBlockDataFactoryDecorator";
 import { strictBlockInputFactoryDecorator } from "./helpers/strictBlockInputFactoryDecorator";
@@ -57,8 +57,6 @@ export declare type BlockIndexItem = {
     visible: boolean;
 } & BlockIndexData;
 export declare type BlockIndex = Array<BlockIndexItem>;
-
-export type WarningSeverity = `${WarningSeverityEnum}`;
 
 export interface BlockWarning {
     message: string;

--- a/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
+++ b/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
@@ -2,6 +2,7 @@ import { Type } from "class-transformer";
 import { IsBoolean, IsEnum, IsJSON, IsOptional, IsString, IsUrl, ValidateNested } from "class-validator";
 
 import { PixelImageBlock } from "../../dam/blocks/pixel-image.block";
+import { WarningSeverity } from "../../warnings/entities/warning-severity.enum";
 import {
     Block,
     BlockData,
@@ -15,7 +16,6 @@ import {
     ExtractBlockInput,
     SimpleBlockInputInterface,
     TraversableTransformBlockResponse,
-    WarningSeverity,
 } from "../block";
 import { ChildBlock } from "../decorators/child-block";
 import { ChildBlockInput } from "../decorators/child-block-input";
@@ -139,8 +139,7 @@ export function createSeoBlock<ImageBlock extends Block = typeof PixelImageBlock
 
         warnings() {
             if (!this.htmlTitle) {
-                const severity: WarningSeverity = "low";
-                return [{ severity, message: "missingHtmlTitle" }];
+                return [{ severity: WarningSeverity.low, message: "missingHtmlTitle" }];
             }
             return [];
         }

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -49,7 +49,6 @@ export {
     transformToBlockSave,
     TraversableTransformBlockResponse,
     TraversableTransformBlockResponseArray,
-    WarningSeverity,
 } from "./blocks/block";
 export { BlocksModule } from "./blocks/blocks.module";
 export { getBlocksMeta } from "./blocks/blocks-meta";


### PR DESCRIPTION
## Description

Addresses concerns raised by @raphaelblum in https://github.com/vivid-planet/comet/pull/3654 by only using the enum.

## Open TODOs/questions

-   [x] Decide which approach to use

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-955
