### PR TITLE
Use type alias for warning severity

### DIFF
--- a/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
+++ b/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
@@ -11,11 +11,11 @@ import {
     blockInputToData,
     BlockMetaField,
     BlockMetaFieldKind,
+    BlockWarning,
     createBlock,
     ExtractBlockInput,
     SimpleBlockInputInterface,
     TraversableTransformBlockResponse,
-    WarningSeverity,
 } from "../block";
 import { ChildBlock } from "../decorators/child-block";
 import { ChildBlockInput } from "../decorators/child-block-input";
@@ -137,10 +137,9 @@ export function createSeoBlock<ImageBlock extends Block = typeof PixelImageBlock
             };
         }
 
-        warnings() {
+        warnings(): BlockWarning[] {
             if (!this.htmlTitle) {
-                const severity: WarningSeverity = "low";
-                return [{ severity, message: "missingHtmlTitle" }];
+                return [{ severity: "low", message: "missingHtmlTitle" }];
             }
             return [];
         }

--- a/packages/api/cms-api/src/warnings/entities/warning.entity.ts
+++ b/packages/api/cms-api/src/warnings/entities/warning.entity.ts
@@ -33,7 +33,7 @@ export class Warning extends BaseEntity {
 
     @Enum({ items: () => WarningSeverity })
     @Field(() => WarningSeverity)
-    severity: WarningSeverity;
+    severity: `${WarningSeverity}`;
 
     @Property({ type: "jsonb" })
     sourceInfo: WarningSourceInfo;

--- a/packages/api/cms-api/src/warnings/warning.service.ts
+++ b/packages/api/cms-api/src/warnings/warning.service.ts
@@ -6,7 +6,6 @@ import { v5 } from "uuid";
 import { BlockWarning } from "../blocks/block";
 import { WarningSourceInfo } from "./dto/warning-source-info";
 import { Warning } from "./entities/warning.entity";
-import { WarningSeverity } from "./entities/warning-severity.enum";
 
 @Injectable()
 export class WarningService {
@@ -28,7 +27,7 @@ export class WarningService {
                 id,
                 type,
                 message: warning.message,
-                severity: WarningSeverity[warning.severity as keyof typeof WarningSeverity],
+                severity: warning.severity,
                 sourceInfo,
             },
             { onConflictExcludeFields: ["createdAt"] },


### PR DESCRIPTION
## Description

Using [suggestion](https://github.com/vivid-planet/comet/pull/3661) from @johnnyomair to simplify handling warning severity. Problem is described in this PR: https://github.com/vivid-planet/comet/pull/3654

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-955
