### PR TITLE
Remove unused field `allowedImageSizes` from DamConfig

### DIFF
--- a/.changeset/loud-items-begin.md
+++ b/.changeset/loud-items-begin.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Remove unused field `allowedImageSizes` from DamConfig

--- a/packages/admin/cms-admin/src/dam/config/damConfig.ts
+++ b/packages/admin/cms-admin/src/dam/config/damConfig.ts
@@ -14,7 +14,6 @@ export interface DamConfig {
         generateImageTitle?: boolean;
     };
     uploadsMaxFileSize: number;
-    allowedImageSizes: number[];
     allowedImageAspectRatios: string[];
 }
 


### PR DESCRIPTION
## Description

The field `allowedImageSizes` in the Admin DamConfig isn't used anywhere in Demo Admin or the Admin packages.

This field caused problems when updating the starter, because in the starter the comet-config.json looks differently: 
https://github.com/vivid-planet/comet-starter/blob/main/api/src/comet-config.json#L1-L9

There is no `allowedImageSizes` field in the config. This causes a type error during updates. We will have the same problem in all our projects, so I think we should remove the unnecessary field.

In https://github.com/vivid-planet/comet/pull/3680 I change the config to be identical to starter

## Acceptance criteria

-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)

