### PR TITLE
Define the image sizes in the comet config according to the starter setup

### DIFF
--- a/demo/api/src/comet-config.json
+++ b/demo/api/src/comet-config.json
@@ -1,11 +1,14 @@
 {
     "dam": {
         "allowedImageAspectRatios": ["16x9", "4x3", "3x2", "3x1", "2x1", "1x1", "1x2", "1x3", "2x3", "3x4", "9x16", "1200x630"],
-        "allowedImageSizes": [320, 420, 768, 1024, 1200, 2048],
         "uploadsMaxFileSize": 500
     },
     "fileUploads": {
         "maxFileSize": 15
+    },
+    "images": {
+        "deviceSizes": [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+        "imageSizes": [16, 32, 48, 64, 96, 128, 256, 320, 384]
     },
     "imgproxy": {
         "maxSrcResolution": 70,

--- a/demo/api/src/config/config.ts
+++ b/demo/api/src/config/config.ts
@@ -45,6 +45,7 @@ export function createConfig(processEnv: NodeJS.ProcessEnv) {
         dam: {
             ...cometConfig.dam,
             secret: envVars.DAM_SECRET,
+            allowedImageSizes: [...cometConfig.images.imageSizes, ...cometConfig.images.deviceSizes],
         },
         azureAiTranslator:
             envVars.AZURE_AI_TRANSLATOR_ENDPOINT && envVars.AZURE_AI_TRANSLATOR_KEY && envVars.AZURE_AI_TRANSLATOR_REGION

--- a/demo/site/next.config.mjs
+++ b/demo/site/next.config.mjs
@@ -12,9 +12,7 @@ const withBundleAnalyzer = nextBundleAnalyzer({
  * @type {import('next').NextConfig}
  **/
 const nextConfig = {
-    images: {
-        deviceSizes: cometConfig.dam.allowedImageSizes,
-    },
+    images: cometConfig.images,
     typescript: {
         ignoreBuildErrors: process.env.NODE_ENV === "production",
     },


### PR DESCRIPTION
## Description

The comet-config in the starter looked different to Demo. I now changed the Demo setup to be identical to starter.

See

- https://github.com/vivid-planet/comet-starter/blob/main/api/src/comet-config.json
- https://github.com/vivid-planet/comet-starter/blob/f2b6537d35450693564c337a8701d1abc8b02723/api/src/config/config.ts#L40
- https://github.com/vivid-planet/comet-starter/blob/abff6e7b9dba160cb40462cefa92607860f73b9a/site/next.config.mjs#L15
