### PR TITLE
User Permissions: Allow permission-specific content scopes to override by-rule content scopes

### DIFF
--- a/.changeset/odd-pots-dream.md
+++ b/.changeset/odd-pots-dream.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+User Permissions: remove isRowSelectable logic from overrideContentScopeDataGrid to enable the selection of all options again

--- a/.changeset/odd-pots-dream.md
+++ b/.changeset/odd-pots-dream.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": patch
 ---
 
-User Permissions: remove isRowSelectable logic from overrideContentScopeDataGrid to enable the selection of all options again
+User Permissions: Allow permission-specific content scopes to override by-rule content scopes

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/OverrideContentScopesDialog.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/OverrideContentScopesDialog.tsx
@@ -2,7 +2,6 @@ import { gql, useApolloClient, useQuery } from "@apollo/client";
 import { CancelButton, DataGridToolbar, Field, FinalForm, FinalFormSwitch, SaveButton, ToolbarFillSpace, ToolbarItem } from "@comet/admin";
 import { CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
 import { DataGrid, GridColDef, GridToolbarQuickFilter } from "@mui/x-data-grid";
-import isEqual from "lodash.isequal";
 import { FormattedMessage } from "react-intl";
 
 import { generateGridColumnsFromContentScopeProperties } from "./ContentScopeGrid";
@@ -141,9 +140,6 @@ export const OverrideContentScopesDialog = ({ permissionId, userId, handleDialog
                                                     Toolbar: OverrideContentScopesDialogGridToolbar,
                                                 }}
                                                 pageSize={25}
-                                                isRowSelectable={(params) => {
-                                                    return !data.userContentScopesSkipManual.some((cs: ContentScope) => isEqual(cs, params.row));
-                                                }}
                                             />
                                         );
                                     }}


### PR DESCRIPTION
## Description

Remove `isRowSelectable` from Data Grid in `OverrideContentScopesDialog` so all options are selectable again.

Regression introduced with https://github.com/vivid-planet/comet/pull/3147.

## Acceptance criteria

-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
