### PR TITLE
Admin Generator: Change cometGen to default export instead of (possibly multiple) named exports [BREAKING]

### DIFF
--- a/demo/admin/src/news/NewsForm.cometGen.ts
+++ b/demo/admin/src/news/NewsForm.cometGen.ts
@@ -1,10 +1,10 @@
-import { type FormConfig } from "@comet/admin-generator";
+import { defineConfig } from "@comet/admin-generator";
 import { DamImageBlock } from "@comet/cms-admin";
 import { type GQLNews } from "@src/graphql.generated";
 
 import { NewsContentBlock } from "./blocks/NewsContentBlock";
 
-export const NewsForm: FormConfig<GQLNews> = {
+export default defineConfig<GQLNews>({
     type: "form",
     gqlType: "News",
     fragmentName: "NewsForm",
@@ -48,4 +48,4 @@ export const NewsForm: FormConfig<GQLNews> = {
             block: NewsContentBlock,
         },
     ],
-};
+});

--- a/demo/admin/src/news/NewsGrid.cometGen.ts
+++ b/demo/admin/src/news/NewsGrid.cometGen.ts
@@ -1,10 +1,10 @@
-import { type GridConfig } from "@comet/admin-generator";
+import { defineConfig } from "@comet/admin-generator";
 import { DamImageBlock } from "@comet/cms-admin";
 import { type GQLNews } from "@src/graphql.generated";
 
 import { NewsContentBlock } from "./blocks/NewsContentBlock";
 
-export const NewsGrid: GridConfig<GQLNews> = {
+export default defineConfig<GQLNews>({
     type: "grid",
     gqlType: "News",
     fragmentName: "NewsGrid",
@@ -38,4 +38,4 @@ export const NewsGrid: GridConfig<GQLNews> = {
             block: NewsContentBlock,
         },
     ],
-};
+});

--- a/demo/admin/src/products/future/CreateCapProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/CreateCapProductForm.cometGen.ts
@@ -1,10 +1,10 @@
-import { type FormConfig } from "@comet/admin-generator";
+import { defineConfig } from "@comet/admin-generator";
 import { DamImageBlock } from "@comet/cms-admin";
 import { type GQLProduct } from "@src/graphql.generated";
 
 import { validateTitle } from "./validateTitle";
 
-export const CreateCapProductForm: FormConfig<GQLProduct> = {
+export default defineConfig<GQLProduct>({
     type: "form",
     gqlType: "Product",
     mode: "add",
@@ -24,4 +24,4 @@ export const CreateCapProductForm: FormConfig<GQLProduct> = {
         { type: "date", name: "availableSince", startAdornment: { icon: "CalendarToday" } },
         { type: "block", name: "image", label: "Image", block: DamImageBlock },
     ],
-};
+});

--- a/demo/admin/src/products/future/IdFieldInForm.cometGen.ts
+++ b/demo/admin/src/products/future/IdFieldInForm.cometGen.ts
@@ -1,8 +1,8 @@
-import { type FormConfig } from "@comet/admin-generator";
+import { defineConfig } from "@comet/admin-generator";
 import { DamImageBlock } from "@comet/cms-admin";
 import { type GQLProduct } from "@src/graphql.generated";
 
-export const ProductForm: FormConfig<GQLProduct> = {
+export default defineConfig<GQLProduct>({
     type: "form",
     gqlType: "Product",
     fragmentName: "IdFieldInForm",
@@ -11,4 +11,4 @@ export const ProductForm: FormConfig<GQLProduct> = {
         { type: "text", name: "title", label: "Title", required: true },
         { type: "block", name: "image", label: "Image", block: DamImageBlock },
     ],
-};
+});

--- a/demo/admin/src/products/future/ManufacturersGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ManufacturersGrid.cometGen.ts
@@ -1,7 +1,7 @@
-import { type GridConfig } from "@comet/admin-generator";
+import { defineConfig } from "@comet/admin-generator";
 import { type GQLManufacturer } from "@src/graphql.generated";
 
-export const ManufacturersGrid: GridConfig<GQLManufacturer> = {
+export default defineConfig<GQLManufacturer>({
     type: "grid",
     gqlType: "Manufacturer",
     fragmentName: "ManufacturersGridFuture", // configurable as it must be unique across project
@@ -24,4 +24,4 @@ export const ManufacturersGrid: GridConfig<GQLManufacturer> = {
         { type: "text", name: "addressAsEmbeddable.alternativeAddress.street", headerName: "Alt-Street 2" },
         { type: "number", name: "addressAsEmbeddable.alternativeAddress.streetNumber", headerName: "Alt-Street number 2" },
     ],
-};
+});

--- a/demo/admin/src/products/future/ProductForm.cometGen.tsx
+++ b/demo/admin/src/products/future/ProductForm.cometGen.tsx
@@ -1,11 +1,11 @@
-import { type FormConfig } from "@comet/admin-generator";
+import { defineConfig } from "@comet/admin-generator";
 import { DamImageBlock } from "@comet/cms-admin";
 import { type GQLProduct } from "@src/graphql.generated";
 import { FormattedMessage } from "react-intl";
 
 import { FutureProductNotice } from "../helpers/FutureProductNotice";
 
-export const ProductForm: FormConfig<GQLProduct> = {
+export default defineConfig<GQLProduct>({
     type: "form",
     gqlType: "Product",
     fragmentName: "ProductFormDetails", // configurable as it must be unique across project
@@ -83,7 +83,7 @@ export const ProductForm: FormConfig<GQLProduct> = {
             ],
         },
     ],
-};
+});
 
 /*
 TODO

--- a/demo/admin/src/products/future/ProductPriceForm.cometGen.ts
+++ b/demo/admin/src/products/future/ProductPriceForm.cometGen.ts
@@ -1,10 +1,10 @@
-import { type FormConfig } from "@comet/admin-generator";
+import { defineConfig } from "@comet/admin-generator";
 import { type GQLProduct } from "@src/graphql.generated";
 
-export const ProductPriceForm: FormConfig<GQLProduct> = {
+export default defineConfig<GQLProduct>({
     type: "form",
     gqlType: "Product",
     mode: "edit",
     fragmentName: "ProductPriceFormDetails", // configurable as it must be unique across project
     fields: [{ type: "number", name: "price", helperText: "Enter price in this format: 123,45", startAdornment: "€" }],
-};
+});

--- a/demo/admin/src/products/future/ProductVariantsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/ProductVariantsGrid.cometGen.ts
@@ -1,7 +1,7 @@
-import { type GridConfig } from "@comet/admin-generator";
+import { defineConfig } from "@comet/admin-generator";
 import { type GQLProductVariant } from "@src/graphql.generated";
 
-export const ProductVariantsGrid: GridConfig<GQLProductVariant> = {
+export default defineConfig<GQLProductVariant>({
     type: "grid",
     gqlType: "ProductVariant",
     fragmentName: "ProductVariantsGridFuture", // configurable as it must be unique across project
@@ -10,4 +10,4 @@ export const ProductVariantsGrid: GridConfig<GQLProductVariant> = {
         { type: "text", name: "name", headerName: "Name" },
         { type: "date", name: "createdAt", headerName: "Created at" },
     ],
-};
+});

--- a/demo/admin/src/products/future/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.tsx
@@ -1,5 +1,5 @@
 import { GridCellContent } from "@comet/admin";
-import { type GridConfig } from "@comet/admin-generator";
+import { defineConfig } from "@comet/admin-generator";
 import { type GQLProduct } from "@src/graphql.generated";
 import { type ReactNode } from "react";
 import { FormattedMessage, FormattedNumber } from "react-intl";
@@ -10,7 +10,7 @@ import { ProductTitle } from "./ProductTitle";
 
 const typeValues = [{ value: "Cap", label: "great Cap" }, "Shirt", "Tie"];
 
-export const ProductsGrid: GridConfig<GQLProduct> = {
+export default defineConfig<GQLProduct>({
     type: "grid",
     gqlType: "Product",
     fragmentName: "ProductsGridFuture", // configurable as it must be unique across project
@@ -137,4 +137,4 @@ export const ProductsGrid: GridConfig<GQLProduct> = {
             component: ProductsGridPreviewAction,
         },
     ],
-};
+});

--- a/demo/admin/src/products/future/SelectProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/future/SelectProductsGrid.cometGen.ts
@@ -1,7 +1,7 @@
-import { type GridConfig } from "@comet/admin-generator";
+import { defineConfig } from "@comet/admin-generator";
 import { type GQLProduct } from "@src/graphql.generated";
 
-export const SelectProductsGrid: GridConfig<GQLProduct> = {
+export default defineConfig<GQLProduct>({
     type: "grid",
     gqlType: "Product",
     fragmentName: "SelectProductsGridFuture",
@@ -15,4 +15,4 @@ export const SelectProductsGrid: GridConfig<GQLProduct> = {
         { type: "date", name: "availableSince", width: 140 },
         { type: "dateTime", name: "createdAt", width: 170 },
     ],
-};
+});

--- a/demo/admin/src/products/future/generated/IdFieldInForm.tsx
+++ b/demo/admin/src/products/future/generated/IdFieldInForm.tsx
@@ -37,7 +37,7 @@ interface FormProps {
     slug: string;
 }
 
-export function ProductForm({ id, type, description, slug }: FormProps) {
+export function IdFieldInForm({ id, type, description, slug }: FormProps) {
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
     const formApiRef = useFormApiRef<FormValues>();

--- a/packages/admin/admin-generator/src/commands/generate/generate-command.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generate-command.ts
@@ -25,7 +25,7 @@ import { generateForm } from "./generateForm/generateForm";
 import { generateGrid } from "./generateGrid/generateGrid";
 import { type UsableFields } from "./generateGrid/usableFields";
 import { type ColumnVisibleOption } from "./utils/columnVisibility";
-import { configsFromSourceFile, morphTsSource } from "./utils/tsMorphHelper";
+import { configFromSourceFile, morphTsSource } from "./utils/tsMorphHelper";
 import { writeGenerated } from "./utils/writeGenerated";
 
 type IconObject = Pick<IconProps, "color" | "fontSize"> & {
@@ -123,7 +123,7 @@ export type FormConfig<T extends { __typename?: string }> = {
     fields: (FormFieldConfig<T> | FormLayoutConfig<T> | ComponentFormFieldConfig)[];
 };
 
-type TabsConfig = { type: "tabs"; tabs: { name: string; content: GeneratorConfig }[] };
+type TabsConfig<T extends { __typename?: string }> = { type: "tabs"; tabs: { name: string; content: GeneratorConfig<T> }[] };
 
 type BaseColumnConfig = Pick<GridColDef, "headerName" | "width" | "minWidth" | "maxWidth" | "flex" | "pinned" | "disableExport"> & {
     headerInfoTooltip?: string;
@@ -184,7 +184,11 @@ export type GridConfig<T extends { __typename?: string }> = {
     selectionProps?: "multiSelect" | "singleSelect";
 };
 
-export type GeneratorConfig = FormConfig<any> | GridConfig<any> | TabsConfig;
+export type GeneratorConfig<T extends { __typename?: string }> = FormConfig<T> | GridConfig<T> | TabsConfig<T>;
+
+export function defineConfig<T extends { __typename?: string }>(config: GeneratorConfig<T>) {
+    return config;
+}
 
 type GQLDocumentConfig = { document: string; export: boolean };
 export type GQLDocumentConfigMap = Record<string, GQLDocumentConfig>;
@@ -206,29 +210,29 @@ async function runGenerate(filePattern = "src/**/*.cometGen.{ts,tsx}") {
         const targetDirectory = `${dirname(file)}/generated`;
         const baseOutputFilename = basename(file).replace(/\.cometGen\.tsx?$/, "");
 
-        const configs = configsFromSourceFile(morphTsSource(file));
+        console.log(`generating ${file}`);
+
+        const config = configFromSourceFile(morphTsSource(file));
+        const exportName = file.match(/([^/]+)\.cometGen\.tsx?$/)?.[1];
+        if (!exportName) throw new Error("Can not determine exportName");
+
         //const configs = await import(`${process.cwd()}/${file.replace(/\.ts$/, "")}`);
 
         const codeOuputFilename = `${targetDirectory}/${basename(file.replace(/\.cometGen\.tsx?$/, ""))}.tsx`;
         await fs.rm(codeOuputFilename, { force: true });
 
-        console.log(`generating ${file}`);
-
-        for (const exportName in configs) {
-            const config = configs[exportName];
-            let generated: GeneratorReturn;
-            if (config.type == "form") {
-                generated = generateForm({ exportName, gqlIntrospection, baseOutputFilename, targetDirectory }, config);
-            } else if (config.type == "grid") {
-                generated = generateGrid({ exportName, gqlIntrospection, baseOutputFilename, targetDirectory }, config);
-            } else {
-                throw new Error(`Unknown config type: ${config.type}`);
-            }
-            outputCode += generated.code;
-            for (const queryName in generated.gqlDocuments) {
-                const exportStatement = generated.gqlDocuments[queryName].export ? "export " : "";
-                gqlDocumentsOutputCode += `${exportStatement} const ${queryName} = gql\`${generated.gqlDocuments[queryName].document}\`\n`;
-            }
+        let generated: GeneratorReturn;
+        if (config.type == "form") {
+            generated = generateForm({ exportName, gqlIntrospection, baseOutputFilename, targetDirectory }, config);
+        } else if (config.type == "grid") {
+            generated = generateGrid({ exportName, gqlIntrospection, baseOutputFilename, targetDirectory }, config);
+        } else {
+            throw new Error(`Unknown config type: ${config.type}`);
+        }
+        outputCode += generated.code;
+        for (const queryName in generated.gqlDocuments) {
+            const exportStatement = generated.gqlDocuments[queryName].export ? "export " : "";
+            gqlDocumentsOutputCode += `${exportStatement} const ${queryName} = gql\`${generated.gqlDocuments[queryName].document}\`\n`;
         }
 
         await writeGenerated(codeOuputFilename, outputCode);

--- a/packages/admin/admin-generator/src/commands/generate/utils/__tests__/tsMorphHelper.ts
+++ b/packages/admin/admin-generator/src/commands/generate/utils/__tests__/tsMorphHelper.ts
@@ -1,6 +1,6 @@
 import { Project } from "ts-morph";
 
-import { configsFromSourceFile } from "../tsMorphHelper";
+import { configFromSourceFile } from "../tsMorphHelper";
 
 describe("AdminGenerator TsMorph Parse Config", () => {
     const project = new Project({
@@ -9,45 +9,45 @@ describe("AdminGenerator TsMorph Parse Config", () => {
     });
     function parseString(sourceFileText: string) {
         const tsSource = project.createSourceFile("test.tsx", sourceFileText, { overwrite: true });
-        return configsFromSourceFile(tsSource);
+        return configFromSourceFile(tsSource);
     }
     it("parses a simple static json", () => {
-        const configs = parseString(`
-            import { future_GridConfig as GridConfig } from "@comet/cms-admin";
+        const config = parseString(`
+            import { defineConfig } from "@comet/admin-generator";
             import { GQLProduct } from "@src/graphql.generated";
 
-            export const ProductsGrid: GridConfig<GQLProduct> = {
+            export default defineConfig<GQLProduct>({
                 type: "grid",
                 gqlType: "Product",
-            }
+            });
         `);
-        expect(configs.ProductsGrid).toEqual({ type: "grid", gqlType: "Product" });
+        expect(config).toEqual({ type: "grid", gqlType: "Product" });
     });
 
     it("parses an arrow function", () => {
-        const configs = parseString(`
-            import { future_GridConfig as GridConfig } from "@comet/cms-admin";
+        const config = parseString(`
+            import { defineConfig } from "@comet/admin-generator";
             import { GQLProduct } from "@src/graphql.generated";
 
-            export const ProductForm: FormConfig<GQLProduct> = {
+            export default defineConfig<GQLProduct>({
                 type: "form",
                 fields: [{
                     name: "foo",
                     validate: () => true
                 }]
-            }
+            });
         `);
-        expect(configs.ProductForm).toEqual({ type: "form", fields: [{ name: "foo", validate: { code: "() => true", imports: [] } }] });
+        expect(config).toEqual({ type: "form", fields: [{ name: "foo", validate: { code: "() => true", imports: [] } }] });
     });
 
     it("parses an arrow function referencing an imported component", () => {
-        const configs = parseString(`
-            import { future_GridConfig as GridConfig } from "@comet/cms-admin";
+        const config = parseString(`
+            import { defineConfig } from "@comet/admin-generator";
             import { GQLProduct } from "@src/graphql.generated";
 
             import { ProductTitle } from "./ProductTitle";
 
-            export const ProductsGrid: GridConfig<GQLProduct> = {
+            export default defineConfig<GQLProduct>({
                 type: "grid",
                 columns: [
                     {
@@ -55,12 +55,9 @@ describe("AdminGenerator TsMorph Parse Config", () => {
                         renderCell: () => <ProductTitle />,
                     }
                 ]
-            }
-            export const ProductsGrid: GridConfig<GQLProduct> = {
-                foo: () => <ProductTitle />,
-            }
+            });
         `);
-        expect(configs.ProductsGrid).toEqual({
+        expect(config).toEqual({
             type: "grid",
             columns: [
                 {
@@ -72,13 +69,13 @@ describe("AdminGenerator TsMorph Parse Config", () => {
     });
 
     it("parses an arrow function referencing an imported component using an function body", () => {
-        const configs = parseString(`
-            import { future_GridConfig as GridConfig } from "@comet/cms-admin";
+        const config = parseString(`
+            import { defineConfig } from "@comet/admin-generator";
             import { GQLProduct } from "@src/graphql.generated";
 
             import { ProductTitle } from "./ProductTitle";
 
-            export const ProductsGrid: GridConfig<GQLProduct> = {
+            export default defineConfig<GQLProduct>({
                 type: "grid",
                 columns: [
                     {
@@ -86,9 +83,9 @@ describe("AdminGenerator TsMorph Parse Config", () => {
                         renderCell: () => { return <ProductTitle /> },
                     }
                 ]
-            }
+            });
         `);
-        expect(configs.ProductsGrid).toEqual({
+        expect(config).toEqual({
             type: "grid",
             columns: [
                 {
@@ -100,17 +97,17 @@ describe("AdminGenerator TsMorph Parse Config", () => {
     });
 
     it("parses a reference to a locally defined variable", () => {
-        const configs = parseString(`
-            import { future_GridConfig as GridConfig } from "@comet/cms-admin";
+        const config = parseString(`
+            import { defineConfig } from "@comet/admin-generator";
             import { GQLProduct } from "@src/graphql.generated";
 
             const abc = 123;
 
-            export const ProductsGrid: GridConfig<GQLProduct> = {
+            export default defineConfig<GQLProduct>({
                 foo: abc
-            }
+            });
         `);
-        expect(configs.ProductsGrid).toEqual({
+        expect(config).toEqual({
             foo: 123,
         });
     });
@@ -118,12 +115,12 @@ describe("AdminGenerator TsMorph Parse Config", () => {
     it("parser throws error for function at unsupported location", () => {
         expect(() => {
             parseString(`
-                import { future_GridConfig as GridConfig } from "@comet/cms-admin";
+                import { defineConfig } from "@comet/admin-generator";
                 import { GQLProduct } from "@src/graphql.generated";
         
-                export const ProductsGrid: GridConfig<GQLProduct> = {
+                export default defineConfig<GQLProduct>({
                     foo: () => true
-                }
+                });
             `);
         }).toThrow();
     });
@@ -131,14 +128,14 @@ describe("AdminGenerator TsMorph Parse Config", () => {
     it("parser throws error for import at unsupported location", () => {
         expect(() => {
             parseString(`
-                import { future_GridConfig as GridConfig } from "@comet/cms-admin";
+                import { defineConfig } from "@comet/admin-generator";
                 import { GQLProduct } from "@src/graphql.generated";
 
                 import { Foo } from "./Foo";
         
-                export const ProductsGrid: GridConfig<GQLProduct> = {
+                export default defineConfig<GQLProduct>({
                     foo: Foo
-                }
+                });
             `);
         }).toThrow();
     });

--- a/packages/admin/admin-generator/src/index.ts
+++ b/packages/admin/admin-generator/src/index.ts
@@ -1,1 +1,2 @@
 export type { FormConfig, FormFieldConfig, GeneratorConfig, GridColumnConfig, GridConfig } from "./commands/generate/generate-command";
+export { defineConfig } from "./commands/generate/generate-command";


### PR DESCRIPTION
Breaking Change ahead, just in time for 8.0 release (hopefully)

Change the way cometGet files need to export their config:
- now only a single export is supported (before it was theoretically possible to define multiple configs in one file resulting in multiple Forms or Grids in one generated file. This is something we _never_ want, and I doubt it even works correctly in all cases)
- the export name of the generated component is now based on the filename (before it was the export name - which doesn't exist anmore)
    - users might not expect this, but I think in practice it will always work
- add a new defineConfig helper (same pattern as mikro-orm, eslint, vite and others, with the exception that we need a type argument)
    - the old way is also supported, but I would recommend the new way
    - possible future issue with defineConfig: if a specific configs needs multiple/other generic arguments, this is not possible using a single defineConfig.

Old:
```
            export const ProductForm: FormConfig<GQLProduct> = {
                type: "grid",
                columns: [ ... ]
            });
```

New:
```
            export default defineConfig<GQLProduct>({
                type: "grid",
                columns: [ ... ]
            });
```