### PR TITLE
Com 1856 duplicated loading in user detail page

### DIFF
--- a/.changeset/four-spiders-know.md
+++ b/.changeset/four-spiders-know.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Improve loading handling in UserPermission - User Page

--- a/packages/admin/cms-admin/src/userPermissions/user/UserPageToolbar.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/UserPageToolbar.tsx
@@ -1,47 +1,20 @@
-import { gql, useQuery } from "@apollo/client";
-import { CrudMoreActionsMenu, FillSpace, Loading, StackToolbar, ToolbarActions, ToolbarBackButton, ToolbarTitleItem } from "@comet/admin";
+import { CrudMoreActionsMenu, FillSpace, StackToolbar, ToolbarActions, ToolbarBackButton } from "@comet/admin";
 import { ImpersonateUser, Reset } from "@comet/admin-icons";
-import { styled } from "@mui/material/styles";
 
 import { commonImpersonationMessages } from "../../common/impersonation/commonImpersonationMessages";
 import { ContentScopeIndicator } from "../../contentScope/ContentScopeIndicator";
 import { useCurrentUser, useUserPermissionCheck } from "../hooks/currentUser";
 import { startImpersonation, stopImpersonation } from "../utils/handleImpersonation";
-import { type GQLUserPageQuery, type GQLUserPageQueryVariables } from "./UserPageToolbar.generated";
+import { ToolbarUserTitleItem } from "./userTitleItem/ToolbarUserTitleItem";
 
 export const UserPermissionsUserPageToolbar = ({ userId }: { userId: string }) => {
     const currentUser = useCurrentUser();
     const isAllowed = useUserPermissionCheck();
 
-    const { data, error, loading } = useQuery<GQLUserPageQuery, GQLUserPageQueryVariables>(
-        gql`
-            query UserPage($id: String!) {
-                user: userPermissionsUserById(id: $id) {
-                    name
-                    email
-                }
-            }
-        `,
-        {
-            variables: { id: userId },
-        },
-    );
-
-    if (error) {
-        throw new Error(error.message);
-    }
-
-    if (loading || !data) {
-        return <Loading />;
-    }
-
     return (
         <StackToolbar scopeIndicator={<ContentScopeIndicator global />}>
             <ToolbarBackButton />
-            <ToolbarTitleItem>
-                <TitleText>{data.user.name}</TitleText>
-                <SupportText>{data.user.email}</SupportText>
-            </ToolbarTitleItem>
+            <ToolbarUserTitleItem userId={userId} />
             <FillSpace />
             <ToolbarActions>
                 {isAllowed("impersonation") && (
@@ -66,17 +39,3 @@ export const UserPermissionsUserPageToolbar = ({ userId }: { userId: string }) =
         </StackToolbar>
     );
 };
-
-const TitleText = styled("div")`
-    font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
-    font-size: 18px;
-    line-height: 21px;
-    color: ${({ theme }) => theme.palette.text.primary};
-`;
-
-const SupportText = styled("div")`
-    font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
-    font-size: 14px;
-    line-height: 20px;
-    color: ${({ theme }) => theme.palette.text.secondary};
-`;

--- a/packages/admin/cms-admin/src/userPermissions/user/basicData/UserBasicData.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/basicData/UserBasicData.tsx
@@ -26,10 +26,6 @@ export const UserPermissionsUserPageBasicDataPanel = ({ userId }: { userId: stri
         throw new Error(error.message);
     }
 
-    if (loading || !data) {
-        return <Loading />;
-    }
-
     return (
         <Card>
             <CardToolbar>
@@ -39,28 +35,32 @@ export const UserPermissionsUserPageBasicDataPanel = ({ userId }: { userId: stri
                 <FillSpace />
             </CardToolbar>
             <CardContent>
-                <FinalForm
-                    mode="edit"
-                    initialValues={data.user}
-                    onSubmit={() => {
-                        /* do nothing */
-                    }}
-                >
-                    <Field
-                        variant="horizontal"
-                        name="email"
-                        component={FinalFormInput}
-                        disabled={true}
-                        label={<FormattedMessage id="comet.userPermissions.email" defaultMessage="E-Mail" />}
-                    />
-                    <Field
-                        variant="horizontal"
-                        name="name"
-                        component={FinalFormInput}
-                        disabled={true}
-                        label={<FormattedMessage id="comet.userPermissions.name" defaultMessage="Name" />}
-                    />
-                </FinalForm>
+                {loading || !data ? (
+                    <Loading />
+                ) : (
+                    <FinalForm
+                        mode="edit"
+                        initialValues={data.user}
+                        onSubmit={() => {
+                            /* do nothing */
+                        }}
+                    >
+                        <Field
+                            variant="horizontal"
+                            name="email"
+                            component={FinalFormInput}
+                            disabled={true}
+                            label={<FormattedMessage id="comet.userPermissions.email" defaultMessage="E-Mail" />}
+                        />
+                        <Field
+                            variant="horizontal"
+                            name="name"
+                            component={FinalFormInput}
+                            disabled={true}
+                            label={<FormattedMessage id="comet.userPermissions.name" defaultMessage="Name" />}
+                        />
+                    </FinalForm>
+                )}
             </CardContent>
         </Card>
     );

--- a/packages/admin/cms-admin/src/userPermissions/user/userTitleItem/ToolbarUserTitleItem.gql.ts
+++ b/packages/admin/cms-admin/src/userPermissions/user/userTitleItem/ToolbarUserTitleItem.gql.ts
@@ -1,0 +1,11 @@
+import { gql } from "@apollo/client";
+
+export const userTitleItemQuery = gql`
+    query UserTitleItem($id: String!) {
+        user: userPermissionsUserById(id: $id) {
+            id
+            name
+            email
+        }
+    }
+`;

--- a/packages/admin/cms-admin/src/userPermissions/user/userTitleItem/ToolbarUserTitleItem.styles.ts
+++ b/packages/admin/cms-admin/src/userPermissions/user/userTitleItem/ToolbarUserTitleItem.styles.ts
@@ -1,0 +1,15 @@
+import { styled } from "@mui/material/styles";
+
+export const TitleText = styled("div")`
+    font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
+    font-size: 18px;
+    line-height: 21px;
+    color: ${({ theme }) => theme.palette.text.primary};
+`;
+
+export const SupportText = styled("div")`
+    font-weight: ${({ theme }) => theme.typography.fontWeightRegular};
+    font-size: 14px;
+    line-height: 20px;
+    color: ${({ theme }) => theme.palette.text.secondary};
+`;

--- a/packages/admin/cms-admin/src/userPermissions/user/userTitleItem/ToolbarUserTitleItem.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/userTitleItem/ToolbarUserTitleItem.tsx
@@ -1,0 +1,34 @@
+import { useQuery } from "@apollo/client";
+import { ToolbarTitleItem } from "@comet/admin";
+import { type FunctionComponent } from "react";
+
+import { userTitleItemQuery } from "./ToolbarUserTitleItem.gql";
+import type { GQLUserTitleItemQuery, GQLUserTitleItemQueryVariables } from "./ToolbarUserTitleItem.gql.generated";
+import { SupportText, TitleText } from "./ToolbarUserTitleItem.styles";
+import { ToolbarUserTitleItemSkeleton } from "./ToolbarUserTitleItemSkeleton";
+
+type UserTitleItemProps = {
+    userId: string;
+};
+export const ToolbarUserTitleItem: FunctionComponent<UserTitleItemProps> = ({ userId }) => {
+    const { data, error, loading } = useQuery<GQLUserTitleItemQuery, GQLUserTitleItemQueryVariables>(userTitleItemQuery, {
+        variables: { id: userId },
+    });
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    return (
+        <ToolbarTitleItem>
+            {loading || !data ? (
+                <ToolbarUserTitleItemSkeleton />
+            ) : (
+                <>
+                    <TitleText>{data.user.name}</TitleText>
+                    <SupportText>{data.user.email}</SupportText>
+                </>
+            )}
+        </ToolbarTitleItem>
+    );
+};

--- a/packages/admin/cms-admin/src/userPermissions/user/userTitleItem/ToolbarUserTitleItemSkeleton.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/userTitleItem/ToolbarUserTitleItemSkeleton.tsx
@@ -1,0 +1,13 @@
+import { Box, Skeleton } from "@mui/material";
+import { type FunctionComponent } from "react";
+
+export const ToolbarUserTitleItemSkeleton: FunctionComponent = () => {
+    return (
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+            <Box>
+                <Skeleton variant="text" width={200} />
+                <Skeleton variant="text" width={150} height={16} />
+            </Box>
+        </Box>
+    );
+};


### PR DESCRIPTION
## Description
- extract ToolbarUserTitleItem into own component
- handle loading state with Loading Skeleton inside ToolbarUserTitleItem
- User Permission Detail - add loading state more local to basic data card

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  ![Screen Recording 2025-03-24 at 11 29 03](https://github.com/user-attachments/assets/53f56215-24ce-4f28-9ee4-e2e537689796) | ![Screen Recording 2025-03-24 at 11 28 33](https://github.com/user-attachments/assets/e0fe7d22-ef0f-452c-b1a0-073c1f15e5b7)  |

## Open TODOs/questions

-   [ ] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1856
