### PR TITLE
Fix broken `gql:watch` script

### DIFF
--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -20,7 +20,7 @@
         "generate-block-types": "comet generate-block-types --inputs",
         "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"$npm_execpath generate-block-types\"",
         "gql:types": "graphql-codegen",
-        "gql:watch": "$npm_execpath generate-graphql-types --watch",
+        "gql:watch": "$npm_execpath graphql-codegen --watch",
         "lint": "run-p gql:types generate-block-types && run-p lint:prettier lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0 src/ **/*.json --no-warn-ignored",
         "lint:prettier": "npx prettier --check './**/*.{js,json,md,yml,yaml}'",


### PR DESCRIPTION
## Description
The `gql:watch` script broke in Pull Request: https://github.com/vivid-planet/comet/pull/3688

<img width="578" alt="Screenshot 2025-03-25 at 08 57 07" src="https://github.com/user-attachments/assets/4a196237-292d-4296-b1ec-82f7e9e349ae" />
<img width="989" alt="Screenshot 2025-03-25 at 08 56 58" src="https://github.com/user-attachments/assets/d4aea65b-3404-46e2-ba1e-5cbe601828d8" />
