### PR TITLE
Fix using wrong warning severity

### DIFF
--- a/demo/admin/src/warnings/WarningsGrid.tsx
+++ b/demo/admin/src/warnings/WarningsGrid.tsx
@@ -109,7 +109,7 @@ export function WarningsGrid({ warningMessages: projectWarningMessages }: Warnin
                 };
                 return (
                     <Chip
-                        icon={params.value === "critical" ? <WarningSolid /> : undefined}
+                        icon={params.value === "high" ? <WarningSolid /> : undefined}
                         color={colorMapping[params.value as GQLWarningSeverity]}
                         label={params.value}
                     />


### PR DESCRIPTION
## Description
When updating warning severity from low, high, critical to low, medium, high i have forgotten this part
## Screenshots

Before:
![Screenshot 2025-03-25 at 09 05 31](https://github.com/user-attachments/assets/db75e8e8-853f-47cf-ac5b-70a00452d38d)

after:
![Screenshot 2025-03-25 at 09 05 08](https://github.com/user-attachments/assets/8e551767-b740-4fd3-ad45-2768159a5917)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-955
