### PR TITLE
Add missing `DialogContent` components

### DIFF
--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -12,7 +12,7 @@ import {
     useStackSwitchApi,
     useStoredState,
 } from "@comet/admin";
-import { Slide, type SlideProps, Snackbar } from "@mui/material";
+import { DialogContent, Slide, type SlideProps, Snackbar } from "@mui/material";
 import { DataGrid, type GridRowClassNameParams, type GridRowSelectionModel, useGridApiRef } from "@mui/x-data-grid";
 import { useEffect, useState } from "react";
 import { type FileRejection, useDropzone } from "react-dropzone";
@@ -581,10 +581,10 @@ const FolderDataGrid = ({
             >
                 {({ selectedId, selectionMode }) => {
                     return (
-                        <>
+                        <DialogContent>
                             {selectionMode === "add" && <AddFolder parentId={selectedId} selectionApi={selectionApi} />}
                             {selectionMode === "edit" && <EditFolder id={selectedId as string} selectionApi={selectionApi} />}
-                        </>
+                        </DialogContent>
                     );
                 }}
             </EditDialog>

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -16,7 +16,7 @@ import {
     useStoredState,
 } from "@comet/admin";
 import { Add } from "@comet/admin-icons";
-import { Box, Button, Divider, FormControlLabel, LinearProgress, Paper, Switch } from "@mui/material";
+import { Box, Button, DialogContent, Divider, FormControlLabel, LinearProgress, Paper, Switch } from "@mui/material";
 import { type ComponentType, type ReactNode, useCallback, useMemo, useRef } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -207,12 +207,14 @@ export function PagesPage({
                         </PageTreeContext.Provider>
 
                         <EditDialog>
-                            <EditPageNode
-                                id={editDialogSelection.id || null}
-                                mode={editDialogSelection.mode ?? "add"}
-                                category={category}
-                                documentTypes={documentTypes}
-                            />
+                            <DialogContent>
+                                <EditPageNode
+                                    id={editDialogSelection.id || null}
+                                    mode={editDialogSelection.mode ?? "add"}
+                                    category={category}
+                                    documentTypes={documentTypes}
+                                />
+                            </DialogContent>
                         </EditDialog>
                     </StackPage>
                     <StackPage name="edit" title={intl.formatMessage({ id: "comet.pages.pages.editContent", defaultMessage: "Edit content" })}>


### PR DESCRIPTION
## Description

`DialogContent` is no longer added by default when using `EditDialog`, see https://github.com/vivid-planet/comet/pull/3401. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="713" alt="Add Folder Dialog Previously" src="https://github.com/user-attachments/assets/ffb905ed-b56b-4d67-825a-0e0fcca8f7e9" />   | <img width="713" alt="Add Folder Dialog Now" src="https://github.com/user-attachments/assets/c8aa6b03-04b2-409a-b3d1-96399995f41d" />  |
| <img width="713" alt="Add page dialog previously" src="https://github.com/user-attachments/assets/9b9c84f3-3758-485a-9c60-d63daa2d9b7b" />   | <img width="713" alt="Add page dialog now" src="https://github.com/user-attachments/assets/1ab5bda5-6642-4c44-ad4f-4da981c4021e" />  |
| <img width="713" alt="Rename Folder Dialog Previously" src="https://github.com/user-attachments/assets/ba29e5b9-6ae0-4d9d-b116-95d004d92523" />   | <img width="713" alt="Rename Folder Dialog Now" src="https://github.com/user-attachments/assets/df5abcd4-b6f1-483c-a377-2765417afd08" />  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1703
