### PR TITLE
Slightly improve the ImportFromPicsum dialog

### DIFF
--- a/demo/admin/src/dam/ImportFromPicsum.tsx
+++ b/demo/admin/src/dam/ImportFromPicsum.tsx
@@ -1,7 +1,8 @@
-import { Button, CancelButton, SaveButton } from "@comet/admin";
+import { Button, CancelButton, Loading, SaveButton } from "@comet/admin";
 import { Reload } from "@comet/admin-icons";
 import { useCurrentDamFolder, useDamAcceptedMimeTypes, useDamFileUpload } from "@comet/cms-admin";
 import {
+    Box,
     // eslint-disable-next-line no-restricted-imports
     Dialog,
     DialogActions,
@@ -26,13 +27,14 @@ export const ImportFromPicsum = () => {
     });
 
     const handleOpenDialog = async () => {
+        setIsOpen(true);
         const image = await getRandomPicsumImage();
         setPicsumImage(image);
-        setIsOpen(true);
     };
 
     const handleCloseDialog = () => {
         setIsOpen(false);
+        setPicsumImage(undefined);
     };
 
     const handleSave = async () => {
@@ -59,7 +61,9 @@ export const ImportFromPicsum = () => {
                 <div>
                     <DialogTitle>Import from Picsum</DialogTitle>
                     <DialogContent>
-                        <ImagePreview src={picsumImage?.url} alt="image" />
+                        <Box sx={{ aspectRatio: "16/9", lineHeight: 0 }}>
+                            {picsumImage ? <ImagePreview src={picsumImage?.url} alt="image" /> : <Loading behavior="fillParent" />}
+                        </Box>
                     </DialogContent>
                     <DialogActions>
                         <CancelButton onClick={handleCloseDialog} />


### PR DESCRIPTION
## Description

The dialog is now shown immediately, when clicking the button. 
Previously it seemed unresponsive as the dialog would wait for the image to be loaded. 

Additionally a loading indicator has been added with the same aspect-ratio as the image that is loaded to prevent layout-shift. `lineHeight: 0` prevents the whitespace below the loaded image from having a height and causing uneven spacing and layout-shift when the image is loaded. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1703
