### PR TITLE
Add all supported `video/` mimetypes to allowedMimetypes of `DamVideoBlock`

### DIFF
--- a/.changeset/blind-eyes-see.md
+++ b/.changeset/blind-eyes-see.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `video/webm` to allowedMimetypes of `DamVideoBlock`

--- a/.changeset/blind-eyes-see.md
+++ b/.changeset/blind-eyes-see.md
@@ -2,4 +2,7 @@
 "@comet/cms-admin": minor
 ---
 
-Add `video/webm` to allowedMimetypes of `DamVideoBlock`
+Add all supported `video/` mimetypes to allowedMimetypes of `DamVideoBlock`
+
+Per default, following mimetypes are now allowed: `video/mp4`, `video/webm`, `video/ogg`, `video/quicktime`.
+This list can be extended in the project via the `acceptedMimetypes` prop of the `DamConfigProvider`.

--- a/.cspellignore
+++ b/.cspellignore
@@ -20,3 +20,4 @@ subcomponent
 subpage
 Traefik
 typesafe
+quicktime

--- a/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
@@ -21,6 +21,7 @@ import { FormattedMessage } from "react-intl";
 
 import { DamVideoBlockData, DamVideoBlockInput } from "../blocks.generated";
 import { useContentScope } from "../contentScope/Provider";
+import { useDamAcceptedMimeTypes } from "../dam/config/useDamAcceptedMimeTypes";
 import { useDependenciesConfig } from "../dependencies/DependenciesConfig";
 import { DamPathLazy } from "../form/file/DamPathLazy";
 import { FileField } from "../form/file/FileField";
@@ -132,6 +133,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
         const contentScope = useContentScope();
         const apolloClient = useApolloClient();
         const dependencyMap = useDependenciesConfig();
+        const acceptedVideoMimetypes = useDamAcceptedMimeTypes().filteredAcceptedMimeTypes.video;
 
         const showMenu = Boolean(dependencyMap["DamFile"]);
 
@@ -200,7 +202,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                             </AdminComponentPaper>
                         </FieldContainer>
                     ) : (
-                        <Field name="damFile" component={FileField} fullWidth allowedMimetypes={["video/mp4", "video/webm"]} />
+                        <Field name="damFile" component={FileField} fullWidth allowedMimetypes={acceptedVideoMimetypes} />
                     )}
                     <VideoOptionsFields />
                     <AdminComponentSection title={<FormattedMessage id="comet.blocks.video.previewImage" defaultMessage="Preview Image" />}>

--- a/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
@@ -200,7 +200,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                             </AdminComponentPaper>
                         </FieldContainer>
                     ) : (
-                        <Field name="damFile" component={FileField} fullWidth allowedMimetypes={["video/mp4"]} />
+                        <Field name="damFile" component={FileField} fullWidth allowedMimetypes={["video/mp4", "video/webm"]} />
                     )}
                     <VideoOptionsFields />
                     <AdminComponentSection title={<FormattedMessage id="comet.blocks.video.previewImage" defaultMessage="Preview Image" />}>


### PR DESCRIPTION
## Description

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

- [Internal discussion](https://vividplanet.slack.com/archives/C052UQJ5DLN/p1742289648601109)
