### PR TITLE
Make selects in `createSeoBlock` required

### DIFF
--- a/packages/admin/cms-admin/src/blocks/createSeoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createSeoBlock.tsx
@@ -1,6 +1,6 @@
-import { Field, type FieldProps, FinalFormInput, FinalFormSelect, Loading, messages } from "@comet/admin";
+import { Field, type FieldProps, FinalFormInput, Loading, messages, SelectField } from "@comet/admin";
 import { Add, ArtificialIntelligence, Delete } from "@comet/admin-icons";
-import { Box, Divider, Grid, IconButton, MenuItem, Paper, Typography } from "@mui/material";
+import { Box, Divider, Grid, IconButton, Paper, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import arrayMutators from "final-form-arrays";
 import { useState } from "react";
@@ -223,42 +223,26 @@ export function createSeoBlock(
                                             >
                                                 <Divider />
                                                 <Box padding={4}>
-                                                    <Field
+                                                    <SelectField
                                                         label={intl.formatMessage({
                                                             id: "comet.blocks.seo.sitemap.priority",
                                                             defaultMessage: "Priority",
                                                         })}
                                                         name="priority"
                                                         fullWidth
-                                                    >
-                                                        {(props) => (
-                                                            <FinalFormSelect {...props} fullWidth>
-                                                                {priorityOptions.map((option) => (
-                                                                    <MenuItem value={option.value} key={option.value}>
-                                                                        {option.label}
-                                                                    </MenuItem>
-                                                                ))}
-                                                            </FinalFormSelect>
-                                                        )}
-                                                    </Field>
-                                                    <Field
+                                                        required
+                                                        options={priorityOptions}
+                                                    />
+                                                    <SelectField
                                                         label={intl.formatMessage({
                                                             id: "comet.blocks.seo.sitemap.changeFrequency",
                                                             defaultMessage: "Change Frequency",
                                                         })}
                                                         name="changeFrequency"
                                                         fullWidth
-                                                    >
-                                                        {(props) => (
-                                                            <FinalFormSelect {...props} fullWidth>
-                                                                {changeFrequencyOptions.map((option) => (
-                                                                    <MenuItem value={option.value} key={option.value}>
-                                                                        {option.label}
-                                                                    </MenuItem>
-                                                                ))}
-                                                            </FinalFormSelect>
-                                                        )}
-                                                    </Field>
+                                                        required
+                                                        options={changeFrequencyOptions}
+                                                    />
                                                 </Box>
                                             </Collapsible>
                                         </Paper>


### PR DESCRIPTION
## Description

As there is an initial value and the value is required by the API to save, there is no need for the clear button.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="389" alt="Sitemap selects previously" src="https://github.com/user-attachments/assets/688ddead-1cc2-47c6-87c8-543ed277a632" />   | <img width="389" alt="Sitemap selects now" src="https://github.com/user-attachments/assets/2c224081-80e8-465e-91d7-09015ff5a2da" />  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1703
