### PR TITLE
Don't unnecessarily render an empty `UserGroupChip`

### DIFF
--- a/demo/admin/src/userGroups/UserGroupChip.tsx
+++ b/demo/admin/src/userGroups/UserGroupChip.tsx
@@ -12,13 +12,19 @@ interface Props {
 function UserGroupChip({ item }: Props): JSX.Element | null {
     if (item.userGroup === "All") {
         return null;
-    } else {
-        return (
-            <Box paddingTop={2}>
-                <Chip label={userGroupOptions.find((option) => option.value === item.userGroup)?.label} />
-            </Box>
-        );
     }
+
+    const label = userGroupOptions.find((option) => option.value === item.userGroup)?.label;
+
+    if (!label) {
+        return null;
+    }
+
+    return (
+        <Box paddingTop={2}>
+            <Chip label={label} />
+        </Box>
+    );
 }
 
 export { UserGroupChip };


### PR DESCRIPTION
## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="387" alt="Page Blocks Previously" src="https://github.com/user-attachments/assets/7ea62d46-a807-43d7-a211-6b4b4ad29ae8" />   | <img width="387" alt="Page Blocks Now" src="https://github.com/user-attachments/assets/62570a54-a5db-437d-bf83-5a95373e7ebc" />  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1703
