### PR TITLE
Demo Site: Remove incorrect `/` from `createSitePath`

### DIFF
--- a/demo/site/src/util/createSitePath.ts
+++ b/demo/site/src/util/createSitePath.ts
@@ -15,5 +15,5 @@ export const createSitePath = ({ path, scope }: CreateSitePathOptions) => {
         throw new Error("Path must start with a `/`.");
     }
 
-    return `/${scope.language}/${path}`;
+    return `/${scope.language}${path}`;
 };


### PR DESCRIPTION
## Description

See https://github.com/vivid-planet/comet-starter/pull/808#discussion_r2013499651.
