### PR TITLE
Only allow mp4 and webm videos again

### DIFF
--- a/.changeset/blind-eyes-see.md
+++ b/.changeset/blind-eyes-see.md
@@ -2,7 +2,4 @@
 "@comet/cms-admin": minor
 ---
 
-Add all supported `video/` mimetypes to allowedMimetypes of `DamVideoBlock`
-
-Per default, following mimetypes are now allowed: `video/mp4`, `video/webm`, `video/ogg`, `video/quicktime`.
-This list can be extended in the project via the `acceptedMimetypes` prop of the `DamConfigProvider`.
+Add `video/webm` to allowedMimetypes of `DamVideoBlock`

--- a/.cspellignore
+++ b/.cspellignore
@@ -20,4 +20,3 @@ subcomponent
 subpage
 Traefik
 typesafe
-quicktime

--- a/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
@@ -21,7 +21,6 @@ import { FormattedMessage } from "react-intl";
 
 import { DamVideoBlockData, DamVideoBlockInput } from "../blocks.generated";
 import { useContentScope } from "../contentScope/Provider";
-import { useDamAcceptedMimeTypes } from "../dam/config/useDamAcceptedMimeTypes";
 import { useDependenciesConfig } from "../dependencies/DependenciesConfig";
 import { DamPathLazy } from "../form/file/DamPathLazy";
 import { FileField } from "../form/file/FileField";
@@ -133,7 +132,6 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
         const contentScope = useContentScope();
         const apolloClient = useApolloClient();
         const dependencyMap = useDependenciesConfig();
-        const acceptedVideoMimetypes = useDamAcceptedMimeTypes().filteredAcceptedMimeTypes.video;
 
         const showMenu = Boolean(dependencyMap["DamFile"]);
 
@@ -202,7 +200,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                             </AdminComponentPaper>
                         </FieldContainer>
                     ) : (
-                        <Field name="damFile" component={FileField} fullWidth allowedMimetypes={acceptedVideoMimetypes} />
+                        <Field name="damFile" component={FileField} fullWidth allowedMimetypes={["video/mp4", "video/webm"]} />
                     )}
                     <VideoOptionsFields />
                     <AdminComponentSection title={<FormattedMessage id="comet.blocks.video.previewImage" defaultMessage="Preview Image" />}>


### PR DESCRIPTION
## Description

Reverts the second commit of https://github.com/vivid-planet/comet/pull/3701 and only allows mp4 and webm for no.

Reason: Concerns about support for mov and ogv in browsers that we have to test more thoroughly
