### PR TITLE
Fix selection of date-time in Final Form

### DIFF
--- a/.changeset/eight-eyes-agree.md
+++ b/.changeset/eight-eyes-agree.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin-date-time": minor
+---
+
+Add support for `onBlur` and `onFocus` props to the `DateTimePicker`
+
+These events will be triggered when either of the date or time picker is focused or blurred.

--- a/.changeset/sweet-fireants-fold.md
+++ b/.changeset/sweet-fireants-fold.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-date-time": patch
+---
+
+Fix selection of a date where the month/year differs from the current selection in `DateTimeField` and `FinalFormDateTimePicker`

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
@@ -1,5 +1,5 @@
 import { createComponentSlot, ThemedComponentBaseProps } from "@comet/admin";
-import { ComponentsOverrides, FormControl } from "@mui/material";
+import { ComponentsOverrides, FormControl, InputBaseProps } from "@mui/material";
 import { css, Theme, useThemeProps } from "@mui/material/styles";
 import { useRef } from "react";
 import { useIntl } from "react-intl";
@@ -57,10 +57,12 @@ export interface DateTimePickerProps
     onChange?: (value?: Date) => void;
     value?: Date;
     required?: boolean;
+    onBlur?: InputBaseProps["onBlur"];
+    onFocus?: InputBaseProps["onFocus"];
 }
 
 export const DateTimePicker = (inProps: DateTimePickerProps) => {
-    const { onChange, value, required, slotProps, ...restProps } = useThemeProps({
+    const { onChange, value, required, slotProps, onBlur, onFocus, ...restProps } = useThemeProps({
         props: inProps,
         name: "CometAdminDateTimePicker",
     });
@@ -108,6 +110,14 @@ export const DateTimePicker = (inProps: DateTimePickerProps) => {
                     fullWidth
                     required={required}
                     {...slotProps?.datePicker}
+                    onBlur={(event) => {
+                        onBlur?.(event);
+                        slotProps?.datePicker?.onBlur?.(event);
+                    }}
+                    onFocus={(event) => {
+                        onFocus?.(event);
+                        slotProps?.datePicker?.onFocus?.(event);
+                    }}
                 />
             </DateFormControl>
             <TimeFormControl {...slotProps?.timeFormControl}>
@@ -119,6 +129,14 @@ export const DateTimePicker = (inProps: DateTimePickerProps) => {
                     fullWidth
                     required={required}
                     {...slotProps?.timePicker}
+                    onBlur={(event) => {
+                        onBlur?.(event);
+                        slotProps?.timePicker?.onBlur?.(event);
+                    }}
+                    onFocus={(event) => {
+                        onFocus?.(event);
+                        slotProps?.timePicker?.onFocus?.(event);
+                    }}
                 />
             </TimeFormControl>
         </Root>

--- a/packages/admin/admin-date-time/src/dateTimePicker/FinalFormDateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/FinalFormDateTimePicker.tsx
@@ -4,6 +4,6 @@ import { DateTimePicker, DateTimePickerProps } from "./DateTimePicker";
 
 export type FinalFormDateTimePickerProps = DateTimePickerProps & FieldRenderProps<Date, HTMLInputElement | HTMLTextAreaElement>;
 
-export const FinalFormDateTimePicker = ({ meta, input, ...restProps }: FinalFormDateTimePickerProps) => {
-    return <DateTimePicker {...input} {...restProps} />;
+export const FinalFormDateTimePicker = ({ meta, input: { onBlur, onFocus, ...restInput }, ...restProps }: FinalFormDateTimePickerProps) => {
+    return <DateTimePicker {...restInput} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/dateTimePicker/FinalFormDateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/FinalFormDateTimePicker.tsx
@@ -4,6 +4,6 @@ import { DateTimePicker, DateTimePickerProps } from "./DateTimePicker";
 
 export type FinalFormDateTimePickerProps = DateTimePickerProps & FieldRenderProps<Date, HTMLInputElement | HTMLTextAreaElement>;
 
-export const FinalFormDateTimePicker = ({ meta, input: { onBlur, onFocus, ...restInput }, ...restProps }: FinalFormDateTimePickerProps) => {
-    return <DateTimePicker {...restInput} {...restProps} />;
+export const FinalFormDateTimePicker = ({ meta, input, ...restProps }: FinalFormDateTimePickerProps) => {
+    return <DateTimePicker {...input} {...restProps} />;
 };


### PR DESCRIPTION
## Description

Previously `onBlur` was passed from `Field` (from `react-final-form`) into the `Root` slot ( a `div`) of `DateTimePicker`. 
This caused unexpected behavior, preventing the selection of a date with a different month or year than the current value.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/34d6bc36-7107-4e24-a62c-2c4a1e9058ee" />   | <video src="https://github.com/user-attachments/assets/d956210e-c979-40dc-98dd-3cc7b10563c9" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/SVK-646
