### PR TITLE
Use correct filename for MUI X dependency codemod

### DIFF
--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -832,7 +832,7 @@ In `package.json` update the version of the MUI X packages to `^7.22.3`.
 :::note Handled by following upgrade script
 
 ```sh
-npx @comet/upgrade v8/mui-x-upgrade.ts
+npx @comet/upgrade v8/update-mui-x-dependencies.ts
 ```
 
 :::


### PR DESCRIPTION
## Description

The codemod file is named `update-mui-x-dependencies`: https://github.com/vivid-planet/comet-upgrade/blob/main/src/v8/update-mui-x-dependencies.ts
