### PR TITLE
Replace storybook-wide `body` styles with MUIs `CssBaseline`

### DIFF
--- a/storybook/.storybook/preview-head.html
+++ b/storybook/.storybook/preview-head.html
@@ -1,12 +1,5 @@
 <title>Comet</title>
 <style>
-    body {
-        font-family: "Lato", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-        font-size: 14px;
-        line-height: 1.4;
-        -webkit-font-smoothing: antialiased;
-    }
-
     #root pre:not(.prismjs) {
         background-color: #efefef;
         font-size: 10px;

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -3,7 +3,7 @@ import "@fontsource-variable/roboto-flex/full.css";
 import { DataGridPanel, MainContent, MuiThemeProvider } from "@comet/admin";
 import { DateFnsLocaleProvider } from "@comet/admin-date-time";
 import { createCometTheme } from "@comet/admin-theme";
-import { createTheme as createMuiTheme, GlobalStyles } from "@mui/material";
+import { createTheme as createMuiTheme, CssBaseline, GlobalStyles } from "@mui/material";
 import type { Preview } from "@storybook/react";
 import { Locale as DateFnsLocale } from "date-fns";
 import { de as deLocale, enUS as enLocale } from "date-fns/locale";
@@ -87,6 +87,7 @@ const preview: Preview = {
 
             return (
                 <MuiThemeProvider theme={theme}>
+                    <CssBaseline />
                     <IntlProvider locale={selectedLocale} messages={messages[selectedLocale] ?? {}}>
                         <DateFnsLocaleProvider value={dateFnsLocales[selectedLocale]}>
                             <GlobalStyles styles={previewGlobalStyles} />


### PR DESCRIPTION
## Description

Currently, `CssBaseline` is added to each application by default, as all content is nested within `MasterLayout`, which renders the `CssBaseline` component. 

As `MasterLayout` is not used in all stories, this could lead to styling inconsistencies of individual components in their usage inside a project, compared to their component-story in storybook. 

For example, this was an issue with `DialogTitle`, where `box-sizing` would differ, causing the component to look correct in the story, while it was broken in actual usages, see: https://github.com/vivid-planet/comet/pull/3347

Additionally, the `body` styling of storybook could override theme-styles, leading to more inconsistencies. 
Removing those `body` styles has no affect on the styling of storybook itself, just on the body of the `iframe` rendered inside the stories. 


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1605
