### PR TITLE
Change type of values prop of ContentScopeProvider

### DIFF
--- a/.changeset/cyan-suns-smell.md
+++ b/.changeset/cyan-suns-smell.md
@@ -1,0 +1,43 @@
+---
+"@comet/cms-admin": major
+---
+
+Change type of the `values` prop of ContentScopeProvider
+
+**Before**
+
+```ts
+const values: ContentScopeValues<ContentScope> = [
+    {
+        domain: { label: "Main", value: "main" },
+        language: { label: "English", value: "en" },
+    },
+    {
+        domain: { label: "Main", value: "main" },
+        language: { label: "German", value: "de" },
+    },
+    {
+        domain: { label: "Secondary", value: "secondary" },
+        language: { label: "English", value: "en" },
+    },
+];
+```
+
+**Now**
+
+```ts
+const values: ContentScopeValues<ContentScope> = [
+    {
+        scope: { domain: "main", language: "en" },
+        label: { domain: "Main", language: "English" },
+    },
+    {
+        scope: { domain: "main", language: "de" },
+        label: { domain: "Main", language: "German" },
+    },
+    {
+        scope: { domain: "secondary", language: "en" },
+        label: { domain: "Secondary", language: "English" },
+    },
+];
+```

--- a/demo/admin/src/common/ContentScopeProvider.tsx
+++ b/demo/admin/src/common/ContentScopeProvider.tsx
@@ -30,8 +30,8 @@ export const ContentScopeProvider = ({ children }: Pick<ContentScopeProviderProp
     ) as ContentScope[];
 
     const values: ContentScopeValues<ContentScope> = userContentScopes.map((contentScope) => ({
-        domain: { value: contentScope.domain },
-        language: { value: contentScope.language, label: contentScope.language.toUpperCase() },
+        scope: contentScope,
+        label: { language: contentScope.language.toUpperCase() },
     }));
 
     if (user.allowedContentScopes.length === 0) {

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
@@ -23,10 +23,9 @@ export const ContentScopeIndicator = ({ global = false, scope: passedScope, chil
 
     const findLabelForScopePart = (scopePart: keyof ContentScopeInterface) => {
         const label = values.find((value) => {
-            return value[scopePart] && value[scopePart]?.value === scope[scopePart];
-        })?.[scopePart].label;
-
-        return label ?? (scope[scopePart] ? capitalizeString(scope[scopePart]) : undefined);
+            return value.scope[scopePart] === scope[scopePart];
+        })?.label;
+        return (label && label[scopePart]) ?? (scope[scopePart] ? capitalizeString(scope[scopePart]) : undefined);
     };
 
     let content: ReactNode;

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
@@ -22,7 +22,8 @@ import { findTextMatches, MarkedMatches } from "../common/MarkedMatches";
 import { type ContentScopeInterface } from "./Provider";
 
 type Option<Value extends ContentScopeInterface = ContentScopeInterface> = {
-    [Key in keyof Value]: { label?: string; value: Value[Key] };
+    scope: Value;
+    label?: { [Key in keyof Value]?: string };
 };
 
 interface Props<Value extends ContentScopeInterface> {
@@ -56,9 +57,10 @@ export function ContentScopeSelect<Value extends ContentScopeInterface = Content
 
     if (searchable) {
         filteredOptions = options.filter((option) => {
-            return Object.values(option).some(({ label, value }) => {
-                return value.toLowerCase().includes(searchValue.toLowerCase()) || label?.toLowerCase().includes(searchValue.toLowerCase());
-            });
+            return (
+                Object.values(option.scope).some((value) => value.toLowerCase().includes(searchValue.toLowerCase())) ||
+                Object.values(option.label || []).some((value) => value?.toLowerCase().includes(searchValue.toLowerCase()))
+            );
         });
     }
 
@@ -67,12 +69,12 @@ export function ContentScopeSelect<Value extends ContentScopeInterface = Content
     if (groupBy) {
         if (hasMultipleDimensions) {
             for (const option of filteredOptions) {
-                const groupForOption = groups.find((group) => group.value === option[groupBy].value);
+                const groupForOption = groups.find((group) => group.value === option.scope[groupBy]);
 
                 if (groupForOption) {
                     groupForOption.options.push(option);
                 } else {
-                    groups.push({ value: option[groupBy].value, label: option[groupBy].label, options: [option] });
+                    groups.push({ value: option.scope[groupBy], label: option.label ? option.label[groupBy] : undefined, options: [option] });
                 }
             }
         } else {
@@ -84,7 +86,7 @@ export function ContentScopeSelect<Value extends ContentScopeInterface = Content
     }
 
     const selectedOption = options.find((option) => {
-        return Object.keys(option).every((key) => value[key] === option[key].value);
+        return Object.keys(option.scope).every((key) => value[key] === option.scope[key]);
     });
 
     if (!selectedOption) {
@@ -93,9 +95,9 @@ export function ContentScopeSelect<Value extends ContentScopeInterface = Content
 
     if (!renderOption) {
         renderOption = (option, query) => {
-            const text = Object.entries(option)
+            const text = Object.entries(option.scope)
                 .filter(([dimension]) => (hasMultipleDimensions && groupBy ? dimension !== groupBy : true))
-                .map(([, option]) => option.label ?? option.value)
+                .map(([key, value]) => (option.label && option.label[key]) ?? value)
                 .join(" – ");
             const matches = findTextMatches(text, query);
 
@@ -116,8 +118,8 @@ export function ContentScopeSelect<Value extends ContentScopeInterface = Content
 
     if (!renderSelectedOption) {
         renderSelectedOption = (option) => {
-            return Object.values(option)
-                .map((option) => humanReadableLabel(option))
+            return Object.keys(option.scope)
+                .map((key) => humanReadableLabel({ label: option.label ? option.label[key] : undefined, value: option.scope[key] }))
                 .join(" / ");
         };
     }
@@ -267,7 +269,7 @@ export function ContentScopeSelect<Value extends ContentScopeInterface = Content
                                                 key={JSON.stringify(option)}
                                                 onClick={() => {
                                                     hideDropdown();
-                                                    onChange(optionToValue<Value>(option));
+                                                    onChange(option.scope);
                                                     setSearchValue("");
                                                 }}
                                                 selected={isSelected}
@@ -299,16 +301,6 @@ export function ContentScopeSelect<Value extends ContentScopeInterface = Content
             )}
         </AppHeaderDropdown>
     );
-}
-
-function optionToValue<Value extends ContentScopeInterface = ContentScopeInterface>(option: Option<Value>): Value {
-    const value: Record<string, unknown> = {};
-
-    Object.keys(option).forEach((key) => {
-        value[key] = option[key].value;
-    });
-
-    return value as Value;
 }
 
 function humanReadableLabel({ label, value }: { label?: string; value: string }) {

--- a/packages/admin/cms-admin/src/contentScope/Provider.tsx
+++ b/packages/admin/cms-admin/src/contentScope/Provider.tsx
@@ -50,7 +50,8 @@ export type UseContentScopeApi<S extends ContentScopeInterface = ContentScopeInt
 };
 
 export type ContentScopeValues<S extends ContentScopeInterface = ContentScopeInterface> = Array<{
-    [P in keyof S]: { label?: string; value: NonNull<S[P]> };
+    scope: S;
+    label?: { [P in keyof S]?: string };
 }>;
 
 // @TODO (maybe): factory for Provider (and other components) to be able to create a generic context https://ordina-jworks.github.io/architecture/2021/02/12/react-generic-context.html

--- a/packages/admin/cms-admin/src/contentScope/utils/defaultCreatePath.test.ts
+++ b/packages/admin/cms-admin/src/contentScope/utils/defaultCreatePath.test.ts
@@ -3,12 +3,12 @@ import { defaultCreatePath } from "./defaultCreatePath";
 
 describe("defaultCreatePath", () => {
     it("should create paths from content scope values", () => {
-        const values: ContentScopeValues = [
-            { domain: { value: "main" }, language: { label: "DE", value: "de" } },
-            { domain: { value: "main" }, language: { label: "EN", value: "en" } },
-            { domain: { value: "secondary" }, language: { label: "EN", value: "en" } },
-            { domain: { value: "secondary" }, language: { label: "DE", value: "de" } },
-            { country: { value: "secondary" } },
+        const values: ContentScopeValues<{ domain: string; language: string } | { country: string }> = [
+            { scope: { domain: "main", language: "de" }, label: { language: "DE" } },
+            { scope: { domain: "main", language: "en" }, label: { language: "EN" } },
+            { scope: { domain: "secondary", language: "en" }, label: { language: "EN" } },
+            { scope: { domain: "secondary", language: "de" }, label: { language: "DE" } },
+            { scope: { country: "secondary" } },
         ];
         const result = defaultCreatePath(values);
 
@@ -24,7 +24,7 @@ describe("defaultCreatePath", () => {
     });
 
     it("should handle single value", () => {
-        const values: ContentScopeValues = [{ domain: { value: "main" } }];
+        const values: ContentScopeValues = [{ scope: { domain: "main" } }];
 
         const result = defaultCreatePath(values);
 
@@ -32,7 +32,7 @@ describe("defaultCreatePath", () => {
     });
 
     it("should handle multiple dimensions", () => {
-        const values: ContentScopeValues = [{ domain: { value: "main" }, language: { value: "de" }, country: { value: "DE" } }];
+        const values: ContentScopeValues = [{ scope: { domain: "main", language: "de", country: "DE" } }];
 
         const result = defaultCreatePath(values);
 

--- a/packages/admin/cms-admin/src/contentScope/utils/defaultCreatePath.ts
+++ b/packages/admin/cms-admin/src/contentScope/utils/defaultCreatePath.ts
@@ -13,12 +13,12 @@ export function defaultCreatePath(values: ContentScopeValues) {
 
     groupObjectsIntoArrays(values).forEach((value) => {
         const dimensionValues: { [dimension: string]: Set<string> } = {};
-        value.forEach((innerValue: { [x: string]: { value: string } }) => {
-            Object.keys(innerValue).forEach((dimension) => {
+        value.forEach((innerValue: { scope: { [x: string]: string } }) => {
+            Object.keys(innerValue.scope).forEach((dimension) => {
                 if (!dimensionValues[dimension]) {
                     dimensionValues[dimension] = new Set();
                 }
-                dimensionValues[dimension].add(innerValue[dimension].value);
+                dimensionValues[dimension].add(innerValue.scope[dimension]);
             });
         });
         const path = createPathFromDimensionValues(dimensionValues);

--- a/packages/admin/cms-admin/src/contentScope/utils/groupObjectsIntoArrays.ts
+++ b/packages/admin/cms-admin/src/contentScope/utils/groupObjectsIntoArrays.ts
@@ -15,7 +15,7 @@ import { type ContentScopeValues } from "../Provider";
 export function groupObjectsIntoArrays(values: ContentScopeValues) {
     const grouped = new Map();
     values.forEach((item) => {
-        const key = JSON.stringify(Object.keys(item).sort());
+        const key = JSON.stringify(Object.keys(item.scope).sort());
         if (grouped.has(key)) {
             grouped.get(key).push(item);
         } else {

--- a/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.stories.tsx
+++ b/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.stories.tsx
@@ -13,10 +13,10 @@ export const OptionalDimensions = function () {
     type ContentScope = { organizationId?: string; channelId?: string };
 
     const values: ContentScopeValues<ContentScope> = [
-        { organizationId: { value: "organization-1", label: "Organization 1" } },
-        { organizationId: { value: "organization-2", label: "Organization 2" } },
-        { channelId: { value: "channel-1", label: "Channel 1" } },
-        { channelId: { value: "channel-2", label: "Channel 2" } },
+        { scope: { organizationId: "organization-1" }, label: { organizationId: "Organization 1" } },
+        { scope: { organizationId: "organization-2" }, label: { organizationId: "Organization 2" } },
+        { scope: { channelId: "channel-1" }, label: { channelId: "Channel 1" } },
+        { scope: { channelId: "channel-2" }, label: { channelId: "Channel 2" } },
     ];
 
     function PrintContentScope() {

--- a/storybook/src/cms-admin/ContentScopeSelect.stories.tsx
+++ b/storybook/src/cms-admin/ContentScopeSelect.stories.tsx
@@ -29,9 +29,9 @@ export const Basic = function () {
                 setValue(value);
             }}
             options={[
-                { domain: { label: "Main", value: "main" } },
-                { domain: { label: "Secondary", value: "secondary" } },
-                { domain: { label: "Tertiary", value: "tertiary" } },
+                { scope: { domain: "main" }, label: { domain: "Main" } },
+                { scope: { domain: "secondary" }, label: { domain: "Secondary" } },
+                { scope: { domain: "tertiary" }, label: { domain: "Tertiary" } },
             ]}
         />
     );
@@ -46,10 +46,10 @@ export const MultipleDimensions = function () {
                 setValue(value);
             }}
             options={[
-                { domain: { label: "Main", value: "main" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Main", value: "main" }, language: { label: "German", value: "de" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "German", value: "de" } },
+                { scope: { domain: "main", language: "en" }, label: { domain: "Main", language: "English" } },
+                { scope: { domain: "main", language: "de" }, label: { domain: "Main", language: "German" } },
+                { scope: { domain: "secondary", language: "en" }, label: { domain: "Secondary", language: "English" } },
+                { scope: { domain: "secondary", language: "de" }, label: { domain: "Secondary", language: "German" } },
             ]}
         />
     );
@@ -66,10 +66,10 @@ export const Searchable = function () {
                 setValue(value);
             }}
             options={[
-                { domain: { label: "Main", value: "main" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Main", value: "main" }, language: { label: "German", value: "de" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "German", value: "de" } },
+                { scope: { domain: "main", language: "en" }, label: { domain: "Main", language: "English" } },
+                { scope: { domain: "main", language: "de" }, label: { domain: "Main", language: "German" } },
+                { scope: { domain: "secondary", language: "en" }, label: { domain: "Secondary", language: "English" } },
+                { scope: { domain: "secondary", language: "de" }, label: { domain: "Secondary", language: "German" } },
             ]}
             searchable
         />
@@ -85,10 +85,10 @@ export const Groups = function () {
                 setValue(value);
             }}
             options={[
-                { domain: { label: "Main", value: "main" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Main", value: "main" }, language: { label: "German", value: "de" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "German", value: "de" } },
+                { scope: { domain: "main", language: "en" }, label: { domain: "Main", language: "English" } },
+                { scope: { domain: "main", language: "de" }, label: { domain: "Main", language: "German" } },
+                { scope: { domain: "secondary", language: "en" }, label: { domain: "Secondary", language: "English" } },
+                { scope: { domain: "secondary", language: "de" }, label: { domain: "Secondary", language: "German" } },
             ]}
             groupBy="domain"
             searchable
@@ -105,10 +105,10 @@ export const CustomIcon = function () {
                 setValue(value);
             }}
             options={[
-                { domain: { label: "Main", value: "main" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Main", value: "main" }, language: { label: "German", value: "de" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "German", value: "de" } },
+                { scope: { domain: "main", language: "en" }, label: { domain: "Main", language: "English" } },
+                { scope: { domain: "main", language: "de" }, label: { domain: "Main", language: "German" } },
+                { scope: { domain: "secondary", language: "en" }, label: { domain: "Secondary", language: "English" } },
+                { scope: { domain: "secondary", language: "de" }, label: { domain: "Secondary", language: "German" } },
             ]}
             icon={<Language />}
         />
@@ -126,10 +126,10 @@ export const CustomRenderOption = function () {
                 setValue(value);
             }}
             options={[
-                { domain: { label: "Main", value: "main" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Main", value: "main" }, language: { label: "German", value: "de" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "German", value: "de" } },
+                { scope: { domain: "main", language: "en" }, label: { domain: "Main", language: "English" } },
+                { scope: { domain: "main", language: "de" }, label: { domain: "Main", language: "German" } },
+                { scope: { domain: "secondary", language: "en" }, label: { domain: "Secondary", language: "English" } },
+                { scope: { domain: "secondary", language: "de" }, label: { domain: "Secondary", language: "German" } },
             ]}
             renderOption={(option) => (
                 <>
@@ -139,7 +139,7 @@ export const CustomRenderOption = function () {
                     <ListItemText
                         primary={
                             <>
-                                {option.domain.label} – {option.language.label}
+                                {option.label!.domain} – {option.label!.language}
                             </>
                         }
                     />
@@ -162,13 +162,25 @@ export const CustomRenderOptionWithSearchHighlighting = {
                     setValue(value);
                 }}
                 options={[
-                    { domain: { label: "Main", value: "main" }, language: { label: "English", value: "en" } },
-                    { domain: { label: "Main", value: "main" }, language: { label: "German", value: "de" } },
-                    { domain: { label: "Secondary", value: "secondary" }, language: { label: "English", value: "en" } },
-                    { domain: { label: "Secondary", value: "secondary" }, language: { label: "German", value: "de" } },
+                    {
+                        scope: { domain: "main", language: "en" },
+                        label: { domain: "Main", language: "English" },
+                    },
+                    {
+                        scope: { domain: "main", language: "de" },
+                        label: { domain: "Main", language: "German" },
+                    },
+                    {
+                        scope: { domain: "secondary", language: "en" },
+                        label: { domain: "Secondary", language: "English" },
+                    },
+                    {
+                        scope: { domain: "secondary", language: "de" },
+                        label: { domain: "Secondary", language: "German" },
+                    },
                 ]}
                 renderOption={(option, query) => {
-                    const text = `${option.domain.label} – ${option.language.label}`;
+                    const text = `${option.label!.domain} – ${option.label!.language}`;
                     const matches = findTextMatches(text, query);
                     return <ListItemText primary={<MarkedMatches text={text} matches={matches} />} />;
                 }}
@@ -187,14 +199,14 @@ export const CustomRenderSelectedOption = function () {
                 setValue(value);
             }}
             options={[
-                { domain: { label: "Main", value: "main" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Main", value: "main" }, language: { label: "German", value: "de" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "English", value: "en" } },
-                { domain: { label: "Secondary", value: "secondary" }, language: { label: "German", value: "de" } },
+                { scope: { domain: "main", language: "en" }, label: { domain: "Main", language: "English" } },
+                { scope: { domain: "main", language: "de" }, label: { domain: "Main", language: "German" } },
+                { scope: { domain: "secondary", language: "en" }, label: { domain: "Secondary", language: "English" } },
+                { scope: { domain: "secondary", language: "de" }, label: { domain: "Secondary", language: "German" } },
             ]}
             renderSelectedOption={(option) => (
                 <>
-                    {option.domain.label}: {option.language.label}
+                    {option.label!.domain}: {option.label!.language}
                 </>
             )}
         />
@@ -213,39 +225,32 @@ export const ThreeDimensions = function () {
             }}
             options={[
                 {
-                    company: { label: "A Inc.", value: "a-inc" },
-                    country: { label: "Austria", value: "at" },
-                    language: { label: "German", value: "de" },
+                    scope: { company: "a-inc", country: "at", language: "de" },
+                    label: { company: "A Inc.", country: "Austria", language: "German" },
                 },
                 {
-                    company: { label: "A Inc.", value: "a-inc" },
-                    country: { label: "Austria", value: "at" },
-                    language: { label: "English", value: "en" },
+                    scope: { company: "a-inc", country: "at", language: "en" },
+                    label: { company: "A Inc.", country: "Austria", language: "English" },
                 },
                 {
-                    company: { label: "B Inc.", value: "b-inc" },
-                    country: { label: "Austria", value: "at" },
-                    language: { label: "German", value: "de" },
+                    scope: { company: "b-inc", country: "at", language: "de" },
+                    label: { company: "B Inc.", country: "Austria", language: "German" },
                 },
                 {
-                    company: { label: "B Inc.", value: "b-inc" },
-                    country: { label: "Austria", value: "at" },
-                    language: { label: "English", value: "en" },
+                    scope: { company: "b-inc", country: "at", language: "en" },
+                    label: { company: "B Inc.", country: "Austria", language: "English" },
                 },
                 {
-                    company: { label: "C Inc.", value: "c-inc" },
-                    country: { label: "Switzerland", value: "ch" },
-                    language: { label: "German", value: "de" },
+                    scope: { company: "c-inc", country: "ch", language: "de" },
+                    label: { company: "C Inc.", country: "Switzerland", language: "German" },
                 },
                 {
-                    company: { label: "C Inc.", value: "c-inc" },
-                    country: { label: "Switzerland", value: "ch" },
-                    language: { label: "English", value: "en" },
+                    scope: { company: "c-inc", country: "ch", language: "en" },
+                    label: { company: "C Inc.", country: "Switzerland", language: "English" },
                 },
                 {
-                    company: { label: "C Inc.", value: "c-inc" },
-                    country: { label: "Switzerland", value: "ch" },
-                    language: { label: "French", value: "fr" },
+                    scope: { company: "c-inc", country: "ch", language: "fr" },
+                    label: { company: "C Inc.", country: "Switzerland", language: "French" },
                 },
             ]}
             groupBy="company"


### PR DESCRIPTION
Prerequisite PR for https://github.com/vivid-planet/comet/pull/2172

https://vivid-planet.atlassian.net/browse/COM-848

Changing the type has to following advantages:
- Easier understandable
- More thorough typing (especially for future PRs which will support this type in the graphql api)

The migration effort will be minimal once the follow-up PRs will be merged. Hence, there is no migration guide for this single change yet.