### PR TITLE
Prevent content of `AdminComponentRoot` from being cut off when not contained within tabs

### DIFF
--- a/.changeset/sharp-flowers-approve.md
+++ b/.changeset/sharp-flowers-approve.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Prevent the content of `AdminComponentRoot` from being cut off at the top when not rendered inside tabs

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
@@ -15,12 +15,11 @@ const AdminComponentRoot = (props: PropsWithChildren<Props>) => {
             <StackBreadcrumbs
                 sx={({ palette, spacing }) => ({
                     paddingTop: 0,
-                    paddingBottom: "20px",
+                    paddingBottom: spacing(4),
                     position: "sticky",
                     zIndex: 15,
                     backgroundColor: palette.background.default,
                     top: 0,
-                    marginTop: spacing(-4),
                 })}
             />
             <ChildrenContainer>{children}</ChildrenContainer>

--- a/packages/admin/blocks-admin/src/blocks/common/AdminTabsTabContent.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminTabsTabContent.tsx
@@ -1,4 +1,3 @@
-import { Box } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { PropsWithChildren } from "react";
 
@@ -12,9 +11,7 @@ export const TabContent = ({ children, selectedTab }: PropsWithChildren<TabConte
     const scrollRestoration = useScrollRestoration<HTMLDivElement>(`adminTabsTabContent-${selectedTab}`);
     return (
         <Root {...scrollRestoration}>
-            <Box marginBottom={4} marginTop={4}>
-                {children}
-            </Box>
+            <Content>{children}</Content>
         </Root>
     );
 };
@@ -22,4 +19,13 @@ export const TabContent = ({ children, selectedTab }: PropsWithChildren<TabConte
 const Root = styled("div")`
     overflow-y: auto;
     overflow-x: hidden;
+`;
+
+const Content = styled("div")`
+    margin-top: ${({ theme }) => theme.spacing(4)};
+    margin-bottom: ${({ theme }) => theme.spacing(4)};
+
+    & > .CometAdminStackBreadcrumbs-root:first-child {
+        margin-top: -${({ theme }) => theme.spacing(4)};
+    }
 `;


### PR DESCRIPTION
## Description

`TabContent` adds a `margin-top` so there is some space between the tabs and their content, see https://github.com/vivid-planet/comet/pull/1071. 

When rendering `StackBreadcrumbs` at the top of the tabs content, there should be no spacing on the top, according to the design. That's why a negative `margin-top` was added to `StackBreadcrumbs`. 

This negative margin however, was also applied when used outside of tabs, which caused the content below to be moved up into negative space, causing it to be cut off, see the "Before" screenshot below. 

This is now fixed by only applying the negative margin directly to the breadcrumbs, when used as the first child inside the tabs content. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="1024" alt="Editing Page-Content Previously" src="https://github.com/user-attachments/assets/56773ef9-1c02-4eda-83cd-a51dff60fa49" />   | <img width="1024" alt="Editing Page-Content Now" src="https://github.com/user-attachments/assets/06c37f38-a678-41e6-8a22-2d5fb1edd0e0" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1863
