### PR TITLE
Make styling of different List components consistent and match the design

### DIFF
--- a/.changeset/clear-parts-sniff.md
+++ b/.changeset/clear-parts-sniff.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": minor
+---
+
+Adapt styling of MUI's List and Menu components according to the Comet DXP design
+
+This affects the following components: `List`, `Menu`, `ListItem`, `MenuItem`, `ListItemButton`, `ListItemIcon`, `ListItemText`.

--- a/packages/admin/admin/src/theme/componentsTheme/MuiList.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiList.ts
@@ -1,0 +1,19 @@
+import { dividerClasses } from "@mui/material";
+
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { type GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiList: GetMuiComponentTheme<"MuiList"> = (component, { palette }) => ({
+    ...component,
+    defaultProps: {
+        ...component?.defaultProps,
+    },
+    styleOverrides: mergeOverrideStyles<"MuiList">(component?.styleOverrides, {
+        root: {
+            [`& .${dividerClasses.root}`]: {
+                margin: "8px 10px",
+                borderColor: palette.grey[50],
+            },
+        },
+    }),
+});

--- a/packages/admin/admin/src/theme/componentsTheme/MuiListItemButton.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiListItemButton.ts
@@ -2,9 +2,9 @@ import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { commonListItemRootStyles } from "./commonListStyles";
 import { type GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiListItem: GetMuiComponentTheme<"MuiListItem"> = (component, { spacing }) => ({
+export const getMuiListItemButton: GetMuiComponentTheme<"MuiListItemButton"> = (component) => ({
     ...component,
-    styleOverrides: mergeOverrideStyles<"MuiListItem">(component?.styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiListItemButton">(component?.styleOverrides, {
         root: {
             ...commonListItemRootStyles,
         },

--- a/packages/admin/admin/src/theme/componentsTheme/MuiListItemIcon.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiListItemIcon.tsx
@@ -1,11 +1,12 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { type GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiListItemIcon: GetMuiComponentTheme<"MuiListItemIcon"> = (component) => ({
+export const getMuiListItemIcon: GetMuiComponentTheme<"MuiListItemIcon"> = (component, { spacing }) => ({
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiListItemIcon">(component?.styleOverrides, {
         root: {
             minWidth: 0,
+            marginRight: spacing(2),
         },
     }),
 });

--- a/packages/admin/admin/src/theme/componentsTheme/MuiListItemText.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiListItemText.ts
@@ -1,0 +1,20 @@
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { commonListItemPrimaryTextStyles } from "./commonListStyles";
+import { type GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiListItemText: GetMuiComponentTheme<"MuiListItemText"> = (component) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiListItemText">(component?.styleOverrides, {
+        root: {
+            marginTop: 0,
+            marginBottom: 0,
+        },
+        primary: {
+            ...commonListItemPrimaryTextStyles,
+        },
+        secondary: {
+            fontSize: 13,
+            lineHeight: "16px",
+        },
+    }),
+});

--- a/packages/admin/admin/src/theme/componentsTheme/MuiMenu.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiMenu.tsx
@@ -4,20 +4,10 @@ import { type GetMuiComponentTheme } from "./getComponentsTheme";
 export const getMuiMenu: GetMuiComponentTheme<"MuiMenu"> = (component, theme) => ({
     ...component,
     styleOverrides: mergeOverrideStyles<"MuiMenu">(component?.styleOverrides, {
-        paper: { minWidth: 220, borderRadius: "4px" },
-        root: {
-            "& .MuiMenuItem-root": {
-                padding: "8px 15px 8px 30px",
-                columnGap: "10px",
-            },
-
-            "& .MuiDivider-root": {
-                borderColor: theme.palette.grey[50],
-            },
-
-            "& .MuiDivider-root, &.MuiMenuItem-root+.MuiDivider-root": {
-                margin: "8px 10px",
-            },
+        paper: {
+            minWidth: 220,
+            borderRadius: 4,
+            boxShadow: theme.shadows[3],
         },
     }),
 });

--- a/packages/admin/admin/src/theme/componentsTheme/MuiMenuItem.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiMenuItem.ts
@@ -1,0 +1,24 @@
+import { dividerClasses, listItemIconClasses } from "@mui/material";
+
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { commonListItemRootStyles } from "./commonListStyles";
+import { type GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiMenuItem: GetMuiComponentTheme<"MuiMenuItem"> = (component) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiMenuItem">(component?.styleOverrides, {
+        root: {
+            ...commonListItemRootStyles,
+            minHeight: 0,
+
+            [`.${listItemIconClasses.root}`]: {
+                minWidth: 0,
+            },
+
+            [`&+.${dividerClasses.root}`]: {
+                marginTop: 8,
+                marginBottom: 8,
+            },
+        },
+    }),
+});

--- a/packages/admin/admin/src/theme/componentsTheme/commonListStyles.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/commonListStyles.ts
@@ -1,0 +1,10 @@
+export const commonListItemPrimaryTextStyles = {
+    fontSize: 14,
+    lineHeight: "19px",
+    fontWeight: 250,
+};
+
+export const commonListItemRootStyles = {
+    ...commonListItemPrimaryTextStyles,
+    padding: "8px 15px",
+};

--- a/packages/admin/admin/src/theme/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/getComponentsTheme.ts
@@ -30,10 +30,14 @@ import { getMuiInputAdornment } from "./MuiInputAdornment";
 import { getMuiInputBase } from "./MuiInputBase";
 import { getMuiLinearProgress } from "./MuiLinearProgress";
 import { getMuiLink } from "./MuiLink";
+import { getMuiList } from "./MuiList";
 import { getMuiListItem } from "./MuiListItem";
 import { getMuiListItemAvatar } from "./MuiListItemAvatar";
+import { getMuiListItemButton } from "./MuiListItemButton";
 import { getMuiListItemIcon } from "./MuiListItemIcon";
+import { getMuiListItemText } from "./MuiListItemText";
 import { getMuiMenu } from "./MuiMenu";
+import { getMuiMenuItem } from "./MuiMenuItem";
 import { getMuiNativeSelect } from "./MuiNativeSelect";
 import { getMuiPaper } from "./MuiPaper";
 import { getMuiPopover } from "./MuiPopover";
@@ -87,10 +91,14 @@ export const getComponentsTheme = (components: Components, theme: Theme): ThemeO
     MuiInputBase: getMuiInputBase(components.MuiInputBase, theme),
     MuiLinearProgress: getMuiLinearProgress(components.MuiLinearProgress, theme),
     MuiLink: getMuiLink(components.MuiLink, theme),
+    MuiList: getMuiList(components.MuiList, theme),
     MuiListItem: getMuiListItem(components.MuiListItem, theme),
+    MuiListItemText: getMuiListItemText(components.MuiListItemText, theme),
+    MuiListItemButton: getMuiListItemButton(components.MuiListItemButton, theme),
     MuiListItemIcon: getMuiListItemIcon(components.MuiListItemIcon, theme),
     MuiListItemAvatar: getMuiListItemAvatar(components.MuiListItemAvatar, theme),
     MuiMenu: getMuiMenu(components.MuiMenu, theme),
+    MuiMenuItem: getMuiMenuItem(components.MuiMenuItem, theme),
     MuiNativeSelect: getMuiNativeSelect(components.MuiNativeSelect, theme),
     MuiPaper: getMuiPaper(components.MuiPaper, theme),
     MuiPopover: getMuiPopover(components.MuiPopover, theme),

--- a/storybook/src/admin/mui/ListAndMenu.stories.tsx
+++ b/storybook/src/admin/mui/ListAndMenu.stories.tsx
@@ -1,0 +1,84 @@
+import { Button } from "@comet/admin";
+import { Add } from "@comet/admin-icons";
+import { Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText, Menu, MenuItem, Paper } from "@mui/material";
+import { useRef, useState } from "react";
+
+export default {
+    title: "@comet/admin/mui",
+};
+
+export const ListAndMenu = {
+    render: () => {
+        const buttonRef = useRef<HTMLButtonElement>(null);
+        const [open, setOpen] = useState(false);
+
+        return (
+            <div>
+                <Paper sx={{ mb: 4 }}>
+                    <List>
+                        <ListItem>Simple list item</ListItem>
+                        <ListItem>
+                            <ListItemText primary="Using ListItemText" />
+                        </ListItem>
+                        <ListItem>
+                            <ListItemIcon>
+                                <Add />
+                            </ListItemIcon>
+                            <ListItemText primary="List item with icon" />
+                        </ListItem>
+                        <Divider />
+                        <ListItem>
+                            <ListItemIcon>
+                                <Add />
+                            </ListItemIcon>
+                            <ListItemText primary="List item with icon" secondary="And secondary text" />
+                        </ListItem>
+                    </List>
+                </Paper>
+                <Paper sx={{ mb: 4 }}>
+                    <List>
+                        <ListItemButton>Simple list item button</ListItemButton>
+                        <ListItemButton>
+                            <ListItemText primary="Using ListItemText" />
+                        </ListItemButton>
+                        <ListItemButton>
+                            <ListItemIcon>
+                                <Add />
+                            </ListItemIcon>
+                            <ListItemText primary="List item button with icon" />
+                        </ListItemButton>
+                        <Divider />
+                        <ListItemButton>
+                            <ListItemIcon>
+                                <Add />
+                            </ListItemIcon>
+                            <ListItemText primary="List item button with icon" secondary="And secondary text" />
+                        </ListItemButton>
+                    </List>
+                </Paper>
+                <Button ref={buttonRef} onClick={() => setOpen(true)}>
+                    Open menu
+                </Button>
+                <Menu open={open} onClose={() => setOpen(false)} anchorEl={buttonRef.current}>
+                    <MenuItem>Simple menu item</MenuItem>
+                    <MenuItem>
+                        <ListItemText primary="Using ListItemText" />
+                    </MenuItem>
+                    <MenuItem>
+                        <ListItemIcon>
+                            <Add />
+                        </ListItemIcon>
+                        <ListItemText primary="Menu item with icon" />
+                    </MenuItem>
+                    <Divider />
+                    <MenuItem>
+                        <ListItemIcon>
+                            <Add />
+                        </ListItemIcon>
+                        <ListItemText primary="Menu item with icon" secondary="And secondary text" />
+                    </MenuItem>
+                </Menu>
+            </div>
+        );
+    },
+};


### PR DESCRIPTION
## Description

The different types of List/Menu items did not match the design, as defined by UX. 
Also the styling was inconsistent and looked broken in `next`, between `ListItem`, `ListItemButton` and `MenuItem`, as well as between `Divider` inside `List` and `Menu`. 


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="320" alt="Lists Previously" src="https://github.com/user-attachments/assets/1977466b-781e-4c25-95a7-c1925e787a5a" />   | <img width="320" alt="Lists Now" src="https://github.com/user-attachments/assets/f4898158-b841-4265-992e-57f897b8c4fc" />  |

## Open TODOs/questions

-   [x] Add changeset
-   [x] Merge parent https://github.com/vivid-planet/comet/pull/3729

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1864
