### PR TITLE
Remove icon from the "Add new block" list

### DIFF
--- a/packages/admin/cms-admin/src/blocks/common/AddBlockDrawer.tsx
+++ b/packages/admin/cms-admin/src/blocks/common/AddBlockDrawer.tsx
@@ -1,5 +1,5 @@
 import { useStoredState } from "@comet/admin";
-import { Close, Dashboard, Search } from "@comet/admin-icons";
+import { Close, Search } from "@comet/admin-icons";
 import {
     Checkbox,
     DialogContent,
@@ -11,7 +11,6 @@ import {
     InputBase,
     List,
     ListItemButton,
-    ListItemIcon,
     Paper,
     Typography,
 } from "@mui/material";
@@ -184,10 +183,7 @@ export function AddBlockDrawer({ open, onClose, blocks, onAddNewBlock }: Props) 
                             <Paper elevation={0}>
                                 <List disablePadding>
                                     {category.blocks.map(([type, block]) => (
-                                        <ListItemButton key={type} dense={false} divider onClick={() => handleListItemClick(type)}>
-                                            <ListItemIcon>
-                                                <Dashboard />
-                                            </ListItemIcon>
+                                        <ListItemButton key={type} divider onClick={() => handleListItemClick(type)}>
                                             {block.displayName}
                                         </ListItemButton>
                                     ))}


### PR DESCRIPTION
## Description

According to UX, this icon is unnecessary and should be removed. 
A changeset was not added, as this does not affect developers of comet projects. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="379" alt="Add new block previously" src="https://github.com/user-attachments/assets/e391e31b-2c21-43b5-8afc-15252bf985a2" />   | <img width="379" alt="Add new block now" src="https://github.com/user-attachments/assets/5df39b5c-41d7-4d2c-b0c1-e8e10505645a" />  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1864
