### PR TITLE
Load mobile image in BasicStageBlock with priority

### DIFF
--- a/demo/site/src/common/blocks/MediaBlock.tsx
+++ b/demo/site/src/common/blocks/MediaBlock.tsx
@@ -11,9 +11,9 @@ import {
 import { MediaBlockData } from "@src/blocks.generated";
 import { DamImageBlock } from "@src/common/blocks/DamImageBlock";
 
-const getSupportedBlocks = (sizes: string, aspectRatio: string, fill?: boolean): SupportedBlocks => {
+const getSupportedBlocks = (sizes: string, aspectRatio: string, fill?: boolean, priority?: boolean): SupportedBlocks => {
     return {
-        image: (data) => <DamImageBlock data={data} sizes={sizes} aspectRatio={aspectRatio} fill={fill} />,
+        image: (data) => <DamImageBlock data={data} sizes={sizes} aspectRatio={aspectRatio} fill={fill} priority={priority} />,
         damVideo: (data) => <DamVideoBlock data={data} previewImageSizes={sizes} aspectRatio={aspectRatio} fill={fill} />,
         youTubeVideo: (data) => <YouTubeVideoBlock data={data} previewImageSizes={sizes} aspectRatio={aspectRatio} fill={fill} />,
         vimeoVideo: (data) => <VimeoVideoBlock data={data} previewImageSizes={sizes} aspectRatio={aspectRatio} fill={fill} />,
@@ -24,13 +24,14 @@ interface MediaBlockProps extends PropsWithData<MediaBlockData> {
     sizes?: string;
     aspectRatio: string;
     fill?: boolean;
+    priority?: boolean;
 }
 
 export const MediaBlock = withPreview(
-    ({ data, sizes = "100vw", aspectRatio, fill }: MediaBlockProps) => {
+    ({ data, sizes = "100vw", aspectRatio, fill, priority }: MediaBlockProps) => {
         return (
             <PreviewSkeleton type="media" hasContent={Boolean(data)}>
-                <OneOfBlock data={data} supportedBlocks={getSupportedBlocks(sizes, aspectRatio, fill)} />
+                <OneOfBlock data={data} supportedBlocks={getSupportedBlocks(sizes, aspectRatio, fill, priority)} />
             </PreviewSkeleton>
         );
     },

--- a/demo/site/src/documents/pages/blocks/BasicStageBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/BasicStageBlock.tsx
@@ -13,7 +13,7 @@ export const BasicStageBlock = withPreview(
     ({ data: { media, heading, text, overlay, alignment, callToActionList } }: PropsWithData<BasicStageBlockData>) => (
         <Root>
             <MediaPhone>
-                <MediaBlock data={media} aspectRatio="1x2" fill />
+                <MediaBlock data={media} aspectRatio="1x2" fill priority />
             </MediaPhone>
             <MediaTablet>
                 <MediaBlock data={media} aspectRatio="1x1" fill />


### PR DESCRIPTION
## Description

The image of the BasicStageBlock displayed at the mobile breakpoint is loaded with priority. This allows Next.js to preload the image and therefore improve the Largest Contentful Paint (LCP) metric.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| https://github.com/user-attachments/assets/8c41a19a-3e81-4c56-8c5a-18d5a49354b5 | https://github.com/user-attachments/assets/493f26f9-c5de-4cd5-9d7c-7256e89cc4a0 |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1643
