### PR TITLE
Demo Admin: Output error message when user has no scopes

### DIFF
--- a/demo/admin/src/common/ContentScopeProvider.tsx
+++ b/demo/admin/src/common/ContentScopeProvider.tsx
@@ -3,6 +3,7 @@ import {
     ContentScopeProvider as ContentScopeProviderLibrary,
     type ContentScopeProviderProps,
     type ContentScopeValues,
+    StopImpersonationButton,
     useContentScope as useContentScopeLibrary,
     type UseContentScopeApi,
     useContentScopeConfig as useContentScopeConfigLibrary,
@@ -35,7 +36,12 @@ export const ContentScopeProvider = ({ children }: Pick<ContentScopeProviderProp
     }));
 
     if (user.allowedContentScopes.length === 0) {
-        throw new Error("User does not have access to any scopes.");
+        return (
+            <>
+                Error: user does not have access to any scopes.
+                {user.impersonated && <StopImpersonationButton />}
+            </>
+        );
     }
 
     return (


### PR DESCRIPTION
As this might occur when impersonating an user without scopes also present a button to stop impersonation.

Sidenote: we should consider providing an error component to show user facing errors outside the MasterLayout.

![image](https://github.com/user-attachments/assets/e2cea72a-0d80-4e8b-9be8-4ad3b03bb4df)

TODO (in separate PR):
- Use the [InlineAlert](https://github.com/vivid-planet/comet/pull/3663) component
