### PR TITLE
Admin Generator: add support for array queryFields in Grid column type=virtual by adding a FollowArrays argument to UsableFields

### DIFF
--- a/demo/admin/src/products/future/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.tsx
@@ -133,6 +133,13 @@ export default defineConfig<GQLProduct>({
             filterOperators: ManufacturerFilterOperators,
         },
         {
+            type: "virtual",
+            name: "tags",
+            headerName: "Tags",
+            queryFields: ["tags.title"],
+            renderCell: ({ row }) => <>{row.tags.map(tag => tag.title).join(", ")}</>,
+        },
+        {
             type: "actions",
             component: ProductsGridPreviewAction,
         },

--- a/demo/admin/src/products/future/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/future/ProductsGrid.cometGen.tsx
@@ -137,7 +137,7 @@ export default defineConfig<GQLProduct>({
             name: "tags",
             headerName: "Tags",
             queryFields: ["tags.title"],
-            renderCell: ({ row }) => <>{row.tags.map(tag => tag.title).join(", ")}</>,
+            renderCell: ({ row }) => <>{row.tags.map((tag) => tag.title).join(", ")}</>,
         },
         {
             type: "actions",

--- a/demo/admin/src/products/future/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/future/generated/ProductsGrid.tsx
@@ -67,6 +67,9 @@ const productsFragment = gql`
         manufacturer {
             name
         }
+        tags {
+            title
+        }
     }
 `;
 
@@ -316,6 +319,14 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             sortable: false,
             valueGetter: (params, row) => row.manufacturer?.name,
             filterOperators: ManufacturerFilterOperators,
+            flex: 1,
+            minWidth: 150,
+        },
+        {
+            field: "tags",
+            headerName: intl.formatMessage({ id: "product.tags", defaultMessage: "Tags" }),
+            sortable: false,
+            renderCell: ({ row }) => <>{row.tags.map((tag) => tag.title).join(", ")}</>,
             flex: 1,
             minWidth: 150,
         },

--- a/packages/admin/admin-generator/src/commands/generate/generate-command.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generate-command.ts
@@ -151,7 +151,7 @@ export type ActionsGridColumnConfig = { type: "actions"; component?: ComponentTy
 export type VirtualGridColumnConfig<T extends GridValidRowModel> = {
     type: "virtual";
     name: string;
-    queryFields?: UsableFields<T>[];
+    queryFields?: UsableFields<T, true>[];
     renderCell: (params: GridRenderCellParams<T, any, any>) => JSX.Element;
 } & Pick<GridColDef, "sortBy"> &
     BaseColumnConfig;

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/usableFields.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/usableFields.ts
@@ -1,13 +1,22 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type GqlLeaves<T> = T extends any
-    ? "__typename" extends keyof T
-        ? {
-              [K in keyof T as K extends "__typename" ? never : K]-?: GqlLeaves<T[K]>;
-          }
-        : never
-    : never;
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+type GqlLeaves<T, FollowArrays extends boolean = false, Depth extends number = 5> = [Depth] extends [never]
+    ? never
+    : T extends any
+      ? T extends Array<infer ArrayType>
+          ? FollowArrays extends true
+              ? GqlLeaves<ArrayType, FollowArrays, Prev[Depth]>
+              : never
+          : "__typename" extends keyof T
+            ? {
+                  [K in keyof T as K extends "__typename" ? never : K]-?: GqlLeaves<T[K], FollowArrays, Prev[Depth]>;
+              }
+            : never
+      : never;
 
 type FieldNames<T> = {
     [K in keyof T]: `${Exclude<K, symbol>}${FieldNames<T[K]> extends never ? "" : `.${FieldNames<T[K]>}`}`;
 }[keyof T];
-export type UsableFields<T> = FieldNames<GqlLeaves<T>>;
+export type UsableFields<T, FollowArrays extends boolean = false> = FieldNames<GqlLeaves<T, FollowArrays>>;


### PR DESCRIPTION
before this didn't work (because tags is an array):
```
        {
            type: "virtual",
            name: "tags",
            headerName: "Tags",
            queryFields: ["tags.title"],
            renderCell: ({ row }) => <>{row.tags.map(tag => tag.title).join(", ")}</>,
        },
```

- this was implemented as boolean argument (FollowArrays) to UsableFields, as we don't need it for all other use cases (text column or form fields)
- if tags has a reference back to products this would result in an endless recursion; add a Depth argument to stop the recursion