### PR TITLE
Demo: Remove unused faker from API as it was replaced by a fork

### DIFF
--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -61,7 +61,6 @@
         "elastic-apm-node": "^3.0.0",
         "exifr": "^6.0.0",
         "express": "^4.17.1",
-        "faker": "^5.0.0",
         "file-type": "^16.0.0",
         "graphql": "^15.0.0",
         "graphql-scalars": "^1.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,9 +504,6 @@ importers:
       express:
         specifier: ^4.17.1
         version: 4.18.2
-      faker:
-        specifier: ^5.0.0
-        version: 5.5.3
       file-type:
         specifier: ^16.0.0
         version: 16.5.4


### PR DESCRIPTION
Old: https://www.npmjs.com/package/faker
New: https://www.npmjs.com/package/@faker-js/faker

However, the old one isn't used anymore.
