### PR TITLE
Handle scope correctly in import-redirects script

### DIFF
--- a/.changeset/cyan-pens-lick.md
+++ b/.changeset/cyan-pens-lick.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-api": patch
+---
+
+Make `import-redirects` console script consider scope when loading the target `PageTreeNode` for a redirect
+
+Previously, the scope wasn't considered when loading the node.
+This resulted in redirects that targeted a node in a different scope -> these redirects didn't work.

--- a/packages/api/cms-api/src/redirects/import-redirects.console.ts
+++ b/packages/api/cms-api/src/redirects/import-redirects.console.ts
@@ -44,7 +44,7 @@ export class ImportRedirectsConsole {
         let errors = 0;
 
         for (const row of rows) {
-            const node = await this.pageTreeService.createReadApi({ visibility: "all" }).getNodeByPath(row["target"]);
+            const node = await this.pageTreeService.createReadApi({ visibility: "all" }).getNodeByPath(row["target"], { scope: row["scope"] });
 
             const where: FilterQuery<RedirectInterface> = { source: row.source };
             if (row["scope"]) {

--- a/packages/api/cms-api/src/redirects/import-redirects.console.ts
+++ b/packages/api/cms-api/src/redirects/import-redirects.console.ts
@@ -8,6 +8,7 @@ import * as fs from "fs";
 import { Command, Console } from "nestjs-console";
 
 import { PageTreeService } from "../page-tree/page-tree.service";
+import { PageTreeReadApiOptions } from "../page-tree/page-tree-read-api";
 import { RedirectInterface } from "./entities/redirect-entity.factory";
 import { REDIRECTS_LINK_BLOCK } from "./redirects.constants";
 import { RedirectGenerationType, RedirectSourceTypeValues } from "./redirects.enum";
@@ -44,7 +45,11 @@ export class ImportRedirectsConsole {
         let errors = 0;
 
         for (const row of rows) {
-            const node = await this.pageTreeService.createReadApi({ visibility: "all" }).getNodeByPath(row["target"], { scope: row["scope"] });
+            const options: PageTreeReadApiOptions = {};
+            if (row["scope"]) {
+                options.scope = row["scope"];
+            }
+            const node = await this.pageTreeService.createReadApi({ visibility: "all" }).getNodeByPath(row["target"], options);
 
             const where: FilterQuery<RedirectInterface> = { source: row.source };
             if (row["scope"]) {


### PR DESCRIPTION
## Description

Make `import-redirects` console script consider scope when loading the target `PageTreeNode` for a redirect

Previously, the scope wasn't considered when loading the node.
This resulted in redirects that targeted a node in a different scope -> these redirects didn't work.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1242" alt="Bildschirmfoto 2025-04-03 um 09 34 24" src="https://github.com/user-attachments/assets/9ada3f31-a7a6-4169-99f9-73d4616e382f" />   | <img width="1249" alt="Bildschirmfoto 2025-04-03 um 09 33 54" src="https://github.com/user-attachments/assets/0cdc037f-fa99-46d6-9698-2ad91b37c968" />  |


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1869
