### PR TITLE
Undeprecate `category` option in `createCompositeBlock`

### DIFF
--- a/.changeset/friendly-feet-lay.md
+++ b/.changeset/friendly-feet-lay.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Undeprecate `category` option in `createCompositeBlock`

--- a/.cspellignore
+++ b/.cspellignore
@@ -20,3 +20,4 @@ subcomponent
 subpage
 Traefik
 typesafe
+Undeprecate

--- a/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx
+++ b/packages/admin/blocks-admin/src/blocks/factories/createCompositeBlock.tsx
@@ -39,9 +39,6 @@ interface NormalizedBlockConfiguration extends BlockConfiguration {
 interface CreateCompositeBlockOptionsBase {
     name: string;
     displayName: ReactNode;
-    /**
-     * @deprecated Use override instead to adapt the factored block
-     */
     category?: BlockCategory | CustomBlockCategory;
     adminLayout?: "stacked";
     blocks: Record<string, BlockConfiguration>;


### PR DESCRIPTION
## Description

It shouldn't be necessary to use `override` for this basic option.