### PR TITLE
Add possibility for dependency injection in block warnings

### DIFF
--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -35,6 +35,7 @@ import { Page } from "./documents/pages/Page";
 import { getMessages } from "./lang";
 import { NewsDependency } from "./news/dependencies/NewsDependency";
 import { pageTreeCategories } from "./pageTree/pageTreeCategories";
+import { RedirectDependency } from "./redirects/RedirectsDependency";
 
 const GlobalStyle = () => (
     <Global
@@ -95,6 +96,7 @@ export function App() {
                                     Page,
                                     Link,
                                     News: NewsDependency,
+                                    Redirect: RedirectDependency,
                                     DamFile: createDamFileDependency(),
                                 }}
                             >

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -1,6 +1,7 @@
 import { Assets, Dashboard, Data, PageTree, Snips, Wrench } from "@comet/admin-icons";
 import {
     ContentScopeIndicator,
+    createRedirectLinkBlock,
     createRedirectsPage,
     CronJobsPage,
     DamPage,
@@ -45,7 +46,13 @@ export const pageTreeDocumentTypes: Record<string, DocumentInterface<any, any>> 
     Page,
     Link,
 };
-const RedirectsPage = createRedirectsPage({ customTargets: { news: NewsLinkBlock }, scopeParts: ["domain"] });
+
+const customTargets = {
+    news: NewsLinkBlock,
+};
+export const RedirectLinkBlock = createRedirectLinkBlock(customTargets);
+// TODO: instead of passing customTargets here, we should use the createRedirectLinkBlock function to create a custom link block for the redirects. Needs a rework in the library before this is possible.
+const RedirectsPage = createRedirectsPage({ customTargets, scopeParts: ["domain"] });
 
 export const masterMenuData: MasterMenuData = [
     {

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -1,8 +1,6 @@
 import { Assets, Dashboard, Data, PageTree, Snips, Wrench } from "@comet/admin-icons";
 import {
     ContentScopeIndicator,
-    createRedirectLinkBlock,
-    createRedirectsPage,
     CronJobsPage,
     DamPage,
     type DocumentInterface,
@@ -22,7 +20,6 @@ import { PredefinedPage } from "@src/documents/predefinedPages/PredefinedPage";
 import { EditFooterPage } from "@src/footer/EditFooterPage";
 import { type GQLPageTreeNodeCategory } from "@src/graphql.generated";
 import MainMenu from "@src/mainMenu/MainMenu";
-import { NewsLinkBlock } from "@src/news/blocks/NewsLinkBlock";
 import { NewsPage } from "@src/news/NewsPage";
 import { categoryToUrlParam, pageTreeCategories, urlParamToCategory } from "@src/pageTree/pageTreeCategories";
 import ProductCategoriesPage from "@src/products/categories/ProductCategoriesPage";
@@ -34,6 +31,7 @@ import { ProductsWithLowPricePage as FutureProductsWithLowPricePage } from "@src
 import { ManufacturersPage as ManufacturersHandmadePage } from "@src/products/ManufacturersPage";
 import ProductsHandmadePage from "@src/products/ProductsPage";
 import ProductTagsPage from "@src/products/tags/ProductTagsPage";
+import { RedirectsPage } from "@src/redirects/RedirectsPage";
 import { type ContentScope } from "@src/site-configs";
 import { FormattedMessage } from "react-intl";
 import { Redirect, type RouteComponentProps } from "react-router";
@@ -46,13 +44,6 @@ export const pageTreeDocumentTypes: Record<string, DocumentInterface<any, any>> 
     Page,
     Link,
 };
-
-const customTargets = {
-    news: NewsLinkBlock,
-};
-export const RedirectLinkBlock = createRedirectLinkBlock(customTargets);
-// TODO: instead of passing customTargets here, we should use the createRedirectLinkBlock function to create a custom link block for the redirects. Needs a rework in the library before this is possible.
-const RedirectsPage = createRedirectsPage({ customTargets, scopeParts: ["domain"] });
 
 export const masterMenuData: MasterMenuData = [
     {

--- a/demo/admin/src/redirects/RedirectsDependency.tsx
+++ b/demo/admin/src/redirects/RedirectsDependency.tsx
@@ -1,6 +1,7 @@
 import { createDependencyMethods, type DependencyInterface } from "@comet/cms-admin";
-import { RedirectLinkBlock } from "@src/common/MasterMenu";
 import { FormattedMessage } from "react-intl";
+
+import { RedirectsLinkBlock } from "./RedirectsPage";
 
 export const RedirectDependency: DependencyInterface = {
     displayName: <FormattedMessage id="redirect.displayName" defaultMessage="Redirect" />,
@@ -8,7 +9,7 @@ export const RedirectDependency: DependencyInterface = {
         rootQueryName: "redirect",
         rootBlocks: {
             target: {
-                block: RedirectLinkBlock,
+                block: RedirectsLinkBlock,
             },
         },
         basePath: ({ id }) => `/system/redirects/${id}/edit`,

--- a/demo/admin/src/redirects/RedirectsDependency.tsx
+++ b/demo/admin/src/redirects/RedirectsDependency.tsx
@@ -1,0 +1,16 @@
+import { createDependencyMethods, type DependencyInterface } from "@comet/cms-admin";
+import { LinkBlock } from "@src/common/blocks/LinkBlock";
+import { FormattedMessage } from "react-intl";
+
+export const RedirectDependency: DependencyInterface = {
+    displayName: <FormattedMessage id="redirect.displayName" defaultMessage="Redirect" />,
+    ...createDependencyMethods({
+        rootQueryName: "redirect",
+        rootBlocks: {
+            target: {
+                block: LinkBlock,
+            },
+        },
+        basePath: ({ id }) => `/system/redirects/${id}/edit`,
+    }),
+};

--- a/demo/admin/src/redirects/RedirectsDependency.tsx
+++ b/demo/admin/src/redirects/RedirectsDependency.tsx
@@ -1,5 +1,5 @@
 import { createDependencyMethods, type DependencyInterface } from "@comet/cms-admin";
-import { LinkBlock } from "@src/common/blocks/LinkBlock";
+import { RedirectLinkBlock } from "@src/common/MasterMenu";
 import { FormattedMessage } from "react-intl";
 
 export const RedirectDependency: DependencyInterface = {
@@ -8,7 +8,7 @@ export const RedirectDependency: DependencyInterface = {
         rootQueryName: "redirect",
         rootBlocks: {
             target: {
-                block: LinkBlock,
+                block: RedirectLinkBlock,
             },
         },
         basePath: ({ id }) => `/system/redirects/${id}/edit`,

--- a/demo/admin/src/redirects/RedirectsPage.tsx
+++ b/demo/admin/src/redirects/RedirectsPage.tsx
@@ -1,0 +1,9 @@
+import { createRedirectsLinkBlock, createRedirectsPage } from "@comet/cms-admin";
+import { NewsLinkBlock } from "@src/news/blocks/NewsLinkBlock";
+
+const customTargets = {
+    news: NewsLinkBlock,
+};
+export const RedirectsLinkBlock = createRedirectsLinkBlock(customTargets);
+// TODO: instead of passing customTargets here, we should use the createRedirectsLinkBlock function to create a custom link block for the redirects. Needs a rework in the library before this is possible.
+export const RedirectsPage = createRedirectsPage({ customTargets, scopeParts: ["domain"] });

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -197,7 +197,7 @@ export type { BlockPreviewApi } from "./preview/block/useBlockPreview";
 export { useBlockPreview } from "./preview/block/useBlockPreview";
 export { openPreviewWindow, openSitePreviewWindow } from "./preview/openSitePreviewWindow";
 export { SitePreview } from "./preview/site/SitePreview";
-export { createRedirectLinkBlock, createRedirectsPage } from "./redirects/createRedirectsPage";
+export { createRedirectsLinkBlock, createRedirectsPage } from "./redirects/createRedirectsPage";
 export type { SiteConfig } from "./sitesConfig/SitesConfigContext";
 export { SitesConfigProvider } from "./sitesConfig/SitesConfigProvider";
 export { useSiteConfig } from "./sitesConfig/useSiteConfig";

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -197,7 +197,7 @@ export type { BlockPreviewApi } from "./preview/block/useBlockPreview";
 export { useBlockPreview } from "./preview/block/useBlockPreview";
 export { openPreviewWindow, openSitePreviewWindow } from "./preview/openSitePreviewWindow";
 export { SitePreview } from "./preview/site/SitePreview";
-export { createRedirectsPage } from "./redirects/createRedirectsPage";
+export { createRedirectLinkBlock, createRedirectsPage } from "./redirects/createRedirectsPage";
 export type { SiteConfig } from "./sitesConfig/SitesConfigContext";
 export { SitesConfigProvider } from "./sitesConfig/SitesConfigProvider";
 export { useSiteConfig } from "./sitesConfig/useSiteConfig";

--- a/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
+++ b/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
@@ -12,11 +12,11 @@ import { RedirectForm } from "./RedirectForm";
 import { RedirectsGrid } from "./RedirectsGrid";
 
 interface CreateRedirectsPageOptions {
-    customTargets?: Record<string, BlockInterface>; // TODO: Remove customTargets here and instead use createRedirectLinkBlock to create a custom link block for the redirects
+    customTargets?: Record<string, BlockInterface>; // TODO: Remove customTargets here and instead use createRedirectsLinkBlock to create a custom link block for the redirects
     scopeParts?: string[];
 }
 
-export function createRedirectLinkBlock(customTargets?: Record<string, BlockInterface>) {
+export function createRedirectsLinkBlock(customTargets?: Record<string, BlockInterface>) {
     return createOneOfBlock({
         supportedBlocks: { internal: InternalLinkBlock, external: ExternalLinkBlock, ...customTargets },
         name: "RedirectsLink",
@@ -26,7 +26,7 @@ export function createRedirectLinkBlock(customTargets?: Record<string, BlockInte
 }
 
 function createRedirectsPage({ customTargets, scopeParts = [] }: CreateRedirectsPageOptions = {}): ComponentType {
-    const linkBlock = createRedirectLinkBlock(customTargets);
+    const linkBlock = createRedirectsLinkBlock(customTargets);
 
     function Redirects(): JSX.Element {
         const intl = useIntl();

--- a/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
+++ b/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
@@ -12,17 +12,21 @@ import { RedirectForm } from "./RedirectForm";
 import { RedirectsGrid } from "./RedirectsGrid";
 
 interface CreateRedirectsPageOptions {
-    customTargets?: Record<string, BlockInterface>;
+    customTargets?: Record<string, BlockInterface>; // TODO: Remove customTargets here and instead use createRedirectLinkBlock to create a custom link block for the redirects
     scopeParts?: string[];
 }
 
-function createRedirectsPage({ customTargets, scopeParts = [] }: CreateRedirectsPageOptions = {}): ComponentType {
-    const linkBlock = createOneOfBlock({
+export function createRedirectLinkBlock(customTargets?: Record<string, BlockInterface>) {
+    return createOneOfBlock({
         supportedBlocks: { internal: InternalLinkBlock, external: ExternalLinkBlock, ...customTargets },
         name: "RedirectsLink",
         displayName: <FormattedMessage id="comet.blocks.link" defaultMessage="Link" />,
         allowEmpty: false,
     });
+}
+
+function createRedirectsPage({ customTargets, scopeParts = [] }: CreateRedirectsPageOptions = {}): ComponentType {
+    const linkBlock = createRedirectLinkBlock(customTargets);
 
     function Redirects(): JSX.Element {
         const intl = useIntl();

--- a/packages/admin/cms-admin/src/warnings/warningMessages.tsx
+++ b/packages/admin/cms-admin/src/warnings/warningMessages.tsx
@@ -6,4 +6,10 @@ export const warningMessages = {
     fileLicenseExpired: <FormattedMessage id="comet.warnings.file.license.expired" defaultMessage="File license has expired" />,
     fileLicenseRequired: <FormattedMessage id="comet.warnings.file.license.required" defaultMessage="File license is missing" />,
     missingAltText: <FormattedMessage id="comet.warnings.missingAltText" defaultMessage="Missing alt text" />,
+    invalidInternalLinkTarget: (
+        <FormattedMessage id="comet.warnings.internalLinkTargetPageInvalid" defaultMessage="Invalid Target in Page Tree Link" />
+    ),
+    missingInternalLinkTarget: (
+        <FormattedMessage id="comet.warnings.internalLinkTargetPageNotDefined" defaultMessage="Missing Target in Page Tree Link" />
+    ),
 };

--- a/packages/admin/cms-admin/src/warnings/warningMessages.tsx
+++ b/packages/admin/cms-admin/src/warnings/warningMessages.tsx
@@ -6,10 +6,6 @@ export const warningMessages = {
     fileLicenseExpired: <FormattedMessage id="comet.warnings.file.license.expired" defaultMessage="File license has expired" />,
     fileLicenseRequired: <FormattedMessage id="comet.warnings.file.license.required" defaultMessage="File license is missing" />,
     missingAltText: <FormattedMessage id="comet.warnings.missingAltText" defaultMessage="Missing alt text" />,
-    invalidInternalLinkTarget: (
-        <FormattedMessage id="comet.warnings.internalLinkTargetPageInvalid" defaultMessage="Invalid Target in Page Tree Link" />
-    ),
-    missingInternalLinkTarget: (
-        <FormattedMessage id="comet.warnings.internalLinkTargetPageNotDefined" defaultMessage="Missing Target in Page Tree Link" />
-    ),
+    invalidTarget: <FormattedMessage id="comet.warnings.invalidTarget" defaultMessage="Invalid Target" />,
+    missingTarget: <FormattedMessage id="comet.warnings.missingTarget" defaultMessage="Missing Target" />,
 };

--- a/packages/api/cms-api/src/blocks/block.ts
+++ b/packages/api/cms-api/src/blocks/block.ts
@@ -18,6 +18,10 @@ export interface BlockTransformerServiceInterface<
     transformToPlain(block: Block, context: BlockContext): T | Promise<T>;
 }
 
+export interface BlockWarningsServiceInterface<Block extends BlockDataInterface = BlockDataInterface> {
+    warnings(block: Block): Promise<BlockWarning[]>;
+}
+
 export interface TraversableTransformBlockResponse {
     [member: string]:
         | string
@@ -69,7 +73,7 @@ export interface BlockDataInterface {
     transformToPlain(context: BlockContext): Promise<Type<BlockTransformerServiceInterface> | TraversableTransformBlockResponse>;
     transformToSave(): TraversableTransformBlockResponse;
     indexData(): BlockIndexData;
-    warnings(): BlockWarning[];
+    warnings(): Promise<Type<BlockWarningsServiceInterface> | BlockWarning[]>;
     searchText(): SearchText[];
     childBlocksInfo(): ChildBlockInfo[]; // @TODO: better name for method and Type, maybe ReflectChildBlocks ?
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -91,7 +95,7 @@ export abstract class BlockData implements BlockDataInterface {
         return {};
     }
 
-    warnings(): BlockWarning[] {
+    async warnings(): Promise<Type<BlockWarningsServiceInterface> | BlockWarning[]> {
         return [];
     }
 

--- a/packages/api/cms-api/src/blocks/block.ts
+++ b/packages/api/cms-api/src/blocks/block.ts
@@ -73,7 +73,7 @@ export interface BlockDataInterface {
     transformToPlain(context: BlockContext): Promise<Type<BlockTransformerServiceInterface> | TraversableTransformBlockResponse>;
     transformToSave(): TraversableTransformBlockResponse;
     indexData(): BlockIndexData;
-    warnings(): Promise<Type<BlockWarningsServiceInterface> | BlockWarning[]>;
+    warnings(): BlockWarning[] | Promise<BlockWarning[]> | Type<BlockWarningsServiceInterface>;
     searchText(): SearchText[];
     childBlocksInfo(): ChildBlockInfo[]; // @TODO: better name for method and Type, maybe ReflectChildBlocks ?
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -95,7 +95,7 @@ export abstract class BlockData implements BlockDataInterface {
         return {};
     }
 
-    async warnings(): Promise<Type<BlockWarningsServiceInterface> | BlockWarning[]> {
+    warnings(): BlockWarning[] | Promise<BlockWarning[]> | Type<BlockWarningsServiceInterface> {
         return [];
     }
 

--- a/packages/api/cms-api/src/page-tree/blocks/internal-link-block-warnings.service.ts
+++ b/packages/api/cms-api/src/page-tree/blocks/internal-link-block-warnings.service.ts
@@ -1,0 +1,33 @@
+import { EntityRepository } from "@mikro-orm/core";
+import { InjectRepository } from "@mikro-orm/nestjs";
+import { Injectable } from "@nestjs/common";
+
+import { BlockWarning, BlockWarningsServiceInterface } from "../../blocks/block";
+import { PageTreeNodeBase } from "../entities/page-tree-node-base.entity";
+import type { InternalLinkBlockData } from "./internal-link.block";
+
+@Injectable()
+export class InternalLinkBlockWarningsService implements BlockWarningsServiceInterface<InternalLinkBlockData> {
+    constructor(@InjectRepository("PageTreeNode") private readonly pageTreeRepository: EntityRepository<PageTreeNodeBase>) {}
+
+    async warnings(block: InternalLinkBlockData): Promise<BlockWarning[]> {
+        const warnings: BlockWarning[] = [];
+
+        if (block.targetPageId) {
+            const linkedPageTreeNode = await this.pageTreeRepository.findOne({ id: block.targetPageId });
+            if (!linkedPageTreeNode) {
+                warnings.push({
+                    message: "invalidInternalLinkTarget",
+                    severity: "high",
+                });
+            }
+        } else {
+            warnings.push({
+                message: "missingInternalLinkTarget",
+                severity: "high",
+            });
+        }
+
+        return warnings;
+    }
+}

--- a/packages/api/cms-api/src/page-tree/blocks/internal-link-block-warnings.service.ts
+++ b/packages/api/cms-api/src/page-tree/blocks/internal-link-block-warnings.service.ts
@@ -17,13 +17,13 @@ export class InternalLinkBlockWarningsService implements BlockWarningsServiceInt
             const linkedPageTreeNode = await this.pageTreeRepository.findOne({ id: block.targetPageId });
             if (!linkedPageTreeNode) {
                 warnings.push({
-                    message: "invalidInternalLinkTarget",
+                    message: "invalidTarget",
                     severity: "high",
                 });
             }
         } else {
             warnings.push({
-                message: "missingInternalLinkTarget",
+                message: "missingTarget",
                 severity: "high",
             });
         }

--- a/packages/api/cms-api/src/page-tree/blocks/internal-link.block.ts
+++ b/packages/api/cms-api/src/page-tree/blocks/internal-link.block.ts
@@ -5,6 +5,7 @@ import { AnnotationBlockMeta, BlockField } from "../../blocks/decorators/field";
 import { PAGE_TREE_ENTITY } from "../page-tree.constants";
 import { PageExists } from "../validators/page-exists.validator";
 import { InternalLinkBlockTransformerService } from "./internal-link-block-transformer.service";
+import { InternalLinkBlockWarningsService } from "./internal-link-block-warnings.service";
 
 class InternalLinkBlockData extends BlockData {
     targetPageId?: string;
@@ -29,6 +30,10 @@ class InternalLinkBlockData extends BlockData {
                 },
             ],
         };
+    }
+
+    async warnings() {
+        return InternalLinkBlockWarningsService;
     }
 }
 

--- a/packages/api/cms-api/src/page-tree/blocks/internal-link.block.ts
+++ b/packages/api/cms-api/src/page-tree/blocks/internal-link.block.ts
@@ -32,7 +32,7 @@ class InternalLinkBlockData extends BlockData {
         };
     }
 
-    async warnings() {
+    warnings() {
         return InternalLinkBlockWarningsService;
     }
 }

--- a/packages/api/cms-api/src/page-tree/page-tree.module.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.module.ts
@@ -6,6 +6,7 @@ import { DependentsResolverFactory } from "../dependencies/dependents.resolver.f
 import { DocumentInterface } from "../document/dto/document-interface";
 import { AttachedDocumentLoaderService } from "./attached-document-loader.service";
 import { InternalLinkBlockTransformerService } from "./blocks/internal-link-block-transformer.service";
+import { InternalLinkBlockWarningsService } from "./blocks/internal-link-block-warnings.service";
 import { createPageTreeResolver } from "./createPageTreeResolver";
 import { DocumentSubscriberFactory } from "./document-subscriber";
 import { PageTreeNodeBaseCreateInput, PageTreeNodeBaseUpdateInput } from "./dto/page-tree-node.input";
@@ -92,6 +93,7 @@ export class PageTreeModule {
                 PageTreeNodeDocumentEntityInfoService,
                 PageTreeNodeDocumentEntityScopeService,
                 InternalLinkBlockTransformerService,
+                InternalLinkBlockWarningsService,
                 {
                     provide: SITE_PREVIEW_CONFIG,
                     useValue: {


### PR DESCRIPTION
## Description

It should be possible to use dependency injection for block warnings. I took a look at the code from transformToPlain and used it for warnings.

It just checks if there is an invalid targetPage or missing targetPage. It would be easy to check for the page tree visibility now in this case as well.
However, this would then throw warnings when an invisible page links to an invisible page, which we don't want I guess.

I could think of a few useful warnings that might be interesting but are more complex:
 - Checking if the anchor is available on the targetPage
 - Checking if both the Entity and InternalLinkBlock is visible, but the target is not
 - Checking if an ExternalLink is available (maybe with a fetch request that checks for status code)

But since I mainly wanted to add dependency injection here and added 1 case (internal link) for testing, I would only want to deal with this in further PRs anyway. But we can define what's useful in Wednesday's meeting.

## Screenshots/screencasts

![Screenshot 2025-04-04 at 14 06 41](https://github.com/user-attachments/assets/5ea7cb13-9f26-4558-a762-5f3c2699d400)

https://github.com/user-attachments/assets/a4789572-9c87-4285-9e2a-0c48c8e9263a

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1942
