### PR TITLE
Add new command to base64 encode site-config envs

### DIFF
--- a/.changeset/cool-parrots-pretend.md
+++ b/.changeset/cool-parrots-pretend.md
@@ -1,0 +1,5 @@
+---
+"@comet/cli": minor
+---
+
+Add `npx @comet/cli encode-base64` command

--- a/demo/.env.site-configs.tpl
+++ b/demo/.env.site-configs.tpl
@@ -1,3 +1,3 @@
-PRIVATE_SITE_CONFIGS='{{ site://configs/private/local }}'
-PUBLIC_SITE_CONFIGS='{{ site://configs/public/local }}'
+PRIVATE_SITE_CONFIGS='[[ base64://{{ site://configs/private/local }} ]]'
+PUBLIC_SITE_CONFIGS='[[ base64://{{ site://configs/public/local }} ]]'
 NEXT_PUBLIC_SITE_CONFIGS=$PUBLIC_SITE_CONFIGS

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "license": "BSD-2-Clause",
     "scripts": {
-        "create-site-configs-env": "npx @comet/cli inject-site-configs -f demo/site-configs/site-configs.ts -i demo/.env.site-configs.tpl -o demo/.env.site-configs --base64",
+        "create-site-configs-env": "npx @comet/cli inject-site-configs -f demo/site-configs/site-configs.ts -i demo/.env.site-configs.tpl -o demo/.env.site-configs && npx @comet/cli encode-base64 -i demo/.env.site-configs -o demo/.env.site-configs",
         "build:storybook": "pnpm recursive --filter '@comet/*admin*' --filter '@comet/eslint-plugin' --filter '@comet/cli' run build && pnpm --filter comet-storybook run build-storybook",
         "build:packages": "pnpm recursive --filter '@comet/*' run build",
         "build:docs": "pnpm recursive --filter '@comet/eslint-plugin' --filter '@comet/admin*' --filter 'comet-docs' run build",

--- a/packages/cli/src/comet.ts
+++ b/packages/cli/src/comet.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 
+import { encodeBase64Command } from "./commands/encode-base64";
 import { generateBlockTypes } from "./commands/generate-block-types";
 import { injectSiteConfigsCommand } from "./commands/site-configs";
 
@@ -7,5 +8,6 @@ const program = new Command();
 
 program.addCommand(generateBlockTypes);
 program.addCommand(injectSiteConfigsCommand);
+program.addCommand(encodeBase64Command);
 
 program.parse();

--- a/packages/cli/src/commands/encode-base64.ts
+++ b/packages/cli/src/commands/encode-base64.ts
@@ -1,0 +1,16 @@
+/* eslint-disable no-console */
+import { Command } from "commander";
+import fs from "fs";
+import { resolve } from "path";
+
+export const encodeBase64Command = new Command("encode-base64")
+    .description("Encode masked parts of a file to base64")
+    .requiredOption("-i, --in-file <file>", "The filename of a template file to inject.")
+    .requiredOption("-o, --out-file <file>", "Write the injected template to a file.")
+    .action(async (options) => {
+        console.log(`encode-base64: ${options.inFile}`);
+
+        let str = fs.readFileSync(resolve(process.cwd(), options.inFile)).toString();
+        str = str.replace(/\[\[ base64:\/\/(.*) \]\]/g, (_match, toEncode) => Buffer.from(toEncode).toString("base64"));
+        fs.writeFileSync(resolve(process.cwd(), options.outFile), str);
+    });

--- a/packages/cli/src/commands/site-configs.ts
+++ b/packages/cli/src/commands/site-configs.ts
@@ -45,7 +45,7 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
                 })),
         };
         str = str.replace(/"({{ site:\/\/configs\/.*\/.* }})"/g, "'$1'"); // convert to single quotes
-        str = await replaceAsync(str, RegExp(`{{ site://configs/(.*)/(.*) }}`, "g"), async (substr, type, env) => {
+        str = await replaceAsync(str, RegExp(`{{ site://configs/(private|public)/([a-z0-9]*) }}`, "g"), async (substr, type, env) => {
             const siteConfigs = await getSiteConfigs(env);
             console.log(`inject-site-configs: - ${substr} (${siteConfigs.length} sites)`);
             if (replacerFunctions[type] == undefined) {


### PR DESCRIPTION
https://vivid-planet.atlassian.net/browse/PHSB2C-6281

We recently added a --base64 option for the `inject-site-configs` command. The problem with this approach is that we sometimes encode a call for embedding passwords into the site-config files which are then encrypted and not executed.

To solve this problem this PR suggests to provide a separate step for encoding to base64.