### PR TITLE
Check node version before starting services

### DIFF
--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -20,7 +20,8 @@
         "lint:tsc": "tsc --project .",
         "lint:generated-files-not-modified": "$npm_execpath admin-generator && git diff --exit-code HEAD -- src/**/generated",
         "serve": "node server",
-        "start": "run-s intl:compile && run-p gql:types generate-block-types && dotenv -e .env.site-configs -- vite"
+        "check-node-version": "check-node-version --node $(cat ../../.nvmrc)",
+        "start": "$npm_execpath check-node-version && run-s intl:compile && run-p gql:types generate-block-types && dotenv -e .env.site-configs -- vite"
     },
     "dependencies": {
         "@apollo/client": "^3.7.0",
@@ -118,6 +119,7 @@
         "@types/uuid": "^7.0.0",
         "@types/zen-observable": "^0.8.0",
         "@vitejs/plugin-react-swc": "^3.6.0",
+        "check-node-version": "^4.2.1",
         "chokidar-cli": "^2.0.0",
         "cosmiconfig-toml-loader": "^1.0.0",
         "dotenv-cli": "^4.0.0",

--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -18,7 +18,8 @@
         "lint:tsc": "tsc --project ./tsconfig.lint.json",
         "lint:generated-files-not-modified": "$npm_execpath api-generator && git diff --exit-code HEAD -- src/**/generated",
         "start": "$npm_execpath prebuild && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",
-        "start:dev": "run-p dev:*",
+        "check-node-version": "check-node-version --node $(cat ../../.nvmrc)",
+        "start:dev": "$npm_execpath check-node-version && run-p dev:*",
         "dev:nest": "$npm_execpath prebuild && $npm_execpath db:migrate && $npm_execpath console createBlockIndexViews && NODE_OPTIONS='--max-old-space-size=512' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",
         "dev:reload": "rimraf src/reload.ts && chokidar \"node_modules/@comet/cms-api/lib/**\" \"node_modules/@comet/blocks-api/lib/**\" -s -c \"echo '// change' >> src/reload.ts\"",
         "start:prod": "node dist/main"
@@ -101,6 +102,7 @@
         "@types/response-time": "^2.3.8",
         "@types/rimraf": "^3.0.0",
         "@types/uuid": "^8.0.0",
+        "check-node-version": "^4.2.1",
         "chokidar-cli": "^3.0.0",
         "dotenv-cli": "^7.0.0",
         "eslint": "^8.0.0",

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -4,7 +4,8 @@
     "private": true,
     "scripts": {
         "build": "run-s intl:compile && run-p gql:types generate-block-types && tsc --project tsconfig.server.json && next build",
-        "dev": "run-s intl:compile && run-p gql:types generate-block-types && tsc --project tsconfig.server.json && NODE_OPTIONS='--inspect=localhost:9230 --max-old-space-size=512' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node dist/server.js",
+        "check-node-version": "check-node-version --node $(cat ../../.nvmrc)",
+        "dev": "$npm_execpath check-node-version && run-s intl:compile && run-p gql:types generate-block-types && tsc --project tsconfig.server.json && NODE_OPTIONS='--inspect=localhost:9230 --max-old-space-size=512' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node dist/server.js",
         "export": "next export",
         "generate-block-types": "comet generate-block-types",
         "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"$npm_execpath generate-block-types\"",
@@ -70,6 +71,7 @@
         "@types/react-dom": "^18.2.22",
         "@types/react-is": "^17.0.0",
         "@types/react-select": "^4.0.0",
+        "check-node-version": "^4.2.1",
         "chokidar-cli": "^2.0.0",
         "cosmiconfig-toml-loader": "^1.0.0",
         "dotenv-cli": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^3.6.0
         version: 3.6.0(vite@5.1.6)
+      check-node-version:
+        specifier: ^4.2.1
+        version: 4.2.1
       chokidar-cli:
         specifier: ^2.0.0
         version: 2.1.0
@@ -25843,7 +25846,7 @@ packages:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
     dependencies:
-      minimist: 1.2.7
+      minimist: 1.2.8
 
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -27485,6 +27488,7 @@ packages:
 
   /minimist@1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
+    dev: true
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,6 +619,9 @@ importers:
       '@types/uuid':
         specifier: ^8.0.0
         version: 8.3.4
+      check-node-version:
+        specifier: ^4.2.1
+        version: 4.2.1
       chokidar-cli:
         specifier: ^3.0.0
         version: 3.0.0
@@ -797,6 +800,9 @@ importers:
       '@types/react-select':
         specifier: ^4.0.0
         version: 4.0.18
+      check-node-version:
+        specifier: ^4.2.1
+        version: 4.2.1
       chokidar-cli:
         specifier: ^2.0.0
         version: 2.1.0
@@ -18695,6 +18701,19 @@ packages:
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
+  /check-node-version@4.2.1:
+    resolution: {integrity: sha512-YYmFYHV/X7kSJhuN/QYHUu998n/TRuDe8UenM3+m5NrkiH670lb9ILqHIvBencvJc4SDh+XcbXMR4b+TtubJiw==}
+    engines: {node: '>=8.3.0'}
+    hasBin: true
+    dependencies:
+      chalk: 3.0.0
+      map-values: 1.0.1
+      minimist: 1.2.8
+      object-filter: 1.0.2
+      run-parallel: 1.2.0
+      semver: 6.3.1
+    dev: true
+
   /cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
     dependencies:
@@ -26601,6 +26620,10 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /map-values@1.0.1:
+    resolution: {integrity: sha512-BbShUnr5OartXJe1GeccAWtfro11hhgNJg6G9/UtWKjVGvV5U4C09cg5nk8JUevhXODaXY+hQ3xxMUKSs62ONQ==}
+    dev: true
+
   /mapcap@1.0.0:
     resolution: {integrity: sha512-KcNlZSlFPx+r1jYZmxEbTVymG+dIctf10WmWkuhrhrblM+KMoF77HelwihL5cxYlORye79KoR4IlOOk99lUJ0g==}
     dev: false
@@ -28037,6 +28060,10 @@ packages:
   /object-filter-sequence@1.0.0:
     resolution: {integrity: sha512-CsubGNxhIEChNY4cXYuA6KXafztzHqzLLZ/y3Kasf3A+sa3lL9thq3z+7o0pZqzEinjXT6lXDPAfVWI59dUyzQ==}
     dev: false
+
+  /object-filter@1.0.2:
+    resolution: {integrity: sha512-NahvP2vZcy1ZiiYah30CEPw0FpDcSkSePJBMpzl5EQgCmISijiGuJm3SPYp7U+Lf2TljyaIw3E5EgkEx/TNEVA==}
+    dev: true
 
   /object-hash@2.2.0:
     resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
@@ -33358,7 +33385,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       json5: 2.2.3
-      minimist: 1.2.7
+      minimist: 1.2.8
       strip-bom: 3.0.0
     dev: true
 
@@ -33367,7 +33394,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       json5: 2.2.3
-      minimist: 1.2.7
+      minimist: 1.2.8
       strip-bom: 3.0.0
 
   /tslib@1.14.1:


### PR DESCRIPTION
## Description

Check the current node version against the node version specified in .nvmrc before starting a microservice in development mode.

This prevents starting the app with an unsupported node version that could lead to strange errors.

## Screenshots/screencasts

<img width="538" alt="Bildschirmfoto 2025-04-07 um 10 00 21" src="https://github.com/user-attachments/assets/1a046402-e13e-4be1-8aa1-100535ce557b" />


<img width="540" alt="Bildschirmfoto 2025-04-07 um 10 00 40" src="https://github.com/user-attachments/assets/f0c47369-5c7b-42cc-9ba4-71407a5ac465" />


<img width="540" alt="Bildschirmfoto 2025-04-07 um 10 00 58" src="https://github.com/user-attachments/assets/41363664-2ee1-425d-bf5a-7269d4bad170" />


