### PR TITLE
Adapt DateTimePicker styling on mobile devices

### DIFF
--- a/.changeset/breezy-parrots-press.md
+++ b/.changeset/breezy-parrots-press.md
@@ -1,7 +1,5 @@
 ---
-"@comet/admin": patch
+"@comet/admin-date-time": patch
 ---
 
 Adapt styling of `DateTimePicker` on mobile devices to improve readability of the placeholder
-
-Return `null` for `ClearInputAdornment` if there is no content to be cleared. This avoids overlapping placeholders in the field.

--- a/.changeset/breezy-parrots-press.md
+++ b/.changeset/breezy-parrots-press.md
@@ -3,3 +3,5 @@
 ---
 
 Adapt styling of `DateTimePicker` on mobile devices to improve readability of the placeholder
+
+Return `null` for `ClearInputAdornment` if there is no content to be cleared. This avoids overlapping placeholders in the field.

--- a/.changeset/breezy-parrots-press.md
+++ b/.changeset/breezy-parrots-press.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Adapt styling of `DateTimePicker` on mobile devices to improve readability of the placeholder

--- a/.changeset/old-oranges-applaud.md
+++ b/.changeset/old-oranges-applaud.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+The placeholder in the `ClearInputAdornment` is no longer overlapped by a non-visible clear-button

--- a/.changeset/old-oranges-applaud.md
+++ b/.changeset/old-oranges-applaud.md
@@ -2,4 +2,4 @@
 "@comet/admin": patch
 ---
 
-The placeholder in the `ClearInputAdornment` is no longer overlapped by a non-visible clear-button
+Prevent overlapping placeholders by a non-visible clear-button

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
@@ -14,27 +14,45 @@ export type DateTimePickerClassKey = "root" | "dateFormControl" | "timeFormContr
 const Root = createComponentSlot("div")<DateTimePickerClassKey>({
     componentName: "DateTimePicker",
     slotName: "root",
-})(css`
-    display: flex;
-    align-items: center;
-`);
+})(
+    ({ theme }) => css`
+        ${theme.breakpoints.up("sm")} {
+            display: flex;
+            align-items: center;
+        }
+    `,
+);
 
 const DateFormControl = createComponentSlot(FormControl)<DateTimePickerClassKey>({
     componentName: "DateTimePicker",
     slotName: "dateFormControl",
 })(
     ({ theme }) => css`
-        flex-grow: 1;
-        margin-right: ${theme.spacing(2)};
+        margin-bottom: ${theme.spacing(2)};
+        width: 100%;
+
+        ${theme.breakpoints.up("sm")} {
+            flex-grow: 1;
+            margin-right: ${theme.spacing(2)};
+            margin-bottom: 0;
+            width: auto;
+        }
     `,
 );
 
 const TimeFormControl = createComponentSlot(FormControl)<DateTimePickerClassKey>({
     componentName: "DateTimePicker",
     slotName: "timeFormControl",
-})(css`
-    flex-grow: 1;
-`);
+})(
+    ({ theme }) => css`
+        width: 100%;
+        flex-grow: 1;
+
+        ${theme.breakpoints.up("sm")} {
+            width: auto;
+        }
+    `,
+);
 
 const DatePicker = createComponentSlot(DatePickerBase)<DateTimePickerClassKey>({
     componentName: "DateTimePicker",

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
@@ -39,12 +39,24 @@ const TimeFormControl = createComponentSlot(FormControl)<DateTimePickerClassKey>
 const DatePicker = createComponentSlot(DatePickerBase)<DateTimePickerClassKey>({
     componentName: "DateTimePicker",
     slotName: "datePicker",
-})();
+})(
+    () => css`
+        .MuiInputBase-input {
+            text-overflow: ellipsis;
+        }
+    `,
+);
 
 const TimePicker = createComponentSlot(TimePickerBase)<DateTimePickerClassKey>({
     componentName: "DateTimePicker",
     slotName: "timePicker",
-})();
+})(
+    () => css`
+        .MuiInputBase-input {
+            text-overflow: ellipsis;
+        }
+    `,
+);
 
 export interface DateTimePickerProps
     extends ThemedComponentBaseProps<{

--- a/packages/admin/admin/src/common/ClearInputAdornment.tsx
+++ b/packages/admin/admin/src/common/ClearInputAdornment.tsx
@@ -45,6 +45,10 @@ export const ClearInputAdornment = (inProps: ClearInputAdornmentProps) => {
         position,
     };
 
+    if (!hasClearableContent) {
+        return null;
+    }
+
     return (
         <Grow in={hasClearableContent}>
             <Root position={position} ownerState={ownerState} {...slotProps?.root} {...restProps}>


### PR DESCRIPTION
## Description

- Set `text-overflow: ellipsis` on the input of the DateTimePicker fields to avoid placeholders from being cut off
- On mobile devices, the inputs should be underneath each other. 
- An empty clear input button should not take any space/overlap the placeholder

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="330" alt="Screenshot 2025-04-08 at 09 12 30" src="https://github.com/user-attachments/assets/27f57c35-6b66-4760-8123-900c6763ab30" />   | <img width="307" alt="Screenshot 2025-04-08 at 09 10 43" src="https://github.com/user-attachments/assets/bdcf637a-11f8-4644-8f31-bb8723e544ce" /> |


Screencast: 

https://github.com/user-attachments/assets/054788ed-0191-4a41-b52f-09b2920d0aa5



## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/SVK-718
