### PR TITLE
Prevent `ContentScopeSelect` from overlapping the header

### DIFF
--- a/.changeset/old-elephants-listen.md
+++ b/.changeset/old-elephants-listen.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Prevent `ContentScopeSelect` from overlapping the header

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
@@ -191,7 +191,7 @@ export function ContentScopeSelect<Value extends ContentScopeInterface = Content
                     PaperProps: {
                         sx: (theme) => ({
                             minWidth: "350px",
-
+                            maxHeight: "calc(100vh - 60px)",
                             [theme.breakpoints.down("md")]: {
                                 width: "100%",
                                 maxWidth: "none",


### PR DESCRIPTION
## Description

Large amounts of content in the “ContentScopeSelect” lead to an overlap of the “ContentScopeSelect” with the menu. Set max-height to avoid this behaviour.


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1669" alt="Screenshot 2025-04-09 at 15 25 37" src="https://github.com/user-attachments/assets/20a35070-8a77-450f-8db0-0a4a6faf9cef" />  | <img width="1666" alt="Screenshot 2025-04-09 at 15 25 14" src="https://github.com/user-attachments/assets/7f11de11-fe0c-4fd2-9d3f-3ecf9c2089a5" />


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1712
