### PR TITLE
Admin Generator: Fix form with nullable Async Select

### DIFF
--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -134,7 +134,7 @@ export function ProductForm({ id, width }: FormProps) {
             ...formValues,
             image: rootBlocks.image.state2Output(formValues.image),
             type: formValues.type as GQLProductType,
-            category: formValues.category?.id,
+            category: formValues.category ? formValues.category.id : null,
             tags: formValues.tags.map((i) => i.id),
             articleNumbers: [],
             discounts: [],

--- a/demo/admin/src/products/future/generated/CreateCapProductForm.tsx
+++ b/demo/admin/src/products/future/generated/CreateCapProductForm.tsx
@@ -56,7 +56,7 @@ export function CreateCapProductForm({ type }: FormProps) {
     const handleSubmit = async (formValues: FormValues, form: FormApi<FormValues>, event: FinalFormSubmitEvent) => {
         const output = {
             ...formValues,
-            category: formValues.category?.id,
+            category: formValues.category ? formValues.category.id : null,
             image: rootBlocks.image.state2Output(formValues.image),
         };
 

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -133,7 +133,7 @@ export function ProductForm({ id }: FormProps) {
         if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");
         const output = {
             ...formValues,
-            category: formValues.category?.id,
+            category: formValues.category ? formValues.category.id : null,
             dimensions:
                 dimensionsEnabled && formValues.dimensions
                     ? {
@@ -142,7 +142,7 @@ export function ProductForm({ id }: FormProps) {
                           depth: parseFloat(formValues.dimensions.depth),
                       }
                     : null,
-            manufacturer: formValues.manufacturer?.id,
+            manufacturer: formValues.manufacturer ? formValues.manufacturer.id : null,
             image: rootBlocks.image.state2Output(formValues.image),
             priceList: formValues.priceList ? formValues.priceList.id : null,
             datasheets: formValues.datasheets?.map(({ id }) => id),

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -533,7 +533,13 @@ export function generateFormField({
             finalFormConfig = { subscription: { values: true }, renderProps: { values: true, form: true } };
         }
 
-        formValueToGqlInputCode = !config.virtual ? `${name}: formValues.${name}?.id,` : ``;
+        if (!config.virtual) {
+            if (!required) {
+                formValueToGqlInputCode = `${name}: formValues.${name} ? formValues.${name}.id : null,`;
+            } else {
+                formValueToGqlInputCode = `${name}: formValues.${name}?.id,`;
+            }
+        }
 
         imports.push({
             name: `GQL${queryName}Query`,


### PR DESCRIPTION
Don't send undefined (resulting from formValues.fieldname?.id) as value, as that means don't update to the update mutation. Instead send null, which means set to null.

Also fix in Handmade.