### PR TITLE
Admin Generator: Fix Form Textfield Update to an empty string

### DIFF
--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -132,6 +132,7 @@ export function ProductForm({ id, width }: FormProps) {
 
         const output = {
             ...formValues,
+            description: formValues.description ?? "",
             image: rootBlocks.image.state2Output(formValues.image),
             type: formValues.type as GQLProductType,
             category: formValues.category?.id,
@@ -198,12 +199,7 @@ export function ProductForm({ id, width }: FormProps) {
                         startAdornment={<InputAdornment position="start">€</InputAdornment>}
                         disableSlider
                     />
-                    <TextAreaField
-                        required
-                        fullWidth
-                        name="description"
-                        label={<FormattedMessage id="product.description" defaultMessage="Description" />}
-                    />
+                    <TextAreaField fullWidth name="description" label={<FormattedMessage id="product.description" defaultMessage="Description" />} />
                     <DateField
                         required
                         fullWidth

--- a/demo/admin/src/products/future/ProductForm.cometGen.tsx
+++ b/demo/admin/src/products/future/ProductForm.cometGen.tsx
@@ -29,7 +29,7 @@ export default defineConfig<GQLProduct>({
                 },
                 { type: "text", name: "slug" },
                 { type: "date", name: "createdAt", label: "Created", readOnly: true },
-                { type: "text", name: "description", label: "Description", multiline: true },
+                { type: "text", name: "description", label: "Description", multiline: true, required: false },
                 {
                     type: "staticSelect",
                     name: "type",

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -133,6 +133,7 @@ export function ProductForm({ id }: FormProps) {
         if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");
         const output = {
             ...formValues,
+            description: formValues.description ?? "",
             category: formValues.category?.id,
             dimensions:
                 dimensionsEnabled && formValues.dimensions
@@ -246,7 +247,6 @@ export function ProductForm({ id }: FormProps) {
                             />
 
                             <TextAreaField
-                                required
                                 variant="horizontal"
                                 fullWidth
                                 name="description"

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -192,6 +192,9 @@ export function generateFormField({
             }
             ${validateCode}
         />`;
+        if (!config.virtual && !required && !config.readOnly) {
+            formValueToGqlInputCode = `${name}: formValues.${name} ?? "",`;
+        }
     } else if (config.type == "number") {
         code = `
             <NumberField


### PR DESCRIPTION
Work around final-form 'feature' that uses undefined for empty text inputs (https://final-form.org/docs/final-form/faq#why-does-final-form-set-my--field-value-to-undefined) causing update mutation to leave the field unchanged (as undefined is sent - which means basically the field is not sent)

Solution is to add a formValues.field ?? '', which changes undefined to ''.

In Demo, to reproduce this issue, change the description field to non-required, allowing an empty string. (still not nullable in database though)

(See https://github.com/vivid-planet/comet/pull/3769, which does the same for asyncSelect)