### PR TITLE
Adapt warning message for SEO title to also include meta description

### DIFF
--- a/packages/admin/cms-admin/src/warnings/warningMessages.tsx
+++ b/packages/admin/cms-admin/src/warnings/warningMessages.tsx
@@ -1,7 +1,7 @@
 import { FormattedMessage } from "react-intl";
 
 export const warningMessages = {
-    missingHtmlTitle: <FormattedMessage id="comet.warnings.missingHtmlTitle" defaultMessage="Missing HTML Title" />,
+    missingSeoMetadata: <FormattedMessage id="comet.warnings.missingSeoMetadata" defaultMessage="Missing SEO Meta Data" />,
     fileLicenseSoonToExpire: <FormattedMessage id="comet.warnings.file.license.soonToExpire" defaultMessage="File license expires soon" />,
     fileLicenseExpired: <FormattedMessage id="comet.warnings.file.license.expired" defaultMessage="File license has expired" />,
     fileLicenseRequired: <FormattedMessage id="comet.warnings.file.license.required" defaultMessage="File license is missing" />,

--- a/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
+++ b/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
@@ -138,8 +138,8 @@ export function createSeoBlock<ImageBlock extends Block = typeof PixelImageBlock
         }
 
         warnings(): BlockWarning[] {
-            if (!this.htmlTitle) {
-                return [{ severity: "low", message: "missingHtmlTitle" }];
+            if (!this.htmlTitle || !this.metaDescription) {
+                return [{ severity: "low", message: "missingSeoMetadata" }];
             }
             return [];
         }


### PR DESCRIPTION
## Description
Instead of just checking for the htmlTitle I check for metaDescription now as well. I have combined it in one warning message, but I could also make 2.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1968
