### PR TITLE
Fix a bug where calling the createWarnings function without bulkCreateWarnings does not work

### DIFF
--- a/packages/api/cms-api/src/warnings/decorators/create-warnings.decorator.ts
+++ b/packages/api/cms-api/src/warnings/decorators/create-warnings.decorator.ts
@@ -8,7 +8,7 @@ interface BulkCreateWarningData {
     targetId: string;
 }
 
-export type BulkCreateWarningsFunction<Entity extends AnyEntity = AnyEntity> = (item: Entity) => Promise<WarningData[]>;
+export type CreateWarningsFunction<Entity extends AnyEntity = AnyEntity> = (item: Entity) => Promise<WarningData[]>;
 type CreateWarningsBulkFunction = () => AsyncGenerator<BulkCreateWarningData>;
 
 export interface CreateWarningsServiceInterface<Entity extends AnyEntity = AnyEntity> {
@@ -28,12 +28,10 @@ export interface CreateWarningsServiceInterface<Entity extends AnyEntity = AnyEn
      * This function is called whenever an entity is created or updated.
      * If `bulkCreateWarnings` is not defined, it is also invoked by the warning-checker command,
      */
-    createWarnings: BulkCreateWarningsFunction<Entity>;
+    createWarnings: CreateWarningsFunction<Entity>;
 }
 
-export type CreateWarningsMeta<Entity extends AnyEntity = AnyEntity> =
-    | BulkCreateWarningsFunction<Entity>
-    | Type<CreateWarningsServiceInterface<Entity>>;
+export type CreateWarningsMeta<Entity extends AnyEntity = AnyEntity> = CreateWarningsFunction<Entity> | Type<CreateWarningsServiceInterface<Entity>>;
 
 export function CreateWarnings<Entity extends AnyEntity = AnyEntity>(value: CreateWarningsMeta<Entity>): CustomDecorator<string> {
     return SetMetadata<string, CreateWarningsMeta<Entity>>("createWarnings", value);

--- a/packages/api/cms-api/src/warnings/warning-checker.command.ts
+++ b/packages/api/cms-api/src/warnings/warning-checker.command.ts
@@ -1,5 +1,5 @@
 import { CreateRequestContext, EntityClass, MikroORM } from "@mikro-orm/core";
-import { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
+import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable, Type } from "@nestjs/common";
 import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
 import { ModuleRef, Reflector } from "@nestjs/core";
@@ -8,7 +8,7 @@ import { Block, BlockData } from "src/blocks/block";
 
 import { FlatBlocks } from "../blocks/flat-blocks/flat-blocks";
 import { DiscoverService } from "../dependencies/discover.service";
-import { BulkCreateWarningsFunction, CreateWarningsMeta, CreateWarningsServiceInterface } from "./decorators/create-warnings.decorator";
+import { CreateWarningsMeta, CreateWarningsServiceInterface } from "./decorators/create-warnings.decorator";
 import { Warning } from "./entities/warning.entity";
 import { WarningService } from "./warning.service";
 
@@ -125,59 +125,52 @@ export class WarningCheckerCommand extends CommandRunner {
                             }
                         }
                     } else {
-                        await this.processEntityWarningsIndividually({
-                            repository,
-                            createWarnings: service.createWarnings,
-                            rootEntityName: entity.name,
-                            rootPrimaryKey: entityMetadata.primaryKeys[0],
-                        });
+                        let rows = [];
+                        const limit = 50;
+                        let offset = 0;
+                        do {
+                            rows = await repository.find({}, { limit, offset });
+                            offset += limit;
+
+                            for (const row of rows) {
+                                await this.warningService.saveWarnings({
+                                    warnings: await service.createWarnings(row),
+                                    type: "Entity",
+                                    sourceInfo: {
+                                        rootEntityName: entity.name,
+                                        rootPrimaryKey: entityMetadata.primaryKeys[0],
+                                        targetId: row[entityMetadata.primaryKeys[0]],
+                                    },
+                                });
+                            }
+                        } while (rows.length > 0);
                     }
                 } else {
-                    await this.processEntityWarningsIndividually({
-                        repository,
-                        createWarnings,
-                        rootEntityName: entity.name,
-                        rootPrimaryKey: entityMetadata.primaryKeys[0],
-                    });
+                    let rows = [];
+                    const limit = 50;
+                    let offset = 0;
+                    do {
+                        rows = await repository.find({}, { limit, offset });
+                        offset += limit;
+
+                        for (const row of rows) {
+                            await this.warningService.saveWarnings({
+                                warnings: await createWarnings(row),
+                                type: "Entity",
+                                sourceInfo: {
+                                    rootEntityName: entity.name,
+                                    rootPrimaryKey: entityMetadata.primaryKeys[0],
+                                    targetId: row[entityMetadata.primaryKeys[0]],
+                                },
+                            });
+                        }
+                    } while (rows.length > 0);
                 }
             }
         }
 
         // remove all Entity-Warnings that are not present anymore
         await this.entityManager.nativeDelete(Warning, { type: "Entity", updatedAt: { $lt: startDate } });
-    }
-
-    private async processEntityWarningsIndividually({
-        repository,
-        createWarnings,
-        rootEntityName,
-        rootPrimaryKey,
-    }: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        repository: EntityRepository<any>;
-        createWarnings: BulkCreateWarningsFunction;
-        rootEntityName: string;
-        rootPrimaryKey: string;
-    }) {
-        let rows = [];
-        const limit = 50;
-        let offset = 0;
-        do {
-            rows = await repository.find({}, { limit, offset });
-            offset += limit;
-
-            for (const row of rows) {
-                await this.warningService.saveWarnings({
-                    warnings: await createWarnings(row),
-                    type: "Entity",
-                    sourceInfo: {
-                        rootEntityName,
-                        rootPrimaryKey,
-                        targetId: row[rootPrimaryKey],
-                    },
-                });
-            }
-        } while (rows.length > 0);
     }
 
     private isService(meta: CreateWarningsMeta): meta is Type<CreateWarningsServiceInterface> {


### PR DESCRIPTION
## Description
I found a strange bug by accident. I created the function `processEntityWarningsIndividually` so I wouldn't have to repeat the same code. But I found out that doing this caused a problem when calling `createWarnings` of the service. I kept getting this error:
![Screenshot 2025-04-10 at 14 19 58](https://github.com/user-attachments/assets/15b90597-ecf0-494a-b43b-76b2a5b1c7ba)

It seems like when I pass `service.createWarnings` into another function, dependency injection stops working. I couldn’t figure out how to fix it, so for now I just copied the code instead. Let me know if you have another idea what I could do instead.

Also, the function name typing was incorrect. I used `BulkCreateWarningsFunction` for `CreateWarningsFunction`, which is actually only for a single row.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-955
