### PR TITLE
Admin Generator: Don't use GraphQL inferred nullable for default value of required for text fields

### DIFF
--- a/demo/admin/src/products/future/CreateCapProductForm.cometGen.ts
+++ b/demo/admin/src/products/future/CreateCapProductForm.cometGen.ts
@@ -17,7 +17,7 @@ export default defineConfig<GQLProduct>({
             required: true, // default is inferred from gql schema
             validate: validateTitle,
         },
-        { type: "text", name: "slug" },
+        { type: "text", name: "slug", required: true },
         { type: "text", name: "description", label: "Description", multiline: true },
         { type: "asyncSelect", name: "category", rootQuery: "productCategories" },
         { type: "boolean", name: "inStock" },

--- a/demo/admin/src/products/future/ProductForm.cometGen.tsx
+++ b/demo/admin/src/products/future/ProductForm.cometGen.tsx
@@ -21,13 +21,13 @@ export default defineConfig<GQLProduct>({
                     type: "text",
                     name: "title",
                     label: "Titel", // default is generated from name (camelCaseToHumanReadable)
-                    required: true, // default is inferred from gql schema
+                    required: true,
                     validate: (value: string) =>
                         value.length < 3 ? (
                             <FormattedMessage id="product.validate.titleMustBe3CharsLog" defaultMessage="Title must be at least 3 characters long" />
                         ) : undefined,
                 },
-                { type: "text", name: "slug" },
+                { type: "text", name: "slug", required: true },
                 { type: "date", name: "createdAt", label: "Created", readOnly: true },
                 { type: "text", name: "description", label: "Description", multiline: true },
                 {

--- a/demo/admin/src/products/future/generated/CreateCapProductForm.tsx
+++ b/demo/admin/src/products/future/generated/CreateCapProductForm.tsx
@@ -103,7 +103,6 @@ export function CreateCapProductForm({ type }: FormProps) {
                     />
 
                     <TextAreaField
-                        required
                         variant="horizontal"
                         fullWidth
                         name="description"

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -246,7 +246,6 @@ export function ProductForm({ id }: FormProps) {
                             />
 
                             <TextAreaField
-                                required
                                 variant="horizontal"
                                 fullWidth
                                 name="description"

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -172,6 +172,7 @@ export function generateFormField({
     let formValueToGqlInputCode = "";
     let formFragmentField = name;
     if (config.type == "text") {
+        const required = config.required !== undefined ? config.required : false; // don't use inferred from gql here, non-nullable textinput allows empty string
         const TextInputComponent = config.multiline ? "TextAreaField" : "TextField";
         code = `
         <${TextInputComponent}


### PR DESCRIPTION
Required doesn't allow empty strings, but the non-nullable api does.

(breaking change)