### PR TITLE
Adapt DAM styling

### DIFF
--- a/.changeset/beige-comics-serve.md
+++ b/.changeset/beige-comics-serve.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Optimize responsive behavior of `CrudMoreActionsMenu`

--- a/.changeset/gentle-boats-hunt.md
+++ b/.changeset/gentle-boats-hunt.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Adapt styling of `DamTable` to align with Comet DXP design

--- a/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
@@ -134,7 +134,7 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
 
     return (
         <CrudMoreActionsMenuContext.Provider value={{ closeMenu: handleClose }}>
-            <MoreActionsButton variant="textDark" endIcon={<MoreVertical />} {...buttonProps} onClick={handleClick}>
+            <MoreActionsButton variant="textDark" endIcon={<MoreVertical />} {...buttonProps} onClick={handleClick} responsive>
                 <FormattedMessage id="comet.crudMoreActions.title" defaultMessage="More" />
                 {!!selectionSize && <MoreActionsSelectedItemsChip size="small" color="primary" {...chipProps} label={selectionSize} />}
             </MoreActionsButton>

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from "@apollo/client";
 import {
     EditDialogApiContext,
-    FillSpace,
     IFilterApi,
     ISortInformation,
     SortDirection,
@@ -9,8 +8,6 @@ import {
     StackPage,
     StackSwitch,
     Toolbar,
-    ToolbarActions,
-    ToolbarItem,
     useEditDialog,
     useStackApi,
     useStoredState,
@@ -22,8 +19,6 @@ import { useIntl } from "react-intl";
 import { CurrentDamFolderProvider } from "./CurrentDamFolderProvider";
 import { ManualDuplicatedFilenamesHandlerContextProvider } from "./DataGrid/duplicatedFilenames/ManualDuplicatedFilenamesHandler";
 import { FileUploadContextProvider } from "./DataGrid/fileUpload/FileUploadContext";
-import { UploadFilesButton } from "./DataGrid/fileUpload/UploadFilesButton";
-import { DamTableFilter } from "./DataGrid/filter/DamTableFilter";
 import FolderDataGrid, {
     damFolderQuery,
     GQLDamFileTableFragment,
@@ -32,7 +27,6 @@ import FolderDataGrid, {
     GQLDamFolderTableFragment,
 } from "./DataGrid/FolderDataGrid";
 import { RenderDamLabelOptions } from "./DataGrid/label/DamItemLabelColumn";
-import { DamMoreActions } from "./DataGrid/selection/DamMoreActions";
 import { DamSelectionProvider } from "./DataGrid/selection/DamSelectionContext";
 import EditFile from "./FileForm/EditFile";
 
@@ -65,38 +59,12 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
         skip: selectedFolderId === undefined,
     });
 
-    const uploadFilters = {
-        allowedMimetypes: props.allowedMimetypes,
-    };
-
     return (
         <CurrentDamFolderProvider folderId={id}>
             <StackSwitch initialPage="table">
                 <StackPage name="table">
                     <EditDialogApiContext.Provider value={editDialogApi}>
-                        <Toolbar scopeIndicator={props.contentScopeIndicator}>
-                            <ToolbarItem>
-                                <DamTableFilter hideArchiveFilter={props.hideArchiveFilter} filterApi={filterApi} />
-                            </ToolbarItem>
-                            <FillSpace />
-                            <ToolbarActions>
-                                {props.additionalToolbarItems}
-                                <DamMoreActions
-                                    anchorOrigin={{
-                                        vertical: "bottom",
-                                        horizontal: "left",
-                                    }}
-                                    transformOrigin={{
-                                        vertical: "top",
-                                        horizontal: "left",
-                                    }}
-                                    folderId={id}
-                                    filter={uploadFilters}
-                                />
-
-                                <UploadFilesButton folderId={id} filter={uploadFilters} />
-                            </ToolbarActions>
-                        </Toolbar>
+                        <Toolbar scopeIndicator={props.contentScopeIndicator} />
                         <FolderDataGrid id={id} breadcrumbs={stackApi?.breadCrumbs} selectionApi={selectionApi} filterApi={filterApi} {...props} />
                     </EditDialogApiContext.Provider>
                 </StackPage>

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -79,6 +79,55 @@ interface FolderDataGridProps extends DamConfig {
     selectionApi: ISelectionApi;
 }
 
+interface FolderDataGridToolbarProps {
+    id?: string;
+    breadcrumbs?: BreadcrumbItem[];
+    filterApi: IFilterApi<DamFilter>;
+    selectionApi: ISelectionApi;
+    hideArchiveFilter?: boolean;
+    additionalToolbarItems?: React.ReactNode;
+    uploadFilters: {
+        allowedMimetypes?: string[];
+    };
+}
+
+function FolderDataGridToolbar(props: FolderDataGridToolbarProps) {
+    const { id: currentFolderId } = props;
+    const { data } = useQuery<GQLDamFolderQuery, GQLDamFolderQueryVariables>(damFolderQuery, {
+        variables: {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            id: currentFolderId!,
+        },
+        skip: currentFolderId === undefined,
+    });
+
+    return (
+        <DataGridToolbar>
+            <ToolbarItem>
+                <DamTableFilter hideArchiveFilter={props.hideArchiveFilter} filterApi={props.filterApi} />
+            </ToolbarItem>
+            <FillSpace />
+            <ToolbarActions>
+                {props.additionalToolbarItems}
+                <DamMoreActions
+                    anchorOrigin={{
+                        vertical: "bottom",
+                        horizontal: "left",
+                    }}
+                    transformOrigin={{
+                        vertical: "top",
+                        horizontal: "left",
+                    }}
+                    folderId={data?.damFolder.id}
+                    filter={props.uploadFilters}
+                />
+
+                <UploadFilesButton folderId={data?.damFolder.id} filter={props.uploadFilters} />
+            </ToolbarActions>
+        </DataGridToolbar>
+    );
+}
+
 const FolderDataGrid = ({
     id: currentFolderId,
     filterApi,
@@ -543,45 +592,9 @@ const FolderDataGrid = ({
         },
     ];
 
-    const { data } = useQuery<GQLDamFolderQuery, GQLDamFolderQueryVariables>(damFolderQuery, {
-        variables: {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            id: currentFolderId!,
-        },
-        skip: currentFolderId === undefined,
-    });
-
     const uploadFilters = {
         allowedMimetypes: props.allowedMimetypes,
     };
-
-    function FolderDataGridToolbar() {
-        return (
-            <DataGridToolbar>
-                <ToolbarItem>
-                    <DamTableFilter hideArchiveFilter={hideArchiveFilter} filterApi={filterApi} />
-                </ToolbarItem>
-                <FillSpace />
-                <ToolbarActions>
-                    {props.additionalToolbarItems}
-                    <DamMoreActions
-                        anchorOrigin={{
-                            vertical: "bottom",
-                            horizontal: "left",
-                        }}
-                        transformOrigin={{
-                            vertical: "top",
-                            horizontal: "left",
-                        }}
-                        folderId={data?.damFolder.id}
-                        filter={uploadFilters}
-                    />
-
-                    <UploadFilesButton folderId={data?.damFolder.id} filter={uploadFilters} />
-                </ToolbarActions>
-            </DataGridToolbar>
-        );
-    }
 
     return (
         <sc.FolderWrapper>
@@ -604,6 +617,16 @@ const FolderDataGrid = ({
                     initialState={{ columns: { columnVisibilityModel: { importSourceType: importSources !== undefined } } }}
                     components={{
                         Toolbar: FolderDataGridToolbar,
+                    }}
+                    componentsProps={{
+                        toolbar: {
+                            id: currentFolderId,
+                            breadcrumbs,
+                            filterApi,
+                            selectionApi,
+                            uploadFilters,
+                            additionalToolbarItems: props.additionalToolbarItems,
+                        },
                     }}
                 />
             </sc.FolderOuterHoverHighlight>

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -81,9 +81,7 @@ interface FolderDataGridProps extends DamConfig {
 
 interface FolderDataGridToolbarProps {
     id?: string;
-    breadcrumbs?: BreadcrumbItem[];
     filterApi: IFilterApi<DamFilter>;
-    selectionApi: ISelectionApi;
     hideArchiveFilter?: boolean;
     additionalToolbarItems?: React.ReactNode;
     uploadFilters: {
@@ -93,9 +91,7 @@ interface FolderDataGridToolbarProps {
 
 function FolderDataGridToolbar({
     id: currentFolderId,
-    breadcrumbs,
     filterApi,
-    selectionApi,
     hideArchiveFilter,
     additionalToolbarItems,
     uploadFilters,

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -91,8 +91,15 @@ interface FolderDataGridToolbarProps {
     };
 }
 
-function FolderDataGridToolbar(props: FolderDataGridToolbarProps) {
-    const { id: currentFolderId } = props;
+function FolderDataGridToolbar({
+    id: currentFolderId,
+    breadcrumbs,
+    filterApi,
+    selectionApi,
+    hideArchiveFilter,
+    additionalToolbarItems,
+    uploadFilters,
+}: FolderDataGridToolbarProps) {
     const { data } = useQuery<GQLDamFolderQuery, GQLDamFolderQueryVariables>(damFolderQuery, {
         variables: {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -104,11 +111,11 @@ function FolderDataGridToolbar(props: FolderDataGridToolbarProps) {
     return (
         <DataGridToolbar>
             <ToolbarItem>
-                <DamTableFilter hideArchiveFilter={props.hideArchiveFilter} filterApi={props.filterApi} />
+                <DamTableFilter hideArchiveFilter={hideArchiveFilter} filterApi={filterApi} />
             </ToolbarItem>
             <FillSpace />
             <ToolbarActions>
-                {props.additionalToolbarItems}
+                {additionalToolbarItems}
                 <DamMoreActions
                     anchorOrigin={{
                         vertical: "bottom",
@@ -119,10 +126,10 @@ function FolderDataGridToolbar(props: FolderDataGridToolbarProps) {
                         horizontal: "left",
                     }}
                     folderId={data?.damFolder.id}
-                    filter={props.uploadFilters}
+                    filter={uploadFilters}
                 />
 
-                <UploadFilesButton folderId={data?.damFolder.id} filter={props.uploadFilters} />
+                <UploadFilesButton folderId={data?.damFolder.id} filter={uploadFilters} />
             </ToolbarActions>
         </DataGridToolbar>
     );

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/UploadFilesButton.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/UploadFilesButton.tsx
@@ -42,6 +42,7 @@ export const UploadFilesButton = ({ folderId, filter }: UploadFilesButtonProps) 
                     // Trigger file input with button click
                     fileInputRef.current?.click();
                 }}
+                responsive
             >
                 <FormattedMessage id="comet.pages.dam.uploadFiles" defaultMessage="Upload files" />
             </Button>


### PR DESCRIPTION
## Description

Adapt DamTable styling to design: https://www.figma.com/design/O4jTKKiFjdvtZVRJZYS8kM/COMET-DXP-Designs?node-id=3947-132187&m=dev

- Remove breadcrumbs from Datagrid
- Remove Toolbar from Page and use DataGridToolbar instead
- Set Buttons responsive (More and Upload Files)

(Note: The button "Import from Picsum" was not moved to the CrudMoreActions, as it is in the design, as this button is currently only implemented in the demo and should not be added to the package as it is implemented at the moment)

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1431" alt="Screenshot 2025-04-11 at 10 06 16" src="https://github.com/user-attachments/assets/7ca577f1-50d1-49bb-8fdf-c3a408efae4e" /> | <img width="1431" alt="Screenshot 2025-05-14 at 14 57 19" src="https://github.com/user-attachments/assets/21895335-a0f3-46a7-b5b6-3cf26c7fd974" />


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1654
