### PR TITLE
Update predefined button components

### DIFF
--- a/.changeset/free-queens-swim.md
+++ b/.changeset/free-queens-swim.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": major
+---
+
+Update props and styling of `StackBackButton`, `OkayButton`, `CancelButton`, and `DeleteButton` to match the Comet `Button` component and the Comet DXP design
+
+- Adds support for the `responsive` prop
+- Removes the `color` prop and updates the values of the `variant` prop

--- a/packages/admin/admin/src/common/buttons/cancel/CancelButton.tsx
+++ b/packages/admin/admin/src/common/buttons/cancel/CancelButton.tsx
@@ -1,20 +1,14 @@
 import { Clear } from "@comet/admin-icons";
-import { Button, type ButtonClassKey } from "@mui/material";
-import { type ButtonProps } from "@mui/material/Button";
 import { type Theme, useThemeProps } from "@mui/material/styles";
 import { type ComponentsOverrides } from "@mui/material/styles/overrides";
 import { FormattedMessage } from "react-intl";
 
 import { createComponentSlot } from "../../../helpers/createComponentSlot";
 import { messages } from "../../../messages";
+import { Button, type ButtonClassKey, type ButtonProps } from "../Button";
 
 export type CancelButtonProps = ButtonProps;
 export type CancelButtonClassKey = ButtonClassKey;
-
-const Root = createComponentSlot(Button)<CancelButtonClassKey>({
-    componentName: "CancelButton",
-    slotName: "root",
-})();
 
 export function CancelButton(inProps: CancelButtonProps) {
     const {
@@ -24,11 +18,16 @@ export function CancelButton(inProps: CancelButtonProps) {
     } = useThemeProps({ props: inProps, name: "CometAdminCancelButton" });
 
     return (
-        <Root color="info" startIcon={startIcon} {...restProps}>
+        <Root variant="textDark" startIcon={startIcon} {...restProps}>
             {children}
         </Root>
     );
 }
+
+const Root = createComponentSlot(Button)<CancelButtonClassKey>({
+    componentName: "CancelButton",
+    slotName: "root",
+})();
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {

--- a/packages/admin/admin/src/common/buttons/delete/DeleteButton.tsx
+++ b/packages/admin/admin/src/common/buttons/delete/DeleteButton.tsx
@@ -1,26 +1,14 @@
 import { Delete } from "@comet/admin-icons";
-import { Button, type ButtonClassKey, type ButtonProps, type ComponentsOverrides } from "@mui/material";
-import { css, type Theme, useThemeProps } from "@mui/material/styles";
+import { type ComponentsOverrides } from "@mui/material";
+import { type Theme, useThemeProps } from "@mui/material/styles";
 import { FormattedMessage } from "react-intl";
 
 import { createComponentSlot } from "../../../helpers/createComponentSlot";
 import { messages } from "../../../messages";
+import { Button, type ButtonClassKey, type ButtonProps } from "../Button";
 
 export type DeleteButtonClassKey = ButtonClassKey;
 export type DeleteButtonProps = ButtonProps;
-
-const Root = createComponentSlot(Button)<DeleteButtonClassKey>({
-    componentName: "DeleteButton",
-    slotName: "root",
-})(
-    ({ theme }) => css`
-        background-color: ${theme.palette.error.main};
-        color: ${theme.palette.error.contrastText};
-        &:hover {
-            background-color: ${theme.palette.error.dark};
-        }
-    `,
-);
 
 export function DeleteButton(inProps: DeleteButtonProps) {
     const {
@@ -30,11 +18,16 @@ export function DeleteButton(inProps: DeleteButtonProps) {
     } = useThemeProps({ props: inProps, name: "CometAdminDeleteButton" });
 
     return (
-        <Root startIcon={startIcon} {...restProps}>
+        <Root startIcon={startIcon} variant="destructive" {...restProps}>
             {children}
         </Root>
     );
 }
+
+const Root = createComponentSlot(Button)<DeleteButtonClassKey>({
+    componentName: "DeleteButton",
+    slotName: "root",
+})();
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {

--- a/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
+++ b/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
@@ -1,34 +1,33 @@
 import { Check } from "@comet/admin-icons";
-import { Button, type ButtonClassKey, type ButtonProps, type ComponentsOverrides } from "@mui/material";
+import { type ComponentsOverrides } from "@mui/material";
 import { type Theme, useThemeProps } from "@mui/material/styles";
 import { FormattedMessage } from "react-intl";
 
 import { createComponentSlot } from "../../../helpers/createComponentSlot";
 import { messages } from "../../../messages";
+import { Button, type ButtonClassKey, type ButtonProps } from "../Button";
 
 export type OkayButtonClassKey = ButtonClassKey;
 export type OkayButtonProps = ButtonProps;
-
-const Root = createComponentSlot(Button)<OkayButtonClassKey>({
-    componentName: "OkayButton",
-    slotName: "root",
-})();
 
 export function OkayButton(inProps: OkayButtonProps) {
     const {
         children = <FormattedMessage {...messages.ok} />,
         startIcon = <Check />,
-        color = "primary",
-        variant = "contained",
         ...restProps
     } = useThemeProps({ props: inProps, name: "CometAdminOkayButton" });
 
     return (
-        <Root startIcon={startIcon} color={color} variant={variant} {...restProps}>
+        <Root startIcon={startIcon} {...restProps}>
             {children}
         </Root>
     );
 }
+
+const Root = createComponentSlot(Button)<OkayButtonClassKey>({
+    componentName: "OkayButton",
+    slotName: "root",
+})();
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {

--- a/packages/admin/admin/src/stack/backbutton/StackBackButton.tsx
+++ b/packages/admin/admin/src/stack/backbutton/StackBackButton.tsx
@@ -1,8 +1,8 @@
 import { ArrowLeft } from "@comet/admin-icons";
-import { Button, type ButtonClassKey, type ButtonProps, type ComponentsOverrides } from "@mui/material";
-import { type Theme, useThemeProps } from "@mui/material/styles";
+import { type ComponentsOverrides, type Theme, useThemeProps } from "@mui/material/styles";
 import { FormattedMessage } from "react-intl";
 
+import { Button, type ButtonClassKey, type ButtonProps } from "../../common/buttons/Button";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { messages } from "../../messages";
 import { StackApiContext } from "../Api";
@@ -10,13 +10,8 @@ import { StackApiContext } from "../Api";
 export type StackBackButtonClassKey = ButtonClassKey;
 export type StackBackButtonProps = ButtonProps;
 
-const Root = createComponentSlot(Button)<StackBackButtonClassKey>({
-    componentName: "StackBackButton",
-    slotName: "root",
-})();
-
 export function StackBackButton(inProps: StackBackButtonProps) {
-    const { startIcon = <ArrowLeft />, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminStackBackButton" });
+    const { startIcon = <ArrowLeft />, variant = "textDark", ...restProps } = useThemeProps({ props: inProps, name: "CometAdminStackBackButton" });
 
     return (
         <StackApiContext.Consumer>
@@ -26,6 +21,7 @@ export function StackBackButton(inProps: StackBackButtonProps) {
                         disabled={stackApi?.breadCrumbs == null || stackApi?.breadCrumbs.length <= 1}
                         onClick={stackApi?.goBack}
                         startIcon={startIcon}
+                        variant={variant}
                         {...restProps}
                     >
                         <FormattedMessage {...messages.back} />
@@ -35,6 +31,11 @@ export function StackBackButton(inProps: StackBackButtonProps) {
         </StackApiContext.Consumer>
     );
 }
+
+const Root = createComponentSlot(Button)<StackBackButtonClassKey>({
+    componentName: "StackBackButton",
+    slotName: "root",
+})();
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {


### PR DESCRIPTION
## Description

These buttons now use the new Comet `Button` instead of MUI's `Button`.
The styling of `StackBackButton` and `DeleteButton` was changed to match the design guidelines. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="440" alt="Buttons previously" src="https://github.com/user-attachments/assets/b2d44d5e-71e6-4b1a-b86c-b04efaa218e7" />  | <img width="440" alt="Buttons now" src="https://github.com/user-attachments/assets/d0f6ad3e-2769-4214-8bd2-cf7266348900" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1966
