### PR TITLE
Remove unintended white background on `Button` with `textDark` variant when disabled

### DIFF
--- a/.changeset/chilly-cameras-peel.md
+++ b/.changeset/chilly-cameras-peel.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Remove unintended white background on `Button` with `textDark` variant when disabled

--- a/packages/admin/admin/src/common/buttons/Button.tsx
+++ b/packages/admin/admin/src/common/buttons/Button.tsx
@@ -156,7 +156,6 @@ const Root = createComponentSlot(MuiButton)<ButtonClassKey, OwnerState>({
         css`
             color: ${theme.palette.common.black};
             &.Mui-disabled {
-                background-color: ${theme.palette.secondary.contrastText};
                 color: ${theme.palette.grey[200]};
             }
         `}


### PR DESCRIPTION
## Description

The background was previously defined in the design but was removed, as it was unintentional and looked odd. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

See the "Collapse all" button on the right, above the page-tree. 

| Before | After |
| ------ | ----- |
| <img width="751" alt="Page Tree Previously" src="https://github.com/user-attachments/assets/84dfc595-3095-4664-a3b2-2566b7f04e20" />   | <img width="751" alt="Page Tree Now" src="https://github.com/user-attachments/assets/05a44336-d9b5-4fba-9e4f-dfb306af0b48" /> |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1972
