### PR TITLE
API Generator: Activate transpileOnly for better performance and fix enum issue we have with it

### DIFF
--- a/.changeset/many-kids-look.md
+++ b/.changeset/many-kids-look.md
@@ -1,0 +1,5 @@
+---
+"@comet/api-generator": patch
+---
+
+Activate transpileOnly for better performance and fix enum issue we have with it

--- a/packages/api/api-generator/bin/api-generator.js
+++ b/packages/api/api-generator/bin/api-generator.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 require("ts-node").register({
     require: ["tsconfig-paths/register"],
+    transpileOnly: true,
 });
 require("../lib/apiGenerator");

--- a/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
@@ -69,7 +69,8 @@ export function buildOptions(metadata: EntityMetadata<any>, generatorOptions: Cr
                 prop.type === "DateType" ||
                 prop.type === "Date" ||
                 prop.kind === "m:1" ||
-                prop.type === "EnumArrayType"),
+                prop.type === "EnumArrayType" ||
+                prop.enum),
     );
     const hasSortArg = crudSortProps.length > 0;
 


### PR DESCRIPTION
based on #3446

This improves startup performance (time `CLIHelper.getORM` takes) from 37s to 700ms for demo on my machine.

There might be other compatibility issues with transpileOnly and enums