### PR TITLE
Fix `PixelImageBlock` fixed height, auto width issue

### DIFF
--- a/.changeset/hip-eagles-play.md
+++ b/.changeset/hip-eagles-play.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": minor
+---
+
+Fix `PixelImageBlock` issue when setting fixed height and width auto

--- a/.changeset/hip-eagles-play.md
+++ b/.changeset/hip-eagles-play.md
@@ -1,5 +1,5 @@
 ---
-"@comet/cms-site": minor
+"@comet/cms-site": patch
 ---
 
 Fix `PixelImageBlock` issue when setting fixed height and width auto

--- a/packages/site/cms-site/src/blocks/PixelImageBlock.tsx
+++ b/packages/site/cms-site/src/blocks/PixelImageBlock.tsx
@@ -94,6 +94,6 @@ function createDominantImageDataUrl(w: number, h: number, dominantColor = "#ffff
 
 const ImageContainer = styled.div<{ $aspectRatio: number }>`
     position: relative;
-    width: 100%;
+    height: 100%;
     aspect-ratio: ${({ $aspectRatio }) => $aspectRatio};
 `;

--- a/packages/site/cms-site/src/blocks/PixelImageBlock.tsx
+++ b/packages/site/cms-site/src/blocks/PixelImageBlock.tsx
@@ -94,6 +94,7 @@ function createDominantImageDataUrl(w: number, h: number, dominantColor = "#ffff
 
 const ImageContainer = styled.div<{ $aspectRatio: number }>`
     position: relative;
+    width: 100%;
     height: 100%;
     aspect-ratio: ${({ $aspectRatio }) => $aspectRatio};
 `;


### PR DESCRIPTION
## Description

fix `PixelImageBlock` fixed height, auto width issue

### Problem

When you want to display an admin-manageable image with a fixed height while maintaining the original aspect ratio, this is currently not possible with the PixelImageBlock.

Use cases for this would be, for example:

A scope-dependent, manageable logo in the header. In each scope, a different logo could be uploaded, which may have different widths but should always have the same height.
A bar of manageable logos that should all have the same fixed height but a dynamic width/aspect ratio.

[debug-render-bugs-with-pixel-image-block-in-demo](https://github.com/vivid-planet/comet/tree/debug-render-bugs-with-pixel-image-block-in-demo)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  <img width="547" alt="Screenshot 2025-04-15 at 12 02 29" src="https://github.com/user-attachments/assets/19e19cee-525f-4f0b-8c27-62a40857e6d5" /> |<img width="563" alt="Screenshot 2025-04-15 at 11 41 37" src="https://github.com/user-attachments/assets/a263c801-5fca-4359-a591-9e3ef1dd97ac" /> |


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1679
