### PR TITLE
Demo: Add additional sizes to allowedImageSizes configuration

### DIFF
--- a/demo/api/src/comet-config.json
+++ b/demo/api/src/comet-config.json
@@ -1,7 +1,7 @@
 {
     "dam": {
         "allowedImageAspectRatios": ["16x9", "4x3", "3x2", "3x1", "2x1", "1x1", "1x2", "1x3", "2x3", "3x4", "9x16", "1200x630"],
-        "allowedImageSizes": [320, 420, 768, 1024, 1200, 2048],
+        "allowedImageSizes": [320, 420, 768, 1024, 1200, 2048, 2560, 3200, 3840],
         "uploadsMaxFileSize": 500
     },
     "fileUploads": {


### PR DESCRIPTION
## Description

Add additional sizes 2560, 3200, 3840 to the allowedImageSize configuration.
More larger image sizes are needed to fulfill larger display sizes - optimize performance on larger high definition displays

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1717
