### PR TITLE
Remove youtube.com from and add player.vimeo.com to CSP

### DIFF
--- a/demo/site/src/middleware/cspHeaders.ts
+++ b/demo/site/src/middleware/cspHeaders.ts
@@ -20,7 +20,7 @@ export function withCspHeadersMiddleware(middleware: CustomMiddleware) {
                     frame-ancestors ${process.env.ADMIN_URL ?? "none"};
                     upgrade-insecure-requests; 
                     block-all-mixed-content;
-                    frame-src 'self' https://*.youtube.com https://*.youtube-nocookie.com;
+                    frame-src 'self' https://*.youtube-nocookie.com https://player.vimeo.com;
                 `
                 .replace(/\s{2,}/g, " ")
                 .trim(),


### PR DESCRIPTION
## Description

- We support the VimeoVideoBlock so the Domain should be allowed in the CSP
- Allowing `https://*.youtube.com` in the CSP is not necessary, since we only use `youtube-nocookie.com` in the Youtube block https://github.com/vivid-planet/comet/blob/6163b83a41b17d8c110133dfebb6633b7a3c699b/packages/site/cms-site/src/blocks/YouTubeVideoBlock.tsx#L85
