### PR TITLE
Add aria-hidden to SvgUse Component to hide SVGs by default

### DIFF
--- a/demo/site-pages/src/common/helpers/SvgUse.tsx
+++ b/demo/site-pages/src/common/helpers/SvgUse.tsx
@@ -5,7 +5,7 @@ interface SvgUseProps extends SVGProps<SVGSVGElement> {
 }
 
 export const SvgUse = ({ href, ...props }: SvgUseProps) => (
-    <svg {...props}>
+    <svg aria-hidden="true" {...props}>
         <use href={href} xlinkHref={href} />
     </svg>
 );

--- a/demo/site/src/common/helpers/SvgUse.tsx
+++ b/demo/site/src/common/helpers/SvgUse.tsx
@@ -6,7 +6,7 @@ interface SvgUseProps extends SVGProps<SVGSVGElement> {
 }
 
 export const SvgUse = ({ href, ...props }: SvgUseProps) => (
-    <svg {...props}>
+    <svg aria-hidden="true" {...props}>
         <use href={href} xlinkHref={href} />
     </svg>
 );


### PR DESCRIPTION
## Description

Decorative elements and non-interactive content (such as icons) should not be exposed to accessibility APIs. The aria-hidden attribute ensures these elements are excluded from the accessibility tree.

However, since some elements may still be relevant, this attribute can be overridden when necessary.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

https://github.com/user-attachments/assets/3a6b9be2-d653-4df1-85be-00b43515ec0c

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1713
