### PR TITLE
Demo Site: Add createImageSizes helper

### DIFF
--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -8,22 +8,26 @@ import styled, { css } from "styled-components";
 import { DamImageBlock } from "./DamImageBlock";
 import { RichTextBlock } from "./RichTextBlock";
 
-export const TextImageBlock = withPreview(
+const TextImageBlock = withPreview(
     ({ data: { text, image, imageAspectRatio, imagePosition } }: PropsWithData<TextImageBlockData>) => {
         return (
-            <PageLayout>
-                <Root $imagePosition={imagePosition}>
-                    <ImageContainer $imageAspectRatio={imageAspectRatio.replace("x", "/")}>
-                        <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes={createImageSizes({ md: "100vw" }, "30vw")} />
-                    </ImageContainer>
-                    <TextContainer>
-                        <RichTextBlock data={text} />
-                    </TextContainer>
-                </Root>
-            </PageLayout>
+            <Root $imagePosition={imagePosition}>
+                <ImageContainer $imageAspectRatio={imageAspectRatio.replace("x", "/")}>
+                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes={createImageSizes({ md: "100vw" }, "30vw")} />
+                </ImageContainer>
+                <TextContainer>
+                    <RichTextBlock data={text} />
+                </TextContainer>
+            </Root>
         );
     },
     { label: "Text/Image" },
+);
+
+export const PageContentTextImageBlock = (props: PropsWithData<TextImageBlockData>) => (
+    <PageLayout>
+        <TextImageBlock {...props} />
+    </PageLayout>
 );
 
 const Root = styled.div<{ $imagePosition: TextImageBlockData["imagePosition"] }>`

--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -8,12 +8,12 @@ import styled, { css } from "styled-components";
 import { DamImageBlock } from "./DamImageBlock";
 import { RichTextBlock } from "./RichTextBlock";
 
-const TextImageBlock = withPreview(
+export const TextImageBlock = withPreview(
     ({ data: { text, image, imageAspectRatio, imagePosition } }: PropsWithData<TextImageBlockData>) => {
         return (
             <Root $imagePosition={imagePosition}>
-                <ImageContainer $imageAspectRatio={imageAspectRatio.replace("x", "/")}>
-                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes={createImageSizes({ xs: "100vw", md: "30vw" })} />
+                <ImageContainer>
+                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} sizes={createImageSizes({ xs: "100vw", md: "30vw" })} />
                 </ImageContainer>
                 <TextContainer>
                     <RichTextBlock data={text} />
@@ -46,10 +46,9 @@ const Root = styled.div<{ $imagePosition: TextImageBlockData["imagePosition"] }>
         `}
 `;
 
-const ImageContainer = styled.div<{ $imageAspectRatio: TextImageBlockData["imageAspectRatio"] }>`
+const ImageContainer = styled.div`
     position: relative;
     flex: 1;
-    aspect-ratio: ${({ $imageAspectRatio }) => $imageAspectRatio};
 `;
 
 const TextContainer = styled.div`

--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -13,7 +13,7 @@ export const TextImageBlock = withPreview(
         return (
             <Root $imagePosition={imagePosition}>
                 <ImageContainer>
-                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} sizes={createImageSizes({ xs: "100vw", md: "30vw" })} />
+                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} sizes={createImageSizes({ default: "100vw", md: "30vw" })} />
                 </ImageContainer>
                 <TextContainer>
                     <RichTextBlock data={text} />

--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { TextImageBlockData } from "@src/blocks.generated";
+import { PageLayout } from "@src/layout/PageLayout";
 import styled, { css } from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";
@@ -9,14 +10,16 @@ import { RichTextBlock } from "./RichTextBlock";
 export const TextImageBlock = withPreview(
     ({ data: { text, image, imageAspectRatio, imagePosition } }: PropsWithData<TextImageBlockData>) => {
         return (
-            <Root $imagePosition={imagePosition}>
-                <ImageContainer>
-                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} sizes="50vw" />
-                </ImageContainer>
-                <TextContainer>
-                    <RichTextBlock data={text} />
-                </TextContainer>
-            </Root>
+            <PageLayout>
+                <Root $imagePosition={imagePosition}>
+                    <ImageContainer $imageAspectRatio={imageAspectRatio.replace("x", "/")}>
+                        <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes="50vw" />
+                    </ImageContainer>
+                    <TextContainer>
+                        <RichTextBlock data={text} />
+                    </TextContainer>
+                </Root>
+            </PageLayout>
         );
     },
     { label: "Text/Image" },
@@ -24,8 +27,12 @@ export const TextImageBlock = withPreview(
 
 const Root = styled.div<{ $imagePosition: TextImageBlockData["imagePosition"] }>`
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     gap: 20px;
+
+    ${({ theme }) => theme.breakpoints.md.mediaQuery} {
+        flex-direction: row;
+    }
 
     ${({ $imagePosition }) =>
         $imagePosition === "left" &&
@@ -34,8 +41,10 @@ const Root = styled.div<{ $imagePosition: TextImageBlockData["imagePosition"] }>
         `}
 `;
 
-const ImageContainer = styled.div`
+const ImageContainer = styled.div<{ $imageAspectRatio: TextImageBlockData["imageAspectRatio"] }>`
+    position: relative;
     flex: 1;
+    aspect-ratio: ${({ $imageAspectRatio }) => $imageAspectRatio};
 `;
 
 const TextContainer = styled.div`

--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -13,7 +13,7 @@ const TextImageBlock = withPreview(
         return (
             <Root $imagePosition={imagePosition}>
                 <ImageContainer $imageAspectRatio={imageAspectRatio.replace("x", "/")}>
-                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes={createImageSizes({ md: "30vw" }, "100vw")} />
+                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes={createImageSizes({ xs: "100vw", md: "30vw" })} />
                 </ImageContainer>
                 <TextContainer>
                     <RichTextBlock data={text} />

--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -13,7 +13,7 @@ const TextImageBlock = withPreview(
         return (
             <Root $imagePosition={imagePosition}>
                 <ImageContainer $imageAspectRatio={imageAspectRatio.replace("x", "/")}>
-                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes={createImageSizes({ md: "100vw" }, "30vw")} />
+                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes={createImageSizes({ md: "30vw" }, "100vw")} />
                 </ImageContainer>
                 <TextContainer>
                     <RichTextBlock data={text} />

--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -2,7 +2,7 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { TextImageBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
-import { createNextImageSizes } from "@src/util/createNextImageSizes";
+import { createImageSizes } from "@src/util/createImageSizes";
 import styled, { css } from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";
@@ -14,7 +14,7 @@ export const TextImageBlock = withPreview(
             <PageLayout>
                 <Root $imagePosition={imagePosition}>
                     <ImageContainer $imageAspectRatio={imageAspectRatio.replace("x", "/")}>
-                        <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes={createNextImageSizes({ md: "100vw" }, "30vw")} />
+                        <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes={createImageSizes({ md: "100vw" }, "30vw")} />
                     </ImageContainer>
                     <TextContainer>
                         <RichTextBlock data={text} />

--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -2,6 +2,7 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { TextImageBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { createNextImageSizes } from "@src/util/createNextImageSizes";
 import styled, { css } from "styled-components";
 
 import { DamImageBlock } from "./DamImageBlock";
@@ -13,7 +14,7 @@ export const TextImageBlock = withPreview(
             <PageLayout>
                 <Root $imagePosition={imagePosition}>
                     <ImageContainer $imageAspectRatio={imageAspectRatio.replace("x", "/")}>
-                        <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes="50vw" />
+                        <DamImageBlock data={image} aspectRatio={imageAspectRatio} fill sizes={createNextImageSizes({ md: "100vw" }, "30vw")} />
                     </ImageContainer>
                     <TextContainer>
                         <RichTextBlock data={text} />

--- a/demo/site/src/documents/pages/blocks/PageContentBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/PageContentBlock.tsx
@@ -11,7 +11,7 @@ import { SpaceBlock } from "@src/common/blocks/SpaceBlock";
 import { PageContentStandaloneCallToActionListBlock } from "@src/common/blocks/StandaloneCallToActionListBlock";
 import { PageContentStandaloneHeadingBlock } from "@src/common/blocks/StandaloneHeadingBlock";
 import { StandaloneMediaBlock } from "@src/common/blocks/StandaloneMediaBlock";
-import { TextImageBlock } from "@src/common/blocks/TextImageBlock";
+import { PageContentTextImageBlock } from "@src/common/blocks/TextImageBlock";
 import { BillboardTeaserBlock } from "@src/documents/pages/blocks/BillboardTeaserBlock";
 import { ColumnsBlock } from "@src/documents/pages/blocks/ColumnsBlock";
 import { ContentGroupBlock } from "@src/documents/pages/blocks/ContentGroupBlock";
@@ -42,7 +42,7 @@ const supportedBlocks: SupportedBlocks = {
     newsDetail: (props) => <NewsDetailBlock data={props} />,
     image: (props) => <DamImageBlock data={props} aspectRatio="inherit" />,
     layout: (props) => <LayoutBlock data={props} />,
-    textImage: (props) => <TextImageBlock data={props} />,
+    textImage: (props) => <PageContentTextImageBlock data={props} />,
     fullWidthImage: (props) => <FullWidthImageBlock data={props} />,
 };
 

--- a/demo/site/src/news/blocks/NewsContentBlock.tsx
+++ b/demo/site/src/news/blocks/NewsContentBlock.tsx
@@ -3,13 +3,13 @@ import { NewsContentBlockData } from "@src/blocks.generated";
 import { DamImageBlock } from "@src/common/blocks/DamImageBlock";
 import { HeadingBlock } from "@src/common/blocks/HeadingBlock";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
-import { TextImageBlock } from "@src/common/blocks/TextImageBlock";
+import { PageContentTextImageBlock } from "@src/common/blocks/TextImageBlock";
 
 const supportedBlocks: SupportedBlocks = {
     heading: (props) => <HeadingBlock data={props} />,
     richText: (props) => <RichTextBlock data={props} />,
     image: (props) => <DamImageBlock data={props} aspectRatio="inherit" />,
-    textImage: (props) => <TextImageBlock data={props} />,
+    textImage: (props) => <PageContentTextImageBlock data={props} />,
 };
 
 export const NewsContentBlock = ({ data }: PropsWithData<NewsContentBlockData>) => {

--- a/demo/site/src/theme.ts
+++ b/demo/site/src/theme.ts
@@ -57,7 +57,6 @@ export const theme = {
     },
     fontFamily: "Arial, sans-serif",
     breakpoints: {
-        xs: createBreakpoint(0),
         sm: createBreakpoint(600),
         md: createBreakpoint(900),
         lg: createBreakpoint(1200),

--- a/demo/site/src/theme.ts
+++ b/demo/site/src/theme.ts
@@ -78,7 +78,7 @@ export const theme = {
 
 export default theme;
 
-type Theme = typeof theme;
+export type Theme = typeof theme;
 
 declare module "styled-components" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/demo/site/src/theme.ts
+++ b/demo/site/src/theme.ts
@@ -57,6 +57,7 @@ export const theme = {
     },
     fontFamily: "Arial, sans-serif",
     breakpoints: {
+        xs: createBreakpoint(0),
         sm: createBreakpoint(600),
         md: createBreakpoint(900),
         lg: createBreakpoint(1200),

--- a/demo/site/src/util/createImageSizes.ts
+++ b/demo/site/src/util/createImageSizes.ts
@@ -1,11 +1,11 @@
 import theme, { Theme } from "@src/theme";
 
-type BreakpointWidths = { xs: string | number } & Partial<Record<keyof Theme["breakpoints"], string | number>>;
+type BreakpointWidths = { default: string | number } & Partial<Record<keyof Theme["breakpoints"], string | number>>;
 
 export function createImageSizes(breakpointWidths: BreakpointWidths) {
     const sizes: string[] = [];
     const breakpoints = Object.entries(theme.breakpoints).reverse();
-    const defaultSize = breakpointWidths.xs;
+    const defaultSize = breakpointWidths.default;
 
     breakpoints.forEach(([breakpointKey, breakpointValue]) => {
         const size = breakpointWidths[breakpointKey];

--- a/demo/site/src/util/createImageSizes.ts
+++ b/demo/site/src/util/createImageSizes.ts
@@ -1,6 +1,6 @@
 import theme, { Theme } from "@src/theme";
 
-export function createNextImageSizes(
+export function createImageSizes(
     breakpointWidths: Partial<Record<keyof Theme["breakpoints"], string | number>>,
     defaultWidth: string | number = "100vw",
 ) {

--- a/demo/site/src/util/createImageSizes.ts
+++ b/demo/site/src/util/createImageSizes.ts
@@ -16,7 +16,7 @@ export function createImageSizes(breakpointWidths: BreakpointWidths) {
         }
     });
 
-    sizes.push(`(min-width: 0px) ${typeof defaultSize === "string" ? defaultSize : `${defaultSize}px`}`);
+    sizes.push(`${typeof defaultSize === "string" ? defaultSize : `${defaultSize}px`}`);
 
     return sizes.join(", ");
 }

--- a/demo/site/src/util/createImageSizes.ts
+++ b/demo/site/src/util/createImageSizes.ts
@@ -1,9 +1,6 @@
 import theme, { Theme } from "@src/theme";
 
-export function createImageSizes(
-    breakpointWidths: Partial<Record<keyof Theme["breakpoints"], string | number>>,
-    defaultWidth: string | number = "100vw",
-) {
+export function createImageSizes(breakpointWidths: Partial<Record<keyof Theme["breakpoints"], string | number>>) {
     const sizes: string[] = [];
     const breakpoints = Object.entries(theme.breakpoints).reverse();
 
@@ -15,8 +12,6 @@ export function createImageSizes(
             sizes.push(`(min-width: ${minWidth}px) ${typeof width === "string" ? width : `${width}px`}`);
         }
     });
-
-    sizes.push(typeof defaultWidth === "string" ? defaultWidth : `${defaultWidth}px`);
 
     return sizes.join(", ");
 }

--- a/demo/site/src/util/createImageSizes.ts
+++ b/demo/site/src/util/createImageSizes.ts
@@ -1,17 +1,22 @@
 import theme, { Theme } from "@src/theme";
 
-export function createImageSizes(breakpointWidths: Partial<Record<keyof Theme["breakpoints"], string | number>>) {
+type BreakpointWidths = { xs: string | number } & Partial<Record<keyof Theme["breakpoints"], string | number>>;
+
+export function createImageSizes(breakpointWidths: BreakpointWidths) {
     const sizes: string[] = [];
     const breakpoints = Object.entries(theme.breakpoints).reverse();
+    const defaultSize = breakpointWidths.xs;
 
     breakpoints.forEach(([breakpointKey, breakpointValue]) => {
-        const width = breakpointWidths[breakpointKey];
+        const size = breakpointWidths[breakpointKey];
         const minWidth = breakpointValue.value;
 
-        if (width !== undefined) {
-            sizes.push(`(min-width: ${minWidth}px) ${typeof width === "string" ? width : `${width}px`}`);
+        if (size !== undefined) {
+            sizes.push(`(min-width: ${minWidth}px) ${typeof size === "string" ? size : `${size}px`}`);
         }
     });
+
+    sizes.push(`(min-width: 0px) ${typeof defaultSize === "string" ? defaultSize : `${defaultSize}px`}`);
 
     return sizes.join(", ");
 }

--- a/demo/site/src/util/createImageSizes.ts
+++ b/demo/site/src/util/createImageSizes.ts
@@ -5,14 +5,14 @@ export function createImageSizes(
     defaultWidth: string | number = "100vw",
 ) {
     const sizes: string[] = [];
-    const breakpoints = Object.entries(theme.breakpoints);
+    const breakpoints = Object.entries(theme.breakpoints).reverse();
 
     breakpoints.forEach(([breakpointKey, breakpointValue]) => {
         const width = breakpointWidths[breakpointKey];
-        const maxWidth = breakpointValue.value;
+        const minWidth = breakpointValue.value;
 
         if (width !== undefined) {
-            sizes.push(`(max-width: ${maxWidth}px) ${typeof width === "string" ? width : `${width}px`}`);
+            sizes.push(`(min-width: ${minWidth}px) ${typeof width === "string" ? width : `${width}px`}`);
         }
     });
 

--- a/demo/site/src/util/createImageSizes.ts
+++ b/demo/site/src/util/createImageSizes.ts
@@ -4,7 +4,7 @@ type BreakpointWidths = { default: string | number } & Partial<Record<keyof Them
 
 export function createImageSizes(breakpointWidths: BreakpointWidths) {
     const sizes: string[] = [];
-    const breakpoints = Object.entries(theme.breakpoints).reverse();
+    const breakpoints = Object.entries(theme.breakpoints).sort((a, b) => b[1].value - a[1].value); // breakpoint values have to be sorted in descending order when using min-width in the sizes property
     const defaultSize = breakpointWidths.default;
 
     breakpoints.forEach(([breakpointKey, breakpointValue]) => {

--- a/demo/site/src/util/createNextImageSizes.ts
+++ b/demo/site/src/util/createNextImageSizes.ts
@@ -1,24 +1,15 @@
-type Breakpoints = {
-    sm: number;
-    md: number;
-    lg: number;
-    xl: number;
-};
+import theme, { Theme } from "@src/theme";
 
-const breakpointMapping: Record<keyof Breakpoints, number> = {
-    sm: 600,
-    md: 900,
-    lg: 1200,
-    xl: 1600,
-};
-
-export function createNextImageSizes(breakpointWidths: Partial<Record<keyof Breakpoints, string | number>>, defaultWidth: string | number = "100vw") {
+export function createNextImageSizes(
+    breakpointWidths: Partial<Record<keyof Theme["breakpoints"], string | number>>,
+    defaultWidth: string | number = "100vw",
+) {
     const sizes: string[] = [];
-    const breakpoints: (keyof Breakpoints)[] = ["sm", "md", "lg", "xl"];
+    const breakpoints = Object.entries(theme.breakpoints);
 
-    breakpoints.forEach((breakpoint) => {
-        const width = breakpointWidths[breakpoint];
-        const maxWidth = breakpointMapping[breakpoint];
+    breakpoints.forEach(([breakpointKey, breakpointValue]) => {
+        const width = breakpointWidths[breakpointKey];
+        const maxWidth = breakpointValue.value;
 
         if (width !== undefined) {
             sizes.push(`(max-width: ${maxWidth}px) ${typeof width === "string" ? width : `${width}px`}`);

--- a/demo/site/src/util/createNextImageSizes.ts
+++ b/demo/site/src/util/createNextImageSizes.ts
@@ -1,0 +1,31 @@
+type Breakpoints = {
+    sm: number;
+    md: number;
+    lg: number;
+    xl: number;
+};
+
+const breakpointMapping: Record<keyof Breakpoints, number> = {
+    sm: 600,
+    md: 900,
+    lg: 1200,
+    xl: 1600,
+};
+
+export function createNextImageSizes(breakpointWidths: Partial<Record<keyof Breakpoints, string | number>>, defaultWidth: string | number = "100vw") {
+    const sizes: string[] = [];
+    const breakpoints: (keyof Breakpoints)[] = ["sm", "md", "lg", "xl"];
+
+    breakpoints.forEach((breakpoint) => {
+        const width = breakpointWidths[breakpoint];
+        const maxWidth = breakpointMapping[breakpoint];
+
+        if (width !== undefined) {
+            sizes.push(`(max-width: ${maxWidth}px) ${typeof width === "string" ? width : `${width}px`}`);
+        }
+    });
+
+    sizes.push(typeof defaultWidth === "string" ? defaultWidth : `${defaultWidth}px`);
+
+    return sizes.join(", ");
+}


### PR DESCRIPTION
## Description

The function `createImageSizes` is implemented to generate the `sizes` attribute string for Next.js images based on the breakpoints in the project. The `sizes` attribute is used by the browser to decide which image from the `srcset` to load depending on the viewport width. ~~If not set, it defaults to `100vw`.~~

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

https://github.com/user-attachments/assets/3a606d14-bad7-46bf-a9c4-6981adf2938f

## Further information

-  Task: https://vivid-planet.atlassian.net/browse/COM-1715
- https://nextjs.org/docs/pages/api-reference/components/image#sizes
