### PR TITLE
Demo Api: Add api-generator watch process to dev-pm config

### DIFF
--- a/dev-pm.config.js
+++ b/dev-pm.config.js
@@ -136,6 +136,12 @@ module.exports = {
             group: ["demo-api", "demo"],
         },
         {
+            name: "demo-api-generator",
+            script: "pnpm --filter comet-demo-api exec comet-api-generator generate --watch",
+            group: ["demo-api", "demo"],
+            waitOn: [...waitOnPackages("@comet/cms-api"), "packages/api/api-generator/lib/apiGenerator.js"],
+        },
+        {
             name: "demo-api",
             script: "pnpm --filter comet-demo-api run start:dev",
             group: ["demo-api", "demo"],


### PR DESCRIPTION
Now that we have a [watch mode](https://github.com/vivid-planet/comet/pull/3447) for api-generator, it should be possible to start it via dev-pm.