### PR TITLE
Dev: use env var `SERVER_HOST` for host to allow a quicker change

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,8 @@
 # node
 NODE_ENV=development
 
+SERVER_HOST=localhost
+
 # project
 PROJECT_NAME=comet-demo
 DEV_DOMAIN_POSTFIX=demo

--- a/demo/admin/vite.config.mts
+++ b/demo/admin/vite.config.mts
@@ -76,7 +76,7 @@ export default defineConfig(({ mode }) => {
             adminPackagesHotReloadPlugin,
         ],
         server: {
-            host: "localhost",
+            host: process.env.SERVER_HOST ?? "localhost",
             port: Number(process.env.ADMIN_PORT),
             proxy: {
                 "/api": {

--- a/demo/api/src/main.ts
+++ b/demo/api/src/main.ts
@@ -71,7 +71,8 @@ async function bootstrap(): Promise<void> {
     }
 
     const port = config.apiPort;
-    await app.listen(port, "localhost");
-    console.log(`Application is running on: http://localhost:${port}/`);
+    const host = process.env.SERVER_HOST ?? "localhost";
+    await app.listen(port, host);
+    console.log(`Application is running on: http://${host}:${port}/`);
 }
 bootstrap();

--- a/demo/site/server.ts
+++ b/demo/site/server.ts
@@ -5,12 +5,12 @@ import { parse } from "url";
 import { withMetrics } from "./opentelemetry-metrics";
 
 const dev = process.env.NODE_ENV !== "production";
-const hostname = "localhost";
+const host = process.env.SERVER_HOST ?? "localhost";
 const port = parseInt(process.env.PORT || "3000", 10);
 const cdnOriginCheckSecret = process.env.CDN_ORIGIN_CHECK_SECRET;
 
 // when using middleware `hostname` and `port` must be provided below
-const app = next({ dev, hostname, port });
+const app = next({ dev, hostname: host, port });
 
 app.prepare().then(() => {
     if (process.env.TRACING == "production") {
@@ -90,8 +90,8 @@ app.prepare().then(() => {
             console.error(err);
             process.exit(1);
         })
-        .listen(port, "localhost", () => {
+        .listen(port, host, () => {
             // eslint-disable-next-line no-console
-            console.log(`> Ready on http://localhost:${port}`);
+            console.log(`> Ready on http://${host}:${port}`);
         });
 });


### PR DESCRIPTION
Depends on #3785

By default we use localhost, which prohibits remote access. When changing `SERVER_HOST` to `0.0.0.0`, remote access to test on another device is possible.

I think it should not be possible to access the db remotely, so I did not add the var here.
