### PR TITLE
Close Dialog with ESC Key or Backdrop Click

### DIFF
--- a/.changeset/itchy-dancers-kick.md
+++ b/.changeset/itchy-dancers-kick.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Close `Dialog` with ESC key or backdrop click

--- a/packages/admin/admin/src/common/Dialog.tsx
+++ b/packages/admin/admin/src/common/Dialog.tsx
@@ -48,7 +48,7 @@ export function Dialog(inProps: DialogProps) {
     };
 
     return (
-        <Root open={open} {...slotProps?.root} {...restProps}>
+        <Root open={open} onClose={onClose} {...slotProps?.root} {...restProps}>
             {onClose && (
                 <CloseButton {...slotProps?.closeButton} onClick={(event) => onClose(event, "escapeKeyDown")}>
                     {closeIcon}

--- a/storybook/src/admin/common/dialog/Dialog.stories.tsx
+++ b/storybook/src/admin/common/dialog/Dialog.stories.tsx
@@ -1,0 +1,39 @@
+import { Button, Dialog } from "@comet/admin";
+import { Box } from "@mui/material";
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+type Story = StoryObj<typeof Dialog>;
+
+const config: Meta<typeof Dialog> = {
+    component: Dialog,
+    title: "@comet/admin/common/Dialog",
+};
+
+export default config;
+export const DialogStory: Story = {
+    render: () => {
+        const [open, setOpen] = useState(false);
+        return (
+            <div>
+                <Button
+                    onClick={() => {
+                        setOpen(true);
+                    }}
+                >
+                    Open Dialog
+                </Button>
+                <Dialog
+                    open={open}
+                    onClose={() => {
+                        setOpen(!open);
+                    }}
+                    title="Dialog"
+                >
+                    <Box padding={4}>Content</Box>
+                </Dialog>
+            </div>
+        );
+    },
+};
+DialogStory.storyName = "Dialog";


### PR DESCRIPTION
## Description

currently the `Dialog` from `@comet/admin` can not be closed with ESC Key or Backdrop click, what is normally the default behaviour of MUI. 

This Pull Requests fixes forwarding the `onClose` to the `Dialog` component. This will trigger an `onClose` when the User clicks ESC Key or a Backdrop Click.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| clicking Backdrop or hitting ESC Key does not close Dialog           | clicking Backdrop and hitting ESC Key closes Dialog  |
 | ![Screen Recording 2025-04-29 at 13 28 18](https://github.com/user-attachments/assets/48fe8394-e6a7-49b5-ab97-b073c39b9e4f) |  ![Screen Recording 2025-04-29 at 13 30 51](https://github.com/user-attachments/assets/5d5cbcee-ecad-44ce-b391-048298ab6396) |
