### PR TITLE
Fix type of Dialog's title prop

### DIFF
--- a/.changeset/silent-pugs-sort.md
+++ b/.changeset/silent-pugs-sort.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+`title` prop of the Dialog got merged with `title` Prop of `MuiDialogProps`. This lead to errors when forwarding ReactNodes to title.

--- a/packages/admin/admin/src/common/Dialog.tsx
+++ b/packages/admin/admin/src/common/Dialog.tsx
@@ -25,7 +25,7 @@ export type DialogProps = ThemedComponentBaseProps<{
     iconMapping?: {
         closeIcon?: ReactNode;
     };
-} & MuiDialogProps;
+} & Omit<MuiDialogProps, "title">;
 
 type OwnerState = {
     hasCloseButton: boolean;


### PR DESCRIPTION
## Description

In the current implementation of the `Dialog` Component, the `title` prop gets merged with the `title` prop of `MuiDialogProps`, which can lead to type errors when, for example forwarding a ReactNode to the Dialog.

comet's `Dialog`'s `title` Props are typed like`title?: ReactNode`

and Mui's DialogProps are typed as `title?: string` see: 
<img width="1121" alt="Screenshot 2025-04-29 at 15 35 49" src="https://github.com/user-attachments/assets/eafe3a49-cd83-41a9-93a5-dfab349f33fc" />


If one wants to forward a ReactNode to comet's Dialog title - one will receive following Error:

<img width="1981" alt="Screenshot 2025-04-29 at 15 26 09" src="https://github.com/user-attachments/assets/e6b5c600-d7a4-41cf-8417-fc39966c1a72" />


If the `title` prop of MUIDialogProps get's omited, the overrided title type does not get merged anymore, and a ReactNode can be passed without a problem:

<img width="1061" alt="Screenshot 2025-04-29 at 15 26 47" src="https://github.com/user-attachments/assets/bd6455d8-3b12-4392-a1a0-522a5d6c04b8" />
