### PR TITLE
RFC: Fix `defaultRedirectPathAfterChange` implementation

### DIFF
--- a/packages/admin/cms-admin/src/contentScope/Provider.tsx
+++ b/packages/admin/cms-admin/src/contentScope/Provider.tsx
@@ -1,3 +1,4 @@
+import { isUUID } from "class-validator";
 import { createContext, type Dispatch, type ReactNode, type SetStateAction, useCallback, useContext, useMemo, useState } from "react";
 import { type match, Redirect, Route, Switch, useHistory, useLocation, useRouteMatch } from "react-router";
 
@@ -138,10 +139,20 @@ export function ContentScopeProvider<S extends ContentScopeInterface = ContentSc
     let defaultRedirectPathAfterChange: string | undefined;
 
     if (match) {
-        // Location: /main/en/dashboard
-        // Match: /main/en
-        // Page: Location - Match = /dashboard
-        defaultRedirectPathAfterChange = currentLocation.pathname.replace(match.url, "");
+        defaultRedirectPathAfterChange = "";
+
+        for (const segment of currentLocation.pathname.replace(match.url, "").split("/")) {
+            if (segment === "") {
+                continue;
+            }
+
+            // Likely a detail page -> break
+            if (isUUID(segment)) {
+                break;
+            }
+
+            defaultRedirectPathAfterChange += `/${segment}`;
+        }
     }
 
     return (


### PR DESCRIPTION
## Description

The default implementation introduced in https://github.com/vivid-planet/comet/pull/2631 didn't consider detail pages. For instance, the application remained on same the page tree node edit page when changing scopes, causing a not found error. The problem is caused by a flaw in this logic:

```ts
// Location: /main/en/dashboard
// Match: /main/en
// Page: Location - Match = /dashboard
```

For a page `http://localhost:8000/secondary/en/pages/pagetree/main-navigation/c58b7cb6-eea5-4557-8b17-f3f5d3045d53/edit` the result would be `/pages/pagetree/main-navigation/c58b7cb6-eea5-4557-8b17-f3f5d3045d53/edit`, where it should actually be `/pages/pagetree/main-navigation`.

I "fixed" this by removing all parts of after the first UUID. This may prove sufficient for most cases, but isn't perfect. We should decide if we still want to go with this solution, or revert the original PR and add no default implementation.

## Open TODOs/questions

- [x] Decide if we want to use this fix

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1221
