### PR TITLE
Consider required permission of ancestors in `MasterMenuRoutes`

### DIFF
--- a/.changeset/little-houses-wink.md
+++ b/.changeset/little-houses-wink.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Consider required permission of parent group or collapsible in `MasterMenuRoutes`

--- a/.changeset/little-houses-wink.md
+++ b/.changeset/little-houses-wink.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": patch
 ---
 
-Consider required permission of parent group or collapsible in `MasterMenuRoutes`
+Consider required permission of ancestors in `MasterMenuRoutes`

--- a/demo/admin/src/news/NewsPage.tsx
+++ b/demo/admin/src/news/NewsPage.tsx
@@ -12,7 +12,7 @@ import {
     ToolbarBackButton,
 } from "@comet/admin";
 import { ContentScopeIndicator } from "@comet/cms-admin";
-import { useContentScope } from "@src/common/ContentScopeProvider";
+import { useContentScope, useContentScopeConfig } from "@src/common/ContentScopeProvider";
 import { useIntl } from "react-intl";
 
 import { NewsForm } from "./generated/NewsForm";
@@ -32,6 +32,9 @@ const FormToolbar = () => (
 export function NewsPage() {
     const intl = useIntl();
     const { scope } = useContentScope();
+
+    useContentScopeConfig({ redirectPathAfterChange: "/structured-content/news" });
+
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "news.news", defaultMessage: "News" })}>
             <StackSwitch>

--- a/demo/api/src/auth/access-control.service.ts
+++ b/demo/api/src/auth/access-control.service.ts
@@ -7,21 +7,15 @@ export class AccessControlService extends AbstractAccessControlService {
         if (user.isAdmin) {
             return UserPermissions.allPermissions;
         } else {
-            const deniedPermissions = ["userPermissions", "news"];
-            return [
-                ...availablePermissions.filter((permission) => !deniedPermissions.includes(permission)).map((permission) => ({ permission })),
-                { permission: "news", contentScopes: [{ domain: "main", language: "en" }] },
-            ];
+            const deniedPermissions = ["userPermissions"];
+            return availablePermissions.filter((permission) => !deniedPermissions.includes(permission)).map((permission) => ({ permission }));
         }
     }
     getContentScopesForUser(user: User): ContentScopesForUser {
         if (user.isAdmin) {
             return UserPermissions.allContentScopes;
         } else {
-            return [
-                { domain: "main", language: "en" },
-                { domain: "main", language: "de" },
-            ];
+            return [{ domain: "main", language: "en" }];
         }
     }
 }

--- a/demo/api/src/auth/access-control.service.ts
+++ b/demo/api/src/auth/access-control.service.ts
@@ -7,15 +7,21 @@ export class AccessControlService extends AbstractAccessControlService {
         if (user.isAdmin) {
             return UserPermissions.allPermissions;
         } else {
-            const deniedPermissions = ["userPermissions"];
-            return availablePermissions.filter((permission) => !deniedPermissions.includes(permission)).map((permission) => ({ permission }));
+            const deniedPermissions = ["userPermissions", "news"];
+            return [
+                ...availablePermissions.filter((permission) => !deniedPermissions.includes(permission)).map((permission) => ({ permission })),
+                { permission: "news", contentScopes: [{ domain: "main", language: "en" }] },
+            ];
         }
     }
     getContentScopesForUser(user: User): ContentScopesForUser {
         if (user.isAdmin) {
             return UserPermissions.allContentScopes;
         } else {
-            return [{ domain: "main", language: "en" }];
+            return [
+                { domain: "main", language: "en" },
+                { domain: "main", language: "de" },
+            ];
         }
     }
 }

--- a/packages/admin/cms-admin/jest.config.ts
+++ b/packages/admin/cms-admin/jest.config.ts
@@ -195,4 +195,8 @@ export default {
 
     // Whether to use watchman for file crawling
     // watchman: true,
+
+    moduleNameMapper: {
+        "^react-dnd$": "<rootDir>/testing/stub-file.ts",
+    },
 };

--- a/packages/admin/cms-admin/src/common/MasterMenuRoutes.test.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenuRoutes.test.tsx
@@ -1,0 +1,93 @@
+import { MasterMenuData } from "./MasterMenu";
+import { useRoutePropsFromMasterMenuData } from "./MasterMenuRoutes";
+
+jest.mock("../userPermissions/hooks/currentUser", () => ({
+    useUserPermissionCheck: () => (permission: string) => permission === "allowed",
+}));
+
+describe("useRoutePropsFromMasterMenuData", () => {
+    it("should include item without requiredPermission", () => {
+        const items: MasterMenuData = [
+            {
+                type: "route",
+                route: { path: "/allowed" },
+                primary: "Test",
+                icon: undefined,
+            },
+        ];
+
+        const routes = useRoutePropsFromMasterMenuData(items);
+
+        expect(routes).toEqual([{ path: "/allowed" }]);
+    });
+
+    it("should filter item with missing permission", () => {
+        const items: MasterMenuData = [
+            {
+                type: "route",
+                route: { path: "/allowed" },
+                primary: "Allowed",
+                icon: undefined,
+                requiredPermission: "allowed",
+            },
+            {
+                type: "route",
+                route: { path: "/disallowed" },
+                primary: "Disallowed",
+                icon: undefined,
+                requiredPermission: "disallowed",
+            },
+        ];
+
+        const routes = useRoutePropsFromMasterMenuData(items);
+
+        expect(routes).toEqual([{ path: "/allowed" }]);
+    });
+
+    it("should include item if ancestors are allowed", () => {
+        const items: MasterMenuData = [
+            {
+                type: "collapsible",
+                primary: "Allowed",
+                icon: undefined,
+                requiredPermission: "allowed",
+                items: [
+                    {
+                        type: "route",
+                        route: { path: "/allowed" },
+                        primary: "Allowed",
+                        icon: undefined,
+                    },
+                ],
+            },
+        ];
+
+        const routes = useRoutePropsFromMasterMenuData(items);
+
+        expect(routes).toEqual([{ path: "/allowed" }]);
+    });
+
+    it("should filter item if ancestors aren't allowed", () => {
+        const items: MasterMenuData = [
+            {
+                type: "collapsible",
+                primary: "Disallowed",
+                icon: undefined,
+                requiredPermission: "disallowed",
+                items: [
+                    {
+                        type: "route",
+                        route: { path: "/allowed" },
+                        primary: "Allowed",
+                        requiredPermission: "allowed",
+                        icon: undefined,
+                    },
+                ],
+            },
+        ];
+
+        const routes = useRoutePropsFromMasterMenuData(items);
+
+        expect(routes).toEqual([]);
+    });
+});

--- a/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
@@ -63,37 +63,7 @@ export const MasterMenuRoutes = ({ menu }: MasterMenuRoutesProps) => {
             {routes.map((route, index) => (
                 <RouteWithErrorBoundary key={index} {...route} path={`${match.path}${route.path}`} />
             ))}
-            <RouteWithErrorBoundary
-                path={`${match.path}/:path*`}
-                render={(props) => {
-                    if (isMasterMenuItemRoute(menu, `/${props.match.params.path}`) && routes.length > 0) {
-                        // Route exists but user is not allowed to access it -> redirect to first allowed route.
-                        return <Redirect to={`${match.url}${routes[0].path}`} />;
-                    }
-
-                    // TODO: Show a 404 page here
-                    // https://github.com/vivid-planet/comet/pull/3870
-                    return null;
-                }}
-            />
+            <Redirect to={`${match.url}${routes[0].path}`} from={match.path} />
         </Switch>
     );
 };
-
-function isMasterMenuItemRoute(menu: MasterMenuData, path: string): boolean {
-    return menu.some((item) => {
-        if (item.type === "externalLink") {
-            return false;
-        }
-        if (item.type === "group") {
-            return isMasterMenuItemRoute(item.items, path);
-        }
-        if (item.route && item.route.path === path) {
-            return true;
-        }
-        if (item.type === "collapsible") {
-            return isMasterMenuItemRoute(item.items as Array<MasterMenuItem & { icon?: ReactNode }>, path);
-        }
-        return false;
-    });
-}

--- a/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
@@ -63,7 +63,37 @@ export const MasterMenuRoutes = ({ menu }: MasterMenuRoutesProps) => {
             {routes.map((route, index) => (
                 <RouteWithErrorBoundary key={index} {...route} path={`${match.path}${route.path}`} />
             ))}
-            <Redirect to={`${match.url}${routes[0].path}`} from={match.path} />
+            <RouteWithErrorBoundary
+                path={`${match.path}/:path*`}
+                render={(props) => {
+                    if (isMasterMenuItemRoute(menu, `/${props.match.params.path}`) && routes.length > 0) {
+                        // Route exists but user is not allowed to access it -> redirect to first allowed route.
+                        return <Redirect to={`${match.url}${routes[0].path}`} />;
+                    }
+
+                    // TODO: Show a 404 page here
+                    // https://github.com/vivid-planet/comet/pull/3870
+                    return null;
+                }}
+            />
         </Switch>
     );
 };
+
+function isMasterMenuItemRoute(menu: MasterMenuData, path: string): boolean {
+    return menu.some((item) => {
+        if (item.type === "externalLink") {
+            return false;
+        }
+        if (item.type === "group") {
+            return isMasterMenuItemRoute(item.items, path);
+        }
+        if (item.route && item.route.path === path) {
+            return true;
+        }
+        if (item.type === "collapsible") {
+            return isMasterMenuItemRoute(item.items as Array<MasterMenuItem & { icon?: ReactNode }>, path);
+        }
+        return false;
+    });
+}

--- a/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
@@ -8,17 +8,19 @@ import { MasterMenuData, MasterMenuItem } from "./MasterMenu";
 export function useRoutePropsFromMasterMenuData(items: MasterMenuData): RouteProps[] {
     const isAllowed = useUserPermissionCheck();
     const checkPermission = (item: MasterMenuItem, ancestors: MasterMenuItem[]): boolean => {
+        let allowed = true;
+
         if (item.requiredPermission) {
-            return isAllowed(item.requiredPermission);
+            allowed &&= isAllowed(item.requiredPermission);
         }
 
         for (const ancestor of ancestors) {
             if (ancestor.requiredPermission) {
-                return isAllowed(ancestor.requiredPermission);
+                allowed &&= isAllowed(ancestor.requiredPermission);
             }
         }
 
-        return true;
+        return allowed;
     };
 
     const flat = (

--- a/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
@@ -60,10 +60,10 @@ export const MasterMenuRoutes = ({ menu }: MasterMenuRoutesProps) => {
 
     return (
         <Switch>
+            <Redirect to={`${match.url}${routes[0].path}`} exact={true} from={match.path} />
             {routes.map((route, index) => (
                 <RouteWithErrorBoundary key={index} {...route} path={`${match.path}${route.path}`} />
             ))}
-            <Redirect to={`${match.url}${routes[0].path}`} from={match.path} />
         </Switch>
     );
 };

--- a/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
@@ -29,10 +29,12 @@ export function useRoutePropsFromMasterMenuData(items: MasterMenuData): RoutePro
             return routes.concat(item.items.reduce((routes, child) => flat(routes, child, item), [] as RouteProps[]));
         }
         if (item.route && checkPermission(item, parent)) {
-            routes.push(item.route);
+            return routes.concat(item.route);
         }
         if (item.type === "collapsible" && !!item.items?.length) {
-            routes.concat((item.items as Array<MasterMenuItem & { icon?: ReactNode }>).reduce((routes, child) => flat(routes, child, item), routes));
+            return routes.concat(
+                (item.items as Array<MasterMenuItem & { icon?: ReactNode }>).reduce((routes, child) => flat(routes, child, item), [] as RouteProps[]),
+            );
         }
         return routes;
     };

--- a/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
@@ -7,24 +7,36 @@ import { MasterMenuData, MasterMenuItem } from "./MasterMenu";
 
 export function useRoutePropsFromMasterMenuData(items: MasterMenuData): RouteProps[] {
     const isAllowed = useUserPermissionCheck();
-    const checkPermission = (item: MasterMenuItem): boolean => !item.requiredPermission || isAllowed(item.requiredPermission);
+    const checkPermission = (item: MasterMenuItem, parent?: MasterMenuItem): boolean => {
+        if (item.requiredPermission) {
+            return isAllowed(item.requiredPermission);
+        } else if (parent?.requiredPermission) {
+            return isAllowed(parent.requiredPermission);
+        } else {
+            return true;
+        }
+    };
 
-    const flat = (routes: RouteProps[], item: MasterMenuItem & { icon?: ReactNode }): RouteProps[] => {
+    const flat = (
+        routes: RouteProps[],
+        item: MasterMenuItem & { icon?: ReactNode },
+        parent?: MasterMenuItem & { icon?: ReactNode },
+    ): RouteProps[] => {
         if (item.type === "externalLink") {
             return routes;
         }
         if (item.type === "group") {
-            return routes.concat(item.items.reduce(flat, []));
+            return routes.concat(item.items.reduce((routes, child) => flat(routes, child, item), [] as RouteProps[]));
         }
-        if (item.route && checkPermission(item)) {
+        if (item.route && checkPermission(item, parent)) {
             routes.push(item.route);
         }
         if (item.type === "collapsible" && !!item.items?.length) {
-            routes.concat((item.items as Array<MasterMenuItem & { icon?: ReactNode }>).reduce(flat, routes));
+            routes.concat((item.items as Array<MasterMenuItem & { icon?: ReactNode }>).reduce((routes, child) => flat(routes, child, item), routes));
         }
         return routes;
     };
-    return items.reduce(flat, []);
+    return items.reduce((routes, item) => flat(routes, item), [] as RouteProps[]);
 }
 
 export interface MasterMenuRoutesProps {
@@ -37,10 +49,10 @@ export const MasterMenuRoutes = ({ menu }: MasterMenuRoutesProps) => {
 
     return (
         <Switch>
-            <Redirect to={`${match.url}${routes[0].path}`} exact={true} from={match.path} />
             {routes.map((route, index) => (
                 <RouteWithErrorBoundary key={index} {...route} path={`${match.path}${route.path}`} />
             ))}
+            <Redirect to={`${match.url}${routes[0].path}`} from={match.path} />
         </Switch>
     );
 };

--- a/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
@@ -35,10 +35,10 @@ export function useRoutePropsFromMasterMenuData(items: MasterMenuData): RoutePro
             return routes.concat(item.items.reduce((routes, child) => flat(routes, child, [...ancestors, item]), [] as RouteProps[]));
         }
         if (item.route && checkPermission(item, ancestors)) {
-            return routes.concat(item.route);
+            routes = routes.concat(item.route);
         }
         if (item.type === "collapsible" && !!item.items?.length) {
-            return routes.concat(
+            routes = routes.concat(
                 (item.items as Array<MasterMenuItem & { icon?: ReactNode }>).reduce(
                     (routes, child) => flat(routes, child, [...ancestors, item]),
                     [] as RouteProps[],

--- a/packages/admin/cms-admin/src/testing/stub-file.ts
+++ b/packages/admin/cms-admin/src/testing/stub-file.ts
@@ -1,4 +1,4 @@
-// This is a stub file for testing purposes. It it used in the jest.config.ts (moduleNameMapper) in order to mock certain file types, or modules that are in ESM format
+// This is a stub file for testing purposes. It is used in the jest.config.ts (moduleNameMapper) in order to mock certain file types, or modules that are in ESM format
 // Documentation of the use of stub files in jest's moduleNameMapper can be found here: https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring
 
 export default "";

--- a/packages/admin/cms-admin/src/testing/stub-file.ts
+++ b/packages/admin/cms-admin/src/testing/stub-file.ts
@@ -1,0 +1,4 @@
+// This is a stub file for testing purposes. It it used in the jest.config.ts (moduleNameMapper) in order to mock certain file types, or modules that are in ESM format
+// Documentation of the use of stub files in jest's moduleNameMapper can be found here: https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring
+
+export default "";


### PR DESCRIPTION
## Description

It's possible to provide a required permission for a collapsible or group in `MasterMenuData`, but the parent permissions wasn't considered in `MasterMenuRoutes`. This PR adds a check for the required permission of the ancestors.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

### Error

https://github.com/user-attachments/assets/cedab3ed-e1d3-45c4-b132-4b02e8109ae4

### Fix

https://github.com/user-attachments/assets/d285b170-547c-495d-b79d-6a74f2c172e7

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1221
