### PR TITLE
Demo: Prevent responses to status requests from being cached

### DIFF
--- a/demo/admin/server/index.js
+++ b/demo/admin/server/index.js
@@ -37,6 +37,7 @@ app.use(
 );
 
 app.get("/status/health", (req, res) => {
+    res.setHeader("cache-control", "no-store");
     res.send("OK!");
 });
 

--- a/demo/api/src/status/status.controller.ts
+++ b/demo/api/src/status/status.controller.ts
@@ -1,6 +1,6 @@
 import { DisableCometGuards } from "@comet/cms-api";
 import { EntityManager } from "@mikro-orm/postgresql";
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Header } from "@nestjs/common";
 
 @Controller("status")
 @DisableCometGuards()
@@ -8,6 +8,7 @@ export class StatusController {
     constructor(private readonly entityManager: EntityManager) {}
 
     @Get("liveness")
+    @Header("Cache-Control", "no-store")
     liveness(): string {
         // If this controller returns a non 2xx status code, the pod is restarted by kubernetes
         // see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -15,6 +16,7 @@ export class StatusController {
     }
 
     @Get("readiness")
+    @Header("Cache-Control", "no-store")
     async readiness(): Promise<string> {
         // If this controller returns a non 2xx status code, the pod does not receive traffic
         // If the database is not available, it does not make sense to restart the pod

--- a/demo/api/src/status/status.controller.ts
+++ b/demo/api/src/status/status.controller.ts
@@ -8,7 +8,7 @@ export class StatusController {
     constructor(private readonly entityManager: EntityManager) {}
 
     @Get("liveness")
-    @Header("Cache-Control", "no-store")
+    @Header("cache-control", "no-store")
     liveness(): string {
         // If this controller returns a non 2xx status code, the pod is restarted by kubernetes
         // see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -16,7 +16,7 @@ export class StatusController {
     }
 
     @Get("readiness")
-    @Header("Cache-Control", "no-store")
+    @Header("cache-control", "no-store")
     async readiness(): Promise<string> {
         // If this controller returns a non 2xx status code, the pod does not receive traffic
         // If the database is not available, it does not make sense to restart the pod

--- a/demo/site/src/middleware/status.ts
+++ b/demo/site/src/middleware/status.ts
@@ -5,7 +5,7 @@ import { CustomMiddleware } from "./chain";
 export function withStatusMiddleware(middleware: CustomMiddleware) {
     return async (request: NextRequest) => {
         if (request.nextUrl.pathname === "/api/status") {
-            return NextResponse.json({ status: "OK" });
+            return NextResponse.json({ status: "OK" }, { headers: { "Cache-Control": "no-store" } });
         }
         return middleware(request);
     };

--- a/demo/site/src/middleware/status.ts
+++ b/demo/site/src/middleware/status.ts
@@ -5,7 +5,7 @@ import { CustomMiddleware } from "./chain";
 export function withStatusMiddleware(middleware: CustomMiddleware) {
     return async (request: NextRequest) => {
         if (request.nextUrl.pathname === "/api/status") {
-            return NextResponse.json({ status: "OK" }, { headers: { "Cache-Control": "no-store" } });
+            return NextResponse.json({ status: "OK" }, { headers: { "cache-control": "no-store" } });
         }
         return middleware(request);
     };


### PR DESCRIPTION
If cache-control is not explicitly defined, defaults from a CDN might apply