### PR TITLE
Remove content scope generic from changeset

### DIFF
--- a/.changeset/cyan-suns-smell.md
+++ b/.changeset/cyan-suns-smell.md
@@ -7,7 +7,7 @@ Change type of the `values` prop of ContentScopeProvider
 **Before**
 
 ```ts
-const values: ContentScopeValues<ContentScope> = [
+const values: ContentScopeValues = [
     {
         domain: { label: "Main", value: "main" },
         language: { label: "English", value: "en" },
@@ -26,7 +26,7 @@ const values: ContentScopeValues<ContentScope> = [
 **Now**
 
 ```ts
-const values: ContentScopeValues<ContentScope> = [
+const values: ContentScopeValues = [
     {
         scope: { domain: "main", language: "en" },
         label: { domain: "Main", language: "English" },


### PR DESCRIPTION
## Description

We should remove the generic from the unreleased changeset since we plan to remove the generic in https://github.com/vivid-planet/comet/pull/3756.

## Open TODOs/questions

-   [x] Merge parent PR https://github.com/vivid-planet/comet/pull/3756
