### PR TITLE
DAM: Set `cache-control: no-store` for folder download

### DIFF
--- a/.changeset/lazy-avocados-divide.md
+++ b/.changeset/lazy-avocados-divide.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+DAM: Set `cache-control: no-store` for folder download
+
+Explicitly set `cache-control: no-store` for folder download to prevent caching of the response. Normally this should not be cached by any CDN, because the Request contains a cookie, but it is better to be explicit about it.

--- a/packages/api/cms-api/src/dam/files/folders.controller.ts
+++ b/packages/api/cms-api/src/dam/files/folders.controller.ts
@@ -31,6 +31,7 @@ export class FoldersController {
 
         res.setHeader("Content-Disposition", `attachment; filename="${folder.name}.zip"`);
         res.setHeader("Content-Type", "application/zip");
+        res.setHeader("cache-control", "no-store");
         zipStream.pipe(res);
     }
 }


### PR DESCRIPTION
Explicitly set `cache-control: no-store` for folder download to prevent caching of the response. Normally this should not be cached by any CDN, because the Request contains a cookie, but it is better to be explicit about it.