### PR TITLE
Fix: admin form generator create triggers dirty handler

### DIFF
--- a/.changeset/fruity-bats-kick.md
+++ b/.changeset/fruity-bats-kick.md
@@ -2,4 +2,4 @@
 "@comet/admin-generator": patch
 ---
 
-Create Form triggered Dirtyhandler on successfull submit
+Create Form triggered Dirty-handler on successful submit

--- a/.changeset/fruity-bats-kick.md
+++ b/.changeset/fruity-bats-kick.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-generator": patch
+---
+
+Create Form triggered Dirtyhandler on successfull submit

--- a/demo/admin/src/news/generated/NewsForm.tsx
+++ b/demo/admin/src/news/generated/NewsForm.tsx
@@ -101,12 +101,15 @@ export function NewsForm({ id, scope }: FormProps) {
                 mutation: createNewsMutation,
                 variables: { input: output, scope },
             });
+
             if (!event.navigatingBack) {
                 const id = mutationResponse?.createNews.id;
                 if (id) {
+                    console.log("News Form - handleSubmit - before timeout - isDirty", form.getState().dirty);
                     setTimeout(() => {
+                        console.log("News Form - handleSubmit - in timeout - isDirty", form.getState().dirty);
                         stackSwitchApi.activatePage(`edit`, id);
-                    }, 100);
+                    });
                 }
             }
         }
@@ -123,6 +126,13 @@ export function NewsForm({ id, scope }: FormProps) {
             apiRef={formApiRef}
             onSubmit={handleSubmit}
             mode={mode}
+            onAfterSubmit={(values, form) => {
+                /*console.log("NewsForm - onAfterSubmit - beforeTimeout - isDirty", form.getState().dirty);
+                setTimeout(() => {
+                    console.log("NewsForm - onAfterSubmit - inTimeout - isDirty", form.getState().dirty);
+                    stackSwitchApi.activatePage(`edit`, id);
+                });*/
+            }}
             initialValues={initialValues}
             initialValuesEqual={isEqual} //required to compare block data correctly
             subscription={{}}

--- a/demo/admin/src/news/generated/NewsForm.tsx
+++ b/demo/admin/src/news/generated/NewsForm.tsx
@@ -106,7 +106,7 @@ export function NewsForm({ id, scope }: FormProps) {
                 if (id) {
                     setTimeout(() => {
                         stackSwitchApi.activatePage(`edit`, id);
-                    });
+                    }, 100);
                 }
             }
         }

--- a/demo/admin/src/products/future/generated/CreateCapProductForm.tsx
+++ b/demo/admin/src/products/future/generated/CreateCapProductForm.tsx
@@ -70,7 +70,7 @@ export function CreateCapProductForm({ type }: FormProps) {
             if (id) {
                 setTimeout(() => {
                     stackSwitchApi.activatePage(`edit`, id);
-                });
+                }, 100);
             }
         }
     };

--- a/demo/admin/src/products/future/generated/IdFieldInForm.tsx
+++ b/demo/admin/src/products/future/generated/IdFieldInForm.tsx
@@ -94,7 +94,7 @@ export function IdFieldInForm({ id, type, description, slug }: FormProps) {
                 if (id) {
                     setTimeout(() => {
                         stackSwitchApi.activatePage(`edit`, id);
-                    });
+                    }, 100);
                 }
             }
         }

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -165,7 +165,7 @@ export function ProductForm({ id }: FormProps) {
                 if (id) {
                     setTimeout(() => {
                         stackSwitchApi.activatePage(`edit`, id);
-                    });
+                    }, 100);
                 }
             }
         }

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateForm.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateForm.ts
@@ -458,7 +458,7 @@ export function generateForm(
                     if (id) {
                         setTimeout(() => {
                             stackSwitchApi.activatePage(\`edit\`, id);
-                        });
+                        }, 100);
                     }
                 }
                 `

--- a/packages/admin/admin/src/FinalForm.tsx
+++ b/packages/admin/admin/src/FinalForm.tsx
@@ -229,7 +229,10 @@ export function FinalForm<FormValues = AnyObject, InitialFormValues = Partial<Fo
             <FinalFormContextProvider {...formContext}>
                 {saveBoundaryApi && (
                     <FormSpy subscription={{ dirty: true }}>
-                        {(props) => <Savable hasChanges={props.dirty} doSave={doSave} doReset={doReset} />}
+                        {(props) => {
+                            console.log("FinalForm - RenderForm - isDirty", props.dirty);
+                            return <Savable hasChanges={props.dirty} doSave={doSave} doReset={doReset} />;
+                        }}
                     </FormSpy>
                 )}
                 <RouterPromptIf formApi={formRenderProps.form} doSave={doSave} subRoutePath={subRoutePath}>
@@ -261,6 +264,8 @@ export function FinalForm<FormValues = AnyObject, InitialFormValues = Partial<Fo
         return Promise.resolve(ret)
             .then((data) => {
                 // setTimeout is required because of https://github.com/final-form/final-form/pull/229
+                console.log("Final Form - handleSubmit - before timeout (onAfterSubmit) - isDirty", form.getState().dirty);
+
                 setTimeout(() => {
                     if (props.mode === "add") {
                         if (tableQuery) {
@@ -273,6 +278,7 @@ export function FinalForm<FormValues = AnyObject, InitialFormValues = Partial<Fo
                         }
                     }
 
+                    console.log("Final Form - handleSubmit - before timeout (onAfterSubmit)- isDirty", form.getState().dirty);
                     onAfterSubmit?.(values, form);
                 });
                 return data;

--- a/packages/admin/admin/src/router/Prompt.tsx
+++ b/packages/admin/admin/src/router/Prompt.tsx
@@ -39,6 +39,7 @@ export const RouterPrompt = ({ message, saveAction, resetAction, subRoutePath, c
     if (subRoutePath && subRoutePath.startsWith("./")) {
         subRoutePath = subRoutePrefix + subRoutePath.substring(1);
     }
+
     useEffect(() => {
         if (context) {
             context.register({ id, message, saveAction, resetAction, path, subRoutePath, promptRoutes });

--- a/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
+++ b/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
@@ -68,10 +68,13 @@ export const SaveBoundary = ({ onAfterSave, ...props }: PropsWithChildren<SaveBo
     }, [onAfterSave]);
 
     const reset = useCallback(() => {
+        console.log("SaveBoundary - reset");
         for (const savable of Object.values(saveStates.current)) {
             savable.doReset?.();
         }
     }, []);
+
+    console.log("SaveBoundary - render - hasChanges", hasChanges);
 
     const onSaveStatesChanged = useCallback(() => {
         const hasChanges = Object.values(saveStates.current).some((saveState) => saveState.hasChanges);
@@ -80,6 +83,7 @@ export const SaveBoundary = ({ onAfterSave, ...props }: PropsWithChildren<SaveBo
 
     const register = useCallback(
         (id: string, props: SavableProps) => {
+            console.log("SaveBoundary - Register", id);
             saveStates.current[id] = props;
             onSaveStatesChanged();
         },
@@ -87,6 +91,7 @@ export const SaveBoundary = ({ onAfterSave, ...props }: PropsWithChildren<SaveBo
     );
     const unregister = useCallback(
         (id: string) => {
+            console.log("SaveBoundary - Unregister", id);
             delete saveStates.current[id];
             onSaveStatesChanged();
         },
@@ -96,6 +101,8 @@ export const SaveBoundary = ({ onAfterSave, ...props }: PropsWithChildren<SaveBo
     return (
         <RouterPrompt
             message={() => {
+                // This decides if the dirty modal is shown or not
+                console.log("SaveBoundary - message (DECISION IF DIRTY DIALOG SHOWN) - hasChanges", hasChanges);
                 if (hasChanges) {
                     return intl.formatMessage(messages.saveUnsavedChanges);
                 }
@@ -136,11 +143,14 @@ export const Savable = ({ doSave, doReset, hasChanges }: SavableProps) => {
     const id = useConstant<string>(() => uuid());
     const saveBoundaryApi = useSaveBoundaryApi();
     if (!saveBoundaryApi) throw new Error("Savable must be inside SaveBoundary");
+
+    console.log("Savable - render - hasChanges (IMPORTANT)", hasChanges);
+
     useEffect(() => {
         saveBoundaryApi.register(id, { doSave, doReset, hasChanges });
         return function cleanup() {
             saveBoundaryApi.unregister(id);
         };
     }, [id, doSave, doReset, hasChanges, saveBoundaryApi]);
-    return null;
+    return <div style={{ backgroundColor: "red" }}>Savable {hasChanges.toString()}</div>;
 };


### PR DESCRIPTION
## Description

A Form - generated with the Admin Generator - in mode `add` behaves wrongly and triggers the DirtyHandler on a successful submission. If user says enters save to DirtyHandler Modal -> the entity gets created twice, because the mutation got sent twice.

This Pull Request will fix this behaviour by delaying the navigation to the edit page by 100 ms.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| ![Screen Recording 2025-05-06 at 10 56 15](https://github.com/user-attachments/assets/2b77af5b-d13f-448e-bdcb-f67a12c48d2b) |  ![Screen Recording 2025-05-06 at 11 04 48](https://github.com/user-attachments/assets/33dab2b6-d28b-4b5e-9ad7-d131da7a4e95) |
