### PR TITLE
fix: make description required in Product Form

### DIFF
--- a/demo/admin/src/products/future/ProductForm.cometGen.tsx
+++ b/demo/admin/src/products/future/ProductForm.cometGen.tsx
@@ -29,7 +29,7 @@ export default defineConfig<GQLProduct>({
                 },
                 { type: "text", name: "slug", required: true },
                 { type: "date", name: "createdAt", label: "Created", readOnly: true },
-                { type: "text", name: "description", label: "Description", multiline: true, required: false },
+                { type: "text", name: "description", label: "Description", multiline: true, required: true },
                 {
                     type: "staticSelect",
                     name: "type",

--- a/demo/admin/src/products/future/generated/ProductForm.tsx
+++ b/demo/admin/src/products/future/generated/ProductForm.tsx
@@ -133,7 +133,6 @@ export function ProductForm({ id }: FormProps) {
         if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");
         const output = {
             ...formValues,
-            description: formValues.description ?? "",
             category: formValues.category ? formValues.category.id : null,
             dimensions:
                 dimensionsEnabled && formValues.dimensions
@@ -247,6 +246,7 @@ export function ProductForm({ id }: FormProps) {
                             />
 
                             <TextAreaField
+                                required
                                 variant="horizontal"
                                 fullWidth
                                 name="description"


### PR DESCRIPTION
## Description

The `description` field in the Demo's ProductForm is wrongly configured as `required: false` - it is required in the API. This leads to when the User wants to fill out the ProductForm and misses the description field - that he receives and API error.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  ![Screen Recording 2025-05-06 at 11 18 46](https://github.com/user-attachments/assets/b0f06483-db19-42d4-8164-666f90fdc3ac) | ![Screen Recording 2025-05-06 at 11 20 00](https://github.com/user-attachments/assets/d160b0c3-f720-4906-b3ed-d8cd331d912e)  |
