### PR TITLE
Bugfixes warning module

### DIFF
--- a/packages/api/cms-api/src/warnings/warning-checker.command.ts
+++ b/packages/api/cms-api/src/warnings/warning-checker.command.ts
@@ -100,7 +100,7 @@ export class WarningCheckerCommand extends CommandRunner {
 
                             if (this.isBlockWarningService(warningsOrWarningsService)) {
                                 const warningsService = warningsOrWarningsService;
-                                const service: BlockWarningsServiceInterface = await this.moduleRef.resolve(warningsService);
+                                const service: BlockWarningsServiceInterface = await this.moduleRef.get(warningsService, { strict: false });
 
                                 warnings = await service.warnings(node.block);
                             } else {

--- a/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
+++ b/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
@@ -86,7 +86,7 @@ export class WarningEventSubscriber implements EventSubscriber {
 
                     if (this.isBlockWarningService(warningsOrWarningsService)) {
                         const warningsService = warningsOrWarningsService;
-                        const service: BlockWarningsServiceInterface = await this.moduleRef.resolve(warningsService);
+                        const service: BlockWarningsServiceInterface = await this.moduleRef.get(warningsService, { strict: false });
 
                         warnings = await service.warnings(node.block);
                     } else {

--- a/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
+++ b/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
@@ -135,6 +135,7 @@ export class WarningEventSubscriber implements EventSubscriber {
                         warnings,
                         type: "Entity",
                         sourceInfo,
+                        scope: row.scope,
                     });
                     await this.warningService.deleteOutdatedWarnings({ date: startDate, type: "Entity", sourceInfo });
                 }


### PR DESCRIPTION
## Description

First commit fixes this error:
<img width="1665" alt="Screenshot 2025-05-07 at 12 26 32" src="https://github.com/user-attachments/assets/14226c0b-1fe8-48e9-bd50-63dfed9bf3fb" />

**As far as I read about it:**
 - this.moduleRef.resolve resolves a new instance of the service each time it is called.
 - this.moduleRef.get returns the same instance (singleton) of the service and gets the provider from the nestjs injection container

But in general i'm not quite sure when i should use which method. But resolve throws an error and it works with get. 

Second commit fixes an error where scope was not correctly set when updating/creating, but it worked for executing the console/command job

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1979
