### PR TITLE
Set correct permission for warning module in master menu

### DIFF
--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -190,7 +190,7 @@ export const masterMenuData: MasterMenuData = [
                     path: "/system/warnings",
                     component: WarningsPage,
                 },
-                requiredPermission: "pageTree",
+                requiredPermission: "warnings",
             },
         ],
     },


### PR DESCRIPTION
## Description
The permission was wrong, it should be warnings:
https://github.com/vivid-planet/comet/blob/feature/warning-module/packages/api/cms-api/src/warnings/warning.resolver.ts#L18

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1979
