### PR TITLE
Remove TODO for checking the data in the database

### DIFF
--- a/packages/api/cms-api/src/warnings/warning-checker.command.ts
+++ b/packages/api/cms-api/src/warnings/warning-checker.command.ts
@@ -48,7 +48,6 @@ export class WarningCheckerCommand extends CommandRunner {
     async run(): Promise<void> {
         let startDate = new Date();
 
-        // TODO: (in the next PRs) Check if data itself is valid in the database. (Maybe some data was put into database and is not correct or a migration was done wrong)
         for (const data of this.groupRootBlockDataByEntity()) {
             const { tableName, className, rootBlockData, hasScope } = data;
 


### PR DESCRIPTION
## Description

When I started with the warnings module I thought about checking the data in the database as well. 
In case someone made for example a wrong block migration.

In one of our last meetings I think we discussed that that is not really possible if I remember correctly, so I'm removing the comment.

And such an error would be for a developer to fix and the WarningsModule currently is targeted for content editors.

or do you think we should discuss the topic again in detail?

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1979
