### PR TITLE
API Generator: Add support for extending entities

### DIFF
--- a/.changeset/small-islands-create.md
+++ b/.changeset/small-islands-create.md
@@ -1,0 +1,5 @@
+---
+"@comet/api-generator": minor
+---
+
+Add basic support for inheritance used by entities

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-extend-entity.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-extend-entity.spec.ts
@@ -60,10 +60,10 @@ describe("GenerateCrudInputExtendEntity", () => {
         const updatedAtField = properties.find((prop) => prop.name === "updatedAt");
 
         expect(createdAtField).toBeDefined();
-        expect(createdAtField?.type).toBe("DateFilter");
+        expect(createdAtField?.type).toBe("DateTimeFilter");
 
         expect(updatedAtField).toBeDefined();
-        expect(updatedAtField?.type).toBe("DateFilter");
+        expect(updatedAtField?.type).toBe("DateTimeFilter");
 
         orm.close();
     });

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-extend-entity.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-extend-entity.spec.ts
@@ -1,0 +1,70 @@
+import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
+import { Field } from "@nestjs/graphql";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { v4 as uuid } from "uuid";
+
+import { formatGeneratedFiles, parseSource } from "../../utils/test-helper";
+import { generateCrud } from "../generate-crud";
+
+@Entity({ abstract: true })
+export abstract class TimestampEntity extends BaseEntity {
+    @Property({
+        columnType: "timestamp with time zone",
+    })
+    @Field()
+    createdAt: Date = new Date();
+
+    @Property({ onUpdate: () => new Date(), columnType: "timestamp with time zone" })
+    @Field()
+    updatedAt: Date = new Date();
+}
+
+@Entity()
+export class TestEntityWithTimestamps extends TimestampEntity {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @Property()
+    foo: string;
+}
+
+describe("GenerateCrudInputExtendEntity", () => {
+    it("should include timestamp fields in the generated CRUD files", async () => {
+        LazyMetadataStorage.load();
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                connect: false,
+                entities: [TestEntityWithTimestamps, TimestampEntity],
+            }),
+        );
+
+        const out = await generateCrud({ targetDirectory: __dirname }, orm.em.getMetadata().get("TestEntityWithTimestamps"));
+        const formattedOut = await formatGeneratedFiles(out);
+
+        const file = formattedOut.find((file) => file.name === "dto/test-entity-with-timestamps.filter.ts");
+        if (!file) throw new Error("File not found");
+
+        const source = parseSource(file.content);
+
+        const classes = source.getClasses();
+        expect(classes.length).toBe(1);
+
+        const cls = classes[0];
+        expect(cls.getName()).toBe("TestEntityWithTimestampsFilter");
+
+        const structure = cls.getStructure();
+        const properties = structure.properties || [];
+
+        const createdAtField = properties.find((prop) => prop.name === "createdAt");
+        const updatedAtField = properties.find((prop) => prop.name === "updatedAt");
+
+        expect(createdAtField).toBeDefined();
+        expect(createdAtField?.type).toBe("DateFilter");
+
+        expect(updatedAtField).toBeDefined();
+        expect(updatedAtField?.type).toBe("DateFilter");
+
+        orm.close();
+    });
+});

--- a/packages/api/api-generator/src/commands/generate/utils/ts-morph-helper.ts
+++ b/packages/api/api-generator/src/commands/generate/utils/ts-morph-helper.ts
@@ -21,8 +21,14 @@ function morphTsClass(metadata: EntityMetadata<any>) {
     return tsClass;
 }
 export function morphTsProperty(name: string, metadata: EntityMetadata<any>) {
-    const tsClass = morphTsClass(metadata);
-    return tsClass.getPropertyOrThrow(name);
+    let currentClass: ClassDeclaration | undefined = morphTsClass(metadata);
+    while (currentClass) {
+        const prop = currentClass.getProperty(name);
+        if (prop) return prop;
+
+        currentClass = currentClass.getBaseClass();
+    }
+    throw new Error(`Property ${name} not found in ${metadata.className}`);
 }
 
 function findImportPath(importName: string, targetDirectory: string, metadata: EntityMetadata<any>) {


### PR DESCRIPTION
## Description

Add support for extending entities in API Generator.

## Example

```
@Entity({ abstract: true })
export abstract class TimestampEntity extends BaseEntity {
    @Property({
        columnType: "timestamp with time zone",
    })
    @Field()
    createdAt: Date = new Date();

    @Property({ onUpdate: () => new Date(), columnType: "timestamp with time zone" })
    @Field()
    updatedAt: Date = new Date();
}

@Entity()
export class TestEntityWithTimestamps extends TimestampEntity {
    @PrimaryKey({ type: "uuid" })
    id: string = uuid();

    @Property()
    foo: string;
}
```

NOTE: We don't recommend inheritance for code reusage

## Limits

This is just basic support, it will probably break when the base class involves root blocks or enums (where we depend on ts-morph)