### PR TITLE
Add story for RteWithoutAutofocus

### DIFF
--- a/storybook/src/admin-rte/RteWithoutAutofocus.stories.tsx
+++ b/storybook/src/admin-rte/RteWithoutAutofocus.stories.tsx
@@ -1,0 +1,64 @@
+import { IRteOptions, makeRteApi, Rte } from "@comet/admin-rte";
+import { Box, Card, CardContent } from "@mui/material";
+import { ReactNode } from "react";
+
+import { PrintEditorState } from "./helper";
+
+const GreenCustomHeader = ({ children }: { children?: ReactNode }) => <h2 style={{ color: "green" }}>{children}</h2>;
+
+export const rteOptions: IRteOptions = {
+    supports: [
+        "bold",
+        "italic",
+        "underline",
+        "strikethrough",
+        "sub",
+        "sup",
+        "header-one",
+        "header-two",
+        "header-three",
+        "header-four",
+        "header-five",
+        "header-six",
+    ],
+    listLevelMax: 2,
+    blocktypeMap: {
+        "header-custom-green": {
+            label: "Custom Green Header",
+            renderConfig: {
+                element: (p) => <GreenCustomHeader {...p} />,
+                aliasedElements: ["h2"],
+            },
+        },
+    },
+    standardBlockType: "header-custom-green",
+};
+
+const [useRteApi] = makeRteApi();
+
+export default {
+    title: "@comet/admin-rte",
+
+    excludeStories: ["makeApiOptions", "apiOptions", "rteOptions"],
+};
+
+export const RteStandardBlockType = {
+    render: () => {
+        const { editorState, setEditorState } = useRteApi();
+
+        return (
+            <>
+                <Box marginBottom={4}>
+                    <Card variant="outlined">
+                        <CardContent>
+                            <Rte value={editorState} onChange={setEditorState} options={rteOptions} />
+                        </CardContent>
+                    </Card>
+                </Box>
+                <PrintEditorState editorState={editorState} />
+            </>
+        );
+    },
+
+    name: "Rte without autofocus",
+};


### PR DESCRIPTION
## Description

Issue: When a `standardBlockType` is defined in the RTE, the type is not preselected in the dropdown. The `editorState` with the correct type is only updated after clicking into the RTE field.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

https://github.com/user-attachments/assets/23e2b289-68bf-4b4a-b6c8-13d1b6bcd687

## Open TODOs/questions

-   [x] Add changeset
