### PR TITLE
Fix console error when rendering generated icons

### DIFF
--- a/.changeset/pink-wings-deny.md
+++ b/.changeset/pink-wings-deny.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-icons": patch
+---
+
+generate-icons.ts converts svg attributes into camelCase to generate valid JSX

--- a/.changeset/pink-wings-deny.md
+++ b/.changeset/pink-wings-deny.md
@@ -2,4 +2,4 @@
 "@comet/admin-icons": patch
 ---
 
-generate-icons.ts converts svg attributes into camelCase to generate valid JSX
+Transform SVG attributes into camelCase to generate valid JSX

--- a/packages/admin/admin-icons/generate-icons.ts
+++ b/packages/admin/admin-icons/generate-icons.ts
@@ -78,10 +78,9 @@ const getSVGData = (icon: Icon) => {
 
             return true;
         },
-    });
-    const parsed = parsedXml.parse(fileContents.toString());
+    }).parse(fileContents.toString());
 
-    return parsed.svg;
+    return parsedXml.svg;
 };
 
 const writeComponent = async (icon: Icon, svgString: string) => {

--- a/packages/admin/admin-icons/generate-icons.ts
+++ b/packages/admin/admin-icons/generate-icons.ts
@@ -69,9 +69,29 @@ const getSVGData = (icon: Icon) => {
             delete attrs["@_fill"];
             return true;
         },
-    }).parse(fileContents.toString());
+    });
+    const parsed = parsedXml.parse(fileContents.toString());
 
-    return parsedXml.svg;
+    return convertAttributesToCamelCase(parsed.svg);
+};
+
+const convertAttributesToCamelCase = (node: any): any => {
+    if (Array.isArray(node)) {
+        return node.map(convertAttributesToCamelCase);
+    }
+
+    if (typeof node !== "object" || node === null) {
+        return node;
+    }
+
+    const result: any = {};
+
+    for (const [key, value] of Object.entries(node)) {
+        const camelCaseKey = key.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+        result[camelCaseKey] = convertAttributesToCamelCase(value);
+    }
+
+    return result;
 };
 
 const writeComponent = async (icon: Icon, svgString: string) => {

--- a/packages/admin/admin-icons/generate-icons.ts
+++ b/packages/admin/admin-icons/generate-icons.ts
@@ -67,31 +67,21 @@ const getSVGData = (icon: Icon) => {
         ignoreAttributes: false,
         updateTag(_, __, attrs) {
             delete attrs["@_fill"];
+            // Convert all attribute keys to camelCase
+            for (const key of Object.keys(attrs)) {
+                const camelKey = key.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+                if (camelKey !== key) {
+                    attrs[camelKey] = attrs[key];
+                    delete attrs[key];
+                }
+            }
+
             return true;
         },
     });
     const parsed = parsedXml.parse(fileContents.toString());
 
-    return convertAttributesToCamelCase(parsed.svg);
-};
-
-const convertAttributesToCamelCase = (node: any): any => {
-    if (Array.isArray(node)) {
-        return node.map(convertAttributesToCamelCase);
-    }
-
-    if (typeof node !== "object" || node === null) {
-        return node;
-    }
-
-    const result: any = {};
-
-    for (const [key, value] of Object.entries(node)) {
-        const camelCaseKey = key.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
-        result[camelCaseKey] = convertAttributesToCamelCase(value);
-    }
-
-    return result;
+    return parsed.svg;
 };
 
 const writeComponent = async (icon: Icon, svgString: string) => {


### PR DESCRIPTION
## Description

Currently, the `generated-icons.ts` script of the `@comet/admin-icons` package is generating Icons with incorrect usage of SVG attributes. It is using those attributes (e.g., `clip-rule` or `fill-rule`  in snake-case syntax, because the script is simply forwarding the attributes like in the original SVG. In JSX, those attributes must be in camelCase. 

This leads, for example, to the following console errors in the demo and in projects.:

![Screenshot 2025-05-14 at 08 06 03](https://github.com/user-attachments/assets/67c6403f-3430-4eac-b621-727f6ccb43e0)

![Screenshot 2025-05-14 at 08 06 07](https://github.com/user-attachments/assets/870a04a0-dbd2-4282-8367-269c7dcac5cf)


This Pull Request fixes this issue.

### Generated Icons 

before:

<img width="1606" alt="Screenshot 2025-05-14 at 08 05 50" src="https://github.com/user-attachments/assets/2ec02f32-286e-429c-b2a8-c1c8e5fa7d86" />

after:

<img width="1647" alt="Screenshot 2025-05-14 at 07 58 46" src="https://github.com/user-attachments/assets/ce52e3c6-3605-49dc-a971-5ebb224c4eea" />
