### PR TITLE
Revert deprecation of Final Form components and mention that fields should be preferred

### DIFF
--- a/packages/admin/admin-color-picker/src/FinalFormColorPicker.tsx
+++ b/packages/admin/admin-color-picker/src/FinalFormColorPicker.tsx
@@ -4,6 +4,11 @@ import { ColorPicker, type ColorPickerProps } from "./ColorPicker";
 
 export type FinalFormColorPickerProps = ColorPickerProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
 
+/**
+ * Final Form-compatible ColorPicker component.
+ *
+ * @see {@link ColorField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export const FinalFormColorPicker = ({ meta, input, ...restProps }: FinalFormColorPickerProps) => {
     return <ColorPicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-color-picker/src/index.ts
+++ b/packages/admin/admin-color-picker/src/index.ts
@@ -2,13 +2,4 @@ export { ColorField, ColorFieldProps } from "./ColorField";
 export { ColorPickerNoColorPreviewProps } from "./ColorPicker";
 export { ColorPicker, ColorPickerColorPreviewProps, ColorPickerProps, ColorPickerPropsComponents } from "./ColorPicker";
 export { ColorPickerClassKey } from "./ColorPicker.slots";
-export {
-    /**
-     * @deprecated Use `<ColorField />` instead of `<Field component={FinalFormColorPicker} />`
-     */
-    FinalFormColorPicker,
-    /**
-     * @deprecated Use `<ColorField />` instead of `<Field component={FinalFormColorPicker} />`
-     */
-    FinalFormColorPickerProps,
-} from "./FinalFormColorPicker";
+export { FinalFormColorPicker, FinalFormColorPickerProps } from "./FinalFormColorPicker";

--- a/packages/admin/admin-date-time/src/datePicker/FinalFormDatePicker.tsx
+++ b/packages/admin/admin-date-time/src/datePicker/FinalFormDatePicker.tsx
@@ -4,6 +4,11 @@ import { DatePicker, type DatePickerProps } from "./DatePicker";
 
 export type FinalFormDatePickerProps = DatePickerProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
 
+/**
+ * Final Form-compatible DatePicker component.
+ *
+ * @see {@link DateField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export const FinalFormDatePicker = ({ meta, input, ...restProps }: FinalFormDatePickerProps) => {
     return <DatePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/dateRangePicker/FinalFormDateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/FinalFormDateRangePicker.tsx
@@ -4,6 +4,11 @@ import { type DateRange, DateRangePicker, type DateRangePickerProps } from "./Da
 
 export type FinalFormDateRangePickerProps = DateRangePickerProps & FieldRenderProps<DateRange, HTMLInputElement | HTMLTextAreaElement>;
 
+/**
+ * Final Form-compatible DateRangerPicker component.
+ *
+ * @see {@link DateRangeField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export const FinalFormDateRangePicker = ({ meta, input, ...restProps }: FinalFormDateRangePickerProps) => {
     return <DateRangePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/dateTimePicker/FinalFormDateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/FinalFormDateTimePicker.tsx
@@ -4,6 +4,11 @@ import { DateTimePicker, type DateTimePickerProps } from "./DateTimePicker";
 
 export type FinalFormDateTimePickerProps = DateTimePickerProps & FieldRenderProps<Date, HTMLInputElement | HTMLTextAreaElement>;
 
+/**
+ * Final Form-compatible DateTimePicker component.
+ *
+ * @see {@link DateTimeField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export const FinalFormDateTimePicker = ({ meta, input, ...restProps }: FinalFormDateTimePickerProps) => {
     return <DateTimePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/index.ts
+++ b/packages/admin/admin-date-time/src/index.ts
@@ -1,61 +1,20 @@
 export { DateField, DateFieldProps } from "./datePicker/DateField";
 export { DatePicker, DatePickerProps } from "./datePicker/DatePicker";
-export {
-    /**
-     * @deprecated Use `<DateField />` instead of `<Field component={FinalFormDatePicker} />`
-     */
-    FinalFormDatePicker,
-    /**
-     * @deprecated Use `<DateField />` instead of `<Field component={FinalFormDatePicker} />`
-     */
-    FinalFormDatePickerProps,
-} from "./datePicker/FinalFormDatePicker";
+export { FinalFormDatePicker, FinalFormDatePickerProps } from "./datePicker/FinalFormDatePicker";
 export { DatePickerNavigationClassKey, DatePickerNavigationProps } from "./DatePickerNavigation";
 export { DateRangeField, DateRangeFieldProps } from "./dateRangePicker/DateRangeField";
 export { DateRange, DateRangePicker, DateRangePickerProps } from "./dateRangePicker/DateRangePicker";
-export {
-    /**
-     * @deprecated Use `<DateRangeField />` instead of `<Field component={FinalFormDateRangePicker} />`
-     */
-    FinalFormDateRangePicker,
-    /**
-     * @deprecated Use `<DateRangeField />` instead of `<Field component={FinalFormDateRangePicker} />`
-     */
-    FinalFormDateRangePickerProps,
-} from "./dateRangePicker/FinalFormDateRangePicker";
+export { FinalFormDateRangePicker, FinalFormDateRangePickerProps } from "./dateRangePicker/FinalFormDateRangePicker";
 export { DateTimeField, DateTimeFieldProps } from "./dateTimePicker/DateTimeField";
 export { DateTimePickerClassKey } from "./dateTimePicker/DateTimePicker";
 export { DateTimePicker, DateTimePickerProps } from "./dateTimePicker/DateTimePicker";
-export {
-    /**
-     * @deprecated Use `<DateTimeField />` instead of `<Field component={FinalFormDateTimePicker} />`
-     */
-    FinalFormDateTimePicker,
-    /**
-     * @deprecated Use `<DateTimeField />` instead of `<Field component={FinalFormDateTimePicker} />`
-     */
-    FinalFormDateTimePickerProps,
-} from "./dateTimePicker/FinalFormDateTimePicker";
+export { FinalFormDateTimePicker, FinalFormDateTimePickerProps } from "./dateTimePicker/FinalFormDateTimePicker";
 export { FinalFormTimePickerProps } from "./timePicker/FinalFormTimePicker";
-export {
-    /**
-     * @deprecated Use `<TimeField />` instead of `<Field component={FinalFormTimePicker} />`
-     */
-    FinalFormTimePicker,
-} from "./timePicker/FinalFormTimePicker";
+export { FinalFormTimePicker } from "./timePicker/FinalFormTimePicker";
 export { TimeField, TimeFieldProps } from "./timePicker/TimeField";
 export { TimePickerClassKey } from "./timePicker/TimePicker";
 export { TimePicker, TimePickerProps } from "./timePicker/TimePicker";
-export {
-    /**
-     * @deprecated Use `<TimeRangeField />` instead of `<Field component={FinalFormTimeRangePicker} />`
-     */
-    FinalFormTimeRangePicker,
-    /**
-     * @deprecated Use `<TimeRangeField />` instead of `<Field component={FinalFormTimeRangePicker} />`
-     */
-    FinalFormTimeRangePickerProps,
-} from "./timeRangePicker/FinalFormTimeRangePicker";
+export { FinalFormTimeRangePicker, FinalFormTimeRangePickerProps } from "./timeRangePicker/FinalFormTimeRangePicker";
 export { TimeRangeField, TimeRangeFieldProps } from "./timeRangePicker/TimeRangeField";
 export { TimeRangePickerClassKey } from "./timeRangePicker/TimeRangePicker";
 export { TimeRange, TimeRangePicker, TimeRangePickerProps } from "./timeRangePicker/TimeRangePicker";

--- a/packages/admin/admin-date-time/src/timePicker/FinalFormTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/FinalFormTimePicker.tsx
@@ -4,6 +4,11 @@ import { TimePicker, type TimePickerProps } from "./TimePicker";
 
 export type FinalFormTimePickerProps = TimePickerProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
 
+/**
+ * Final Form-compatible TimePicker component.
+ *
+ * @see {@link TimeField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export const FinalFormTimePicker = ({ meta, input, ...restProps }: FinalFormTimePickerProps) => {
     return <TimePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/timeRangePicker/FinalFormTimeRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/timeRangePicker/FinalFormTimeRangePicker.tsx
@@ -4,6 +4,11 @@ import { type TimeRange, TimeRangePicker, type TimeRangePickerProps } from "./Ti
 
 export type FinalFormTimeRangePickerProps = TimeRangePickerProps & FieldRenderProps<TimeRange, HTMLInputElement | HTMLTextAreaElement>;
 
+/**
+ * Final Form-compatible TimeRangePicker component.
+ *
+ * @see {@link TimeRangeField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export const FinalFormTimeRangePicker = ({ meta, input, ...restProps }: FinalFormTimeRangePickerProps) => {
     return <TimeRangePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -16,6 +16,11 @@ export type FinalFormAutocompleteProps<
         clearable?: boolean;
     };
 
+/**
+ * Final Form-compatible Autocomplete component.
+ *
+ * @see {@link AutocompleteField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export const FinalFormAutocomplete = <
     T extends Record<string, any>,
     Multiple extends boolean | undefined,

--- a/packages/admin/admin/src/form/Checkbox.tsx
+++ b/packages/admin/admin/src/form/Checkbox.tsx
@@ -4,7 +4,9 @@ import { type FieldRenderProps } from "react-final-form";
 export type FinalFormCheckboxProps = FieldRenderProps<string, HTMLInputElement> & CheckboxProps;
 
 /**
- * @deprecated Use CheckboxListField or CheckboxField instead
+ * Final Form-compatible Checkbox component.
+ *
+ * @see {@link CheckboxField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
 export const FinalFormCheckbox = ({ input: { checked, name, onChange, ...restInput }, meta, ...rest }: FinalFormCheckboxProps) => {
     return <MuiCheckbox {...rest} name={name} inputProps={restInput} onChange={onChange} checked={checked} />;

--- a/packages/admin/admin/src/form/FinalFormAsyncAutocomplete.tsx
+++ b/packages/admin/admin/src/form/FinalFormAsyncAutocomplete.tsx
@@ -10,6 +10,11 @@ export interface FinalFormAsyncAutocompleteProps<
     loadOptions: () => Promise<T[]>;
 }
 
+/**
+ * Final Form-compatible AsyncAutocomplete component.
+ *
+ * @see {@link AsyncAutocompleteField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export function FinalFormAsyncAutocomplete<
     T extends Record<string, any>,
     Multiple extends boolean | undefined,

--- a/packages/admin/admin/src/form/FinalFormAsyncSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormAsyncSelect.tsx
@@ -7,6 +7,11 @@ export interface FinalFormAsyncSelectProps<T> extends FinalFormSelectProps<T>, O
     loadOptions: () => Promise<T[]>;
 }
 
+/**
+ * Final Form-compatible AsyncSelect component.
+ *
+ * @see {@link AsyncSelectField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export function FinalFormAsyncSelect<T>({ loadOptions, ...rest }: FinalFormAsyncSelectProps<T>) {
     return <FinalFormSelect<T> {...useAsyncOptionsProps(loadOptions)} {...rest} />;
 }

--- a/packages/admin/admin/src/form/FinalFormNumberInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormNumberInput.tsx
@@ -11,6 +11,11 @@ export type FinalFormNumberInputProps = InputBaseProps &
         decimals?: number;
     };
 
+/**
+ * Final Form-compatible NumberInput component.
+ *
+ * @see {@link NumberField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export function FinalFormNumberInput({ meta, input, innerRef, clearable, endAdornment, decimals = 0, ...props }: FinalFormNumberInputProps) {
     const intl = useIntl();
 

--- a/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
+++ b/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
@@ -12,6 +12,11 @@ export interface FinalFormSearchTextFieldProps extends FinalFormInputProps {
     clearable?: boolean;
 }
 
+/**
+ * Final Form-compatible SearchTextField component.
+ *
+ * @see {@link SearchField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export function FinalFormSearchTextField(inProps: FinalFormSearchTextFieldProps) {
     const {
         icon = <Search />,

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -23,6 +23,11 @@ const getHasClearableContent = (value: unknown, multiple: boolean | undefined) =
     return value !== undefined && value !== "";
 };
 
+/**
+ * Final Form-compatible Select component.
+ *
+ * @see {@link SelectField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export const FinalFormSelect = <T,>({
     input: { checked, value, name, onChange, onFocus, onBlur, ...restInput },
     meta,

--- a/packages/admin/admin/src/form/FinalFormToggleButtonGroup.tsx
+++ b/packages/admin/admin/src/form/FinalFormToggleButtonGroup.tsx
@@ -8,6 +8,11 @@ export interface FinalFormToggleButtonGroupProps<FieldValue> extends FieldRender
     optionsPerRow?: number;
 }
 
+/**
+ * Final Form-compatible ToggleButtonGroup component.
+ *
+ * @see {@link ToggleButtonGroupField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export function FinalFormToggleButtonGroup<FieldValue = unknown>({
     input: { value, onChange },
     options,

--- a/packages/admin/admin/src/form/Radio.tsx
+++ b/packages/admin/admin/src/form/Radio.tsx
@@ -2,8 +2,11 @@ import MuiRadio, { type RadioProps } from "@mui/material/Radio";
 import { type FieldRenderProps } from "react-final-form";
 
 export type FinalFormRadioProps = RadioProps & FieldRenderProps<string, HTMLInputElement>;
+
 /**
- * @deprecated Use RadioGroupField instead
+ * Final Form-compatible RadioGroup component.
+ *
+ * @see {@link RadioGroupField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
 export const FinalFormRadio = ({ input: { checked, value, name, onChange, ...restInput }, meta, ...rest }: FinalFormRadioProps) => (
     <MuiRadio {...rest} name={name} inputProps={restInput} onChange={onChange} checked={!!checked} value={value} />

--- a/packages/admin/admin/src/form/Switch.tsx
+++ b/packages/admin/admin/src/form/Switch.tsx
@@ -3,6 +3,11 @@ import { type FieldRenderProps } from "react-final-form";
 
 export type FinalFormSwitchProps = SwitchProps & FieldRenderProps<string, HTMLInputElement>;
 
+/**
+ * Final Form-compatible Switch component.
+ *
+ * @see {@link SwitchField} – preferred for typical form use. Use this only if no Field wrapper is needed.
+ */
 export const FinalFormSwitch = ({ input: { checked, name, onChange, ...restInput }, meta, ...rest }: FinalFormSwitchProps) => {
     return <MuiSwitch {...rest} name={name} inputProps={restInput} onChange={onChange} checked={checked} />;
 };

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -88,26 +88,8 @@ export {
     FinalFormSaveCancelButtonsLegacyProps,
 } from "./FinalFormSaveCancelButtonsLegacy";
 export { FinalFormSaveSplitButton } from "./FinalFormSaveSplitButton";
-export {
-    /**
-     * @deprecated Use `<AutocompleteField />` instead of `<Field component={FinalFormAutocomplete} />`
-     */
-    FinalFormAutocomplete,
-    /**
-     * @deprecated Use `<AutocompleteField />` instead of `<Field component={FinalFormAutocomplete} />`
-     */
-    FinalFormAutocompleteProps,
-} from "./form/Autocomplete";
-export {
-    /**
-     * @deprecated Use `<CheckboxField />` instead of `<Field />` with `<FormControlLabel />` and `<FinalFormCheckbox />`
-     */
-    FinalFormCheckbox,
-    /**
-     * @deprecated Use `<CheckboxField />` instead of `<Field />` with `<FormControlLabel />` and `<FinalFormCheckbox />`
-     */
-    FinalFormCheckboxProps,
-} from "./form/Checkbox";
+export { FinalFormAutocomplete, FinalFormAutocompleteProps } from "./form/Autocomplete";
+export { FinalFormCheckbox, FinalFormCheckboxProps } from "./form/Checkbox";
 export { Field, FieldProps } from "./form/Field";
 export { FieldContainer, FieldContainerClassKey, FieldContainerProps } from "./form/FieldContainer";
 export { AsyncAutocompleteField, AsyncAutocompleteFieldProps } from "./form/fields/AsyncAutocompleteField";
@@ -128,83 +110,20 @@ export { FileDropzone, FileDropzoneClassKey, FileDropzoneProps } from "./form/fi
 export { FileSelect, FileSelectClassKey, FileSelectProps } from "./form/file/FileSelect";
 export { ErrorFileSelectItem, FileSelectItem, LoadingFileSelectItem, ValidFileSelectItem } from "./form/file/fileSelectItemTypes";
 export { FileSelectListItem, FileSelectListItemClassKey, FileSelectListItemProps } from "./form/file/FileSelectListItem";
-export {
-    /**
-     * @deprecated Use `<AsyncAutocompleteField />` instead of `<Field component={FinalFormAsyncAutocomplete} />`
-     */
-    FinalFormAsyncAutocomplete,
-    /**
-     * @deprecated Use `<AsyncAutocompleteField />` instead of `<Field component={FinalFormAsyncAutocomplete} />`
-     */
-    FinalFormAsyncAutocompleteProps,
-} from "./form/FinalFormAsyncAutocomplete";
-export {
-    /**
-     * @deprecated Use `<AsyncSelectField />` instead of `<Field component={FinalFormAsyncSelect} />`
-     */
-    FinalFormAsyncSelect,
-    /**
-     * @deprecated Use `<AsyncSelectField />` instead of `<Field component={FinalFormAsyncSelect} />`
-     */
-    FinalFormAsyncSelectProps,
-} from "./form/FinalFormAsyncSelect";
+export { FinalFormAsyncAutocomplete, FinalFormAsyncAutocompleteProps } from "./form/FinalFormAsyncAutocomplete";
+export { FinalFormAsyncSelect, FinalFormAsyncSelectProps } from "./form/FinalFormAsyncSelect";
 export { FinalFormContext, FinalFormContextProvider, FinalFormContextProviderProps, useFinalFormContext } from "./form/FinalFormContextProvider";
 export { FinalFormFileSelect, FinalFormFileSelectProps } from "./form/FinalFormFileSelect";
 export { FinalFormInput, FinalFormInputProps } from "./form/FinalFormInput";
-export {
-    /**
-     * @deprecated Use `<NumberField />` instead of `<Field component={FinalFormNumberInput} />`
-     */
-    FinalFormNumberInput,
-    /**
-     * @deprecated Use `<NumberField />` instead of `<Field component={FinalFormNumberInput} />`
-     */
-    FinalFormNumberInputProps,
-} from "./form/FinalFormNumberInput";
+export { FinalFormNumberInput, FinalFormNumberInputProps } from "./form/FinalFormNumberInput";
 export { FinalFormRangeInput, FinalFormRangeInputClassKey, FinalFormRangeInputProps } from "./form/FinalFormRangeInput";
-export {
-    /**
-     * @deprecated Use `<SearchField />` instead of `<Field component={FinalFormSearchTextField} />`
-     */
-    FinalFormSearchTextField,
-    /**
-     * @deprecated Use `<SearchField />` instead of `<Field component={FinalFormSearchTextField} />`
-     */
-    FinalFormSearchTextFieldProps,
-} from "./form/FinalFormSearchTextField";
-export {
-    /**
-     * @deprecated Use `<SelectField />` instead of `<Field />` with `<FinalFormSelect />`
-     */
-    FinalFormSelect,
-    /**
-     * @deprecated Use `<SelectField />` instead of `<Field />` with `<FinalFormSelect />`
-     */
-    FinalFormSelectProps,
-} from "./form/FinalFormSelect";
-export {
-    /**
-     * @deprecated Use `<ToggleButtonGroupField />` instead of `<Field />` with `<FormControlLabel />` and `<FinalFormToggleButtonGroup />`
-     */
-    FinalFormToggleButtonGroup,
-    /**
-     * @deprecated Use `<ToggleButtonGroupField />` instead of `<Field />` with `<FormControlLabel />` and `<FinalFormToggleButtonGroup />`
-     */
-    FinalFormToggleButtonGroupProps,
-} from "./form/FinalFormToggleButtonGroup";
+export { FinalFormSearchTextField, FinalFormSearchTextFieldProps } from "./form/FinalFormSearchTextField";
+export { FinalFormSelect, FinalFormSelectProps } from "./form/FinalFormSelect";
+export { FinalFormToggleButtonGroup, FinalFormToggleButtonGroupProps } from "./form/FinalFormToggleButtonGroup";
 export { FormSection, FormSectionClassKey, FormSectionProps } from "./form/FormSection";
 export { OnChangeField } from "./form/helpers/OnChangeField";
 export { FinalFormRadio, FinalFormRadioProps } from "./form/Radio";
-export {
-    /**
-     * @deprecated Use `<SwitchField />` instead of `<Field />` with `<FormControlLabel />` and `<FinalFormSwitch />`
-     */
-    FinalFormSwitch,
-    /**
-     * @deprecated Use `<SwitchField />` instead of `<Field />` with `<FormControlLabel />` and `<FinalFormSwitch />`
-     */
-    FinalFormSwitchProps,
-} from "./form/Switch";
+export { FinalFormSwitch, FinalFormSwitchProps } from "./form/Switch";
 export { FormMutation } from "./FormMutation";
 export { createComponentSlot } from "./helpers/createComponentSlot";
 export { PrettyBytes } from "./helpers/PrettyBytes";


### PR DESCRIPTION
## Description

`FinalFormComponents` are not deprecated, but `ComponentField` components should be preferred.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2022
