### PR TITLE
Remove workarounds in inject-site-configs

### DIFF
--- a/.changeset/seven-rockets-crash.md
+++ b/.changeset/seven-rockets-crash.md
@@ -1,0 +1,7 @@
+---
+"@comet/cli": major
+---
+
+Remove workarounds in `inject-site-configs` command.
+
+Please use the command like the current implementation in the starter.

--- a/packages/cli/src/commands/site-configs.ts
+++ b/packages/cli/src/commands/site-configs.ts
@@ -9,7 +9,6 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
     .description("Inject site-configs into a file")
     .requiredOption("-i, --in-file <file>", "The filename of a template file to inject.")
     .requiredOption("-o, --out-file <file>", "Write the injected template to a file.")
-    .option("-d --dotenv", "dotenv compatibility") // https://github.com/motdotla/dotenv/issues/521#issuecomment-999016064
     .option("--base64", "use base64 encoding")
     .option("-f, --site-config-file <file>", "Path to ts-file which provides a default export with (env: string) => SiteConfig[]")
     .action(async (options) => {
@@ -51,12 +50,10 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
                 console.error(`inject-site-configs: ERROR: type must be ${Object.keys(replacerFunctions).join("|")} (got ${type})`);
                 return substr;
             }
-            const str = replacerFunctions[type](siteConfigs, env);
+            const ret = JSON.stringify(replacerFunctions[type](siteConfigs, env));
             if (options.base64) {
-                return Buffer.from(JSON.stringify(str)).toString("base64");
+                return Buffer.from(ret).toString("base64");
             }
-            const ret = JSON.stringify(str).replace(/\\/g, "\\\\");
-            if (options.dotenv) return ret.replace(/\$/g, "\\$");
             return ret;
         });
 


### PR DESCRIPTION
See https://github.com/vivid-planet/comet/pull/3786#issuecomment-2883001939

> I will close it as --plain should be the default mode, [workarounds](https://github.com/vivid-planet/comet/pull/3786/files#diff-988d45bc7ce740b51859ade193981d3edeeac9e228ab7147b62a5689c5756b05R63) like these should never have made it to the code. We currently work around the workaround in our internal cli package so we don't need this PR anymore. Nevertheless, I created a PR for next.