### PR TITLE
Fix loading visualization in FinalFormSelect

### DIFF
--- a/.changeset/deep-geckos-care.md
+++ b/.changeset/deep-geckos-care.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix loading state of FinalFormSelect when loading asynchronous options

--- a/packages/admin/admin/src/form/FinalFormSelect.sc.ts
+++ b/packages/admin/admin/src/form/FinalFormSelect.sc.ts
@@ -1,0 +1,8 @@
+import { MenuItem, menuItemClasses } from "@mui/material";
+import { styled } from "@mui/material/styles";
+
+export const MenuItemDisabledOverrideOpacity = styled(MenuItem)({
+    [`&.${menuItemClasses.disabled}`]: {
+        opacity: 1.0,
+    },
+});

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -102,7 +102,14 @@ export const FinalFormSelect = <T,>({
                         : options.find((i) => getOptionValue(i) == value),
                 );
             }}
-            value={Array.isArray(value) ? value.map((i) => getOptionValue(i)) : getOptionValue(value)}
+            value={value}
+            renderValue={() => {
+                if (Array.isArray(value)) {
+                    return value.map((i) => getOptionValue(i));
+                } else {
+                    return getOptionValue(value);
+                }
+            }}
         >
             {loading && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -123,11 +123,12 @@ export const FinalFormSelect = <T,>({
                         {getOptionLabel(value)}
                     </MenuItem>
                 ))}
-            {options.map((option: T) => (
-                <MenuItem value={getOptionValue(option)} key={getOptionValue(option)}>
-                    {getOptionLabel(option)}
-                </MenuItem>
-            ))}
+            {!loading &&
+                options.map((option: T) => (
+                    <MenuItem value={getOptionValue(option)} key={getOptionValue(option)}>
+                        {getOptionLabel(option)}
+                    </MenuItem>
+                ))}
         </Select>
     );
 };

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage } from "react-intl";
 
 import { ClearInputAdornment } from "../common/ClearInputAdornment";
 import { type AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
+import { MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
 
 export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> {
     getOptionLabel?: (option: T) => string;
@@ -83,12 +84,14 @@ export const FinalFormSelect = <T,>({
             {...selectProps}
             endAdornment={
                 <>
-                    {loading && (
+                    {loading ? (
                         <InputAdornment position="end">
                             <CircularProgress size={16} color="inherit" />
+                            {endAdornment}
                         </InputAdornment>
+                    ) : (
+                        <InputAdornment position="end">{endAdornment}</InputAdornment>
                     )}
-                    {endAdornment}
                 </>
             }
             onChange={(event) => {
@@ -102,9 +105,9 @@ export const FinalFormSelect = <T,>({
             value={Array.isArray(value) ? value.map((i) => getOptionValue(i)) : getOptionValue(value)}
         >
             {loading && (
-                <MenuItem value="" disabled>
+                <MenuItemDisabledOverrideOpacity value="" disabled>
                     <FormattedMessage id="common.loading" defaultMessage="Loading ..." />
-                </MenuItem>
+                </MenuItemDisabledOverrideOpacity>
             )}
 
             {options.length === 0 &&

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -16,7 +16,6 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     const handleOpen = async () => {
         setOpen(true);
         setLoading(true);
-        setOptions([]); // Reset options to show loading
         const newOptions = await loadOptions();
         setOptions(newOptions);
         setLoading(false);

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -11,12 +11,15 @@ export interface AsyncOptionsProps<T> {
 export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncOptionsProps<T> {
     const [open, setOpen] = useState(false);
     const [options, setOptions] = useState<T[]>([]);
-    const loading = open && options.length === 0;
+    const [loading, setLoading] = useState(false);
 
     const handleOpen = async () => {
         setOpen(true);
+        setLoading(true);
         setOptions([]); // Reset options to show loading
-        setOptions(await loadOptions());
+        const options = await loadOptions();
+        setOptions(options);
+        setLoading(false);
     };
 
     return {

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -17,8 +17,8 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
         setOpen(true);
         setLoading(true);
         setOptions([]); // Reset options to show loading
-        const options = await loadOptions();
-        setOptions(options);
+        const newOptions = await loadOptions();
+        setOptions(newOptions);
         setLoading(false);
     };
 

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -1,0 +1,249 @@
+import { gql, useApolloClient } from "@apollo/client";
+import { Alert, AsyncSelectField, FinalForm } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import type { Manufacturer } from "../../../.storybook/mocks/handlers";
+import { apolloStoryDecorator } from "../../apollo-story.decorator";
+
+type Story = StoryObj<typeof AsyncSelectField>;
+const config: Meta<typeof AsyncSelectField> = {
+    component: AsyncSelectField,
+    title: "@comet/admin/form/AsyncSelectField",
+};
+export default config;
+
+/**
+ * This story demonstrates the usage of the AsyncSelectField component.
+ *
+ * Options are fake loaded with a delay and returned as an array of strings.
+ */
+export const SimpleList: Story = {
+    render: () => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{ type: "value-1" }}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <AsyncSelectField
+                                loadOptions={async () => {
+                                    // simulate loading
+                                    await new Promise((resolve) => setTimeout(resolve, 200));
+                                    return ["value-1", "value-2", "value-3", "value-4"];
+                                }}
+                                getOptionLabel={(option) => {
+                                    return option;
+                                }}
+                                name="type"
+                                label="AsyncSelectField"
+                                fullWidth
+                                variant="horizontal"
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+/**
+ * This story demonstrates the usage of the AsyncSelectField component where the options are loaded as objects.
+ *
+ * The options are loaded as objects, the visual representation must be extracted inside the getOptionLabel function.
+ */
+export const WithObjectOptions: Story = {
+    render: () => {
+        interface FormValues {
+            type: {
+                id: string;
+                name: string;
+            };
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{
+                    type: {
+                        id: "1",
+                        name: "Name 1",
+                    },
+                }}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <AsyncSelectField
+                                loadOptions={async () => {
+                                    // simulate loading
+                                    await new Promise((resolve) => setTimeout(resolve, 200));
+
+                                    return [
+                                        {
+                                            id: "1",
+                                            name: "Name 1",
+                                        },
+                                        {
+                                            id: "2",
+                                            name: "Name 2",
+                                        },
+                                        {
+                                            id: "3",
+                                            name: "Name 3",
+                                        },
+                                        {
+                                            id: "4",
+                                            name: "Name 4",
+                                        },
+                                        {
+                                            id: "5",
+                                            name: "Name 5",
+                                        },
+                                    ];
+                                }}
+                                getOptionLabel={(option) => {
+                                    return option.name;
+                                }}
+                                name="type"
+                                label="AsyncSelectField"
+                                fullWidth
+                                variant="horizontal"
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+/**
+ * This story demonstrates the usage of the AsyncSelectField where the loading time got extended to visualize the loading state.
+ */
+export const LongLoading: Story = {
+    render: () => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{ type: "value-1" }}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <AsyncSelectField
+                                loadOptions={async () => {
+                                    // simulate loading
+                                    await new Promise((resolve) => setTimeout(resolve, 4000));
+                                    return ["value-1", "value-2", "value-3", "value-4"];
+                                }}
+                                getOptionLabel={(option) => {
+                                    return option;
+                                }}
+                                name="type"
+                                label="AsyncSelectField"
+                                fullWidth
+                                variant="horizontal"
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+/**
+ * This story demonstrates the usage of the AsyncSelectField component where the options are loaded from an API
+ *
+ * This can be used when ALL options can be loaded at once.
+ */
+export const AsyncLoadingDataFromApi: Story = {
+    decorators: [apolloStoryDecorator("/graphql")],
+
+    render: () => {
+        const client = useApolloClient();
+
+        interface FormValues {
+            type: {
+                id: string;
+                name: string;
+            };
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{}}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <AsyncSelectField
+                                loadOptions={async () => {
+                                    const { data } = await client.query<{ manufacturers: Manufacturer[] }>({
+                                        query: gql`
+                                            query Manufacturers {
+                                                manufacturers {
+                                                    id
+                                                    name
+                                                }
+                                            }
+                                        `,
+                                    });
+
+                                    return data.manufacturers;
+                                }}
+                                getOptionLabel={(option) => {
+                                    return option.name;
+                                }}
+                                name="type"
+                                label="AsyncSelectField"
+                                fullWidth
+                                variant="horizontal"
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request fixes an issue where the `FinalFormSelect` component did not correctly display the loading indicator while loading async options. The loading indicator overlapped with the clear button.
 
## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| ![Screen Recording 2025-05-16 at 13 07 46](https://github.com/user-attachments/assets/f328a74c-146a-44aa-8b33-fc8b2988232d) | ![Screen Recording 2025-05-16 at 13 05 31](https://github.com/user-attachments/assets/3ab3123e-2d25-4b65-8cf5-0e717dc9bbb6) |
