### PR TITLE
Add no options to FinalFormSelect

### DIFF
--- a/.changeset/bumpy-geckos-tap.md
+++ b/.changeset/bumpy-geckos-tap.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Add the prop `getNoOptionsLabel` to the `FinalFormSelect` to customize it.

--- a/.changeset/bumpy-geckos-tap.md
+++ b/.changeset/bumpy-geckos-tap.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-Add the prop `getNoOptionsLabel` to the `FinalFormSelect` to customize it.
+Add the prop `noOptionsLabel ` to the `FinalFormSelect` to customize it.

--- a/.changeset/happy-peaches-pick.md
+++ b/.changeset/happy-peaches-pick.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Add a default message "No options." when the FinalFormSelect has no options

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -8,7 +8,7 @@ import { type AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 import { MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
 
 export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> {
-    getNoOptionsLabel?: () => ReactNode;
+    getNoOptionsLabel?: ReactNode;
     getOptionLabel?: (option: T) => string;
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
@@ -44,13 +44,11 @@ export const FinalFormSelect = <T,>({
             return String(option);
         }
     },
-    getNoOptionsLabel = () => {
-        return (
-            <Typography variant="body2">
-                <FormattedMessage id="finalFormSelect.noOptions" defaultMessage="No options." />
-            </Typography>
-        );
-    },
+    getNoOptionsLabel = (
+        <Typography variant="body2">
+            <FormattedMessage id="finalFormSelect.noOptions" defaultMessage="No options." />
+        </Typography>
+    ),
     children,
     required,
     ...rest
@@ -141,7 +139,7 @@ export const FinalFormSelect = <T,>({
 
             {loading === false && options.length === 0 && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
-                    {getNoOptionsLabel()}
+                    {getNoOptionsLabel}
                 </MenuItemDisabledOverrideOpacity>
             )}
 

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress, InputAdornment, MenuItem, Select, type SelectProps } from "@mui/material";
+import { CircularProgress, InputAdornment, MenuItem, Select, type SelectProps, Typography } from "@mui/material";
 import { type ReactNode } from "react";
 import { type FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
@@ -8,6 +8,7 @@ import { type AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 import { MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
 
 export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> {
+    getNoOptionsLabel?: () => ReactNode;
     getOptionLabel?: (option: T) => string;
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
@@ -42,6 +43,13 @@ export const FinalFormSelect = <T,>({
         } else {
             return String(option);
         }
+    },
+    getNoOptionsLabel = () => {
+        return (
+            <Typography variant="body2">
+                <FormattedMessage id="finalFormSelect.noOptions" defaultMessage="No options." />
+            </Typography>
+        );
     },
     children,
     required,
@@ -130,6 +138,13 @@ export const FinalFormSelect = <T,>({
                         {getOptionLabel(value)}
                     </MenuItem>
                 ))}
+
+            {loading === false && options.length === 0 && (
+                <MenuItemDisabledOverrideOpacity value="" disabled>
+                    {getNoOptionsLabel()}
+                </MenuItemDisabledOverrideOpacity>
+            )}
+
             {!loading &&
                 options.map((option: T) => (
                     <MenuItem value={getOptionValue(option)} key={getOptionValue(option)}>

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -8,7 +8,7 @@ import { type AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 import { MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
 
 export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> {
-    getNoOptionsLabel?: ReactNode;
+    noOptionsLabel?: ReactNode;
     getOptionLabel?: (option: T) => string;
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
@@ -44,7 +44,7 @@ export const FinalFormSelect = <T,>({
             return String(option);
         }
     },
-    getNoOptionsLabel = (
+    noOptionsLabel = (
         <Typography variant="body2">
             <FormattedMessage id="finalFormSelect.noOptions" defaultMessage="No options." />
         </Typography>
@@ -139,7 +139,7 @@ export const FinalFormSelect = <T,>({
 
             {loading === false && options.length === 0 && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
-                    {getNoOptionsLabel}
+                    {noOptionsLabel}
                 </MenuItemDisabledOverrideOpacity>
             )}
 

--- a/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
+++ b/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
@@ -5,7 +5,7 @@ import { FinalFormAsyncSelect } from "../FinalFormAsyncSelect";
 
 export interface AsyncSelectFieldProps<Option> extends FieldProps<Option, HTMLSelectElement> {
     loadOptions: () => Promise<Option[]>;
-    getNoOptionsLabel?: () => ReactNode;
+    getNoOptionsLabel?: ReactNode;
 
     getOptionLabel?: (option: Option) => string;
     getOptionValue?: (option: Option) => string;

--- a/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
+++ b/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
@@ -1,8 +1,12 @@
+import { type ReactNode } from "react";
+
 import { Field, type FieldProps } from "../Field";
 import { FinalFormAsyncSelect } from "../FinalFormAsyncSelect";
 
 export interface AsyncSelectFieldProps<Option> extends FieldProps<Option, HTMLSelectElement> {
     loadOptions: () => Promise<Option[]>;
+    getNoOptionsLabel?: () => ReactNode;
+
     getOptionLabel?: (option: Option) => string;
     getOptionValue?: (option: Option) => string;
     clearable?: boolean;

--- a/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
+++ b/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
@@ -5,7 +5,7 @@ import { FinalFormAsyncSelect } from "../FinalFormAsyncSelect";
 
 export interface AsyncSelectFieldProps<Option> extends FieldProps<Option, HTMLSelectElement> {
     loadOptions: () => Promise<Option[]>;
-    getNoOptionsLabel?: ReactNode;
+    noOptionsLabel?: ReactNode;
 
     getOptionLabel?: (option: Option) => string;
     getOptionValue?: (option: Option) => string;

--- a/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
+++ b/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
@@ -6,7 +6,6 @@ import { FinalFormAsyncSelect } from "../FinalFormAsyncSelect";
 export interface AsyncSelectFieldProps<Option> extends FieldProps<Option, HTMLSelectElement> {
     loadOptions: () => Promise<Option[]>;
     noOptionsLabel?: ReactNode;
-
     getOptionLabel?: (option: Option) => string;
     getOptionValue?: (option: Option) => string;
     clearable?: boolean;

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -232,7 +232,7 @@ export const NoOptions: Story = {
 };
 
 /**
- * If no options are available, the getNoOptionsLabel function can be used to customize the label.
+ * If no options are available, the noOptionsLabel function can be used to customize the label.
  */
 export const NoOptionsWithCustomNoOptionsLabel: Story = {
     render: () => {
@@ -261,7 +261,7 @@ export const NoOptionsWithCustomNoOptionsLabel: Story = {
                                 getOptionLabel={(option) => {
                                     return option;
                                 }}
-                                getNoOptionsLabel={
+                                noOptionsLabel={
                                     <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
                                         <Info color="info" />
                                         No options available at this point in time

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -1,5 +1,6 @@
 import { gql, useApolloClient } from "@apollo/client";
 import { Alert, AsyncSelectField, FinalForm } from "@comet/admin";
+import { Info } from "@comet/admin-icons";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import type { Manufacturer } from "../../../.storybook/mocks/handlers";
@@ -166,6 +167,107 @@ export const LongLoading: Story = {
                                 }}
                                 getOptionLabel={(option) => {
                                     return option;
+                                }}
+                                name="type"
+                                label="AsyncSelectField"
+                                fullWidth
+                                variant="horizontal"
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+/**
+ * This story demonstrates the usage of the AsyncSelectField component where no options are returned.
+ */
+export const NoOptions: Story = {
+    render: () => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{}}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <AsyncSelectField
+                                loadOptions={async () => {
+                                    // simulate loading
+                                    await new Promise((resolve) => setTimeout(resolve, 200));
+                                    return [];
+                                }}
+                                getOptionLabel={(option) => {
+                                    return option;
+                                }}
+                                name="type"
+                                label="AsyncSelectField"
+                                fullWidth
+                                variant="horizontal"
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+/**
+ * If no options are available, the getNoOptionsLabel function can be used to customize the label.
+ */
+export const NoOptionsWithCustomNoOptionsLabel: Story = {
+    render: () => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{}}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <AsyncSelectField
+                                loadOptions={async () => {
+                                    // simulate loading
+                                    await new Promise((resolve) => setTimeout(resolve, 200));
+
+                                    return [];
+                                }}
+                                getOptionLabel={(option) => {
+                                    return option;
+                                }}
+                                getNoOptionsLabel={() => {
+                                    return (
+                                        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                                            <Info color="info" />
+                                            No options available at this point in time
+                                        </div>
+                                    );
                                 }}
                                 name="type"
                                 label="AsyncSelectField"

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -261,14 +261,12 @@ export const NoOptionsWithCustomNoOptionsLabel: Story = {
                                 getOptionLabel={(option) => {
                                     return option;
                                 }}
-                                getNoOptionsLabel={() => {
-                                    return (
-                                        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                                            <Info color="info" />
-                                            No options available at this point in time
-                                        </div>
-                                    );
-                                }}
+                                getNoOptionsLabel={
+                                    <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                                        <Info color="info" />
+                                        No options available at this point in time
+                                    </div>
+                                }
                                 name="type"
                                 label="AsyncSelectField"
                                 fullWidth


### PR DESCRIPTION
## Description
This Pull Request adds a "no options" message to the `FinalFormSelect` component's dropdown and adds the ability to customize it with the `getNoOptionsLabel` prop.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| ![Screen Recording 2025-05-16 at 13 44 23](https://github.com/user-attachments/assets/f2c86b9d-8c38-429b-9c1e-3bd111c8b346) | ![Screen Recording 2025-05-16 at 13 43 05](https://github.com/user-attachments/assets/17f831d0-0a80-4a54-892c-bd020b38c2de)  |
 

