### PR TITLE
Add error handling to FinalFormSelect with customizable error message via errorLabel

### DIFF
--- a/.changeset/big-mangos-dance.md
+++ b/.changeset/big-mangos-dance.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Add error handling for asynchronous option loading in `FinalFormSelect`. When loading fails, an error message is shown in the dropdown.

--- a/.changeset/ninety-shirts-grab.md
+++ b/.changeset/ninety-shirts-grab.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+yAdd the possibility to customize the `FinalFormSelect` error message with `getErrorOptionsLabel` prop.

--- a/.changeset/ninety-shirts-grab.md
+++ b/.changeset/ninety-shirts-grab.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-Add the possibility to customize the `FinalFormSelect` error message with `getErrorOptionsLabel` prop.
+Add the possibility to customize the `FinalFormSelect` error message with `errorLabel ` prop.

--- a/.changeset/ninety-shirts-grab.md
+++ b/.changeset/ninety-shirts-grab.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-Add the possibility to customize the `FinalFormSelect` error message with `errorLabel ` prop.
+Add the possibility to customize the `FinalFormSelect` error message with `errorLabel` prop.

--- a/.changeset/ninety-shirts-grab.md
+++ b/.changeset/ninety-shirts-grab.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-yAdd the possibility to customize the `FinalFormSelect` error message with `getErrorOptionsLabel` prop.
+Add the possibility to customize the `FinalFormSelect` error message with `getErrorOptionsLabel` prop.

--- a/packages/admin/admin/src/form/FinalFormAsyncSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormAsyncSelect.tsx
@@ -3,7 +3,7 @@ import { type SelectProps } from "@mui/material";
 import { useAsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 import { FinalFormSelect, type FinalFormSelectProps } from "./FinalFormSelect";
 
-export interface FinalFormAsyncSelectProps<T> extends FinalFormSelectProps<T>, Omit<SelectProps, "input"> {
+export interface FinalFormAsyncSelectProps<T> extends FinalFormSelectProps<T>, Omit<SelectProps, "input" | "error"> {
     loadOptions: () => Promise<T[]>;
 }
 

--- a/packages/admin/admin/src/form/FinalFormAsyncSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormAsyncSelect.tsx
@@ -3,7 +3,7 @@ import { type SelectProps } from "@mui/material";
 import { useAsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 import { FinalFormSelect, type FinalFormSelectProps } from "./FinalFormSelect";
 
-export interface FinalFormAsyncSelectProps<T> extends FinalFormSelectProps<T>, Omit<SelectProps, "input" | "error"> {
+export interface FinalFormAsyncSelectProps<T> extends FinalFormSelectProps<T>, Omit<SelectProps, "input"> {
     loadOptions: () => Promise<T[]>;
 }
 

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -15,7 +15,7 @@ export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputEl
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
     required?: boolean;
-    error?: Error | null;
+    loadingError?: Error | null;
 }
 
 const getHasClearableContent = (value: unknown, multiple: boolean | undefined) => {
@@ -32,7 +32,7 @@ export const FinalFormSelect = <T,>({
     isAsync = false,
     options = [],
     loading = false,
-    error,
+    loadingError,
     getOptionLabel = (option: T) => {
         if (typeof option === "object") {
             console.error(`The \`getOptionLabel\` method of FinalFormSelect returned an object instead of a string for${JSON.stringify(option)}.`);
@@ -62,7 +62,7 @@ export const FinalFormSelect = <T,>({
     children,
     required,
     ...rest
-}: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input" | "endAdornment" | "error">) => {
+}: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input" | "endAdornment">) => {
     // Depending on the usage, `multiple` is either a root prop or in the `input` prop.
     // 1. <Field component={FinalFormSelect} multiple /> -> multiple is in restInput
     // 2. <Field>{(props) => <FinalFormSelect {...props} multiple />}</Field> -> multiple is in rest
@@ -100,7 +100,7 @@ export const FinalFormSelect = <T,>({
             {...selectProps}
             endAdornment={
                 <InputAdornment position="end">
-                    {error && <Error color="error" />}
+                    {loadingError && <Error color="error" />}
 
                     {endAdornment}
                 </InputAdornment>
@@ -142,12 +142,12 @@ export const FinalFormSelect = <T,>({
                     </MenuItem>
                 ))}
 
-            {loading === false && error == null && options.length === 0 && (
+            {loading === false && loadingError == null && options.length === 0 && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
                     {noOptionsLabel}
                 </MenuItemDisabledOverrideOpacity>
             )}
-            {loading === false && error != null && (
+            {loading === false && loadingError != null && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
                     {errorLabel}
                 </MenuItemDisabledOverrideOpacity>

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -15,6 +15,7 @@ export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputEl
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
     required?: boolean;
+    error?: Error | null;
 }
 
 const getHasClearableContent = (value: unknown, multiple: boolean | undefined) => {
@@ -61,7 +62,7 @@ export const FinalFormSelect = <T,>({
     children,
     required,
     ...rest
-}: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input" | "endAdornment">) => {
+}: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input" | "endAdornment" | "error">) => {
     // Depending on the usage, `multiple` is either a root prop or in the `input` prop.
     // 1. <Field component={FinalFormSelect} multiple /> -> multiple is in restInput
     // 2. <Field>{(props) => <FinalFormSelect {...props} multiple />}</Field> -> multiple is in rest
@@ -141,12 +142,12 @@ export const FinalFormSelect = <T,>({
                     </MenuItem>
                 ))}
 
-            {loading === false && options.length === 0 && (
+            {loading === false && error == null && options.length === 0 && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
                     {noOptionsLabel}
                 </MenuItemDisabledOverrideOpacity>
             )}
-            {loading === false && error === true && (
+            {loading === false && error != null && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
                     {errorLabel}
                 </MenuItemDisabledOverrideOpacity>

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -10,7 +10,7 @@ import { MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
 
 export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> {
     noOptionsLabel?: ReactNode;
-    getErrorOptionsLabel?: () => ReactNode;
+    errorLabel?: ReactNode;
     getOptionLabel?: (option: T) => string;
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
@@ -47,18 +47,17 @@ export const FinalFormSelect = <T,>({
             return String(option);
         }
     },
+
     noOptionsLabel = (
         <Typography variant="body2">
             <FormattedMessage id="finalFormSelect.noOptions" defaultMessage="No options." />
         </Typography>
     ),
-    getErrorOptionsLabel = () => {
-        return (
-            <Typography variant="body2">
-                <FormattedMessage id="finalFormSelect.error" defaultMessage="Error loading options." />
-            </Typography>
-        );
-    },
+    errorLabel = (
+        <Typography variant="body2">
+            <FormattedMessage id="finalFormSelect.error" defaultMessage="Error loading options." />
+        </Typography>
+    ),
     children,
     required,
     ...rest
@@ -149,7 +148,7 @@ export const FinalFormSelect = <T,>({
             )}
             {loading === false && error === true && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
-                    {getErrorOptionsLabel()}
+                    {errorLabel}
                 </MenuItemDisabledOverrideOpacity>
             )}
 

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -1,3 +1,4 @@
+import { Error } from "@comet/admin-icons";
 import { InputAdornment, MenuItem, Select, type SelectProps, Typography } from "@mui/material";
 import { type ReactNode } from "react";
 import { type FieldRenderProps } from "react-final-form";
@@ -9,6 +10,7 @@ import { MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
 
 export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> {
     noOptionsLabel?: ReactNode;
+    getErrorOptionsLabel?: () => ReactNode;
     getOptionLabel?: (option: T) => string;
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
@@ -29,6 +31,7 @@ export const FinalFormSelect = <T,>({
     isAsync = false,
     options = [],
     loading = false,
+    error,
     getOptionLabel = (option: T) => {
         if (typeof option === "object") {
             console.error(`The \`getOptionLabel\` method of FinalFormSelect returned an object instead of a string for${JSON.stringify(option)}.`);
@@ -49,6 +52,13 @@ export const FinalFormSelect = <T,>({
             <FormattedMessage id="finalFormSelect.noOptions" defaultMessage="No options." />
         </Typography>
     ),
+    getErrorOptionsLabel = () => {
+        return (
+            <Typography variant="body2">
+                <FormattedMessage id="finalFormSelect.error" defaultMessage="Error loading options." />
+            </Typography>
+        );
+    },
     children,
     required,
     ...rest
@@ -88,7 +98,13 @@ export const FinalFormSelect = <T,>({
     return (
         <Select
             {...selectProps}
-            endAdornment={<InputAdornment position="end">{endAdornment}</InputAdornment>}
+            endAdornment={
+                <InputAdornment position="end">
+                    {error && <Error color="error" />}
+
+                    {endAdornment}
+                </InputAdornment>
+            }
             onChange={(event) => {
                 const value = event.target.value;
                 onChange(
@@ -129,6 +145,11 @@ export const FinalFormSelect = <T,>({
             {loading === false && options.length === 0 && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
                     {noOptionsLabel}
+                </MenuItemDisabledOverrideOpacity>
+            )}
+            {loading === false && error === true && (
+                <MenuItemDisabledOverrideOpacity value="" disabled>
+                    {getErrorOptionsLabel()}
                 </MenuItemDisabledOverrideOpacity>
             )}
 

--- a/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
+++ b/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
@@ -6,6 +6,7 @@ import { FinalFormAsyncSelect } from "../FinalFormAsyncSelect";
 export interface AsyncSelectFieldProps<Option> extends FieldProps<Option, HTMLSelectElement> {
     loadOptions: () => Promise<Option[]>;
     noOptionsLabel?: ReactNode;
+    errorLabel?: ReactNode;
     getOptionLabel?: (option: Option) => string;
     getOptionValue?: (option: Option) => string;
     clearable?: boolean;

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -16,6 +16,7 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     const [error, setError] = useState<Error | null>(null);
 
     const handleOpen = async () => {
+        setError(null);
         setOpen(true);
         setLoading(true);
         try {

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -4,6 +4,7 @@ export interface AsyncOptionsProps<T> {
     isAsync: boolean;
     open: boolean;
     options: T[];
+    error: boolean;
     loading?: boolean;
     onOpen: (event: ChangeEvent) => void;
     onClose: (event: ChangeEvent) => void;
@@ -12,18 +13,25 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     const [open, setOpen] = useState(false);
     const [options, setOptions] = useState<T[]>([]);
     const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<Error | null>(null);
 
     const handleOpen = async () => {
         setOpen(true);
         setLoading(true);
-        const newOptions = await loadOptions();
-        setOptions(newOptions);
-        setLoading(false);
+        try {
+            const newOptions = await loadOptions();
+            setOptions(newOptions);
+        } catch (e) {
+            setError(e);
+        } finally {
+            setLoading(false);
+        }
     };
 
     return {
         isAsync: true,
         open,
+        error: error !== null,
         options,
         loading,
         onOpen: handleOpen,

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -4,7 +4,7 @@ export interface AsyncOptionsProps<T> {
     isAsync: boolean;
     open: boolean;
     options: T[];
-    error: boolean;
+    error: Error | null;
     loading?: boolean;
     onOpen: (event: ChangeEvent) => void;
     onClose: (event: ChangeEvent) => void;
@@ -31,7 +31,7 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     return {
         isAsync: true,
         open,
-        error: error !== null,
+        error,
         options,
         loading,
         onOpen: handleOpen,

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -4,7 +4,7 @@ export interface AsyncOptionsProps<T> {
     isAsync: boolean;
     open: boolean;
     options: T[];
-    error: Error | null;
+    loadingError: Error | null;
     loading?: boolean;
     onOpen: (event: ChangeEvent) => void;
     onClose: (event: ChangeEvent) => void;
@@ -31,7 +31,7 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     return {
         isAsync: true,
         open,
-        error,
+        loadingError: error,
         options,
         loading,
         onOpen: handleOpen,

--- a/storybook/.storybook/decorators/ThemeProvider.decorator.tsx
+++ b/storybook/.storybook/decorators/ThemeProvider.decorator.tsx
@@ -1,6 +1,6 @@
 import { createCometTheme, MuiThemeProvider } from "@comet/admin";
 import { createTheme as createMuiTheme, CssBaseline } from "@mui/material";
-import { type Decorator } from "@storybook/react";
+import { type Decorator } from "@storybook/react-webpack5";
 
 export enum ThemeOption {
     Comet = "comet",

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -1,6 +1,6 @@
 import { gql, useApolloClient } from "@apollo/client";
 import { Alert, AsyncSelectField, FinalForm } from "@comet/admin";
-import { Info } from "@comet/admin-icons";
+import { Info, WarningSolid } from "@comet/admin-icons";
 import type { Meta, StoryObj } from "@storybook/react-webpack5";
 
 import type { Manufacturer } from "../../../.storybook/mocks/handlers";
@@ -267,6 +267,105 @@ export const NoOptionsWithCustomNoOptionsLabel: Story = {
                                         No options available at this point in time
                                     </div>
                                 }
+                                name="type"
+                                label="AsyncSelectField"
+                                fullWidth
+                                variant="horizontal"
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+/**
+ * This story demonstrates the usage of the AsyncSelectField component where an error occurs while loading the options.
+ */
+export const ErrorLoadingOptions: Story = {
+    render: () => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{}}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <AsyncSelectField
+                                loadOptions={async () => {
+                                    // simulate loading
+                                    await new Promise((resolve) => setTimeout(resolve, 500));
+                                    throw Error("Error loading options");
+                                    return [];
+                                }}
+                                getOptionLabel={(option) => {
+                                    return option;
+                                }}
+                                name="type"
+                                label="AsyncSelectField"
+                                fullWidth
+                                variant="horizontal"
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const ErrorLoadingOptionsWithCustomErrorLabel: Story = {
+    render: () => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{}}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <AsyncSelectField
+                                loadOptions={async () => {
+                                    // simulate loading
+                                    await new Promise((resolve) => setTimeout(resolve, 500));
+                                    throw Error("Error loading options");
+                                    return [];
+                                }}
+                                getOptionLabel={(option) => {
+                                    return option;
+                                }}
+                                getErrorOptionsLabel={() => {
+                                    return (
+                                        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                                            <WarningSolid color="error" />
+                                            Error loading options
+                                        </div>
+                                    );
+                                }}
                                 name="type"
                                 label="AsyncSelectField"
                                 fullWidth

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -358,14 +358,12 @@ export const ErrorLoadingOptionsWithCustomErrorLabel: Story = {
                                 getOptionLabel={(option) => {
                                     return option;
                                 }}
-                                getErrorOptionsLabel={() => {
-                                    return (
-                                        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                                            <WarningSolid color="error" />
-                                            Error loading options
-                                        </div>
-                                    );
-                                }}
+                                errorLabel={
+                                    <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                                        <WarningSolid color="error" />
+                                        Error loading options
+                                    </div>
+                                }
                                 name="type"
                                 label="AsyncSelectField"
                                 fullWidth


### PR DESCRIPTION
## Description

This PR improves the `FinalFormSelect` component by introducing error handling for asynchronous option loading. When an error occurs during the fetch process, an error message is shown in the dropdown and an error icon is displayed inside the select.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|![Screen Recording 2025-05-16 at 13 55 46](https://github.com/user-attachments/assets/7e234473-50cf-4841-8ea6-e723d6a070d7)   | ![Screen Recording 2025-05-16 at 13 53 49](https://github.com/user-attachments/assets/15d2a65d-5fd8-425e-af8b-5f1afb96bf38)  |


