### PR TITLE
Savable: add optional fetchHasChanges that can return hasChanges (aka dirty) before Savable re-renders and updates the hasChanges prop

### DIFF
--- a/.changeset/olive-aliens-double.md
+++ b/.changeset/olive-aliens-double.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": minor
+---
+
+Savable: add optional fetchHasChanges that can return hasChanges (aka dirty) before Savable re-renders and updates the hasChanges prop
+
+Fixes issue in Form where a "Save changes?"-Dialog appars right after adding a new entry

--- a/packages/admin/admin/src/FinalForm.tsx
+++ b/packages/admin/admin/src/FinalForm.tsx
@@ -229,7 +229,18 @@ export function FinalForm<FormValues = AnyObject, InitialFormValues = Partial<Fo
             <FinalFormContextProvider {...formContext}>
                 {saveBoundaryApi && (
                     <FormSpy subscription={{ dirty: true }}>
-                        {(props) => <Savable hasChanges={props.dirty} doSave={doSave} doReset={doReset} />}
+                        {(props) => {
+                            return (
+                                <Savable
+                                    hasChanges={props.dirty}
+                                    doSave={doSave}
+                                    doReset={doReset}
+                                    fetchHasChanges={() => {
+                                        return formRenderProps.form.getState().dirty;
+                                    }}
+                                />
+                            );
+                        }}
                     </FormSpy>
                 )}
                 <RouterPromptIf formApi={formRenderProps.form} doSave={doSave} subRoutePath={subRoutePath}>

--- a/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
+++ b/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
@@ -96,6 +96,13 @@ export const SaveBoundary = ({ onAfterSave, ...props }: PropsWithChildren<SaveBo
     return (
         <RouterPrompt
             message={() => {
+                const hasChanges = Object.values(saveStates.current).some((saveState) => {
+                    if (saveState.fetchHasChanges) {
+                        return saveState.fetchHasChanges();
+                    } else {
+                        return saveState.hasChanges;
+                    }
+                });
                 if (hasChanges) {
                     return intl.formatMessage(messages.saveUnsavedChanges);
                 }
@@ -128,19 +135,20 @@ export const SaveBoundary = ({ onAfterSave, ...props }: PropsWithChildren<SaveBo
 
 export interface SavableProps {
     hasChanges: boolean;
+    fetchHasChanges?: () => boolean;
     doSave: () => Promise<SaveActionSuccess> | SaveActionSuccess;
     doReset?: () => void;
 }
 
-export const Savable = ({ doSave, doReset, hasChanges }: SavableProps) => {
+export const Savable = ({ doSave, doReset, hasChanges, fetchHasChanges }: SavableProps) => {
     const id = useConstant<string>(() => uuid());
     const saveBoundaryApi = useSaveBoundaryApi();
     if (!saveBoundaryApi) throw new Error("Savable must be inside SaveBoundary");
     useEffect(() => {
-        saveBoundaryApi.register(id, { doSave, doReset, hasChanges });
+        saveBoundaryApi.register(id, { doSave, doReset, hasChanges, fetchHasChanges });
         return function cleanup() {
             saveBoundaryApi.unregister(id);
         };
-    }, [id, doSave, doReset, hasChanges, saveBoundaryApi]);
+    }, [id, doSave, doReset, hasChanges, fetchHasChanges, saveBoundaryApi]);
     return null;
 };


### PR DESCRIPTION
Fixes issue in Form where a "Save changes?"-Dialog appars right after adding a new entry

## Problem
Problem is that [Savable](https://github.com/vivid-planet/comet/blob/next/packages/admin/admin/src/FinalForm.tsx#L232) needs to re-render to update hasChanges, which is does, but also deferred, like the Timeout in the form:
```
            if (!event.navigatingBack) {
                const id = mutationResponse?.createProduct.id;
                if (id) {
                    setTimeout(() => {
                        stackSwitchApi.activatePage(`edit`, id);
                    });
                }
            }
```

## Solution 1
One solution is to defer the activatePage more than the re-render (#3823)

## Solution 2
the other solution implemented in this PR is to not rely on re-render anymore and instead add a method that fetches the current dirty state right out of the form state - which is guaranteed to be correct.

## why hasChanges PLUS fetchHasChanges
- hasChanges is used to update the UI according to dirty state (to enable/disable the save button) - this is not possible using fetchHasChanges
- fetchHasChanges is optional with fallback to hasChanges
- in pratice most use cases are a form anyway where you don't have to implement that manually

## Naming

fetchHasChanges could i a bit strange name, alternatives?