### PR TITLE
SaveBoundary: fix confusing naming of context

### DIFF
--- a/.changeset/honest-views-hide.md
+++ b/.changeset/honest-views-hide.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": major
+---
+
+SaveBoundary: rename useSavable to useSaveBoundaryState

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -235,8 +235,8 @@ export {
     SaveBoundary,
     SaveBoundaryApi,
     SaveBoundaryApiContext,
-    useSavable,
     useSaveBoundaryApi,
+    useSaveBoundaryState,
 } from "./saveBoundary/SaveBoundary";
 export { SaveBoundarySaveButton } from "./saveBoundary/SaveBoundarySaveButton";
 export { Selected } from "./Selected";

--- a/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
+++ b/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
@@ -12,7 +12,7 @@ export interface SaveBoundaryApi {
     register: (id: string, props: SavableProps) => void;
     unregister: (id: string) => void;
 }
-export interface Savable {
+export interface SaveBoundaryState {
     hasErrors: boolean;
     hasChanges: boolean;
     saving: boolean;
@@ -23,9 +23,9 @@ export function useSaveBoundaryApi() {
     return useContext(SaveBoundaryApiContext);
 }
 
-const SavableContext = createContext<Savable | undefined>(undefined);
-export function useSavable() {
-    return useContext(SavableContext);
+const SaveBoundaryStateContext = createContext<SaveBoundaryState | undefined>(undefined);
+export function useSaveBoundaryState() {
+    return useContext(SaveBoundaryStateContext);
 }
 
 interface SaveBoundaryProps {
@@ -105,7 +105,7 @@ export const SaveBoundary = ({ onAfterSave, ...props }: PropsWithChildren<SaveBo
             resetAction={reset}
             subRoutePath={subRoutePath}
         >
-            <SavableContext.Provider
+            <SaveBoundaryStateContext.Provider
                 value={{
                     hasErrors,
                     hasChanges,
@@ -121,7 +121,7 @@ export const SaveBoundary = ({ onAfterSave, ...props }: PropsWithChildren<SaveBo
                 >
                     {props.children}
                 </SaveBoundaryApiContext.Provider>
-            </SavableContext.Provider>
+            </SaveBoundaryStateContext.Provider>
         </RouterPrompt>
     );
 };

--- a/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
+++ b/packages/admin/admin/src/saveBoundary/SaveBoundary.tsx
@@ -12,7 +12,7 @@ export interface SaveBoundaryApi {
     register: (id: string, props: SavableProps) => void;
     unregister: (id: string) => void;
 }
-export interface SaveBoundaryState {
+interface SaveBoundaryState {
     hasErrors: boolean;
     hasChanges: boolean;
     saving: boolean;

--- a/packages/admin/admin/src/saveBoundary/SaveBoundarySaveButton.tsx
+++ b/packages/admin/admin/src/saveBoundary/SaveBoundarySaveButton.tsx
@@ -1,8 +1,8 @@
 import { SaveButton, type SaveButtonProps } from "../common/buttons/SaveButton";
-import { useSavable, useSaveBoundaryApi } from "./SaveBoundary";
+import { useSaveBoundaryApi, useSaveBoundaryState } from "./SaveBoundary";
 
 export function SaveBoundarySaveButton(props: SaveButtonProps) {
-    const saveBoundaryState = useSavable();
+    const saveBoundaryState = useSaveBoundaryState();
     const saveBoundaryApi = useSaveBoundaryApi();
     if (!saveBoundaryState || !saveBoundaryApi) throw new Error("SaveBoundarySaveButton must be inside SaveBoundary");
 


### PR DESCRIPTION
rename useSavable to useSaveBoundaryState (and internal Context)

Things got mixed during the renames in the original PR https://github.com/vivid-planet/comet/pull/1448

I found no usages of useSavable, this incompatible change should not effect any project. (So I didn't add a deprecated export or migration guide or upgrade script)