### PR TITLE
RichTextBlock: add childBlocksInfo for embedded links in order to have them in block index

### DIFF
--- a/.changeset/witty-oranges-stare.md
+++ b/.changeset/witty-oranges-stare.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+RichTextBlock: add childBlocksInfo for embedded links in order to have them in block index
+
+This fixes missing dependencies for internal links

--- a/packages/api/cms-api/src/blocks/factories/createRichTextBlock.ts
+++ b/packages/api/cms-api/src/blocks/factories/createRichTextBlock.ts
@@ -9,6 +9,7 @@ import {
     BlockDataInterface,
     BlockInputFactory,
     BlockInputInterface,
+    ChildBlockInfo,
     ExtractBlockInput,
     registerBlock,
 } from "../block";
@@ -106,6 +107,21 @@ export function createRichTextBlock<LinkBlock extends Block>(
                         return block.text;
                 }
             });
+        }
+
+        childBlocksInfo(): ChildBlockInfo[] {
+            const ret: ChildBlockInfo[] = [];
+            Object.entries(this.draftContent.entityMap).map(([key, entity]) => {
+                if (entity.type === "LINK") {
+                    ret.push({
+                        visible: true,
+                        relJsonPath: ["draftContent", "entityMap", key, "data"],
+                        block: entity.data as BlockDataInterface,
+                        name: LinkBlock.name,
+                    });
+                }
+            });
+            return ret;
         }
     }
 


### PR DESCRIPTION
This fixes missing dependencies for internal links

next branch as this bug doesn't show up in main, as we don't use the dependencies to pages for anything yet