### PR TITLE
Switch icons of LatestWarningsDashboardWidget and LatestContentUpdatesDashboardWidget

### DIFF
--- a/packages/admin/cms-admin/src/dashboard/widgets/LatestContentUpdatesDashboardWidget.tsx
+++ b/packages/admin/cms-admin/src/dashboard/widgets/LatestContentUpdatesDashboardWidget.tsx
@@ -1,5 +1,5 @@
 import { type GridColDef } from "@comet/admin";
-import { ArrowRight, Warning } from "@comet/admin-icons";
+import { ArrowRight, Reload } from "@comet/admin-icons";
 import { IconButton } from "@mui/material";
 import { DataGrid, type DataGridProps } from "@mui/x-data-grid";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -58,7 +58,7 @@ export const LatestContentUpdatesDashboardWidget = <Row extends MinimalRow>({
 
     return (
         <DashboardWidgetRoot
-            icon={<Warning />}
+            icon={<Reload />}
             header={<FormattedMessage id="dashboard.latestContentUpdatesWidget.title" defaultMessage="Latest Content Updates" />}
         >
             <DataGrid disableColumnMenu hideFooter autoHeight columns={columns} rows={rows} loading={loading} />

--- a/packages/admin/cms-admin/src/warnings/LatestWarningsDashboardWidget.tsx
+++ b/packages/admin/cms-admin/src/warnings/LatestWarningsDashboardWidget.tsx
@@ -1,6 +1,6 @@
 import { gql, useQuery } from "@apollo/client";
 import { dataGridDateTimeColumn, type GridColDef } from "@comet/admin";
-import { Reload } from "@comet/admin-icons";
+import { Warning } from "@comet/admin-icons";
 import { DataGrid } from "@mui/x-data-grid";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -61,7 +61,7 @@ export const LatestWarningsDashboardWidget = () => {
 
     return (
         <DashboardWidgetRoot
-            icon={<Reload />}
+            icon={<Warning />}
             header={<FormattedMessage id="dashboard.latestWarningsWidget.title" defaultMessage="Latest Warnings" />}
         >
             <DataGrid disableColumnMenu hideFooter columns={columns} rows={data?.warnings.nodes ?? []} loading={loading} />


### PR DESCRIPTION
## Description

The icons were switched:

<img width="1920" alt="Bildschirmfoto 2025-05-19 um 10 49 19" src="https://github.com/user-attachments/assets/7a751eff-c06e-459f-b8a1-8e3c46d1ca7d" />


Now they are correct:

<img width="1920" alt="Bildschirmfoto 2025-05-19 um 10 51 39" src="https://github.com/user-attachments/assets/c082a468-bb7a-41b9-ba31-d40e1c6e3286" />

