### PR TITLE
Include entity info in warning grid

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -222,6 +222,7 @@ type Warning {
   sourceInfo: WarningSourceInfo!
   status: WarningStatus!
   scope: JSONObject
+  entityInfo: EntityInfo
 }
 
 enum WarningSeverity {
@@ -234,6 +235,11 @@ enum WarningStatus {
   open
   resolved
   ignored
+}
+
+type EntityInfo {
+  name: String!
+  secondaryInformation: String
 }
 
 type PaginatedWarnings {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -225,6 +225,7 @@ type Warning {
   sourceInfo: WarningSourceInfo!
   status: WarningStatus!
   scope: JSONObject
+  entityInfo: EntityInfo
 }
 
 enum WarningSeverity {
@@ -237,6 +238,11 @@ enum WarningStatus {
   open
   resolved
   ignored
+}
+
+type EntityInfo {
+  name: String!
+  secondaryInformation: String
 }
 
 type PaginatedWarnings {

--- a/packages/api/cms-api/src/common/entityInfo/entity-info.decorator.ts
+++ b/packages/api/cms-api/src/common/entityInfo/entity-info.decorator.ts
@@ -1,7 +1,7 @@
 import { type AnyEntity } from "@mikro-orm/postgresql";
 import { type Type } from "@nestjs/common";
 
-interface EntityInfoInterface {
+export interface EntityInfoInterface {
     name: string;
     secondaryInformation?: string;
 }

--- a/packages/api/cms-api/src/common/entityInfo/entity-info.module.ts
+++ b/packages/api/cms-api/src/common/entityInfo/entity-info.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+
+import { EntityInfoService } from "./entity-info.service";
+
+@Module({
+    imports: [],
+    providers: [EntityInfoService],
+    exports: [EntityInfoService],
+})
+export class EntityInfoModule {}

--- a/packages/api/cms-api/src/common/entityInfo/entity-info.object.ts
+++ b/packages/api/cms-api/src/common/entityInfo/entity-info.object.ts
@@ -1,0 +1,10 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+
+@ObjectType("EntityInfo")
+export class EntityInfoObject {
+    @Field()
+    name: string;
+
+    @Field({ nullable: true })
+    secondaryInformation?: string;
+}

--- a/packages/api/cms-api/src/common/entityInfo/entity-info.service.ts
+++ b/packages/api/cms-api/src/common/entityInfo/entity-info.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger, Type } from "@nestjs/common";
+import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
+import { ModuleRef } from "@nestjs/core";
+
+import { EntityInfoGetter, EntityInfoInterface, EntityInfoServiceInterface } from "./entity-info.decorator";
+
+@Injectable()
+export class EntityInfoService {
+    private readonly logger = new Logger(EntityInfoService.name);
+
+    constructor(private readonly moduleRef: ModuleRef) {}
+
+    async getEntityInfo(instance: object): Promise<EntityInfoInterface | undefined> {
+        const entityInfoGetter: EntityInfoGetter | undefined = Reflect.getMetadata(`data:entityInfo`, instance.constructor);
+
+        if (entityInfoGetter === undefined) {
+            this.logger.warn(
+                `Warning: ${instance.constructor.name} doesn't provide any entity info. You should add a @EntityInfo() decorator to the class. Otherwise it won't be displayed correctly as a dependency.`,
+            );
+            return undefined;
+        }
+
+        if (this.isService(entityInfoGetter)) {
+            const service = this.moduleRef.get(entityInfoGetter, { strict: false });
+            const { name, secondaryInformation } = await service.getEntityInfo(instance);
+            return { name, secondaryInformation };
+        } else {
+            const { name, secondaryInformation } = await entityInfoGetter(instance);
+            return { name, secondaryInformation };
+        }
+    }
+
+    private isService(entityInfoGetter: EntityInfoGetter): entityInfoGetter is Type<EntityInfoServiceInterface> {
+        // Check if class has @Injectable() decorator -> if true it's a service class else it's a function
+        return Reflect.hasMetadata(INJECTABLE_WATERMARK, entityInfoGetter);
+    }
+}

--- a/packages/api/cms-api/src/dam/files/entities/file.entity.ts
+++ b/packages/api/cms-api/src/dam/files/entities/file.entity.ts
@@ -16,7 +16,7 @@ import { Type } from "@nestjs/common";
 import { Field, ID, Int, ObjectType } from "@nestjs/graphql";
 import { v4 as uuid } from "uuid";
 
-import { EntityInfo } from "../../../dependencies/decorators/entity-info.decorator";
+import { EntityInfo } from "../../../common/entityInfo/entity-info.decorator";
 import { CreateWarnings } from "../../../warnings/decorators/create-warnings.decorator";
 import { DamScopeInterface } from "../../types";
 import { FileWarningService } from "../file-warning.service";

--- a/packages/api/cms-api/src/dam/files/files-entity-info.service.ts
+++ b/packages/api/cms-api/src/dam/files/files-entity-info.service.ts
@@ -1,6 +1,6 @@
 import { forwardRef, Inject, Injectable } from "@nestjs/common";
 
-import { EntityInfoServiceInterface } from "../../dependencies/decorators/entity-info.decorator";
+import { EntityInfoServiceInterface } from "../../common/entityInfo/entity-info.decorator";
 import { FileInterface } from "./entities/file.entity";
 import { FilesService } from "./files.service";
 

--- a/packages/api/cms-api/src/dependencies/dependencies.module.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.module.ts
@@ -1,13 +1,14 @@
 import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { Global, Module } from "@nestjs/common";
 
+import { EntityInfoModule } from "../common/entityInfo/entity-info.module";
 import { DependenciesService } from "./dependencies.service";
 import { DiscoverService } from "./discover.service";
 import { BlockIndexRefresh } from "./entities/block-index-refresh.entity";
 
 @Global()
 @Module({
-    imports: [MikroOrmModule.forFeature([BlockIndexRefresh])],
+    imports: [MikroOrmModule.forFeature([BlockIndexRefresh]), EntityInfoModule],
     providers: [DiscoverService, DependenciesService],
     exports: [DiscoverService, DependenciesService],
 })

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -1,12 +1,10 @@
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { AnyEntity, Connection, EntityManager, EntityRepository, Knex, QueryOrder } from "@mikro-orm/postgresql";
-import { Injectable, Logger, Type } from "@nestjs/common";
-import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
-import { ModuleRef } from "@nestjs/core";
+import { Injectable, Logger } from "@nestjs/common";
 import { subMinutes } from "date-fns";
 import { v4 as uuid } from "uuid";
 
-import { EntityInfoGetter, EntityInfoServiceInterface } from "./decorators/entity-info.decorator";
+import { EntityInfoService } from "../common/entityInfo/entity-info.service";
 import { DiscoverService } from "./discover.service";
 import { BaseDependencyInterface } from "./dto/base-dependency.interface";
 import { DependencyFilter, DependentFilter } from "./dto/dependencies.filter";
@@ -28,8 +26,8 @@ export class DependenciesService {
     constructor(
         @InjectRepository(BlockIndexRefresh) private readonly refreshRepository: EntityRepository<BlockIndexRefresh>,
         private readonly discoverService: DiscoverService,
+        private readonly entityInfoService: EntityInfoService,
         private entityManager: EntityManager,
-        private readonly moduleRef: ModuleRef,
     ) {
         this.connection = entityManager.getConnection();
     }
@@ -202,7 +200,7 @@ export class DependenciesService {
 
             let dependency: Dependency = result;
             if (instance) {
-                const entityInfo = await this.getEntityInfo(instance);
+                const entityInfo = await this.entityInfoService.getEntityInfo(instance);
                 dependency = { ...dependency, ...entityInfo };
             }
             ret.push(dependency);
@@ -244,7 +242,7 @@ export class DependenciesService {
 
             let dependency: Dependency = result;
             if (instance) {
-                const entityInfo = await this.getEntityInfo(instance);
+                const entityInfo = await this.entityInfoService.getEntityInfo(instance);
                 dependency = { ...dependency, ...entityInfo };
             }
             ret.push(dependency);
@@ -254,31 +252,6 @@ export class DependenciesService {
         const totalCount = countResult[0]?.count ?? 0;
 
         return new PaginatedDependencies(ret, Number(totalCount));
-    }
-
-    private async getEntityInfo(instance: object) {
-        const entityInfoGetter: EntityInfoGetter | undefined = Reflect.getMetadata(`data:entityInfo`, instance.constructor);
-
-        if (entityInfoGetter === undefined) {
-            this.logger.warn(
-                `Warning: ${instance.constructor.name} doesn't provide any entity info. You should add a @EntityInfo() decorator to the class. Otherwise it won't be displayed correctly as a dependency.`,
-            );
-            return {};
-        }
-
-        if (this.isService(entityInfoGetter)) {
-            const service = this.moduleRef.get(entityInfoGetter, { strict: false });
-            const { name, secondaryInformation } = await service.getEntityInfo(instance);
-            return { name, secondaryInformation };
-        } else {
-            const { name, secondaryInformation } = await entityInfoGetter(instance);
-            return { name, secondaryInformation };
-        }
-    }
-
-    private isService(entityInfoGetter: EntityInfoGetter): entityInfoGetter is Type<EntityInfoServiceInterface> {
-        // Check if class has @Injectable() decorator -> if true it's a service class else it's a function
-        return Reflect.hasMetadata(INJECTABLE_WATERMARK, entityInfoGetter);
     }
 
     private getQueryBuilderWithFilters(

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -125,6 +125,7 @@ export {
 } from "./common/decorators/crud-generator.decorator";
 export { getRequestContextHeadersFromRequest, RequestContext, RequestContextInterface } from "./common/decorators/request-context.decorator";
 export { getRequestFromExecutionContext } from "./common/decorators/utils";
+export { EntityInfo, EntityInfoServiceInterface } from "./common/entityInfo/entity-info.decorator";
 export { CometException } from "./common/errors/comet.exception";
 export { CometEntityNotFoundException } from "./common/errors/entity-not-found.exception";
 export { ExceptionFilter } from "./common/errors/exception.filter";
@@ -191,7 +192,6 @@ export { ImagesService } from "./dam/images/images.service";
 export { IsAllowedImageAspectRatio, IsAllowedImageAspectRatioConstraint } from "./dam/images/validators/is-allowed-aspect-ratio.validator";
 export { IsAllowedImageSize, IsAllowedImageSizeConstraint } from "./dam/images/validators/is-allowed-image-size.validator";
 export { IsValidImageAspectRatio, IsValidImageAspectRatioConstraint } from "./dam/images/validators/is-valid-aspect-ratio.validator";
-export { EntityInfo, EntityInfoServiceInterface } from "./dependencies/decorators/entity-info.decorator";
 export { DependenciesModule } from "./dependencies/dependencies.module";
 export { DependenciesResolverFactory } from "./dependencies/dependencies.resolver.factory";
 export { DependenciesService } from "./dependencies/dependencies.service";

--- a/packages/api/cms-api/src/page-tree/page-tree-node-document-entity-info.service.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree-node-document-entity-info.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 
-import { EntityInfoServiceInterface } from "../dependencies/decorators/entity-info.decorator";
+import { EntityInfoServiceInterface } from "../common/entityInfo/entity-info.decorator";
 import { DocumentInterface } from "../document/dto/document-interface";
 import { PageTreeService } from "./page-tree.service";
 

--- a/packages/api/cms-api/src/warnings/warning.module.ts
+++ b/packages/api/cms-api/src/warnings/warning.module.ts
@@ -1,6 +1,7 @@
 import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { Module } from "@nestjs/common";
 
+import { EntityInfoModule } from "../common/entityInfo/entity-info.module";
 import { Warning } from "./entities/warning.entity";
 import { WarningResolver } from "./warning.resolver";
 import { WarningService } from "./warning.service";
@@ -8,7 +9,7 @@ import { WarningCheckerCommand } from "./warning-checker.command";
 import { WarningEventSubscriber } from "./warning-event-subscriber";
 
 @Module({
-    imports: [MikroOrmModule.forFeature([Warning])],
+    imports: [MikroOrmModule.forFeature([Warning]), EntityInfoModule],
     providers: [WarningResolver, WarningCheckerCommand, WarningService, WarningEventSubscriber],
     exports: [WarningService],
 })

--- a/packages/api/cms-api/src/warnings/warning.resolver.ts
+++ b/packages/api/cms-api/src/warnings/warning.resolver.ts
@@ -1,10 +1,12 @@
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository, FindOptions } from "@mikro-orm/postgresql";
 import { UnauthorizedException } from "@nestjs/common";
-import { Args, ID, Query, Resolver } from "@nestjs/graphql";
+import { Args, ID, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import isEqual from "lodash.isequal";
 
 import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
+import { EntityInfoObject } from "../common/entityInfo/entity-info.object";
+import { EntityInfoService } from "../common/entityInfo/entity-info.service";
 import { gqlArgsToMikroOrmQuery } from "../common/filter/mikro-orm";
 import { AffectedEntity } from "../user-permissions/decorators/affected-entity.decorator";
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
@@ -19,6 +21,7 @@ import { Warning } from "./entities/warning.entity";
 export class WarningResolver {
     constructor(
         private readonly entityManager: EntityManager,
+        private readonly entityInfoService: EntityInfoService,
         @InjectRepository(Warning) private readonly repository: EntityRepository<Warning>,
     ) {}
 
@@ -98,5 +101,18 @@ export class WarningResolver {
 
         const [entities, totalCount] = await this.repository.findAndCount(where, options);
         return new PaginatedWarnings(entities, totalCount);
+    }
+
+    @ResolveField(() => EntityInfoObject, { nullable: true })
+    async entityInfo(@Parent() warning: Warning): Promise<EntityInfoObject | undefined> {
+        const repository = this.entityManager.getRepository(warning.sourceInfo.rootEntityName);
+        const instance = await repository.findOne({ [warning.sourceInfo.rootPrimaryKey]: warning.sourceInfo.targetId });
+
+        if (instance) {
+            const entityInfo = await this.entityInfoService.getEntityInfo(instance);
+            return entityInfo;
+        }
+
+        return undefined;
     }
 }


### PR DESCRIPTION
## Description

- Add entity info to warning grid
- Add EntityInfoService used by dependencies and warnings

### Why?

Before the grid entries contained no info about the affected entity:

<img width="1920" alt="Bildschirmfoto 2025-05-19 um 14 56 32" src="https://github.com/user-attachments/assets/7ef5e33e-5b17-4bc6-98a2-3c6291e92cac" />

This feels strange to me because the user has no idea if the warning concerns, e.g. the home page or some unimportant page before they click on the link. Thus, I added the entity info and type to the grid:

<img width="1920" alt="Bildschirmfoto 2025-05-19 um 14 54 24" src="https://github.com/user-attachments/assets/6959c581-fd2c-41bc-b39d-8e9b816aab78" />


### Open problems

Since the entity info is loaded in a field resolver and not saved with the warning, it's not possible to use it for sorting or filtering. Same with the entity type. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset) -> not required since the feature is unreleased
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-954
