### PR TITLE
Temporarily remove status column from warnings

### DIFF
--- a/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
@@ -34,7 +34,6 @@ const warningsFragment = gql`
         message
         type
         severity
-        status
         sourceInfo {
             rootEntityName
             rootColumnName
@@ -152,17 +151,6 @@ export function WarningsGrid() {
 
                 return intl.formatMessage(messages.globalContentScope);
             },
-        },
-        {
-            field: "status",
-            headerName: intl.formatMessage({ id: "warning.status", defaultMessage: "Status" }),
-            type: "singleSelect",
-            valueOptions: [
-                { value: "open", label: intl.formatMessage({ id: "warning.status.open", defaultMessage: "Open" }) },
-                { value: "resolved", label: intl.formatMessage({ id: "warning.status.resolved", defaultMessage: "Resolved" }) },
-                { value: "ignored", label: intl.formatMessage({ id: "warning.status.ignored", defaultMessage: "Ignored" }) },
-            ],
-            width: 150,
         },
         {
             field: "actions",


### PR DESCRIPTION
## Description

Currently, all warnings are deleted automatically once resolved.  For the first version, we will leave it this way. Thus, I removed the status column from the admin for now.

We plan to add "Ignored" and  maybe "Resolved" later. Then the status field will be relevant again.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset) -> not required since the feature is unreleased
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  <img width="1920" alt="Bildschirmfoto 2025-05-19 um 14 56 32" src="https://github.com/user-attachments/assets/6f746ea8-dce4-4a12-8e2d-6411ed70e06f" /> | <img width="1920" alt="Bildschirmfoto 2025-05-19 um 15 19 30" src="https://github.com/user-attachments/assets/998253d4-5761-4f4f-9c56-265d5ce9e152" />  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-954
