### PR TITLE
Add tooltip to warning actions

### DIFF
--- a/packages/admin/admin/src/messages.ts
+++ b/packages/admin/admin/src/messages.ts
@@ -54,4 +54,6 @@ export const messages = defineMessages({
     deleteItem: { id: "comet.generic.deleteItem", defaultMessage: "Delete Item" },
     empty: { id: "comet.generic.empty", defaultMessage: "Empty" },
     downloadAsExcel: { id: "comet.generic.downloadAsExcel", defaultMessage: "Download as Excel" },
+    openInNewTab: { id: "comet.generic.openInNewTab", defaultMessage: "Open in new tab" },
+    openInThisTab: { id: "comet.generic.openInThisTab", defaultMessage: "Open in this tab" },
 });

--- a/packages/admin/cms-admin/src/warnings/WarningActions.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningActions.tsx
@@ -1,4 +1,5 @@
 import { useApolloClient } from "@apollo/client";
+import { Tooltip } from "@comet/admin";
 import { ArrowRight, OpenNewTab } from "@comet/admin-icons";
 import { IconButton } from "@mui/material";
 import { FormattedMessage } from "react-intl";
@@ -52,23 +53,27 @@ export function WarningActions({ sourceInfo, scope }: Props) {
 
     return (
         <div style={{ display: "flex" }}>
-            <IconButton
-                onClick={async () => {
-                    const url = await loadUrl();
-                    window.open(url, "_blank");
-                }}
-            >
-                <OpenNewTab />
-            </IconButton>
-            <IconButton
-                onClick={async () => {
-                    const url = await loadUrl();
+            <Tooltip title={<FormattedMessage id="comet.warnings.actions.tooltip.openInNewTab" defaultMessage="Open in new tab" />}>
+                <IconButton
+                    onClick={async () => {
+                        const url = await loadUrl();
+                        window.open(url, "_blank");
+                    }}
+                >
+                    <OpenNewTab />
+                </IconButton>
+            </Tooltip>
+            <Tooltip title={<FormattedMessage id="comet.warnings.actions.tooltip.openInThisTab" defaultMessage="Open in this tab" />}>
+                <IconButton
+                    onClick={async () => {
+                        const url = await loadUrl();
 
-                    history.push(url);
-                }}
-            >
-                <ArrowRight />
-            </IconButton>
+                        history.push(url);
+                    }}
+                >
+                    <ArrowRight />
+                </IconButton>
+            </Tooltip>
         </div>
     );
 }

--- a/packages/admin/cms-admin/src/warnings/WarningActions.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningActions.tsx
@@ -1,5 +1,5 @@
 import { useApolloClient } from "@apollo/client";
-import { Tooltip } from "@comet/admin";
+import { messages, Tooltip } from "@comet/admin";
 import { ArrowRight, OpenNewTab } from "@comet/admin-icons";
 import { IconButton } from "@mui/material";
 import { FormattedMessage } from "react-intl";
@@ -53,7 +53,7 @@ export function WarningActions({ sourceInfo, scope }: Props) {
 
     return (
         <div style={{ display: "flex" }}>
-            <Tooltip title={<FormattedMessage id="comet.warnings.actions.tooltip.openInNewTab" defaultMessage="Open in new tab" />}>
+            <Tooltip title={<FormattedMessage {...messages.openInNewTab} />}>
                 <IconButton
                     onClick={async () => {
                         const url = await loadUrl();
@@ -63,7 +63,7 @@ export function WarningActions({ sourceInfo, scope }: Props) {
                     <OpenNewTab />
                 </IconButton>
             </Tooltip>
-            <Tooltip title={<FormattedMessage id="comet.warnings.actions.tooltip.openInThisTab" defaultMessage="Open in this tab" />}>
+            <Tooltip title={<FormattedMessage {...messages.openInThisTab} />}>
                 <IconButton
                     onClick={async () => {
                         const url = await loadUrl();


### PR DESCRIPTION
## Description

Add tooltips to warning actions

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset) -> not required since the feature is unreleased
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

<img width="1920" alt="Bildschirmfoto 2025-05-19 um 15 26 16" src="https://github.com/user-attachments/assets/5ce4114f-1755-4208-ad99-14a6fbfe71c5" />

<img width="1920" alt="Bildschirmfoto 2025-05-19 um 15 26 20" src="https://github.com/user-attachments/assets/d6bb46c2-8527-4b1e-96da-054a30bf21bc" />

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-954
