### PR TITLE
Fix GraphQL type for numbers

### DIFF
--- a/.changeset/heavy-wolves-explode.md
+++ b/.changeset/heavy-wolves-explode.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix: Change GraphQL Type of numberOfDescendants from Float to Int

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -451,7 +451,7 @@ type PageTreeNode {
   category: PageTreeNodeCategory!
   userGroup: UserGroup!
   childNodes: [PageTreeNode!]!
-  numberOfDescendants: Float!
+  numberOfDescendants: Int!
   parentNode: PageTreeNode
   path: String!
   parentNodes: [PageTreeNode!]!

--- a/demo/api/src/products/entities/manufacturer.entity.ts
+++ b/demo/api/src/products/entities/manufacturer.entity.ts
@@ -12,7 +12,7 @@ export class AlternativeAddress {
     @IsString()
     street: string;
 
-    @Field(() => Number, { nullable: true })
+    @Field({ nullable: true })
     @Property({ nullable: true })
     @IsNumber()
     @IsNullable()
@@ -49,7 +49,7 @@ export class AlternativeAddressAsEmbeddable {
     @IsString()
     street: string;
 
-    @Field(() => Number, { nullable: true })
+    @Field({ nullable: true })
     @Property({ nullable: true })
     @IsNumber()
     @IsNullable()

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -219,7 +219,7 @@ type PageTreeNode {
   updatedAt: DateTime!
   category: String!
   childNodes: [PageTreeNode!]!
-  numberOfDescendants: Float!
+  numberOfDescendants: Int!
   parentNode: PageTreeNode
   path: String!
   parentNodes: [PageTreeNode!]!

--- a/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
+++ b/packages/api/cms-api/src/page-tree/createPageTreeResolver.ts
@@ -1,5 +1,5 @@
 import { Inject, Type } from "@nestjs/common";
-import { Args, ArgsType, createUnionType, ID, Info, Mutation, ObjectType, Parent, Query, ResolveField, Resolver, Union } from "@nestjs/graphql";
+import { Args, ArgsType, createUnionType, ID, Info, Int, Mutation, ObjectType, Parent, Query, ResolveField, Resolver, Union } from "@nestjs/graphql";
 import { GraphQLError, GraphQLResolveInfo } from "graphql";
 
 import { PaginatedResponseFactory } from "../common/pagination/paginated-response.factory";
@@ -140,7 +140,7 @@ export function createPageTreeResolver({
             return this.pageTreeReadApi.getChildNodes(node);
         }
 
-        @ResolveField(() => Number)
+        @ResolveField(() => Int)
         async numberOfDescendants(@Parent() node: PageTreeNodeInterface): Promise<number> {
             const childNodes = await this.pageTreeReadApi.getChildNodes(node);
             let numberOfDescendants = childNodes.length;


### PR DESCRIPTION
Number is invalid, it should either be `Float` (default) or `Int` from `@nestjs/graphql`

---

In Demo we have several possibilities of using Int instead of Float, but this is OOS for this PR.
