### PR TITLE
Fix color of undo button in snackbar

### DIFF
--- a/.changeset/tall-vans-deny.md
+++ b/.changeset/tall-vans-deny.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix color of button in `UndoSnackbar`

--- a/packages/admin/admin/src/snackbar/UndoSnackbar.tsx
+++ b/packages/admin/admin/src/snackbar/UndoSnackbar.tsx
@@ -26,7 +26,7 @@ export const UndoSnackbar = <Payload,>({ onUndoClick, payload, ...props }: UndoS
             anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
             autoHideDuration={5000}
             action={
-                <Button variant="textDark" size="small" onClick={onClick}>
+                <Button variant="textLight" size="small" onClick={onClick}>
                     <FormattedMessage {...messages.undo} />
                 </Button>
             }


### PR DESCRIPTION
## Description

The button in the `UndoSnackbar` used the wrong variant and wasn't readable. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="301" alt="Screenshot 2025-05-20 at 09 45 35" src="https://github.com/user-attachments/assets/f48c8afb-9e4c-41cd-9331-4bb587250fcc" />  | <img width="307" alt="Screenshot 2025-05-20 at 09 41 19" src="https://github.com/user-attachments/assets/90eca1ed-46a0-4b40-822b-d6c1b679a752" /> </br>Hover:</br><img width="307" alt="Screenshot 2025-05-20 at 09 41 01" src="https://github.com/user-attachments/assets/c8a37e5b-3297-4f74-932d-252c6f67a5ba" /> |

 

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2033
