### PR TITLE
Accordion: prevent content from receiving focus when collapsed

### DIFF
--- a/.changeset/old-wombats-drop.md
+++ b/.changeset/old-wombats-drop.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-site": patch
+---
+
+`AccordionBlock`: prevent content from receiving focus when collapsed

--- a/.changeset/old-wombats-drop.md
+++ b/.changeset/old-wombats-drop.md
@@ -1,5 +1,0 @@
----
-"@comet/cms-site": patch
----
-
-`AccordionBlock`: prevent content from receiving focus when collapsed

--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -101,8 +101,8 @@ const ContentWrapper = styled.div<{ $isExpanded: boolean }>`
 const ContentWrapperInner = styled.div<{ $isExpanded: boolean }>`
     overflow: hidden;
     visibility: hidden;
-    transition: visibility 350ms;
-    transition-delay: ${({ $isExpanded }) => ($isExpanded ? "0ms" : "350ms")};
+    transition: visibility;
+    transition-delay: ${({ $isExpanded }) => ($isExpanded ? "0s" : "0.5s")};
 
     ${({ $isExpanded }) =>
         $isExpanded &&

--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -46,7 +46,7 @@ export const AccordionItemBlock = withPreview(
                     </IconWrapper>
                 </TitleWrapper>
                 <ContentWrapper aria-hidden={!isExpanded} $isExpanded={isExpanded}>
-                    <ContentWrapperInner $isExpanded={isExpanded}>
+                    <ContentWrapperInner>
                         <AccordionContentBlock data={content} />
                     </ContentWrapperInner>
                 </ContentWrapper>
@@ -88,25 +88,19 @@ const ContentWrapper = styled.div<{ $isExpanded: boolean }>`
     position: relative;
     display: grid;
     grid-template-rows: 0fr;
-    transition: grid-template-rows 0.5s ease-out;
+    transition: grid-template-rows 0.5s ease-out, visibility 0s linear 0.5s;
+    visibility: hidden;
 
     ${({ $isExpanded }) =>
         $isExpanded &&
         css`
             grid-template-rows: 1fr;
             padding-bottom: ${({ theme }) => theme.spacing.S300};
+            visibility: visible;
+            transition-delay: 0s;
         `}
 `;
 
-const ContentWrapperInner = styled.div<{ $isExpanded: boolean }>`
+const ContentWrapperInner = styled.div`
     overflow: hidden;
-    visibility: hidden;
-    transition: visibility;
-    transition-delay: ${({ $isExpanded }) => ($isExpanded ? "0s" : "0.5s")};
-
-    ${({ $isExpanded }) =>
-        $isExpanded &&
-        css`
-            visibility: visible;
-        `}
 `;

--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -46,7 +46,7 @@ export const AccordionItemBlock = withPreview(
                     </IconWrapper>
                 </TitleWrapper>
                 <ContentWrapper aria-hidden={!isExpanded} $isExpanded={isExpanded}>
-                    <ContentWrapperInner>
+                    <ContentWrapperInner $isExpanded={isExpanded}>
                         <AccordionContentBlock data={content} />
                     </ContentWrapperInner>
                 </ContentWrapper>
@@ -98,6 +98,15 @@ const ContentWrapper = styled.div<{ $isExpanded: boolean }>`
         `}
 `;
 
-const ContentWrapperInner = styled.div`
+const ContentWrapperInner = styled.div<{ $isExpanded: boolean }>`
     overflow: hidden;
+    visibility: hidden;
+    transition: visibility 350ms;
+    transition-delay: ${({ $isExpanded }) => ($isExpanded ? "0ms" : "350ms")};
+
+    ${({ $isExpanded }) =>
+        $isExpanded &&
+        css`
+            visibility: visible;
+        `}
 `;


### PR DESCRIPTION
## Description

When focusable elements are in the accordions content, they are focusable even when the accordion is collapsed. `visibility: hidden;` prevents the content from receiving focus.
