### PR TITLE
Admin Generator: fix FormValues type for rootBlocks

### DIFF
--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateForm.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateForm.ts
@@ -341,11 +341,11 @@ export function generateForm(
     ${customFilterByFragment}
 
     type FormValues = ${
-        formValuesConfig.filter((config) => !!config.omitFromFragmentType).length > 0
-            ? `Omit<${filterByFragmentType}, ${formValuesConfig
-                  .filter((config) => !!config.omitFromFragmentType)
-                  .map((config) => `"${config.omitFromFragmentType}"`)
-                  .join(" | ")}>`
+        formValuesConfig.filter((config) => !!config.omitFromFragmentType).length > 0 || rootBlockFields.length > 0
+            ? `Omit<${filterByFragmentType}, ${[
+                  ...(rootBlockFields.length > 0 ? ["keyof typeof rootBlocks"] : []),
+                  ...formValuesConfig.filter((config) => !!config.omitFromFragmentType).map((config) => `"${config.omitFromFragmentType}"`),
+              ].join(" | ")}>`
             : `${filterByFragmentType}`
     } ${
         formValuesConfig.filter((config) => !!config.typeCode).length > 0


### PR DESCRIPTION
Example in NewsForm:
`GQLNewsFormFragment["image"]` is merged with `BlockState<typeof rootBlocks.image>` instead of replacing it (using & operator). Add Omit to properly replace.

This avoids possible incompatible types from GQL and block state.

before:
```
const rootBlocks = {
    image: DamImageBlock, content: NewsContentBlock
};
type FormValues = GQLNewsFormFragment & {
    image: BlockState<typeof rootBlocks.image>;
    content: BlockState<typeof rootBlocks.content>;
};
```
now:
```
const rootBlocks = {
    image: DamImageBlock, content: NewsContentBlock
};
type FormValues = Omit<GQLNewsFormFragment, keyof typeof rootBlocks> & {
    image: BlockState<typeof rootBlocks.image>;
    content: BlockState<typeof rootBlocks.content>;
};
```