### PR TITLE
Fix delete dialog on close

### DIFF
--- a/.changeset/modern-pugs-kiss.md
+++ b/.changeset/modern-pugs-kiss.md
@@ -1,5 +1,5 @@
 ---
-"@comet/admin": minor
+"@comet/admin": patch
 ---
 
-Change the `onClose` prop of `DeleteDialog` to use the `onCancel` function instead of `onDelete`
+Don't delete an item when closing the delete dialog in `CrudContextMenu`

--- a/.changeset/modern-pugs-kiss.md
+++ b/.changeset/modern-pugs-kiss.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Change the `onClose` prop of `DeleteDialog` to use the `onCancel` function instead of `onDelete`

--- a/packages/admin/admin/src/common/DeleteDialog.tsx
+++ b/packages/admin/admin/src/common/DeleteDialog.tsx
@@ -16,7 +16,7 @@ export const DeleteDialog = (props: DeleteDialogProps) => {
     const { dialogOpen, onDelete, onCancel } = props;
 
     return (
-        <Dialog open={dialogOpen} onClose={onDelete} maxWidth="sm">
+        <Dialog open={dialogOpen} onClose={onCancel} maxWidth="sm">
             <DialogTitle>
                 <FormattedMessage id="comet.table.deleteDialog.title" defaultMessage="Attention. Please confirm." />
             </DialogTitle>


### PR DESCRIPTION
## Description
This fixes a bug in the `CrudContextMenu`, where the `DeleteDialog` would also trigger the `onDelete` function, when the dialog is closed (eg. by clicking on the backdrop).

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset