### PR TITLE
Prevent the `UserPermissionsUserGrid` from losing focus while entering text in the search input

### DIFF
--- a/.changeset/wild-items-shake.md
+++ b/.changeset/wild-items-shake.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Prevent the `UserPermissionsUserGrid` from losing focus while entering text in the search input

--- a/packages/admin/cms-admin/src/userPermissions/UserGrid.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/UserGrid.tsx
@@ -24,6 +24,21 @@ import { useCurrentUser } from "./hooks/currentUser";
 import { GQLUserForGridFragment, GQLUserGridQuery, GQLUserGridQueryVariables } from "./UserGrid.generated";
 import { startImpersonation, stopImpersonation } from "./utils/handleImpersonation";
 
+function UserPermissionsGridToolbar({ toolbarAction }: { toolbarAction?: React.ReactNode }) {
+    return (
+        <DataGridToolbar>
+            <ToolbarItem>
+                <GridToolbarQuickFilter />
+            </ToolbarItem>
+            <ToolbarItem>
+                <GridFilterButton />
+            </ToolbarItem>
+            <FillSpace />
+            {toolbarAction && <ToolbarActions>{toolbarAction}</ToolbarActions>}
+        </DataGridToolbar>
+    );
+}
+
 type Props = {
     toolbarAction?: React.ReactNode;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -224,18 +239,7 @@ export const UserPermissionsUserGrid = ({ toolbarAction, rowAction, actionsColum
             rowCount={data?.users.totalCount ?? 0}
             loading={loading}
             components={{
-                Toolbar: () => (
-                    <DataGridToolbar>
-                        <ToolbarItem>
-                            <GridToolbarQuickFilter />
-                        </ToolbarItem>
-                        <ToolbarItem>
-                            <GridFilterButton />
-                        </ToolbarItem>
-                        <FillSpace />
-                        {toolbarAction && <ToolbarActions>{toolbarAction}</ToolbarActions>}
-                    </DataGridToolbar>
-                ),
+                Toolbar: UserPermissionsGridToolbar,
             }}
             componentsProps={{
                 toolbar: { toolbarAction },


### PR DESCRIPTION
## Description

Prevent the `UserPermissionsUserGrid` from losing focus while entering text in the search input

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

### Before


https://github.com/user-attachments/assets/1e289ac0-183f-4a51-b7c8-db33d4c8cd9a



### After


https://github.com/user-attachments/assets/d7786f1e-d1b0-4826-901d-f55415cfdceb

