### PR TITLE
Remove type in warning entity

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -217,7 +217,6 @@ type Warning {
   createdAt: DateTime!
   updatedAt: DateTime!
   message: String!
-  type: String!
   severity: WarningSeverity!
   sourceInfo: WarningSourceInfo!
   status: WarningStatus!

--- a/demo/api/src/db/migrations/Migration20241108073817.ts
+++ b/demo/api/src/db/migrations/Migration20241108073817.ts
@@ -3,7 +3,7 @@ import { Migration } from '@mikro-orm/migrations';
 export class Migration20241108073817 extends Migration {
 
   async up(): Promise<void> {
-    this.addSql('create table "Warning" ("id" uuid not null, "createdAt" timestamptz(0) not null, "updatedAt" timestamptz(0) not null, "message" text not null, "type" varchar(255) not null, "severity" text check ("severity" in (\'high\', \'medium\', \'low\')) not null, "status" text check ("status" in (\'open\', \'resolved\', \'ignored\')) not null default \'open\', constraint "Warning_pkey" primary key ("id"));');
+    this.addSql('create table "Warning" ("id" uuid not null, "createdAt" timestamptz(0) not null, "updatedAt" timestamptz(0) not null, "message" text not null, "severity" text check ("severity" in (\'high\', \'medium\', \'low\')) not null, "status" text check ("status" in (\'open\', \'resolved\', \'ignored\')) not null default \'open\', constraint "Warning_pkey" primary key ("id"));');
   }
 
 }

--- a/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
@@ -34,7 +34,6 @@ const warningsFragment = gql`
         createdAt
         updatedAt
         message
-        type
         severity
         sourceInfo {
             rootEntityName

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -220,7 +220,6 @@ type Warning {
   createdAt: DateTime!
   updatedAt: DateTime!
   message: String!
-  type: String!
   severity: WarningSeverity!
   sourceInfo: WarningSourceInfo!
   status: WarningStatus!

--- a/packages/api/cms-api/src/warnings/entities/warning.entity.ts
+++ b/packages/api/cms-api/src/warnings/entities/warning.entity.ts
@@ -29,10 +29,6 @@ export class Warning extends BaseEntity {
     @Field()
     message: string;
 
-    @Property()
-    @Field()
-    type: string;
-
     @Enum({ items: () => WarningSeverity })
     @Field(() => WarningSeverity)
     severity: `${WarningSeverity}`;

--- a/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
+++ b/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
@@ -103,11 +103,10 @@ export class WarningEventSubscriber implements EventSubscriber {
 
                     await this.warningService.saveWarnings({
                         warnings,
-                        type: "Block",
                         sourceInfo,
                         scope,
                     });
-                    await this.warningService.deleteOutdatedWarnings({ date: startDate, type: "Block", sourceInfo });
+                    await this.warningService.deleteOutdatedWarnings({ date: startDate, sourceInfo });
                 }
             }
 
@@ -133,11 +132,10 @@ export class WarningEventSubscriber implements EventSubscriber {
                     };
                     await this.warningService.saveWarnings({
                         warnings,
-                        type: "Entity",
                         sourceInfo,
                         scope: row.scope,
                     });
-                    await this.warningService.deleteOutdatedWarnings({ date: startDate, type: "Entity", sourceInfo });
+                    await this.warningService.deleteOutdatedWarnings({ date: startDate, sourceInfo });
                 }
             }
         }

--- a/packages/api/cms-api/src/warnings/warning.service.ts
+++ b/packages/api/cms-api/src/warnings/warning.service.ts
@@ -13,12 +13,10 @@ export class WarningService {
 
     private async saveWarning({
         warning,
-        type,
         sourceInfo,
         scope,
     }: {
         warning: WarningData;
-        type: string;
         sourceInfo: WarningSourceInfo;
         scope?: ContentScope;
     }): Promise<void> {
@@ -31,7 +29,6 @@ export class WarningService {
                 createdAt: new Date(),
                 updatedAt: new Date(),
                 id,
-                type,
                 message: warning.message,
                 severity: warning.severity,
                 sourceInfo,
@@ -43,26 +40,23 @@ export class WarningService {
 
     public async saveWarnings({
         warnings,
-        type,
         sourceInfo,
         scope,
     }: {
         warnings: WarningData[];
-        type: string;
         sourceInfo: WarningSourceInfo;
         scope?: ContentScope;
     }): Promise<void> {
         for (const warning of warnings) {
             await this.saveWarning({
                 warning,
-                type,
                 sourceInfo,
                 scope,
             });
         }
     }
 
-    public async deleteOutdatedWarnings({ date, type, sourceInfo }: { date: Date; type: string; sourceInfo: WarningSourceInfo }): Promise<void> {
-        await this.entityManager.nativeDelete(Warning, { type, updatedAt: { $lt: date }, sourceInfo });
+    public async deleteOutdatedWarnings({ date, sourceInfo }: { date: Date; sourceInfo: WarningSourceInfo }): Promise<void> {
+        await this.entityManager.nativeDelete(Warning, { updatedAt: { $lt: date }, sourceInfo });
     }
 }


### PR DESCRIPTION
## Description
I wasnt 100% sure if the type was needed so I had to try it, see this discussion:
https://github.com/vivid-planet/comet/pull/3869#discussion_r2107517214

I removed the type and tested it. I thought that it might make problems when there is an entity and a block with similar sourceInfo. I created warnings for an entity and a block(in the same entity) and tested if the entities are correctly resolved and that worked. So type can be removed

I just updated the migration because it's still in the feature branch

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)


## Further information

-  Task: https://vivid-planet.atlassian.net/browse/COM-954
