### PR TITLE
Fix indicator for sublevel menu entries in collapsed MainNavigation

### DIFF
--- a/packages/admin/admin/src/mui/mainNavigation/CollapsibleItem.styles.ts
+++ b/packages/admin/admin/src/mui/mainNavigation/CollapsibleItem.styles.ts
@@ -102,6 +102,7 @@ export const CollapsibleIndicator = createComponentSlot("div")<MainNavigationCol
         css`
             font-size: 12px;
             color: ${theme.palette.grey[200]};
+            margin-left: -2px;
 
             ${ownerState.subMenuOpen &&
             css`

--- a/packages/admin/admin/src/mui/mainNavigation/CollapsibleItem.styles.ts
+++ b/packages/admin/admin/src/mui/mainNavigation/CollapsibleItem.styles.ts
@@ -102,7 +102,6 @@ export const CollapsibleIndicator = createComponentSlot("div")<MainNavigationCol
         css`
             font-size: 12px;
             color: ${theme.palette.grey[200]};
-            margin-left: -2px;
 
             ${ownerState.subMenuOpen &&
             css`

--- a/packages/admin/admin/src/mui/mainNavigation/Item.styles.ts
+++ b/packages/admin/admin/src/mui/mainNavigation/Item.styles.ts
@@ -324,7 +324,11 @@ export const Root = createComponentSlot(ListItemButton)<MainNavigationItemClassK
 export const Icon = createComponentSlot(ListItemIcon)<MainNavigationItemClassKey, OwnerState>({
     componentName: "MainNavigationItem",
     slotName: "icon",
-})();
+})(
+    () => css`
+        margin-right: 0;
+    `,
+);
 
 export const Text = createComponentSlot(ListItemText)<MainNavigationItemClassKey, OwnerState>({
     componentName: "MainNavigationItem",


### PR DESCRIPTION
## Description

The indicator for sublevel menu entries in the collapsed MainNavigation was not displayed.

-  Correct margin to make it visible again


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="389" alt="Screenshot 2025-05-28 at 15 23 17" src="https://github.com/user-attachments/assets/33689c0f-c18c-489b-a47b-e0506d4ee387" />   | <img width="295" alt="Screenshot 2025-06-05 at 14 40 25" src="https://github.com/user-attachments/assets/e0f5eb2c-64e6-493c-a0cc-16ffaafd7356" />
  

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1992
