### PR TITLE
Create a block_index view that contains a flat list of all blocks existing in the project

### DIFF
--- a/.changeset/late-trees-grow.md
+++ b/.changeset/late-trees-grow.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Create a block_index view that contains a flat list of all blocks existing in the project

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -35,11 +35,11 @@ export class DependenciesService {
     }
 
     async createViews(): Promise<void> {
-        await this.createDependenciesViews();
-        await this.createBlockIndexViews();
+        await this.createDependenciesView();
+        await this.createBlockIndexView();
     }
 
-    async createDependenciesViews(): Promise<void> {
+    private async createDependenciesView(): Promise<void> {
         const indexSelects: string[] = [];
         const targetEntities = this.discoverService.discoverTargetEntities();
 
@@ -97,7 +97,7 @@ export class DependenciesService {
         console.timeEnd("creating block dependency materialized view index");
     }
 
-    async createBlockIndexViews(): Promise<void> {
+    private async createBlockIndexView(): Promise<void> {
         const indexSelects: string[] = [];
 
         for (const rootBlockEntity of this.discoverService.discoverRootBlocks()) {

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -122,9 +122,10 @@ export class DependenciesService {
 
         const viewSql = indexSelects.join("\n UNION ALL \n");
 
-        console.time("creating block dependency materialized view");
+        console.time("creating block index view");
         await this.connection.execute(`DROP VIEW IF EXISTS block_index`);
         await this.connection.execute(`CREATE VIEW block_index AS ${viewSql}`);
+        console.timeEnd("creating block index view");
     }
 
     async refreshViews(options?: { force?: boolean; awaitRefresh?: boolean }): Promise<void> {


### PR DESCRIPTION
This creates a new database view block_index, similar to the block_index_dependencies, containing a flat list of all blocks existing in the project

- so far, the view is not used by any code at runtime, it's for dev purpose only
- because of that, it is not materialized and doesn't need any refresh mechanism
- although not directly related to dependencies, I decided to add this view in the dependencies module
    - else fixtures command (=project code) would need a new .createViews(); call 

Example usage:
`SELECT COUNT(*) FROM block_index WHERE blockname = 'Space'`