### PR TITLE
Fix type error in `RedirectsGrid`

### DIFF
--- a/.changeset/fast-memes-roll.md
+++ b/.changeset/fast-memes-roll.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix type error in `RedirectsGrid`

--- a/.changeset/fast-memes-roll.md
+++ b/.changeset/fast-memes-roll.md
@@ -1,5 +1,0 @@
----
-"@comet/cms-admin": patch
----
-
-Fix type error in `RedirectsGrid`

--- a/packages/admin/cms-admin/src/redirects/RedirectsGrid.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsGrid.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@apollo/client";
 import {
     Button,
+    dataGridDateTimeColumn,
     DataGridToolbar,
     FillSpace,
     type GridColDef,
@@ -126,6 +127,7 @@ export function RedirectsGrid({ linkBlock, scope }: Props): JSX.Element {
             type: "boolean",
         },
         {
+            ...dataGridDateTimeColumn,
             field: "activatedAt",
             headerName: intl.formatMessage({
                 id: "comet.pages.redirects.redirect.activatedAt",
@@ -133,10 +135,6 @@ export function RedirectsGrid({ linkBlock, scope }: Props): JSX.Element {
             }),
             sortable: false,
             width: 170,
-            renderCell: (params) => {
-                if (!params.value) return null;
-                return <>{new Date(params.value).toLocaleString()}</>;
-            },
         },
         {
             field: "actions",

--- a/packages/admin/cms-admin/src/redirects/RedirectsGrid.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsGrid.tsx
@@ -132,9 +132,11 @@ export function RedirectsGrid({ linkBlock, scope }: Props): JSX.Element {
                 defaultMessage: "Activation Date",
             }),
             sortable: false,
-            type: "dateTime",
-            valueGetter: ({ value }) => value && new Date(value),
             width: 170,
+            renderCell: (params) => {
+                if (!params.value) return null;
+                return <>{new Date(params.value).toLocaleString()}</>;
+            },
         },
         {
             field: "actions",


### PR DESCRIPTION
## Description

Fix type error in `RedirectsGrid` caused by `activatedAt` column. This happened, if a redirect was deactivated and the activatedAt field was set to null. The error was caused by the grid not handling null values correctly for this column. 

_This error only appears on the next branch, likely because of Mui's strict type handling in v7: https://mui.com/x/migration/migration-data-grid-v6/#columns_



## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1391" alt="Screenshot 2025-05-30 at 10 10 21" src="https://github.com/user-attachments/assets/f9b46c4a-a14e-499a-831d-a29f4d1dfd7e" /> | <img width="1391" alt="Screenshot 2025-05-30 at 10 09 49" src="https://github.com/user-attachments/assets/57bdc63c-2c1e-4d92-ac15-50f5c59f3adb" /> |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2052
