### PR TITLE
Add a `getFileContent` method to the `FileUploadsService`

### DIFF
--- a/.changeset/itchy-news-play.md
+++ b/.changeset/itchy-news-play.md
@@ -2,7 +2,7 @@
 "@comet/cms-api": minor
 ---
 
-Add a `getFileAsBase64DataUri` method to the `FileUploadsService`
+Add new methods `getFileContent` and `getFileAsBase64DataUri` to the `FileUploadsService`
 
-This method allows you to retrieve a file as a base64-encoded data URI.
-It is meant to be used for embedding images, e.g., when generating a PDF.
+These methods allow you to retrieve a file content.
+This is needed for cases like embedding images in a PDF or attaching files to emails.

--- a/.changeset/itchy-news-play.md
+++ b/.changeset/itchy-news-play.md
@@ -2,7 +2,7 @@
 "@comet/cms-api": minor
 ---
 
-Add new methods `getFileContent` and `getFileAsBase64DataUri` to the `FileUploadsService`
+Add new methods `getFileContent` to the `FileUploadsService`
 
-These methods allow you to retrieve a file content.
+These methods allow you to retrieve a file's content as Buffer.
 This is needed for cases like embedding images in a PDF or attaching files to emails.

--- a/.changeset/itchy-news-play.md
+++ b/.changeset/itchy-news-play.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-api": minor
+---
+
+Add a `getFileAsBase64DataUri` method to the `FileUploadsService`
+
+This method allows you to retrieve a file as a base64-encoded data URI.
+It is meant to be used for embedding images, e.g., when generating a PDF.

--- a/.changeset/itchy-news-play.md
+++ b/.changeset/itchy-news-play.md
@@ -2,7 +2,7 @@
 "@comet/cms-api": minor
 ---
 
-Add new methods `getFileContent` to the `FileUploadsService`
+Add new `getFileContent` method to the `FileUploadsService`
 
-These methods allow you to retrieve a file's content as Buffer.
+This method allows you to retrieve a file's content as a Buffer.
 This is needed for cases like embedding images in a PDF or attaching files to emails.

--- a/packages/api/cms-api/src/file-uploads/file-uploads.service.spec.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.service.spec.ts
@@ -80,16 +80,4 @@ describe("FileUploadsService", () => {
             await expect(service.getFileContent(fileUpload)).rejects.toThrow("File not found");
         });
     });
-
-    describe("getFileContentAsBase64DataUri", () => {
-        it("should return base64 data URI", async () => {
-            const buffer = Buffer.from("test");
-            mockBlobStorageBackendService.fileExists.mockResolvedValue(true);
-            mockBlobStorageBackendService.getFile.mockResolvedValue(Readable.from([buffer]));
-
-            const result = await service.getFileContentAsBase64DataUri(fileUpload);
-
-            expect(result).toBe(`data:${fileUpload.mimetype};base64,${buffer.toString("base64")}`);
-        });
-    });
 });

--- a/packages/api/cms-api/src/file-uploads/file-uploads.service.spec.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.service.spec.ts
@@ -1,0 +1,95 @@
+import { getRepositoryToken } from "@mikro-orm/nestjs";
+import { EntityManager } from "@mikro-orm/postgresql";
+import { Test, TestingModule } from "@nestjs/testing";
+import { Readable } from "stream";
+
+import { BlobStorageBackendService } from "../blob-storage/backends/blob-storage-backend.service";
+import { FileUpload } from "./entities/file-upload.entity";
+import { FileUploadsConfig } from "./file-uploads.config";
+import { FILE_UPLOADS_CONFIG } from "./file-uploads.constants";
+import { FileUploadsService } from "./file-uploads.service";
+
+const mockBlobStorageBackendService = {
+    upload: jest.fn(),
+    fileExists: jest.fn(),
+    getFile: jest.fn(),
+};
+
+const mockEntityManager = {
+    persist: jest.fn(),
+};
+
+const mockRepository = {
+    create: jest.fn(),
+};
+
+const mockConfig: FileUploadsConfig = {
+    directory: "test-dir",
+    download: {
+        secret: "test-secret",
+    },
+    maxFileSize: 10485760, // 10 MB
+    acceptedMimeTypes: ["image/png", "image/jpeg", "application/pdf"],
+};
+
+const fileUpload = {
+    id: "mock-uuid",
+    name: "testfile.txt",
+    size: 123456,
+    mimetype: "text/plain",
+    contentHash: "abc123def456abc123def456abc123de",
+    createdAt: new Date("2023-01-01T00:00:00Z"),
+    updatedAt: new Date("2023-01-01T00:00:00Z"),
+} as FileUpload;
+
+describe("FileUploadsService", () => {
+    let service: FileUploadsService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                FileUploadsService,
+                { provide: getRepositoryToken(FileUpload), useValue: mockRepository },
+                { provide: BlobStorageBackendService, useValue: mockBlobStorageBackendService },
+                { provide: FILE_UPLOADS_CONFIG, useValue: mockConfig },
+                { provide: EntityManager, useValue: mockEntityManager },
+            ],
+        }).compile();
+
+        service = module.get<FileUploadsService>(FileUploadsService);
+
+        jest.clearAllMocks();
+    });
+
+    describe("getFileContent", () => {
+        it("should return file buffer if file exists", async () => {
+            const buffer = Buffer.from("test");
+            mockBlobStorageBackendService.fileExists.mockResolvedValue(true);
+            mockBlobStorageBackendService.getFile.mockResolvedValue(Readable.from([buffer]));
+
+            const result = await service.getFileContent(fileUpload);
+
+            expect(result).toEqual(buffer);
+            expect(mockBlobStorageBackendService.fileExists).toHaveBeenCalled();
+            expect(mockBlobStorageBackendService.getFile).toHaveBeenCalled();
+        });
+
+        it("should throw if file does not exist", async () => {
+            mockBlobStorageBackendService.fileExists.mockResolvedValue(false);
+
+            await expect(service.getFileContent(fileUpload)).rejects.toThrow("File not found");
+        });
+    });
+
+    describe("getFileContentAsBase64DataUri", () => {
+        it("should return base64 data URI", async () => {
+            const buffer = Buffer.from("test");
+            mockBlobStorageBackendService.fileExists.mockResolvedValue(true);
+            mockBlobStorageBackendService.getFile.mockResolvedValue(Readable.from([buffer]));
+
+            const result = await service.getFileContentAsBase64DataUri(fileUpload);
+
+            expect(result).toBe(`data:${fileUpload.mimetype};base64,${buffer.toString("base64")}`);
+        });
+    });
+});

--- a/packages/api/cms-api/src/file-uploads/file-uploads.service.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.service.ts
@@ -5,8 +5,10 @@ import { createHmac } from "crypto";
 import { addHours } from "date-fns";
 import hasha from "hasha";
 import { basename, extname, parse } from "path";
+import { Readable } from "stream";
 
 import { BlobStorageBackendService } from "../blob-storage/backends/blob-storage-backend.service";
+import { createHashedPath } from "../blob-storage/utils/create-hashed-path.util";
 import { FileUploadInput } from "../dam/files/dto/file-upload.input";
 import { slugifyFilename } from "../dam/files/files.utils";
 import { ALL_TYPES } from "../dam/images/images.constants";
@@ -89,5 +91,24 @@ export class FileUploadsService {
         const filename = parse(file.name).name;
 
         return ["/file-uploads", hash, file.id, timeout, resizeWidth, filename].join("/");
+    }
+
+    async getFileAsBase64DataUri(file: FileUpload): Promise<string> {
+        const filePath = createHashedPath(file.contentHash);
+        const fileExists = await this.blobStorageBackendService.fileExists(this.config.directory, filePath);
+
+        if (!fileExists) {
+            throw new Error("File not found");
+        }
+
+        const stream = await this.blobStorageBackendService.getFile(this.config.directory, filePath);
+
+        const chunks: Buffer[] = [];
+        for await (const chunk of stream as Readable) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        const buffer = Buffer.concat(chunks);
+        const base64 = buffer.toString("base64");
+        return `data:${file.mimetype};base64,${base64}`;
     }
 }

--- a/packages/api/cms-api/src/file-uploads/file-uploads.service.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.service.ts
@@ -93,7 +93,7 @@ export class FileUploadsService {
         return ["/file-uploads", hash, file.id, timeout, resizeWidth, filename].join("/");
     }
 
-    async getFileAsBase64DataUri(file: FileUpload): Promise<string> {
+    async getFileContent(file: FileUpload): Promise<Buffer> {
         const filePath = createHashedPath(file.contentHash);
         const fileExists = await this.blobStorageBackendService.fileExists(this.config.directory, filePath);
 
@@ -108,6 +108,11 @@ export class FileUploadsService {
             chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
         }
         const buffer = Buffer.concat(chunks);
+        return buffer;
+    }
+
+    async getFileContentAsBase64DataUri(file: FileUpload): Promise<string> {
+        const buffer = await this.getFileContent(file);
         const base64 = buffer.toString("base64");
         return `data:${file.mimetype};base64,${base64}`;
     }

--- a/packages/api/cms-api/src/file-uploads/file-uploads.service.ts
+++ b/packages/api/cms-api/src/file-uploads/file-uploads.service.ts
@@ -110,10 +110,4 @@ export class FileUploadsService {
         const buffer = Buffer.concat(chunks);
         return buffer;
     }
-
-    async getFileContentAsBase64DataUri(file: FileUpload): Promise<string> {
-        const buffer = await this.getFileContent(file);
-        const base64 = buffer.toString("base64");
-        return `data:${file.mimetype};base64,${base64}`;
-    }
 }


### PR DESCRIPTION
## Description

This method allows you to retrieve a file as a base64-encoded data URI. It is meant to be used for embedding images, e.g., when generating a PDF.

## Acceptance criteria

-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
