### PR TITLE
Set `altText` and `title` fields to null in the DAM when deleting the field value

### DIFF
--- a/.changeset/tiny-lizards-appear.md
+++ b/.changeset/tiny-lizards-appear.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Set `altText` and `title` fields to null in the DAM when deleting the field value
+
+Previously, the `altText` and `title` fields value couldn't be completely removed.

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -146,8 +146,8 @@ const EditFileInner = ({ file, id, contentScopeIndicator }: EditFileInnerProps) 
                     id,
                     input: {
                         name: values.name,
-                        title: values.title,
-                        altText: values.altText,
+                        altText: values.altText ?? null,
+                        title: values.title ?? null,
                         image: {
                             cropArea,
                         },

--- a/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
@@ -126,6 +126,7 @@ export const FileSettingsFields = ({ file }: SettingsFormProps) => {
                         return `${value}.${extension}`;
                     }}
                     fullWidth
+                    required
                 />
             </FormSection>
             {isImage && <CropSettingsFields />}


### PR DESCRIPTION
## Description

Set `altText` and `title` fields to null in the DAM when deleting the field value

Previously, the `altText` and `title` fields value couldn't be completely removed.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Before

https://github.com/user-attachments/assets/03e9f7c2-e7fa-4c23-ab59-0829d3095974


After


https://github.com/user-attachments/assets/581b9007-008d-497a-8580-7502b1744f25
