### PR TITLE
Revert "Prevent form components used within `Field`/`FieldContainer` from overflowing their parent"

### DIFF
--- a/.changeset/smart-poems-compare.md
+++ b/.changeset/smart-poems-compare.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": patch
+---
+
+Revert "Prevent form components used within `Field`/`FieldContainer` from overflowing their parent" introduced in v7.20.0
+
+This change caused the BlocksBlock to break when rendering it inside a `Field`.

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -200,8 +200,6 @@ const InputContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
     slotName: "inputContainer",
 })(
     ({ ownerState }) => css`
-        overflow: hidden;
-
         ${ownerState.variant === "horizontal" &&
         ownerState.fullWidth &&
         css`

--- a/storybook/src/admin/form/AllFieldComponents.stories.tsx
+++ b/storybook/src/admin/form/AllFieldComponents.stories.tsx
@@ -49,6 +49,10 @@ export const AllFieldComponents = {
             { value: "chocolate", label: "Chocolate" },
             { value: "strawberry", label: "Strawberry" },
             { value: "vanilla", label: "Vanilla" },
+            {
+                value: "fruit salad",
+                label: "Strawberries, Raspberries, Bananas, Mangos, Pineapples, Apples, Pears, Melons, Grapes, Blueberries, Peaches",
+            },
         ];
 
         const initalValues = useMemo(() => ({ multiSelect: [] }), []);

--- a/storybook/src/admin/form/AllFieldComponents.stories.tsx
+++ b/storybook/src/admin/form/AllFieldComponents.stories.tsx
@@ -49,10 +49,6 @@ export const AllFieldComponents = {
             { value: "chocolate", label: "Chocolate" },
             { value: "strawberry", label: "Strawberry" },
             { value: "vanilla", label: "Vanilla" },
-            {
-                value: "fruit salad",
-                label: "Strawberries, Raspberries, Bananas, Mangos, Pineapples, Apples, Pears, Melons, Grapes, Blueberries, Peaches",
-            },
         ];
 
         const initalValues = useMemo(() => ({ multiSelect: [] }), []);


### PR DESCRIPTION
## Description

Revert "Prevent form components used within `Field`/`FieldContainer` from overflowing their parent" introduced in v7.20.0

This change caused the BlocksBlock to break when rendering it inside a `Field`.

![image (19)](https://github.com/user-attachments/assets/34c3d987-f2c6-4392-bbb8-4ffa6f57fe13)

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
