### PR TITLE
Fix FileUploadField props

### DIFF
--- a/.changeset/green-crews-smile.md
+++ b/.changeset/green-crews-smile.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Added missing prop types to `FileUploadFieldProps` that are forwarded to `FinalFormFileUpload`, ensuring consistent typing and easier customization.

--- a/packages/admin/cms-admin/src/form/file/FileUploadField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileUploadField.tsx
@@ -1,19 +1,29 @@
 import { Field, type FieldProps } from "@comet/admin";
 
-import { FinalFormFileUpload } from "./FinalFormFileUpload";
+import { FinalFormFileUpload, type FinalFormFileUploadProps } from "./FinalFormFileUpload";
 import { type GQLFinalFormFileUploadDownloadableFragment, type GQLFinalFormFileUploadFragment } from "./FinalFormFileUpload.generated";
 
-type SingleFileUploadProps = FieldProps<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment, HTMLInputElement> & {
-    multiple?: false;
-    maxFiles?: 1;
-};
+type SingleFileUploadProps<Multiple extends boolean | undefined> = FieldProps<
+    GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment,
+    HTMLInputElement
+> &
+    Partial<FinalFormFileUploadProps<Multiple>> & {
+        multiple?: false;
+        maxFiles?: 1;
+    };
 
-type MultipleFileUploadProps = FieldProps<Array<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment>, HTMLInputElement> & {
-    multiple: true;
-    maxFiles?: number;
-};
+type MultipleFileUploadProps<Multiple extends boolean | undefined> = FieldProps<
+    Array<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment>,
+    HTMLInputElement
+> &
+    Partial<FinalFormFileUploadProps<Multiple>> & {
+        multiple: true;
+        maxFiles?: number;
+    };
 
-export type FileUploadFieldProps<Multiple extends boolean | undefined> = Multiple extends true ? MultipleFileUploadProps : SingleFileUploadProps;
+export type FileUploadFieldProps<Multiple extends boolean | undefined> = Multiple extends true
+    ? MultipleFileUploadProps<Multiple>
+    : SingleFileUploadProps<Multiple>;
 
 export const FileUploadField = <Multiple extends boolean | undefined>({ name, ...restProps }: FileUploadFieldProps<Multiple>) => {
     return (

--- a/packages/admin/cms-admin/src/form/file/FileUploadField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileUploadField.tsx
@@ -3,27 +3,19 @@ import { Field, type FieldProps } from "@comet/admin";
 import { FinalFormFileUpload, type FinalFormFileUploadProps } from "./FinalFormFileUpload";
 import { type GQLFinalFormFileUploadDownloadableFragment, type GQLFinalFormFileUploadFragment } from "./FinalFormFileUpload.generated";
 
-type SingleFileUploadProps<Multiple extends boolean | undefined> = FieldProps<
-    GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment,
-    HTMLInputElement
-> &
-    Partial<FinalFormFileUploadProps<Multiple>> & {
+type SingleFileUploadProps = FieldProps<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment, HTMLInputElement> &
+    Partial<FinalFormFileUploadProps<false>> & {
         multiple?: false;
         maxFiles?: 1;
     };
 
-type MultipleFileUploadProps<Multiple extends boolean | undefined> = FieldProps<
-    Array<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment>,
-    HTMLInputElement
-> &
-    Partial<FinalFormFileUploadProps<Multiple>> & {
+type MultipleFileUploadProps = FieldProps<Array<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment>, HTMLInputElement> &
+    Partial<FinalFormFileUploadProps<true>> & {
         multiple: true;
         maxFiles?: number;
     };
 
-export type FileUploadFieldProps<Multiple extends boolean | undefined> = Multiple extends true
-    ? MultipleFileUploadProps<Multiple>
-    : SingleFileUploadProps<Multiple>;
+export type FileUploadFieldProps<Multiple extends boolean | undefined> = Multiple extends true ? MultipleFileUploadProps : SingleFileUploadProps;
 
 export const FileUploadField = <Multiple extends boolean | undefined>({ name, ...restProps }: FileUploadFieldProps<Multiple>) => {
     return (


### PR DESCRIPTION
## Description

The `FileUploadField` component is currently missing type information for the props it forwards to its child components.

This pull request improves the usability of the field by ensuring that auto-completion in editors correctly shows the available props. This change makes it easier to discover and use valid props like `accept` for the `FinalFormFileUpload` component. Currently, the `catch-all` type signature `[otherProp: string]: any` in [FieldProps](https://github.com/vivid-planet/comet/blob/next/packages/admin/admin/src/form/Field.tsx#L35) can hide misspellings (e.g. `acept` instead of `accept`) and allow passing invalid props on updates, leading to runtime bugs that are hard to catch.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  <img width="1227" alt="Screenshot 2025-06-04 at 11 20 59" src="https://github.com/user-attachments/assets/2b582e9c-8d9e-46c9-b08d-e526b9d11124" />  | <img width="622" alt="Screenshot 2025-06-04 at 11 21 48" src="https://github.com/user-attachments/assets/c25783ee-f47f-40c6-80fb-8363aaced191" /> |

