### PR TITLE
Increase cache time for static site assets

### DIFF
--- a/demo/site/server.ts
+++ b/demo/site/server.ts
@@ -41,10 +41,11 @@ app.prepare().then(() => {
                 // assets in public/assets/* are cached for 1 week. When updated without changing the filename, the cache is not invalidated.
                 // To force an immediate update of a file, ensure the filename is changed as well
                 maxAge = "604800"; // 1 week cache
-            } else if (parsedUrl.pathname == "/favicon.ico" || parsedUrl.pathname == "/apple-icon.png" || parsedUrl.pathname == "/icon.svg") {
-                // images/icons in the /app folder automatically have a hash added to the filename, so they can be cached for a long time because the hash changes when the file content changes
+            } else if (parsedUrl.pathname == "/apple-icon.png" || parsedUrl.pathname == "/icon.svg") {
+                // the icon and apple-icon in the /app folder automatically have a generated string added to the filename, so they can be cached for a long time because the hash changes when the file content changes
+                // see: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/app-icons#icon
                 maxAge = "31536000"; // 1 year cache
-            } else if (parsedUrl.pathname == "/robots.txt" || parsedUrl.pathname == "/sitemap.xml") {
+            } else if (parsedUrl.pathname == "/robots.txt" || parsedUrl.pathname == "/sitemap.xml" || parsedUrl.pathname == "/favicon.ico") {
                 maxAge = "900"; // 15 minutes cache
             }
 

--- a/demo/site/server.ts
+++ b/demo/site/server.ts
@@ -34,15 +34,18 @@ app.prepare().then(() => {
                     return;
                 }
             }
+            const isAssetsPath = parsedUrl.pathname?.startsWith("/assets/");
             if (
-                parsedUrl.pathname?.startsWith("/assets/") || // TODO move public/* files into public/assets folder
+                isAssetsPath ||
                 parsedUrl.pathname == "/favicon.ico" ||
                 parsedUrl.pathname == "/apple-icon.png" ||
                 parsedUrl.pathname == "/icon.svg" ||
                 parsedUrl.pathname == "/robots.txt" ||
                 parsedUrl.pathname == "/sitemap.xml"
             ) {
-                res.setHeader("Cache-Control", "public, max-age=900");
+                const maxAge = isAssetsPath ? "604800" : "900"; // 1 week cache for /assets/*, otherwise 15 minutes
+                res.setHeader("Cache-Control", `public, max-age=${maxAge}`);
+
                 const origSetHeader = res.setHeader;
                 res.setHeader = function (name: string, value: string | number | readonly string[]) {
                     if (name === "cache-control" || name === "Cache-Control") {


### PR DESCRIPTION
## Description
For users who visit the website frequently, it helps performance if the cache time is set higher so that the asset is still stored in the browser cache.

[Google](https://developer.chrome.com/docs/lighthouse/performance/uses-long-cache-ttl/?utm_source=lighthouse&utm_medium=lr#how_to_cache_static_resources_using_http_caching) recommends setting it to a year or longer, but also mentions:

> Note: One risk of long cache durations is that your users won't see updates to static files. You can avoid this issue by configuring your build tool to embed a hash in your static asset filenames so that each version is unique, prompting the browser to fetch the new version from the server. (To learn how to embed hashes using webpack, see webpack's [Caching](https://webpack.js.org/guides/caching/) guide.)

This PR increases the cache time to one week as a compromise as suggested by @nsams.
If possible, however, it would probably be best to embed the static assets with a hash in the future, as Google suggests.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

![Screenshot 2025-06-04 at 12 24 15](https://github.com/user-attachments/assets/941bdfa1-6777-4930-a3d4-a7d7df8d926f)


![Screenshot 2025-06-04 at 14 00 41](https://github.com/user-attachments/assets/5438210e-127d-411c-87c0-bb25f51a6d6e)


## TODO

- [x]  While creating this PR, i saw that the icon.svg has a a generated string at the end. I can probably set it to a year then. Validate if my assumption is true
