### PR TITLE
Page Tree: Add support for scope parts

### DIFF
--- a/.changeset/beige-ties-wave.md
+++ b/.changeset/beige-ties-wave.md
@@ -1,0 +1,16 @@
+---
+"@comet/cms-admin": minor
+---
+
+Page Tree: Add support for scope parts
+
+**Example**
+
+```tsx
+<CmsBlockContextProvider
+    // Dimension "domain" is used for the page tree scope
+    pageTreeScopeParts={["domain"]}
+>
+    {/* ... */}
+</CmsBlockContextProvider>
+```

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -112,6 +112,7 @@ export function App() {
                                                         pageTreeCategories={pageTreeCategories}
                                                         pageTreeDocumentTypes={pageTreeDocumentTypes}
                                                         additionalPageTreeNodeFragment={additionalPageTreeNodeFieldsFragment}
+                                                        pageTreeScopeParts={["domain", "language"]}
                                                     >
                                                         <ErrorDialogHandler />
                                                         <CurrentUserProvider>

--- a/packages/admin/cms-admin/jest.config.ts
+++ b/packages/admin/cms-admin/jest.config.ts
@@ -195,4 +195,8 @@ export default {
 
     // Whether to use watchman for file crawling
     // watchman: true,
+
+    moduleNameMapper: {
+        "^react-dnd$": "<rootDir>/testing/stub-file.ts",
+    },
 };

--- a/packages/admin/cms-admin/src/blocks/CmsBlockContextProvider.tsx
+++ b/packages/admin/cms-admin/src/blocks/CmsBlockContextProvider.tsx
@@ -22,6 +22,15 @@ export interface CmsBlockContext {
         name: string;
         fragment: DocumentNode;
     };
+    /**
+     * Specifies which dimensions of the content scope should be used for the page tree scope.
+     *
+     * @example
+     * // Dimension "domain" is used for the page tree scope
+     * <CmsBlockContextProvider pageTreeScopeParts={["domain"]} />
+     */
+    // TODO move to CometConfigProvider in Comet v8
+    pageTreeScopeParts?: string[];
 }
 
 interface CmsBlockContextProviderProps extends Omit<CmsBlockContext, "apolloClient"> {

--- a/packages/admin/cms-admin/src/pages/config/usePageTreeScope.test.tsx
+++ b/packages/admin/cms-admin/src/pages/config/usePageTreeScope.test.tsx
@@ -1,0 +1,103 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { RouterMemoryRouter } from "@comet/admin";
+import { renderHook } from "@testing-library/react-hooks";
+import { ReactNode } from "react";
+
+import { CmsBlockContext, CmsBlockContextProvider } from "../../blocks/CmsBlockContextProvider";
+import { ContentScopeProvider } from "../../contentScope/Provider";
+import { usePageTreeScope } from "./usePageTreeScope";
+
+describe("usePageTreeScope", () => {
+    function Providers({ children }: { children: ReactNode }) {
+        return (
+            <MockedProvider>
+                <RouterMemoryRouter>
+                    <ContentScopeProvider
+                        values={[{ domain: { value: "main" }, language: { value: "en" } }]}
+                        defaultValue={{ domain: "main", language: "en" }}
+                    >
+                        {() => <>{children}</>}
+                    </ContentScopeProvider>
+                </RouterMemoryRouter>
+            </MockedProvider>
+        );
+    }
+
+    const baseCmsBlockContext = {} as CmsBlockContext;
+
+    it("should work without CmsBlockContextProvider", () => {
+        const { result } = renderHook(() => usePageTreeScope(), {
+            wrapper: ({ children }) => <Providers>{children}</Providers>,
+        });
+
+        expect(result.current).toEqual({ domain: "main", language: "en" });
+    });
+
+    it("should work with CmsBlockContextProvider", () => {
+        const { result } = renderHook(() => usePageTreeScope(), {
+            wrapper: ({ children }) => (
+                <Providers>
+                    <CmsBlockContextProvider {...baseCmsBlockContext}>{children}</CmsBlockContextProvider>
+                </Providers>
+            ),
+        });
+
+        expect(result.current).toEqual({ domain: "main", language: "en" });
+    });
+
+    it("should work for a single dimension", () => {
+        const { result } = renderHook(() => usePageTreeScope(), {
+            wrapper: ({ children }) => (
+                <Providers>
+                    <CmsBlockContextProvider {...baseCmsBlockContext} pageTreeScopeParts={["domain"]}>
+                        {children}
+                    </CmsBlockContextProvider>
+                </Providers>
+            ),
+        });
+
+        expect(result.current).toEqual({ domain: "main" });
+    });
+
+    it("should work for multiple dimensions", () => {
+        const { result } = renderHook(() => usePageTreeScope(), {
+            wrapper: ({ children }) => (
+                <Providers>
+                    <CmsBlockContextProvider {...baseCmsBlockContext} pageTreeScopeParts={["domain", "language"]}>
+                        {children}
+                    </CmsBlockContextProvider>
+                </Providers>
+            ),
+        });
+
+        expect(result.current).toEqual({ domain: "main", language: "en" });
+    });
+
+    it("should work for no dimensions", () => {
+        const { result } = renderHook(() => usePageTreeScope(), {
+            wrapper: ({ children }) => (
+                <Providers>
+                    <CmsBlockContextProvider {...baseCmsBlockContext} pageTreeScopeParts={[]}>
+                        {children}
+                    </CmsBlockContextProvider>
+                </Providers>
+            ),
+        });
+
+        expect(result.current).toEqual({});
+    });
+
+    it("should ignore unknown dimensions", () => {
+        const { result } = renderHook(() => usePageTreeScope(), {
+            wrapper: ({ children }) => (
+                <Providers>
+                    <CmsBlockContextProvider {...baseCmsBlockContext} pageTreeScopeParts={["domain", "unknown"]}>
+                        {children}
+                    </CmsBlockContextProvider>
+                </Providers>
+            ),
+        });
+
+        expect(result.current).toEqual({ domain: "main" });
+    });
+});

--- a/packages/admin/cms-admin/src/pages/config/usePageTreeScope.ts
+++ b/packages/admin/cms-admin/src/pages/config/usePageTreeScope.ts
@@ -1,0 +1,20 @@
+import { useCmsBlockContext } from "../../blocks/useCmsBlockContext";
+import { useContentScope } from "../../contentScope/Provider";
+
+export function usePageTreeScope(): Record<string, unknown> {
+    const { pageTreeScopeParts } = useCmsBlockContext();
+    const { scope: completeScope } = useContentScope();
+
+    if (pageTreeScopeParts) {
+        const pageTreeScope = pageTreeScopeParts.reduce((pageTreeScope, dimension) => {
+            if (completeScope[dimension] !== undefined) {
+                pageTreeScope[dimension] = completeScope[dimension];
+            }
+            return pageTreeScope;
+        }, {} as Record<string, unknown>);
+
+        return pageTreeScope;
+    }
+
+    return completeScope;
+}

--- a/packages/admin/cms-admin/src/pages/config/usePageTreeScope.ts
+++ b/packages/admin/cms-admin/src/pages/config/usePageTreeScope.ts
@@ -1,8 +1,8 @@
 import { CmsBlockContext } from "../../blocks/CmsBlockContextProvider";
 import { useCmsBlockContext } from "../../blocks/useCmsBlockContext";
-import { useContentScope } from "../../contentScope/Provider";
+import { ContentScopeInterface, useContentScope } from "../../contentScope/Provider";
 
-export function usePageTreeScope(): Record<string, unknown> {
+export function usePageTreeScope(): Partial<ContentScopeInterface> {
     const context = useCmsBlockContext() as CmsBlockContext | undefined;
     const { scope: completeScope } = useContentScope();
 
@@ -12,7 +12,7 @@ export function usePageTreeScope(): Record<string, unknown> {
                 pageTreeScope[dimension] = completeScope[dimension];
             }
             return pageTreeScope;
-        }, {} as Record<string, unknown>);
+        }, {} as Partial<ContentScopeInterface>);
 
         return pageTreeScope;
     }

--- a/packages/admin/cms-admin/src/pages/config/usePageTreeScope.ts
+++ b/packages/admin/cms-admin/src/pages/config/usePageTreeScope.ts
@@ -1,12 +1,13 @@
+import { CmsBlockContext } from "../../blocks/CmsBlockContextProvider";
 import { useCmsBlockContext } from "../../blocks/useCmsBlockContext";
 import { useContentScope } from "../../contentScope/Provider";
 
 export function usePageTreeScope(): Record<string, unknown> {
-    const { pageTreeScopeParts } = useCmsBlockContext();
+    const context = useCmsBlockContext() as CmsBlockContext | undefined;
     const { scope: completeScope } = useContentScope();
 
-    if (pageTreeScopeParts) {
-        const pageTreeScope = pageTreeScopeParts.reduce((pageTreeScope, dimension) => {
+    if (context?.pageTreeScopeParts) {
+        const pageTreeScope = context.pageTreeScopeParts.reduce((pageTreeScope, dimension) => {
             if (completeScope[dimension] !== undefined) {
                 pageTreeScope[dimension] = completeScope[dimension];
             }

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -11,11 +11,11 @@ import { FormSpy } from "react-final-form";
 import { FormattedMessage, useIntl } from "react-intl";
 import slugify from "slugify";
 
-import { useContentScope } from "../contentScope/Provider";
 import { DocumentInterface, DocumentType } from "../documents/types";
 import { SyncFields } from "../form/SyncFields";
 import { GQLSlugAvailability } from "../graphql.generated";
 import { useLocale } from "../locale/useLocale";
+import { usePageTreeScope } from "./config/usePageTreeScope";
 import {
     GQLCreatePageNodeMutation,
     GQLCreatePageNodeMutationVariables,
@@ -102,7 +102,7 @@ export function createEditPageNode({
 
         const intl = useIntl();
         const apollo = useApolloClient();
-        const { scope } = useContentScope();
+        const scope = usePageTreeScope();
         const locale = useLocale({ scope });
 
         const [manuallyChangedSlug, setManuallyChangedSlug] = useState<boolean>(mode === "edit");

--- a/packages/admin/cms-admin/src/pages/pageTree/MovePageMenuItem.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/MovePageMenuItem.tsx
@@ -3,8 +3,8 @@ import { RowActionsItem, RowActionsMenu } from "@comet/admin";
 import { MovePage } from "@comet/admin-icons";
 import { FormattedMessage } from "react-intl";
 
-import { useContentScope } from "../../contentScope/Provider";
 import { DocumentInterface, DocumentType } from "../../documents/types";
+import { usePageTreeScope } from "../config/usePageTreeScope";
 import { GQLUpdatePageTreeNodeCategoryMutation, GQLUpdatePageTreeNodeCategoryMutationVariables } from "./MovePageMenuItem.generated";
 import { PageTreePage } from "./usePageTree";
 import { usePageTreeContext } from "./usePageTreeContext";
@@ -25,7 +25,7 @@ export function MovePageMenuItem({ page }: Props) {
             }
         }
     `);
-    const { scope } = useContentScope();
+    const scope = usePageTreeScope();
     const { allCategories, query, getDocumentTypesByCategory } = usePageTreeContext();
 
     if (allCategories.length <= 1) {

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
@@ -9,7 +9,7 @@ import AutoSizer from "react-virtualized-auto-sizer";
 import { Align, FixedSizeList as List } from "react-window";
 import { useDebouncedCallback } from "use-debounce";
 
-import { useContentScope } from "../../contentScope/Provider";
+import { usePageTreeScope } from "../config/usePageTreeScope";
 import { GQLPagesQuery, GQLPagesQueryVariables } from "../pagesPage/createPagesQuery";
 import {
     GQLMovePageTreeNodesByPosMutation,
@@ -123,7 +123,7 @@ const PageTree: ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = (
     }, [pages]);
 
     const pageTreeService = useMemo(() => new PageTreeService(levelOffsetPx, pages), [pages]);
-    const { scope } = useContentScope();
+    const scope = usePageTreeScope();
     const snackbarApi = useSnackbarApi();
 
     const debouncedSetHoverState = useDebouncedCallback(

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages.tsx
@@ -4,9 +4,10 @@ import { ReactNode, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { useCmsBlockContext } from "../../blocks/useCmsBlockContext";
-import { ContentScopeInterface, useContentScope } from "../../contentScope/Provider";
+import { ContentScopeInterface } from "../../contentScope/Provider";
 import { useDamScope } from "../../dam/config/useDamScope";
 import { GQLDocument, GQLPageQuery, GQLPageQueryVariables } from "../../documents/types";
+import { usePageTreeScope } from "../config/usePageTreeScope";
 import { useProgressDialog } from "./useCopyPastePages/ProgressDialog";
 import { sendPages, SendPagesOptions } from "./useCopyPastePages/sendPages";
 import { GQLPageTreePageFragment } from "./usePageTree";
@@ -67,7 +68,7 @@ interface UseCopyPastePagesApi {
 function useCopyPastePages(): UseCopyPastePagesApi {
     const { documentTypes, currentCategory } = usePageTreeContext();
     const client = useApolloClient();
-    const { scope } = useContentScope();
+    const scope = usePageTreeScope();
     const damScope = useDamScope();
     const blockContext = useCmsBlockContext();
     const progress = useProgressDialog({ title: <FormattedMessage id="comet.pages.insertingPages" defaultMessage="Inserting pages" /> });

--- a/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
@@ -8,8 +8,9 @@ import { FormattedMessage } from "react-intl";
 import { FixedSizeList as List, ListChildComponentProps } from "react-window";
 
 import { useCmsBlockContext } from "../../blocks/useCmsBlockContext";
-import { ContentScopeInterface, useContentScope } from "../../contentScope/Provider";
+import { ContentScopeInterface } from "../../contentScope/Provider";
 import { Maybe } from "../../graphql.generated";
+import { usePageTreeScope } from "../config/usePageTreeScope";
 import { PageSearch } from "../pageSearch/PageSearch";
 import { usePageSearch } from "../pageSearch/usePageSearch";
 import { createPagesQuery, GQLPagesQuery, GQLPagesQueryVariables, GQLPageTreePageFragment } from "../pagesPage/createPagesQuery";
@@ -69,7 +70,7 @@ interface PageTreeSelectProps {
 
 export default function PageTreeSelectDialog({ value, onChange, open, onClose, defaultCategory }: PageTreeSelectProps): JSX.Element {
     const { pageTreeCategories, pageTreeDocumentTypes, additionalPageTreeNodeFragment } = useCmsBlockContext();
-    const { scope } = useContentScope();
+    const scope = usePageTreeScope();
     const [category, setCategory] = useState<string>(defaultCategory);
     const refList = useRef<List>(null);
     const [height, setHeight] = useState(200);
@@ -111,7 +112,8 @@ export default function PageTreeSelectDialog({ value, onChange, open, onClose, d
     const pageSearchApi = usePageSearch({
         tree,
         pagesToRender,
-        domain: scope.domain,
+        // TODO remove hardcoded domain here
+        domain: (scope as ContentScopeInterface).domain,
         setExpandedIds,
         onUpdateCurrentMatch: (pageId, pagesToRender) => {
             const index = pagesToRender.findIndex((c) => c.id === pageId);

--- a/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
@@ -113,7 +113,7 @@ export default function PageTreeSelectDialog({ value, onChange, open, onClose, d
         tree,
         pagesToRender,
         // TODO remove hardcoded domain here
-        domain: (scope as ContentScopeInterface).domain,
+        domain: scope.domain,
         setExpandedIds,
         onUpdateCurrentMatch: (pageId, pagesToRender) => {
             const index = pagesToRender.findIndex((c) => c.id === pageId);

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -57,8 +57,8 @@ export function PagesPage({
     renderContentScopeIndicator,
 }: Props) {
     const intl = useIntl();
-    const { setRedirectPathAfterChange } = useContentScope();
-    const scope = usePageTreeScope();
+    const { scope, setRedirectPathAfterChange } = useContentScope();
+    const pageTreeScope = usePageTreeScope();
     const { additionalPageTreeNodeFragment } = useCmsBlockContext();
     useContentScopeConfig({ redirectPathAfterChange: path });
 
@@ -76,7 +76,7 @@ export function PagesPage({
     const { loading, data, error, refetch, startPolling, stopPolling } = useQuery<GQLPagesQuery, GQLPagesQueryVariables>(pagesQuery, {
         fetchPolicy: "cache-and-network",
         variables: {
-            contentScope: scope,
+            contentScope: pageTreeScope,
             category,
         },
         context: LocalErrorScopeApolloContext,
@@ -122,7 +122,7 @@ export function PagesPage({
         tree,
         pagesToRender,
         // TODO remove hardcoded domain here
-        domain: (scope as ContentScopeInterface).domain,
+        domain: (pageTreeScope as ContentScopeInterface).domain,
         setExpandedIds,
         onUpdateCurrentMatch: (pageId, pagesToRender) => {
             const index = pagesToRender.findIndex((c) => c.id === pageId);
@@ -142,7 +142,7 @@ export function PagesPage({
             <Stack topLevelTitle={intl.formatMessage({ id: "comet.pages.pages", defaultMessage: "Pages" })}>
                 <StackSwitch>
                     <StackPage name="table">
-                        <Toolbar scopeIndicator={renderContentScopeIndicator(scope)}>
+                        <Toolbar scopeIndicator={renderContentScopeIndicator(pageTreeScope)}>
                             <ToolbarItem sx={{ flexGrow: 1 }}>
                                 <PageSearch query={query} onQueryChange={setQuery} pageSearchApi={pageSearchApi} />
                             </ToolbarItem>

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -27,6 +27,7 @@ import { useContentScopeConfig } from "../../contentScope/useContentScopeConfig"
 import { DamScopeProvider } from "../../dam/config/DamScopeProvider";
 import { DocumentInterface, DocumentType } from "../../documents/types";
 import { useSiteConfig } from "../../sitesConfig/useSiteConfig";
+import { usePageTreeScope } from "../config/usePageTreeScope";
 import { EditPageNodeProps } from "../createEditPageNode";
 import { PageSearch } from "../pageSearch/PageSearch";
 import { usePageSearch } from "../pageSearch/usePageSearch";
@@ -56,7 +57,8 @@ export function PagesPage({
     renderContentScopeIndicator,
 }: Props) {
     const intl = useIntl();
-    const { scope, setRedirectPathAfterChange } = useContentScope();
+    const { setRedirectPathAfterChange } = useContentScope();
+    const scope = usePageTreeScope();
     const { additionalPageTreeNodeFragment } = useCmsBlockContext();
     useContentScopeConfig({ redirectPathAfterChange: path });
 
@@ -119,7 +121,8 @@ export function PagesPage({
     const pageSearchApi = usePageSearch({
         tree,
         pagesToRender,
-        domain: scope.domain,
+        // TODO remove hardcoded domain here
+        domain: (scope as ContentScopeInterface).domain,
         setExpandedIds,
         onUpdateCurrentMatch: (pageId, pagesToRender) => {
             const index = pagesToRender.findIndex((c) => c.id === pageId);

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -122,7 +122,7 @@ export function PagesPage({
         tree,
         pagesToRender,
         // TODO remove hardcoded domain here
-        domain: (pageTreeScope as ContentScopeInterface).domain,
+        domain: pageTreeScope.domain,
         setExpandedIds,
         onUpdateCurrentMatch: (pageId, pagesToRender) => {
             const index = pagesToRender.findIndex((c) => c.id === pageId);

--- a/packages/admin/cms-admin/src/testing/stub-file.ts
+++ b/packages/admin/cms-admin/src/testing/stub-file.ts
@@ -1,0 +1,4 @@
+// This is a stub file for testing purposes. It is used in the jest.config.ts (moduleNameMapper) in order to mock certain file types, or modules that are in ESM format
+// Documentation of the use of stub files in jest's moduleNameMapper can be found here: https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring
+
+export default "";


### PR DESCRIPTION
## Description

Introduce a new `usePageTreeScope()` hook that uses `pageTreeScopeParts` specified in the application (using `CmsBlockContextProvider`). Note: This will be moved to `CometConfigProvider` in `next`.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1984
