### PR TITLE
Refactor MetricType

### DIFF
--- a/demo/api/src/open-telemetry/metrics.ts
+++ b/demo/api/src/open-telemetry/metrics.ts
@@ -9,14 +9,13 @@ import {
     type UpDownCounter,
 } from "@opentelemetry/api";
 
-enum MetricType {
-    "Counter" = "Counter",
-    "UpDownCounter" = "UpDownCounter",
-    "Histogram" = "Histogram",
-    "ObservableGauge" = "ObservableGauge",
-    "ObservableCounter" = "ObservableCounter",
-    "ObservableUpDownCounter" = "ObservableUpDownCounter",
-}
+type MetricType =
+    | "Counter"
+    | "UpDownCounter"
+    | "Histogram"
+    | "ObservableGauge"
+    | "ObservableCounter"
+    | "ObservableUpDownCounter";
 type GenericMetric = Counter | UpDownCounter | Histogram | ObservableGauge | ObservableCounter | ObservableUpDownCounter;
 const OTEL_METER_NAME = "nestjs-otel";
 
@@ -33,28 +32,28 @@ function getOrCreate(name: string, options: MetricOptions = {}, type: MetricType
 }
 
 export function getOrCreateHistogram(name: string, options: MetricOptions = {}): Histogram {
-    return getOrCreate(name, options, MetricType.Histogram) as Histogram;
+    return getOrCreate(name, options, "Histogram") as Histogram;
 }
 
 export function getOrCreateCounter(name: string, options: MetricOptions = {}): Counter {
-    return getOrCreate(name, options, MetricType.Counter) as Counter;
+    return getOrCreate(name, options, "Counter") as Counter;
 }
 
 // TODO: metric functions below are here for demonstration purpose. More metrics will be added in the future which will probably need this functions.
 /*
 export function getOrCreateUpDownCounter(name: string, options: MetricOptions = {}): UpDownCounter {
-    return getOrCreate(name, options, MetricType.UpDownCounter) as UpDownCounter;
+    return getOrCreate(name, options, "UpDownCounter") as UpDownCounter;
 }
 
 export function getOrCreateObservableGauge(name: string, options: MetricOptions = {}): ObservableGauge {
-    return getOrCreate(name, options, MetricType.ObservableGauge) as ObservableGauge;
+    return getOrCreate(name, options, "ObservableGauge") as ObservableGauge;
 }
 
 export function getOrCreateObservableCounter(name: string, options: MetricOptions = {}): ObservableCounter {
-    return getOrCreate(name, options, MetricType.ObservableCounter) as ObservableCounter;
+    return getOrCreate(name, options, "ObservableCounter") as ObservableCounter;
 }
 
 export function getOrCreateObservableUpDownCounter(name: string, options: MetricOptions = {}): ObservableUpDownCounter {
-    return getOrCreate(name, options, MetricType.ObservableUpDownCounter) as ObservableUpDownCounter;
+    return getOrCreate(name, options, "ObservableUpDownCounter") as ObservableUpDownCounter;
 }
 */


### PR DESCRIPTION
## Summary
- update the demo/api open-telemetry metrics helper
- swap the `MetricType` enum for a string union
- adjust metric helper calls accordingly

## Testing
- `npm run lint:tsc` *(fails: Cannot find module './generated/footer.resolver')*

------
https://chatgpt.com/codex/tasks/task_e_68413708bec883259287a638a8c1cb9c