### PR TITLE
Fix prettier formatting of site-react CHANGELOG

### DIFF
--- a/packages/site/site-nextjs/CHANGELOG.md
+++ b/packages/site/site-nextjs/CHANGELOG.md
@@ -4,31 +4,31 @@
 
 ### Patch Changes
 
-- @comet/site-react@8.0.0-beta.5
+-   @comet/site-react@8.0.0-beta.5
 
 ## 7.21.1
 
 ### Patch Changes
 
-- c84874edf: Revert "Fix `PixelImageBlock` fixed height, auto width issue" added in v7.20.0
+-   c84874edf: Revert "Fix `PixelImageBlock` fixed height, auto width issue" added in v7.20.0
 
     In v7.20.0, height was set to `100%` for `PixelImageBlock`.
     This caused issues when the image was not wrapped, as it would inherit the height of the next parent element instead of maintaining its aspect ratio.
     Thus, we are reverting this change to restore the previous behavior.
 
-    - @comet/site-react@7.21.1
+    -   @comet/site-react@7.21.1
 
 ## 7.21.0
 
 ### Minor Changes
 
-- 904ff5f1d: Introduce new package `@comet/site-nextjs` as copy of `@comet/cms-site`
+-   904ff5f1d: Introduce new package `@comet/site-nextjs` as copy of `@comet/cms-site`
 
     Changes:
 
-    - Remove `styled-components` as peer dependency
-    - use SCSS modules instead
-    - `@comet/site-nextjs` is pure ESM
+    -   Remove `styled-components` as peer dependency
+    -   use SCSS modules instead
+    -   `@comet/site-nextjs` is pure ESM
 
     To load the CSS, you need to import it like this:
 
@@ -40,5 +40,5 @@
 
 ### Patch Changes
 
-- Updated dependencies [ede41201a]
-    - @comet/site-react@7.21.0
+-   Updated dependencies [ede41201a]
+    -   @comet/site-react@7.21.0

--- a/packages/site/site-react/CHANGELOG.md
+++ b/packages/site/site-react/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Minor Changes
 
-- ede41201a: Introduce new package `@comet/site-react`
+-   ede41201a: Introduce new package `@comet/site-react`
 
     While `@comet/cms-site` and `@comet/site-nextjs` are Next.js specific, `@comet/site-react` is framework-agnostic and works in all React projects.
     `@comet/site-react` is pure ESM and uses SCSS modules instead of `styled-components`.


### PR DESCRIPTION
## Summary
- format packages/site/site-react/CHANGELOG.md using Prettier v2

## Testing
- `pnpm --filter "@comet/site-react" run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841431dc8dc83259fc73223fcacdddc