### PR TITLE
Fix scroll behavior in `AdminComponentRoot`

### DIFF
--- a/.changeset/odd-impalas-do.md
+++ b/.changeset/odd-impalas-do.md
@@ -1,0 +1,5 @@
+---
+"@comet/blocks-admin": patch
+---
+
+Fix sticky behavior of `RteToolbar`

--- a/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
+++ b/packages/admin/blocks-admin/src/blocks/common/AdminComponentRoot.tsx
@@ -30,7 +30,7 @@ const AdminComponentRoot = (props: PropsWithChildren<Props>) => {
 export { AdminComponentRoot };
 
 const ChildrenContainer = styled("div")`
-    > .CometAdminRte-root > .CometAdminRteToolbar-root {
+    .CometAdminRte-root > .CometAdminRteToolbar-root {
         top: 70px;
     }
 `;


### PR DESCRIPTION
## Description

The RTE-Header is not visible, if a large amount of text is entered. This was caused by a wrong CSS selector, that was too strict and therefor didn't apply the styling on the CometAdminRteToolbar-root. 



## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| https://github.com/user-attachments/assets/1c68f02a-fcdd-47d1-963a-186356a7bb57 <img width="460" alt="Screenshot 2025-06-05 at 10 40 01" src="https://github.com/user-attachments/assets/da880b33-216b-4ab5-8ac7-9cae6bbd7973" />| https://github.com/user-attachments/assets/bd0f9fa6-1c24-4a35-86e2-0630b06b4780 <img width="471" alt="Screenshot 2025-06-05 at 10 39 26" src="https://github.com/user-attachments/assets/30ae6fee-5267-40b1-bd34-7e891e9263d3" />|

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2015
