### PR TITLE
Fix scroll behaviour in AdminComponentRoot in Next

### DIFF
--- a/.changeset/calm-numbers-press.md
+++ b/.changeset/calm-numbers-press.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix sticky behavior of `RteToolbar`

--- a/packages/admin/cms-admin/src/blocks/common/BlockAdminComponentRoot.tsx
+++ b/packages/admin/cms-admin/src/blocks/common/BlockAdminComponentRoot.tsx
@@ -30,7 +30,7 @@ const BlockAdminComponentRoot = (props: PropsWithChildren<Props>) => {
 export { BlockAdminComponentRoot };
 
 const ChildrenContainer = styled("div")`
-    > .CometAdminRte-root > .CometAdminRteToolbar-root {
+    .CometAdminRte-root > .CometAdminRteToolbar-root {
         top: 70px;
     }
 `;


### PR DESCRIPTION
## Description

_This addresses the same problem as in https://github.com/vivid-planet/comet/pull/3930, but in the next branch:_

The RTE-Header is not visible, if a large amount of text is entered. This was caused by a wrong CSS selector, that was too strict and therefor didn't apply the styling on the CometAdminRteToolbar-root.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="460" alt="Screenshot 2025-06-05 at 10 40 01" src="https://github.com/user-attachments/assets/3f27f53f-62ed-4300-a1b8-ee70b7492730" /> | <img width="460" alt="Screenshot 2025-06-05 at 10 40 01" src="https://github.com/user-attachments/assets/1d775ac3-49d9-46a0-b7fc-922576d1d6d7" /> |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2015
