### PR TITLE
Fix language property name in cms-api spec

### DIFF
--- a/packages/api/cms-api/src/generator/generate-crud-scope.spec.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-scope.spec.ts
@@ -9,16 +9,15 @@ import { lintGeneratedFiles, parseSource } from "./utils/test-helper";
 
 @Entity()
 @ScopedEntity<TestEntityWithScopedEntity>((entity) => {
-    return { language: entity.langauge };
+    return { language: entity.language };
 })
 export class TestEntityWithScopedEntity extends BaseEntity<TestEntityWithScopedEntity, "id"> {
     @PrimaryKey({ type: "uuid" })
     id: string = uuid();
 
     @Property({ columnType: "text" })
-    langauge: string;
+    language: string;
 }
-1;
 
 describe("GenerateCrud with ScopedEntity", () => {
     it("resolver must not have skipScopeCheck", async () => {


### PR DESCRIPTION
## Summary
- fix typo 'langauge' in `generate-crud-scope.spec.ts`
- remove stray `1;` after class definition

## Testing
- `pnpm --filter @comet/cms-api test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac0ee5c8832b86b4c1865cbcbffe