### PR TITLE
Fix typos in docs, tests and comment

### DIFF
--- a/docs/docs/2-core-concepts/2-blocks/1-your-first-block.mdx
+++ b/docs/docs/2-core-concepts/2-blocks/1-your-first-block.mdx
@@ -223,7 +223,7 @@ export const HeadlineBlock = createCompositeBlock(
 );
 ```
 
-Please note that the names of the keys of the `blocks` object must be the same as the name of fields in the the API block (eyebrow, headline and level).
+Please note that the names of the keys of the `blocks` object must be the same as the name of fields in the API block (eyebrow, headline and level).
 
 ### The Admin Component
 

--- a/packages/admin/admin-rte/src/core/extension/SoftHyphen/ToolbarButton.tsx
+++ b/packages/admin/admin-rte/src/core/extension/SoftHyphen/ToolbarButton.tsx
@@ -14,7 +14,7 @@ export function ToolbarButton({ editorState, setEditorState }: IControlProps) {
         e.preventDefault(); // important to preserve focus
         const currentContent = editorState.getCurrentContent();
         const selection = editorState.getSelection();
-        //@TODO: insert \u00ad in a way that link-entities dont break when inserted in the middle of a link text
+        //@TODO: insert \u00ad in a way that link-entities don’t break when inserted in the middle of a link text
         // right now the link is split into 2 link-entities
         // works as expected when \u00ad is copied and pasted: https://unicode.flopp.net/c/00AD
         const textWithEntity = Modifier.insertText(currentContent, selection, String.fromCharCode(SHY_UNICODE_CHAR));

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
@@ -207,7 +207,7 @@ describe("UserPermissionsGuard", () => {
         ).toBe(true);
     });
 
-    it("denies user without one the the required permissions", async () => {
+    it("denies user without one of the required permissions", async () => {
         mockAnnotations({
             requiredPermission: {
                 requiredPermission: ["p1", "p2"], // One of the permissions is required


### PR DESCRIPTION
## Summary
- fix repeated word in first-block doc
- fix typo in user-permissions guard test title
- restore complete comment in RTE SoftHyphen button

## Testing
- `pnpm lint` *(failed: Error fetching pnpm package)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac1f4e94832bae53cc3660d22b8a