### PR TITLE
Remove awaits from state setters

### DIFF
--- a/packages/admin/admin/src/table/excelexport/useExportDisplayedTableData.tsx
+++ b/packages/admin/admin/src/table/excelexport/useExportDisplayedTableData.tsx
@@ -17,11 +17,11 @@ export function useExportDisplayedTableData(options?: IExcelExportOptions): IExp
 
     async function exportTable() {
         if (tableRef != null) {
-            await setLoading(true);
+            setLoading(true);
             try {
                 await createExcelExportDownload(tableRef.props.columns, tableRef.props.data, options);
             } finally {
-                await setLoading(false);
+                setLoading(false);
             }
         } else {
             throw new Error("No table ref set");

--- a/packages/admin/admin/src/table/excelexport/useExportPagedTableQuery.tsx
+++ b/packages/admin/admin/src/table/excelexport/useExportPagedTableQuery.tsx
@@ -31,8 +31,8 @@ export function useExportPagedTableQuery<IVariables>(
 
     async function exportTable() {
         if (tableRef != null) {
-            await setProgress(0);
-            await setLoading(true);
+            setProgress(0);
+            setLoading(true);
 
             const { fromPage = 1, toPage = 1 } = options;
 
@@ -56,13 +56,13 @@ export function useExportPagedTableQuery<IVariables>(
                         exportData.push(...data.data);
                     }
                     const progressInPercent = (i / (toPage - fromPage)) * 100;
-                    await setProgress(progressInPercent);
+                    setProgress(progressInPercent);
                 }
                 createExcelExportDownload<any>(tableRef.props.columns, exportData, excelOptions);
             } catch (e) {
                 throw new Error("Error happend while exporting data");
             } finally {
-                await setLoading(false);
+                setLoading(false);
             }
         }
     }

--- a/packages/admin/admin/src/table/excelexport/useExportTableQuery.tsx
+++ b/packages/admin/admin/src/table/excelexport/useExportTableQuery.tsx
@@ -20,7 +20,7 @@ export function useExportTableQuery<IVariables>(api: ITableQueryApi, variables: 
 
     async function exportTable() {
         if (tableRef != null) {
-            await setLoading(true);
+            setLoading(true);
             try {
                 const query = api.getQuery();
                 const innerOptions = api.getInnerOptions();
@@ -39,7 +39,7 @@ export function useExportTableQuery<IVariables>(api: ITableQueryApi, variables: 
             } catch (e) {
                 throw new Error("Error happend while exporting data");
             } finally {
-                await setLoading(false);
+                setLoading(false);
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid awaiting React state setter calls during table export

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.5.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.5.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6841ae01bd38832b9c0a69cde6f327c6