### PR TITLE
Change S3 blob-storage config

### DIFF
--- a/.changeset/wise-forks-shine.md
+++ b/.changeset/wise-forks-shine.md
@@ -2,6 +2,6 @@
 "@comet/cms-api": major
 ---
 
-Changed s3 blob-storage config
+Change S3 config for BlobStorage
 
-Now the config is the same as the s3-client config, so you can use any of the available options.
+Now the config has all fields from `S3ClientConfig` provided by `@aws-sdk/client-s3`, so you override all options in the project.

--- a/.changeset/wise-forks-shine.md
+++ b/.changeset/wise-forks-shine.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": major
+---
+
+Changed s3 blob-storage config
+
+Now the config is the same as the s3-client config, so you can use any of the available options.

--- a/demo/api/src/config/config.ts
+++ b/demo/api/src/config/config.ts
@@ -75,8 +75,10 @@ export function createConfig(processEnv: NodeJS.ProcessEnv) {
                     region: envVars.S3_REGION,
                     endpoint: envVars.S3_ENDPOINT,
                     bucket: envVars.S3_BUCKET,
-                    accessKeyId: envVars.S3_ACCESS_KEY_ID,
-                    secretAccessKey: envVars.S3_SECRET_ACCESS_KEY,
+                    credentials: {
+                        accessKeyId: envVars.S3_ACCESS_KEY_ID,
+                        secretAccessKey: envVars.S3_SECRET_ACCESS_KEY,
+                    },
                 },
             },
             storageDirectoryPrefix: envVars.BLOB_STORAGE_DIRECTORY_PREFIX,

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -857,7 +857,7 @@ npx @comet/upgrade v8/update-s3-config.ts
 
 :::
 
-Previously configuration had it's own structure, now credentials are nested under `credentials` and the `accessKeyId` and `secretAccessKey` are no longer top-level properties. Bucket is not part of s3-config but still required, so it's passed as a top-level property.
+Previously configuration had its own structure, now credentials are nested under `credentials` and the `accessKeyId` and `secretAccessKey` are no longer top-level properties. Bucket is not part of s3-config but still required, so it's passed as a top-level property.
 
 ```diff title=api/src/config/config.ts
 blob: {

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -841,6 +841,53 @@ npx @comet/upgrade v8/move-maxSrcResolution-in-comet-config.ts
 
 </details>
 
+### ✅ Change s3 blob-storage config structure
+
+It's now possible to configure the S3-client completely.
+
+<details>
+
+<summary>Handled by @comet/upgrade</summary>
+
+:::note Handled by following upgrade script
+
+```sh
+npx @comet/upgrade v8/update-s3-config.ts
+```
+
+:::
+
+Previously configuration had it's own structure, now credentials are nested under `credentials` and the `accessKeyId` and `secretAccessKey` are no longer top-level properties. Bucket is not part of s3-config but still required, so it's passed as a top-level property.
+
+```diff title=api/src/config/config.ts
+blob: {
+    storage: {
+        driver: envVars.BLOB_STORAGE_DRIVER,
+        file: {
+            path: envVars.FILE_STORAGE_PATH,
+        },
+        azure: {
+            accountName: envVars.AZURE_ACCOUNT_NAME,
+            accountKey: envVars.AZURE_ACCOUNT_KEY,
+        },
+        s3: {
+            region: envVars.S3_REGION,
+            endpoint: envVars.S3_ENDPOINT,
+            bucket: envVars.S3_BUCKET,
+-            accessKeyId: envVars.S3_ACCESS_KEY_ID,
+-            secretAccessKey: envVars.S3_SECRET_ACCESS_KEY,
++            credentials: {
++                 accessKeyId: envVars.S3_ACCESS_KEY_ID,
++                 secretAccessKey: envVars.S3_SECRET_ACCESS_KEY,
++            },
+        },
+    },
+    storageDirectoryPrefix: envVars.BLOB_STORAGE_DIRECTORY_PREFIX,
+},
+```
+
+</details>
+
 ## Admin
 
 ### Upgrade peer dependencies

--- a/packages/api/cms-api/src/blob-storage/backends/s3/blob-storage-s3.config.ts
+++ b/packages/api/cms-api/src/blob-storage/backends/s3/blob-storage-s3.config.ts
@@ -1,6 +1,6 @@
-import { S3ClientConfig } from "@aws-sdk/client-s3";
+import { type S3ClientConfig } from "@aws-sdk/client-s3";
 
 export interface BlobStorageS3Config {
     driver: "s3";
-    s3: S3ClientConfig & { bucket: string; };
+    s3: S3ClientConfig & { bucket: string };
 }

--- a/packages/api/cms-api/src/blob-storage/backends/s3/blob-storage-s3.config.ts
+++ b/packages/api/cms-api/src/blob-storage/backends/s3/blob-storage-s3.config.ts
@@ -1,14 +1,6 @@
-import { type ClientDefaults } from "@aws-sdk/client-s3";
+import { S3ClientConfig } from "@aws-sdk/client-s3";
 
 export interface BlobStorageS3Config {
     driver: "s3";
-    s3: {
-        accessKeyId: string;
-        secretAccessKey: string;
-        endpoint: string;
-        region: string;
-        bucket: string;
-
-        requestHandler?: ClientDefaults["requestHandler"];
-    };
+    s3: S3ClientConfig & { bucket: string; };
 }

--- a/packages/api/cms-api/src/blob-storage/backends/s3/blob-storage-s3.storage.ts
+++ b/packages/api/cms-api/src/blob-storage/backends/s3/blob-storage-s3.storage.ts
@@ -11,21 +11,14 @@ export class BlobStorageS3Storage implements BlobStorageBackendInterface {
     private readonly config: BlobStorageS3Config["s3"];
 
     constructor(config: BlobStorageS3Config["s3"]) {
-        this.client = new AWS.S3({
-            requestHandler: config.requestHandler ?? {
-                // https://github.com/aws/aws-sdk-js-v3/blob/main/supplemental-docs/CLIENTS.md#request-handler-requesthandler
-                // Workaround to prevent socket exhaustion caused by dangling streams (e.g., when the user leaves the site).
-                // Close the connection when no request/response was sent for 60 seconds, indicating that the file stream was terminated.
-                requestTimeout: 60000,
-                connectionTimeout: 6000, // fail faster if there are no available connections
-            },
-            credentials: {
-                accessKeyId: config.accessKeyId,
-                secretAccessKey: config.secretAccessKey,
-            },
-            endpoint: config.endpoint,
-            region: config.region,
-        });
+        config.requestHandler = config.requestHandler ?? {
+            // https://github.com/aws/aws-sdk-js-v3/blob/main/supplemental-docs/CLIENTS.md#request-handler-requesthandler
+            // Workaround to prevent socket exhaustion caused by dangling streams (e.g., when the user leaves the site).
+            // Close the connection when no request/response was sent for 60 seconds, indicating that the file stream was terminated.
+            requestTimeout: 60000,
+            connectionTimeout: 6000, // fail faster if there are no available connections
+        };
+        this.client = new AWS.S3(config);
         this.config = config;
     }
 

--- a/packages/api/cms-api/src/blob-storage/backends/s3/blob-storage-s3.storage.ts
+++ b/packages/api/cms-api/src/blob-storage/backends/s3/blob-storage-s3.storage.ts
@@ -11,14 +11,17 @@ export class BlobStorageS3Storage implements BlobStorageBackendInterface {
     private readonly config: BlobStorageS3Config["s3"];
 
     constructor(config: BlobStorageS3Config["s3"]) {
-        config.requestHandler = config.requestHandler ?? {
-            // https://github.com/aws/aws-sdk-js-v3/blob/main/supplemental-docs/CLIENTS.md#request-handler-requesthandler
-            // Workaround to prevent socket exhaustion caused by dangling streams (e.g., when the user leaves the site).
-            // Close the connection when no request/response was sent for 60 seconds, indicating that the file stream was terminated.
-            requestTimeout: 60000,
-            connectionTimeout: 6000, // fail faster if there are no available connections
-        };
-        this.client = new AWS.S3(config);
+        const { bucket, requestHandler, ...clientConfig } = config;
+        this.client = new AWS.S3({
+            requestHandler: requestHandler ?? {
+                // https://github.com/aws/aws-sdk-js-v3/blob/main/supplemental-docs/CLIENTS.md#request-handler-requesthandler
+                // Workaround to prevent socket exhaustion caused by dangling streams (e.g., when the user leaves the site).
+                // Close the connection when no request/response was sent for 60 seconds, indicating that the file stream was terminated.
+                requestTimeout: 60000,
+                connectionTimeout: 6000,
+            },
+            ...clientConfig,
+        });
         this.config = config;
     }
 


### PR DESCRIPTION
## Description
Allow setting all S3 client options via blob-storage-s3 config. This enables configuring s3-client for specific requirements of the connected storage-server, e.g. `requestChecksumCalculation: "WHEN_REQUIRED",`

This requires restructuring the current configuration, so this is a breaking change. The change is handled with this [upgrade-script](https://github.com/vivid-planet/comet-upgrade/pull/93) and does apply this change: 

app/src/config/config.ts
``` diff
  {
    endpoint: envVars.S3_ENDPOINT,
    bucket: envVars.S3_BUCKET,
-   accessKeyId: envVars.S3_ACCESS_KEY_ID,
-   secretAccessKey: envVars.S3_SECRET_ACCESS_KEY,
+   credentials: {
+       accessKeyId: envVars.S3_ACCESS_KEY_ID,
+       secretAccessKey: envVars.S3_SECRET_ACCESS_KEY,
+   },
  },
```


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2070
