### PR TITLE
Data Grid: Fix styling of input filter

### DIFF
--- a/.changeset/twelve-islands-flow.md
+++ b/.changeset/twelve-islands-flow.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-theme": patch
+---
+
+Fix styling of filter input fields

--- a/.changeset/twelve-islands-flow.md
+++ b/.changeset/twelve-islands-flow.md
@@ -2,4 +2,4 @@
 "@comet/admin-theme": patch
 ---
 
-Fix styling of filter input fields
+Data Grid: Fix styling of filter input fields

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDataGrid.tsx
@@ -1,5 +1,6 @@
 import { ArrowDown, ArrowUp, Check, Clear, Close, Delete, MoreVertical, Search } from "@comet/admin-icons";
 import {
+    autocompleteClasses,
     buttonBaseClasses,
     getSwitchUtilityClass,
     iconButtonClasses,
@@ -242,6 +243,28 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
 
             "&:empty": {
                 display: "none", // Make space for `filterFormOperatorInput` to expand and take up the full width
+            },
+
+            [`&& .${autocompleteClasses.inputRoot}`]: {
+                padding: 0,
+                height: "40px",
+                display: "flex",
+                alignItems: "center",
+                border: `1px solid ${palette.grey[100]}`,
+
+                [`& > .${autocompleteClasses.input}`]: {
+                    padding: `calc(${spacing(2)} - 1px)`,
+                    display: "flex",
+                    alignItems: "center",
+                },
+
+                [`& > .MuiOutlinedInput-notchedOutline`]: {
+                    display: "none",
+                },
+
+                "&.Mui-focused": {
+                    border: `1px solid ${palette.primary.main}`,
+                },
             },
 
             [`& .${inputBaseClasses.root}`]: {


### PR DESCRIPTION
## Description

The input field of the "is any of" operator is not styled as the other input fields in the filter. Fix this issue by styling autoCompleteClasses.

_Note:  In the ticket, there was an assumption that the cause of this styling issue was an incorrectly rendered field (TextField instead of InputBase). I checked this and couldn't find the issue as you can see in the screenshots:_

| Contains operator(styled correctly): | isAnyOf Operator: |
| ------ | ----- |
|  <img width="1168" alt="Screenshot 2025-06-06 at 09 00 12" src="https://github.com/user-attachments/assets/3746c81d-a6a0-4f90-b703-ef40d151f4d0" /> | <img width="1172" alt="Screenshot 2025-06-06 at 08 52 54" src="https://github.com/user-attachments/assets/c0aaa112-acd8-4d5f-8a50-c17f47034ea4" />
 



## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="777" alt="Screenshot 2025-06-06 at 08 19 09" src="https://github.com/user-attachments/assets/fa8b4aeb-caf7-462c-9ddb-cc39c42cafe2" />   | <img width="783" alt="Screenshot 2025-06-06 at 08 18 40" src="https://github.com/user-attachments/assets/b470cab5-52a1-448d-b99d-caab3c6bb184" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1650
