### PR TITLE
MRE: Setting DateTimeField `disabled`

### DIFF
--- a/storybook/src/admin-date-time/DateTimePicker.stories.tsx
+++ b/storybook/src/admin-date-time/DateTimePicker.stories.tsx
@@ -12,11 +12,13 @@ export const DateTimePicker = {
         interface Values {
             dateTimeOne?: Date;
             dateTimeTwo?: Date;
+            dateTimeThree?: Date;
         }
 
         const initialValues: Partial<Values> = {
             dateTimeOne: undefined,
             dateTimeTwo: new Date(),
+            dateTimeThree: new Date(),
         };
 
         return (
@@ -28,6 +30,7 @@ export const DateTimePicker = {
                                 <CardContent>
                                     <Field name="dateTimeOne" label="Date-Time" fullWidth component={FinalFormDateTimePicker} />
                                     <Field name="dateTimeTwo" label="Required" fullWidth required component={FinalFormDateTimePicker} />
+                                    <Field name="dateTimeThree" label="Disabled" fullWidth disabled component={FinalFormDateTimePicker} />
                                 </CardContent>
                             </Card>
                             <pre>{JSON.stringify(values, null, 4)}</pre>


### PR DESCRIPTION
## Description

DateTimeField does not support disabled. The prop is not applied.

## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

![Screenshot 2025-06-06 at 10 04 21](https://github.com/user-attachments/assets/ace46174-1737-45d6-b466-7301589f6e32)


## Open TODOs/questions

-   [ ] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-XXX
