### PR TITLE
Fix: FinalFormRangeInput does not support `disabled`

### DIFF
--- a/.changeset/tasty-cameras-move.md
+++ b/.changeset/tasty-cameras-move.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Support the `disabled` prop in the `FinalFormRangeInput`

--- a/packages/admin/admin/src/form/FinalFormRangeInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormRangeInput.tsx
@@ -87,6 +87,7 @@ export interface FinalFormRangeInputProps
     separator?: ReactNode;
     disableSlider?: boolean;
     sliderProps?: Omit<SliderProps, "min" | "max">;
+    disabled?: boolean;
 }
 
 export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
@@ -100,6 +101,7 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
         sliderProps,
         input: { name, onChange, value: fieldValue },
         slotProps,
+        disabled,
         ...restProps
     } = useThemeProps({ props: inProps, name: "CometAdminFinalFormRangeInput" });
 
@@ -142,6 +144,7 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
                                 type: "number",
                                 placeholder: min.toString(),
                             }}
+                            disabled={disabled}
                             startAdornment={startAdornment}
                             endAdornment={endAdornment}
                             onBlur={() => {
@@ -171,6 +174,7 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
                                 type: "number",
                                 placeholder: max.toString(),
                             }}
+                            disabled={disabled}
                             startAdornment={startAdornment ? startAdornment : ""}
                             endAdornment={endAdornment ? endAdornment : ""}
                             onBlur={() => {
@@ -199,6 +203,7 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
                         value={[fieldValue.min ? fieldValue.min : min, fieldValue.max ? fieldValue.max : max]}
                         onChange={handleSliderChange}
                         {...sliderProps}
+                        disabled={disabled || sliderProps?.disabled}
                     />
                 </SliderWrapper>
             )}

--- a/storybook/src/admin/form/RangeInput.stories.tsx
+++ b/storybook/src/admin/form/RangeInput.stories.tsx
@@ -150,6 +150,43 @@ export const RangeInput = () => {
                         </CardContent>
                     </Card>
                 </Box>
+                <Box marginBottom={4}>
+                    <Card variant="outlined">
+                        <CardContent>
+                            <Typography variant="h3" gutterBottom>
+                                disabled
+                            </Typography>
+                            <Form
+                                onSubmit={(values) => {
+                                    // values
+                                }}
+                                initialValues={{ price: { min: 50, max: 80 } }}
+                                render={({ values, form, initialValues }) => (
+                                    <>
+                                        <Field
+                                            component={FinalFormRangeInput}
+                                            name="price"
+                                            min={0}
+                                            max={100}
+                                            endAdornment={<span>€</span>}
+                                            sliderProps={{ components: { Thumb } }}
+                                            disabled
+                                            readOnly
+                                        />
+                                        <Button
+                                            onClick={() => {
+                                                form.reset();
+                                            }}
+                                        >
+                                            Reset
+                                        </Button>
+                                        <pre>{JSON.stringify(values, undefined, 2)}</pre>
+                                    </>
+                                )}
+                            />
+                        </CardContent>
+                    </Card>
+                </Box>
             </div>
         </>
     );


### PR DESCRIPTION
## Description

### Problem

FinalFormRangeInput does not support `disabled`. The prop is not applied.

### Solution

Pass the `disabled` prop on in the `FinalFormRangeInput`

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1920" alt="Bildschirmfoto 2025-06-06 um 10 41 56" src="https://github.com/user-attachments/assets/55f842a6-4409-4747-b5b8-20bb57652606" />    | <img width="1920" alt="Bildschirmfoto 2025-06-06 um 10 56 51" src="https://github.com/user-attachments/assets/7856c4fb-9f5c-48f9-b015-001d976133de" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2073
