### PR TITLE
Remove circular loading in async select field

### DIFF
--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress, InputAdornment, MenuItem, Select, type SelectProps, Typography } from "@mui/material";
+import { InputAdornment, MenuItem, Select, type SelectProps, Typography } from "@mui/material";
 import { type ReactNode } from "react";
 import { type FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
@@ -91,10 +91,7 @@ export const FinalFormSelect = <T,>({
             endAdornment={
                 <>
                     {loading ? (
-                        <InputAdornment position="end">
-                            <CircularProgress size={16} color="inherit" />
-                            {endAdornment}
-                        </InputAdornment>
+                        <InputAdornment position="end">{endAdornment}</InputAdornment>
                     ) : (
                         <InputAdornment position="end">{endAdornment}</InputAdornment>
                     )}

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -88,15 +88,7 @@ export const FinalFormSelect = <T,>({
     return (
         <Select
             {...selectProps}
-            endAdornment={
-                <>
-                    {loading ? (
-                        <InputAdornment position="end">{endAdornment}</InputAdornment>
-                    ) : (
-                        <InputAdornment position="end">{endAdornment}</InputAdornment>
-                    )}
-                </>
-            }
+            endAdornment={<InputAdornment position="end">{endAdornment}</InputAdornment>}
             onChange={(event) => {
                 const value = event.target.value;
                 onChange(


### PR DESCRIPTION
## Description
This Pull Request removes the `CircularLoading` inside the `FinalFormSelect` Component

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| ![Screen Recording 2025-06-10 at 10 34 31](https://github.com/user-attachments/assets/526a8aa1-7cae-449d-8b9c-8c5ec668cf71) | ![Screen Recording 2025-06-10 at 10 33 22](https://github.com/user-attachments/assets/870e4015-849e-4b80-bc1b-8e6cc1c72e0a) |
