### PR TITLE
fix: styling issue - datagrid search input has border bottom on pseud…

### DIFF
--- a/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
@@ -5,6 +5,7 @@ import {
     checkboxClasses,
     iconButtonClasses,
     inputBaseClasses,
+    inputClasses,
     inputLabelClasses,
     nativeSelectClasses,
     svgIconClasses,
@@ -304,6 +305,10 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
 
             [`& .${svgIconClasses.root}`]: {
                 fontSize: 16,
+            },
+
+            [`& .${inputClasses.underline}::before`]: {
+                borderBottom: "unset",
             },
 
             [`& .${buttonBaseClasses.root}`]: {


### PR DESCRIPTION
## Description

This Pull Request fixes an issue with the DataGrid's Search Input. There is an borderBottom on an pseudo element inside the qucikfilters. 


## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| ![Screenshot 2025-06-11 at 08 22 36](https://github.com/user-attachments/assets/47058163-04d9-406f-a83e-f25874003b99)   |  ![Screenshot 2025-06-11 at 08 19 37](https://github.com/user-attachments/assets/76c8e48c-83dc-47bb-a5f0-a492d4aba875) |


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2006
