### PR TITLE
Data Grid: use switches instead of checkboxes for columns management

### DIFF
--- a/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.sc.ts
+++ b/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.sc.ts
@@ -1,0 +1,49 @@
+import { css, List as MuiList, ListItem as MuiListItem, Switch as MuiSwitch, Typography } from "@mui/material";
+
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import { type DataGridColumnsManagementClassKey } from "./DataGridColumnsManagement";
+
+export const Root = createComponentSlot("div")<DataGridColumnsManagementClassKey>({
+    componentName: "DataGridColumnsManagement",
+    slotName: "root",
+})();
+
+export const List = createComponentSlot(MuiList)<DataGridColumnsManagementClassKey>({
+    componentName: "DataGridColumnsManagement",
+    slotName: "list",
+})();
+
+export const ListItem = createComponentSlot(MuiListItem)<DataGridColumnsManagementClassKey>({
+    componentName: "DataGridColumnsManagement",
+    slotName: "listItem",
+})(css`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 0;
+`);
+
+export const Switch = createComponentSlot(MuiSwitch)<DataGridColumnsManagementClassKey>({
+    componentName: "DataGridColumnsManagement",
+    slotName: "switch",
+})();
+
+export const ListItemTitle = createComponentSlot(Typography)<DataGridColumnsManagementClassKey>({
+    componentName: "DataGridColumnsManagement",
+    slotName: "listItemTitle",
+})();
+
+export const Body = createComponentSlot("div")<DataGridColumnsManagementClassKey>({
+    componentName: "DataGridColumnsManagement",
+    slotName: "body",
+})(
+    ({ theme }) => css`
+        padding: ${theme.spacing(2)};
+        display: flex;
+        flex-direction: column;
+        overflow: auto;
+        flex: 1 1;
+        max-height: 400px;
+        align-items: flex-start;
+    `,
+);

--- a/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.sc.ts
+++ b/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.sc.ts
@@ -1,4 +1,4 @@
-import { css, List as MuiList, ListItem as MuiListItem, Switch as MuiSwitch, Typography } from "@mui/material";
+import { css, List as MuiList, ListItem as MuiListItem, ListItemText, Switch as MuiSwitch } from "@mui/material";
 
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type DataGridColumnsManagementClassKey } from "./DataGridColumnsManagement";
@@ -28,7 +28,7 @@ export const Switch = createComponentSlot(MuiSwitch)<DataGridColumnsManagementCl
     slotName: "switch",
 })();
 
-export const ListItemTitle = createComponentSlot(Typography)<DataGridColumnsManagementClassKey>({
+export const ListItemTitle = createComponentSlot(ListItemText)<DataGridColumnsManagementClassKey>({
     componentName: "DataGridColumnsManagement",
     slotName: "listItemTitle",
 })();

--- a/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.tsx
+++ b/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.tsx
@@ -3,9 +3,10 @@ import {
     type ComponentsOverrides,
     type List as MuiList,
     type ListItem as MuiListItem,
+    type ListItemText,
     type Switch as MuiSwitch,
     type Theme,
-    type Typography,
+    Typography,
     useThemeProps,
 } from "@mui/material";
 import { gridColumnVisibilityModelSelector, useGridApiContext, useGridSelector } from "@mui/x-data-grid-pro";
@@ -20,7 +21,7 @@ export type DataGridColumnsManagementProps = ThemedComponentBaseProps<{
     switch: typeof MuiSwitch;
     list: typeof MuiList;
     listItem: typeof MuiListItem;
-    listItemTitle: typeof Typography;
+    listItemTitle: typeof ListItemText;
 }>;
 
 export type DataGridColumnsManagementClassKey = "root" | "body" | "list" | "listItem" | "switch" | "listItemTitle";
@@ -54,7 +55,7 @@ export const DataGridColumnsManagement = (inProps: DataGridColumnsManagementProp
                     {columns.map((column, index) => {
                         const checked = columnVisibilityModel?.[column.field] ?? true;
                         return (
-                            <ListItem key={index} {...slotProps.listItem}>
+                            <ListItem key={column.field} {...slotProps.listItem}>
                                 <Switch
                                     name={column.field}
                                     checked={checked}
@@ -62,8 +63,8 @@ export const DataGridColumnsManagement = (inProps: DataGridColumnsManagementProp
                                     disabled={!column.hideable}
                                     {...slotProps.switch}
                                 />
-                                <ListItemTitle variant={checked ? "subtitle2" : "body2"} {...slotProps.listItemTitle}>
-                                    {column.headerName || column.field}
+                                <ListItemTitle {...slotProps.listItemTitle}>
+                                    <Typography variant={checked ? "subtitle2" : "body2"}>{column.headerName || column.field}</Typography>
                                 </ListItemTitle>
                             </ListItem>
                         );

--- a/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.tsx
+++ b/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.tsx
@@ -6,7 +6,6 @@ import {
     type ListItemText,
     type Switch as MuiSwitch,
     type Theme,
-    Typography,
     useThemeProps,
 } from "@mui/material";
 import { gridColumnVisibilityModelSelector, useGridApiContext, useGridSelector } from "@mui/x-data-grid-pro";
@@ -63,8 +62,15 @@ export const DataGridColumnsManagement = (inProps: DataGridColumnsManagementProp
                                     disabled={!column.hideable}
                                     {...slotProps.switch}
                                 />
-                                <ListItemTitle {...slotProps.listItemTitle}>
-                                    <Typography variant={checked ? "subtitle2" : "body2"}>{column.headerName || column.field}</Typography>
+                                <ListItemTitle
+                                    slotProps={{
+                                        primary: {
+                                            variant: checked ? "subtitle2" : "body2",
+                                        },
+                                    }}
+                                    {...slotProps.listItemTitle}
+                                >
+                                    {column.headerName || column.field}
                                 </ListItemTitle>
                             </ListItem>
                         );

--- a/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.tsx
+++ b/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.tsx
@@ -54,7 +54,7 @@ export const DataGridColumnsManagement = (inProps: DataGridColumnsManagementProp
                     {columns.map((column, index) => {
                         const checked = columnVisibilityModel?.[column.field] ?? true;
                         return (
-                            <ListItem key={`columns-management-row${index}`} {...slotProps.listItem}>
+                            <ListItem key={index} {...slotProps.listItem}>
                                 <Switch
                                     name={column.field}
                                     checked={checked}

--- a/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.tsx
+++ b/packages/admin/admin/src/dataGrid/DataGridColumnsManagement.tsx
@@ -1,0 +1,92 @@
+// MUI's implementation: https://github.com/mui/mui-x/blob/v7.x/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
+import {
+    type ComponentsOverrides,
+    type List as MuiList,
+    type ListItem as MuiListItem,
+    type Switch as MuiSwitch,
+    type Theme,
+    type Typography,
+    useThemeProps,
+} from "@mui/material";
+import { gridColumnVisibilityModelSelector, useGridApiContext, useGridSelector } from "@mui/x-data-grid-pro";
+import { type ChangeEvent } from "react";
+
+import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+import { Body, List, ListItem, ListItemTitle, Root, Switch } from "./DataGridColumnsManagement.sc";
+
+export type DataGridColumnsManagementProps = ThemedComponentBaseProps<{
+    root: "div";
+    body: "div";
+    switch: typeof MuiSwitch;
+    list: typeof MuiList;
+    listItem: typeof MuiListItem;
+    listItemTitle: typeof Typography;
+}>;
+
+export type DataGridColumnsManagementClassKey = "root" | "body" | "list" | "listItem" | "switch" | "listItemTitle";
+
+export const DataGridColumnsManagement = (inProps: DataGridColumnsManagementProps) => {
+    const { sx, className, slotProps = {} } = useThemeProps({ props: inProps, name: "CometAdminDataGridColumnsManagement" });
+
+    const apiRef = useGridApiContext();
+    const columnVisibilityModel = useGridSelector(apiRef, gridColumnVisibilityModelSelector);
+    const columns = apiRef.current.getAllColumns();
+
+    const toggleColumn = (event: ChangeEvent<HTMLInputElement>) => {
+        const { name: field } = event.target;
+        const column = columns.find((value) => value.field === field);
+        if (column?.hideable) {
+            const isCurrentlyVisible = columnVisibilityModel[field] !== false;
+
+            const newVisibilityModel = {
+                ...columnVisibilityModel,
+                [field]: !isCurrentlyVisible,
+            };
+
+            apiRef.current.setColumnVisibilityModel(newVisibilityModel);
+        }
+    };
+
+    return (
+        <Root sx={sx} className={className} {...slotProps.root}>
+            <Body {...slotProps.body}>
+                <List {...slotProps.list}>
+                    {columns.map((column, index) => {
+                        const checked = columnVisibilityModel?.[column.field] ?? true;
+                        return (
+                            <ListItem key={`columns-management-row${index}`} {...slotProps.listItem}>
+                                <Switch
+                                    name={column.field}
+                                    checked={checked}
+                                    onChange={toggleColumn}
+                                    disabled={!column.hideable}
+                                    {...slotProps.switch}
+                                />
+                                <ListItemTitle variant={checked ? "subtitle2" : "body2"} {...slotProps.listItemTitle}>
+                                    {column.headerName || column.field}
+                                </ListItemTitle>
+                            </ListItem>
+                        );
+                    })}
+                </List>
+            </Body>
+        </Root>
+    );
+};
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminDataGridColumnsManagement: DataGridColumnsManagementProps;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminDataGridColumnsManagement: DataGridColumnsManagementClassKey;
+    }
+
+    interface Components {
+        CometAdminDataGridColumnsManagement?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminDataGridColumnsManagement"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDataGridColumnsManagement"];
+        };
+    }
+}

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -54,6 +54,7 @@ export { CrudContextMenu, CrudContextMenuClassKey, CrudContextMenuProps } from "
 export { CrudMoreActionsMenuClassKey } from "./dataGrid/CrudMoreActionsMenu";
 export { CrudMoreActionsMenu, CrudMoreActionsMenuContext, CrudMoreActionsMenuItem, CrudMoreActionsMenuProps } from "./dataGrid/CrudMoreActionsMenu";
 export { CrudVisibility, CrudVisibilityProps } from "./dataGrid/CrudVisibility";
+export { DataGridColumnsManagement, DataGridColumnsManagementClassKey, DataGridColumnsManagementProps } from "./dataGrid/DataGridColumnsManagement";
 export { DataGridPanel, DataGridPanelClassKey, DataGridPanelProps } from "./dataGrid/DataGridPanel";
 export { ExportApi, useDataGridExcelExport } from "./dataGrid/excelExport/useDataGridExcelExport";
 export { GridCellContent, GridCellContentClassKey, GridCellContentProps } from "./dataGrid/GridCellContent";

--- a/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
@@ -18,6 +18,7 @@ import {
 import { COMFORTABLE_DENSITY_FACTOR, COMPACT_DENSITY_FACTOR, getDataGridUtilityClass, gridClasses } from "@mui/x-data-grid";
 import type {} from "@mui/x-data-grid/themeAugmentation";
 
+import { DataGridColumnsManagement } from "../../dataGrid/DataGridColumnsManagement";
 import { DataGridPanel } from "../../dataGrid/DataGridPanel";
 import { DataGridPagination } from "../../dataGrid/pagination/DataGridPagination";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
@@ -69,6 +70,7 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             columnMenuIcon: (props: SvgIconProps) => <MoreVertical {...props} fontSize="medium" />,
             panel: DataGridPanel,
             pagination: DataGridPagination,
+            columnsManagement: DataGridColumnsManagement,
             ...component?.defaultProps?.slots,
         },
         slotProps: {


### PR DESCRIPTION
## Description

This Pull Request adds a new Custom Comet `DataGridColumnsManagement` Component, and uses it as DataGrids default. Columns can be hidden/shown with a switch.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| ![Screen Recording 2025-06-11 at 13 07 30](https://github.com/user-attachments/assets/42be8452-75bd-4e4d-bcfd-66597a9512e4) |  ![Screen Recording 2025-06-11 at 13 08 34](https://github.com/user-attachments/assets/d290d0b3-eba1-410e-b96f-f06c66523d0e)  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2000
