### PR TITLE
Limit image title to 150 characters in `AzureOpenAiContentGenerationService`

### DIFF
--- a/.changeset/wicked-countries-rush.md
+++ b/.changeset/wicked-countries-rush.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Limit image title to 150 characters in `AzureOpenAiContentGenerationService`

--- a/packages/api/cms-api/src/content-generation/azure-open-ai/azure-open-ai-content-generation.service.ts
+++ b/packages/api/cms-api/src/content-generation/azure-open-ai/azure-open-ai-content-generation.service.ts
@@ -101,7 +101,7 @@ export class AzureOpenAiContentGenerationService implements ContentGenerationSer
         const prompt: Array<ChatCompletionMessageParam> = [
             {
                 role: "system",
-                content: `The user will provide you with an image. Write a short text that can be displayed in the HTML title attribute of this image. Do not put the title inside quotation marks. Answer in the language "${language}".`,
+                content: `The user will provide you with an image. Write a short text with less than 150 characters that can be displayed in the HTML title attribute of this image. Do not put the title inside quotation marks. Answer in the language "${language}".`,
             },
             {
                 role: "user",


### PR DESCRIPTION
## Description

Previously, generated image title sometimes were very long. This PR changes the prompt to limit them to 150 characters.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
