### PR TITLE
Prevent socket exhaustion and crashing due to stream errors in the `FileUploadsDownloadController`

### DIFF
--- a/.changeset/ten-pans-shout.md
+++ b/.changeset/ten-pans-shout.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Prevent socket exhaustion when streaming files and prevent the API from crashing due to stream errors in the `FileUploadsDownloadController`
+
+We already added this fix to the DAM in the past.


### PR DESCRIPTION
## Description

Prevent socket exhaustion when streaming files and prevent the API from crashing due to stream errors in the `FileUploadsDownloadController`

We already added this fix to the DAM in the past.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
