### PR TITLE
Allow uploading .vtt files to the DAM

### DIFF
--- a/.changeset/metal-cups-dream.md
+++ b/.changeset/metal-cups-dream.md
@@ -1,0 +1,6 @@
+---
+"@comet/cms-admin": minor
+"@comet/cms-api": minor
+---
+
+Allow uploading .vtt files to the DAM

--- a/packages/admin/cms-admin/src/dam/config/damDefaultAcceptedMimeTypes.ts
+++ b/packages/admin/cms-admin/src/dam/config/damDefaultAcceptedMimeTypes.ts
@@ -25,6 +25,8 @@ export const damDefaultAcceptedMimeTypes = [
     "video/quicktime",
     "video/ogg",
     "video/webm",
+    // subtitles
+    "text/vtt",
     // pdf
     "application/pdf",
     // text document

--- a/packages/api/cms-api/src/dam/common/mimeTypes/dam-default-accepted-mimetypes.ts
+++ b/packages/api/cms-api/src/dam/common/mimeTypes/dam-default-accepted-mimetypes.ts
@@ -25,6 +25,8 @@ export const damDefaultAcceptedMimetypes = [
     "video/quicktime",
     "video/ogg",
     "video/webm",
+    // subtitles
+    "text/vtt",
     // pdf
     "application/pdf",
     // text document


### PR DESCRIPTION
## Description

Allow uploading .vtt files to the DAM

### Background

.vtt is the most common format for subtitles. We need to allow uploading subtitles in the DAM and attaching them to a video to comply with accessibility regulations.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts


https://github.com/user-attachments/assets/5d10b907-7ffa-4ebf-9809-74a8e4e9e3dc


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2079
