### PR TITLE
Fix arrow icon in Data Grid page size select

### DIFF
--- a/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
@@ -18,6 +18,7 @@ import { FormattedMessage, FormattedNumber } from "react-intl";
 
 import { DataGridPanel } from "../../dataGrid/DataGridPanel";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { commonSelectDefaultProps } from "./getCommonSelectTheme";
 import { type GetMuiComponentTheme } from "./getComponentsTheme";
 
 const getDensityHeightValue = (density: string) => {
@@ -69,6 +70,13 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             baseButton: {
                 color: "info",
                 ...component?.defaultProps?.slotProps?.baseButton,
+            },
+            pagination: {
+                slotProps: {
+                    select: {
+                        ...commonSelectDefaultProps,
+                    },
+                },
             },
         },
         localeText: {


### PR DESCRIPTION
## Description

This Pull Request changes the DataGrid's TablePagination - Page Selection Icon to an Chevron, like in Comet Design Library
## Screenshots/screencasts

| Design | Before | After |
| ------ |------ | ----- |
| ![Screenshot 2025-06-16 at 08 12 03](https://github.com/user-attachments/assets/7ec6860e-1084-485a-b0d9-bb13016b5c2a) |![Screenshot 2025-06-16 at 08 11 45](https://github.com/user-attachments/assets/cb55353e-b21c-48a0-8b82-6961bd111022)   | ![Screenshot 2025-06-16 at 08 12 48](https://github.com/user-attachments/assets/8c901fa4-f238-4fc9-963b-fd4384b09d09)  |


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2009
