### PR TITLE
Fix DAM Data Grid jumping when selecting rows

### DIFF
--- a/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
@@ -33,7 +33,7 @@ import { Button } from "../common/buttons/Button";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
-export type CrudMoreActionsMenuClassKey = "root" | "group" | "divider" | "button" | "content" | "chip" | "menuItem";
+export type CrudMoreActionsMenuClassKey = "root" | "group" | "divider" | "button" | "chip" | "menuItem";
 
 interface ActionItem extends ComponentProps<typeof MenuItem> {
     label: ReactNode;
@@ -45,7 +45,6 @@ export interface CrudMoreActionsMenuProps
         menu: typeof Menu;
         menuItem: typeof MenuItem;
         button: typeof Button;
-        content: "div";
         group: typeof CrudMoreActionsGroup;
         divider: typeof Divider;
         chip: typeof Chip;
@@ -95,15 +94,7 @@ const MoreActionsButton = createComponentSlot(Button)<CrudMoreActionsMenuClassKe
     slotName: "button",
 })(css`
     margin: 0 10px;
-`);
-
-const MoreActionsButtonContent = createComponentSlot("div")<CrudMoreActionsMenuClassKey>({
-    componentName: "CrudMoreActions",
-    slotName: "content",
-})(css`
-    min-height: 20px;
-    display: flex;
-    align-items: center;
+    min-height: 44px;
 `);
 
 const MoreActionsMenuItem = createComponentSlot(MenuItem)<CrudMoreActionsMenuClassKey>({
@@ -152,10 +143,8 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
     return (
         <CrudMoreActionsMenuContext.Provider value={{ closeMenu: handleClose }}>
             <MoreActionsButton variant="textDark" endIcon={<MoreVertical />} {...buttonProps} onClick={handleClick} responsive>
-                <MoreActionsButtonContent>
-                    <FormattedMessage id="comet.crudMoreActions.title" defaultMessage="More" />
-                    {!!selectionSize && <MoreActionsSelectedItemsChip size="small" color="primary" {...chipProps} label={selectionSize} />}
-                </MoreActionsButtonContent>
+                <FormattedMessage id="comet.crudMoreActions.title" defaultMessage="More" />
+                {!!selectionSize && <MoreActionsSelectedItemsChip size="small" color="primary" {...chipProps} label={selectionSize} />}
             </MoreActionsButton>
             <Menu
                 keepMounted={false}

--- a/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
@@ -33,7 +33,7 @@ import { Button } from "../common/buttons/Button";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
-export type CrudMoreActionsMenuClassKey = "root" | "group" | "divider" | "button" | "chip" | "menuItem";
+export type CrudMoreActionsMenuClassKey = "root" | "group" | "divider" | "button" | "content" | "chip" | "menuItem";
 
 interface ActionItem extends ComponentProps<typeof MenuItem> {
     label: ReactNode;
@@ -45,6 +45,7 @@ export interface CrudMoreActionsMenuProps
         menu: typeof Menu;
         menuItem: typeof MenuItem;
         button: typeof Button;
+        content: "div";
         group: typeof CrudMoreActionsGroup;
         divider: typeof Divider;
         chip: typeof Chip;
@@ -96,6 +97,15 @@ const MoreActionsButton = createComponentSlot(Button)<CrudMoreActionsMenuClassKe
     margin: 0 10px;
 `);
 
+const MoreActionsButtonContent = createComponentSlot("div")<CrudMoreActionsMenuClassKey>({
+    componentName: "CrudMoreActions",
+    slotName: "content",
+})(css`
+    min-height: 20px;
+    display: flex;
+    align-items: center;
+`);
+
 const MoreActionsMenuItem = createComponentSlot(MenuItem)<CrudMoreActionsMenuClassKey>({
     componentName: "CrudMoreActions",
     slotName: "menuItem",
@@ -142,8 +152,10 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
     return (
         <CrudMoreActionsMenuContext.Provider value={{ closeMenu: handleClose }}>
             <MoreActionsButton variant="textDark" endIcon={<MoreVertical />} {...buttonProps} onClick={handleClick} responsive>
-                <FormattedMessage id="comet.crudMoreActions.title" defaultMessage="More" />
-                {!!selectionSize && <MoreActionsSelectedItemsChip size="small" color="primary" {...chipProps} label={selectionSize} />}
+                <MoreActionsButtonContent>
+                    <FormattedMessage id="comet.crudMoreActions.title" defaultMessage="More" />
+                    {!!selectionSize && <MoreActionsSelectedItemsChip size="small" color="primary" {...chipProps} label={selectionSize} />}
+                </MoreActionsButtonContent>
             </MoreActionsButton>
             <Menu
                 keepMounted={false}


### PR DESCRIPTION
## Description

This Pull Request fixes a jumping issue, when the user select a DataGrid Row which has a `CrudMoreActionsMenu`- for example Dam.

Problem:
- The `MoreActionsButton` is a normal button with padding.
- initially there is only a Text - e.g. More -> Text has a height of 16 px.
- if the user selects a DataGrid Row -> a Badge gets added to the `MoreActionButton` which shows the amount of selected Rows. 
- The Badge has a height of 20 px which forces the button to grow, which will also grow the DataGridToolbar.

Solution:
- adding an additional Div for the content of the More Button, and setting a minHeight of 20 px solves the jumping.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| ![Screen Recording 2025-06-16 at 12 55 55](https://github.com/user-attachments/assets/20b8d6c0-16d1-47ea-b4ba-492f044fa9a5)   | ![Screen Recording 2025-06-16 at 12 47 50](https://github.com/user-attachments/assets/c1d9fbe5-2457-45c6-bb79-037c44afdaac)  |

