### PR TITLE
Fix horizontal scrolling in DAM Data Grid

### DIFF
--- a/packages/admin/cms-admin/src/dam/DamPage.tsx
+++ b/packages/admin/cms-admin/src/dam/DamPage.tsx
@@ -1,4 +1,3 @@
-import { styled } from "@mui/material/styles";
 import { type ReactNode } from "react";
 import { useRouteMatch } from "react-router";
 
@@ -28,13 +27,6 @@ const DefaultContentScopeIndicator = () => {
     }
 };
 
-const DamTableWrapper = styled("div")`
-    display: grid;
-    height: calc(100vh - var(--comet-admin-master-layout-content-top-spacing));
-    grid-template-columns: 1fr;
-    grid-template-rows: max-content;
-`;
-
 function DamPage({ renderContentScopeIndicator, additionalToolbarItems }: Props) {
     const { scope, match } = useContentScope();
     const routeMatch = useRouteMatch();
@@ -44,12 +36,10 @@ function DamPage({ renderContentScopeIndicator, additionalToolbarItems }: Props)
 
     return (
         <DamScopeProvider>
-            <DamTableWrapper>
-                <DamTable
-                    contentScopeIndicator={renderContentScopeIndicator ? renderContentScopeIndicator(scope) : <DefaultContentScopeIndicator />}
-                    additionalToolbarItems={damConfig.additionalToolbarItems ?? additionalToolbarItems}
-                />
-            </DamTableWrapper>
+            <DamTable
+                contentScopeIndicator={renderContentScopeIndicator ? renderContentScopeIndicator(scope) : <DefaultContentScopeIndicator />}
+                additionalToolbarItems={damConfig.additionalToolbarItems ?? additionalToolbarItems}
+            />
         </DamScopeProvider>
     );
 }

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -5,6 +5,7 @@ import {
     type ISortInformation,
     SortDirection,
     Stack,
+    StackMainContent,
     StackPage,
     StackSwitch,
     Toolbar,
@@ -65,7 +66,15 @@ const Folder = ({ id, filterApi, ...props }: FolderProps) => {
                 <StackPage name="table">
                     <EditDialogApiContext.Provider value={editDialogApi}>
                         <Toolbar scopeIndicator={props.contentScopeIndicator} />
-                        <FolderDataGrid id={id} breadcrumbs={stackApi?.breadCrumbs} selectionApi={selectionApi} filterApi={filterApi} {...props} />
+                        <StackMainContent fullHeight>
+                            <FolderDataGrid
+                                id={id}
+                                breadcrumbs={stackApi?.breadCrumbs}
+                                selectionApi={selectionApi}
+                                filterApi={filterApi}
+                                {...props}
+                            />
+                        </StackMainContent>
                     </EditDialogApiContext.Provider>
                 </StackPage>
                 <StackPage name="edit" title={intl.formatMessage({ id: "comet.pages.dam.edit", defaultMessage: "Edit" })}>

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -8,7 +8,6 @@ import {
     type GridColDef,
     type IFilterApi,
     type ISelectionApi,
-    MainContent,
     PrettyBytes,
     ToolbarActions,
     ToolbarItem,
@@ -601,7 +600,7 @@ const FolderDataGrid = ({
     };
 
     return (
-        <MainContent>
+        <>
             <sc.FolderOuterHoverHighlight isHovered={hoveredId === "root"} {...getFileRootProps()}>
                 <DataGrid
                     apiRef={apiRef}
@@ -660,7 +659,7 @@ const FolderDataGrid = ({
                     closeMoveDialog();
                 }}
             />
-        </MainContent>
+        </>
     );
 };
 


### PR DESCRIPTION
## Description

The DAM DataGrid has an issue, It always uses full width, and the main content scrolls. This Pull Request changes this, and wrappes the Dam's Folder DataGrid inside a `StackMainContent` which leads to that the content of the datagrid gets scrolled, and the page gets layed out responsive.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  ![Screen Recording 2025-06-16 at 13 10 29](https://github.com/user-attachments/assets/3cdd5a73-0d4e-477d-8db5-a3a49b2b9572) |   ![Screen Recording 2025-06-16 at 13 09 25](https://github.com/user-attachments/assets/c4dc99d8-4449-4b55-a3f0-08dd83d4117a) |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2011
