### PR TITLE
Fix the styling of DataGrid inputs

### DIFF
--- a/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
@@ -7,9 +7,11 @@ import {
     inputBaseClasses,
     inputLabelClasses,
     nativeSelectClasses,
+    Select,
     svgIconClasses,
     type SvgIconProps,
     tablePaginationClasses,
+    TextField,
     toolbarClasses,
 } from "@mui/material";
 import { COMFORTABLE_DENSITY_FACTOR, COMPACT_DENSITY_FACTOR, getDataGridUtilityClass, gridClasses } from "@mui/x-data-grid";
@@ -56,6 +58,8 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             quickFilterIcon: Search,
             quickFilterClearIcon: Clear,
             filterPanelDeleteIcon: (props: SvgIconProps) => <Delete {...props} fontSize="medium" />,
+            baseTextField: TextField,
+            baseSelect: Select,
             booleanCellTrueIcon: Check,
             booleanCellFalseIcon: Close,
             columnSortedAscendingIcon: ArrowUp,


### PR DESCRIPTION
## Description

E.g., the search-input of `GridToolbarQuickFilter` and the textfield/select components of the filters panel now use the standard MUI components.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="721" alt="DataGrid Search and Filters Previously" src="https://github.com/user-attachments/assets/56bbed21-41c2-48dc-95ed-e4716164dcf6" />   | <img width="721" alt="DataGrid Search and Filters Now" src="https://github.com/user-attachments/assets/3e867100-95c1-448b-97e9-3ce281713573" />  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2008
