### PR TITLE
`ContentScopeSelect`: Exclude scopes from grouping

### DIFF
--- a/.changeset/calm-boats-wave.md
+++ b/.changeset/calm-boats-wave.md
@@ -1,0 +1,19 @@
+---
+"@comet/cms-admin": patch
+---
+
+Add `excludeFromGrouping` to `ContentScopeSelect`
+
+This method allows you to exclude specific options from the grouping.
+The excluded scopes are always shown on top of the scope selector.
+
+This can be useful for scopes with optional parts like
+
+```
+interface ContentScope {
+    country: string;
+    company?: string;
+}
+```
+
+Here you might have scopes for different companies within a country and one overview scope (`{ country: "at", company: undefined }`) that should be excluded.

--- a/storybook/src/cms-admin/ContentScopeSelect.stories.tsx
+++ b/storybook/src/cms-admin/ContentScopeSelect.stories.tsx
@@ -296,6 +296,7 @@ export const GroupingWithOptionalScopeParts = function () {
                 },
             ]}
             groupBy="country"
+            excludeFromGrouping={(option) => option.company === undefined}
             searchable
             renderOption={(option, query, isSelected) => {
                 let text: string;


### PR DESCRIPTION
depends on https://github.com/vivid-planet/comet/pull/3972

## Description

### Problem

If you have a scope with an optional part, this scope is still included in the grouping. This can result in an empty option in the scope selector:

<img width="1610" alt="Bildschirmfoto 2025-06-17 um 08 25 33" src="https://github.com/user-attachments/assets/69a6a819-672c-4fe2-8b9c-95b020891cd1" />
(here the scope is `{ country: "at", company: undefined }`)

These overview scopes should be shown at the top of the selector. 

### Solution

I added a method to exclude scopes from the grouping. Those are shown at the top:

<img width="1610" alt="Bildschirmfoto 2025-06-17 um 08 36 04" src="https://github.com/user-attachments/assets/2eeca371-6f79-420b-9e61-415a48dffd5f" />


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2087
