### PR TITLE
AsyncSelectField add ReloadButton to error Option

### DIFF
--- a/.changeset/big-mangos-dance.md
+++ b/.changeset/big-mangos-dance.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Add error handling for asynchronous option loading in `FinalFormSelect`. When loading fails, an error message is shown in the dropdown.

--- a/.changeset/ninety-shirts-grab.md
+++ b/.changeset/ninety-shirts-grab.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+yAdd the possibility to customize the `FinalFormSelect` error message with `getErrorOptionsLabel` prop.

--- a/.changeset/ninety-shirts-grab.md
+++ b/.changeset/ninety-shirts-grab.md
@@ -2,4 +2,4 @@
 "@comet/admin": minor
 ---
 
-yAdd the possibility to customize the `FinalFormSelect` error message with `getErrorOptionsLabel` prop.
+Add the possibility to customize the `FinalFormSelect` error message with `getErrorOptionsLabel` prop.

--- a/packages/admin/admin/src/form/FinalFormAsyncSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormAsyncSelect.tsx
@@ -3,7 +3,7 @@ import { type SelectProps } from "@mui/material";
 import { useAsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 import { FinalFormSelect, type FinalFormSelectProps } from "./FinalFormSelect";
 
-export interface FinalFormAsyncSelectProps<T> extends FinalFormSelectProps<T>, Omit<SelectProps, "input"> {
+export interface FinalFormAsyncSelectProps<T> extends FinalFormSelectProps<T>, Omit<SelectProps, "input" | "error"> {
     loadOptions: () => Promise<T[]>;
 }
 

--- a/packages/admin/admin/src/form/FinalFormAsyncSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormAsyncSelect.tsx
@@ -3,7 +3,7 @@ import { type SelectProps } from "@mui/material";
 import { useAsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 import { FinalFormSelect, type FinalFormSelectProps } from "./FinalFormSelect";
 
-export interface FinalFormAsyncSelectProps<T> extends FinalFormSelectProps<T>, Omit<SelectProps, "input" | "error"> {
+export interface FinalFormAsyncSelectProps<T> extends FinalFormSelectProps<T>, Omit<SelectProps, "input"> {
     loadOptions: () => Promise<T[]>;
 }
 

--- a/packages/admin/admin/src/form/FinalFormSelect.sc.ts
+++ b/packages/admin/admin/src/form/FinalFormSelect.sc.ts
@@ -5,4 +5,15 @@ export const MenuItemDisabledOverrideOpacity = styled(MenuItem)({
     [`&.${menuItemClasses.disabled}`]: {
         opacity: 1.0,
     },
+
+    height: "48px",
+    cursor: "default",
 });
+
+export const MenuItemContainerContent = styled("div")`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    margin: 0;
+`;

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -15,6 +15,7 @@ export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputEl
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
     required?: boolean;
+    error?: Error | null;
 }
 
 const getHasClearableContent = (value: unknown, multiple: boolean | undefined) => {
@@ -61,7 +62,7 @@ export const FinalFormSelect = <T,>({
     children,
     required,
     ...rest
-}: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input" | "endAdornment">) => {
+}: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input" | "endAdornment" | "error">) => {
     // Depending on the usage, `multiple` is either a root prop or in the `input` prop.
     // 1. <Field component={FinalFormSelect} multiple /> -> multiple is in restInput
     // 2. <Field>{(props) => <FinalFormSelect {...props} multiple />}</Field> -> multiple is in rest
@@ -150,12 +151,12 @@ export const FinalFormSelect = <T,>({
                     </MenuItem>
                 ))}
 
-            {loading === false && options.length === 0 && (
+            {loading === false && error == null && options.length === 0 && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
                     {noOptionsLabel}
                 </MenuItemDisabledOverrideOpacity>
             )}
-            {loading === false && error === true && (
+            {loading === false && error != null && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
                     {errorLabel}
                 </MenuItemDisabledOverrideOpacity>

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -10,7 +10,7 @@ import { MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
 
 export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> {
     noOptionsLabel?: ReactNode;
-    getErrorOptionsLabel?: () => ReactNode;
+    errorLabel?: ReactNode;
     getOptionLabel?: (option: T) => string;
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
@@ -47,18 +47,17 @@ export const FinalFormSelect = <T,>({
             return String(option);
         }
     },
+
     noOptionsLabel = (
         <Typography variant="body2">
             <FormattedMessage id="finalFormSelect.noOptions" defaultMessage="No options." />
         </Typography>
     ),
-    getErrorOptionsLabel = () => {
-        return (
-            <Typography variant="body2">
-                <FormattedMessage id="finalFormSelect.error" defaultMessage="Error loading options." />
-            </Typography>
-        );
-    },
+    errorLabel = (
+        <Typography variant="body2">
+            <FormattedMessage id="finalFormSelect.error" defaultMessage="Error loading options." />
+        </Typography>
+    ),
     children,
     required,
     ...rest
@@ -158,7 +157,7 @@ export const FinalFormSelect = <T,>({
             )}
             {loading === false && error === true && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
-                    {getErrorOptionsLabel()}
+                    {errorLabel}
                 </MenuItemDisabledOverrideOpacity>
             )}
 

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -1,3 +1,4 @@
+import { Error } from "@comet/admin-icons";
 import { CircularProgress, InputAdornment, MenuItem, Select, type SelectProps, Typography } from "@mui/material";
 import { type ReactNode } from "react";
 import { type FieldRenderProps } from "react-final-form";
@@ -9,6 +10,7 @@ import { MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
 
 export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> {
     noOptionsLabel?: ReactNode;
+    getErrorOptionsLabel?: () => ReactNode;
     getOptionLabel?: (option: T) => string;
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
@@ -29,6 +31,7 @@ export const FinalFormSelect = <T,>({
     isAsync = false,
     options = [],
     loading = false,
+    error,
     getOptionLabel = (option: T) => {
         if (typeof option === "object") {
             console.error(`The \`getOptionLabel\` method of FinalFormSelect returned an object instead of a string for${JSON.stringify(option)}.`);
@@ -49,6 +52,13 @@ export const FinalFormSelect = <T,>({
             <FormattedMessage id="finalFormSelect.noOptions" defaultMessage="No options." />
         </Typography>
     ),
+    getErrorOptionsLabel = () => {
+        return (
+            <Typography variant="body2">
+                <FormattedMessage id="finalFormSelect.error" defaultMessage="Error loading options." />
+            </Typography>
+        );
+    },
     children,
     required,
     ...rest
@@ -96,7 +106,11 @@ export const FinalFormSelect = <T,>({
                             {endAdornment}
                         </InputAdornment>
                     ) : (
-                        <InputAdornment position="end">{endAdornment}</InputAdornment>
+                        <InputAdornment position="end">
+                            {error && <Error color="error" />}
+
+                            {endAdornment}
+                        </InputAdornment>
                     )}
                 </>
             }
@@ -140,6 +154,11 @@ export const FinalFormSelect = <T,>({
             {loading === false && options.length === 0 && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
                     {noOptionsLabel}
+                </MenuItemDisabledOverrideOpacity>
+            )}
+            {loading === false && error === true && (
+                <MenuItemDisabledOverrideOpacity value="" disabled>
+                    {getErrorOptionsLabel()}
                 </MenuItemDisabledOverrideOpacity>
             )}
 

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -1,16 +1,18 @@
-import { Error } from "@comet/admin-icons";
-import { CircularProgress, InputAdornment, MenuItem, Select, type SelectProps, Typography } from "@mui/material";
+import { Error, Reload } from "@comet/admin-icons";
+import { CircularProgress, IconButton, InputAdornment, MenuItem, Select, type SelectProps, Typography } from "@mui/material";
 import { type ReactNode } from "react";
 import { type FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
 import { ClearInputAdornment } from "../common/ClearInputAdornment";
 import { type AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
-import { MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
+import { MenuItemContainerContent, MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
 
+export type ReloadFunction = () => void;
 export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> {
     noOptionsLabel?: ReactNode;
-    errorLabel?: ReactNode;
+    renderErrorLabel?: (reload?: ReloadFunction) => ReactNode;
+    reload?: ReloadFunction;
     getOptionLabel?: (option: T) => string;
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
@@ -48,17 +50,30 @@ export const FinalFormSelect = <T,>({
             return String(option);
         }
     },
-
+    reload,
     noOptionsLabel = (
         <Typography variant="body2">
             <FormattedMessage id="finalFormSelect.noOptions" defaultMessage="No options." />
         </Typography>
     ),
-    errorLabel = (
-        <Typography variant="body2">
-            <FormattedMessage id="finalFormSelect.error" defaultMessage="Error loading options." />
-        </Typography>
+    renderErrorLabel = (reloadFunction) => (
+        <MenuItemContainerContent>
+            <Typography variant="body2">
+                <FormattedMessage id="finalFormSelect.error" defaultMessage="Error loading options." />
+            </Typography>
+            {reloadFunction && (
+                <IconButton
+                    onClick={(event) => {
+                        event.stopPropagation();
+                        reloadFunction?.();
+                    }}
+                >
+                    <Reload fontSize="small" />
+                </IconButton>
+            )}
+        </MenuItemContainerContent>
     ),
+
     children,
     required,
     ...rest
@@ -157,8 +172,16 @@ export const FinalFormSelect = <T,>({
                 </MenuItemDisabledOverrideOpacity>
             )}
             {loading === false && loadingError != null && (
-                <MenuItemDisabledOverrideOpacity value="" disabled>
-                    {errorLabel}
+                <MenuItemDisabledOverrideOpacity
+                    value=""
+                    disableRipple
+                    onMouseDown={(e) => {
+                        // prevents the ripple effect of the menu item
+                        e.stopPropagation();
+                        e.preventDefault();
+                    }}
+                >
+                    {renderErrorLabel(reload)}
                 </MenuItemDisabledOverrideOpacity>
             )}
 

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -15,7 +15,7 @@ export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputEl
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
     required?: boolean;
-    error?: Error | null;
+    loadingError?: Error | null;
 }
 
 const getHasClearableContent = (value: unknown, multiple: boolean | undefined) => {
@@ -32,7 +32,7 @@ export const FinalFormSelect = <T,>({
     isAsync = false,
     options = [],
     loading = false,
-    error,
+    loadingError,
     getOptionLabel = (option: T) => {
         if (typeof option === "object") {
             console.error(`The \`getOptionLabel\` method of FinalFormSelect returned an object instead of a string for${JSON.stringify(option)}.`);
@@ -62,7 +62,7 @@ export const FinalFormSelect = <T,>({
     children,
     required,
     ...rest
-}: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input" | "endAdornment" | "error">) => {
+}: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input" | "endAdornment">) => {
     // Depending on the usage, `multiple` is either a root prop or in the `input` prop.
     // 1. <Field component={FinalFormSelect} multiple /> -> multiple is in restInput
     // 2. <Field>{(props) => <FinalFormSelect {...props} multiple />}</Field> -> multiple is in rest
@@ -107,7 +107,7 @@ export const FinalFormSelect = <T,>({
                         </InputAdornment>
                     ) : (
                         <InputAdornment position="end">
-                            {error && <Error color="error" />}
+                            {loadingError && <Error color="error" />}
 
                             {endAdornment}
                         </InputAdornment>
@@ -151,12 +151,12 @@ export const FinalFormSelect = <T,>({
                     </MenuItem>
                 ))}
 
-            {loading === false && error == null && options.length === 0 && (
+            {loading === false && loadingError == null && options.length === 0 && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
                     {noOptionsLabel}
                 </MenuItemDisabledOverrideOpacity>
             )}
-            {loading === false && error != null && (
+            {loading === false && loadingError != null && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
                     {errorLabel}
                 </MenuItemDisabledOverrideOpacity>

--- a/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
+++ b/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
@@ -6,6 +6,7 @@ import { FinalFormAsyncSelect } from "../FinalFormAsyncSelect";
 export interface AsyncSelectFieldProps<Option> extends FieldProps<Option, HTMLSelectElement> {
     loadOptions: () => Promise<Option[]>;
     noOptionsLabel?: ReactNode;
+    errorLabel?: ReactNode;
     getOptionLabel?: (option: Option) => string;
     getOptionValue?: (option: Option) => string;
     clearable?: boolean;

--- a/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
+++ b/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
@@ -2,11 +2,12 @@ import { type ReactNode } from "react";
 
 import { Field, type FieldProps } from "../Field";
 import { FinalFormAsyncSelect } from "../FinalFormAsyncSelect";
+import { type ReloadFunction } from "../FinalFormSelect";
 
 export interface AsyncSelectFieldProps<Option> extends FieldProps<Option, HTMLSelectElement> {
     loadOptions: () => Promise<Option[]>;
     noOptionsLabel?: ReactNode;
-    errorLabel?: ReactNode;
+    renderErrorLabel?: ReloadFunction;
     getOptionLabel?: (option: Option) => string;
     getOptionValue?: (option: Option) => string;
     clearable?: boolean;

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -16,6 +16,7 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     const [error, setError] = useState<Error | null>(null);
 
     const handleOpen = async () => {
+        setError(null);
         setOpen(true);
         setLoading(true);
         try {

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -4,6 +4,7 @@ export interface AsyncOptionsProps<T> {
     isAsync: boolean;
     open: boolean;
     options: T[];
+    error: boolean;
     loading?: boolean;
     onOpen: (event: ChangeEvent) => void;
     onClose: (event: ChangeEvent) => void;
@@ -12,18 +13,25 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     const [open, setOpen] = useState(false);
     const [options, setOptions] = useState<T[]>([]);
     const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<Error | null>(null);
 
     const handleOpen = async () => {
         setOpen(true);
         setLoading(true);
-        const newOptions = await loadOptions();
-        setOptions(newOptions);
-        setLoading(false);
+        try {
+            const newOptions = await loadOptions();
+            setOptions(newOptions);
+        } catch (e) {
+            setError(e);
+        } finally {
+            setLoading(false);
+        }
     };
 
     return {
         isAsync: true,
         open,
+        error: error !== null,
         options,
         loading,
         onOpen: handleOpen,

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -4,7 +4,7 @@ export interface AsyncOptionsProps<T> {
     isAsync: boolean;
     open: boolean;
     options: T[];
-    error: boolean;
+    error: Error | null;
     loading?: boolean;
     onOpen: (event: ChangeEvent) => void;
     onClose: (event: ChangeEvent) => void;
@@ -31,7 +31,7 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     return {
         isAsync: true,
         open,
-        error: error !== null,
+        error,
         options,
         loading,
         onOpen: handleOpen,

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useState } from "react";
+import { type ChangeEvent, useCallback, useState } from "react";
 
 export interface AsyncOptionsProps<T> {
     isAsync: boolean;
@@ -6,6 +6,7 @@ export interface AsyncOptionsProps<T> {
     options: T[];
     loadingError: Error | null;
     loading?: boolean;
+    reload: () => void;
     onOpen: (event: ChangeEvent) => void;
     onClose: (event: ChangeEvent) => void;
 }
@@ -15,9 +16,10 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<Error | null>(null);
 
-    const handleOpen = async () => {
+    const handleOpen = useCallback(async () => {
         setError(null);
         setOpen(true);
+        setOptions([]);
         setLoading(true);
         try {
             const newOptions = await loadOptions();
@@ -27,9 +29,10 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
         } finally {
             setLoading(false);
         }
-    };
+    }, [loadOptions]);
 
     return {
+        reload: handleOpen,
         isAsync: true,
         open,
         loadingError: error,

--- a/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
+++ b/packages/admin/admin/src/hooks/useAsyncOptionsProps.ts
@@ -4,7 +4,7 @@ export interface AsyncOptionsProps<T> {
     isAsync: boolean;
     open: boolean;
     options: T[];
-    error: Error | null;
+    loadingError: Error | null;
     loading?: boolean;
     onOpen: (event: ChangeEvent) => void;
     onClose: (event: ChangeEvent) => void;
@@ -31,7 +31,7 @@ export function useAsyncOptionsProps<T>(loadOptions: () => Promise<T[]>): AsyncO
     return {
         isAsync: true,
         open,
-        error,
+        loadingError: error,
         options,
         loading,
         onOpen: handleOpen,

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -358,14 +358,12 @@ export const ErrorLoadingOptionsWithCustomErrorLabel: Story = {
                                 getOptionLabel={(option) => {
                                     return option;
                                 }}
-                                getErrorOptionsLabel={() => {
-                                    return (
-                                        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                                            <WarningSolid color="error" />
-                                            Error loading options
-                                        </div>
-                                    );
-                                }}
+                                errorLabel={
+                                    <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                                        <WarningSolid color="error" />
+                                        Error loading options
+                                    </div>
+                                }
                                 name="type"
                                 label="AsyncSelectField"
                                 fullWidth

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -1,6 +1,6 @@
 import { gql, useApolloClient } from "@apollo/client";
 import { Alert, AsyncSelectField, FinalForm } from "@comet/admin";
-import { Info } from "@comet/admin-icons";
+import { Info, WarningSolid } from "@comet/admin-icons";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import type { Manufacturer } from "../../../.storybook/mocks/handlers";
@@ -267,6 +267,105 @@ export const NoOptionsWithCustomNoOptionsLabel: Story = {
                                         No options available at this point in time
                                     </div>
                                 }
+                                name="type"
+                                label="AsyncSelectField"
+                                fullWidth
+                                variant="horizontal"
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+/**
+ * This story demonstrates the usage of the AsyncSelectField component where an error occurs while loading the options.
+ */
+export const ErrorLoadingOptions: Story = {
+    render: () => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{}}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <AsyncSelectField
+                                loadOptions={async () => {
+                                    // simulate loading
+                                    await new Promise((resolve) => setTimeout(resolve, 500));
+                                    throw Error("Error loading options");
+                                    return [];
+                                }}
+                                getOptionLabel={(option) => {
+                                    return option;
+                                }}
+                                name="type"
+                                label="AsyncSelectField"
+                                fullWidth
+                                variant="horizontal"
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const ErrorLoadingOptionsWithCustomErrorLabel: Story = {
+    render: () => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{}}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <AsyncSelectField
+                                loadOptions={async () => {
+                                    // simulate loading
+                                    await new Promise((resolve) => setTimeout(resolve, 500));
+                                    throw Error("Error loading options");
+                                    return [];
+                                }}
+                                getOptionLabel={(option) => {
+                                    return option;
+                                }}
+                                getErrorOptionsLabel={() => {
+                                    return (
+                                        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                                            <WarningSolid color="error" />
+                                            Error loading options
+                                        </div>
+                                    );
+                                }}
                                 name="type"
                                 label="AsyncSelectField"
                                 fullWidth

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -1,6 +1,7 @@
 import { gql, useApolloClient } from "@apollo/client";
 import { Alert, AsyncSelectField, FinalForm } from "@comet/admin";
-import { Info, WarningSolid } from "@comet/admin-icons";
+import { Info, Reset, WarningSolid } from "@comet/admin-icons";
+import { IconButton } from "@mui/material";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import type { Manufacturer } from "../../../.storybook/mocks/handlers";
@@ -336,6 +337,7 @@ export const ErrorLoadingOptionsWithCustomErrorLabel: Story = {
         interface FormValues {
             type: string;
         }
+
         return (
             <FinalForm<FormValues>
                 initialValues={{}}
@@ -358,12 +360,22 @@ export const ErrorLoadingOptionsWithCustomErrorLabel: Story = {
                                 getOptionLabel={(option) => {
                                     return option;
                                 }}
-                                errorLabel={
-                                    <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                                        <WarningSolid color="error" />
-                                        Error loading options
-                                    </div>
-                                }
+                                renderErrorLabel={(reload) => {
+                                    return (
+                                        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                                            <WarningSolid color="error" />
+                                            Error loading options
+                                            <IconButton
+                                                onClick={(event) => {
+                                                    event.stopPropagation();
+                                                    reload?.();
+                                                }}
+                                            >
+                                                <Reset fontSize="small" />
+                                            </IconButton>
+                                        </div>
+                                    );
+                                }}
                                 name="type"
                                 label="AsyncSelectField"
                                 fullWidth


### PR DESCRIPTION
depends on: https://github.com/vivid-planet/comet/pull/3863

## Description

This Pull Request add to the `AsyncSelectField` a Reload Button, when an error occured while loading the options. 

![Screen Recording 2025-06-17 at 13 04 24](https://github.com/user-attachments/assets/c2721988-f188-432e-815e-710dcbda5461)



## Further information

-   Task: https://vivid-planet.atlassian.net/browse/PGO-282
