### PR TITLE
Remove internal grid from DashboardWidgetRoot

### DIFF
--- a/.changeset/light-chefs-build.md
+++ b/.changeset/light-chefs-build.md
@@ -1,0 +1,15 @@
+---
+"@comet/cms-admin": major
+---
+
+Remove `Grid` layout responsibility from `DashboardWidgetRoot`.
+
+The component `DashboardWidgetRoot` no longer wraps its content inside a `<Grid>` component. This change delegates layout responsibility (e.g., grid column sizing) to the parent component.
+
+**Before:**
+`DashboardWidgetRoot` was always wrapped in `<Grid size={{ xs: 12, lg: 6 }}>`.
+
+**After:**
+No layout assumptions — parent components must now position the widget explicitly.
+
+This change may require updates where `DashboardWidgetRoot` is used inside grid layouts.

--- a/demo/admin/src/dashboard/DashboardPage.tsx
+++ b/demo/admin/src/dashboard/DashboardPage.tsx
@@ -38,8 +38,27 @@ export function DashboardPage() {
                             <LatestContentUpdates />
                         </Grid>
                     )}
-                    {import.meta.env.MODE !== "development" && <LatestBuildsDashboardWidget />}
-                    {isAllowed("warnings") && <LatestWarningsDashboardWidget />}
+
+                    {import.meta.env.MODE !== "development" && (
+                        <Grid
+                            size={{
+                                xs: 12,
+                                lg: 6,
+                            }}
+                        >
+                            <LatestBuildsDashboardWidget />
+                        </Grid>
+                    )}
+                    {isAllowed("warnings") && (
+                        <Grid
+                            size={{
+                                xs: 12,
+                                lg: 6,
+                            }}
+                        >
+                            <LatestWarningsDashboardWidget />
+                        </Grid>
+                    )}
                 </Grid>
             </MainContent>
         </Stack>

--- a/demo/admin/src/dashboard/DashboardPage.tsx
+++ b/demo/admin/src/dashboard/DashboardPage.tsx
@@ -28,7 +28,16 @@ export function DashboardPage() {
             <Toolbar scopeIndicator={<ContentScopeIndicator global />} />
             <MainContent>
                 <Grid container direction="row" spacing={4}>
-                    {isAllowed("pageTree") && <LatestContentUpdates />}
+                    {isAllowed("pageTree") && (
+                        <Grid
+                            size={{
+                                xs: 12,
+                                lg: 6,
+                            }}
+                        >
+                            <LatestContentUpdates />
+                        </Grid>
+                    )}
                     {import.meta.env.MODE !== "development" && <LatestBuildsDashboardWidget />}
                     {isAllowed("warnings") && <LatestWarningsDashboardWidget />}
                 </Grid>

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -2052,3 +2052,99 @@ This rule ensures that TypeScript type-only imports are explicitly marked with i
   Using import type ensures that types do not introduce unintended runtime dependencies.
 
 </details>
+
+### `FinalFormToggleButtonGroup` deprecated
+
+`FinalFormToggleButtonGroup` has been deprecated and a new component `ToggleButtonGroupField` got introduced that has the Final Form Field wrapped around it.
+
+```diff
+- import { FinalFormToggleButtonGroup } from "@comet/cms-admin";
++ import { ToggleGroupButtonField } from "@comet/admin";
+
+...
++ FormValueType = "value1" | "value2";
+
+- <Field
+-   name="formValue"
+-   label={"Field Label"}
+-   component={FinalFormToggleButtonGroup}
+-   options={[
+-       { value: "value1", icon: <Info /> },
+-       { value: "value2", icon: <Error /> },
+-   ]}
+-   optionsPerRow={2}
+- />
++ <ToggleGroupButtonField<FormValueType>
++    name="formValue"
++    label={"Field Label"}
++    options={[
++        { value: "value1", label: <Info /> },
++        { value: "value2", label: <Error /> },
++    ]}
++    optionsPerRow={2}
++    />
+```
+
+The `FinalFormToggleButtonGroup` component is still available, but moved from `@comet/cms-admin` to `@comet/admin` package. Furthermore, the value `icon` in the `options` prop has been renamed to `label`.
+
+```diff
+- <Field
+-   name="formValue"
+-   label={"Field Label"}
+-   component={FinalFormToggleButtonGroup}
+-   options={[
+-       { value: "value1", icon: <Info /> },
++       { value: "value1", label: <Info /> },
+-       { value: "value2", icon: <Info /> },
++       { value: "value2", label: <Info /> },
+-   ]}
+-   optionsPerRow={2}
+- />
+```
+
+### DashboardWidgetRoot no longer handles Grid layout
+
+:::note Handled by following upgrade script
+
+```sh
+npx @comet/upgrade v8/add-grid-to-latest-content-updates.ts
+```
+
+:::
+
+The `DashboardWidgetRoot` / `LatestContentUpdates` component no longer wraps its children in a `<Grid>` component. This means that layout and sizing must now be handled by the parent component.
+
+**Migration steps `DashboardWidgetRoot:**
+
+- **Before:**  
+  `DashboardWidgetRoot` automatically wrapped its content in a grid item, e.g.
+
+    ```tsx
+    <DashboardWidgetRoot>{/* widget content */}</DashboardWidgetRoot>
+    ```
+
+- **After:**  
+  You must now wrap `DashboardWidgetRoot` in a `<Grid item>` yourself:
+    ```tsx
+    <Grid size={{ xs: 12, lg: 6 }}>
+        <DashboardWidgetRoot>{/* widget content */}</DashboardWidgetRoot>
+    </Grid>
+    ```
+
+**Migration steps `LatestContentUpdates`:**
+
+- **Before:**
+
+    ```tsx
+    <LatestContentUpdates />
+    ```
+
+- **After:**
+    ```tsx
+    <Grid size={{ xs: 12, lg: 6 }}>
+        <LatestContentUpdates />
+    </Grid>
+    ```
+
+**Action required:**  
+Review all usages of `DashboardWidgetRoot` / `LatestContentUpdates` in your dashboards and ensure they are wrapped in a `<Grid>` (or another layout component as appropriate). This gives you full control over widget placement and sizing.

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -1809,6 +1809,54 @@ scalars: rootBlocks.reduce(
 )
 ```
 
+### `DashboardWidgetRoot` / `LatestContentUpdates` no longer handles Grid layout
+
+:::note Handled by following upgrade script
+
+```sh
+
+npx @comet/upgrade v8/add-grid-to-latest-content-updates-and-dashboard-widget-root.ts
+```
+
+:::
+
+The `DashboardWidgetRoot` / `LatestContentUpdates` component no longer wraps its children in a `<Grid>` component. This means that layout and sizing must now be handled by the parent component.
+
+**Migration steps `DashboardWidgetRoot:**
+
+- **Before:**  
+  `DashboardWidgetRoot` automatically wrapped its content in a grid item, e.g.
+
+    ```tsx
+    <DashboardWidgetRoot>{/* widget content */}</DashboardWidgetRoot>
+    ```
+
+- **After:**  
+  You must now wrap `DashboardWidgetRoot` in a `<Grid item>` yourself:
+    ```tsx
+    <Grid size={{ xs: 12, lg: 6 }}>
+        <DashboardWidgetRoot>{/* widget content */}</DashboardWidgetRoot>
+    </Grid>
+    ```
+
+**Migration steps `LatestContentUpdates`:**
+
+- **Before:**
+
+    ```tsx
+    <LatestContentUpdates />
+    ```
+
+- **After:**
+    ```tsx
+    <Grid size={{ xs: 12, lg: 6 }}>
+        <LatestContentUpdates />
+    </Grid>
+    ```
+
+**Action required:**  
+Review all usages of `DashboardWidgetRoot` / `LatestContentUpdates` in your dashboards and ensure they are wrapped in a `<Grid>` (or another layout component as appropriate). This gives you full control over widget placement and sizing.
+
 ## Site
 
 ### Switch from `@comet/cms-site` to `@comet/site-nextjs`
@@ -2052,51 +2100,3 @@ This rule ensures that TypeScript type-only imports are explicitly marked with i
   Using import type ensures that types do not introduce unintended runtime dependencies.
 
 </details>
-
-### `DashboardWidgetRoot` / `LatestContentUpdates` no longer handles Grid layout
-
-:::note Handled by following upgrade script
-
-```sh
-
-npx @comet/upgrade v8/add-grid-to-latest-content-updates-and-dashboard-widget-root.ts
-```
-
-:::
-
-The `DashboardWidgetRoot` / `LatestContentUpdates` component no longer wraps its children in a `<Grid>` component. This means that layout and sizing must now be handled by the parent component.
-
-**Migration steps `DashboardWidgetRoot:**
-
-- **Before:**  
-  `DashboardWidgetRoot` automatically wrapped its content in a grid item, e.g.
-
-    ```tsx
-    <DashboardWidgetRoot>{/* widget content */}</DashboardWidgetRoot>
-    ```
-
-- **After:**  
-  You must now wrap `DashboardWidgetRoot` in a `<Grid item>` yourself:
-    ```tsx
-    <Grid size={{ xs: 12, lg: 6 }}>
-        <DashboardWidgetRoot>{/* widget content */}</DashboardWidgetRoot>
-    </Grid>
-    ```
-
-**Migration steps `LatestContentUpdates`:**
-
-- **Before:**
-
-    ```tsx
-    <LatestContentUpdates />
-    ```
-
-- **After:**
-    ```tsx
-    <Grid size={{ xs: 12, lg: 6 }}>
-        <LatestContentUpdates />
-    </Grid>
-    ```
-
-**Action required:**  
-Review all usages of `DashboardWidgetRoot` / `LatestContentUpdates` in your dashboards and ensure they are wrapped in a `<Grid>` (or another layout component as appropriate). This gives you full control over widget placement and sizing.

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -2053,55 +2053,6 @@ This rule ensures that TypeScript type-only imports are explicitly marked with i
 
 </details>
 
-### `FinalFormToggleButtonGroup` deprecated
-
-`FinalFormToggleButtonGroup` has been deprecated and a new component `ToggleButtonGroupField` got introduced that has the Final Form Field wrapped around it.
-
-```diff
-- import { FinalFormToggleButtonGroup } from "@comet/cms-admin";
-+ import { ToggleGroupButtonField } from "@comet/admin";
-
-...
-+ FormValueType = "value1" | "value2";
-
-- <Field
--   name="formValue"
--   label={"Field Label"}
--   component={FinalFormToggleButtonGroup}
--   options={[
--       { value: "value1", icon: <Info /> },
--       { value: "value2", icon: <Error /> },
--   ]}
--   optionsPerRow={2}
-- />
-+ <ToggleGroupButtonField<FormValueType>
-+    name="formValue"
-+    label={"Field Label"}
-+    options={[
-+        { value: "value1", label: <Info /> },
-+        { value: "value2", label: <Error /> },
-+    ]}
-+    optionsPerRow={2}
-+    />
-```
-
-The `FinalFormToggleButtonGroup` component is still available, but moved from `@comet/cms-admin` to `@comet/admin` package. Furthermore, the value `icon` in the `options` prop has been renamed to `label`.
-
-```diff
-- <Field
--   name="formValue"
--   label={"Field Label"}
--   component={FinalFormToggleButtonGroup}
--   options={[
--       { value: "value1", icon: <Info /> },
-+       { value: "value1", label: <Info /> },
--       { value: "value2", icon: <Info /> },
-+       { value: "value2", label: <Info /> },
--   ]}
--   optionsPerRow={2}
-- />
-```
-
 ### `DashboardWidgetRoot` / `LatestContentUpdates` no longer handles Grid layout
 
 :::note Handled by following upgrade script

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -2107,7 +2107,8 @@ The `FinalFormToggleButtonGroup` component is still available, but moved from `@
 :::note Handled by following upgrade script
 
 ```sh
-npx @comet/upgrade v8/add-grid-to-latest-content-updates.ts
+
+npx @comet/upgrade v8/add-grid-to-latest-content-updates-and-dashboard-widget-root.ts
 ```
 
 :::

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -2102,7 +2102,7 @@ The `FinalFormToggleButtonGroup` component is still available, but moved from `@
 - />
 ```
 
-### DashboardWidgetRoot no longer handles Grid layout
+### `DashboardWidgetRoot` / `LatestContentUpdates` no longer handles Grid layout
 
 :::note Handled by following upgrade script
 

--- a/packages/admin/cms-admin/src/dashboard/widgets/DashboardWidgetRoot.tsx
+++ b/packages/admin/cms-admin/src/dashboard/widgets/DashboardWidgetRoot.tsx
@@ -1,4 +1,4 @@
-import { Grid, Paper, Typography } from "@mui/material";
+import { Paper, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { type PropsWithChildren, type ReactNode } from "react";
 
@@ -9,20 +9,13 @@ export type DashboardWidgetRootProps = PropsWithChildren<{
 
 export const DashboardWidgetRoot = ({ header, icon, children }: DashboardWidgetRootProps) => {
     return (
-        <Grid
-            size={{
-                xs: 12,
-                lg: 6,
-            }}
-        >
-            <Paper square={false} sx={{ borderRadius: 2 }}>
-                <HeaderWrapper>
-                    {icon}
-                    <Typography variant="h5">{header}</Typography>
-                </HeaderWrapper>
-                {children}
-            </Paper>
-        </Grid>
+        <Paper square={false} sx={{ borderRadius: 2 }}>
+            <HeaderWrapper>
+                {icon}
+                <Typography variant="h5">{header}</Typography>
+            </HeaderWrapper>
+            {children}
+        </Paper>
     );
 };
 

--- a/storybook/src/cms-admin/dashboard/widgets/DashboardWidgetRoot.stories.tsx
+++ b/storybook/src/cms-admin/dashboard/widgets/DashboardWidgetRoot.stories.tsx
@@ -1,0 +1,70 @@
+import { InfoFilled } from "@comet/admin-icons";
+import { DashboardWidgetRoot } from "@comet/cms-admin";
+import { Grid } from "@mui/material";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof DashboardWidgetRoot>;
+
+const config: Meta<typeof DashboardWidgetRoot> = {
+    component: DashboardWidgetRoot,
+    title: "@comet/cms-admin/dashboard/widgets/DashboardWidgetRoot",
+};
+
+export default config;
+export const Default: Story = {
+    args: {
+        header: "Widget Header",
+        children: <div style={{ padding: "20px" }}>Some content goes here</div>,
+    },
+};
+
+export const WithIcon: Story = {
+    args: {
+        header: "Widget Header",
+        icon: <InfoFilled />,
+        children: <div style={{ padding: "20px" }}>Some content goes here</div>,
+    },
+};
+
+export const WidgetInGrid: Story = {
+    args: {
+        header: "Widget Header",
+        children: <div style={{ padding: "20px" }}>Some content goes here</div>,
+    },
+    render: (args, context) => {
+        return (
+            <Grid
+                container
+                spacing={4}
+                columns={{
+                    xs: 1,
+                    sm: 6,
+                    lg: 12,
+                }}
+            >
+                <Grid size={12}>
+                    <DashboardWidgetRoot {...args} />
+                </Grid>
+                <Grid size={6}>
+                    <DashboardWidgetRoot {...args} />
+                </Grid>
+                <Grid size={6}>
+                    <DashboardWidgetRoot {...args} />
+                </Grid>
+
+                <Grid size={3}>
+                    <DashboardWidgetRoot {...args} />
+                </Grid>
+                <Grid size={3}>
+                    <DashboardWidgetRoot {...args} />
+                </Grid>
+                <Grid size={3}>
+                    <DashboardWidgetRoot {...args} />
+                </Grid>
+                <Grid size={3}>
+                    <DashboardWidgetRoot {...args} />
+                </Grid>
+            </Grid>
+        );
+    },
+};


### PR DESCRIPTION
## Description

• Removed the internal `Grid` wrapper from the `DashboardWidgetRoot` component.

### Why this change?

The `DashboardWidgetRoot` should not be concerned with layout or positioning (like Grid). That responsibility belongs to the parent component that arranges widgets in the dashboard. By removing the layout logic, the component becomes more focused, reusable, and flexible in different contexts.

With this change, its possible to have different sized widget's on the Dashboard, or somewher else. Parent Components can control this:

<img width="2258" alt="Screenshot 2025-06-23 at 11 26 55" src="https://github.com/user-attachments/assets/b1601177-1463-4eeb-9bd3-2b916ce145aa" />


---- 

Codemod available: https://github.com/vivid-planet/comet-upgrade/pull/94

---

https://vivid-planet.atlassian.net/browse/COM-2108