### PR TITLE
Add captions to `useDamAcceptedMimeTypes#filteredAcceptedMimeTypes`

### DIFF
--- a/packages/admin/cms-admin/src/dam/config/useDamAcceptedMimeTypes.tsx
+++ b/packages/admin/cms-admin/src/dam/config/useDamAcceptedMimeTypes.tsx
@@ -30,6 +30,7 @@ interface UseDamAcceptedMimeTypesApi {
         video: string[];
         document: string[];
         pdf: string[];
+        captions: string[];
     };
 }
 
@@ -40,12 +41,13 @@ export const useDamAcceptedMimeTypes = (): UseDamAcceptedMimeTypesApi => {
     return {
         allAcceptedMimeTypes,
         filteredAcceptedMimeTypes: {
-            svgImage: ["image/svg+xml"],
+            svgImage: allAcceptedMimeTypes.filter((mimetype) => mimetype === "image/svg+xml"),
             pixelImage: allAcceptedMimeTypes.filter(isPixelImage),
             audio: allAcceptedMimeTypes.filter(isAudio),
             video: allAcceptedMimeTypes.filter(isVideo),
             document: allAcceptedMimeTypes.filter(isDocument),
-            pdf: ["application/pdf"],
+            pdf: allAcceptedMimeTypes.filter((mimetype) => mimetype === "application/pdf"),
+            captions: allAcceptedMimeTypes.filter((mimetype) => mimetype === "text/vtt"),
         },
     };
 };


### PR DESCRIPTION
## Description

We might support more file types for captions in the future, so I want to add this filter at a central point.

Also I changed svgImage and pdf to filter `allAcceptedMimeTypes` (instead of hardcoding the mimetype) because theoretically they could be removed from `allAcceptedMimeTypes`

