### PR TITLE
Adjust styling of `DialogTitle`

### DIFF
--- a/.changeset/twenty-aliens-invent.md
+++ b/.changeset/twenty-aliens-invent.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": patch
+---
+
+Fix styling of `DialogTitle`
+
+- The title text and the close button are now aligned correctly on mobile
+- Long titles are no longer overlapped by the close button

--- a/packages/admin/admin/src/common/Dialog.tsx
+++ b/packages/admin/admin/src/common/Dialog.tsx
@@ -72,14 +72,10 @@ const DialogTitle = createComponentSlot(MuiDialogTitle)<DialogClassKey, OwnerSta
     componentName: "Dialog",
     slotName: "dialogTitle",
 })(
-    ({ ownerState }) => css`
-        min-height: 20px;
-        display: flex;
-        align-items: center;
-
+    ({ ownerState, theme }) => css`
         ${ownerState.hasCloseButton &&
         css`
-            padding-right: 40px;
+            padding-right: ${theme.spacing(10)};
         `}
     `,
 );
@@ -91,8 +87,12 @@ const CloseButton = createComponentSlot(IconButton)<DialogClassKey>({
     ({ theme }) => css`
         position: absolute;
         right: 12px;
-        top: 14px;
+        top: 9px;
         color: ${theme.palette.secondary.contrastText};
+
+        ${theme.breakpoints.up("sm")} {
+            top: 14px;
+        }
     `,
 );
 

--- a/packages/admin/admin/src/theme/componentsTheme/MuiDialogTitle.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiDialogTitle.ts
@@ -8,16 +8,19 @@ export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (compon
     },
     styleOverrides: mergeOverrideStyles<"MuiDialogTitle">(component?.styleOverrides, {
         root: {
+            display: "flex",
+            alignItems: "center",
             backgroundColor: palette.grey["A200"],
             color: "#ffffff",
-            padding: spacing(2),
+            padding: spacing(2, 4),
             fontSize: "14px",
-            boxSizing: "unset",
+            boxSizing: "border-box",
+            minHeight: 50,
 
             [breakpoints.up("sm")]: {
                 minWidth: 0,
                 fontSize: "16px",
-                padding: spacing(4),
+                minHeight: 60,
             },
         },
     }),

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -37,7 +37,6 @@ const StyledDialogTitle = styled(DialogTitle)`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    width: 100%;
 `;
 
 const CloseButton = styled(IconButton)`

--- a/storybook/src/admin/mui/Dialog.stories.tsx
+++ b/storybook/src/admin/mui/Dialog.stories.tsx
@@ -43,6 +43,8 @@ export default {
             control: "select",
             options: {
                 "Dialog Title Example": "Dialog Title Example",
+                "Really long dialog title":
+                    "Really long dialog title that is really long and takes up a lot of space because of all the words that are used in this title of the dialog you are seeing here in the storybook example inside comet that is used to test the dialog title",
                 None: "",
             },
         },


### PR DESCRIPTION
## Description

The mobile styling now matches the design and the following bugs are fixed:

- The title text and the close button are now aligned correctly on mobile
- Long titles are no longer overlapped by the close button

Additionally, `box-sizing: border-box` prevents overflow issues in dialogs with custom/fixed widths, such as the `ChooseFileDialog` where horizontal scrolling would hide the close button.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="370" alt="Mobile Previously" src="https://github.com/user-attachments/assets/d60fdeba-4e23-4f83-a154-0f9c667048cb" />   | <img width="370" alt="Mobile Now" src="https://github.com/user-attachments/assets/2d138972-a56b-47b5-b7b6-d06c14cc5170" />  |
| <img width="670" alt="Desktop Previously" src="https://github.com/user-attachments/assets/ff7e0548-d425-415c-8683-5feee2a457df" />   | <img width="670" alt="Desktop Now" src="https://github.com/user-attachments/assets/3fd5b9ff-d050-4c80-981a-a96c5e73108f" />  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2003
