### PR TITLE
Fix bug where file replacement deletes the file

### DIFF
--- a/.changeset/calm-ads-behave.md
+++ b/.changeset/calm-ads-behave.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Don't replace a file if the new file is identical to the existing one in the DAM
+
+This previously led to a bug where a file was deleted if it was replaced with the same file.


### PR DESCRIPTION
## Description

Don't replace a file if the new file is identical to the existing one in the DAM

This previously led to a bug where a file was deleted if it was replaced with the same file.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Before:

https://github.com/user-attachments/assets/e142ef54-95ce-4afa-8abc-7eedff1289d0


Now:


https://github.com/user-attachments/assets/8836cfab-dff5-4f1c-903b-63a9a52cfd49


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2105
