### PR TITLE
Revert "Fix arrow icon in Data Grid page size select"

### DIFF
--- a/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
@@ -21,7 +21,6 @@ import { FormattedMessage, FormattedNumber } from "react-intl";
 
 import { DataGridPanel } from "../../dataGrid/DataGridPanel";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
-import { commonSelectDefaultProps } from "./getCommonSelectTheme";
 import { type GetMuiComponentTheme } from "./getComponentsTheme";
 
 const getDensityHeightValue = (density: string) => {
@@ -76,13 +75,6 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
             baseButton: {
                 color: "info",
                 ...component?.defaultProps?.slotProps?.baseButton,
-            },
-            pagination: {
-                slotProps: {
-                    select: {
-                        ...commonSelectDefaultProps,
-                    },
-                },
             },
         },
         localeText: {


### PR DESCRIPTION
## Description
 
Reverts https://github.com/vivid-planet/comet/pull/3968. This breaks multiple Data Grids in Demo with the error `TypeError: Cannot read properties of undefined (reading 'slotProps')`.