### PR TITLE
Demo: fix products fixtures

### DIFF
--- a/demo/api/src/db/fixtures/generators/products-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/products-fixture.service.ts
@@ -72,7 +72,10 @@ export class ProductsFixtureService {
                 inStock: faker.datatype.boolean(),
                 soldCount: faker.number.int({ min: 0, max: 100 }),
                 availableSince: faker.date.past(),
-                image: DamImageBlock.blockInputFactory({ attachedBlocks: [] }).transformToBlockData(),
+                image: DamImageBlock.blockInputFactory({
+                    attachedBlocks: [{ type: "pixelImage", props: {} }],
+                    activeType: "pixelImage",
+                }).transformToBlockData(),
                 manufacturer: faker.helpers.arrayElement(manufacturers),
             });
 


### PR DESCRIPTION
## Description

The `DamImageBlock` requires an `activeType` to be set. This caused an error when editing products created by the fixtures. Adding the `activeType` to the fixtures resolves the issue.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2109