### PR TITLE
Ignore UUID columns in `searchToMikroOrmQuery` when inferring from entity metadata

### DIFF
--- a/.changeset/tidy-plants-juggle.md
+++ b/.changeset/tidy-plants-juggle.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Ignore UUID columns in `searchToMikroOrmQuery` when inferring fields from entity metadata

--- a/packages/api/cms-api/src/generator/utils/search-fields-from-metadata.ts
+++ b/packages/api/cms-api/src/generator/utils/search-fields-from-metadata.ts
@@ -8,7 +8,7 @@ export function getCrudSearchFieldsFromMetadata(metadata: EntityMetadata<any>) {
         .filter((prop) => prop.name != "status")
         .filter((prop) => hasFieldFeature(metadata.class, prop.name, "search") && !prop.name.startsWith("scope_"))
         .reduce((acc, prop) => {
-            if (prop.type === "string" || prop.type === "text") {
+            if ((prop.type === "string" || prop.type === "text") && !prop.columnTypes.includes("uuid")) {
                 acc.push(prop.name);
             } else if (prop.reference == "m:1") {
                 if (!prop.targetMeta) {
@@ -18,7 +18,7 @@ export function getCrudSearchFieldsFromMetadata(metadata: EntityMetadata<any>) {
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     .filter((innerProp) => hasFieldFeature(prop.targetMeta!.class, innerProp.name, "search") && !innerProp.name.startsWith("scope_"))
                     .forEach((innerProp) => {
-                        if (innerProp.type === "string" || innerProp.type === "text") {
+                        if ((innerProp.type === "string" || innerProp.type === "text") && !innerProp.columnTypes.includes("uuid")) {
                             acc.push(`${prop.name}.${innerProp.name}`);
                         }
                     });


### PR DESCRIPTION
## Description

Currently, searching in the products grid fails with the following error:

```
select count(*) as "count" from "Product" as "p0" left join "ProductCategory" as "p1" on "p0"."category" = "p1"."id" left join "Manufacturer" as "m2" on "p0"."manufacturer" = "m2"."id" left join "CometFileUpload" as "f3" on "p0"."priceList" = "f3"."id" where ("p0"."title" ilike '%test%' or "p0"."slug" ilike '%test%' or "p0"."description" ilike '%test%' or "p0"."type" ilike '%test%' or "p1"."title" ilike '%test%' or "p1"."slug" ilike '%test%' or "m2"."name" ilike '%test%' or "m2"."addressAsEmbeddable_street" ilike '%test%' or "m2"."addressAsEmbeddable_country" ilike '%test%' or "m2"."addressAsEmbeddable_alternativeAddress_street" ilike '%test%' or "m2"."addressAsEmbeddable_alternativeAddress_country" ilike '%test%' or "p0"."priceList" ilike '%test%' or "f3"."name" ilike '%test%' or "f3"."mimetype" ilike '%test%' or "f3"."contentHash" ilike '%test%') and "p0"."status" in ('Published', 'Unpublished') - operator does not exist: uuid ~~* unknown
```

This is caused by using `columnType` instead of `type` for the `id` column in [FileUpload](https://github.com/vivid-planet/comet/blob/main/packages/api/cms-api/src/file-uploads/entities/file-upload.entity.ts#L11), which is considered by `getCrudSearchFieldsFromMetadata` due to the `priceList` relation in the product entity.

I could have fixed this by using `type` instead of `columnType` in FileUpload. However, since this bug repeatedly occurs in our projects using the API Generator (aka "API Generator pitfalls"), I decided to ignore `columnType: "uuid"` in `getCrudSearchFieldsFromMetadata` instead.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2109
