### PR TITLE
Admin Generator: fix clearing optional text fields

### DIFF
--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -133,6 +133,7 @@ export function ProductForm({ id, width }: FormProps) {
 
         const output = {
             ...formValues,
+            description: formValues.description ?? null,
             image: rootBlocks.image.state2Output(formValues.image),
             type: formValues.type as GQLProductType,
             category: formValues.category ? formValues.category.id : null,
@@ -199,12 +200,7 @@ export function ProductForm({ id, width }: FormProps) {
                         startAdornment={<InputAdornment position="start">€</InputAdornment>}
                         disableSlider
                     />
-                    <TextAreaField
-                        required
-                        fullWidth
-                        name="description"
-                        label={<FormattedMessage id="product.description" defaultMessage="Description" />}
-                    />
+                    <TextAreaField fullWidth name="description" label={<FormattedMessage id="product.description" defaultMessage="Description" />} />
                     <DateField
                         required
                         fullWidth

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -439,7 +439,7 @@ type Product {
   title: String!
   status: ProductStatus!
   slug: String!
-  description: String!
+  description: String
   type: ProductType!
   additionalTypes: [ProductType!]!
   price: Float
@@ -1553,7 +1553,7 @@ input ProductInput {
   title: String!
   status: ProductStatus! = Unpublished
   slug: String!
-  description: String!
+  description: String = null
   type: ProductType!
   additionalTypes: [ProductType!]! = []
   price: Float = null

--- a/demo/api/src/db/migrations/Migration20250625140332.ts
+++ b/demo/api/src/db/migrations/Migration20250625140332.ts
@@ -1,0 +1,7 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20250625140332 extends Migration {
+    override async up(): Promise<void> {
+        this.addSql(`alter table "Product" alter column "description" drop not null;`);
+    }
+}

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -104,9 +104,9 @@ export class Product extends BaseEntity {
     @Field()
     slug: string;
 
-    @Property()
-    @Field()
-    description: string;
+    @Property({ nullable: true })
+    @Field({ nullable: true })
+    description?: string;
 
     @Enum({ items: () => ProductType })
     @Field(() => ProductType)

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -192,6 +192,9 @@ export function generateFormField({
             }
             ${validateCode}
         />`;
+        if (!config.virtual && !required && !config.readOnly) {
+            formValueToGqlInputCode = `${name}: formValues.${name} ?? null,`;
+        }
     } else if (config.type == "number") {
         code = `
             <NumberField


### PR DESCRIPTION
## Description

Final Form's behavior where an empty text field becomes `undefined` doesn't work correctly with our update API, where `undefined` translates to "don't change it". We therefore submit `null` instead of `undefined`, which sets the column to null.

## Screencast

![demo-clear-optional-text-fields](https://github.com/user-attachments/assets/f47c9fef-dfa6-43fd-8adc-11f066c5948b)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2109
