### PR TITLE
Demo API: Increase max-old-space-size

### DIFF
--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -11,7 +11,7 @@
         "console:prod": "node dist/console.js",
         "db:migrate": "$npm_execpath console migrate --",
         "db:migrate:prod": "$npm_execpath console:prod migrate --",
-        "dev:nest": "$npm_execpath prebuild && $npm_execpath db:migrate && $npm_execpath console createBlockIndexViews && NODE_OPTIONS='--max-old-space-size=512' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",
+        "dev:nest": "$npm_execpath prebuild && $npm_execpath db:migrate && $npm_execpath console createBlockIndexViews && NODE_OPTIONS='--max-old-space-size=1024' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",
         "dev:reload": "rimraf src/reload.ts && chokidar \"node_modules/@comet/cms-api/lib/**\" -s -c \"echo '// change' >> src/reload.ts\"",
         "fixtures": "$npm_execpath console fixtures --",
         "fixtures:prod": "$npm_execpath console:prod fixtures --",


### PR DESCRIPTION
## Description

I've repeatedly faced OOM kills while trying to fix Demo today. I suspect the multiple watchers and restarts (API, API Generator, packages) to be responsible for this. I suggest to increase the memory for the Demo API since it's different to a "normal" Comet application. If we're not okay with this, I will investigate more...