### PR TITLE
Fix Select for object options

### DIFF
--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -118,12 +118,12 @@ export const FinalFormSelect = <T,>({
                         : options.find((i) => getOptionValue(i) == value),
                 );
             }}
-            value={value}
+            value={Array.isArray(value) ? value.map((i) => getOptionValue(i)) : getOptionValue(value)}
             renderValue={() => {
                 if (Array.isArray(value)) {
-                    return value.map((i) => getOptionValue(i));
+                    return value.map((i) => getOptionLabel(i));
                 } else {
-                    return getOptionValue(value);
+                    return getOptionLabel(value);
                 }
             }}
         >


### PR DESCRIPTION
## Description

The changes made in https://github.com/vivid-planet/comet/pull/3861 removed support for object options (e.g., `{ id: string, label: string }`). This PR reverts the change to `value` which causes the problem. Additionally, `renderValue` now uses `getOptionLabel()` to render the label instead of the value.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2109
