### PR TITLE
Add support for `doesNotContain` to `StringFilter`

### DIFF
--- a/.changeset/warm-dragons-drive.md
+++ b/.changeset/warm-dragons-drive.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Add support for `doesNotContain` to `StringFilter`

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -896,6 +896,7 @@ input UserPermissionsUserFilter {
 
 input StringFilter {
   contains: String
+  doesNotContain: String
   startsWith: String
   endsWith: String
   equal: String

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -470,6 +470,7 @@ input RedirectFilter {
 
 input StringFilter {
   contains: String
+  doesNotContain: String
   startsWith: String
   endsWith: String
   equal: String

--- a/packages/api/cms-api/src/common/filter/mikro-orm.ts
+++ b/packages/api/cms-api/src/common/filter/mikro-orm.ts
@@ -40,6 +40,9 @@ export function filterToMikroOrmQuery(
         if (filterProperty.contains !== undefined) {
             ilike.push(`%${quoteLike(filterProperty.contains)}%`);
         }
+        if (filterProperty.doesNotContain !== undefined) {
+            ret.$not = { $ilike: `%${quoteLike(filterProperty.doesNotContain)}%` };
+        }
         if (filterProperty.startsWith !== undefined) {
             ilike.push(`${quoteLike(filterProperty.startsWith)}%`);
         }
@@ -234,6 +237,14 @@ export function filtersToMikroOrmQuery(
                         const query = filterToMikroOrmQuery(filterProperty, filterPropertyName, metadata);
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         if (Object.keys(query as any).length > 0) {
+                            // $not can't be applied like { field: { $not: { ... } } }.
+                            // It has to be applied like { $not: { field: { ... } } }.
+                            if (query.$not) {
+                                acc.$not ??= {};
+                                acc.$not[filterPropertyName] = query.$not;
+                                delete query.$not;
+                            }
+
                             acc[filterPropertyName] = query;
                         }
                     }

--- a/packages/api/cms-api/src/common/filter/string.filter.ts
+++ b/packages/api/cms-api/src/common/filter/string.filter.ts
@@ -11,6 +11,11 @@ export class StringFilter {
     @Field({ nullable: true })
     @IsOptional()
     @IsString()
+    doesNotContain?: string;
+
+    @Field({ nullable: true })
+    @IsOptional()
+    @IsString()
     startsWith?: string;
 
     @Field({ nullable: true })

--- a/packages/api/cms-api/src/redirects/redirects.util.test.ts
+++ b/packages/api/cms-api/src/redirects/redirects.util.test.ts
@@ -30,6 +30,9 @@ describe("redirectMatchesFilter", () => {
         expect(redirectMatchesFilter(redirect, { source: { contains: "our" } })).toBe(true);
         expect(redirectMatchesFilter(redirect, { source: { contains: "arg" } })).toBe(false);
 
+        expect(redirectMatchesFilter(redirect, { source: { doesNotContain: "our" } })).toBe(false);
+        expect(redirectMatchesFilter(redirect, { source: { doesNotContain: "arg" } })).toBe(true);
+
         expect(redirectMatchesFilter(redirect, { source: { startsWith: "/sou" } })).toBe(true);
         expect(redirectMatchesFilter(redirect, { source: { startsWith: "/arg" } })).toBe(false);
 

--- a/packages/api/cms-api/src/redirects/redirects.util.ts
+++ b/packages/api/cms-api/src/redirects/redirects.util.ts
@@ -72,6 +72,8 @@ export function redirectMatchesFilter(redirect: FilterableRedirect, filter: Redi
 function stringMatchesFilter(string: string, filter: StringFilter) {
     if (filter.contains && string.includes(filter.contains)) {
         return true;
+    } else if (filter.doesNotContain && !string.includes(filter.doesNotContain)) {
+        return true;
     } else if (filter.startsWith && string.startsWith(filter.startsWith)) {
         return true;
     } else if (filter.endsWith && string.endsWith(filter.endsWith)) {


### PR DESCRIPTION
## Description

MUI added support for a "does not contain" filter somewhere between MUI X v5 - v7. This change adds support for `doesNotContain` to `StringFilter`

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## TODOs

- [ ] Naming

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2124
