### PR TITLE
Data Grid: fix "does not equal" string filter

### DIFF
--- a/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
+++ b/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
@@ -5,6 +5,7 @@ import { type GridColDef } from "./GridColDef";
 const muiGridOperatorValueToGqlOperator: { [key: string]: string } = {
     contains: "contains",
     equals: "equal",
+    doesNotEqual: "notEqual",
     ">": "greaterThan",
     ">=": "greaterThanEqual",
     "<": "lowerThan",


### PR DESCRIPTION
## Description

Add missing grid operator to GraphQL operator mapping for `doesNotEqual`.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2124
