### PR TITLE
Support dot separated filenames like MyBlock.loader.gql.ts in no-private-sibling-import rule

### DIFF
--- a/packages/eslint-plugin/src/rules/no-private-sibling-import.test.ts
+++ b/packages/eslint-plugin/src/rules/no-private-sibling-import.test.ts
@@ -19,3 +19,8 @@ ruleTester.run("no-private-sibling-import", noPrivateSiblingImport, {
     valid: [{ code: `import FooGql from "./Foo.gql.generated";`, filename: "/path/to/Foo.ts", options }],
     invalid: [{ code: `import BarGql from "./Bar.gql.generated";`, filename: "/path/to/Foo.ts", options, errors }],
 });
+
+ruleTester.run("no-private-sibling-import", noPrivateSiblingImport, {
+    valid: [{ code: `import FooGql from "./FooBlock.loader.gql.generated";`, filename: "/path/to/FooBlock.loader.ts", options }],
+    invalid: [{ code: `import BarGql from "./BarBlock.loader.gql.generated";`, filename: "/path/to/FooBlock.loader.ts", options, errors }],
+});

--- a/packages/eslint-plugin/src/rules/no-private-sibling-import.ts
+++ b/packages/eslint-plugin/src/rules/no-private-sibling-import.ts
@@ -18,7 +18,7 @@ export default {
         return {
             ImportDeclaration: function (node) {
                 const optionSiblingExtensions = context.options[0] ?? ["gql", "sc"];
-                const filePath = context.getPhysicalFilename ? context.getPhysicalFilename() : context.getFilename();
+                const filePath = context.getPhysicalFilename() ? context.getPhysicalFilename() : context.getFilename();
                 if (filePath == "<text>") return; // If the input is from stdin, this test can't fail
                 const isPrivateFileMatch = String(node.source.value).match(new RegExp(`^(.*)\\.(${optionSiblingExtensions.join("|")})$`));
                 if (isPrivateFileMatch) {
@@ -28,7 +28,10 @@ export default {
                             message: "Import private siblings always with relative imports",
                         });
                     } else {
-                        if (isPrivateFileMatch[1] != `./${path.basename(filePath).replace(/\.(.*)$/, "")}`) {
+                        const pattern = `\\.((${[...optionSiblingExtensions, "ts"].join("|")}).*)$`;
+                        const regex = new RegExp(pattern);
+
+                        if (isPrivateFileMatch[1] != `./${path.basename(filePath).replace(regex, "")}`) {
                             context.report({
                                 node,
                                 message: "Avoid private sibling import from other files",


### PR DESCRIPTION
## Description

Previously you weren't allowed to import from `./MyBlock.loader.gql.ts` in `MyBlock.loader.ts`

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
