### PR TITLE
Demo: disable filtering for "Overview" column in products grid

### DIFF
--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -152,6 +152,7 @@ export function ProductsGrid() {
                 return <GridCellContent primaryText={row.title} secondaryText={secondaryValues.filter(Boolean).join(" • ")} />;
             },
             disableExport: true,
+            filterable: false,
         },
         {
             field: "title",


### PR DESCRIPTION
## Description

The overview column is a virtual column and doesn't directly map to a database column. I decided to disable filtering in the handmade grid since it's also disabled in the generated grid.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2124
