### PR TITLE
Fix overridden styles in MainNavigation

### DIFF
--- a/packages/admin/admin/src/mui/mainNavigation/MainNavigation.styles.ts
+++ b/packages/admin/admin/src/mui/mainNavigation/MainNavigation.styles.ts
@@ -36,6 +36,11 @@ const getSharedStyles = (theme: Theme, headerHeight: number) => css`
     .CometAdminMainNavigationItemGroup-root + .CometAdminMainNavigationItem-root {
         margin-top: ${theme.spacing(8)};
     }
+
+    .CometAdminMainNavigationItem-level1 .MuiListItemText-primary {
+        font-weight: 450;
+        font-size: 16px;
+    }
 `;
 
 export const TemporaryDrawer = createComponentSlot(MuiDrawer)<MainNavigationClassKey, OwnerState>({


### PR DESCRIPTION
## Description

The styling for Items in the MainNavigation was overridden by `commonListItemRootStyles`. Those items are an exception  and therefor the styling needs to be overridden. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="302" alt="Screenshot 2025-06-30 at 09 29 20" src="https://github.com/user-attachments/assets/9e326055-43ab-4a2a-a1df-3e25ff7f4dc7" /> | <img width="302" alt="Screenshot 2025-06-30 at 09 27 36" src="https://github.com/user-attachments/assets/cd296a1e-9402-4f2a-ac1f-8e7b696b33c9" />  


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1991
