### PR TITLE
Admin Generator: extend possible static select values

### DIFF
--- a/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
@@ -112,14 +112,14 @@ export default defineConfig<GQLProduct>({
             visible: "up('md')",
             values: [
                 {
-                    value: "true",
+                    value: true,
                     label: {
                         primaryText: "In stock",
                         icon: { name: "StateFilled", color: "success" },
                     },
                 },
                 {
-                    value: "false",
+                    value: false,
                     label: {
                         primaryText: "Out of stock",
                         icon: { name: "StateFilled", color: "error" },

--- a/packages/admin/admin-generator/src/commands/generate/generate-command.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generate-command.ts
@@ -135,13 +135,16 @@ export type StaticSelectLabelCellContent = {
     icon?: Icon;
 };
 
+type StaticSelectValue = string | number | boolean;
+type StaticSelectValueObject = { value: StaticSelectValue; label: string | StaticSelectLabelCellContent };
+
 export type GridColumnConfig<T extends GridValidRowModel> = (
     | { type: "text"; renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element }
     | { type: "number"; currency?: string; decimals?: number; renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element }
     | { type: "boolean"; renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element }
     | { type: "date"; renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element }
     | { type: "dateTime"; renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element }
-    | { type: "staticSelect"; values?: Array<{ value: string; label: string | StaticSelectLabelCellContent } | string> }
+    | { type: "staticSelect"; values?: Array<StaticSelectValue | StaticSelectValueObject> }
     | { type: "block"; block: BlockInterface }
 ) & { name: UsableFields<T>; filterOperators?: GridFilterOperator[] } & BaseColumnConfig;
 

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
@@ -482,10 +482,10 @@ export function generateGrid(
             }
 
             const values = columnValues.map((value) => {
-                if (typeof value === "string") {
+                if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
                     return {
                         value,
-                        label: camelCaseToHumanReadable(value),
+                        label: camelCaseToHumanReadable(value.toString()),
                     };
                 } else {
                     return value;
@@ -494,7 +494,10 @@ export function generateGrid(
 
             const valueOptions = `[${values
                 .map(({ value, label }) => {
-                    const labelData = getValueOptionsLabelData(`${instanceGqlType}.${name}.${value.charAt(0).toLowerCase() + value.slice(1)}`, label);
+                    const labelData = getValueOptionsLabelData(
+                        `${instanceGqlType}.${name}.${value.toString().charAt(0).toLowerCase() + value.toString().slice(1)}`,
+                        label,
+                    );
                     return `{
                         value: ${JSON.stringify(value)},
                         label: ${labelData.textLabel},


### PR DESCRIPTION
## Description

Add support for `boolean` and `number` as static select values. Continues the work started in https://github.com/vivid-planet/comet/pull/3478 (without changing `JSON.stringify(value)`).

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2124
