### PR TITLE
Use boolean column for inStock

### DIFF
--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -23,7 +23,7 @@ import {
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Add as AddIcon, Disabled, Edit, Excel, Online, StateFilled as StateFilledIcon } from "@comet/admin-icons";
+import { Add as AddIcon, Disabled, Edit, Education as EducationIcon, Excel, Online } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { CircularProgress, IconButton, useTheme } from "@mui/material";
 import {
@@ -177,7 +177,27 @@ export function ProductsGrid() {
             width: 100,
             type: "singleSelect",
             visible: theme.breakpoints.up("md"),
-            valueOptions: ["Cap", "Shirt", "Tie"],
+            valueOptions: [
+                {
+                    value: "Cap",
+                    label: intl.formatMessage({ id: "product.type.cap.primary", defaultMessage: "Great cap" }),
+                    cellContent: (
+                        <GridCellContent
+                            primaryText={<FormattedMessage id="product.type.cap.primary" defaultMessage="Great cap" />}
+                            icon={<EducationIcon color="primary" />}
+                        />
+                    ),
+                },
+                {
+                    value: "Shirt",
+                    label: intl.formatMessage({ id: "product.type.shirt", defaultMessage: "Shirt" }),
+                },
+                {
+                    value: "Tie",
+                    label: intl.formatMessage({ id: "product.type.tie", defaultMessage: "Tie" }),
+                },
+            ],
+            renderCell: renderStaticSelectCell,
         },
         {
             field: "additionalTypes",
@@ -228,30 +248,7 @@ export function ProductsGrid() {
         {
             field: "inStock",
             headerName: intl.formatMessage({ id: "product.inStock", defaultMessage: "In Stock" }),
-            type: "singleSelect",
-            valueOptions: [
-                {
-                    value: true,
-                    label: intl.formatMessage({ id: "product.inStock.true.primary", defaultMessage: "In stock" }),
-                    cellContent: (
-                        <GridCellContent
-                            primaryText={<FormattedMessage id="product.inStock.true.primary" defaultMessage="In stock" />}
-                            icon={<StateFilledIcon color="success" />}
-                        />
-                    ),
-                },
-                {
-                    value: false,
-                    label: intl.formatMessage({ id: "product.inStock.false.primary", defaultMessage: "Out of stock" }),
-                    cellContent: (
-                        <GridCellContent
-                            primaryText={<FormattedMessage id="product.inStock.false.primary" defaultMessage="Out of stock" />}
-                            icon={<StateFilledIcon color="error" />}
-                        />
-                    ),
-                },
-            ],
-            renderCell: renderStaticSelectCell,
+            type: "boolean",
             flex: 1,
             minWidth: 80,
             disableExport: true,

--- a/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
@@ -8,7 +8,11 @@ import { ProductsGridPreviewAction } from "../ProductsGridPreviewAction";
 import { ManufacturerFilterOperators } from "./ManufacturerFilter";
 import { ProductTitle } from "./ProductTitle";
 
-const typeValues = [{ value: "Cap", label: "great Cap" }, "Shirt", "Tie"];
+const typeValues = [
+    { value: "Cap", label: { primaryText: "Great cap", icon: { name: "Education" as const, color: "primary" as const } } },
+    "Shirt",
+    "Tie",
+];
 
 export default defineConfig<GQLProduct>({
     type: "grid",
@@ -103,29 +107,12 @@ export default defineConfig<GQLProduct>({
             visible: "up('md')",
         },
         {
-            // TODO: Implement showing actual label in `valueFormatter` (type "staticSelect")
-            type: "staticSelect",
+            type: "boolean",
             name: "inStock",
             headerName: "In stock",
             flex: 1,
             minWidth: 80,
             visible: "up('md')",
-            values: [
-                {
-                    value: true,
-                    label: {
-                        primaryText: "In stock",
-                        icon: { name: "StateFilled", color: "success" },
-                    },
-                },
-                {
-                    value: false,
-                    label: {
-                        primaryText: "Out of stock",
-                        icon: { name: "StateFilled", color: "error" },
-                    },
-                },
-            ],
         },
         // TODO: Implement showing actual label in `valueFormatter` (type "staticSelect")
         { type: "staticSelect", name: "type", maxWidth: 150, values: typeValues, visible: "up('md')" },


### PR DESCRIPTION
## Description

Noticed this while trying to fix the filters for inStock in https://github.com/vivid-planet/comet/pull/4015. It doesn't make sense to use a singleSelect type for inStock as a separate boolean type exists. I've moved the custom singleSelect options to the type column instead.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2124
