### PR TITLE
Admin Generator: inline filter operators

### DIFF
--- a/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
@@ -1,5 +1,6 @@
 import { GridCellContent } from "@comet/admin";
 import { defineConfig } from "@comet/admin-generator";
+import { GridFilterInputValue } from "@mui/x-data-grid-pro";
 import { type GQLProduct } from "@src/graphql.generated";
 import { type ReactNode } from "react";
 import { FormattedMessage, FormattedNumber } from "react-intl";
@@ -146,6 +147,16 @@ export default defineConfig<GQLProduct>({
             headerName: "Tags",
             queryFields: ["tags.title"],
             renderCell: ({ row }) => <>{row.tags.map((tag) => tag.title).join(", ")}</>,
+            filterOperators: [
+                {
+                    label: "Search",
+                    value: "search",
+                    getApplyFilterFn: () => {
+                        throw new Error("not implemented, we filter server side");
+                    },
+                    InputComponent: GridFilterInputValue,
+                },
+            ],
         },
         {
             type: "actions",


### PR DESCRIPTION
## Description

We use inline filter operators for the tags column in the handmade products grid: https://github.com/vivid-planet/comet/blob/admin-generator-inline-filter-operators/demo/admin/src/products/ProductsGrid.tsx#L216-L225. While trying to implement the same operators in the generator, I faced two errors:

1. The getApplyFilterFn isn't allowed by our parser: `Inline Function is not allowed here and calling the function is not supported: [type=grid].columns.filterOperators.getApplyFilterFn`
2. We use a virtual column for the tags column, which doesn't support filterOperators. When changing to something different, e.g., text, the queryFields option isn't present.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2124
