### PR TITLE
Data Grid: remove filter value conversion

### DIFF
--- a/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
+++ b/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
@@ -47,18 +47,6 @@ type GqlFilter = {
     or?: GqlFilter[] | null;
 };
 
-function convertValueByType(value: any, type?: string) {
-    if (type === "number") {
-        return parseFloat(value);
-    } else if (type === "boolean") {
-        if (value === "true") return true;
-        if (value === "false") return false;
-        return undefined;
-    } else {
-        return value;
-    }
-}
-
 export function muiGridFilterToGql(columns: GridColDef[], filterModel?: GridFilterModel): { filter: GqlFilter; search?: string } {
     if (!filterModel) return { filter: {} };
     const filterItems = filterModel.items
@@ -66,11 +54,9 @@ export function muiGridFilterToGql(columns: GridColDef[], filterModel?: GridFilt
         .map((filterItem) => {
             if (!filterItem.operator) throw new Error("operaturValue not set");
             const gqlOperator = muiGridOperatorValueToGqlOperator[filterItem.operator] || filterItem.operator;
-            const column = columns.find((i) => i.field == filterItem.field);
-            const convertedValue = convertValueByType(filterItem.value, column?.type);
             return {
                 [filterItem.field]: {
-                    [gqlOperator]: convertedValue,
+                    [gqlOperator]: filterItem.value,
                 } as GqlStringFilter | GqlNumberFilter,
             };
         });


### PR DESCRIPTION
## Description

Both number and boolean (see https://github.com/vivid-planet/comet/pull/4020) filter values are now their respective types and don't need a type conversion any longer. We can therefore remove the value conversion.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2124
- Change in MUI for booleans: https://github.com/mui/mui-x/pull/15252
