### PR TITLE
Remove `@comet/cms-site` mention from changeset

### DIFF
--- a/.changeset/spicy-facts-judge.md
+++ b/.changeset/spicy-facts-judge.md
@@ -1,5 +1,4 @@
 ---
-"@comet/cms-site": major
 "@comet/site-nextjs": major
 ---
 


### PR DESCRIPTION
## Description

It's not possible to mention a non-existing (or no longer existing) package in a changeset.
