### PR TITLE
Demo: fix additionalTypes filter

### DIFF
--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -180,6 +180,7 @@ export function ProductsGrid() {
             valueOptions: ["Cap", "Shirt", "Tie"],
         },
         {
+            type: "singleSelect",
             field: "additionalTypes",
             headerName: "Additional Types",
             width: 150,


### PR DESCRIPTION
## Description

Explicitly set the column type to `staticSelect` to show the options select for the "contains" filter.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="711" alt="before" src="https://github.com/user-attachments/assets/f27cd95d-662c-4bb1-821a-a93146c5ee36" /> | <img width="711" alt="after" src="https://github.com/user-attachments/assets/771516d6-c771-4c51-b4d6-c7042c5d7869" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2124
