### PR TITLE
Pass link block instead of custom targets for createRedirectsPage

### DIFF
--- a/.changeset/curly-lamps-turn.md
+++ b/.changeset/curly-lamps-turn.md
@@ -2,7 +2,7 @@
 "@comet/cms-admin": minor
 ---
 
-Rework `createRedirectsPage` usage to accept `link` instead of `customTargets`.
+Rework `createRedirectsPage` usage to accept `linkBlock` instead of `customTargets`.
 
 Previously, `customTargets` were passed directly:
 
@@ -17,7 +17,7 @@ export const RedirectsLinkBlock = createRedirectsLinkBlock({
     news: NewsLinkBlock,
 });
 
-export const RedirectsPage = createRedirectsPage({ link: RedirectsLinkBlock, scopeParts: ["domain"] });
+export const RedirectsPage = createRedirectsPage({ linkBlock: RedirectsLinkBlock, scopeParts: ["domain"] });
 ```
 
 This change was made because `RedirectsLinkBlock` is also needed by `RedirectDependency`, and can therefore be reused.

--- a/demo/admin/src/redirects/RedirectsPage.tsx
+++ b/demo/admin/src/redirects/RedirectsPage.tsx
@@ -5,4 +5,4 @@ export const RedirectsLinkBlock = createRedirectsLinkBlock({
     news: NewsLinkBlock,
 });
 
-export const RedirectsPage = createRedirectsPage({ link: RedirectsLinkBlock, scopeParts: ["domain"] });
+export const RedirectsPage = createRedirectsPage({ linkBlock: RedirectsLinkBlock, scopeParts: ["domain"] });

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -1925,7 +1925,7 @@ If your application uses internationalization or a language other than English (
 
 :::
 
-### Rework `createRedirectsPage` usage to accept `link` instead of `customTargets`.
+### Rework `createRedirectsPage` usage to accept `linkBlock` instead of `customTargets`.
 
 Previously, `customTargets` were passed directly:
 
@@ -1944,7 +1944,7 @@ export const RedirectsLinkBlock = createRedirectsLinkBlock({
 });
 
 export const RedirectsPage = createRedirectsPage({
-    link: RedirectsLinkBlock,
+    linkBlock: RedirectsLinkBlock,
     scopeParts: ["domain"],
 });
 ```

--- a/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
+++ b/packages/admin/cms-admin/src/redirects/createRedirectsPage.tsx
@@ -29,7 +29,7 @@ interface RedirectsPageProps {
 }
 
 interface CreateRedirectsPageOptions {
-    link?: BlockInterface;
+    linkBlock?: BlockInterface;
     scopeParts?: string[];
 }
 
@@ -43,7 +43,7 @@ export function createRedirectsLinkBlock(customTargets?: Record<string, BlockInt
 }
 
 function createRedirectsPage({
-    link = createRedirectsLinkBlock(),
+    linkBlock = createRedirectsLinkBlock(),
     scopeParts = [],
 }: CreateRedirectsPageOptions = {}): ComponentType<RedirectsPageProps> {
     function Redirects({ redirectPathAfterChange }: RedirectsPageProps): JSX.Element {
@@ -65,16 +65,16 @@ function createRedirectsPage({
                 <StackSwitch initialPage="grid">
                     <StackPage name="grid">
                         <StackToolbar scopeIndicator={<ContentScopeIndicator global={isGlobalScoped} scope={isGlobalScoped ? undefined : scope} />} />
-                        <RedirectsGrid linkBlock={link} scope={scope} />
+                        <RedirectsGrid linkBlock={linkBlock} scope={scope} />
                     </StackPage>
                     <StackPage name="edit" title={intl.formatMessage({ id: "comet.pages.redirects.edit", defaultMessage: "edit" })}>
                         {(selectedId: string) => {
-                            return <RedirectForm mode="edit" id={selectedId} linkBlock={link} scope={scope} />;
+                            return <RedirectForm mode="edit" id={selectedId} linkBlock={linkBlock} scope={scope} />;
                         }}
                     </StackPage>
                     <StackPage name="add" title={intl.formatMessage({ id: "comet.pages.redirects.create", defaultMessage: "create" })}>
                         {() => {
-                            return <RedirectForm mode="add" linkBlock={link} scope={scope} />;
+                            return <RedirectForm mode="add" linkBlock={linkBlock} scope={scope} />;
                         }}
                     </StackPage>
                 </StackSwitch>


### PR DESCRIPTION
## Description
For the WarningsModule I needed a RedirectsDependency so I can link to the redirect should there be a Warning. The RedirectsDependeny needed the RedirectsLinkBlock.
At that point we said, that I should remove the customTargets and instead the createRedirectsPage should only accept a link.

I chose link as the property for createRedirectsPage, but also thought about customLink, customLinkBlock, linkBlock. I then chose link, because for createRichTextBlock we also just use "link". What do you think?

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Video just shows that it still works, no visual changes:

https://github.com/user-attachments/assets/e531697b-b095-485d-ae80-4dd91eba4ce5

## Open TODOs/questions

-   [x] I have never done a codemod and have no experience with it. Should I look at this for this change, or is it more intended for other changes?

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1965
