### PR TITLE
Admin Generator: correctly handle date-time columns

### DIFF
--- a/demo/admin/codegen.ts
+++ b/demo/admin/codegen.ts
@@ -45,7 +45,7 @@ const config: CodegenConfig = {
                 },
                 enumsAsTypes: true,
                 namingConvention: "keep",
-                scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), { LocalDate: "string" }),
+                scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), { DateTime: "string", Date: "string", LocalDate: "string" }),
                 typesPrefix: "GQL",
                 skipDocumentsValidation: {
                     ignoreRules: ["KnownFragmentNamesRule"], 

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -72,9 +72,10 @@ type ProductFormManualFragment = Omit<GQLProductFormManualFragment, "priceList" 
     datasheets: Array<GQLFinalFormFileUploadFragment>;
 };
 
-type FormValues = Omit<ProductFormManualFragment, "image"> & {
+type FormValues = Omit<ProductFormManualFragment, "image" | "lastCheckedAt"> & {
     image: BlockState<typeof rootBlocks.image>;
     manufacturerCountry?: { id: string; label: string };
+    lastCheckedAt?: Date | null;
 };
 
 // TODO should we use a deep partial here?

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -332,9 +332,16 @@ export function generateFormField({
                 ...defaultFormValuesConfig,
                 ...{
                     initializationCode: `${name}: data.${dataRootName}.${nameWithPrefix} ? new Date(data.${dataRootName}.${nameWithPrefix}) : undefined`,
+                    omitFromFragmentType: name,
+                    typeCode: `${name}${!required ? "?" : ""}: Date${!required ? " | null" : ""};`,
                 },
             },
         ];
+        if (!config.virtual && !config.readOnly) {
+            formValueToGqlInputCode = required
+                ? `${name}: formValues.${name}.toISOString(),`
+                : `${name}: formValues.${name} ? formValues.${name}.toISOString() : null,`;
+        }
     } else if (config.type == "block") {
         code = `<Field name="${nameWithPrefix}" isEqual={isEqual} label={${fieldLabel}} variant="horizontal" fullWidth>
             {createFinalFormBlock(rootBlocks.${String(config.name)})}


### PR DESCRIPTION
## Description

Noticed this while fixing date-only columns: The GraphQL Codegen config missed the mapping for the `DateTime` and `Date` scalars, resulting in `any`. When changing this to `string` for `DateTime`, the product forms (both handmade and generated) had lint errors due to incompatibilities between `Date` and `string`. Since the DateTimePicker uses `Date` as field state, I added the necessary type conversions to fix the lint errors.

## Open TODOs/questions

-   [x] Merge parent PR https://github.com/vivid-planet/comet/pull/4030

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2131
