### PR TITLE
Fix `ContentsScopeProvider` migration guide

### DIFF
--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -1218,99 +1218,6 @@ It is recommended to use the `AutocompleteField` or the `SelectField` components
 + <AutocompleteField name="color" label="Color" options={options} fullWidth />;
 ```
 
-### Change type of the `values` prop of `ContentScopeProvider`
-
-The `ContentScopeProvider` now expects a different structure for the `values` prop.
-
-**Before:**
-
-```ts
-const values: ContentScopeValues = [
-    {
-        domain: { label: "Main", value: "main" },
-        language: { label: "English", value: "en" },
-    },
-    {
-        domain: { label: "Main", value: "main" },
-        language: { label: "German", value: "de" },
-    },
-    {
-        domain: { label: "Secondary", value: "secondary" },
-        language: { label: "English", value: "en" },
-    },
-];
-```
-
-**Now:**
-
-```ts
-const values: ContentScopeValues = [
-    {
-        scope: { domain: "main", language: "en" },
-        label: { domain: "Main", language: "English" },
-    },
-    {
-        scope: { domain: "main", language: "de" },
-        label: { domain: "Main", language: "German" },
-    },
-    {
-        scope: { domain: "secondary", language: "en" },
-        label: { domain: "Secondary", language: "English" },
-    },
-];
-```
-
-The following changes are necessary:
-
-```diff title="admin/src/common/ContentScopeProvider.tsx"
-import {
-+   type ContentScope,
-    // ...
-} from "@comet/cms-admin";
-+ import { type ContentScope as BaseContentScope } from "@src/site-configs";
-
-+ declare module "@comet/cms-admin" {
-+     // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-+     interface ContentScope extends BaseContentScope {}
-+ }
-
-- export function useContentScope(): UseContentScopeApi<ContentScope> {
--    return useContentScopeLibrary<ContentScope>();
-- }
-
-// ...
-
-export const ContentScopeProvider = ({ children }: Pick<ContentScopeProviderProps, "children">) => {
-
-    // ...
-
--    const values: ContentScopeValues<ContentScope> = userContentScopes.map((contentScope) => ({
--        domain: { value: contentScope.domain },
--        language: { value: contentScope.language, label: contentScope.language.toUpperCase() },
-+    const values: ContentScopeValues = userContentScopes.map((contentScope) => ({
-+        scope: contentScope,
-+        label: { language: contentScope.language.toUpperCase() },
-  }));
-
-  if (user.allowedContentScopes.length === 0) {
--        throw new Error("User does not have access to any scopes.");
-+        return (
-+            <>
-+                Error: user does not have access to any scopes.
-+                {user.impersonated && <StopImpersonationButton />}
-+            </>
-+        );
-  }
-
-  return (
--        <ContentScopeProviderLibrary<ContentScope> values={values} defaultValue={userContentScopes[0]}>
-+        <ContentScopeProviderLibrary values={values} defaultValue={userContentScopes[0]}>
-             {children}
-         </ContentScopeProviderLibrary>
-  );
-}
-```
-
 ### ✅ Merge providers into `CometConfigProvider`
 
 The separate providers for CMS features (e.g, `DamConfigProvider`) have been merged into a `CometConfigProvider`.
@@ -1748,7 +1655,33 @@ Example:
     export function App() {
 ```
 
-#### Preferable use ContentScopeProvider directly from Comet
+#### Preferably use ContentScopeProvider directly from Comet
+
+Move the scope labels from admin to the API, for example:
+
+```diff
+UserPermissionsModule.forRootAsync({
+    useFactory: (userService: StaticUsersUserService, accessControlService: AccessControlService) => ({
+        availableContentScopes: config.siteConfigs.flatMap((siteConfig) =>
+-           siteConfig.scope.languages.map((language) => ({
+-               domain: siteConfig.scope.domain,
+-               language,
+-           })),
++           siteConfig.scope.languages.map((language) => ({
++               scope: {
++                   domain: siteConfig.scope.domain,
++                   language,
++               },
++               label: { domain: siteConfig.name },
++           })),
+        ),
+        // ...
+    }),
+    // ...
+}),
+```
+
+Then you can use the `ContentScopeProvider` from `@comet/cms-admin` directly in your `App.tsx` and delete `admin/src/common/ContentScopeProvider.tsx`:
 
 ```diff title="admin/src/App.tsx"
 -   import { ContentScopeProvider } from "./common/ContentScopeProvider";


### PR DESCRIPTION
## Description

I added a migration guide section here: https://github.com/vivid-planet/comet/pull/4016. And Franz changed the `ContentsScopeProvider` in https://github.com/vivid-planet/comet/pull/2172. So now my section is outdated and they contradicted each other.

I also added a note that you should move the scope labels to the API before deleting the `ContentsScopeProvider.tsx`