### PR TITLE
Demo: fix custom cell header name

### DIFF
--- a/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
@@ -91,7 +91,7 @@ export default defineConfig<GQLProduct>({
             type: "text",
             renderCell: ({ value, row }) => <ProductTitle title={value} />,
             name: "title",
-            headerName: "Custom",
+            headerName: "Title",
             minWidth: 200,
             visible: "down('md')",
         },


### PR DESCRIPTION
## Description

Use "Title" instead of "Custom" because the header name is also used for the filter, where "Custom" isn't very clear.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-2109