### PR TITLE
Demo: re-add product tags form

### DIFF
--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -27,9 +27,11 @@ import { ManufacturersPage } from "@src/products/generator/ManufacturersPage";
 import { ProductCategoriesPage } from "@src/products/generator/ProductCategoriesPage";
 import { ProductsPage } from "@src/products/generator/ProductsPage";
 import { ProductsWithLowPricePage } from "@src/products/generator/ProductsWithLowPricePage";
+import { ProductTagsPage } from "@src/products/generator/ProductTagsPage";
 import { ManufacturersPage as ManufacturersHandmadePage } from "@src/products/ManufacturersPage";
 import { ProductCategoriesHandmadePage } from "@src/products/ProductCategoriesPage";
 import ProductsHandmadePage from "@src/products/ProductsPage";
+import { ProductTagsPage as ProductTagsHandmadePage } from "@src/products/tags/ProductTagsPage";
 import { RedirectsPage } from "@src/redirects/RedirectsPage";
 import { type ContentScope } from "@src/site-configs";
 import { FormattedMessage } from "react-intl";
@@ -251,6 +253,14 @@ export const masterMenuData: MasterMenuData = [
                             component: ProductCategoriesPage,
                         },
                     },
+                    {
+                        type: "route",
+                        primary: <FormattedMessage id="menu.productTags" defaultMessage="Product Tags" />,
+                        route: {
+                            path: "/product-tags",
+                            component: ProductTagsPage,
+                        },
+                    },
                 ],
             },
             {
@@ -280,6 +290,14 @@ export const masterMenuData: MasterMenuData = [
                         route: {
                             path: "/product-category-handmade",
                             component: ProductCategoriesHandmadePage,
+                        },
+                    },
+                    {
+                        type: "route",
+                        primary: <FormattedMessage id="menu.productTagsHandmade" defaultMessage="Product Tags Handmade" />,
+                        route: {
+                            path: "/product-tags-handmade",
+                            component: ProductTagsHandmadePage,
                         },
                     },
                 ],

--- a/demo/admin/src/products/generator/ProductTagForm.cometGen.ts
+++ b/demo/admin/src/products/generator/ProductTagForm.cometGen.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "@comet/admin-generator";
+import { type GQLProductTag } from "@src/graphql.generated";
+
+export default defineConfig<GQLProductTag>({
+    type: "form",
+    gqlType: "ProductTag",
+    fragmentName: "ProductTagForm",
+    fields: [{ type: "text", name: "title" }],
+});

--- a/demo/admin/src/products/generator/ProductTagsGrid.cometGen.ts
+++ b/demo/admin/src/products/generator/ProductTagsGrid.cometGen.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@comet/admin-generator";
+import { type GQLProductTag } from "@src/graphql.generated";
+
+export default defineConfig<GQLProductTag>({
+    type: "grid",
+    gqlType: "ProductTag",
+    fragmentName: "ProductTagsGrid",
+    queryParamsPrefix: "productTags",
+    columns: [
+        {
+            type: "text",
+            name: "title",
+            headerName: "Title",
+        },
+    ],
+});

--- a/demo/admin/src/products/generator/ProductTagsPage.tsx
+++ b/demo/admin/src/products/generator/ProductTagsPage.tsx
@@ -1,0 +1,63 @@
+import {
+    FillSpace,
+    SaveBoundary,
+    SaveBoundarySaveButton,
+    Stack,
+    StackMainContent,
+    StackPage,
+    StackSwitch,
+    StackToolbar,
+    ToolbarActions,
+    ToolbarAutomaticTitleItem,
+    ToolbarBackButton,
+} from "@comet/admin";
+import { ContentScopeIndicator } from "@comet/cms-admin";
+import { useIntl } from "react-intl";
+
+import { ProductTagForm } from "./generated/ProductTagForm";
+import { ProductTagsGrid } from "./generated/ProductTagsGrid";
+
+const FormToolbar = () => (
+    <StackToolbar scopeIndicator={<ContentScopeIndicator global />}>
+        <ToolbarBackButton />
+        <ToolbarAutomaticTitleItem />
+        <FillSpace />
+        <ToolbarActions>
+            <SaveBoundarySaveButton />
+        </ToolbarActions>
+    </StackToolbar>
+);
+
+export function ProductTagsPage() {
+    const intl = useIntl();
+    return (
+        <Stack topLevelTitle={intl.formatMessage({ id: "products.productTags", defaultMessage: "Product Tags" })}>
+            <StackSwitch>
+                <StackPage name="grid">
+                    <StackToolbar scopeIndicator={<ContentScopeIndicator global />} />
+                    <StackMainContent fullHeight>
+                        <ProductTagsGrid />
+                    </StackMainContent>
+                </StackPage>
+                <StackPage name="add" title={intl.formatMessage({ id: "products.addProductTag", defaultMessage: "Add product tag" })}>
+                    <SaveBoundary>
+                        <FormToolbar />
+                        <StackMainContent>
+                            <ProductTagForm />
+                        </StackMainContent>
+                    </SaveBoundary>
+                </StackPage>
+                <StackPage name="edit" title={intl.formatMessage({ id: "products.editProductTag", defaultMessage: "Edit product tag" })}>
+                    {(id) => (
+                        <SaveBoundary>
+                            <FormToolbar />
+                            <StackMainContent>
+                                <ProductTagForm id={id} />
+                            </StackMainContent>
+                        </SaveBoundary>
+                    )}
+                </StackPage>
+            </StackSwitch>
+        </Stack>
+    );
+}

--- a/demo/admin/src/products/tags/ProductTagForm.gql.tsx
+++ b/demo/admin/src/products/tags/ProductTagForm.gql.tsx
@@ -1,0 +1,37 @@
+import { gql } from "@apollo/client";
+
+export const productTagFormFragment = gql`
+    fragment ProductTagForm on ProductTag {
+        title
+    }
+`;
+export const productTagQuery = gql`
+    query ProductTag($id: ID!) {
+        productTag(id: $id) {
+            id
+            updatedAt
+            ...ProductTagForm
+        }
+    }
+    ${productTagFormFragment}
+`;
+export const createProductTagMutation = gql`
+    mutation CreateProductTag($input: ProductTagInput!) {
+        createProductTag(input: $input) {
+            id
+            updatedAt
+            ...ProductTagForm
+        }
+    }
+    ${productTagFormFragment}
+`;
+export const updateProductTagMutation = gql`
+    mutation UpdateProductTag($id: ID!, $input: ProductTagUpdateInput!) {
+        updateProductTag(id: $id, input: $input) {
+            id
+            updatedAt
+            ...ProductTagForm
+        }
+    }
+    ${productTagFormFragment}
+`;

--- a/demo/admin/src/products/tags/ProductTagForm.tsx
+++ b/demo/admin/src/products/tags/ProductTagForm.tsx
@@ -1,0 +1,106 @@
+import { useApolloClient, useQuery } from "@apollo/client";
+import { filterByFragment, FinalForm, type FinalFormSubmitEvent, Loading, TextField, useFormApiRef, useStackSwitchApi } from "@comet/admin";
+import { queryUpdatedAt, resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
+import { type FormApi } from "final-form";
+import isEqual from "lodash.isequal";
+import { useMemo } from "react";
+import { FormattedMessage } from "react-intl";
+
+import { createProductTagMutation, productTagFormFragment, productTagQuery, updateProductTagMutation } from "./ProductTagForm.gql";
+import {
+    type GQLCreateProductTagMutation,
+    type GQLCreateProductTagMutationVariables,
+    type GQLProductTagFormFragment,
+    type GQLProductTagQuery,
+    type GQLProductTagQueryVariables,
+    type GQLUpdateProductTagMutation,
+    type GQLUpdateProductTagMutationVariables,
+} from "./ProductTagForm.gql.generated";
+
+type FormValues = GQLProductTagFormFragment;
+interface FormProps {
+    id?: string;
+}
+export function ProductTagForm({ id }: FormProps) {
+    const client = useApolloClient();
+    const mode = id ? "edit" : "add";
+    const formApiRef = useFormApiRef<FormValues>();
+    const stackSwitchApi = useStackSwitchApi();
+    const { data, error, loading, refetch } = useQuery<GQLProductTagQuery, GQLProductTagQueryVariables>(
+        productTagQuery,
+        id ? { variables: { id } } : { skip: true },
+    );
+    const initialValues = useMemo<Partial<FormValues>>(
+        () =>
+            data?.productTag
+                ? {
+                      ...filterByFragment<GQLProductTagFormFragment>(productTagFormFragment, data.productTag),
+                  }
+                : {},
+        [data],
+    );
+    const saveConflict = useFormSaveConflict({
+        checkConflict: async () => {
+            const updatedAt = await queryUpdatedAt(client, "productTag", id);
+            return resolveHasSaveConflict(data?.productTag.updatedAt, updatedAt);
+        },
+        formApiRef,
+        loadLatestVersion: async () => {
+            await refetch();
+        },
+    });
+    const handleSubmit = async (formValues: FormValues, form: FormApi<FormValues>, event: FinalFormSubmitEvent) => {
+        if (await saveConflict.checkForConflicts()) throw new Error("Conflicts detected");
+        const output = {
+            ...formValues,
+        };
+        if (mode === "edit") {
+            if (!id) throw new Error();
+            const { ...updateInput } = output;
+            await client.mutate<GQLUpdateProductTagMutation, GQLUpdateProductTagMutationVariables>({
+                mutation: updateProductTagMutation,
+                variables: { id, input: updateInput },
+            });
+        } else {
+            const { data: mutationResponse } = await client.mutate<GQLCreateProductTagMutation, GQLCreateProductTagMutationVariables>({
+                mutation: createProductTagMutation,
+                variables: { input: output },
+            });
+            if (!event.navigatingBack) {
+                const id = mutationResponse?.createProductTag.id;
+                if (id) {
+                    setTimeout(() => {
+                        stackSwitchApi.activatePage(`edit`, id);
+                    });
+                }
+            }
+        }
+    };
+    if (error) throw error;
+    if (loading) {
+        return <Loading behavior="fillPageHeight" />;
+    }
+    return (
+        <FinalForm<FormValues>
+            apiRef={formApiRef}
+            onSubmit={handleSubmit}
+            mode={mode}
+            initialValues={initialValues}
+            initialValuesEqual={isEqual} //required to compare block data correctly
+            subscription={{}}
+        >
+            {() => (
+                <>
+                    {saveConflict.dialogs}
+                    <TextField
+                        required
+                        variant="horizontal"
+                        fullWidth
+                        name="title"
+                        label={<FormattedMessage id="productTag.title" defaultMessage="Title" />}
+                    />
+                </>
+            )}
+        </FinalForm>
+    );
+}

--- a/demo/admin/src/products/tags/ProductTagsGrid.tsx
+++ b/demo/admin/src/products/tags/ProductTagsGrid.tsx
@@ -1,0 +1,149 @@
+import { gql, useApolloClient, useQuery } from "@apollo/client";
+import {
+    Button,
+    CrudContextMenu,
+    DataGridToolbar,
+    FillSpace,
+    filterByFragment,
+    type GridColDef,
+    GridFilterButton,
+    muiGridFilterToGql,
+    muiGridSortToGql,
+    StackLink,
+    useBufferedRowCount,
+    useDataGridRemote,
+    usePersistentColumnState,
+} from "@comet/admin";
+import { Add as AddIcon, Edit as EditIcon } from "@comet/admin-icons";
+import { IconButton } from "@mui/material";
+import { DataGridPro, type GridSlotsComponent, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import {
+    type GQLCreateProductTagMutation,
+    type GQLCreateProductTagMutationVariables,
+    type GQLDeleteProductTagMutation,
+    type GQLDeleteProductTagMutationVariables,
+    type GQLProductTagsGridFragment,
+    type GQLProductTagsGridQuery,
+    type GQLProductTagsGridQueryVariables,
+} from "./ProductTagsGrid.generated";
+
+const productTagsFragment = gql`
+    fragment ProductTagsGrid on ProductTag {
+        id
+        title
+    }
+`;
+const productTagsQuery = gql`
+    query ProductTagsGrid($offset: Int!, $limit: Int!, $sort: [ProductTagSort!], $search: String, $filter: ProductTagFilter) {
+        productTags(offset: $offset, limit: $limit, sort: $sort, search: $search, filter: $filter) {
+            nodes {
+                ...ProductTagsGrid
+            }
+            totalCount
+        }
+    }
+    ${productTagsFragment}
+`;
+const deleteProductTagMutation = gql`
+    mutation DeleteProductTag($id: ID!) {
+        deleteProductTag(id: $id)
+    }
+`;
+const createProductTagMutation = gql`
+    mutation CreateProductTag($input: ProductTagInput!) {
+        createProductTag(input: $input) {
+            id
+        }
+    }
+`;
+function ProductTagsGridToolbar() {
+    return (
+        <DataGridToolbar>
+            <GridToolbarQuickFilter />
+            <GridFilterButton />
+            <FillSpace />
+            <Button responsive startIcon={<AddIcon />} component={StackLink} pageName="add" payload="add">
+                <FormattedMessage id="productTag.productTagsGrid.newEntry" defaultMessage="New Product Tag" />
+            </Button>
+        </DataGridToolbar>
+    );
+}
+export function ProductTagsGrid() {
+    const client = useApolloClient();
+    const intl = useIntl();
+    const dataGridProps = {
+        ...useDataGridRemote({
+            queryParamsPrefix: "productTags",
+        }),
+        ...usePersistentColumnState("ProductTagsGrid"),
+    };
+    const columns: GridColDef<GQLProductTagsGridFragment>[] = [
+        { field: "title", headerName: intl.formatMessage({ id: "productTag.title", defaultMessage: "Title" }), flex: 1, minWidth: 150 },
+        {
+            field: "actions",
+            headerName: "",
+            sortable: false,
+            filterable: false,
+            type: "actions",
+            align: "right",
+            pinned: "right",
+            width: 84,
+            renderCell: (params) => {
+                return (
+                    <>
+                        <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
+                            <EditIcon />
+                        </IconButton>
+                        <CrudContextMenu
+                            copyData={() => {
+                                // Don't copy id, because we want to create a new entity with this data
+                                const { id, ...filteredData } = filterByFragment(productTagsFragment, params.row);
+                                return filteredData;
+                            }}
+                            onPaste={async ({ input }) => {
+                                await client.mutate<GQLCreateProductTagMutation, GQLCreateProductTagMutationVariables>({
+                                    mutation: createProductTagMutation,
+                                    variables: { input },
+                                });
+                            }}
+                            onDelete={async () => {
+                                await client.mutate<GQLDeleteProductTagMutation, GQLDeleteProductTagMutationVariables>({
+                                    mutation: deleteProductTagMutation,
+                                    variables: { id: params.row.id },
+                                });
+                            }}
+                            refetchQueries={[productTagsQuery]}
+                        />
+                    </>
+                );
+            },
+        },
+    ];
+    const { filter: gqlFilter, search: gqlSearch } = muiGridFilterToGql(columns, dataGridProps.filterModel);
+    const { data, loading, error } = useQuery<GQLProductTagsGridQuery, GQLProductTagsGridQueryVariables>(productTagsQuery, {
+        variables: {
+            filter: gqlFilter,
+            search: gqlSearch,
+            offset: dataGridProps.paginationModel.page * dataGridProps.paginationModel.pageSize,
+            limit: dataGridProps.paginationModel.pageSize,
+            sort: muiGridSortToGql(dataGridProps.sortModel, columns),
+        },
+    });
+    const rowCount = useBufferedRowCount(data?.productTags.totalCount);
+    if (error) throw error;
+    const rows = data?.productTags.nodes ?? [];
+    return (
+        <DataGridPro
+            {...dataGridProps}
+            rows={rows}
+            rowCount={rowCount}
+            columns={columns}
+            loading={loading}
+            slots={{
+                toolbar: ProductTagsGridToolbar as GridSlotsComponent["toolbar"],
+            }}
+        />
+    );
+}

--- a/demo/admin/src/products/tags/ProductTagsPage.tsx
+++ b/demo/admin/src/products/tags/ProductTagsPage.tsx
@@ -1,0 +1,63 @@
+import {
+    FillSpace,
+    SaveBoundary,
+    SaveBoundarySaveButton,
+    Stack,
+    StackMainContent,
+    StackPage,
+    StackSwitch,
+    StackToolbar,
+    ToolbarActions,
+    ToolbarAutomaticTitleItem,
+    ToolbarBackButton,
+} from "@comet/admin";
+import { ContentScopeIndicator } from "@comet/cms-admin";
+import { useIntl } from "react-intl";
+
+import { ProductTagForm } from "./ProductTagForm";
+import { ProductTagsGrid } from "./ProductTagsGrid";
+
+const FormToolbar = () => (
+    <StackToolbar scopeIndicator={<ContentScopeIndicator global />}>
+        <ToolbarBackButton />
+        <ToolbarAutomaticTitleItem />
+        <FillSpace />
+        <ToolbarActions>
+            <SaveBoundarySaveButton />
+        </ToolbarActions>
+    </StackToolbar>
+);
+
+export function ProductTagsPage() {
+    const intl = useIntl();
+    return (
+        <Stack topLevelTitle={intl.formatMessage({ id: "products.productTags", defaultMessage: "Product Tags" })}>
+            <StackSwitch>
+                <StackPage name="grid">
+                    <StackToolbar scopeIndicator={<ContentScopeIndicator global />} />
+                    <StackMainContent fullHeight>
+                        <ProductTagsGrid />
+                    </StackMainContent>
+                </StackPage>
+                <StackPage name="add" title={intl.formatMessage({ id: "products.addProductTag", defaultMessage: "Add product tag" })}>
+                    <SaveBoundary>
+                        <FormToolbar />
+                        <StackMainContent>
+                            <ProductTagForm />
+                        </StackMainContent>
+                    </SaveBoundary>
+                </StackPage>
+                <StackPage name="edit" title={intl.formatMessage({ id: "products.editProductTag", defaultMessage: "Edit product tag" })}>
+                    {(id) => (
+                        <SaveBoundary>
+                            <FormToolbar />
+                            <StackMainContent>
+                                <ProductTagForm id={id} />
+                            </StackMainContent>
+                        </SaveBoundary>
+                    )}
+                </StackPage>
+            </StackSwitch>
+        </Stack>
+    );
+}


### PR DESCRIPTION
## Description

The product tags form generated with the old generator was removed in https://github.com/vivid-planet/comet/pull/3929. Therefore it wasn't possible to add/edit product tags in the admin. This PR re-adds the form generated by the new generator. I also added a handmade variant by copying the generated variant.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2109