### PR TITLE
Update renovate config and add grouping for low risk patch/minor bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,13 @@
     "extends": ["config:recommended", ":semanticCommitsDisabled"],
     "packageRules": [
         {
+            "groupName": "Low-Risk Patches and Minors",
+            "matchUpdateTypes": ["patch", "minor"],
+            "excludePackagePatterns": ["^next$", "^react", "^@nestjs/", "^@apollo/", "^@docusaurus/", "^@mui/", "^@emotion/"],
+            "matchCurrentVersion": "!/^0\\./",
+            "matchVersionPattern": "!/^0\\/"
+        },
+        {
             "groupName": "babel",
             "matchPackageNames": ["/@babel/*/"]
         },


### PR DESCRIPTION
# Optimize Renovate Update Strategy

This PR introduces a new group "Low-Risk Patches and Minors" - which groups all minor and patch updates in a single group.

## Low-Risk Updates Grouping
- All patch and minor updates are now grouped together into a "Low-Risk Patches and Minors" group
- This reduces PR noise and allows for more efficient batch updates
- Excludes `0.x.x` versions to maintain stability

## Expected Behavior

1. Most patch and minor updates will come as a single, grouped PR
2. Critical framework updates will come as individual PRs
3. Any 0.x.x version updates will be separate PRs
4. Major version updates will always be separate PRs


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2138
