### PR TITLE
Fix invalid settings in Renovate config 

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,31 @@
         {
             "groupName": "Low-Risk Patches and Minors",
             "matchUpdateTypes": ["patch", "minor"],
-            "excludePackagePatterns": ["^next$", "^react", "^@nestjs/", "^@apollo/", "^@docusaurus/", "^@mui/", "^@emotion/"],
-            "matchCurrentVersion": "!/^0\\./",
-            "matchVersionPattern": "!/^0\\/"
+            "excludePackagePatterns": [
+                "^next$",
+                "^react",
+                "^@nestjs/",
+                "^@apollo/",
+                "^@mui/",
+                "^@emotion/",
+                "draft-js",
+                "golevelup/ts-jest",
+                "types/draft-js",
+                "rollup-plugin-preserve-directives",
+                "types/pluralize",
+                "class-validator",
+                "apollo-link-rest",
+                "reflect-metadata",
+                "axios",
+                "graphql-mocks",
+                "eslint-plugin-package-json",
+                "opentelemetry/auto-instrumentations-node",
+                "opentelemetry/exporter-prometheus",
+                "opentelemetry/exporter-trace-otlp-http",
+                "opentelemetry/instrumentation-runtime-node",
+                "opentelemetry/sdk-node",
+                "redraft"
+            ]
         },
         {
             "groupName": "babel",


### PR DESCRIPTION
## Description

The [previous Pull Request](https://github.com/vivid-planet/comet/pull/4112) didn’t work due to invalid settings in renovate.json.
<img width="1245" alt="Screenshot 2025-07-07 at 07 31 34" src="https://github.com/user-attachments/assets/37947884-8eeb-4cc2-9de3-a528dcbb0285" />

see: https://developer.mend.io/github/vivid-planet/comet


This Pull Request removes the problematic config and hardcodes grouping for all 0.x packages.

Closes https://github.com/vivid-planet/comet/issues/4113.


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2138
