### PR TITLE
Improve error handling in CrudContextMenu copy action

### DIFF
--- a/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
@@ -186,7 +186,7 @@ export function CrudContextMenu<CopyData>(inProps: CrudContextMenuProps<CopyData
                                 setCopyLoading(true);
                                 try {
                                     await handleCopyClick();
-                                } catch (e) {
+                                } catch (error) {
                                     snackbarApi.showSnackbar(
                                         <Snackbar anchorOrigin={{ vertical: "bottom", horizontal: "left" }} autoHideDuration={5000}>
                                             <Alert severity="error">
@@ -195,7 +195,7 @@ export function CrudContextMenu<CopyData>(inProps: CrudContextMenuProps<CopyData
                                         </Snackbar>,
                                     );
 
-                                    console.error("Copy failed", e);
+                                    console.error("Copy failed", error);
                                 } finally {
                                     setCopyLoading(false);
                                 }


### PR DESCRIPTION
## Description

This pull request improves the error-handling logic in the `CrudContextMenu` component.

### 🐛 Problem

Previously, if an error occurred while copying data, the Copy button would remain in a loading state indefinitely, leaving users without feedback.

### Changes
•	Added try/catch block around the copy action
•	Errors are now caught and displayed using the Snackbar
•	Loading spinner is correctly dismissed if an error occurs

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|![Screen Recording 2025-07-07 at 09 34 11](https://github.com/user-attachments/assets/23b501b3-50da-4f45-a5a4-f5829c57d49f)   |  ![Screen Recording 2025-07-07 at 09 30 45](https://github.com/user-attachments/assets/4b80caf7-13e2-486e-a2b1-8e3776676bf3)  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2125
