### PR TITLE
Loosen styled-components peer dependency in `@comet/cms-site`

### DIFF
--- a/.changeset/ten-dodos-rule.md
+++ b/.changeset/ten-dodos-rule.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-site": patch
+---
+
+Loosen styled-components peer dependency
+
+Allow using styled-components v5 in applications.

--- a/packages/site/cms-site/package.json
+++ b/packages/site/cms-site/package.json
@@ -61,7 +61,7 @@
         "next": "^14.2.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "styled-components": "^6.0.0"
+        "styled-components": "^5.0.0 || ^6.0.0"
     },
     "publishConfig": {
         "access": "public",


### PR DESCRIPTION
## Description

A project of ours needs to use styled-components v5 due to a peer dependency in a third party library. To support this, we loosen our peer dependency on styled-components to allow v5. This shouldn't cause problems since we don't use v6-specific features in the package.
