### PR TITLE
Data Grid: implement ID filter in Admin

### DIFF
--- a/demo/admin/src/products/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/ManufacturersGrid.tsx
@@ -29,6 +29,8 @@ import {
 import gql from "graphql-tag";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { idFilterFilterOperators } from "./helpers/idFilterFilterOperators";
+
 function ManufacturersGridToolbar() {
     return (
         <DataGridToolbar>
@@ -62,6 +64,7 @@ export function ManufacturersGrid() {
                     </Tooltip>
                 </>
             ),
+            filterOperators: idFilterFilterOperators,
         },
         {
             field: "name",

--- a/demo/admin/src/products/generator/ManufacturersGrid.cometGen.ts
+++ b/demo/admin/src/products/generator/ManufacturersGrid.cometGen.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "@comet/admin-generator";
 import { type GQLManufacturer } from "@src/graphql.generated";
 
+import { idFilterFilterOperators } from "../helpers/idFilterFilterOperators";
+
 export default defineConfig<GQLManufacturer>({
     type: "grid",
     gqlType: "Manufacturer",
@@ -8,7 +10,12 @@ export default defineConfig<GQLManufacturer>({
     queryParamsPrefix: "manufacturers",
     newEntryText: "Add Manufacturer",
     columns: [
-        { type: "text", name: "id", headerName: "ID" },
+        {
+            type: "text",
+            name: "id",
+            headerName: "ID",
+            filterOperators: idFilterFilterOperators,
+        },
         { type: "text", name: "name", headerName: "Name" },
         { type: "text", name: "address.street", headerName: "Street" },
         { type: "number", name: "address.streetNumber", headerName: "Street number" },

--- a/demo/admin/src/products/helpers/idFilterFilterOperators.ts
+++ b/demo/admin/src/products/helpers/idFilterFilterOperators.ts
@@ -1,0 +1,6 @@
+import { getGridStringOperators } from "@mui/x-data-grid";
+
+/**
+ * MUI Data Grid filter operators to match the IdFilter GraphQL input type.
+ */
+export const idFilterFilterOperators = getGridStringOperators().filter((operator) => ["isAnyOf", "equals", "doesNotEqual"].includes(operator.value));


### PR DESCRIPTION
## Description

Limit the filter operators of the ID column in the Data Grid to the operators defined in `IdFilter`.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| ![id-filter_before](https://github.com/user-attachments/assets/048602ee-0260-45d1-9898-1127659eeec6) | ![id-filter_after](https://github.com/user-attachments/assets/64e58a91-435f-4e7c-9db5-a9df79208454) |

## Open TODOs/questions

-   [ ] Should we move idFilterFilterOperators into the library?

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2124?atlOrigin=eyJpIjoiYTE2ZDUzYjJlYTFhNDgwZjg5YTczNzljYWY3ZjJlOGQiLCJwIjoiaiJ9
