### PR TITLE
Renovate: exclude Knip and MSW from low risk group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,9 @@
                 "opentelemetry/exporter-trace-otlp-http",
                 "opentelemetry/instrumentation-runtime-node",
                 "opentelemetry/sdk-node",
-                "redraft"
+                "redraft",
+                "msw",
+                "knip"
             ]
         },
         {


### PR DESCRIPTION
## Description

exclude knip and msw (0.x package) from renovates low risk group.