### PR TITLE
YouTube and Vimeo Video: start after clicking preview image

### DIFF
--- a/.changeset/rare-dingos-applaud.md
+++ b/.changeset/rare-dingos-applaud.md
@@ -1,0 +1,7 @@
+---
+"@comet/site-nextjs": patch
+"@comet/site-react": patch
+"@comet/cms-site": patch
+---
+
+YouTube and Vimeo Video Block: fixed bug where the video does not start after clicking the play button in the preview image.

--- a/packages/site/cms-site/src/blocks/VimeoVideoBlock.tsx
+++ b/packages/site/cms-site/src/blocks/VimeoVideoBlock.tsx
@@ -45,15 +45,13 @@ export const VimeoVideoBlock = withPreview(
         const [showPreviewImage, setShowPreviewImage] = useState(true);
         const hasPreviewImage = !!(previewImage && previewImage.damFile);
         const inViewRef = useRef<HTMLDivElement>(null);
-        const iframeRef = useRef<HTMLIFrameElement | null>(null);
+        const iframeRef = useRef<HTMLIFrameElement>(null);
 
         const handleVisibilityChange = (isVisible: boolean) => {
-            if (iframeRef.current?.contentWindow) {
-                iframeRef.current.contentWindow.postMessage(
-                    JSON.stringify({ method: isVisible && autoplay ? "play" : "pause" }),
-                    "https://player.vimeo.com",
-                );
-            }
+            iframeRef.current?.contentWindow?.postMessage(
+                JSON.stringify({ method: isVisible && autoplay ? "play" : "pause" }),
+                "https://player.vimeo.com",
+            );
         };
 
         useIsElementInViewport(inViewRef, handleVisibilityChange);
@@ -65,6 +63,7 @@ export const VimeoVideoBlock = withPreview(
         const identifier = parseVimeoIdentifier(vimeoIdentifier);
 
         const searchParams = new URLSearchParams();
+        if (hasPreviewImage && !showPreviewImage) searchParams.append("autoplay", "1");
         if (autoplay) searchParams.append("muted", "1");
 
         if (loop !== undefined) searchParams.append("loop", Number(loop).toString());

--- a/packages/site/cms-site/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/site/cms-site/src/blocks/YouTubeVideoBlock.tsx
@@ -40,19 +40,15 @@ export const YouTubeVideoBlock = withPreview(
     }: YouTubeVideoBlockProps) => {
         const [showPreviewImage, setShowPreviewImage] = useState(true);
         const hasPreviewImage = !!(previewImage && previewImage.damFile);
-        const iframeRef = useRef<HTMLIFrameElement | null>(null);
-        const inViewRef = useRef(null);
+        const iframeRef = useRef<HTMLIFrameElement>(null);
+        const inViewRef = useRef<HTMLDivElement>(null);
 
         const pauseYouTubeVideo = () => {
-            if (iframeRef.current?.contentWindow) {
-                iframeRef.current.contentWindow.postMessage(`{"event":"command","func":"pauseVideo","args":""}`, "https://www.youtube-nocookie.com");
-            }
+            iframeRef.current?.contentWindow?.postMessage(`{"event":"command","func":"pauseVideo","args":""}`, "https://www.youtube-nocookie.com");
         };
 
         const playYouTubeVideo = () => {
-            if (iframeRef.current?.contentWindow) {
-                iframeRef.current.contentWindow.postMessage(`{"event":"command","func":"playVideo","args":""}`, "https://www.youtube-nocookie.com");
-            }
+            iframeRef.current?.contentWindow?.postMessage(`{"event":"command","func":"playVideo","args":""}`, "https://www.youtube-nocookie.com");
         };
 
         useIsElementInViewport(inViewRef, (inView: boolean) => {
@@ -74,6 +70,9 @@ export const YouTubeVideoBlock = withPreview(
         searchParams.append("modestbranding", "1");
         searchParams.append("rel", "0");
         searchParams.append("enablejsapi", "1");
+
+        // start playing the video when the preview image has been hidden
+        if (hasPreviewImage && !showPreviewImage) searchParams.append("autoplay", "1");
 
         if (autoplay) searchParams.append("mute", "1");
 

--- a/packages/site/cms-site/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/site/cms-site/src/blocks/YouTubeVideoBlock.tsx
@@ -109,7 +109,7 @@ export const YouTubeVideoBlock = withPreview(
                     )
                 ) : (
                     <VideoContainer ref={inViewRef} $aspectRatio={aspectRatio.replace("x", "/")} $fill={fill}>
-                        <YouTubeContainer ref={iframeRef} src={youtubeUrl.toString()} />
+                        <YouTubeContainer ref={iframeRef} allow="autoplay" src={youtubeUrl.toString()} />
                     </VideoContainer>
                 )}
             </>

--- a/packages/site/site-nextjs/src/blocks/VimeoVideoBlock.tsx
+++ b/packages/site/site-nextjs/src/blocks/VimeoVideoBlock.tsx
@@ -43,15 +43,13 @@ export const VimeoVideoBlock = withPreview(
         const [showPreviewImage, setShowPreviewImage] = useState(true);
         const hasPreviewImage = !!(previewImage && previewImage.damFile);
         const inViewRef = useRef<HTMLDivElement>(null);
-        const iframeRef = useRef<HTMLIFrameElement | null>(null);
+        const iframeRef = useRef<HTMLIFrameElement>(null);
 
         const handleVisibilityChange = (isVisible: boolean) => {
-            if (iframeRef.current?.contentWindow) {
-                iframeRef.current.contentWindow.postMessage(
-                    JSON.stringify({ method: isVisible && autoplay ? "play" : "pause" }),
-                    "https://player.vimeo.com",
-                );
-            }
+            iframeRef.current?.contentWindow?.postMessage(
+                JSON.stringify({ method: isVisible && autoplay ? "play" : "pause" }),
+                "https://player.vimeo.com",
+            );
         };
 
         useIsElementInViewport(inViewRef, handleVisibilityChange);
@@ -63,6 +61,7 @@ export const VimeoVideoBlock = withPreview(
         const identifier = parseVimeoIdentifier(vimeoIdentifier);
 
         const searchParams = new URLSearchParams();
+        if (hasPreviewImage && !showPreviewImage) searchParams.append("autoplay", "1");
         if (autoplay) searchParams.append("muted", "1");
 
         if (loop !== undefined) searchParams.append("loop", Number(loop).toString());

--- a/packages/site/site-nextjs/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/site/site-nextjs/src/blocks/YouTubeVideoBlock.tsx
@@ -38,19 +38,15 @@ export const YouTubeVideoBlock = withPreview(
     }: YouTubeVideoBlockProps) => {
         const [showPreviewImage, setShowPreviewImage] = useState(true);
         const hasPreviewImage = !!(previewImage && previewImage.damFile);
-        const iframeRef = useRef<HTMLIFrameElement | null>(null);
-        const inViewRef = useRef(null);
+        const iframeRef = useRef<HTMLIFrameElement>(null);
+        const inViewRef = useRef<HTMLDivElement>(null);
 
         const pauseYouTubeVideo = () => {
-            if (iframeRef.current?.contentWindow) {
-                iframeRef.current.contentWindow.postMessage(`{"event":"command","func":"pauseVideo","args":""}`, "https://www.youtube-nocookie.com");
-            }
+            iframeRef.current?.contentWindow?.postMessage(`{"event":"command","func":"pauseVideo","args":""}`, "https://www.youtube-nocookie.com");
         };
 
         const playYouTubeVideo = () => {
-            if (iframeRef.current?.contentWindow) {
-                iframeRef.current.contentWindow.postMessage(`{"event":"command","func":"playVideo","args":""}`, "https://www.youtube-nocookie.com");
-            }
+            iframeRef.current?.contentWindow?.postMessage(`{"event":"command","func":"playVideo","args":""}`, "https://www.youtube-nocookie.com");
         };
 
         useIsElementInViewport(inViewRef, (inView: boolean) => {
@@ -72,6 +68,9 @@ export const YouTubeVideoBlock = withPreview(
         searchParams.append("modestbranding", "1");
         searchParams.append("rel", "0");
         searchParams.append("enablejsapi", "1");
+
+        // start playing the video when the preview image has been hidden
+        if (hasPreviewImage && !showPreviewImage) searchParams.append("autoplay", "1");
 
         if (autoplay) searchParams.append("mute", "1");
 

--- a/packages/site/site-nextjs/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/site/site-nextjs/src/blocks/YouTubeVideoBlock.tsx
@@ -111,7 +111,7 @@ export const YouTubeVideoBlock = withPreview(
                         className={clsx(styles.videoContainer, fill && styles.fill)}
                         style={!fill ? { "--aspect-ratio": aspectRatio.replace("x", "/") } : undefined}
                     >
-                        <iframe ref={iframeRef} className={styles.youtubeContainer} src={youtubeUrl.toString()} />
+                        <iframe ref={iframeRef} className={styles.youtubeContainer} allow="autoplay" src={youtubeUrl.toString()} />
                     </div>
                 )}
             </>

--- a/packages/site/site-react/src/blocks/helpers/useIsElementInViewport.tsx
+++ b/packages/site/site-react/src/blocks/helpers/useIsElementInViewport.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect } from "react";
+import { type RefObject, useEffect } from "react";
 
-export const useIsElementInViewport = (ref: React.RefObject<Element>, callback: (inView: boolean) => void) => {
+export const useIsElementInViewport = (ref: RefObject<Element>, callback: (inView: boolean) => void) => {
     useEffect(() => {
         if (!ref.current) return;
 


### PR DESCRIPTION
## Description

YouTube and Vimeo Video Block: fixed bug where the video does not start after clicking the play button in the preview image.