### PR TITLE
Create user from JWT if possible

### DIFF
--- a/packages/api/cms-api/src/auth/services/jwt.auth-service.ts
+++ b/packages/api/cms-api/src/auth/services/jwt.auth-service.ts
@@ -70,6 +70,10 @@ export function createJwtAuthService({ jwksOptions, verifyOptions, ...options }:
                 return { authenticationError: "No sub found in JWT. Please implement `convertJwtToUser`" };
             }
 
+            if (typeof jwt.name === "string" && typeof jwt.email === "string") {
+                return { user: { id: jwt.sub, name: jwt.name, email: jwt.email } };
+            }
+
             return { userId: jwt.sub };
         }
 


### PR DESCRIPTION
## Description

This re-adds the behavior from Comet v7 where we create the user from the JWT if possible. If convertJwtToUser is not given (which ist the default) it only invokes loading the user from the UserService if the user cannot be loaded from the JWT.

## Acceptance criteria

-   No changeset needed as the PR establishes the same behaviour like in Comet 7.
