### PR TITLE
Fix search operator in GraphQL filters

### DIFF
--- a/packages/api/cms-api/src/common/filter/mikro-orm.ts
+++ b/packages/api/cms-api/src/common/filter/mikro-orm.ts
@@ -159,7 +159,7 @@ export function filterToMikroOrmQuery(
             if (!prop.targetMeta) {
                 throw new Error("targetMeta is not defined");
             }
-            ret.$and = searchToMikroOrmQuery(filterProperty.search, prop.targetMeta).$and;
+            ret.$and = searchToMikroOrmQuery(filterProperty.search, prop.targetMeta).$and?.map((item) => ({ [propertyName]: item }));
         }
         if (filterProperty.isAnyOf !== undefined) {
             ret.$in = filterProperty.isAnyOf;
@@ -183,7 +183,7 @@ export function filterToMikroOrmQuery(
             if (!prop.targetMeta) {
                 throw new Error("targetMeta is not defined");
             }
-            ret.$and = searchToMikroOrmQuery(filterProperty.search, prop.targetMeta).$and;
+            ret.$and = searchToMikroOrmQuery(filterProperty.search, prop.targetMeta).$and?.map((item) => ({ [propertyName]: item }));
         }
         if (filterProperty.isAnyOf !== undefined) {
             ret.$in = filterProperty.isAnyOf;


### PR DESCRIPTION
## Description

The change to `$and`/`$or` handling in https://github.com/vivid-planet/comet/pull/4021 broke searching for strings in one-to-many and many-to-many relations: instead of applying the condition to the relation's field (e.g., `product.tags.title`) it applied it directly to the entity, resulting in searching the wrong field (e.g., `product.title`).

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2157
