### PR TITLE
Fix MediaAlternatives EditDialog

### DIFF
--- a/packages/admin/cms-admin/src/dam/mediaAlternatives/MediaAlternativesGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/mediaAlternatives/MediaAlternativesGrid.tsx
@@ -17,7 +17,7 @@ import {
 } from "@comet/admin";
 import { DeleteDialog } from "@comet/admin/lib/common/DeleteDialog";
 import { Add as AddIcon, Delete as DeleteIcon, Edit as EditIcon } from "@comet/admin-icons";
-import { IconButton } from "@mui/material";
+import { DialogContent, IconButton } from "@mui/material";
 import { DataGrid, type GridSlotsComponent, GridToolbarQuickFilter } from "@mui/x-data-grid";
 import type { GridToolbarProps } from "@mui/x-data-grid/components/toolbar/GridToolbar";
 import { type ReactElement, useState } from "react";
@@ -205,14 +205,16 @@ export function MediaAlternativesGrid({ file, type, direction }: MediaAlternativ
             />
             <EditDialog>
                 {selection.id && selection.mode ? (
-                    <MediaAlternativeForm
-                        mode={selection.mode}
-                        id={selection.mode === "edit" ? selection.id : undefined}
-                        fileId={file.id}
-                        selectionApi={selectionApi}
-                        type={type}
-                        direction={direction}
-                    />
+                    <DialogContent>
+                        <MediaAlternativeForm
+                            mode={selection.mode}
+                            id={selection.mode === "edit" ? selection.id : undefined}
+                            fileId={file.id}
+                            selectionApi={selectionApi}
+                            type={type}
+                            direction={direction}
+                        />
+                    </DialogContent>
                 ) : null}
             </EditDialog>
             <DeleteDialog


### PR DESCRIPTION
## Description

This was developed in main where <DialogContent> wasn't necessary

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset) -> not necessary, unreleased in v8
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="704" alt="Bildschirmfoto 2025-07-10 um 07 45 26" src="https://github.com/user-attachments/assets/ebca0c88-ee91-4059-81a9-4e76d99b3304" />   | <img width="709" alt="Bildschirmfoto 2025-07-10 um 07 44 50" src="https://github.com/user-attachments/assets/2429ad4d-9b66-4737-be86-cb1e26380b2b" />  |

