### PR TITLE
Admin Generator: add support for one-to-many columns

### DIFF
--- a/.changeset/modern-pans-retire.md
+++ b/.changeset/modern-pans-retire.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": minor
+---
+
+Add new `dataGridOneToManyColumn` column definition
+
+The column definition sets `filterOperators` to match the `OneToManyFilter` GraphQL input type.

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -6,6 +6,7 @@ import {
     CrudVisibility,
     dataGridDateColumn,
     dataGridManyToManyColumn,
+    dataGridOneToManyColumn,
     DataGridToolbar,
     type ExportApi,
     FillSpace,
@@ -234,6 +235,15 @@ export function ProductsGrid() {
             disableExport: true,
         },
         {
+            ...dataGridOneToManyColumn,
+            field: "variants",
+            headerName: "Variants",
+            flex: 1,
+            minWidth: 150,
+            renderCell: (params) => <>{params.row.variants.map((variant) => variant.name).join(", ")}</>,
+            disableExport: true,
+        },
+        {
             field: "inStock",
             headerName: intl.formatMessage({ id: "product.inStock", defaultMessage: "In Stock" }),
             type: "boolean",
@@ -392,6 +402,7 @@ const productsFragment = gql`
         }
         variants {
             id
+            name
         }
         manufacturer {
             name

--- a/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
@@ -134,6 +134,12 @@ export default defineConfig<GQLProduct>({
             labelField: "title",
         },
         {
+            type: "oneToMany",
+            name: "variants",
+            headerName: "Variants",
+            labelField: "name",
+        },
+        {
             type: "actions",
             component: ProductsGridPreviewAction,
         },

--- a/demo/admin/src/products/generator/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/generator/generated/ProductsGrid.tsx
@@ -18,6 +18,7 @@ import { GridColDef } from "@comet/admin";
 import { dataGridDateTimeColumn } from "@comet/admin";
 import { dataGridDateColumn } from "@comet/admin";
 import { dataGridManyToManyColumn } from "@comet/admin";
+import { dataGridOneToManyColumn } from "@comet/admin";
 import { renderStaticSelectCell } from "@comet/admin";
 import { messages } from "@comet/admin";
 import { muiGridFilterToGql } from "@comet/admin";
@@ -46,7 +47,7 @@ import { Education as EducationIcon } from "@comet/admin-icons";
 const productsFragment = gql`
         fragment ProductsGridFuture on Product {
             id
-            category { title } title description price inStock type availableSince createdAt manufacturer { name } tags { title }
+            category { title } title description price inStock type availableSince createdAt manufacturer { name } tags { title } variants { name }
         }
     `;
 const productsQuery = gql`
@@ -202,6 +203,12 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
             headerName: intl.formatMessage({ id: "product.tags", defaultMessage: "Tags" }),
             sortable: false,
             renderCell: ({ row }) => <>{row.tags.map((tag) => tag.title).join(", ")}</>,
+            flex: 1,
+            minWidth: 150, },
+        { ...dataGridOneToManyColumn, field: "variants",
+            headerName: intl.formatMessage({ id: "product.variants", defaultMessage: "Variants" }),
+            sortable: false,
+            renderCell: ({ row }) => <>{row.variants.map((variant) => variant.name).join(", ")}</>,
             flex: 1,
             minWidth: 150, },
         { field: "actions",

--- a/packages/admin/admin-generator/src/commands/generate/generate-command.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generate-command.ts
@@ -156,6 +156,15 @@ export type GridColumnConfig<T extends GridValidRowModel> = (
            */
           labelField?: string;
       }
+    | {
+          type: "oneToMany";
+          renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element;
+          queryFields?: UsableFields<T, true>[];
+          /**
+           * The field to use as label for the default renderCell implementation.
+           */
+          labelField?: string;
+      }
 ) & { name: UsableFields<T>; filterOperators?: GridFilterOperator[] } & BaseColumnConfig;
 
 export type ActionsGridColumnConfig = { type: "actions"; component?: ComponentType<GridCellParams> } & BaseColumnConfig;

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
@@ -185,6 +185,7 @@ export function generateGrid(
         { name: "dataGridDateColumn", importPath: "@comet/admin" },
         { name: "dataGridIdColumn", importPath: "@comet/admin" },
         { name: "dataGridManyToManyColumn", importPath: "@comet/admin" },
+        { name: "dataGridOneToManyColumn", importPath: "@comet/admin" },
         { name: "renderStaticSelectCell", importPath: "@comet/admin" },
         { name: "messages", importPath: "@comet/admin" },
         { name: "muiGridFilterToGql", importPath: "@comet/admin" },
@@ -515,6 +516,8 @@ export function generateGrid(
             gridColumnType = "...dataGridIdColumn,";
         } else if (type == "manyToMany") {
             gridColumnType = "...dataGridManyToManyColumn,";
+        } else if (type == "oneToMany") {
+            gridColumnType = "...dataGridOneToManyColumn,";
         }
 
         if (
@@ -525,7 +528,8 @@ export function generateGrid(
                 column.type == "dateTime" ||
                 column.type == "virtual" ||
                 column.type == "id" ||
-                column.type == "manyToMany") &&
+                column.type == "manyToMany" ||
+                column.type == "oneToMany") &&
             column.renderCell
         ) {
             if (isGeneratorConfigCode(column.renderCell)) {
@@ -536,9 +540,9 @@ export function generateGrid(
             }
         }
 
-        if (column.type === "manyToMany" && !column.renderCell) {
+        if ((column.type === "manyToMany" || column.type === "oneToMany") && !column.renderCell) {
             if (!column.labelField) {
-                throw new Error(`labelField is required for manyToMany column '${name}' if no custom renderCell is provided`);
+                throw new Error(`labelField is required for ${column.type} column '${name}' if no custom renderCell is provided`);
             }
 
             renderCell = `({ row }) => <>{row.${column.name}.map((${singular(column.name)}) => ${singular(column.name)}.${column.labelField}).join(", ")}</>`;

--- a/packages/admin/admin/src/dataGrid/gridColumnTypes.tsx
+++ b/packages/admin/admin/src/dataGrid/gridColumnTypes.tsx
@@ -142,3 +142,19 @@ export const dataGridManyToManyColumn: GridColTypeDef = {
         },
     ],
 };
+
+/*
+ * Data Grid column definition for one-to-many columns.
+ * Sets `filterOperators` to match the `OneToManyFilter` GraphQL input type.
+ */
+export const dataGridOneToManyColumn: GridColTypeDef = {
+    filterOperators: [
+        {
+            value: "search",
+            getApplyFilterFn: () => {
+                throw new Error("not implemented, we filter server side");
+            },
+            InputComponent: GridFilterInputValue,
+        },
+    ],
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -69,7 +69,13 @@ export { ExportApi, useDataGridExcelExport } from "./dataGrid/excelExport/useDat
 export { GridCellContent, GridCellContentClassKey, GridCellContentProps } from "./dataGrid/GridCellContent";
 export { GridActionsColDef, GridBaseColDef, GridColDef, GridSingleSelectColDef } from "./dataGrid/GridColDef";
 export { GridColumnsButton } from "./dataGrid/GridColumnsButton";
-export { dataGridDateColumn, dataGridDateTimeColumn, dataGridIdColumn, dataGridManyToManyColumn } from "./dataGrid/gridColumnTypes";
+export {
+    dataGridDateColumn,
+    dataGridDateTimeColumn,
+    dataGridIdColumn,
+    dataGridManyToManyColumn,
+    dataGridOneToManyColumn,
+} from "./dataGrid/gridColumnTypes";
 export { GridFilterButton } from "./dataGrid/GridFilterButton";
 export { muiGridFilterToGql } from "./dataGrid/muiGridFilterToGql";
 export { muiGridPagingToGql } from "./dataGrid/muiGridPagingToGql";


### PR DESCRIPTION
## Description

Add new `dataGridOneToManyColumn` column definition in `@comet/admin` and use it for the new `oneToMany` column type in the generator.

## Open TODOs/questions

-   [x] Merge parent PR https://github.com/vivid-planet/comet/pull/4127
- [x] How to translate the label

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2157
