### PR TITLE
API Generator: Add `input` option to `@CrudGenerator` decorator

### DIFF
--- a/.changeset/strong-badgers-tap.md
+++ b/.changeset/strong-badgers-tap.md
@@ -1,0 +1,8 @@
+---
+"@comet/api-generator": minor
+---
+
+Add `input` option to `@CrudGenerator` decorator
+
+The `input` option generates the InputType even if `create` and `update` are false.
+It's `false` per default.

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud.spec.ts
@@ -172,4 +172,80 @@ describe("GenerateCrud", () => {
             orm.close();
         });
     });
+
+    describe("input option", () => {
+        it("input should be generated if create is true", async () => {
+            LazyMetadataStorage.load();
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    connect: false,
+                    entities: [TestEntityWithTextRuntimeType],
+                }),
+            );
+
+            const out = await generateCrud({ targetDirectory: __dirname, create: true }, orm.em.getMetadata().get("TestEntityWithTextRuntimeType"));
+
+            expect(out.some((obj) => obj.type === "input")).toBeTruthy();
+
+            orm.close();
+        });
+
+        it("input should be generated if update is true", async () => {
+            LazyMetadataStorage.load();
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    connect: false,
+                    entities: [TestEntityWithTextRuntimeType],
+                }),
+            );
+
+            const out = await generateCrud({ targetDirectory: __dirname, update: true }, orm.em.getMetadata().get("TestEntityWithTextRuntimeType"));
+
+            expect(out.some((obj) => obj.type === "input")).toBeTruthy();
+
+            orm.close();
+        });
+
+        it("input should not be generated if update is false and create is false", async () => {
+            LazyMetadataStorage.load();
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    connect: false,
+                    entities: [TestEntityWithTextRuntimeType],
+                }),
+            );
+
+            const out = await generateCrud(
+                { targetDirectory: __dirname, create: false, update: false },
+                orm.em.getMetadata().get("TestEntityWithTextRuntimeType"),
+            );
+
+            expect(out.some((obj) => obj.type === "input")).toBeFalsy();
+
+            orm.close();
+        });
+
+        it("input should be generated if update is false, create is false and input is true", async () => {
+            LazyMetadataStorage.load();
+            const orm = await MikroORM.init(
+                defineConfig({
+                    dbName: "test-db",
+                    connect: false,
+                    entities: [TestEntityWithTextRuntimeType],
+                }),
+            );
+
+            const out = await generateCrud(
+                { targetDirectory: __dirname, create: false, update: false, input: true },
+                orm.em.getMetadata().get("TestEntityWithTextRuntimeType"),
+            );
+
+            expect(out.some((obj) => obj.type === "input")).toBeTruthy();
+
+            orm.close();
+        });
+    });
 });

--- a/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
@@ -1249,6 +1249,7 @@ export async function generateCrud(generatorOptionsParam: CrudGeneratorOptions, 
         delete: generatorOptionsParam.delete ?? true,
         list: generatorOptionsParam.list ?? true,
         single: generatorOptionsParam.single ?? true,
+        input: generatorOptionsParam.input ?? false,
     };
     if (!generatorOptions.create && !generatorOptions.update && !generatorOptions.delete && !generatorOptions.list && !generatorOptions.single) {
         throw new Error("At least one of create, update, delete, list or single must be true");
@@ -1330,5 +1331,5 @@ export async function generateCrud(generatorOptionsParam: CrudGeneratorOptions, 
     const crudInput = await generateCrudInput(generatorOptions, metadata);
     const crudResolver = await generateCrudResolver();
 
-    return generatorOptions.create || generatorOptions.update ? [...crudInput, ...crudResolver] : [...crudResolver];
+    return generatorOptions.create || generatorOptions.update || generatorOptions.input ? [...crudInput, ...crudResolver] : [...crudResolver];
 }

--- a/packages/api/cms-api/src/common/decorators/crud-generator.decorator.ts
+++ b/packages/api/cms-api/src/common/decorators/crud-generator.decorator.ts
@@ -3,6 +3,7 @@ export interface CrudGeneratorOptions {
     requiredPermission?: string[] | string;
     create?: boolean;
     update?: boolean;
+    input?: boolean;
     delete?: boolean;
     list?: boolean;
     single?: boolean;
@@ -14,6 +15,7 @@ export function CrudGenerator({
     requiredPermission,
     create = true,
     update = true,
+    input = false,
     delete: deleteMutation = true,
     list = true,
     single = true,
@@ -23,7 +25,7 @@ export function CrudGenerator({
     return function (target: Function) {
         Reflect.defineMetadata(
             `data:crudGeneratorOptions`,
-            { targetDirectory, requiredPermission, create, update, delete: deleteMutation, list, single, position },
+            { targetDirectory, requiredPermission, create, update, input, delete: deleteMutation, list, single, position },
             target,
         );
     };


### PR DESCRIPTION
## Description

- add input option to `@CrudGenerator` decorator
- add test cases

## Motivation
- Allow generating GraphQL input even when `create`/`update` are disabled

## Alternatives
- Keep current behavior -> missing types
- Always generate GraphQL input -> see https://github.com/vivid-planet/comet/pull/4167

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)