### PR TITLE
Remove copy/paste feature in handmade product tags grid

### DIFF
--- a/demo/admin/src/products/tags/ProductTagsGrid.tsx
+++ b/demo/admin/src/products/tags/ProductTagsGrid.tsx
@@ -4,7 +4,6 @@ import {
     CrudContextMenu,
     DataGridToolbar,
     FillSpace,
-    filterByFragment,
     type GridColDef,
     GridFilterButton,
     muiGridFilterToGql,
@@ -20,8 +19,6 @@ import { DataGridPro, type GridSlotsComponent, GridToolbarQuickFilter } from "@m
 import { FormattedMessage, useIntl } from "react-intl";
 
 import {
-    type GQLCreateProductTagMutation,
-    type GQLCreateProductTagMutationVariables,
     type GQLDeleteProductTagMutation,
     type GQLDeleteProductTagMutationVariables,
     type GQLProductTagsGridFragment,
@@ -51,13 +48,7 @@ const deleteProductTagMutation = gql`
         deleteProductTag(id: $id)
     }
 `;
-const createProductTagMutation = gql`
-    mutation CreateProductTag($input: ProductTagInput!) {
-        createProductTag(input: $input) {
-            id
-        }
-    }
-`;
+
 function ProductTagsGridToolbar() {
     return (
         <DataGridToolbar>
@@ -97,17 +88,6 @@ export function ProductTagsGrid() {
                             <EditIcon />
                         </IconButton>
                         <CrudContextMenu
-                            copyData={() => {
-                                // Don't copy id, because we want to create a new entity with this data
-                                const { id, ...filteredData } = filterByFragment(productTagsFragment, params.row);
-                                return filteredData;
-                            }}
-                            onPaste={async ({ input }) => {
-                                await client.mutate<GQLCreateProductTagMutation, GQLCreateProductTagMutationVariables>({
-                                    mutation: createProductTagMutation,
-                                    variables: { input },
-                                });
-                            }}
                             onDelete={async () => {
                                 await client.mutate<GQLDeleteProductTagMutation, GQLDeleteProductTagMutationVariables>({
                                     mutation: deleteProductTagMutation,


### PR DESCRIPTION
## Description

This Pull Request removes copy/paste feature from Products Tag DataGrid.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  ![Screen Recording 2025-07-10 at 13 16 59](https://github.com/user-attachments/assets/1c8995b7-3318-44d0-8ef4-5067e711a351)  | ![Screen Recording 2025-07-10 at 13 18 09](https://github.com/user-attachments/assets/6aff001e-38ef-465f-b02e-3bafe54e80b3)  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2125
