### PR TITLE
Redirect to the most recently visited content scope when returning to the application

### DIFF
--- a/.changeset/open-falcons-smash.md
+++ b/.changeset/open-falcons-smash.md
@@ -1,5 +1,5 @@
 ---
-"@comet/cms-admin": patch
+"@comet/cms-admin": minor
 ---
 
-Save selected `ContentScope` to local storage to redirect the user to the most recently visited scope, if no scope is provided in the domain
+Redirect to the most recently visited content scope when returning to the application

--- a/.changeset/open-falcons-smash.md
+++ b/.changeset/open-falcons-smash.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Save selected `ContentScope` to local storage to redirect the user to the most recently visited scope, if no scope is provided in the domain

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
@@ -37,7 +37,7 @@ interface Props {
     renderSelectedOption?: (option: Option) => ReactNode;
 }
 
-const localStorageKey = "contentScopeSelect.selectedScope";
+export const contentScopeLocalStorageKey = "contentScopeSelect.selectedScope";
 
 export function ContentScopeSelect({
     value,
@@ -131,7 +131,7 @@ export function ContentScopeSelect({
     }
 
     const handleChange = (selectedScope: ContentScope) => {
-        localStorage.setItem(localStorageKey, JSON.stringify(selectedScope));
+        localStorage.setItem(contentScopeLocalStorageKey, JSON.stringify(selectedScope));
         onChange(selectedScope);
     };
 

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
@@ -1,4 +1,4 @@
-import { AppHeaderDropdown, ClearInputAdornment } from "@comet/admin";
+import { AppHeaderDropdown, ClearInputAdornment, useStoredState } from "@comet/admin";
 import { Domain, Language, Search } from "@comet/admin-icons";
 import {
     Box,
@@ -37,8 +37,10 @@ interface Props {
     renderSelectedOption?: (option: Option) => ReactNode;
 }
 
+const localStorageKey = "contentScopeSelect.selectedScope";
+
 export function ContentScopeSelect({
-    value,
+    value: propValue,
     onChange,
     options,
     searchable,
@@ -52,6 +54,8 @@ export function ContentScopeSelect({
     const theme = useTheme();
 
     const hasMultipleDimensions = options.some((option) => Object.keys(option.scope).length > 1);
+    const [storedScope, setStoredScope] = useStoredState<ContentScope | undefined>(localStorageKey, undefined);
+    const value = storedScope ? storedScope : propValue;
 
     let filteredOptions = options;
 
@@ -127,6 +131,11 @@ export function ContentScopeSelect({
                 .join(" / ");
         };
     }
+
+    const handleChange = (selectedScope: ContentScope) => {
+        setStoredScope(selectedScope);
+        onChange(selectedScope);
+    };
 
     return (
         <AppHeaderDropdown
@@ -273,7 +282,7 @@ export function ContentScopeSelect({
                                                 key={JSON.stringify(option)}
                                                 onClick={() => {
                                                     hideDropdown();
-                                                    onChange(option.scope);
+                                                    handleChange(option.scope);
                                                     setSearchValue("");
                                                 }}
                                                 selected={isSelected}

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
@@ -1,4 +1,4 @@
-import { AppHeaderDropdown, ClearInputAdornment, useStoredState } from "@comet/admin";
+import { AppHeaderDropdown, ClearInputAdornment } from "@comet/admin";
 import { Domain, Language, Search } from "@comet/admin-icons";
 import {
     Box,
@@ -40,7 +40,7 @@ interface Props {
 const localStorageKey = "contentScopeSelect.selectedScope";
 
 export function ContentScopeSelect({
-    value: propValue,
+    value,
     onChange,
     options,
     searchable,
@@ -54,8 +54,6 @@ export function ContentScopeSelect({
     const theme = useTheme();
 
     const hasMultipleDimensions = options.some((option) => Object.keys(option.scope).length > 1);
-    const [storedScope, setStoredScope] = useStoredState<ContentScope | undefined>(localStorageKey, undefined);
-    const value = storedScope ? storedScope : propValue;
 
     let filteredOptions = options;
 
@@ -133,7 +131,7 @@ export function ContentScopeSelect({
     }
 
     const handleChange = (selectedScope: ContentScope) => {
-        setStoredScope(selectedScope);
+        localStorage.setItem(localStorageKey, JSON.stringify(selectedScope));
         onChange(selectedScope);
     };
 

--- a/packages/admin/cms-admin/src/contentScope/Provider.tsx
+++ b/packages/admin/cms-admin/src/contentScope/Provider.tsx
@@ -3,6 +3,7 @@ import { type match, Redirect, Route, Switch, useHistory, useRouteMatch } from "
 
 import { useCurrentUser } from "../userPermissions/hooks/currentUser";
 import { StopImpersonationButton } from "../userPermissions/user/ImpersonationButtons";
+import { contentScopeLocalStorageKey } from "./ContentScopeSelect";
 import { defaultCreatePath } from "./utils/defaultCreatePath";
 
 export interface ContentScope {
@@ -150,7 +151,7 @@ export function ContentScopeProvider({ children, defaultValue, values, location 
 
     let defaultUrl = location.createUrl(defaultValue);
 
-    const storedScope = localStorage.getItem("contentScopeSelect.selectedScope");
+    const storedScope = localStorage.getItem(contentScopeLocalStorageKey);
 
     if (storedScope && storedScope !== "undefined") {
         defaultUrl = location.createUrl(JSON.parse(storedScope));

--- a/packages/admin/cms-admin/src/contentScope/Provider.tsx
+++ b/packages/admin/cms-admin/src/contentScope/Provider.tsx
@@ -148,7 +148,13 @@ export function ContentScopeProvider({ children, defaultValue, values, location 
         );
     }
 
-    const defaultUrl = location.createUrl(defaultValue);
+    let defaultUrl = location.createUrl(defaultValue);
+
+    const storedScope = localStorage.getItem("contentScopeSelect.selectedScope");
+
+    if (storedScope && storedScope !== "undefined") {
+        defaultUrl = location.createUrl(JSON.parse(storedScope));
+    }
 
     return (
         <Context.Provider

--- a/packages/admin/cms-admin/src/contentScope/Provider.tsx
+++ b/packages/admin/cms-admin/src/contentScope/Provider.tsx
@@ -149,12 +149,14 @@ export function ContentScopeProvider({ children, defaultValue, values, location 
         );
     }
 
-    let defaultUrl = location.createUrl(defaultValue);
-
     const storedScope = localStorage.getItem(contentScopeLocalStorageKey);
+
+    let defaultUrl: string;
 
     if (storedScope && storedScope !== "undefined") {
         defaultUrl = location.createUrl(JSON.parse(storedScope));
+    } else {
+        defaultUrl = location.createUrl(defaultValue);
     }
 
     return (


### PR DESCRIPTION
## Description

Save latest selected `ContentScope` to local storage, so that the most recent visited scope is opened, if the user comes back. If a scope is provided in the domain, the scope from locale storage is not used. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

No locale storage / no provided scope in domain:
![no-locale-storage](https://github.com/user-attachments/assets/0e743bc0-4ffc-48de-bcd1-3dc25634b565)

Local storage (Secondary DE) / no provided scope in domain:
![localestorage](https://github.com/user-attachments/assets/ac03c1b0-9d1b-4c6b-af64-845523cc13a4)


Local storage (Secondary DE) / Scope in domain (Main EN):
![scope-in-domain](https://github.com/user-attachments/assets/bfc696c3-3390-441a-8f53-5d90629724a7)



## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1865
