### PR TITLE
API Generator: Always generate GraphQL input

### DIFF
--- a/.changeset/forty-grapes-poke.md
+++ b/.changeset/forty-grapes-poke.md
@@ -1,0 +1,5 @@
+---
+"@comet/api-generator": minor
+---
+
+Always generate CrudInput

--- a/.changeset/forty-grapes-poke.md
+++ b/.changeset/forty-grapes-poke.md
@@ -2,4 +2,7 @@
 "@comet/api-generator": minor
 ---
 
-Always generate CrudInput
+Always generate GraphQL input
+
+Generate the input even if `create` and `update` are both set to `false`.
+The input is still useful for other operations, e.g., a custom create mutation.

--- a/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
@@ -1249,6 +1249,7 @@ export async function generateCrud(generatorOptionsParam: CrudGeneratorOptions, 
         delete: generatorOptionsParam.delete ?? true,
         list: generatorOptionsParam.list ?? true,
         single: generatorOptionsParam.single ?? true,
+        input: generatorOptionsParam.input ?? false,
     };
     if (!generatorOptions.create && !generatorOptions.update && !generatorOptions.delete && !generatorOptions.list && !generatorOptions.single) {
         throw new Error("At least one of create, update, delete, list or single must be true");
@@ -1330,5 +1331,5 @@ export async function generateCrud(generatorOptionsParam: CrudGeneratorOptions, 
     const crudInput = await generateCrudInput(generatorOptions, metadata);
     const crudResolver = await generateCrudResolver();
 
-    return generatorOptions.create || generatorOptions.update ? [...crudInput, ...crudResolver] : [...crudResolver];
+    return generatorOptions.create || generatorOptions.update || generatorOptions.input ? [...crudInput, ...crudResolver] : [...crudResolver];
 }

--- a/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
@@ -1249,7 +1249,6 @@ export async function generateCrud(generatorOptionsParam: CrudGeneratorOptions, 
         delete: generatorOptionsParam.delete ?? true,
         list: generatorOptionsParam.list ?? true,
         single: generatorOptionsParam.single ?? true,
-        input: generatorOptionsParam.input ?? false,
     };
     if (!generatorOptions.create && !generatorOptions.update && !generatorOptions.delete && !generatorOptions.list && !generatorOptions.single) {
         throw new Error("At least one of create, update, delete, list or single must be true");
@@ -1331,5 +1330,5 @@ export async function generateCrud(generatorOptionsParam: CrudGeneratorOptions, 
     const crudInput = await generateCrudInput(generatorOptions, metadata);
     const crudResolver = await generateCrudResolver();
 
-    return generatorOptions.create || generatorOptions.update || generatorOptions.input ? [...crudInput, ...crudResolver] : [...crudResolver];
+    return [...crudInput, ...crudResolver];
 }

--- a/packages/api/cms-api/src/common/decorators/crud-generator.decorator.ts
+++ b/packages/api/cms-api/src/common/decorators/crud-generator.decorator.ts
@@ -3,7 +3,6 @@ export interface CrudGeneratorOptions {
     requiredPermission?: string[] | string;
     create?: boolean;
     update?: boolean;
-    input?: boolean;
     delete?: boolean;
     list?: boolean;
     single?: boolean;
@@ -15,7 +14,6 @@ export function CrudGenerator({
     requiredPermission,
     create = true,
     update = true,
-    input = false,
     delete: deleteMutation = true,
     list = true,
     single = true,
@@ -25,7 +23,7 @@ export function CrudGenerator({
     return function (target: Function) {
         Reflect.defineMetadata(
             `data:crudGeneratorOptions`,
-            { targetDirectory, requiredPermission, create, update, input, delete: deleteMutation, list, single, position },
+            { targetDirectory, requiredPermission, create, update, delete: deleteMutation, list, single, position },
             target,
         );
     };

--- a/packages/api/cms-api/src/common/decorators/crud-generator.decorator.ts
+++ b/packages/api/cms-api/src/common/decorators/crud-generator.decorator.ts
@@ -3,6 +3,7 @@ export interface CrudGeneratorOptions {
     requiredPermission?: string[] | string;
     create?: boolean;
     update?: boolean;
+    input?: boolean;
     delete?: boolean;
     list?: boolean;
     single?: boolean;
@@ -14,6 +15,7 @@ export function CrudGenerator({
     requiredPermission,
     create = true,
     update = true,
+    input = false,
     delete: deleteMutation = true,
     list = true,
     single = true,
@@ -23,7 +25,7 @@ export function CrudGenerator({
     return function (target: Function) {
         Reflect.defineMetadata(
             `data:crudGeneratorOptions`,
-            { targetDirectory, requiredPermission, create, update, delete: deleteMutation, list, single, position },
+            { targetDirectory, requiredPermission, create, update, input, delete: deleteMutation, list, single, position },
             target,
         );
     };


### PR DESCRIPTION
## Description
- Always generate GraphQL input, even if `create`/`update` are false

## Motivation
- Avoid missing types when `CrudInput` is used outside of `create`/`update`
- Simplifies usage

## Alternatives
- Keep current behavior -> missing types
- Add `input` option -> see https://github.com/vivid-planet/comet/pull/4145#pullrequestreview-3016161090

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)