### PR TITLE
Fix regression error introduced by splitting cms-site

### DIFF
--- a/packages/site/site-nextjs/src/sitePreview/SitePreviewUtils.ts
+++ b/packages/site/site-nextjs/src/sitePreview/SitePreviewUtils.ts
@@ -5,6 +5,7 @@ import { errors, jwtVerify } from "jose";
 type Scope = Record<string, any>;
 
 export type SitePreviewParams = {
+    userId: string;
     scope: Scope;
     path: string;
     previewData?: PreviewData;

--- a/packages/site/site-nextjs/src/sitePreview/appRouter/sitePreviewRoute.ts
+++ b/packages/site/site-nextjs/src/sitePreview/appRouter/sitePreviewRoute.ts
@@ -20,6 +20,7 @@ export async function sitePreviewRoute(request: NextRequest) {
     }
 
     const cookieJwt = await new SignJWT({
+        userId: data.userId,
         scope: data.scope,
         path: data.path,
         previewData: data.previewData,

--- a/packages/site/site-react/src/graphQLFetch/graphQLFetch.ts
+++ b/packages/site/site-react/src/graphQLFetch/graphQLFetch.ts
@@ -22,6 +22,7 @@ export function convertPreviewDataToHeaders(previewData?: PreviewData) {
     // authentication is required when this header is used
     if (includeInvisibleContentHeaderEntries.length > 0) {
         headers["x-include-invisible-content"] = includeInvisibleContentHeaderEntries.join(",");
+        headers["x-preview-dam-urls"] = "1";
     }
     return headers;
 }


### PR DESCRIPTION
The changes from cms-site in https://github.com/vivid-planet/comet/pull/3521 have not been incorporated into https://github.com/vivid-planet/comet/pull/3888