### PR TITLE
API Generator: fix nullable input for many-to-many relations

### DIFF
--- a/.changeset/weak-weeks-occur.md
+++ b/.changeset/weak-weeks-occur.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+API Generator: fix nullable input for many-to-many relations

--- a/packages/api/cms-api/src/generator/generate-crud-input.ts
+++ b/packages/api/cms-api/src/generator/generate-crud-input.ts
@@ -268,7 +268,7 @@ export async function generateCrudInput(
             }
         } else if (prop.reference == "m:n") {
             decorators.length = 0;
-            decorators.push(`@Field(() => [ID], {${prop.nullable ? "nullable" : "defaultValue: []"}})`);
+            decorators.push(`@Field(() => [ID], {${prop.nullable ? "nullable: true" : "defaultValue: []"}})`);
             decorators.push(`@IsArray()`);
 
             if (prop.referencedColumnNames.length > 1) {


### PR DESCRIPTION
## Description

The initializer for `nullable` wasn't generated.