### PR TITLE
Demo: fix fixtures

### DIFF
--- a/demo/api/src/db/fixtures/fixtures.console.ts
+++ b/demo/api/src/db/fixtures/fixtures.console.ts
@@ -1,4 +1,11 @@
-import { BlobStorageBackendService, DependenciesService, PageTreeNodeInterface, PageTreeNodeVisibility, PageTreeService } from "@comet/cms-api";
+import {
+    BlobStorageBackendService,
+    DependenciesService,
+    PageTreeNodeBaseCreateInput,
+    PageTreeNodeInterface,
+    PageTreeNodeVisibility,
+    PageTreeService,
+} from "@comet/cms-api";
 import { CreateRequestContext, MikroORM } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
@@ -148,9 +155,8 @@ export class FixturesConsole {
                             slug: slugify(name),
                             parentId: level > 0 ? faker.random.arrayElement(pages[level - 1]).id : undefined,
                             attachedDocument: { type: "Page" },
-                            // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                             userGroup: UserGroup.all,
-                        },
+                        } as PageTreeNodeBaseCreateInput, // Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                         PageTreeNodeCategory.mainNavigation,
                         {
                             domain,

--- a/demo/api/src/db/fixtures/fixtures.console.ts
+++ b/demo/api/src/db/fixtures/fixtures.console.ts
@@ -149,7 +149,7 @@ export class FixturesConsole {
                             parentId: level > 0 ? faker.random.arrayElement(pages[level - 1]).id : undefined,
                             attachedDocument: { type: "Page" },
                             // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
-                            userGroup: UserGroup.All,
+                            userGroup: UserGroup.all,
                         },
                         PageTreeNodeCategory.mainNavigation,
                         {

--- a/demo/api/src/db/fixtures/generators/document-generator.service.ts
+++ b/demo/api/src/db/fixtures/generators/document-generator.service.ts
@@ -1,4 +1,4 @@
-import { PageTreeNodeInterface, PageTreeNodeVisibility, PageTreeService } from "@comet/cms-api";
+import { PageTreeNodeBaseCreateInput, PageTreeNodeInterface, PageTreeNodeVisibility, PageTreeService } from "@comet/cms-api";
 import { faker } from "@faker-js/faker";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
@@ -54,9 +54,8 @@ export class DocumentGeneratorService {
                     type: "Page",
                 },
                 parentId,
-                // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                 userGroup: UserGroup.all,
-            },
+            } as PageTreeNodeBaseCreateInput, // Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
             category,
             scope,
         );

--- a/demo/api/src/db/fixtures/generators/document-generator.service.ts
+++ b/demo/api/src/db/fixtures/generators/document-generator.service.ts
@@ -55,7 +55,7 @@ export class DocumentGeneratorService {
                 },
                 parentId,
                 // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
-                userGroup: UserGroup.All,
+                userGroup: UserGroup.all,
             },
             category,
             scope,

--- a/demo/api/src/db/fixtures/generators/many-images-test-page-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/many-images-test-page-fixture.service.ts
@@ -1,4 +1,4 @@
-import { PageTreeNodeVisibility, PageTreeService } from "@comet/cms-api";
+import { PageTreeNodeBaseCreateInput, PageTreeNodeVisibility, PageTreeService } from "@comet/cms-api";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
@@ -47,9 +47,8 @@ export class ManyImagesTestPageFixtureService {
                     id: uuidDocument,
                     type: "Page",
                 },
-                // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
                 userGroup: UserGroup.all,
-            },
+            } as PageTreeNodeBaseCreateInput, // Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
             PageTreeNodeCategory.mainNavigation,
             scope,
         );

--- a/demo/api/src/db/fixtures/generators/many-images-test-page-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/many-images-test-page-fixture.service.ts
@@ -48,7 +48,7 @@ export class ManyImagesTestPageFixtureService {
                     type: "Page",
                 },
                 // @ts-expect-error Typing of PageTreeService is wrong https://github.com/vivid-planet/comet/pull/1515#issue-2042001589
-                userGroup: UserGroup.All,
+                userGroup: UserGroup.all,
             },
             PageTreeNodeCategory.mainNavigation,
             scope,


### PR DESCRIPTION
## Description

After changing the values of user group to camelCase (https://github.com/vivid-planet/comet/pull/3907), fixtures are broken as the values were not adapted here. Fix fixtures by using correct userGroup values. 

<img width="678" height="252" alt="Screenshot 2025-07-16 at 10 04 48" src="https://github.com/user-attachments/assets/a424c41a-094d-4490-95ca-1932db453f29" />


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)