### PR TITLE
Fix regression in encoding site configs

### DIFF
--- a/packages/cli/src/commands/site-configs.ts
+++ b/packages/cli/src/commands/site-configs.ts
@@ -54,7 +54,7 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
             if (options.base64) {
                 return Buffer.from(ret).toString("base64");
             }
-            return ret;
+            return ret.replace(/\\/g, "\\\\");
         });
 
         str = str.replace(/"({{ site:\/\/domains\/.*\/.* }})"/g, "$1"); // remove quotes in array


### PR DESCRIPTION
Introduced with https://github.com/vivid-planet/comet/pull/3859

The manual encoding of backslashes is necessary because node itself strips it when calling functions like `replace.`