### PR TITLE
Fix `PreviewSkeleton` for images using fill

### DIFF
--- a/.changeset/dry-waves-drop.md
+++ b/.changeset/dry-waves-drop.md
@@ -1,0 +1,5 @@
+---
+"@comet/site-react": patch
+---
+
+Fix display of images with the `fill` property in the `previewSkeleton` component

--- a/.changeset/dry-waves-drop.md
+++ b/.changeset/dry-waves-drop.md
@@ -2,4 +2,4 @@
 "@comet/site-react": patch
 ---
 
-Fix display of images with the `fill` property in the `previewSkeleton` component
+Fix the aspect ratio of the preview skeleton of images when using `fill`

--- a/packages/site/site-nextjs/src/blocks/PixelImageBlock.tsx
+++ b/packages/site/site-nextjs/src/blocks/PixelImageBlock.tsx
@@ -25,7 +25,7 @@ interface PixelImageBlockProps extends PropsWithData<PixelImageBlockData>, Omit<
 
 export const PixelImageBlock = withPreview(
     ({ aspectRatio, data: { damFile, cropArea, urlTemplate }, fill, ...nextImageProps }: PixelImageBlockProps) => {
-        if (!damFile || !damFile.image) return <PreviewSkeleton type="media" hasContent={false} aspectRatio={aspectRatio} />;
+        if (!damFile || !damFile.image) return <PreviewSkeleton type="media" hasContent={false} aspectRatio={aspectRatio} fill />;
 
         // If we have a crop area set, DAM setting are overwritten, so we use that
         const usedCropArea = cropArea ?? damFile.image.cropArea;

--- a/packages/site/site-nextjs/src/blocks/PixelImageBlock.tsx
+++ b/packages/site/site-nextjs/src/blocks/PixelImageBlock.tsx
@@ -25,7 +25,7 @@ interface PixelImageBlockProps extends PropsWithData<PixelImageBlockData>, Omit<
 
 export const PixelImageBlock = withPreview(
     ({ aspectRatio, data: { damFile, cropArea, urlTemplate }, fill, ...nextImageProps }: PixelImageBlockProps) => {
-        if (!damFile || !damFile.image) return <PreviewSkeleton type="media" hasContent={false} aspectRatio={aspectRatio} fill />;
+        if (!damFile || !damFile.image) return <PreviewSkeleton type="media" hasContent={false} aspectRatio={aspectRatio} fill={fill} />;
 
         // If we have a crop area set, DAM setting are overwritten, so we use that
         const usedCropArea = cropArea ?? damFile.image.cropArea;

--- a/packages/site/site-react/src/previewskeleton/PreviewSkeleton.tsx
+++ b/packages/site/site-react/src/previewskeleton/PreviewSkeleton.tsx
@@ -56,15 +56,13 @@ const PreviewSkeleton = ({
             return (
                 <div
                     className={styles.imageContainer}
-                    style={
-                        {
-                            "--background-color": backgroundColor,
-                            "--color": color,
-                            ...(validAspectRatio === undefined || fill
-                                ? { "--height": typeof height === "string" ? height : `${height}px` }
-                                : { "--aspect-ratio": validAspectRatio }),
-                        } as React.CSSProperties
-                    }
+                    style={{
+                        "--background-color": backgroundColor,
+                        "--color": color,
+                        ...(validAspectRatio === undefined || fill
+                            ? { "--height": typeof height === "string" ? height : `${height}px` }
+                            : { "--aspect-ratio": validAspectRatio }),
+                    }}
                 >
                     {title}
                 </div>

--- a/packages/site/site-react/src/previewskeleton/PreviewSkeleton.tsx
+++ b/packages/site/site-react/src/previewskeleton/PreviewSkeleton.tsx
@@ -14,6 +14,7 @@ interface SkeletonProps extends PropsWithChildren {
     color?: string;
     title?: ReactNode;
     customContainer?: ReactNode;
+    fill?: boolean;
 }
 
 const PreviewSkeleton = ({
@@ -26,6 +27,7 @@ const PreviewSkeleton = ({
     hasContent,
     color = "#A8A7A8",
     backgroundColor = type === "media" ? "#efefef" : "#E0DDE0",
+    fill = false,
 }: SkeletonProps) => {
     const preview = usePreview();
     const validAspectRatio = getValidAspectRatio(aspectRatio);
@@ -50,17 +52,19 @@ const PreviewSkeleton = ({
                 </div>
             );
         } else if (type === "media") {
-            const height = passedHeight ?? 300;
+            const height = fill ? "100%" : passedHeight ?? 300;
             return (
                 <div
                     className={styles.imageContainer}
-                    style={{
-                        "--background-color": backgroundColor,
-                        "--color": color,
-                        ...(validAspectRatio === undefined
-                            ? { "--height": typeof height === "string" ? height : `${height}px` }
-                            : { "--aspect-ratio": validAspectRatio }),
-                    }}
+                    style={
+                        {
+                            "--background-color": backgroundColor,
+                            "--color": color,
+                            ...(validAspectRatio === undefined || fill
+                                ? { "--height": typeof height === "string" ? height : `${height}px` }
+                                : { "--aspect-ratio": validAspectRatio }),
+                        } as React.CSSProperties
+                    }
                 >
                     {title}
                 </div>


### PR DESCRIPTION
## Description

When an image is used with `fill`, the `PreviewSkeleton` is displayed with the provided aspectRatio instead, which leads to inconsistent sizes of the preview and the actual image. 

Add styling depending on `fill` to the `PreviewSkeleton`so that the behaviour is identical between image and preview.


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="891" height="429" alt="Screenshot 2025-07-16 at 11 21 04" src="https://github.com/user-attachments/assets/5cb77f96-928b-4c6b-a442-a54ad6d7f5e4" />   | <img width="600" height="738" alt="Screenshot 2025-07-16 at 15 05 37" src="https://github.com/user-attachments/assets/e2ccd83a-3253-49f6-b94a-71077a2fe16b" />|
| <img width="895" height="737" alt="Screenshot 2025-07-16 at 11 21 21" src="https://github.com/user-attachments/assets/3a286277-5daa-4a29-ab6d-df3c5114f0c6" /> | <img width="893" height="733" alt="Screenshot 2025-07-16 at 11 22 32" src="https://github.com/user-attachments/assets/1ffb6f2f-7a16-4ab6-9505-bfa1b7a03c68" />



## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1848
