### PR TITLE
PoC: Demo Block Preview: Inject domain for all fetch requests as custom header

### DIFF
--- a/demo/site/src/app/block-preview/[domain]/BlockPreviewLayoutClient.tsx
+++ b/demo/site/src/app/block-preview/[domain]/BlockPreviewLayoutClient.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { type PublicSiteConfig } from "@src/site-configs";
+import { type PropsWithChildren, useEffect } from "react";
+
+let currentSiteConfigDomain;
+if (typeof window !== "undefined") {
+    // monkey patch the fetch function to include the scope in the headers
+    const originalFetch = window.fetch;
+    window.fetch = async (input, init: RequestInit = {}) => {
+        const headers = new Headers(init.headers);
+        if (currentSiteConfigDomain) {
+            headers.set("X-Comet-Block-Preview-Domain", currentSiteConfigDomain);
+        }
+        return originalFetch(input, { ...init, headers });
+    };
+}
+export function BlockPreviewLayoutClient({ siteConfig, children }: Readonly<PropsWithChildren<{ siteConfig: PublicSiteConfig }>>) {
+    useEffect(() => {
+        currentSiteConfigDomain = siteConfig.scope.domain;
+    }, [siteConfig]);
+    return children;
+}

--- a/demo/site/src/app/block-preview/[domain]/layout.tsx
+++ b/demo/site/src/app/block-preview/[domain]/layout.tsx
@@ -4,7 +4,13 @@ import { getSiteConfigForDomain } from "@src/util/siteConfig";
 import { SiteConfigProvider } from "@src/util/SiteConfigProvider";
 import { type PropsWithChildren } from "react";
 
+import { BlockPreviewLayoutClient } from "./BlockPreviewLayoutClient";
+
 export default async function BlockPreviewLayout({ children, params: { domain } }: Readonly<PropsWithChildren<{ params: { domain: string } }>>) {
     const siteConfig = await getSiteConfigForDomain(domain);
-    return <SiteConfigProvider siteConfig={siteConfig}>{children}</SiteConfigProvider>;
+    return (
+        <BlockPreviewLayoutClient siteConfig={siteConfig}>
+            <SiteConfigProvider siteConfig={siteConfig}>{children}</SiteConfigProvider>
+        </BlockPreviewLayoutClient>
+    );
 }

--- a/demo/site/src/middleware/domainRewrite.ts
+++ b/demo/site/src/middleware/domainRewrite.ts
@@ -1,5 +1,5 @@
 import { previewParams } from "@comet/site-nextjs";
-import { getHostByHeaders, getSiteConfigForHost } from "@src/util/siteConfig";
+import { getHostByHeaders, getSiteConfigForHeaders } from "@src/util/siteConfig";
 import { type NextRequest, NextResponse } from "next/server";
 
 import { type CustomMiddleware } from "./chain";
@@ -9,10 +9,9 @@ export type VisibilityParam = "default" | "invisiblePages" | "invisibleBlocks";
 export function withDomainRewriteMiddleware(middleware: CustomMiddleware) {
     return async (request: NextRequest) => {
         const headers = request.headers;
-        const host = getHostByHeaders(headers);
-        const siteConfig = await getSiteConfigForHost(host);
+        const siteConfig = await getSiteConfigForHeaders(headers);
         if (!siteConfig) {
-            throw new Error(`Cannot get siteConfig for host ${host}`);
+            throw new Error(`Cannot get siteConfig for host ${getHostByHeaders(headers)}`);
         }
 
         const preview = await previewParams({ skipDraftModeCheck: true });

--- a/demo/site/src/middleware/predefinedPages.ts
+++ b/demo/site/src/middleware/predefinedPages.ts
@@ -1,7 +1,7 @@
 import { gql } from "@comet/site-nextjs";
 import { predefinedPagePaths } from "@src/documents/predefinedPages/predefinedPagePaths";
 import { createGraphQLFetchMiddleware } from "@src/util/graphQLClientMiddleware";
-import { getHostByHeaders, getSiteConfigForDomain, getSiteConfigForHost } from "@src/util/siteConfig";
+import { getHostByHeaders, getSiteConfigForDomain, getSiteConfigForHeaders } from "@src/util/siteConfig";
 import { type NextRequest, NextResponse } from "next/server";
 
 import { memoryCache } from "./cache";
@@ -78,11 +78,9 @@ async function fetchPredefinedPages(domain: string) {
 
 export function withPredefinedPagesMiddleware(middleware: CustomMiddleware) {
     return async (request: NextRequest) => {
-        const headers = request.headers;
-        const host = getHostByHeaders(headers);
-        const siteConfig = await getSiteConfigForHost(host);
+        const siteConfig = await getSiteConfigForHeaders(request.headers);
         if (!siteConfig) {
-            throw new Error(`Cannot get siteConfig for host ${host}`);
+            throw new Error(`Cannot get siteConfig for host ${getHostByHeaders(request.headers)}`);
         }
 
         const { pathname } = new URL(request.url);

--- a/demo/site/src/middleware/preview.ts
+++ b/demo/site/src/middleware/preview.ts
@@ -1,4 +1,4 @@
-import { getHostByHeaders, getSiteConfigForHost } from "@src/util/siteConfig";
+import { getHostByHeaders, getSiteConfigForHeaders } from "@src/util/siteConfig";
 import { type NextRequest, NextResponse } from "next/server";
 
 import { type CustomMiddleware } from "./chain";
@@ -20,7 +20,7 @@ export function withPreviewMiddleware(middleware: CustomMiddleware) {
         // Check if scope has been set via the site-preview api url
         const host = getHostByHeaders(request.headers);
         if (host === process.env.PREVIEW_DOMAIN) {
-            const siteConfig = await getSiteConfigForHost(host);
+            const siteConfig = await getSiteConfigForHeaders(request.headers);
             if (!siteConfig) {
                 return NextResponse.json({ error: "Preview has to be called from within Comet Web preview" }, { status: 404 });
             }

--- a/demo/site/src/middleware/redirectToMainHost.ts
+++ b/demo/site/src/middleware/redirectToMainHost.ts
@@ -1,5 +1,5 @@
 import type { PublicSiteConfig } from "@src/site-configs";
-import { getHostByHeaders, getSiteConfigForHost, getSiteConfigs } from "@src/util/siteConfig";
+import { getHostByHeaders, getSiteConfigForHeaders, getSiteConfigs } from "@src/util/siteConfig";
 import { type NextRequest, NextResponse } from "next/server";
 
 import { type CustomMiddleware } from "./chain";
@@ -24,7 +24,7 @@ export function withRedirectToMainHostMiddleware(middleware: CustomMiddleware) {
     return async (request: NextRequest) => {
         const headers = request.headers;
         const host = getHostByHeaders(headers);
-        const siteConfig = await getSiteConfigForHost(host);
+        const siteConfig = await getSiteConfigForHeaders(headers);
 
         if (!siteConfig) {
             // Redirect to Main Host


### PR DESCRIPTION
alternative to https://github.com/vivid-planet/comet/pull/4179

- We have a single preview domain for multiple site configs (scopes)
- domain is injected into block preview using iframe bridge
- but when block preview in site on client side calls an BFF api request, the api can't resolve the siteConfig
- add a new X-Comet-Block-Preview-Domain header by monkey patching fetch (in block preview only)
- respect this header when resolving siteConfig (middleware)