### PR TITLE
Add product carousel block

### DIFF
--- a/demo/admin/src/common/blocks/ProductListCarouselBlock.tsx
+++ b/demo/admin/src/common/blocks/ProductListCarouselBlock.tsx
@@ -1,0 +1,27 @@
+import { BlockCategory, createCompositeBlock, createListBlock } from "@comet/blocks-admin";
+import { ProductListItemBlock } from "@src/common/blocks/ProductListItemBlock";
+import { FormattedMessage } from "react-intl";
+
+const ProductListBlock = createListBlock({
+    name: "ProductList",
+    block: ProductListItemBlock,
+    itemName: <FormattedMessage id="productList.itemName" defaultMessage="Product" />,
+    itemsName: <FormattedMessage id="productList.itemsName" defaultMessage="Products" />,
+});
+
+export const ProductListCarouselBlock = createCompositeBlock(
+    {
+        name: "ProductListCarousel",
+        displayName: <FormattedMessage id="productListCarousel.displayName" defaultMessage="Product Carousel" />,
+        blocks: {
+            products: {
+                block: ProductListBlock,
+                title: <FormattedMessage id="productListCarousel.products" defaultMessage="Products" />,
+            },
+        },
+    },
+    (block) => {
+        block.category = BlockCategory.Media;
+        return block;
+    },
+);

--- a/demo/admin/src/common/blocks/ProductListItemBlock.tsx
+++ b/demo/admin/src/common/blocks/ProductListItemBlock.tsx
@@ -1,0 +1,27 @@
+import { BlockCategory, createCompositeBlock, createCompositeBlockTextField } from "@comet/blocks-admin";
+import { DamImageBlock } from "@src/common/blocks/DamImageBlock";
+import { FormattedMessage } from "react-intl";
+
+export const ProductListItemBlock = createCompositeBlock(
+    {
+        name: "ProductListItem",
+        displayName: <FormattedMessage id="productList.item.displayName" defaultMessage="Product Item" />,
+        blocks: {
+            image: {
+                block: DamImageBlock,
+                title: <FormattedMessage id="productList.item.image" defaultMessage="Image" />,
+            },
+            name: {
+                block: createCompositeBlockTextField({
+                    fullWidth: true,
+                    label: <FormattedMessage id="productList.item.name" defaultMessage="Name" />,
+                }),
+                hiddenInSubroute: true,
+            },
+        },
+    },
+    (block) => {
+        block.category = BlockCategory.Media;
+        return block;
+    },
+);

--- a/demo/api/src/common/blocks/product-list-carousel.block.ts
+++ b/demo/api/src/common/blocks/product-list-carousel.block.ts
@@ -1,0 +1,30 @@
+import {
+    BlockData,
+    BlockDataInterface,
+    BlockInput,
+    ChildBlock,
+    ChildBlockInput,
+    createBlock,
+    createListBlock,
+    ExtractBlockInput,
+    inputToData,
+} from "@comet/blocks-api";
+import { ProductListItemBlock } from "@src/common/blocks/product-list-item.block";
+
+export const ProductListBlock = createListBlock({ block: ProductListItemBlock }, "ProductList");
+
+class ProductListCarouselBlockData extends BlockData {
+    @ChildBlock(ProductListBlock)
+    products: BlockDataInterface;
+}
+
+class ProductListCarouselBlockInput extends BlockInput {
+    @ChildBlockInput(ProductListBlock)
+    products: ExtractBlockInput<typeof ProductListBlock>;
+
+    transformToBlockData(): ProductListCarouselBlockData {
+        return inputToData(ProductListCarouselBlockData, this);
+    }
+}
+
+export const ProductListCarouselBlock = createBlock(ProductListCarouselBlockData, ProductListCarouselBlockInput, "ProductListCarousel");

--- a/demo/api/src/common/blocks/product-list-item.block.ts
+++ b/demo/api/src/common/blocks/product-list-item.block.ts
@@ -1,0 +1,36 @@
+import {
+    BlockData,
+    BlockDataInterface,
+    BlockField,
+    BlockInput,
+    ChildBlock,
+    ChildBlockInput,
+    createBlock,
+    ExtractBlockInput,
+    inputToData,
+} from "@comet/blocks-api";
+import { DamImageBlock } from "@comet/cms-api";
+import { IsString } from "class-validator";
+
+class ProductListItemBlockData extends BlockData {
+    @ChildBlock(DamImageBlock)
+    image: BlockDataInterface;
+
+    @BlockField()
+    name: string;
+}
+
+class ProductListItemBlockInput extends BlockInput {
+    @ChildBlockInput(DamImageBlock)
+    image: ExtractBlockInput<typeof DamImageBlock>;
+
+    @IsString()
+    @BlockField()
+    name: string;
+
+    transformToBlockData(): ProductListItemBlockData {
+        return inputToData(ProductListItemBlockData, this);
+    }
+}
+
+export const ProductListItemBlock = createBlock(ProductListItemBlockData, ProductListItemBlockInput, "ProductListItem");

--- a/demo/site-pages/src/common/blocks/ProductListCarouselBlock.tsx
+++ b/demo/site-pages/src/common/blocks/ProductListCarouselBlock.tsx
@@ -1,0 +1,53 @@
+import { PixelImageBlock, PropsWithData, withPreview } from "@comet/cms-site";
+import { ProductListCarouselBlockData } from "@src/blocks.generated";
+import styled from "styled-components";
+import SwiperCore from "swiper";
+import { Navigation } from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/react";
+
+SwiperCore.use([Navigation]);
+
+type ProductListCarouselProps = PropsWithData<ProductListCarouselBlockData>;
+
+export const ProductListCarouselBlock = withPreview(
+    ({ data }: ProductListCarouselProps) => {
+        return (
+            <Wrapper>
+                <Swiper
+                    modules={[Navigation]}
+                    slidesPerView={3}
+                    spaceBetween={20}
+                    navigation
+                    longSwipesRatio={0.1}
+                    threshold={3}
+                    allowTouchMove
+                    watchOverflow
+                >
+                    {data.products.blocks.map((block) => (
+                        <SwiperSlide key={block.key}>
+                            <Item>
+                                <PixelImageBlock data={block.props.image} aspectRatio="1x1" />
+                                <Name>{block.props.name}</Name>
+                            </Item>
+                        </SwiperSlide>
+                    ))}
+                </Swiper>
+            </Wrapper>
+        );
+    },
+    { label: "Product Carousel" },
+);
+
+const Wrapper = styled.div`
+    position: relative;
+`;
+
+const Item = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`;
+
+const Name = styled.div`
+    margin-top: 8px;
+`;

--- a/demo/site-pages/src/documents/pages/blocks/PageContentBlock.tsx
+++ b/demo/site-pages/src/documents/pages/blocks/PageContentBlock.tsx
@@ -16,6 +16,7 @@ import { ContentGroupBlock } from "@src/documents/pages/blocks/ContentGroupBlock
 import { FullWidthImageBlock } from "@src/documents/pages/blocks/FullWidthImageBlock";
 import { KeyFactsBlock } from "@src/documents/pages/blocks/KeyFactsBlock";
 import { TeaserBlock } from "@src/documents/pages/blocks/TeaserBlock";
+import { ProductListCarouselBlock } from "@src/common/blocks/ProductListCarouselBlock";
 
 const supportedBlocks: SupportedBlocks = {
     accordion: (props) => <PageContentAccordionBlock data={props} />,
@@ -23,6 +24,7 @@ const supportedBlocks: SupportedBlocks = {
     billboardTeaser: (props) => <BillboardTeaserBlock data={props} />,
     space: (props) => <SpaceBlock data={props} />,
     teaser: (props) => <TeaserBlock data={props} />,
+    productCarousel: (props) => <ProductListCarouselBlock data={props} />,
     richtext: (props) => <PageContentRichTextBlock data={props} disableLastBottomSpacing />,
     heading: (props) => <PageContentStandaloneHeadingBlock data={props} />,
     columns: (props) => <ColumnsBlock data={props} />,

--- a/demo/site/src/common/blocks/ProductListCarouselBlock.tsx
+++ b/demo/site/src/common/blocks/ProductListCarouselBlock.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { PixelImageBlock, PropsWithData, withPreview } from "@comet/site-nextjs";
+import { ProductListCarouselBlockData } from "@src/blocks.generated";
+import styled from "styled-components";
+import SwiperCore from "swiper";
+import { Navigation } from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/react";
+
+SwiperCore.use([Navigation]);
+
+type ProductListCarouselProps = PropsWithData<ProductListCarouselBlockData>;
+
+export const ProductListCarouselBlock = withPreview(
+    ({ data }: ProductListCarouselProps) => {
+        return (
+            <Wrapper>
+                <Swiper
+                    modules={[Navigation]}
+                    slidesPerView={3}
+                    spaceBetween={20}
+                    navigation
+                    longSwipesRatio={0.1}
+                    threshold={3}
+                    allowTouchMove
+                    watchOverflow
+                >
+                    {data.products.blocks.map((block) => (
+                        <SwiperSlide key={block.key}>
+                            <Item>
+                                <PixelImageBlock data={block.props.image} aspectRatio="1x1" />
+                                <Name>{block.props.name}</Name>
+                            </Item>
+                        </SwiperSlide>
+                    ))}
+                </Swiper>
+            </Wrapper>
+        );
+    },
+    { label: "Product Carousel" },
+);
+
+const Wrapper = styled.div`
+    position: relative;
+`;
+
+const Item = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`;
+
+const Name = styled.div`
+    margin-top: 8px;
+`;

--- a/demo/site/src/documents/pages/blocks/PageContentBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/PageContentBlock.tsx
@@ -18,6 +18,7 @@ import { ContentGroupBlock } from "@src/documents/pages/blocks/ContentGroupBlock
 import { FullWidthImageBlock } from "@src/documents/pages/blocks/FullWidthImageBlock";
 import { KeyFactsBlock } from "@src/documents/pages/blocks/KeyFactsBlock";
 import { SliderBlock } from "@src/documents/pages/blocks/SliderBlock";
+import { ProductListCarouselBlock } from "@src/common/blocks/ProductListCarouselBlock";
 import { TeaserBlock } from "@src/documents/pages/blocks/TeaserBlock";
 import { NewsDetailBlock } from "@src/news/blocks/NewsDetailBlock";
 import { NewsListBlock } from "@src/news/blocks/NewsListBlock";
@@ -37,6 +38,7 @@ const supportedBlocks: SupportedBlocks = {
     contentGroup: (props) => <ContentGroupBlock data={props} />,
     mediaGallery: (props) => <PageContentMediaGalleryBlock data={props} />,
     slider: (props) => <SliderBlock data={props} />,
+    productCarousel: (props) => <ProductListCarouselBlock data={props} />,
 
     newsList: (props) => <NewsListBlock data={props} />,
     newsDetail: (props) => <NewsDetailBlock data={props} />,


### PR DESCRIPTION
## Summary
- add ProductListCarousel block to API with list item definition
- create admin blocks for product carousel and item
- implement ProductListCarouselBlock on demo sites
- register the new block for page content

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e0b388a0832b9c436a8c43247c7f