### PR TITLE
Move toGqlFilter callback into column definition (Improve #4135)

### DIFF
--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -23,11 +23,10 @@ import {
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { type ConvertCustomFilterCallback, type GqlFilter } from "@comet/admin/lib/dataGrid/muiGridFilterToGql";
+import { type GqlFilter } from "@comet/admin/lib/dataGrid/muiGridFilterToGql";
 import { Add as AddIcon, Disabled, Edit, Education as EducationIcon, Excel, Online } from "@comet/admin-icons";
 import { DamImageBlock } from "@comet/cms-admin";
 import { CircularProgress, IconButton, useTheme } from "@mui/material";
-import type { GridFilterItem, GridFilterModel } from "@mui/x-data-grid";
 import {
     DataGridPro,
     GridFilterInputSingleSelect,
@@ -225,6 +224,15 @@ export function ProductsGrid() {
             width: 150,
             visible: theme.breakpoints.down(0), // always hidden but used for filtering
             disableExport: true,
+            toGqlFilter: (filterItem) => {
+                return {
+                    or: [
+                        { title: { contains: filterItem.value } },
+                        { slug: { contains: filterItem.value } },
+                        { description: { contains: filterItem.value } },
+                    ],
+                } as GqlFilter;
+            },
         },
         {
             field: "category",
@@ -359,23 +367,9 @@ export function ProductsGrid() {
         },
     ];
 
-    const convertCustomFilters: ConvertCustomFilterCallback = (filterItem: GridFilterItem, columns: GridColDef[], filterModel?: GridFilterModel) => {
-        if (filterItem.field === "titleSlugOrDescription") {
-            return {
-                or: [
-                    { title: { contains: filterItem.value } },
-                    { slug: { contains: filterItem.value } },
-                    { description: { contains: filterItem.value } },
-                ],
-            } as GqlFilter;
-        } else {
-            return false;
-        }
-    };
-
     const { data, loading, error } = useQuery<GQLProductsListQuery, GQLProductsListQueryVariables>(productsQuery, {
         variables: {
-            ...muiGridFilterToGql(columns, dataGridProps.filterModel, convertCustomFilters),
+            ...muiGridFilterToGql(columns, dataGridProps.filterModel),
             offset: dataGridProps.paginationModel.page * dataGridProps.paginationModel.pageSize,
             limit: dataGridProps.paginationModel.pageSize,
             sort: muiGridSortToGql(sortModel, columns),

--- a/packages/admin/admin/src/dataGrid/GridColDef.ts
+++ b/packages/admin/admin/src/dataGrid/GridColDef.ts
@@ -1,5 +1,6 @@
 import {
     type GridActionsColDef as MuiGridActionsColDef,
+    type GridFilterItem,
     type GridSingleSelectColDef as MuiGridSingleSelectColDef,
     type GridValidRowModel,
     type GridValueOptionsParams,
@@ -7,6 +8,8 @@ import {
 import { type GridBaseColDef as MuiGridBaseColDef } from "@mui/x-data-grid/models/colDef/gridColDef";
 import { type GridPinnedColumns } from "@mui/x-data-grid-pro";
 import { type ReactNode } from "react";
+
+import { type GqlFilter } from "./muiGridFilterToGql";
 
 type ValueOption =
     | string
@@ -32,6 +35,10 @@ type GridColDefExtension<R extends GridValidRowModel = any> = {
      * Requires DataGridPro or DataGridPremium.
      */
     pinned?: keyof GridPinnedColumns;
+    /**
+     * Callback to convert a filter item to a GQL filter.
+     */
+    toGqlFilter?: (filterItem: GridFilterItem) => GqlFilter;
 };
 
 export type GridBaseColDef<R extends GridValidRowModel = any, V = any, F = V> = MuiGridBaseColDef<R, V, F> & GridColDefExtension<R>;

--- a/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
+++ b/packages/admin/admin/src/dataGrid/muiGridFilterToGql.tsx
@@ -62,16 +62,12 @@ export type ConvertCustomFilterCallback = (
     filterModel?: GridFilterModel,
 ) => GqlFilter | false | undefined;
 
-export function muiGridFilterToGql(
-    columns: GridColDef[],
-    filterModel?: GridFilterModel,
-    convertCustomFilter?: ConvertCustomFilterCallback,
-): { filter: GqlFilter; search?: string } {
+export function muiGridFilterToGql(columns: GridColDef[], filterModel?: GridFilterModel): { filter: GqlFilter; search?: string } {
     if (!filterModel) return { filter: {} };
     const filterItems = filterModel.items.map((filterItem) => {
-        if (convertCustomFilter) {
-            const customFilter = convertCustomFilter(filterItem, columns, filterModel);
-            if (customFilter) return customFilter;
+        const column = columns.find((col) => col.field === filterItem.field);
+        if (column?.toGqlFilter) {
+            return column.toGqlFilter(filterItem);
         }
         if (!filterItem.operator) throw new Error("operator not set");
         const gqlOperator = muiGridOperatorValueToGqlOperator[filterItem.operator] || filterItem.operator;


### PR DESCRIPTION
This PR tries to improve the API introduced by #4135.

It moves the callback into the column definition.

- no `if (filterItem.field === "titleSlugOrDescription") {` needed
- definition of callback nearer to column (where it belongs)
- doesn't add a 3rd parameter to muiGridFilterToGql

(this PR does not address other issues from #4135)