### PR TITLE
Fix CSS message

### DIFF
--- a/packages/admin/cms-admin/src/blocks/common/AdminTabsTabContent.tsx
+++ b/packages/admin/cms-admin/src/blocks/common/AdminTabsTabContent.tsx
@@ -25,7 +25,7 @@ const Content = styled("div")`
     margin-top: ${({ theme }) => theme.spacing(4)};
     margin-bottom: ${({ theme }) => theme.spacing(4)};
 
-    & > .CometAdminStackBreadcrumbs-root:first-child {
+    & > .CometAdminStackBreadcrumbs-root:first-of-type {
         margin-top: -${({ theme }) => theme.spacing(4)};
     }
 `;


### PR DESCRIPTION
## Description

Message was:

> The pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type".

I just followed the instructions.


## Screenshots/screencasts

<img width="2502" height="414" alt="image" src="https://github.com/user-attachments/assets/40a05da3-635e-4589-88ce-983ffeb9d6fe" />

