### PR TITLE
Include `@comet/site-react` in the bundle of `@comet/site-nextjs` (v7)

### DIFF
--- a/.changeset/shaggy-impalas-cry.md
+++ b/.changeset/shaggy-impalas-cry.md
@@ -1,0 +1,29 @@
+---
+"@comet/site-nextjs": patch
+---
+
+Include `@comet/site-react` in the bundle of `@comet/site-nextjs`
+
+Previously, `@comet/site-react` was treated as an external dependency.
+
+In `@comet/site-nextjs`' index.ts, many exports from `@comet/site-react` are reexported.
+This caused problems in NextJS when using methods from `@comet/site-react` in the middleware.
+Edge runtime errors containing completely unrelated modules occurred, e.g.
+
+> The error was caused by importing 'usehooks-ts/dist/index.js' in '../../packages/site/site-react/lib/cookies/useLocalStorageCookieApi.js'.
+>
+> Import trace for requested module:
+> ../../packages/site/site-react/lib/cookies/useLocalStorageCookieApi.js
+> ../../packages/site/site-react/lib/index.js
+> ../../packages/site/site-nextjs/lib/index.js
+> ./src/middleware/predefinedPages.ts
+> ./src/middleware.ts
+> occurred in a file that only imported
+
+```ts
+import { createFetchWithDefaults, createGraphQLFetch } from "@comet/site-nextjs";
+```
+
+This is due to a Webpack behavior that pulls all exports in the reexport statement into the middleware bundle.
+
+Bundling `@comet/site-react` with `@comet/site-nextjs` prevents this behavior and the associated error.

--- a/.cspellignore
+++ b/.cspellignore
@@ -36,3 +36,5 @@ uuidv
 Colocating
 Lightbox
 kwfscripts
+codegen
+usehooks

--- a/packages/site/site-nextjs/vite.config.mts
+++ b/packages/site/site-nextjs/vite.config.mts
@@ -22,7 +22,10 @@ export default defineConfig({
                 // otherwise vite will bundle them into the library which caused issues with client / server components
                 // supposedly because server code was bundled into the client code
                 return (
-                    source !== "@comet/site-react/css" && // include css from site-react in site-nextjs build
+                    // We include @comet/site-react in the build. There are two reasons
+                    //      1. we want to include the css from @comet/site-react/css in the generated css file
+                    //      2. we want to avoid false-positive edge runtime errors in next when using methods from @comet/site-react in the middleware
+                    !source.startsWith("@comet/site-react") &&
                     !source.startsWith(".") &&
                     !source.startsWith("/")
                 );


### PR DESCRIPTION
## Description

https://github.com/vivid-planet/comet/pull/4172 for v7

I want to recommend switching package before the v8 update in the migration guide. For that it has to work in v7 too.
