### PR TITLE
Convert MetricType enums to unions

### DIFF
--- a/demo/api/src/open-telemetry/metrics.ts
+++ b/demo/api/src/open-telemetry/metrics.ts
@@ -9,14 +9,7 @@ import {
     type UpDownCounter,
 } from "@opentelemetry/api";
 
-enum MetricType {
-    "Counter" = "Counter",
-    "UpDownCounter" = "UpDownCounter",
-    "Histogram" = "Histogram",
-    "ObservableGauge" = "ObservableGauge",
-    "ObservableCounter" = "ObservableCounter",
-    "ObservableUpDownCounter" = "ObservableUpDownCounter",
-}
+type MetricType = "Counter" | "UpDownCounter" | "Histogram" | "ObservableGauge" | "ObservableCounter" | "ObservableUpDownCounter";
 type GenericMetric = Counter | UpDownCounter | Histogram | ObservableGauge | ObservableCounter | ObservableUpDownCounter;
 const OTEL_METER_NAME = "nestjs-otel";
 
@@ -33,28 +26,28 @@ function getOrCreate(name: string, options: MetricOptions = {}, type: MetricType
 }
 
 export function getOrCreateHistogram(name: string, options: MetricOptions = {}): Histogram {
-    return getOrCreate(name, options, MetricType.Histogram) as Histogram;
+    return getOrCreate(name, options, "Histogram") as Histogram;
 }
 
 export function getOrCreateCounter(name: string, options: MetricOptions = {}): Counter {
-    return getOrCreate(name, options, MetricType.Counter) as Counter;
+    return getOrCreate(name, options, "Counter") as Counter;
 }
 
 // TODO: metric functions below are here for demonstration purpose. More metrics will be added in the future which will probably need this functions.
 /*
 export function getOrCreateUpDownCounter(name: string, options: MetricOptions = {}): UpDownCounter {
-    return getOrCreate(name, options, MetricType.UpDownCounter) as UpDownCounter;
+    return getOrCreate(name, options, "UpDownCounter") as UpDownCounter;
 }
 
 export function getOrCreateObservableGauge(name: string, options: MetricOptions = {}): ObservableGauge {
-    return getOrCreate(name, options, MetricType.ObservableGauge) as ObservableGauge;
+    return getOrCreate(name, options, "ObservableGauge") as ObservableGauge;
 }
 
 export function getOrCreateObservableCounter(name: string, options: MetricOptions = {}): ObservableCounter {
-    return getOrCreate(name, options, MetricType.ObservableCounter) as ObservableCounter;
+    return getOrCreate(name, options, "ObservableCounter") as ObservableCounter;
 }
 
 export function getOrCreateObservableUpDownCounter(name: string, options: MetricOptions = {}): ObservableUpDownCounter {
-    return getOrCreate(name, options, MetricType.ObservableUpDownCounter) as ObservableUpDownCounter;
+    return getOrCreate(name, options, "ObservableUpDownCounter") as ObservableUpDownCounter;
 }
 */

--- a/demo/site/opentelemetry-metrics.ts
+++ b/demo/site/opentelemetry-metrics.ts
@@ -12,14 +12,13 @@ import {
 import { IncomingMessage, ServerResponse } from "http";
 import { NextUrlWithParsedQuery } from "next/dist/server/request-meta";
 
-export enum MetricType {
-    "Counter" = "Counter",
-    "UpDownCounter" = "UpDownCounter",
-    "Histogram" = "Histogram",
-    "ObservableGauge" = "ObservableGauge",
-    "ObservableCounter" = "ObservableCounter",
-    "ObservableUpDownCounter" = "ObservableUpDownCounter",
-}
+export type MetricType =
+    | "Counter"
+    | "UpDownCounter"
+    | "Histogram"
+    | "ObservableGauge"
+    | "ObservableCounter"
+    | "ObservableUpDownCounter";
 export type GenericMetric = Counter | UpDownCounter | Histogram | ObservableGauge | ObservableCounter | ObservableUpDownCounter;
 export const OTEL_METER_NAME = "nestjs-otel";
 
@@ -36,27 +35,27 @@ function getOrCreate(name: string, options: MetricOptions = {}, type: MetricType
 }
 
 export function getOrCreateHistogram(name: string, options: MetricOptions = {}): Histogram {
-    return getOrCreate(name, options, MetricType.Histogram) as Histogram;
+    return getOrCreate(name, options, "Histogram") as Histogram;
 }
 
 export function getOrCreateCounter(name: string, options: MetricOptions = {}): Counter {
-    return getOrCreate(name, options, MetricType.Counter) as Counter;
+    return getOrCreate(name, options, "Counter") as Counter;
 }
 
 export function getOrCreateUpDownCounter(name: string, options: MetricOptions = {}): UpDownCounter {
-    return getOrCreate(name, options, MetricType.UpDownCounter) as UpDownCounter;
+    return getOrCreate(name, options, "UpDownCounter") as UpDownCounter;
 }
 
 export function getOrCreateObservableGauge(name: string, options: MetricOptions = {}): ObservableGauge {
-    return getOrCreate(name, options, MetricType.ObservableGauge) as ObservableGauge;
+    return getOrCreate(name, options, "ObservableGauge") as ObservableGauge;
 }
 
 export function getOrCreateObservableCounter(name: string, options: MetricOptions = {}): ObservableCounter {
-    return getOrCreate(name, options, MetricType.ObservableCounter) as ObservableCounter;
+    return getOrCreate(name, options, "ObservableCounter") as ObservableCounter;
 }
 
 export function getOrCreateObservableUpDownCounter(name: string, options: MetricOptions = {}): ObservableUpDownCounter {
-    return getOrCreate(name, options, MetricType.ObservableUpDownCounter) as ObservableUpDownCounter;
+    return getOrCreate(name, options, "ObservableUpDownCounter") as ObservableUpDownCounter;
 }
 
 function getStatusCodeClass(code: number): string {


### PR DESCRIPTION
The MetricType enum in demo/api/src/open-telemetry/metrics.ts and demo/site/openelemetry-metrics.ts currently violates our coding standards for naming enums. And there is no need for this beeing an enum - so simply change it to an union of strings.

## Testing
- `demo/api/node_modules/.bin/eslint -c demo/api/eslint.config.mjs demo/api/src/open-telemetry/metrics.ts --fix`
- `demo/site/node_modules/.bin/eslint --no-config-lookup -c temp.eslint.cjs --no-ignore demo/site/opentelemetry-metrics.ts --fix` (temporary config)

------
https://chatgpt.com/codex/tasks/task_e_687e4294680c8325a17f27da1d339767