### PR TITLE
Add createFetchWithDefaultNextRevalidate that applies next.revalidate only if cache is not set

### DIFF
--- a/.changeset/smooth-moments-learn.md
+++ b/.changeset/smooth-moments-learn.md
@@ -1,0 +1,5 @@
+---
+"@comet/site-nextjs": minor
+---
+
+Add createFetchWithDefaultNextRevalidate that applies next.revalidate only if cache is not set

--- a/demo/site/src/util/graphQLClient.ts
+++ b/demo/site/src/util/graphQLClient.ts
@@ -1,5 +1,6 @@
 import {
     convertPreviewDataToHeaders,
+    createFetchWithDefaultNextRevalidate,
     createFetchWithDefaults,
     createGraphQLFetch as createGraphQLFetchLibrary,
     type SitePreviewData,
@@ -26,10 +27,7 @@ export function createGraphQLFetch() {
     return createGraphQLFetchLibrary(
         // set a default revalidate time of 7.5 minutes to get an effective cache duration of 15 minutes if a CDN cache is enabled
         // see cache-handler.ts for maximum cache duration (24 hours)
-        createFetchWithDefaults(fetch, {
-            next: {
-                revalidate: 7.5 * 60,
-            },
+        createFetchWithDefaults(createFetchWithDefaultNextRevalidate(fetch, 7.5 * 60), {
             headers: {
                 authorization: `Basic ${Buffer.from(`system-user:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
                 ...convertPreviewDataToHeaders(previewData),

--- a/packages/site/site-nextjs/src/graphQLFetch/graphQLFetch.test.ts
+++ b/packages/site/site-nextjs/src/graphQLFetch/graphQLFetch.test.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createFetchWithDefaultNextRevalidate } from "./graphQLFetch";
+
+describe("createFetchWithDefaultNextRevalidate", () => {
+    it("applies default revalidate when cache is not set", async () => {
+        const mockFetch = jest.fn(async (_input, init) => {
+            return { ok: true, status: 200, init } as Response & { init: RequestInit };
+        });
+        const fetch = createFetchWithDefaultNextRevalidate(mockFetch, 42);
+        await fetch("/test");
+        expect(mockFetch).toHaveBeenCalledWith(
+            "/test",
+            expect.objectContaining({
+                next: expect.objectContaining({ revalidate: 42 }),
+            }),
+        );
+    });
+
+    it("applies default revalidate when cache is not disallowed and next.revalidate is undefined", async () => {
+        const mockFetch = jest.fn(async (_input, init) => {
+            // Minimal Response-like mock
+            return { ok: true, status: 200, init } as Response & { init: any };
+        });
+        const fetch = createFetchWithDefaultNextRevalidate(mockFetch, 42);
+        await fetch("/test", { cache: "default" });
+        expect(mockFetch).toHaveBeenCalledWith(
+            "/test",
+            expect.objectContaining({
+                next: expect.objectContaining({ revalidate: 42 }),
+            }),
+        );
+    });
+
+    it("does not apply revalidate if cache is disallowed", async () => {
+        const mockFetch = jest.fn(async (_input, init) => {
+            return { ok: true, status: 200, init } as Response & { init: any };
+        });
+        const fetch = createFetchWithDefaultNextRevalidate(mockFetch, 42);
+        for (const cache of ["no-store", "no-cache", "only-if-cached", "reload"]) {
+            await fetch("/test", { cache: cache as RequestCache });
+            expect(mockFetch).toHaveBeenCalledWith(
+                "/test",
+                expect.objectContaining({
+                    next: expect.not.objectContaining({ revalidate: 42 }),
+                }),
+            );
+        }
+    });
+
+    it("does not override next.revalidate if already set", async () => {
+        const mockFetch = jest.fn(async (_input, init) => {
+            return { ok: true, status: 200, init } as Response & { init: any };
+        });
+        const fetch = createFetchWithDefaultNextRevalidate(mockFetch, 42);
+        await fetch("/test", { cache: "default", next: { revalidate: 99 } });
+        expect(mockFetch).toHaveBeenCalledWith(
+            "/test",
+            expect.objectContaining({
+                next: expect.objectContaining({ revalidate: 99 }),
+            }),
+        );
+    });
+});

--- a/packages/site/site-nextjs/src/graphQLFetch/graphQLFetch.ts
+++ b/packages/site/site-nextjs/src/graphQLFetch/graphQLFetch.ts
@@ -16,3 +16,23 @@ export function createFetchWithDefaults(fetch: Fetch, defaults: RequestInit): Fe
         });
     };
 }
+/**
+ * Create fetch that applies default next.revalidate time if cache is not set to "no-store", "no-cache", "only-if-cached" or "reload".
+ */
+export function createFetchWithDefaultNextRevalidate(baseFetch: Fetch, defaultRevalidate: number): Fetch {
+    return async function (requestInfo: RequestInfo | URL, requestInit?: RequestInit): Promise<Response> {
+        const disallowRevalidate = ["no-store", "no-cache", "only-if-cached", "reload"];
+        const requestCache = requestInit?.cache;
+        const shouldApplyRevalidate = !requestCache || !disallowRevalidate.includes(requestCache);
+
+        const mergedInit = {
+            ...requestInit,
+            next: {
+                ...requestInit?.next,
+                ...(shouldApplyRevalidate && requestInit?.next?.revalidate === undefined ? { revalidate: defaultRevalidate } : {}),
+            },
+        };
+
+        return baseFetch(requestInfo, mergedInit);
+    };
+}

--- a/packages/site/site-nextjs/src/index.ts
+++ b/packages/site/site-nextjs/src/index.ts
@@ -12,7 +12,7 @@ export { PhoneLinkBlock } from "./blocks/PhoneLinkBlock";
 export { PixelImageBlock } from "./blocks/PixelImageBlock";
 export { VimeoVideoBlock } from "./blocks/VimeoVideoBlock";
 export { YouTubeVideoBlock } from "./blocks/YouTubeVideoBlock";
-export { createFetchWithDefaults } from "./graphQLFetch/graphQLFetch";
+export { createFetchWithDefaultNextRevalidate, createFetchWithDefaults } from "./graphQLFetch/graphQLFetch";
 export { Image } from "./image/Image";
 export { previewParams, sitePreviewRoute } from "./sitePreview/appRouter/sitePreviewRoute";
 export { sendSitePreviewIFrameMessage } from "./sitePreview/iframebridge/sendSitePreviewIFrameMessage";


### PR DESCRIPTION
This works around the error 'specified "cache: no-store" and "revalidate: 450", only one should be specified.'

Alternative: extend createFetchWithDefaults with an callback that can apply defaults based on `cache`. I think the new function is easier to use. It has a pretty long name though.