### PR TITLE
Demo: Fix `initialFilter` for generated `ProductsGrid`

### DIFF
--- a/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
@@ -28,7 +28,7 @@ export default defineConfig<GQLProduct>({
         { field: "price", sort: "asc" },
     ],
     initialFilter: {
-        items: [{ field: "type", operator: "is", value: "Shirt" }],
+        items: [{ field: "type", operator: "is", value: "shirt" }],
     },
     columns: [
         {

--- a/demo/admin/src/products/generator/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/generator/generated/ProductsGrid.tsx
@@ -103,7 +103,7 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
     const dataGridProps = { ...useDataGridRemote({ initialSort: [{ field: "inStock", sort: "desc" },
                 { field: "price", sort: "asc" }],
             initialFilter: {
-                items: [{ field: "type", operator: "is", value: "Shirt" }],
+                items: [{ field: "type", operator: "is", value: "shirt" }],
             },
             queryParamsPrefix: "products",
         }), ...usePersistentColumnState("ProductsGrid") };


### PR DESCRIPTION
Previously:
<img width="1719" height="965" alt="Screenshot 2025-07-22 at 16 47 59" src="https://github.com/user-attachments/assets/e3285e53-b8b5-408e-a2c2-820c7f2320f1" />

We should probably improve typing here to make it impossible for this to happen...
<img width="1095" height="160" alt="Screenshot 2025-07-22 at 16 50 39" src="https://github.com/user-attachments/assets/b333ccbf-cdd9-4f06-90a8-43dcd15289c8" />

