### PR TITLE
Update docker-compose images weekly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
     postgres:
         image: bitnami/postgresql:15
+        pull_policy: weekly
         tty: true
         volumes:
             - postgres:/bitnami/postgresql
@@ -15,6 +16,7 @@ services:
 
     imgproxy:
         image: darthsim/imgproxy:v3
+        pull_policy: weekly
         volumes:
             - ./demo/uploads:/uploads:ro
         ports:
@@ -35,6 +37,7 @@ services:
 
     jaeger:
         image: jaegertracing/all-in-one:1
+        pull_policy: weekly
         ports:
             - "127.0.0.1:${JAEGER_UI_PORT}:16686"
             - "127.0.0.1:${JAEGER_OLTP_PORT}:4318" #OLTP over HTTP
@@ -44,6 +47,7 @@ services:
 
     redis:
         image: redis:7
+        pull_policy: weekly
         command: redis-server --maxmemory 256M --maxmemory-policy allkeys-lru --loglevel warning --requirepass ${REDIS_PASSWORD}
         ports:
             - "127.0.0.1:${REDIS_PORT}:6379"


### PR DESCRIPTION
It is good practice to update the images regularly.

However, this requires a rather recent version of Docker, so one might need to update (see https://github.com/docker/compose/pull/12568), which might be a good idea anyways.
