### PR TITLE
Demo Admin: Make name in ProductVariantForm required

### DIFF
--- a/demo/admin/src/products/ProductVariantForm.tsx
+++ b/demo/admin/src/products/ProductVariantForm.tsx
@@ -121,6 +121,7 @@ export function ProductVariantForm({ id, productId }: FormProps) {
                 <>
                     {saveConflict.dialogs}
                     <Field
+                        required
                         fullWidth
                         name="name"
                         component={FinalFormInput}


### PR DESCRIPTION
Before:
```
{
    "errors": [
        {
            "message": "Variable \"$input\" got invalid value { image: { attachedBlocks: [Array], activeType: \"pixelImage\" } }; Field \"name\" of required type \"String!\" was not provided.",
            "locations": [
                {
                    "line": 1,
                    "column": 46
                }
            ],
            "extensions": {
                "code": "BAD_USER_INPUT",
                "stacktrace": [
                    "GraphQLError: Field \"name\" of required type \"String!\" was not provided.",
                    "    at coerceInputValueImpl (/Users/danielkarnutsch/ws/comet-v8/node_modules/.pnpm/graphql@16.11.0/node_modules/graphql/utilities/coerceInputValue.js:111:13)",
                    "    at coerceInputValueImpl (/Users/danielkarnutsch/ws/comet-v8/node_modules/.pnpm/graphql@16.11.0/node_modules/graphql/utilities/coerceInputValue.js:49:14)",
                    "    at coerceInputValue (/Users/danielkarnutsch/ws/comet-v8/node_modules/.pnpm/graphql@16.11.0/node_modules/graphql/utilities/coerceInputValue.js:32:10)",
                    "    at coerceVariableValues (/Users/danielkarnutsch/ws/comet-v8/node_modules/.pnpm/graphql@16.11.0/node_modules/graphql/execution/values.js:132:69)",
                    "    at getVariableValues (/Users/danielkarnutsch/ws/comet-v8/node_modules/.pnpm/graphql@16.11.0/node_modules/graphql/execution/values.js:45:21)",
                    "    at buildExecutionContext (/Users/danielkarnutsch/ws/comet-v8/node_modules/.pnpm/graphql@16.11.0/node_modules/graphql/execution/execute.js:281:63)",
                    "    at execute (/Users/danielkarnutsch/ws/comet-v8/node_modules/.pnpm/graphql@16.11.0/node_modules/graphql/execution/execute.js:116:22)",
                    "    at <anonymous> (/Users/danielkarnutsch/ws/comet-v8/node_modules/.pnpm/@opentelemetry+instrumentation-graphql@0.49.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation-graphql/src/instrumentation.ts:218:59)",
                    "    at safeExecuteInTheMiddle (/Users/danielkarnutsch/ws/comet-v8/node_modules/.pnpm/@opentelemetry+instrumentation@0.201.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/src/utils.ts:32:14)",
                    "    at <anonymous> (/Users/danielkarnutsch/ws/comet-v8/node_modules/.pnpm/@opentelemetry+instrumentation-graphql@0.49.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation-graphql/src/instrumentation.ts:214:40)"
                ]
            }
        }
    ]
}
```

Afterwards:
<img width="1302" height="494" alt="Screenshot 2025-07-22 at 17 22 10" src="https://github.com/user-attachments/assets/5eb97881-d784-4e74-9229-6aae185c742a" />
