### PR TITLE
Validate path parameter in site preview

### DIFF
--- a/.changeset/dark-snails-fail.md
+++ b/.changeset/dark-snails-fail.md
@@ -2,6 +2,6 @@
 "@comet/cms-admin": patch
 ---
 
-Validate path parameter in Site preview
+Validate path parameter in site preview
 
-Prevents phishing attacks
+Prevents phishing attacks.

--- a/.changeset/dark-snails-fail.md
+++ b/.changeset/dark-snails-fail.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Validate path parameter in Site preview
+
+Prevents phishing attacks

--- a/packages/admin/cms-admin/src/preview/site/SitePreview.tsx
+++ b/packages/admin/cms-admin/src/preview/site/SitePreview.tsx
@@ -46,6 +46,7 @@ function useSearchState<ParseFunction extends (value: string | undefined) => Ret
 }
 function SitePreview({ resolvePath, logo = <CometColor sx={{ fontSize: 32 }} /> }: Props) {
     const { scope } = useContentScope();
+    const siteConfig = useSiteConfig({ scope });
 
     //initialPath: path the preview is initialized with; WITHOUT resolvePath called, might be not the path actually used in site
     //doesn't change during navigation within site
@@ -55,11 +56,11 @@ function SitePreview({ resolvePath, logo = <CometColor sx={{ fontSize: 32 }} /> 
     //use case for resolvePath: i18n urls, for example `/${scope.language}${path}`;
     //changes during navigation within site (iframe bridge reports new path)
     const [sitePath, setSitePath] = useSearchState("sitePath", (v) => {
-        if (v) {
-            return v;
-        } else {
-            return resolvePath ? resolvePath(initialPath, scope) : initialPath;
+        if (!v) {
+            v = resolvePath ? resolvePath(initialPath, scope) : initialPath;
         }
+        const url = new URL(v, siteConfig.url); // prevents phishing attacks
+        return url.pathname;
     });
 
     //iframePath: path set for iframe
@@ -77,8 +78,6 @@ function SitePreview({ resolvePath, logo = <CometColor sx={{ fontSize: 32 }} /> 
     const [showOnlyVisible, setShowOnlyVisible] = useSearchState("showOnlyVisible", (v) => !v || v === "true");
 
     const [linkToOpen, setLinkToOpen] = useState<ExternalLinkBlockData | undefined>(undefined);
-
-    const siteConfig = useSiteConfig({ scope });
 
     const intl = useIntl();
 


### PR DESCRIPTION
## Description

The path parameter incorrectly allowed absolute URLs. This could be exploited for phishing attacks. We therefore add a validation to only allow relative paths.

## Further information
- Task: https://vivid-planet.atlassian.net/browse/COM-2189