### PR TITLE
Demo: fix change ProductsGrid initialFilter-value to camelCase

### DIFF
--- a/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
@@ -28,7 +28,7 @@ export default defineConfig<GQLProduct>({
         { field: "price", sort: "asc" },
     ],
     initialFilter: {
-        items: [{ field: "type", operator: "is", value: "Shirt" }],
+        items: [{ field: "type", operator: "is", value: "shirt" }],
     },
     columns: [
         {


### PR DESCRIPTION
## Description

Fix: change initialFilter-value in ProductsGrid from "Shirt" to "shirt" in order to fix GraphQLError.


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1624" height="1056" alt="Bildschirmfoto 2025-07-23 um 12 00 47" src="https://github.com/user-attachments/assets/76a34c2a-851e-4eec-8f2f-0e244786bba2" /> |  <img width="1624" height="1056" alt="Bildschirmfoto 2025-07-23 um 12 00 06" src="https://github.com/user-attachments/assets/4a13b0f4-f360-4cd4-8e7e-595974080f42" /> |
