### PR TITLE
Add dev-story to report bug in edit-dialog when used with data-grid

### DIFF
--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -22,6 +22,7 @@ import { type GQLPageTreeNodeCategory } from "@src/graphql.generated";
 import MainMenu from "@src/mainMenu/MainMenu";
 import { NewsPage } from "@src/news/NewsPage";
 import { categoryToUrlParam, pageTreeCategories, urlParamToCategory } from "@src/pageTree/pageTreeCategories";
+import { EditDialogBugPage } from "@src/products/devStories/EditDialogBugPage";
 import { CreateCapProductPage } from "@src/products/generator/CreateCapProductPage";
 import { ManufacturersPage } from "@src/products/generator/ManufacturersPage";
 import { ProductCategoriesPage } from "@src/products/generator/ProductCategoriesPage";
@@ -208,6 +209,21 @@ export const masterMenuData: MasterMenuData = [
         type: "group",
         title: <FormattedMessage id="menu.products" defaultMessage="Products" />,
         items: [
+            {
+                type: "collapsible",
+                primary: <FormattedMessage id="menu.devStories" defaultMessage="Dev Stories" />,
+                icon: <Snips />,
+                items: [
+                    {
+                        type: "route",
+                        primary: <FormattedMessage id="menu.devStories.editDialogBug" defaultMessage="Edit-Dialog Bug" />,
+                        route: {
+                            path: "/dev-stories/edit-dialog-bug",
+                            component: EditDialogBugPage,
+                        },
+                    },
+                ],
+            },
             {
                 type: "collapsible",
                 primary: <FormattedMessage id="menu.generator" defaultMessage="Generator" />,

--- a/demo/admin/src/products/devStories/EditDialogBugPage.tsx
+++ b/demo/admin/src/products/devStories/EditDialogBugPage.tsx
@@ -1,0 +1,30 @@
+import { Button, Stack, StackMainContent, StackToolbar, useEditDialog } from "@comet/admin";
+import { Add as AddIcon } from "@comet/admin-icons";
+import { ContentScopeIndicator } from "@comet/cms-admin";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { ProductForm } from "../generator/generated/ProductForm";
+import { ProductsGrid } from "../generator/generated/ProductsGrid";
+
+export function EditDialogBugPage() {
+    const intl = useIntl();
+    const [EditDialog, , editDialogApi] = useEditDialog();
+
+    return (
+        <Stack topLevelTitle={intl.formatMessage({ id: "devStories.editDailogBug", defaultMessage: "Edit-Dialog Bug" })}>
+            <StackToolbar scopeIndicator={<ContentScopeIndicator global />} />
+            <StackMainContent fullHeight>
+                <ProductsGrid
+                    toolbarAction={
+                        <Button responsive startIcon={<AddIcon />} onClick={() => editDialogApi?.openAddDialog()}>
+                            <FormattedMessage id="devStories.editDailogBug.newProduct" defaultMessage="New Product" />
+                        </Button>
+                    }
+                />
+                <EditDialog>
+                    <ProductForm />
+                </EditDialog>
+            </StackMainContent>
+        </Stack>
+    );
+}


### PR DESCRIPTION
## Description

Problem DataGrid + EditDialog:

- DataGrid stores some of its state information in the URL as GET parameters (paging, filtering and sorting,...)
- when a subroute is opened (e.g. EditDialog), these parameters disappear
- DataGrid remains visible in the background, but loses the GET parameters -> also lost when the dialog is closed

## Screencast

https://github.com/user-attachments/assets/63eb243d-82ad-41de-a070-642314c47394

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2184
