### PR TITLE
Demo: Set fields to required in HeadingBlock in admin

### DIFF
--- a/demo/admin/src/common/blocks/HeadingBlock.tsx
+++ b/demo/admin/src/common/blocks/HeadingBlock.tsx
@@ -81,6 +81,7 @@ export const HeadingBlock = createCompositeBlock(
                         { value: "h5", label: <FormattedMessage id="headingBlock.headline5" defaultMessage="Headline 5" /> },
                         { value: "h6", label: <FormattedMessage id="headingBlock.headline6" defaultMessage="Headline 6" /> },
                     ],
+                    required: true,
                 }),
             },
         },

--- a/demo/admin/src/common/blocks/StandaloneHeadingBlock.tsx
+++ b/demo/admin/src/common/blocks/StandaloneHeadingBlock.tsx
@@ -19,6 +19,7 @@ export const StandaloneHeadingBlock = createCompositeBlock(
                         { value: "left", label: <FormattedMessage id="standaloneHeading.textAlignment.left" defaultMessage="left" /> },
                         { value: "center", label: <FormattedMessage id="standaloneHeading.textAlignment.center" defaultMessage="center" /> },
                     ],
+                    required: true,
                 }),
             },
         },


### PR DESCRIPTION
## Description

Problem: `htmlTag` (in HeadlineBlock) and `textAlignment` (in StandaloneHeadlineBlock) are required fields, but the Select field is clearable. --> set fields to required
![requiredfields](https://github.com/user-attachments/assets/367deb27-c344-4732-8611-7c5b07ca4b18)


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="542" height="717" alt="Screenshot 2025-07-23 at 14 39 40" src="https://github.com/user-attachments/assets/1a00d062-1c91-4b16-8765-82ebe284115e" /> |  <img width="542" height="717" alt="Screenshot 2025-07-23 at 14 39 40" src="https://github.com/user-attachments/assets/4474e1b3-7985-4d97-aed2-13528d46e841" /> |

## Open TODOs/questions

-   [x] Add changeset
-  [x] Add Starter PR: https://github.com/vivid-planet/comet-starter/pull/921

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2172
