### PR TITLE
Demo: Fix structure of `LinkList` in `Footer`

### DIFF
--- a/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
+++ b/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
@@ -27,11 +27,11 @@ export const FooterContentBlock = withPreview(
                                 {linkList.blocks.length > 0 && (
                                     <LinksWrapper>
                                         {linkList.blocks.map((block) => (
-                                            <Link key={block.key}>
+                                            <li key={block.key}>
                                                 <LinkText as={LinkBlock} data={block.props.link} variant="p200">
                                                     {block.props.text}
                                                 </LinkText>
-                                            </Link>
+                                            </li>
                                         ))}
                                     </LinksWrapper>
                                 )}
@@ -129,9 +129,6 @@ const LinksWrapper = styled.ul`
     gap: ${({ theme }) => theme.spacing.S500};
     flex-wrap: wrap;
     justify-content: center;
-`;
-
-const Link = styled.li`
     list-style: none;
 `;
 

--- a/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
+++ b/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
@@ -28,7 +28,7 @@ export const FooterContentBlock = withPreview(
                                     <LinksWrapper>
                                         {linkList.blocks.map((block) => (
                                             <Link key={block.key}>
-                                                <LinkText key={block.key} as={LinkBlock} data={block.props.link} variant="p200">
+                                                <LinkText as={LinkBlock} data={block.props.link} variant="p200">
                                                     {block.props.text}
                                                 </LinkText>
                                             </Link>

--- a/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
+++ b/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
@@ -130,6 +130,8 @@ const LinksWrapper = styled.ul`
     flex-wrap: wrap;
     justify-content: center;
     list-style: none;
+    margin: 0;
+    padding: 0;
 `;
 
 const CopyrightNotice = styled(Typography)`

--- a/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
+++ b/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
@@ -23,15 +23,19 @@ export const FooterContentBlock = withPreview(
                         </TopContainer>
                         <HorizontalLine />
                         <LinkCopyrightWrapper>
-                            {linkList.blocks.length > 0 && (
-                                <LinksWrapper>
-                                    {linkList.blocks.map((block) => (
-                                        <LinkText key={block.key} as={LinkBlock} data={block.props.link} variant="p200">
-                                            {block.props.text}
-                                        </LinkText>
-                                    ))}
-                                </LinksWrapper>
-                            )}
+                            <nav>
+                                {linkList.blocks.length > 0 && (
+                                    <LinksWrapper>
+                                        {linkList.blocks.map((block) => (
+                                            <Link key={block.key}>
+                                                <LinkText key={block.key} as={LinkBlock} data={block.props.link} variant="p200">
+                                                    {block.props.text}
+                                                </LinkText>
+                                            </Link>
+                                        ))}
+                                    </LinksWrapper>
+                                )}
+                            </nav>
                             {copyrightNotice && <CopyrightNotice variant="p200">{copyrightNotice}</CopyrightNotice>}
                         </LinkCopyrightWrapper>
                     </PageLayoutContent>
@@ -120,11 +124,15 @@ const LinkCopyrightWrapper = styled.div`
     }
 `;
 
-const LinksWrapper = styled.div`
+const LinksWrapper = styled.ul`
     display: flex;
     gap: ${({ theme }) => theme.spacing.S500};
     flex-wrap: wrap;
     justify-content: center;
+`;
+
+const Link = styled.li`
+    list-style: none;
 `;
 
 const CopyrightNotice = styled(Typography)`


### PR DESCRIPTION
## Description

At the moment the links of the `LinkList`in the `Footer` are only nested in divs. This is semantically incorrect -> fix structure of LinkList by adding `<nav>`, `<ul>`, and `<li>` tags.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="745" height="133" alt="Screenshot 2025-07-23 at 15 18 11" src="https://github.com/user-attachments/assets/2941445c-eefb-47c3-8b6e-16c5a3413327" />    | <img width="773" height="214" alt="Screenshot 2025-07-23 at 15 17 42" src="https://github.com/user-attachments/assets/79057ebc-e728-428c-ad67-5fa2ca2723a2" /> |

## Open TODOs/questions

-   [x] Add changeset
- [x] PR in Starter: https://github.com/vivid-planet/comet-starter/pull/922

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2176
