### PR TITLE
Only regenerate warnings for the row that changed in the `WarningEventSubscriber`

### DIFF
--- a/.changeset/curly-rules-obey.md
+++ b/.changeset/curly-rules-obey.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Only regenerate warnings for the row that changed in the `WarningEventSubscriber`
+
+Previously, the warnings were regenerated for all rows of the entity using a lot of memory.

--- a/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
+++ b/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
@@ -111,10 +111,10 @@ export class WarningEventSubscriber implements EventSubscriber {
             }
 
             const createWarnings = this.reflector.getAllAndOverride<CreateWarningsMeta>("createWarnings", [entity]);
-            if (createWarnings && args.changeSet?.originalEntity?.id) {
+            if (createWarnings && args.entity.id) {
                 const repository: EntityRepository<{ id: string; scope: ContentScope }> = this.entityManager.getRepository(entity);
 
-                const row = await repository.findOneOrFail(args.changeSet.originalEntity.id);
+                const row = await repository.findOneOrFail(args.entity.id);
 
                 let warnings: WarningData[] = [];
                 if (this.isService(createWarnings)) {

--- a/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
+++ b/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
@@ -1,5 +1,5 @@
 import { EntityName, EventArgs, EventSubscriber } from "@mikro-orm/core";
-import { EntityClass, EntityManager, MikroORM } from "@mikro-orm/postgresql";
+import { EntityClass, EntityManager, EntityRepository, MikroORM } from "@mikro-orm/postgresql";
 import { Injectable, Type } from "@nestjs/common";
 import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
 import { ModuleRef, Reflector } from "@nestjs/core";
@@ -111,32 +111,30 @@ export class WarningEventSubscriber implements EventSubscriber {
             }
 
             const createWarnings = this.reflector.getAllAndOverride<CreateWarningsMeta>("createWarnings", [entity]);
-            if (createWarnings) {
-                const repository = this.entityManager.getRepository(entity);
+            if (createWarnings && args.changeSet?.originalEntity?.id) {
+                const repository: EntityRepository<{ id: string; scope: ContentScope }> = this.entityManager.getRepository(entity);
 
-                const rows = await repository.find();
+                const row = await repository.findOneOrFail(args.changeSet.originalEntity.id);
 
-                for (const row of rows) {
-                    let warnings: WarningData[] = [];
-                    if (this.isService(createWarnings)) {
-                        const service = this.moduleRef.get(createWarnings, { strict: false });
-                        warnings = await service.createWarnings(row);
-                    } else {
-                        warnings = await createWarnings(row);
-                    }
-                    const startDate = new Date();
-                    const sourceInfo = {
-                        rootEntityName: entity.name,
-                        rootPrimaryKey: args.meta.primaryKeys[0],
-                        targetId: row.id,
-                    };
-                    await this.warningService.saveWarnings({
-                        warnings,
-                        sourceInfo,
-                        scope: row.scope,
-                    });
-                    await this.warningService.deleteOutdatedWarnings({ date: startDate, sourceInfo });
+                let warnings: WarningData[] = [];
+                if (this.isService(createWarnings)) {
+                    const service = this.moduleRef.get(createWarnings, { strict: false });
+                    warnings = await service.createWarnings(row);
+                } else {
+                    warnings = await createWarnings(row);
                 }
+                const startDate = new Date();
+                const sourceInfo = {
+                    rootEntityName: entity.name,
+                    rootPrimaryKey: args.meta.primaryKeys[0],
+                    targetId: row.id,
+                };
+                await this.warningService.saveWarnings({
+                    warnings,
+                    sourceInfo,
+                    scope: row.scope,
+                });
+                await this.warningService.deleteOutdatedWarnings({ date: startDate, sourceInfo });
             }
         }
     }


### PR DESCRIPTION
## Description

Previously, the warnings were regenerated for all rows of the entity using a lot of memory.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

