### PR TITLE
Prefix theme-name of `@comet/admin-date-time` components with `DT`

### DIFF
--- a/.changeset/floppy-grapes-go.md
+++ b/.changeset/floppy-grapes-go.md
@@ -1,0 +1,36 @@
+---
+"@comet/admin-date-time": major
+---
+
+Change the theme name of components by prefixing them with `DT`
+
+All components are now prefixed with `CometAdminDT` instead of `CometAdmin`.
+If any of the components have custom styles or default props defined in the theme, the key needs to be updated.
+
+- `CometAdminDatePickerNavigation` -> `CometAdminDTDatePickerNavigation`
+- `CometAdminDatePicker` -> `CometAdminDTDatePicker`
+- `CometAdminDateRangePicker` -> `CometAdminDTDateRangePicker`
+- `CometAdminDateTimePicker` -> `CometAdminDTDateTimePicker`
+- `CometAdminTimePicker` -> `CometAdminDTTimePicker`
+- `CometAdminTimeRangePicker` -> `CometAdminDTTimeRangePicker`
+
+```diff
+ export const theme = createCometTheme({
+     components: {
+-        CometAdminDatePicker: {
++        CometAdminDTDatePicker: {
+             defaultProps: {
+                 monthsToShow: 2,
+             },
+         },
+-        CometAdminDateTimePicker: {
++        CometAdminDTDateTimePicker: {
+             styleOverrides: {
+                 root: {
+                     backgroundColor: "magenta",
+                 },
+             },
+         },
+     },
+ });
+```

--- a/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
+++ b/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
@@ -22,7 +22,7 @@ export interface DatePickerNavigationProps
 export const DatePickerNavigation = (inProps: DatePickerNavigationProps) => {
     const { focusedDate, changeShownDate, minDate, maxDate, slotProps, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminDatePickerNavigation",
+        name: "CometAdminDTDatePickerNavigation",
     });
     const intl = useIntl();
 
@@ -119,7 +119,7 @@ export type DatePickerNavigationClassKey =
     | "selectYearMenu";
 
 const Root = createComponentSlot("div")<DatePickerNavigationClassKey>({
-    componentName: "DatePickerNavigation",
+    componentName: "DTDatePickerNavigation",
     slotName: "root",
 })(
     ({ theme }) => css`
@@ -134,7 +134,7 @@ const Root = createComponentSlot("div")<DatePickerNavigationClassKey>({
 );
 
 const SelectMonthButton = createComponentSlot(Button)<DatePickerNavigationClassKey>({
-    componentName: "DatePickerNavigation",
+    componentName: "DTDatePickerNavigation",
     slotName: "selectMonthButton",
     classesResolver() {
         return ["selectButton"];
@@ -157,7 +157,7 @@ const SelectMonthButton = createComponentSlot(Button)<DatePickerNavigationClassK
 );
 
 const SelectYearButton = createComponentSlot(Button)<DatePickerNavigationClassKey>({
-    componentName: "DatePickerNavigation",
+    componentName: "DTDatePickerNavigation",
     slotName: "selectYearButton",
     classesResolver() {
         return ["selectButton"];
@@ -180,7 +180,7 @@ const SelectYearButton = createComponentSlot(Button)<DatePickerNavigationClassKe
 );
 
 const SelectMonthMenu = createComponentSlot(Menu)<DatePickerNavigationClassKey>({
-    componentName: "DatePickerNavigation",
+    componentName: "DTDatePickerNavigation",
     slotName: "selectMonthMenu",
     classesResolver() {
         return ["selectMenu"];
@@ -193,7 +193,7 @@ const SelectMonthMenu = createComponentSlot(Menu)<DatePickerNavigationClassKey>(
 `);
 
 const SelectYearMenu = createComponentSlot(Menu)<DatePickerNavigationClassKey>({
-    componentName: "DatePickerNavigation",
+    componentName: "DTDatePickerNavigation",
     slotName: "selectYearMenu",
     classesResolver() {
         return ["selectMenu"];
@@ -207,17 +207,17 @@ const SelectYearMenu = createComponentSlot(Menu)<DatePickerNavigationClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminDatePickerNavigation: DatePickerNavigationClassKey;
+        CometAdminDTDatePickerNavigation: DatePickerNavigationClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminDatePickerNavigation: DatePickerNavigationProps;
+        CometAdminDTDatePickerNavigation: DatePickerNavigationProps;
     }
 
     interface Components {
-        CometAdminDatePickerNavigation?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDatePickerNavigation"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDatePickerNavigation"];
+        CometAdminDTDatePickerNavigation?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminDTDatePickerNavigation"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDTDatePickerNavigation"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/datePicker/DatePicker.slots.ts
+++ b/packages/admin/admin-date-time/src/datePicker/DatePicker.slots.ts
@@ -15,17 +15,17 @@ export type SlotProps = ThemedComponentBaseProps<{
 }>["slotProps"];
 
 export const Root = createComponentSlot(InputWithPopper)<DatePickerClassKey>({
-    componentName: "DatePicker",
+    componentName: "DTDatePicker",
     slotName: "root",
 })();
 
 export const StartAdornment = createComponentSlot(InputAdornment)<DatePickerClassKey>({
-    componentName: "DatePicker",
+    componentName: "DTDatePicker",
     slotName: "startAdornment",
 })();
 
 export const Calendar = createComponentSlot(CalendarBase)<DatePickerClassKey>({
-    componentName: "DatePicker",
+    componentName: "DTDatePicker",
     slotName: "calendar",
 })(({ theme }) =>
     deepmerge<CSSProperties>(getReactDateRangeStyles(theme), {

--- a/packages/admin/admin-date-time/src/datePicker/DatePicker.tsx
+++ b/packages/admin/admin-date-time/src/datePicker/DatePicker.tsx
@@ -36,7 +36,7 @@ export const DatePicker = (inProps: DatePickerProps) => {
         slotProps,
         endAdornment,
         ...inputWithPopperProps
-    } = useThemeProps({ props: inProps, name: "CometAdminDatePicker" });
+    } = useThemeProps({ props: inProps, name: "CometAdminDTDatePicker" });
     const intl = useIntl();
     const dateFnsLocale = useDateFnsLocale();
     const dateValue = value ? new Date(value) : undefined;
@@ -91,17 +91,17 @@ export const DatePicker = (inProps: DatePickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminDatePicker: DatePickerClassKey;
+        CometAdminDTDatePicker: DatePickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminDatePicker: DatePickerProps;
+        CometAdminDTDatePicker: DatePickerProps;
     }
 
     interface Components {
-        CometAdminDatePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDatePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDatePicker"];
+        CometAdminDTDatePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminDTDatePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDTDatePicker"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.slots.ts
+++ b/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.slots.ts
@@ -15,17 +15,17 @@ export type SlotProps = ThemedComponentBaseProps<{
 }>["slotProps"];
 
 export const Root = createComponentSlot(InputWithPopper)<DateRangePickerClassKey>({
-    componentName: "DateRangePicker",
+    componentName: "DTDateRangePicker",
     slotName: "root",
 })();
 
 export const StartAdornment = createComponentSlot(InputAdornment)<DateRangePickerClassKey>({
-    componentName: "DateRangePicker",
+    componentName: "DTDateRangePicker",
     slotName: "startAdornment",
 })();
 
 export const DateRange = createComponentSlot(ReactDateRange)<DateRangePickerClassKey>({
-    componentName: "DateRangePicker",
+    componentName: "DTDateRangePicker",
     slotName: "dateRange",
 })(({ theme }) =>
     deepmerge<CSSProperties>(getReactDateRangeStyles(theme), {

--- a/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.tsx
@@ -83,7 +83,7 @@ export const DateRangePicker = (inProps: DateRangePickerProps) => {
         maxDate = defaultMaxDate,
         slotProps,
         ...inputWithPopperProps
-    } = useThemeProps({ props: inProps, name: "CometAdminDateRangePicker" });
+    } = useThemeProps({ props: inProps, name: "CometAdminDTDateRangePicker" });
     const intl = useIntl();
     const textValue = useDateRangeTextValue(value, rangeStringSeparator, formatDateOptions);
     const dateFnsLocale = useDateFnsLocale();
@@ -150,17 +150,17 @@ export const DateRangePicker = (inProps: DateRangePickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminDateRangePicker: DateRangePickerClassKey;
+        CometAdminDTDateRangePicker: DateRangePickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminDateRangePicker: DateRangePickerProps;
+        CometAdminDTDateRangePicker: DateRangePickerProps;
     }
 
     interface Components {
-        CometAdminDateRangePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDateRangePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDateRangePicker"];
+        CometAdminDTDateRangePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminDTDateRangePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDTDateRangePicker"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
@@ -12,7 +12,7 @@ import { getDateWithNewTime, getTimeStringFromDate } from "../utils/timePickerHe
 export type DateTimePickerClassKey = "root" | "dateFormControl" | "timeFormControl" | "datePicker" | "timePicker";
 
 const Root = createComponentSlot("div")<DateTimePickerClassKey>({
-    componentName: "DateTimePicker",
+    componentName: "DTDateTimePicker",
     slotName: "root",
 })(
     ({ theme }) => css`
@@ -24,7 +24,7 @@ const Root = createComponentSlot("div")<DateTimePickerClassKey>({
 );
 
 const DateFormControl = createComponentSlot(FormControl)<DateTimePickerClassKey>({
-    componentName: "DateTimePicker",
+    componentName: "DTDateTimePicker",
     slotName: "dateFormControl",
 })(
     ({ theme }) => css`
@@ -41,7 +41,7 @@ const DateFormControl = createComponentSlot(FormControl)<DateTimePickerClassKey>
 );
 
 const TimeFormControl = createComponentSlot(FormControl)<DateTimePickerClassKey>({
-    componentName: "DateTimePicker",
+    componentName: "DTDateTimePicker",
     slotName: "timeFormControl",
 })(
     ({ theme }) => css`
@@ -55,7 +55,7 @@ const TimeFormControl = createComponentSlot(FormControl)<DateTimePickerClassKey>
 );
 
 const DatePicker = createComponentSlot(DatePickerBase)<DateTimePickerClassKey>({
-    componentName: "DateTimePicker",
+    componentName: "DTDateTimePicker",
     slotName: "datePicker",
 })(
     () => css`
@@ -66,7 +66,7 @@ const DatePicker = createComponentSlot(DatePickerBase)<DateTimePickerClassKey>({
 );
 
 const TimePicker = createComponentSlot(TimePickerBase)<DateTimePickerClassKey>({
-    componentName: "DateTimePicker",
+    componentName: "DTDateTimePicker",
     slotName: "timePicker",
 })(
     () => css`
@@ -95,7 +95,7 @@ export interface DateTimePickerProps
 export const DateTimePicker = (inProps: DateTimePickerProps) => {
     const { onChange, value, required, disabled, slotProps, onBlur, onFocus, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminDateTimePicker",
+        name: "CometAdminDTDateTimePicker",
     });
     const intl = useIntl();
     const datePickerRef = useRef<HTMLElement>(null);
@@ -178,17 +178,17 @@ export const DateTimePicker = (inProps: DateTimePickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminDateTimePicker: DateTimePickerClassKey;
+        CometAdminDTDateTimePicker: DateTimePickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminDateTimePicker: DateTimePickerProps;
+        CometAdminDTDateTimePicker: DateTimePickerProps;
     }
 
     interface Components {
-        CometAdminDateTimePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDateTimePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDateTimePicker"];
+        CometAdminDTDateTimePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminDTDateTimePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDTDateTimePicker"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/timePicker/TimePicker.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/TimePicker.tsx
@@ -25,22 +25,22 @@ type SlotProps = ThemedComponentBaseProps<{
 }>["slotProps"];
 
 const Root = createComponentSlot(InputWithPopper)<TimePickerClassKey>({
-    componentName: "TimePicker",
+    componentName: "DTTimePicker",
     slotName: "root",
 })();
 
 const StartAdornment = createComponentSlot(InputAdornment)<TimePickerClassKey>({
-    componentName: "TimePicker",
+    componentName: "DTTimePicker",
     slotName: "startAdornment",
 })();
 
 const TimeOptionsList = createComponentSlot(MenuList)<TimePickerClassKey>({
-    componentName: "TimePicker",
+    componentName: "DTTimePicker",
     slotName: "timeOptionsList",
 })();
 
 const TimeOptionItem = createComponentSlot(MenuItem)<TimePickerClassKey>({
-    componentName: "TimePicker",
+    componentName: "DTTimePicker",
     slotName: "timeOptionItem",
 })(
     ({ theme }) => css`
@@ -72,7 +72,7 @@ export const TimePicker = (inProps: TimePickerProps) => {
         max = "23:59",
         slotProps,
         ...inputWithPopperProps
-    } = useThemeProps({ props: inProps, name: "CometAdminTimePicker" });
+    } = useThemeProps({ props: inProps, name: "CometAdminDTTimePicker" });
     const intl = useIntl();
     const focusedItemRef = useRef<HTMLLIElement>(null);
 
@@ -163,17 +163,17 @@ export const TimePicker = (inProps: TimePickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminTimePicker: TimePickerClassKey;
+        CometAdminDTTimePicker: TimePickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminTimePicker: TimePickerProps;
+        CometAdminDTTimePicker: TimePickerProps;
     }
 
     interface Components {
-        CometAdminTimePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminTimePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTimePicker"];
+        CometAdminDTTimePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminDTTimePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDTTimePicker"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/timeRangePicker/TimeRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/timeRangePicker/TimeRangePicker.tsx
@@ -16,7 +16,7 @@ export type TimeRangePickerClassKey =
     | "separator";
 
 const Root = createComponentSlot("div")<TimeRangePickerClassKey>({
-    componentName: "TimeRangePicker",
+    componentName: "DTTimeRangePicker",
     slotName: "root",
 })(css`
     display: flex;
@@ -24,31 +24,31 @@ const Root = createComponentSlot("div")<TimeRangePickerClassKey>({
 `);
 
 const StartFormControl = createComponentSlot(FormControl)<TimeRangePickerClassKey>({
-    componentName: "TimeRangePicker",
+    componentName: "DTTimeRangePicker",
     slotName: "startFormControl",
 })(css`
     flex-grow: 1;
 `);
 
 const EndFormControl = createComponentSlot(FormControl)<TimeRangePickerClassKey>({
-    componentName: "TimeRangePicker",
+    componentName: "DTTimeRangePicker",
     slotName: "endFormControl",
 })(css`
     flex-grow: 1;
 `);
 
 const StartTimePicker = createComponentSlot(TimePickerBase)<TimeRangePickerClassKey>({
-    componentName: "TimeRangePicker",
+    componentName: "DTTimeRangePicker",
     slotName: "startTimePicker",
 })();
 
 const EndTimePicker = createComponentSlot(TimePickerBase)<TimeRangePickerClassKey>({
-    componentName: "TimeRangePicker",
+    componentName: "DTTimeRangePicker",
     slotName: "endTimePicker",
 })();
 
 const Separator = createComponentSlot(Typography)<TimeRangePickerClassKey>({
-    componentName: "TimeRangePicker",
+    componentName: "DTTimeRangePicker",
     slotName: "separator",
 })(
     ({ theme }) => css`
@@ -93,7 +93,7 @@ export const TimeRangePicker = (inProps: TimeRangePickerProps) => {
         required,
         slotProps,
         ...propsForBothTimePickers
-    } = useThemeProps({ props: inProps, name: "CometAdminTimeRangePicker" });
+    } = useThemeProps({ props: inProps, name: "CometAdminDTTimeRangePicker" });
     const intl = useIntl();
 
     const [startTime, setStartTime] = useState<IndividualTimeValue>(value?.start);
@@ -180,17 +180,17 @@ export const TimeRangePicker = (inProps: TimeRangePickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminTimeRangePicker: TimeRangePickerClassKey;
+        CometAdminDTTimeRangePicker: TimeRangePickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminTimeRangePicker: TimeRangePickerProps;
+        CometAdminDTTimeRangePicker: TimeRangePickerProps;
     }
 
     interface Components {
-        CometAdminTimeRangePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminTimeRangePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTimeRangePicker"];
+        CometAdminDTTimeRangePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminDTTimeRangePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDTTimeRangePicker"];
         };
     }
 }


### PR DESCRIPTION
## Description

We use `DT` as a shorthand for `DateTime`, as otherwise we'd have long, confusing names like `CometAdminDateTimeDateTimePicker`.

In the future we are planning to add new date-time components directly to `@comet/admin` and deprecate the `@comet/admin-date-time` package.

We therefore need to use the existing theme-names (e.g. `CometAdminDatePicker`) for the `@comet/admin` components to prevent custom theme-values from being applied to the wrong component and to ensure correct typing.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [ ] Should we use the `DT` prefix? Would `DateTime` be better? 
-   [ ] Should we create an upgrade-script for this?
-   [ ] Should we add a migration-guide entry?

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2118
