### PR TITLE
Remove hardcoded `scope.domain` from `usePageSearch`

### DIFF
--- a/.changeset/itchy-squids-own.md
+++ b/.changeset/itchy-squids-own.md
@@ -2,4 +2,4 @@
 "@comet/cms-admin": patch
 ---
 
-Fix usePageSearch by using domain extracted from `siteConfig.url`
+Fix searching for pages via domain by using the site's URL from the site config

--- a/.changeset/itchy-squids-own.md
+++ b/.changeset/itchy-squids-own.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix usePageSearch by using domain extracted from `siteConfig.url`

--- a/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
+++ b/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
@@ -39,7 +39,14 @@ const usePageSearch = ({ tree, domain, setExpandedIds, onUpdateCurrentMatch, pag
     const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
     const [query, setQuery] = useState("");
 
-    const domainHost = new URL(domain).host;
+    let domainHost: string;
+
+    try {
+        domainHost = new URL(domain).host;
+    } catch (error) {
+        console.error("Invalid domain provided:", domain, error);
+        domainHost = "";
+    }
 
     const inorderPages = useMemo(() => {
         const buildPagesForParent = (parentId = "root", ancestorIds: string[] = []) => {

--- a/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
+++ b/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
@@ -29,12 +29,12 @@ export interface PageSearchApi {
 interface UsePageSearchOptions {
     tree: Map<string, GQLPageSearchFragment[]>;
     pagesToRender: PageTreePage[];
-    domain: string;
+    siteUrl: string;
     setExpandedIds: Dispatch<SetStateAction<string[]>>;
     onUpdateCurrentMatch: (pageId: string, pages: PageTreePage[]) => void;
 }
 
-const usePageSearch = ({ tree, domain, setExpandedIds, onUpdateCurrentMatch, pagesToRender }: UsePageSearchOptions): PageSearchApi => {
+const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pagesToRender }: UsePageSearchOptions): PageSearchApi => {
     const [matches, setMatches] = useState<PageSearchMatch[] | null>(null);
     const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
     const [query, setQuery] = useState("");
@@ -42,9 +42,9 @@ const usePageSearch = ({ tree, domain, setExpandedIds, onUpdateCurrentMatch, pag
     let domainHost: string;
 
     try {
-        domainHost = new URL(domain).host;
+        domainHost = new URL(siteUrl).host;
     } catch (error) {
-        console.error("Invalid domain provided:", domain, error);
+        console.error("Invalid siteUrl provided:", siteUrl, error);
         domainHost = "";
     }
 

--- a/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
+++ b/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
@@ -39,6 +39,8 @@ const usePageSearch = ({ tree, domain, setExpandedIds, onUpdateCurrentMatch, pag
     const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
     const [query, setQuery] = useState("");
 
+    const domainHost = new URL(domain).host;
+
     const inorderPages = useMemo(() => {
         const buildPagesForParent = (parentId = "root", ancestorIds: string[] = []) => {
             const returnValue: Array<{ id: string; parentId: string | null; name: string; ancestorIds: string[]; path: string }> = [];
@@ -94,7 +96,7 @@ const usePageSearch = ({ tree, domain, setExpandedIds, onUpdateCurrentMatch, pag
         try {
             const url = new URL(query);
 
-            if (!url.host.includes(domain)) {
+            if (!url.host.includes(domainHost)) {
                 return;
             }
 
@@ -141,7 +143,7 @@ const usePageSearch = ({ tree, domain, setExpandedIds, onUpdateCurrentMatch, pag
         setCurrentMatchIndex(0);
 
         expandTreeForMatches(matches);
-    }, [query, inorderPages, domain, expandTreeForMatches]);
+    }, [query, inorderPages, expandTreeForMatches, domainHost]);
 
     const pagesToRenderWithMatches = useMemo(
         () => pagesToRender.map((c) => ({ ...c, matches: matches?.filter((match) => match.page.id === c.id) ?? [] })),

--- a/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
+++ b/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
@@ -39,13 +39,13 @@ const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pa
     const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
     const [query, setQuery] = useState("");
 
-    let domainHost: string;
+    let domainHost: string | undefined;
 
     try {
         domainHost = new URL(siteUrl).host;
     } catch (error) {
         console.error("Invalid siteUrl provided:", siteUrl, error);
-        domainHost = "";
+        domainHost = undefined;
     }
 
     const inorderPages = useMemo(() => {
@@ -103,7 +103,7 @@ const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pa
         try {
             const url = new URL(query);
 
-            if (!url.host.includes(domainHost)) {
+            if (domainHost && !url.host.includes(domainHost)) {
                 return;
             }
 

--- a/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
@@ -18,6 +18,7 @@ import { FixedSizeList as List, type ListChildComponentProps } from "react-windo
 
 import { type ContentScope } from "../../contentScope/Provider";
 import { type Maybe } from "../../graphql.generated";
+import { useSiteConfig } from "../../siteConfigs/useSiteConfig";
 import { usePageTreeScope } from "../config/usePageTreeScope";
 import { PageSearch } from "../pageSearch/PageSearch";
 import { usePageSearch } from "../pageSearch/usePageSearch";
@@ -85,6 +86,7 @@ export default function PageTreeSelectDialog({ value, onChange, open, onClose, d
     const [height, setHeight] = useState(200);
     const refDialogContent = useRef<HTMLDivElement>(null);
     const selectedPageId = value?.id;
+    const siteConfig = useSiteConfig({ scope });
 
     const pagesQuery = useMemo(() => createPagesQuery({ additionalPageTreeNodeFragment }), [additionalPageTreeNodeFragment]);
 
@@ -121,8 +123,7 @@ export default function PageTreeSelectDialog({ value, onChange, open, onClose, d
     const pageSearchApi = usePageSearch({
         tree,
         pagesToRender,
-        // TODO remove hardcoded domain here
-        domain: scope.domain,
+        domain: siteConfig.url,
         setExpandedIds,
         onUpdateCurrentMatch: (pageId, pagesToRender) => {
             const index = pagesToRender.findIndex((c) => c.id === pageId);

--- a/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTreeSelect/PageTreeSelectDialog.tsx
@@ -123,7 +123,7 @@ export default function PageTreeSelectDialog({ value, onChange, open, onClose, d
     const pageSearchApi = usePageSearch({
         tree,
         pagesToRender,
-        domain: siteConfig.url,
+        siteUrl: siteConfig.url,
         setExpandedIds,
         onUpdateCurrentMatch: (pageId, pagesToRender) => {
             const index = pagesToRender.findIndex((c) => c.id === pageId);

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -119,8 +119,7 @@ export function PagesPage({
     const pageSearchApi = usePageSearch({
         tree,
         pagesToRender,
-        // TODO remove hardcoded domain here
-        domain: pageTreeScope.domain,
+        domain: siteConfig.url,
         setExpandedIds,
         onUpdateCurrentMatch: (pageId, pagesToRender) => {
             const index = pagesToRender.findIndex((c) => c.id === pageId);

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -119,7 +119,7 @@ export function PagesPage({
     const pageSearchApi = usePageSearch({
         tree,
         pagesToRender,
-        domain: siteConfig.url,
+        siteUrl: siteConfig.url,
         setExpandedIds,
         onUpdateCurrentMatch: (pageId, pagesToRender) => {
             const index = pagesToRender.findIndex((c) => c.id === pageId);


### PR DESCRIPTION
## Description

`usePageTree` uses `scope.domain` for searching, which is not provided in all projects, and therefor not working sometimes. Fix: use `siteConfig.url` and extract the host instead of `scope.domain`.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2141
