### PR TITLE
A11y: Focus on VideoPreviewImage

### DIFF
--- a/.changeset/legal-planets-know.md
+++ b/.changeset/legal-planets-know.md
@@ -1,0 +1,5 @@
+---
+"@comet/site-nextjs": patch
+---
+
+Set focus on `playIcon` in VideoPreviewImage for better visibility

--- a/packages/site/site-nextjs/src/blocks/helpers/VideoPreviewImage.module.scss
+++ b/packages/site/site-nextjs/src/blocks/helpers/VideoPreviewImage.module.scss
@@ -22,6 +22,14 @@
     border: none;
     padding: 0;
     cursor: pointer;
+
+    &:focus {
+        .playIcon {
+            outline: 4px solid white;
+            outline-offset: 10px;
+            border-radius: 2px;
+        }
+    }
 }
 
 .playIcon {


### PR DESCRIPTION
## Description

The focus is poorly visible for the button in the `VideoPreviewImage` (see Screenshot). For better visibility, the focus is also set on the playIcon. 
## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="294" height="155" alt="Screenshot 2025-07-29 at 13 46 07" src="https://github.com/user-attachments/assets/a4cbdb4d-20ec-4d30-b457-8d99ced9bfd0" /> | <img width="267" height="153" alt="Screenshot 2025-07-29 at 13 47 24" src="https://github.com/user-attachments/assets/ad736b24-c3b4-4080-a615-560d9451ea31" />|

![focus-play-button](https://github.com/user-attachments/assets/fb7af566-97fa-4b3b-8b28-6255f30acef0)


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2174
