### PR TITLE
Admin Generator: Make grid and form staticSelect values compatible to allow re-using from a shared file

### DIFF
--- a/demo/admin/src/products/generator/SelectProductsGrid.cometGen.ts
+++ b/demo/admin/src/products/generator/SelectProductsGrid.cometGen.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "@comet/admin-generator";
 import { type GQLProduct } from "@src/graphql.generated";
 
+import { productTypeValues } from "./productTypeValues";
+
 export default defineConfig<GQLProduct>({
     type: "grid",
     gqlType: "Product",
@@ -11,7 +13,7 @@ export default defineConfig<GQLProduct>({
         { type: "text", name: "title", headerName: "Titel", minWidth: 200, maxWidth: 250 },
         { type: "text", name: "description", headerName: "Description" },
         { type: "number", name: "price", headerName: "Price", maxWidth: 150 },
-        { type: "staticSelect", name: "type", maxWidth: 150, values: [{ value: "cap", label: "great Cap" }, "shirt", "tie"] },
+        { type: "staticSelect", name: "type", maxWidth: 150, values: productTypeValues },
         { type: "date", name: "availableSince", width: 140 },
         { type: "dateTime", name: "createdAt", width: 170 },
     ],

--- a/demo/admin/src/products/generator/productTypeValues.tsx
+++ b/demo/admin/src/products/generator/productTypeValues.tsx
@@ -1,1 +1,3 @@
-export const productTypeValues = [{ value: "cap", label: "great Cap" }, { value: "shirt", label: "Shirt" }, "tie"];
+import { type StaticSelectValue } from "@comet/admin-generator";
+
+export const productTypeValues: StaticSelectValue[] = [{ value: "cap", label: "great Cap" }, { value: "shirt", label: "Shirt" }, "tie"];

--- a/packages/admin/admin-generator/src/commands/generate/generate-command.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generate-command.ts
@@ -51,6 +51,7 @@ type InputBaseFieldConfig = {
 };
 
 export type ComponentFormFieldConfig = { type: "component"; component: ComponentType };
+export type StaticSelectValue = { value: string; label: string } | string;
 
 export type FormFieldConfig<T> = (
     | ({ type: "text"; multiline?: boolean } & InputBaseFieldConfig)
@@ -66,7 +67,7 @@ export type FormFieldConfig<T> = (
     | ({ type: "dateTime" } & InputBaseFieldConfig)
     | ({
           type: "staticSelect";
-          values?: Array<{ value: string; label: string } | string>;
+          values?: StaticSelectValue[];
           inputType?: "select" | "radio";
       } & Omit<InputBaseFieldConfig, "endAdornment">)
     | ({
@@ -129,14 +130,20 @@ type BaseColumnConfig = Pick<GridColDef, "headerName" | "width" | "minWidth" | "
     fieldName?: string; // this can be used to overwrite field-prop of column-config
 };
 
-export type StaticSelectLabelCellContent = {
+export type GridColumnStaticSelectLabelCellContent = {
     primaryText?: string;
     secondaryText?: string;
     icon?: Icon;
 };
 
-type StaticSelectValue = string | number | boolean;
-type StaticSelectValueObject = { value: StaticSelectValue; label: string | StaticSelectLabelCellContent };
+export type GridColumnStaticSelectValue =
+    | StaticSelectValue
+    | {
+          value: string | number | boolean;
+          label: string | GridColumnStaticSelectLabelCellContent;
+      }
+    | number
+    | boolean;
 
 export type GridColumnConfig<T extends GridValidRowModel> = (
     | { type: "text"; renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element }
@@ -144,7 +151,7 @@ export type GridColumnConfig<T extends GridValidRowModel> = (
     | { type: "boolean"; renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element }
     | { type: "date"; renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element }
     | { type: "dateTime"; renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element }
-    | { type: "staticSelect"; values?: Array<StaticSelectValue | StaticSelectValueObject> }
+    | { type: "staticSelect"; values?: GridColumnStaticSelectValue[] }
     | { type: "block"; block: BlockInterface }
     | { type: "id"; renderCell?: (params: GridRenderCellParams<T, any, any>) => JSX.Element }
     | {

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
@@ -15,8 +15,8 @@ import {
     type GeneratorReturn,
     type GQLDocumentConfigMap,
     type GridColumnConfig,
+    type GridColumnStaticSelectLabelCellContent,
     type GridConfig,
-    type StaticSelectLabelCellContent,
     type VirtualGridColumnConfig,
 } from "../generate-command";
 import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
@@ -98,7 +98,7 @@ type LabelData = {
     gridCellContent?: ReactNode;
 };
 
-const getValueOptionsLabelData = (messageId: string, label: string | StaticSelectLabelCellContent): LabelData => {
+const getValueOptionsLabelData = (messageId: string, label: string | GridColumnStaticSelectLabelCellContent): LabelData => {
     if (typeof label === "string") {
         return {
             textLabel: `intl.formatMessage({ id: "${messageId}", defaultMessage: "${label}" })`,

--- a/packages/admin/admin-generator/src/index.ts
+++ b/packages/admin/admin-generator/src/index.ts
@@ -1,2 +1,10 @@
-export type { FormConfig, FormFieldConfig, GeneratorConfig, GridColumnConfig, GridConfig } from "./commands/generate/generate-command";
+export type {
+    FormConfig,
+    FormFieldConfig,
+    GeneratorConfig,
+    GridColumnConfig,
+    GridColumnStaticSelectValue,
+    GridConfig,
+    StaticSelectValue,
+} from "./commands/generate/generate-command";
 export { defineConfig } from "./commands/generate/generate-command";


### PR DESCRIPTION
- The Grid Version now extends the Form Version (it has more features)
- new type export: StaticSelectValue that can be used for Grid and Form
- new type export: GridColumnStaticSelectValue that can be used for Grid only

Also add usage example in demo (with typed values export and usage in form+grid)

(replaces #3571)