### PR TITLE
Admin Generator: improve usages of `GridConfig` type

### DIFF
--- a/packages/admin/admin-generator/src/commands/generate/generate-command.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generate-command.ts
@@ -181,13 +181,16 @@ type InitialFilterConfig = {
     linkOperator?: "and" | "or";
 };
 
+// Additional type is necessary to avoid "TS2589: Type instantiation is excessively deep and possibly infinite."
+type GridConfigGridColumnDef<T extends { __typename?: string }> = GridColumnConfig<T> | ActionsGridColumnConfig | VirtualGridColumnConfig<T>;
+
 export type GridConfig<T extends { __typename?: string }> = {
     type: "grid";
     gqlType: T["__typename"];
     fragmentName?: string;
     query?: string;
     queryParamsPrefix?: string;
-    columns: Array<GridColumnConfig<T> | ActionsGridColumnConfig | VirtualGridColumnConfig<T>>;
+    columns: Array<GridConfigGridColumnDef<T>>;
     excelExport?: boolean;
     add?: boolean;
     edit?: boolean;

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGqlFieldList.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGqlFieldList.ts
@@ -1,6 +1,6 @@
 import objectPath from "object-path";
 
-import { type ActionsGridColumnConfig, type GridColumnConfig, type VirtualGridColumnConfig } from "../generate-command";
+import { type GridConfig } from "../generate-command";
 
 type FieldsObjectType = { [key: string]: FieldsObjectType | boolean | string };
 const recursiveStringify = (obj: FieldsObjectType): string => {
@@ -20,12 +20,7 @@ const recursiveStringify = (obj: FieldsObjectType): string => {
     return ret;
 };
 
-export function generateGqlFieldList({
-    columns,
-}: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    columns: Array<GridColumnConfig<any> | ActionsGridColumnConfig | VirtualGridColumnConfig<any>>;
-}) {
+export function generateGqlFieldList<T extends { __typename?: string }>({ columns }: { columns: GridConfig<T>["columns"] }) {
     const fieldsObject: FieldsObjectType = columns.reduce<FieldsObjectType>((acc, field) => {
         if (field.type !== "actions") {
             let hasCustomFields = false;

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/getPropsForFilterProp.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/getPropsForFilterProp.ts
@@ -4,12 +4,11 @@ import { type GridConfig } from "../generate-command";
 import { type Imports } from "../utils/generateImportsCode";
 import { type Prop } from "./generateGrid";
 
-export function getPropsForFilterProp({
+export function getPropsForFilterProp<T extends { __typename?: string }>({
     config,
     filterType,
 }: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    config: GridConfig<any>;
+    config: GridConfig<T>;
     filterType: IntrospectionInputObjectType;
 }): {
     hasFilterProp: boolean;


### PR DESCRIPTION
## Description

Moves the refactoring made in https://github.com/vivid-planet/comet/pull/4123 into a separate PR so we can discuss the two topics independently. Furthermore, I made the following changes:

- Use `T extends { __typename?: string }` everywhere. Both `T extends { __typename: string }` and `T extends { __typename: string } & GridValidRowModel` are incorrect (I don't know why TS doesn't complain)
- Throw an error if `config.gqlType` isn't set

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2146
