### PR TITLE
Admin Generator: Refactor asyncSelect generation into own file

### DIFF
--- a/packages/admin/admin-generator/src/commands/generate/generateForm/asyncSelect/generateAsyncSelect.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/asyncSelect/generateAsyncSelect.ts
@@ -4,7 +4,7 @@ import { type FormConfig, type FormFieldConfig, isFormFieldConfig } from "../../
 import { findQueryTypeOrThrow } from "../../utils/findQueryType";
 import { type Imports } from "../../utils/generateImportsCode";
 import { isFieldOptional } from "../../utils/isFieldOptional";
-import { generateFormFieldOptions } from "../formField/options";
+import { buildFormFieldOptions } from "../formField/options";
 import { findFieldByName, type GenerateFieldsReturn } from "../generateFields";
 import { type Prop } from "../generateForm";
 
@@ -81,7 +81,7 @@ export function generateAsyncSelect({
         startAdornment,
         //endAdornment,
         imports: optionsImports,
-    } = generateFormFieldOptions({ config, formConfig, gqlIntrospection, gqlType });
+    } = buildFormFieldOptions({ config, formConfig, gqlIntrospection, gqlType });
     imports.push(...optionsImports);
 
     const nameWithPrefix = `${namePrefix ? `${namePrefix}.` : ``}${name}`;

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/asyncSelect/generateAsyncSelect.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/asyncSelect/generateAsyncSelect.ts
@@ -1,0 +1,327 @@
+import { type IntrospectionInputValue, type IntrospectionObjectType, type IntrospectionQuery } from "graphql";
+
+import { type FormConfig, type FormFieldConfig, isFormFieldConfig } from "../../generate-command";
+import { findQueryTypeOrThrow } from "../../utils/findQueryType";
+import { type Imports } from "../../utils/generateImportsCode";
+import { isFieldOptional } from "../../utils/isFieldOptional";
+import { formFieldOptions } from "../formField/options";
+import { findFieldByName, type GenerateFieldsReturn } from "../generateFields";
+import { type Prop } from "../generateForm";
+
+function gqlScalarToTypescriptType(scalarName: string): string {
+    if (scalarName === "String" || scalarName === "ID" || scalarName === "DateTime" || scalarName === "LocalDate" || scalarName === "Date") {
+        return "string";
+    } else if (scalarName === "Boolean") {
+        return "boolean";
+    } else if (scalarName === "Int" || scalarName === "Float") {
+        return "number";
+    } else if (scalarName === "JSONObject") {
+        return "unknown";
+    } else {
+        return "unknown";
+    }
+}
+
+function getTypeInfo(arg: IntrospectionInputValue, gqlIntrospection: IntrospectionQuery) {
+    let typeKind = undefined;
+    let typeClass = "unknown";
+    let required = false;
+    let type = arg.type;
+    let inputType = undefined;
+
+    if (type.kind === "NON_NULL") {
+        required = true;
+        type = type.ofType;
+    }
+    if (type.kind === "INPUT_OBJECT") {
+        typeClass = type.name;
+        typeKind = type.kind;
+        inputType = gqlIntrospection.__schema.types.find((type) => type.name === typeClass);
+    } else if (type.kind === "ENUM") {
+        typeClass = type.name;
+        typeKind = type.kind;
+    } else if (type.kind === "SCALAR") {
+        typeClass = type.name;
+        typeKind = type.kind;
+    } else {
+        throw new Error(`getTypeInfo: Resolving kind ${type.kind} currently not supported.`);
+    }
+    return {
+        required,
+        typeKind,
+        typeClass,
+        inputType,
+    };
+}
+
+export function generateAsyncSelect({
+    gqlIntrospection,
+    baseOutputFilename,
+    config,
+    formConfig,
+    gqlType,
+    namePrefix,
+}: {
+    gqlIntrospection: IntrospectionQuery;
+    baseOutputFilename: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    config: Extract<FormFieldConfig<any>, { type: "asyncSelect" }>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    formConfig: FormConfig<any>;
+    gqlType: string;
+    namePrefix?: string;
+}): GenerateFieldsReturn {
+    const imports: Imports = [];
+    const formProps: Prop[] = [];
+
+    const {
+        name,
+        fieldLabel,
+        introspectionFieldType,
+        startAdornment,
+        //endAdornment,
+        imports: optionsImports,
+    } = formFieldOptions({ config, formConfig, gqlIntrospection, gqlType });
+    imports.push(...optionsImports);
+
+    const nameWithPrefix = `${namePrefix ? `${namePrefix}.` : ``}${name}`;
+
+    const required = !isFieldOptional({ config, gqlIntrospection, gqlType });
+
+    const defaultFormValuesConfig: GenerateFieldsReturn["formValuesConfig"][0] = {
+        destructFromFormValues: config.virtual ? name : undefined,
+    };
+    const formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [defaultFormValuesConfig]; // FormFields should only contain one entry
+
+    let finalFormConfig: GenerateFieldsReturn["finalFormConfig"];
+    let code = "";
+    let formValueToGqlInputCode = "";
+
+    if (introspectionFieldType.kind !== "OBJECT") throw new Error(`asyncSelect only supports OBJECT types`);
+    const objectType = gqlIntrospection.__schema.types.find((t) => t.kind === "OBJECT" && t.name === introspectionFieldType.name) as
+        | IntrospectionObjectType
+        | undefined;
+    if (!objectType) throw new Error(`Object type ${introspectionFieldType.name} not found for field ${name}`);
+
+    //find labelField: 1. as configured
+    let labelField = config.labelField;
+
+    //find labelField: 2. common names (name or title)
+    if (!labelField) {
+        labelField = objectType.fields.find((field) => {
+            let type = field.type;
+            if (type.kind == "NON_NULL") type = type.ofType;
+            if ((field.name == "name" || field.name == "title") && type.kind == "SCALAR" && type.name == "String") {
+                return true;
+            }
+        })?.name;
+    }
+
+    //find labelField: 3. first string field
+    if (!labelField) {
+        labelField = objectType.fields.find((field) => {
+            let type = field.type;
+            if (type.kind == "NON_NULL") type = type.ofType;
+            if (field.type.kind == "SCALAR" && field.type.name == "String") {
+                return true;
+            }
+        })?.name;
+    }
+
+    const rootQuery = config.rootQuery; //TODO we should infer a default value from the gql schema
+    const queryName = `${rootQuery[0].toUpperCase() + rootQuery.substring(1)}Select`;
+    const rootQueryType = findQueryTypeOrThrow(rootQuery, gqlIntrospection);
+
+    const formFragmentField = `${name} { id ${labelField} }`;
+
+    const filterConfig = config.filter
+        ? (() => {
+              let filterField: FormFieldConfig<unknown> | undefined;
+              let gqlName = config.filter.gqlName;
+              let filterVar = "";
+
+              if (config.filter.type === "field") {
+                  filterField = findFieldByName(config.filter.fieldName, formConfig.fields);
+                  if (!filterField) {
+                      throw new Error(
+                          `Field ${String(config.name)}: No field with name "${
+                              config.filter.fieldName
+                          }" referenced as filter.fieldName found in form-config.`,
+                      );
+                  }
+                  if (!isFormFieldConfig(filterField)) {
+                      throw new Error(
+                          `Field ${String(config.name)}: Field with name "${config.filter.fieldName}" referenced as filter.fieldName is no FormField.`,
+                      );
+                  }
+
+                  filterVar = `values.${filterField.type === "asyncSelect" ? `${String(filterField.name)}?.id` : String(filterField.name)}`;
+
+                  if (!gqlName) {
+                      gqlName = config.filter.fieldName;
+                  }
+              } else if (config.filter.type === "formProp") {
+                  filterVar = config.filter.propName;
+                  if (!gqlName) {
+                      gqlName = config.filter.propName;
+                  }
+              } else {
+                  throw new Error("unsupported filter type");
+              }
+
+              // try to find arg used to filter by checking names of root-arg and filter-arg-fields
+              const rootArgForName = rootQueryType.args.find((arg) => arg.name === gqlName);
+              let filterType = rootArgForName ? getTypeInfo(rootArgForName, gqlIntrospection) : undefined;
+              let filterVarName = undefined;
+              let filterVarValue = undefined;
+
+              let filterVarType = "unknown";
+
+              if (filterType) {
+                  // there is a query root arg with same name, filter using it
+                  filterVarName = gqlName;
+                  filterVarValue = filterVar;
+                  if (filterType.typeKind === "INPUT_OBJECT" || filterType.typeKind === "ENUM") {
+                      filterVarType = `GQL${filterType.typeClass}`;
+                      imports.push({
+                          name: filterVarType,
+                          importPath: "@src/graphql.generated",
+                      });
+                  } else if (filterType.typeKind === "SCALAR") {
+                      filterVarType = gqlScalarToTypescriptType(filterType.typeClass);
+                  }
+              } else {
+                  // no root-arg with same name, check filter-arg-fields
+                  const rootArgFilter = rootQueryType.args.find((arg) => arg.name === "filter");
+                  filterType = rootArgFilter ? getTypeInfo(rootArgFilter, gqlIntrospection) : undefined;
+                  if (filterType) {
+                      filterVarName = "filter";
+                      filterVarValue = `{ ${gqlName}: { equal: ${filterVar} } }`;
+                      // get type of field.equal in filter-arg used for filtering
+                      if (filterType.inputType?.kind !== "INPUT_OBJECT") {
+                          throw new Error(`Field ${String(config.name)}: Type of filter is no object-type.`);
+                      }
+                      const nestedFilterInput = filterType.inputType.inputFields.find((inputField) => inputField.name === gqlName);
+                      if (!nestedFilterInput) {
+                          throw new Error(`Field ${String(config.name)}: Field filter.${gqlName} does not exist`);
+                      }
+                      const gqlFilterInputType = getTypeInfo(nestedFilterInput, gqlIntrospection);
+                      if (!gqlFilterInputType?.inputType || gqlFilterInputType.inputType.kind !== "INPUT_OBJECT") {
+                          throw new Error(
+                              `Field ${String(config.name)}: Type of filter.${gqlName} is no object-type, but needs to be e.g. StringFilter-type.`,
+                          );
+                      }
+                      const gqlFilterEqualInputType = gqlFilterInputType.inputType.inputFields.find((inputField) => inputField.name === "equal");
+                      if (!gqlFilterEqualInputType) {
+                          throw new Error(`Field ${String(config.name)}: Field filter.${gqlName}.equal does not exist`);
+                      }
+                      const equalFieldType = getTypeInfo(gqlFilterEqualInputType, gqlIntrospection);
+                      if (!equalFieldType) {
+                          throw new Error(
+                              `Field ${String(config.name)}: Field filter.${gqlName}.equal does not exist but is required for filtering.`,
+                          );
+                      }
+                      if (equalFieldType.typeKind === "INPUT_OBJECT" || equalFieldType.typeKind === "ENUM") {
+                          filterVarType = `GQL${equalFieldType.typeClass}`;
+                          imports.push({
+                              name: filterVarType,
+                              importPath: "@src/graphql.generated",
+                          });
+                      } else if (equalFieldType.typeKind === "SCALAR") {
+                          filterVarType = gqlScalarToTypescriptType(equalFieldType.typeClass);
+                      }
+                  } else {
+                      throw new Error(
+                          `Neither filter-prop nor root-prop with name: ${gqlName} for asyncSelect-query not found. Consider setting filterField.gqlVarName explicitly.`,
+                      );
+                  }
+              }
+              if (config.filter.type === "formProp") {
+                  formProps.push({
+                      name: config.filter.propName,
+                      optional: false,
+                      type: filterVarType,
+                  });
+              }
+
+              return {
+                  filterField,
+                  filterType,
+                  filterVarName,
+                  filterVarValue,
+              };
+          })()
+        : undefined;
+    if (filterConfig) {
+        imports.push({ name: "OnChangeField", importPath: "@comet/admin" });
+        finalFormConfig = { subscription: { values: true }, renderProps: { values: true, form: true } };
+    }
+
+    if (!config.virtual) {
+        if (!required) {
+            formValueToGqlInputCode = `${name}: formValues.${name} ? formValues.${name}.id : null,`;
+        } else {
+            formValueToGqlInputCode = `${name}: formValues.${name}?.id,`;
+        }
+    }
+
+    imports.push({
+        name: `GQL${queryName}Query`,
+        importPath: `./${baseOutputFilename}.generated`,
+    });
+    imports.push({
+        name: `GQL${queryName}QueryVariables`,
+        importPath: `./${baseOutputFilename}.generated`,
+    });
+
+    code = `<AsyncSelectField
+                ${required ? "required" : ""}
+                variant="horizontal"
+                fullWidth
+                ${config.readOnly ? "readOnly disabled" : ""}
+                name="${nameWithPrefix}"
+                label={${fieldLabel}}
+                ${config.startAdornment ? `startAdornment={<InputAdornment position="start">${startAdornment.adornmentString}</InputAdornment>}` : ""}
+                loadOptions={async () => {
+                    const { data } = await client.query<GQL${queryName}Query, GQL${queryName}QueryVariables>({
+                        query: gql\`query ${queryName}${
+                            filterConfig
+                                ? `($${filterConfig.filterVarName}: ${filterConfig.filterType.typeClass}${filterConfig.filterType.required ? `!` : ``})`
+                                : ``
+                        } {
+                            ${rootQuery}${filterConfig ? `(${filterConfig.filterVarName}: $${filterConfig.filterVarName})` : ``} {
+                                nodes {
+                                    id
+                                    ${labelField}
+                                }
+                            }
+                        }\`${filterConfig ? `, variables: { ${filterConfig.filterVarName}: ${filterConfig.filterVarValue} }` : ``}
+                    });
+                    return data.${rootQuery}.nodes;
+                }}
+                getOptionLabel={(option) => option.${labelField}}
+                ${filterConfig?.filterField ? `disabled={!values?.${String(filterConfig.filterField.name)}}` : ``}
+            />${
+                filterConfig?.filterField
+                    ? `<OnChangeField name="${String(filterConfig.filterField.name)}">
+                            {(value, previousValue) => {
+                                if (value.id !== previousValue.id) {
+                                    form.change("${String(config.name)}", undefined);
+                                }
+                            }}
+                        </OnChangeField>`
+                    : ``
+            }`;
+
+    return {
+        code,
+        hooksCode: "",
+        formValueToGqlInputCode,
+        formFragmentFields: [formFragmentField],
+        gqlDocuments: {},
+        imports,
+        formProps,
+        formValuesConfig,
+        finalFormConfig,
+    };
+}

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/formField/options.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/formField/options.ts
@@ -11,7 +11,7 @@ type AdornmentData = {
     adornmentImport?: { name: string; importPath: string };
 };
 
-const getAdornmentData = ({ adornmentData }: { adornmentData: Adornment }): AdornmentData => {
+const buildAdornmentData = ({ adornmentData }: { adornmentData: Adornment }): AdornmentData => {
     let adornmentString = "";
     let adornmentImport = { name: "", importPath: "" };
 
@@ -47,9 +47,9 @@ const getAdornmentData = ({ adornmentData }: { adornmentData: Adornment }): Ador
 };
 
 /**
- * Helper function that generates various options needed for generating form fields.
+ * Helper function that builds various options needed for generating form fields.
  */
-export function formFieldOptions({
+export function generateFormFieldOptions({
     config,
     formConfig,
     gqlIntrospection,
@@ -82,7 +82,7 @@ export function formFieldOptions({
     let endAdornment: AdornmentData = { adornmentString: "" };
 
     if ("startAdornment" in config && config.startAdornment) {
-        startAdornment = getAdornmentData({
+        startAdornment = buildAdornmentData({
             adornmentData: config.startAdornment,
         });
         if (startAdornment.adornmentImport) {
@@ -91,7 +91,7 @@ export function formFieldOptions({
     }
 
     if ("endAdornment" in config && config.endAdornment) {
-        endAdornment = getAdornmentData({
+        endAdornment = buildAdornmentData({
             adornmentData: config.endAdornment,
         });
         if (endAdornment.adornmentImport) {

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/formField/options.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/formField/options.ts
@@ -6,7 +6,7 @@ import { convertConfigImport } from "../../utils/convertConfigImport";
 import { type Imports } from "../../utils/generateImportsCode";
 import { isGeneratorConfigImport } from "../../utils/runtimeTypeGuards";
 
-export type AdornmentData = {
+type AdornmentData = {
     adornmentString: string;
     adornmentImport?: { name: string; importPath: string };
 };

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/formField/options.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/formField/options.ts
@@ -49,7 +49,7 @@ const buildAdornmentData = ({ adornmentData }: { adornmentData: Adornment }): Ad
 /**
  * Helper function that builds various options needed for generating form fields.
  */
-export function generateFormFieldOptions({
+export function buildFormFieldOptions({
     config,
     formConfig,
     gqlIntrospection,

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/formField/options.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/formField/options.ts
@@ -1,0 +1,103 @@
+import { type IntrospectionObjectType, type IntrospectionQuery } from "graphql";
+
+import { type Adornment, type FormConfig, type FormFieldConfig } from "../../generate-command";
+import { camelCaseToHumanReadable } from "../../utils/camelCaseToHumanReadable";
+import { convertConfigImport } from "../../utils/convertConfigImport";
+import { type Imports } from "../../utils/generateImportsCode";
+import { isGeneratorConfigImport } from "../../utils/runtimeTypeGuards";
+
+export type AdornmentData = {
+    adornmentString: string;
+    adornmentImport?: { name: string; importPath: string };
+};
+
+const getAdornmentData = ({ adornmentData }: { adornmentData: Adornment }): AdornmentData => {
+    let adornmentString = "";
+    let adornmentImport = { name: "", importPath: "" };
+
+    if (typeof adornmentData === "string") {
+        return { adornmentString: adornmentData };
+    }
+
+    if (typeof adornmentData.icon === "string") {
+        adornmentString = `<${adornmentData.icon}Icon />`;
+        adornmentImport = {
+            name: `${adornmentData.icon} as ${adornmentData.icon}Icon`,
+            importPath: "@comet/admin-icons",
+        };
+    } else if (typeof adornmentData.icon === "object") {
+        if (isGeneratorConfigImport(adornmentData.icon)) {
+            adornmentString = `<${adornmentData.icon.name} />`;
+            adornmentImport = convertConfigImport(adornmentData.icon);
+        } else {
+            const { name, ...iconProps } = adornmentData.icon;
+            adornmentString = `<${name}Icon
+                ${Object.entries(iconProps)
+                    .map(([key, value]) => `${key}="${value}"`)
+                    .join("\n")}
+            />`;
+            adornmentImport = {
+                name: `${adornmentData.icon.name} as ${adornmentData.icon.name}Icon`,
+                importPath: "@comet/admin-icons",
+            };
+        }
+    }
+
+    return { adornmentString, adornmentImport };
+};
+
+/**
+ * Helper function that generates various options needed for generating form fields.
+ */
+export function formFieldOptions({
+    config,
+    formConfig,
+    gqlIntrospection,
+    gqlType,
+}: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    config: FormFieldConfig<any>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    formConfig: FormConfig<any>;
+    gqlIntrospection: IntrospectionQuery;
+    gqlType: string;
+}) {
+    const rootGqlType = formConfig.gqlType;
+    const name = String(config.name);
+    const label = config.label ?? camelCaseToHumanReadable(name);
+    const formattedMessageRootId = rootGqlType[0].toLowerCase() + rootGqlType.substring(1);
+    const fieldLabel = `<FormattedMessage id="${formattedMessageRootId}.${name}" defaultMessage="${label}" />`;
+
+    const introspectionObject = gqlIntrospection.__schema.types.find((type) => type.kind === "OBJECT" && type.name === gqlType) as
+        | IntrospectionObjectType
+        | undefined;
+    if (!introspectionObject) throw new Error(`didn't find object ${gqlType} in gql introspection`);
+
+    const introspectionField = introspectionObject.fields.find((field) => field.name === name);
+    if (!introspectionField) throw new Error(`didn't find field ${name} in gql introspection type ${gqlType}`);
+    const introspectionFieldType = introspectionField.type.kind === "NON_NULL" ? introspectionField.type.ofType : introspectionField.type;
+
+    const imports: Imports = [];
+    let startAdornment: AdornmentData = { adornmentString: "" };
+    let endAdornment: AdornmentData = { adornmentString: "" };
+
+    if ("startAdornment" in config && config.startAdornment) {
+        startAdornment = getAdornmentData({
+            adornmentData: config.startAdornment,
+        });
+        if (startAdornment.adornmentImport) {
+            imports.push(startAdornment.adornmentImport);
+        }
+    }
+
+    if ("endAdornment" in config && config.endAdornment) {
+        endAdornment = getAdornmentData({
+            adornmentData: config.endAdornment,
+        });
+        if (endAdornment.adornmentImport) {
+            imports.push(endAdornment.adornmentImport);
+        }
+    }
+
+    return { name, formattedMessageRootId, fieldLabel, startAdornment, endAdornment, imports, introspectionFieldType };
+}

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -1,106 +1,15 @@
-import {
-    type IntrospectionEnumType,
-    type IntrospectionInputValue,
-    type IntrospectionNamedTypeRef,
-    type IntrospectionObjectType,
-    type IntrospectionQuery,
-} from "graphql";
+import { type IntrospectionEnumType, type IntrospectionNamedTypeRef, type IntrospectionQuery } from "graphql";
 
-import { type Adornment, type FormConfig, type FormFieldConfig, type GQLDocumentConfigMap, isFormFieldConfig } from "../generate-command";
+import { type FormConfig, type FormFieldConfig, type GQLDocumentConfigMap } from "../generate-command";
 import { camelCaseToHumanReadable } from "../utils/camelCaseToHumanReadable";
 import { convertConfigImport } from "../utils/convertConfigImport";
-import { findQueryTypeOrThrow } from "../utils/findQueryType";
 import { type Imports } from "../utils/generateImportsCode";
 import { isFieldOptional } from "../utils/isFieldOptional";
 import { isGeneratorConfigCode, isGeneratorConfigImport } from "../utils/runtimeTypeGuards";
-import { findFieldByName, type GenerateFieldsReturn } from "./generateFields";
+import { generateAsyncSelect } from "./asyncSelect/generateAsyncSelect";
+import { formFieldOptions } from "./formField/options";
+import { type GenerateFieldsReturn } from "./generateFields";
 import { type Prop } from "./generateForm";
-
-type AdornmentData = {
-    adornmentString: string;
-    adornmentImport?: { name: string; importPath: string };
-};
-
-const getAdornmentData = ({ adornmentData }: { adornmentData: Adornment }): AdornmentData => {
-    let adornmentString = "";
-    let adornmentImport = { name: "", importPath: "" };
-
-    if (typeof adornmentData === "string") {
-        return { adornmentString: adornmentData };
-    }
-
-    if (typeof adornmentData.icon === "string") {
-        adornmentString = `<${adornmentData.icon}Icon />`;
-        adornmentImport = {
-            name: `${adornmentData.icon} as ${adornmentData.icon}Icon`,
-            importPath: "@comet/admin-icons",
-        };
-    } else if (typeof adornmentData.icon === "object") {
-        if (isGeneratorConfigImport(adornmentData.icon)) {
-            adornmentString = `<${adornmentData.icon.name} />`;
-            adornmentImport = convertConfigImport(adornmentData.icon);
-        } else {
-            const { name, ...iconProps } = adornmentData.icon;
-            adornmentString = `<${name}Icon
-                ${Object.entries(iconProps)
-                    .map(([key, value]) => `${key}="${value}"`)
-                    .join("\n")}
-            />`;
-            adornmentImport = {
-                name: `${adornmentData.icon.name} as ${adornmentData.icon.name}Icon`,
-                importPath: "@comet/admin-icons",
-            };
-        }
-    }
-
-    return { adornmentString, adornmentImport };
-};
-
-function gqlScalarToTypescriptType(scalarName: string): string {
-    if (scalarName === "String" || scalarName === "ID" || scalarName === "DateTime" || scalarName === "LocalDate" || scalarName === "Date") {
-        return "string";
-    } else if (scalarName === "Boolean") {
-        return "boolean";
-    } else if (scalarName === "Int" || scalarName === "Float") {
-        return "number";
-    } else if (scalarName === "JSONObject") {
-        return "unknown";
-    } else {
-        return "unknown";
-    }
-}
-
-function getTypeInfo(arg: IntrospectionInputValue, gqlIntrospection: IntrospectionQuery) {
-    let typeKind = undefined;
-    let typeClass = "unknown";
-    let required = false;
-    let type = arg.type;
-    let inputType = undefined;
-
-    if (type.kind === "NON_NULL") {
-        required = true;
-        type = type.ofType;
-    }
-    if (type.kind === "INPUT_OBJECT") {
-        typeClass = type.name;
-        typeKind = type.kind;
-        inputType = gqlIntrospection.__schema.types.find((type) => type.name === typeClass);
-    } else if (type.kind === "ENUM") {
-        typeClass = type.name;
-        typeKind = type.kind;
-    } else if (type.kind === "SCALAR") {
-        typeClass = type.name;
-        typeKind = type.kind;
-    } else {
-        throw new Error(`getTypeInfo: Resolving kind ${type.kind} currently not supported.`);
-    }
-    return {
-        required,
-        typeKind,
-        typeClass,
-        inputType,
-    };
-}
 
 export function generateFormField({
     gqlIntrospection,
@@ -120,22 +29,28 @@ export function generateFormField({
     gqlType: string;
     namePrefix?: string;
 }): GenerateFieldsReturn {
-    const rootGqlType = formConfig.gqlType;
-    const formattedMessageRootId = rootGqlType[0].toLowerCase() + rootGqlType.substring(1);
-    const dataRootName = rootGqlType[0].toLowerCase() + rootGqlType.substring(1); // TODO should probably be deteced via query
+    if (config.type == "asyncSelect") {
+        return generateAsyncSelect({ gqlIntrospection, baseOutputFilename, config, formConfig, gqlType, namePrefix });
+    }
+    const imports: Imports = [];
+    const formProps: Prop[] = [];
 
-    const name = String(config.name);
+    const {
+        name,
+        formattedMessageRootId,
+        fieldLabel,
+        introspectionFieldType,
+        startAdornment,
+        endAdornment,
+        imports: optionsImports,
+    } = formFieldOptions({ config, formConfig, gqlType, gqlIntrospection });
+    imports.push(...optionsImports);
+
     const nameWithPrefix = `${namePrefix ? `${namePrefix}.` : ``}${name}`;
-    const label = config.label ?? camelCaseToHumanReadable(name);
 
-    const introspectionObject = gqlIntrospection.__schema.types.find((type) => type.kind === "OBJECT" && type.name === gqlType) as
-        | IntrospectionObjectType
-        | undefined;
-    if (!introspectionObject) throw new Error(`didn't find object ${gqlType} in gql introspection`);
+    const rootGqlType = formConfig.gqlType;
 
-    const introspectionField = introspectionObject.fields.find((field) => field.name === name);
-    if (!introspectionField) throw new Error(`didn't find field ${name} in gql introspection type ${gqlType}`);
-    const introspectionFieldType = introspectionField.type.kind === "NON_NULL" ? introspectionField.type.ofType : introspectionField.type;
+    const dataRootName = rootGqlType[0].toLowerCase() + rootGqlType.substring(1); // TODO should probably be deteced via query
 
     const required = !isFieldOptional({ config, gqlIntrospection, gqlType });
 
@@ -145,8 +60,6 @@ export function generateFormField({
     const readOnlyProps = `readOnly disabled`;
     const readOnlyPropsWithLock = `${readOnlyProps} ${endAdornmentWithLockIconProp}`;
 
-    const imports: Imports = [];
-    const formProps: Prop[] = [];
     const defaultFormValuesConfig: GenerateFieldsReturn["formValuesConfig"][0] = {
         destructFromFormValues: config.virtual ? name : undefined,
     };
@@ -164,29 +77,6 @@ export function generateFormField({
         } else if (isGeneratorConfigCode(config.validate)) {
             validateCode = `validate={${config.validate.code}}`;
             imports.push(...config.validate.imports.map((imprt) => convertConfigImport(imprt)));
-        }
-    }
-
-    const fieldLabel = `<FormattedMessage id="${formattedMessageRootId}.${name}" defaultMessage="${label}" />`;
-
-    let startAdornment: AdornmentData = { adornmentString: "" };
-    let endAdornment: AdornmentData = { adornmentString: "" };
-
-    if ("startAdornment" in config && config.startAdornment) {
-        startAdornment = getAdornmentData({
-            adornmentData: config.startAdornment,
-        });
-        if (startAdornment.adornmentImport) {
-            imports.push(startAdornment.adornmentImport);
-        }
-    }
-
-    if ("endAdornment" in config && config.endAdornment) {
-        endAdornment = getAdornmentData({
-            adornmentData: config.endAdornment,
-        });
-        if (endAdornment.adornmentImport) {
-            imports.push(endAdornment.adornmentImport);
         }
     }
 
@@ -420,7 +310,7 @@ export function generateFormField({
               variant="horizontal"
              fullWidth
              name="${nameWithPrefix}"
-             label={<FormattedMessage id="${formattedMessageRootId}.${name}" defaultMessage="${label}" />}
+             label={${fieldLabel}}
              options={[
                   ${values
                       .map((value) => {
@@ -462,224 +352,6 @@ export function generateFormField({
             }
         </Field>`;
         }
-    } else if (config.type == "asyncSelect") {
-        if (introspectionFieldType.kind !== "OBJECT") throw new Error(`asyncSelect only supports OBJECT types`);
-        const objectType = gqlIntrospection.__schema.types.find((t) => t.kind === "OBJECT" && t.name === introspectionFieldType.name) as
-            | IntrospectionObjectType
-            | undefined;
-        if (!objectType) throw new Error(`Object type ${introspectionFieldType.name} not found for field ${name}`);
-
-        //find labelField: 1. as configured
-        let labelField = config.labelField;
-
-        //find labelField: 2. common names (name or title)
-        if (!labelField) {
-            labelField = objectType.fields.find((field) => {
-                let type = field.type;
-                if (type.kind == "NON_NULL") type = type.ofType;
-                if ((field.name == "name" || field.name == "title") && type.kind == "SCALAR" && type.name == "String") {
-                    return true;
-                }
-            })?.name;
-        }
-
-        //find labelField: 3. first string field
-        if (!labelField) {
-            labelField = objectType.fields.find((field) => {
-                let type = field.type;
-                if (type.kind == "NON_NULL") type = type.ofType;
-                if (field.type.kind == "SCALAR" && field.type.name == "String") {
-                    return true;
-                }
-            })?.name;
-        }
-
-        const rootQuery = config.rootQuery; //TODO we should infer a default value from the gql schema
-        const queryName = `${rootQuery[0].toUpperCase() + rootQuery.substring(1)}Select`;
-        const rootQueryType = findQueryTypeOrThrow(rootQuery, gqlIntrospection);
-
-        formFragmentField = `${name} { id ${labelField} }`;
-
-        const filterConfig = config.filter
-            ? (() => {
-                  let filterField: FormFieldConfig<unknown> | undefined;
-                  let gqlName = config.filter.gqlName;
-                  let filterVar = "";
-
-                  if (config.filter.type === "field") {
-                      filterField = findFieldByName(config.filter.fieldName, formConfig.fields);
-                      if (!filterField) {
-                          throw new Error(
-                              `Field ${String(config.name)}: No field with name "${
-                                  config.filter.fieldName
-                              }" referenced as filter.fieldName found in form-config.`,
-                          );
-                      }
-                      if (!isFormFieldConfig(filterField)) {
-                          throw new Error(
-                              `Field ${String(config.name)}: Field with name "${config.filter.fieldName}" referenced as filter.fieldName is no FormField.`,
-                          );
-                      }
-
-                      filterVar = `values.${filterField.type === "asyncSelect" ? `${String(filterField.name)}?.id` : String(filterField.name)}`;
-
-                      if (!gqlName) {
-                          gqlName = config.filter.fieldName;
-                      }
-                  } else if (config.filter.type === "formProp") {
-                      filterVar = config.filter.propName;
-                      if (!gqlName) {
-                          gqlName = config.filter.propName;
-                      }
-                  } else {
-                      throw new Error("unsupported filter type");
-                  }
-
-                  // try to find arg used to filter by checking names of root-arg and filter-arg-fields
-                  const rootArgForName = rootQueryType.args.find((arg) => arg.name === gqlName);
-                  let filterType = rootArgForName ? getTypeInfo(rootArgForName, gqlIntrospection) : undefined;
-                  let filterVarName = undefined;
-                  let filterVarValue = undefined;
-
-                  let filterVarType = "unknown";
-
-                  if (filterType) {
-                      // there is a query root arg with same name, filter using it
-                      filterVarName = gqlName;
-                      filterVarValue = filterVar;
-                      if (filterType.typeKind === "INPUT_OBJECT" || filterType.typeKind === "ENUM") {
-                          filterVarType = `GQL${filterType.typeClass}`;
-                          imports.push({
-                              name: filterVarType,
-                              importPath: "@src/graphql.generated",
-                          });
-                      } else if (filterType.typeKind === "SCALAR") {
-                          filterVarType = gqlScalarToTypescriptType(filterType.typeClass);
-                      }
-                  } else {
-                      // no root-arg with same name, check filter-arg-fields
-                      const rootArgFilter = rootQueryType.args.find((arg) => arg.name === "filter");
-                      filterType = rootArgFilter ? getTypeInfo(rootArgFilter, gqlIntrospection) : undefined;
-                      if (filterType) {
-                          filterVarName = "filter";
-                          filterVarValue = `{ ${gqlName}: { equal: ${filterVar} } }`;
-                          // get type of field.equal in filter-arg used for filtering
-                          if (filterType.inputType?.kind !== "INPUT_OBJECT") {
-                              throw new Error(`Field ${String(config.name)}: Type of filter is no object-type.`);
-                          }
-                          const nestedFilterInput = filterType.inputType.inputFields.find((inputField) => inputField.name === gqlName);
-                          if (!nestedFilterInput) {
-                              throw new Error(`Field ${String(config.name)}: Field filter.${gqlName} does not exist`);
-                          }
-                          const gqlFilterInputType = getTypeInfo(nestedFilterInput, gqlIntrospection);
-                          if (!gqlFilterInputType?.inputType || gqlFilterInputType.inputType.kind !== "INPUT_OBJECT") {
-                              throw new Error(
-                                  `Field ${String(
-                                      config.name,
-                                  )}: Type of filter.${gqlName} is no object-type, but needs to be e.g. StringFilter-type.`,
-                              );
-                          }
-                          const gqlFilterEqualInputType = gqlFilterInputType.inputType.inputFields.find((inputField) => inputField.name === "equal");
-                          if (!gqlFilterEqualInputType) {
-                              throw new Error(`Field ${String(config.name)}: Field filter.${gqlName}.equal does not exist`);
-                          }
-                          const equalFieldType = getTypeInfo(gqlFilterEqualInputType, gqlIntrospection);
-                          if (!equalFieldType) {
-                              throw new Error(
-                                  `Field ${String(config.name)}: Field filter.${gqlName}.equal does not exist but is required for filtering.`,
-                              );
-                          }
-                          if (equalFieldType.typeKind === "INPUT_OBJECT" || equalFieldType.typeKind === "ENUM") {
-                              filterVarType = `GQL${equalFieldType.typeClass}`;
-                              imports.push({
-                                  name: filterVarType,
-                                  importPath: "@src/graphql.generated",
-                              });
-                          } else if (equalFieldType.typeKind === "SCALAR") {
-                              filterVarType = gqlScalarToTypescriptType(equalFieldType.typeClass);
-                          }
-                      } else {
-                          throw new Error(
-                              `Neither filter-prop nor root-prop with name: ${gqlName} for asyncSelect-query not found. Consider setting filterField.gqlVarName explicitly.`,
-                          );
-                      }
-                  }
-                  if (config.filter.type === "formProp") {
-                      formProps.push({
-                          name: config.filter.propName,
-                          optional: false,
-                          type: filterVarType,
-                      });
-                  }
-
-                  return {
-                      filterField,
-                      filterType,
-                      filterVarName,
-                      filterVarValue,
-                  };
-              })()
-            : undefined;
-        if (filterConfig) {
-            imports.push({ name: "OnChangeField", importPath: "@comet/admin" });
-            finalFormConfig = { subscription: { values: true }, renderProps: { values: true, form: true } };
-        }
-
-        if (!config.virtual) {
-            if (!required) {
-                formValueToGqlInputCode = `${name}: formValues.${name} ? formValues.${name}.id : null,`;
-            } else {
-                formValueToGqlInputCode = `${name}: formValues.${name}?.id,`;
-            }
-        }
-
-        imports.push({
-            name: `GQL${queryName}Query`,
-            importPath: `./${baseOutputFilename}.generated`,
-        });
-        imports.push({
-            name: `GQL${queryName}QueryVariables`,
-            importPath: `./${baseOutputFilename}.generated`,
-        });
-
-        code = `<AsyncSelectField
-                ${required ? "required" : ""}
-                variant="horizontal"
-                fullWidth
-                ${config.readOnly ? readOnlyProps : ""}
-                name="${nameWithPrefix}"
-                label={${fieldLabel}}
-                ${config.startAdornment ? `startAdornment={<InputAdornment position="start">${startAdornment.adornmentString}</InputAdornment>}` : ""}
-                loadOptions={async () => {
-                    const { data } = await client.query<GQL${queryName}Query, GQL${queryName}QueryVariables>({
-                        query: gql\`query ${queryName}${
-                            filterConfig
-                                ? `($${filterConfig.filterVarName}: ${filterConfig.filterType.typeClass}${filterConfig.filterType.required ? `!` : ``})`
-                                : ``
-                        } {
-                            ${rootQuery}${filterConfig ? `(${filterConfig.filterVarName}: $${filterConfig.filterVarName})` : ``} {
-                                nodes {
-                                    id
-                                    ${labelField}
-                                }
-                            }
-                        }\`${filterConfig ? `, variables: { ${filterConfig.filterVarName}: ${filterConfig.filterVarValue} }` : ``}
-                    });
-                    return data.${rootQuery}.nodes;
-                }}
-                getOptionLabel={(option) => option.${labelField}}
-                ${filterConfig?.filterField ? `disabled={!values?.${String(filterConfig.filterField.name)}}` : ``}
-            />${
-                filterConfig?.filterField
-                    ? `<OnChangeField name="${String(filterConfig.filterField.name)}">
-                            {(value, previousValue) => {
-                                if (value.id !== previousValue.id) {
-                                    form.change("${String(config.name)}", undefined);
-                                }
-                            }}
-                        </OnChangeField>`
-                    : ``
-            }`;
     } else {
         throw new Error(`Unsupported type`);
     }

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -7,7 +7,7 @@ import { type Imports } from "../utils/generateImportsCode";
 import { isFieldOptional } from "../utils/isFieldOptional";
 import { isGeneratorConfigCode, isGeneratorConfigImport } from "../utils/runtimeTypeGuards";
 import { generateAsyncSelect } from "./asyncSelect/generateAsyncSelect";
-import { generateFormFieldOptions } from "./formField/options";
+import { buildFormFieldOptions } from "./formField/options";
 import { type GenerateFieldsReturn } from "./generateFields";
 import { type Prop } from "./generateForm";
 
@@ -43,7 +43,7 @@ export function generateFormField({
         startAdornment,
         endAdornment,
         imports: optionsImports,
-    } = generateFormFieldOptions({ config, formConfig, gqlType, gqlIntrospection });
+    } = buildFormFieldOptions({ config, formConfig, gqlType, gqlIntrospection });
     imports.push(...optionsImports);
 
     const nameWithPrefix = `${namePrefix ? `${namePrefix}.` : ``}${name}`;

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -7,7 +7,7 @@ import { type Imports } from "../utils/generateImportsCode";
 import { isFieldOptional } from "../utils/isFieldOptional";
 import { isGeneratorConfigCode, isGeneratorConfigImport } from "../utils/runtimeTypeGuards";
 import { generateAsyncSelect } from "./asyncSelect/generateAsyncSelect";
-import { formFieldOptions } from "./formField/options";
+import { generateFormFieldOptions } from "./formField/options";
 import { type GenerateFieldsReturn } from "./generateFields";
 import { type Prop } from "./generateForm";
 
@@ -43,7 +43,7 @@ export function generateFormField({
         startAdornment,
         endAdornment,
         imports: optionsImports,
-    } = formFieldOptions({ config, formConfig, gqlType, gqlIntrospection });
+    } = generateFormFieldOptions({ config, formConfig, gqlType, gqlIntrospection });
     imports.push(...optionsImports);
 
     const nameWithPrefix = `${namePrefix ? `${namePrefix}.` : ``}${name}`;


### PR DESCRIPTION
This is a simple (but large) refactoring that extracts generation for asyncSelect out of the way too large generateFormField file into it's own file.

For that also a formFieldOptions helper function is added containing code needed for all formFields including asyncSelect to avoid duplicating this code.

No other changes or fixes where made on the way :)

TODO (other PR):
- Move more non-trivial field types into their own file (at least staticSelect)