### PR TITLE
AsyncAutocompleteField: adjust loading UI

### DIFF
--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -32,11 +32,7 @@ export const FinalFormAutocomplete = <
     loading = false,
     isAsync = false,
     clearable,
-    loadingText = (
-        <Typography variant="body2">
-            <FormattedMessage id="common.loading" defaultMessage="Loading ..." />
-        </Typography>
-    ),
+    loadingText = <FormattedMessage id="common.loading" defaultMessage="Loading ..." />,
     popupIcon = <ChevronDown />,
     noOptionsText = <FormattedMessage id="finalFormAutocomplete.noOptions" defaultMessage="No options." />,
     ...rest
@@ -51,7 +47,11 @@ export const FinalFormAutocomplete = <
                 </Typography>
             }
             loading={loading}
-            loadingText={loadingText}
+            loadingText={
+                <Typography variant="body2" component="span">
+                    {loadingText}
+                </Typography>
+            }
             isOptionEqualToValue={(option: T, value: T) => {
                 if (!value) return false;
                 return option === value;

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from "@comet/admin-icons";
-import { Autocomplete, type AutocompleteProps, type AutocompleteRenderInputParams, CircularProgress, InputBase, Typography } from "@mui/material";
+import { Autocomplete, type AutocompleteProps, type AutocompleteRenderInputParams, InputBase, Typography } from "@mui/material";
 import { type FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
@@ -45,6 +45,12 @@ export const FinalFormAutocomplete = <
                     {noOptionsText}
                 </Typography>
             }
+            loading={loading}
+            loadingText={
+                <Typography variant="body2" sx={{ color: "text.primary" }}>
+                    <FormattedMessage id="common.loading" defaultMessage="Loading ..." />
+                </Typography>
+            }
             isOptionEqualToValue={(option: T, value: T) => {
                 if (!value) return false;
                 return option === value;
@@ -61,17 +67,10 @@ export const FinalFormAutocomplete = <
                     {...params}
                     {...params.InputProps}
                     endAdornment={
-                        loading || clearable ? (
-                            <>
-                                {loading && <CircularProgress color="inherit" size={16} />}
-                                {clearable && (
-                                    <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange("")} />
-                                )}
-                                {params.InputProps.endAdornment}
-                            </>
-                        ) : (
-                            params.InputProps.endAdornment
-                        )
+                        <>
+                            {clearable && <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange("")} />}
+                            {params.InputProps.endAdornment}
+                        </>
                     }
                 />
             )}

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -32,6 +32,11 @@ export const FinalFormAutocomplete = <
     loading = false,
     isAsync = false,
     clearable,
+    loadingText = (
+        <Typography variant="body2" sx={{ color: "text.primary" }}>
+            <FormattedMessage id="common.loading" defaultMessage="Loading ..." />
+        </Typography>
+    ),
     popupIcon = <ChevronDown />,
     noOptionsText = <FormattedMessage id="finalFormAutocomplete.noOptions" defaultMessage="No options." />,
     ...rest
@@ -46,11 +51,7 @@ export const FinalFormAutocomplete = <
                 </Typography>
             }
             loading={loading}
-            loadingText={
-                <Typography variant="body2" sx={{ color: "text.primary" }}>
-                    <FormattedMessage id="common.loading" defaultMessage="Loading ..." />
-                </Typography>
-            }
+            loadingText={loadingText}
             isOptionEqualToValue={(option: T, value: T) => {
                 if (!value) return false;
                 return option === value;

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -33,7 +33,7 @@ export const FinalFormAutocomplete = <
     isAsync = false,
     clearable,
     loadingText = (
-        <Typography variant="body2" sx={{ color: "text.primary" }}>
+        <Typography variant="body2">
             <FormattedMessage id="common.loading" defaultMessage="Loading ..." />
         </Typography>
     ),

--- a/packages/admin/admin/src/theme/componentsTheme/MuiAutocomplete.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiAutocomplete.tsx
@@ -11,6 +11,9 @@ export const getMuiAutocomplete: GetMuiComponentTheme<"MuiAutocomplete"> = (comp
         ...component?.defaultProps,
     },
     styleOverrides: mergeOverrideStyles<"MuiAutocomplete">(component?.styleOverrides, {
+        loading: {
+            color: "unset",
+        },
         endAdornment: {
             top: 0,
             bottom: 0,

--- a/packages/admin/admin/src/theme/componentsTheme/MuiAutocomplete.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiAutocomplete.tsx
@@ -12,7 +12,7 @@ export const getMuiAutocomplete: GetMuiComponentTheme<"MuiAutocomplete"> = (comp
     },
     styleOverrides: mergeOverrideStyles<"MuiAutocomplete">(component?.styleOverrides, {
         loading: {
-            color: "unset",
+            color: "inherit",
         },
         endAdornment: {
             top: 0,


### PR DESCRIPTION
## Description

This Pull Request adjust loading UI for `AsyncAutocompleteField`

Changes:

- removes animated loading icon in end adornment of Autocomplete input
- adds `loadingText` in dropdown. (Similar like in `AsyncSelectField`

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  ![Screen Recording 2025-07-31 at 10 41 02](https://github.com/user-attachments/assets/a4566324-b0bb-44f9-b540-5e1346e55f87)  | ![Screen Recording 2025-07-31 at 10 53 29](https://github.com/user-attachments/assets/71981700-b60e-40ac-992d-eeeff6ee1a30)  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1066
