### PR TITLE
Add scope to filter fields in user permissions panel

### DIFF
--- a/.changeset/empty-spoons-leave.md
+++ b/.changeset/empty-spoons-leave.md
@@ -1,0 +1,6 @@
+---
+"@comet/cms-admin": minor
+"@comet/cms-api": minor
+---
+
+Add possibility to filter by content scope in user permissions panel

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -936,6 +936,7 @@ input UserPermissionsUserFilter {
   email: StringFilter
   status: StringFilter
   permission: PermissionFilter
+  scope: ContentScopeFilter
   and: [UserPermissionsUserFilter!]
   or: [UserPermissionsUserFilter!]
 }
@@ -956,6 +957,12 @@ input PermissionFilter {
   equal: Permission
   notEqual: Permission
   isAnyOf: [Permission!]
+}
+
+input ContentScopeFilter {
+  isAnyOf: [JSONObject!]
+  equal: JSONObject
+  notEqual: JSONObject
 }
 
 input UserPermissionsUserSort {
@@ -1344,7 +1351,7 @@ input WarningFilter {
   type: StringFilter
   severity: WarningSeverityEnumFilter
   status: WarningStatusEnumFilter
-  scope: ScopeFilter
+  scope: ContentScopeFilter
   and: [WarningFilter!]
   or: [WarningFilter!]
 }
@@ -1359,12 +1366,6 @@ input WarningStatusEnumFilter {
   isAnyOf: [WarningStatus!]
   equal: WarningStatus
   notEqual: WarningStatus
-}
-
-input ScopeFilter {
-  isAnyOf: [JSONObject!]
-  equal: JSONObject
-  notEqual: JSONObject
 }
 
 input WarningSort {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -609,6 +609,7 @@ input UserPermissionsUserFilter {
   email: StringFilter
   status: StringFilter
   permission: PermissionFilter
+  scope: ContentScopeFilter
   and: [UserPermissionsUserFilter!]
   or: [UserPermissionsUserFilter!]
 }
@@ -617,6 +618,12 @@ input PermissionFilter {
   equal: Permission
   notEqual: Permission
   isAnyOf: [Permission!]
+}
+
+input ContentScopeFilter {
+  isAnyOf: [JSONObject!]
+  equal: JSONObject
+  notEqual: JSONObject
 }
 
 input UserPermissionsUserSort {
@@ -642,7 +649,7 @@ input WarningFilter {
   type: StringFilter
   severity: WarningSeverityEnumFilter
   status: WarningStatusEnumFilter
-  scope: ScopeFilter
+  scope: ContentScopeFilter
   and: [WarningFilter!]
   or: [WarningFilter!]
 }
@@ -657,12 +664,6 @@ input WarningStatusEnumFilter {
   isAnyOf: [WarningStatus!]
   equal: WarningStatus
   notEqual: WarningStatus
-}
-
-input ScopeFilter {
-  isAnyOf: [JSONObject!]
-  equal: JSONObject
-  notEqual: JSONObject
 }
 
 input WarningSort {

--- a/packages/api/cms-api/src/user-permissions/dto/content-scope-filter.input.ts
+++ b/packages/api/cms-api/src/user-permissions/dto/content-scope-filter.input.ts
@@ -1,0 +1,20 @@
+import { Field, InputType } from "@nestjs/graphql";
+import { IsOptional } from "class-validator";
+import { GraphQLJSONObject } from "graphql-scalars";
+
+import { ContentScope } from "../interfaces/content-scope.interface";
+
+@InputType({ isAbstract: true })
+export class ContentScopeFilter {
+    @Field(() => [GraphQLJSONObject], { nullable: true })
+    @IsOptional()
+    isAnyOf?: ContentScope[];
+
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @IsOptional()
+    equal?: ContentScope;
+
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @IsOptional()
+    notEqual?: ContentScope;
+}

--- a/packages/api/cms-api/src/user-permissions/dto/paginated-user-list.ts
+++ b/packages/api/cms-api/src/user-permissions/dto/paginated-user-list.ts
@@ -6,6 +6,7 @@ import { StringFilter } from "../../common/filter/string.filter";
 import { OffsetBasedPaginationArgs } from "../../common/pagination/offset-based.args";
 import { SortDirection } from "../../common/sorting/sort-direction.enum";
 import { CombinedPermission, Permission } from "../user-permissions.types";
+import { ContentScopeFilter } from "./content-scope-filter.input";
 
 @InputType()
 export class PermissionFilter {
@@ -46,6 +47,11 @@ class UserPermissionsUserFilter {
     @ValidateNested()
     @Type(() => PermissionFilter)
     permission?: PermissionFilter;
+
+    @Field(() => ContentScopeFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => ContentScopeFilter)
+    scope?: ContentScopeFilter;
 
     @Field(() => [UserPermissionsUserFilter], { nullable: true })
     @Type(() => UserPermissionsUserFilter)

--- a/packages/api/cms-api/src/warnings/dto/warning.filter.ts
+++ b/packages/api/cms-api/src/warnings/dto/warning.filter.ts
@@ -1,12 +1,11 @@
 import { Field, InputType } from "@nestjs/graphql";
 import { Type } from "class-transformer";
 import { IsOptional, ValidateNested } from "class-validator";
-import { GraphQLJSONObject } from "graphql-scalars";
-import { ContentScope } from "src/user-permissions/interfaces/content-scope.interface";
 
 import { DateTimeFilter } from "../../common/filter/date-time.filter";
 import { createEnumFilter } from "../../common/filter/enum.filter.factory";
 import { StringFilter } from "../../common/filter/string.filter";
+import { ContentScopeFilter } from "../../user-permissions/dto/content-scope-filter.input";
 import { WarningSeverity } from "../entities/warning-severity.enum";
 import { WarningStatus } from "../entities/warning-status.enum";
 
@@ -14,21 +13,6 @@ import { WarningStatus } from "../entities/warning-status.enum";
 class WarningSeverityEnumFilter extends createEnumFilter(WarningSeverity) {}
 @InputType()
 class WarningStatusEnumFilter extends createEnumFilter(WarningStatus) {}
-
-@InputType({ isAbstract: true })
-class ScopeFilter {
-    @Field(() => [GraphQLJSONObject], { nullable: true })
-    @IsOptional()
-    isAnyOf?: ContentScope[];
-
-    @Field(() => GraphQLJSONObject, { nullable: true })
-    @IsOptional()
-    equal?: ContentScope;
-
-    @Field(() => GraphQLJSONObject, { nullable: true })
-    @IsOptional()
-    notEqual?: ContentScope;
-}
 
 @InputType()
 export class WarningFilter {
@@ -68,9 +52,9 @@ export class WarningFilter {
     @Type(() => WarningStatusEnumFilter)
     status?: WarningStatusEnumFilter;
 
-    @Field(() => ScopeFilter, { nullable: true })
+    @Field(() => ContentScopeFilter, { nullable: true })
     @IsOptional()
-    scope?: ScopeFilter;
+    scope?: ContentScopeFilter;
 
     @Field(() => [WarningFilter], { nullable: true })
     @Type(() => WarningFilter)


### PR DESCRIPTION
## Description

We're currently able to filter permission in the administration panel of the user permissions. This PR adds the possibility to filter by content scopes.

## Screenshots/screencasts

https://github.com/user-attachments/assets/0d4e1018-cea6-46fb-bcff-7470da83c5a7


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2151
