### PR TITLE
AsyncAutocompleteField add docs with a mocked api example to showcase server side filtering of autocomplete

### DIFF
--- a/storybook/.storybook/mocks/handlers.ts
+++ b/storybook/.storybook/mocks/handlers.ts
@@ -112,7 +112,7 @@ type Product {
 type Query {
     launchesPastResult(limit: Int, offset: Int, sort: String, order: String, filter: LaunchesPastFilter): LaunchesPastResult!
     launchesPastPagePaging(page: Int, size: Int): LaunchesPastPagePagingResult!
-    manufacturers: [Manufacturer!]!
+    manufacturers(search: String): [Manufacturer!]!
     products(manufacturer: ID): [Product!]!
 }
 `;
@@ -226,9 +226,11 @@ for (let i = 0; i < 10; i += 1) {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const manufacturers: GraphQLFieldResolver<unknown, unknown> = async () => {
+const manufacturers: GraphQLFieldResolver<unknown, unknown> = async (source, args, context, info) => {
     await sleep(500);
-    return allManufacturers;
+    return allManufacturers.filter((manufacturer) => {
+        return !args.search || manufacturer.name.toLowerCase().includes(args.search.toLowerCase());
+    });
 };
 
 export type Product = {


### PR DESCRIPTION
## Description

This Pull Request adds a sample story of how to use an `AsyncAutocompleteField` and performing server side filtering/autocomplete.

Changes:
- MSW manufacturers mock add search argument and performing filtering in mock handler.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1066
