### PR TITLE
A11y `AccordionItemBlock` improvements

### DIFF
--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -36,7 +36,7 @@ export const AccordionItemBlock = withPreview(
 
         return (
             <>
-                <TitleWrapper id={headlineId} onClick={onChange} aria-label={title} aria-expanded={isExpanded} aria-controls={contentId}>
+                <TitleWrapper id={headlineId} onClick={onChange} aria-expanded={isExpanded} aria-controls={contentId}>
                     <Typography variant="h350">{title}</Typography>
                     <IconWrapper>
                         <AnimatedChevron href="/assets/icons/chevron-down.svg#root" $isExpanded={isExpanded} />

--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -42,7 +42,7 @@ export const AccordionItemBlock = withPreview(
                         <AnimatedChevron href="/assets/icons/chevron-down.svg#root" $isExpanded={isExpanded} />
                     </IconWrapper>
                 </TitleWrapper>
-                <ContentWrapper id={contentId} $isExpanded={isExpanded} role="region" aria-labelledby={headlineId}>
+                <ContentWrapper id={contentId} $isExpanded={isExpanded} aria-labelledby={headlineId}>
                     <ContentWrapperInner>
                         <AccordionContentBlock data={content} />
                     </ContentWrapperInner>
@@ -81,7 +81,7 @@ const AnimatedChevron = styled(SvgUse)<{ $isExpanded: boolean }>`
     transition: transform 0.4s ease;
 `;
 
-const ContentWrapper = styled.div<{ $isExpanded: boolean }>`
+const ContentWrapper = styled.section<{ $isExpanded: boolean }>`
     position: relative;
     display: grid;
     grid-template-rows: 0fr;


### PR DESCRIPTION
## Description

Fix concerns regarding accessibility from https://github.com/vivid-planet/comet-starter/pull/929:

- remove aria-label
- use section instead of `role-region` for `ContentWrapper`

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2170
