### PR TITLE
Demo Site: fix broken NODE_OPTIONS for dev script

### DIFF
--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -8,7 +8,7 @@
         "build": "run-s intl:compile && run-p gql:types generate-block-types build-server && next build",
         "build-server": "tsc --project tsconfig.server.json",
         "check-node-version": "check-node-version --node $(cat ../../.nvmrc)",
-        "dev": "$npm_execpath check-node-version && run-s intl:compile && run-p gql:types generate-block-types build-server && NODE_OPTIONS='--inspect=localhost:9230 --max-old-space-size=512' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node dist/server.js",
+        "dev": "$npm_execpath check-node-version && run-s intl:compile && run-p gql:types generate-block-types build-server && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node --inspect=localhost:9230 --max-old-space-size=512 dist/server.js",
         "export": "next export",
         "generate-block-types": "comet generate-block-types",
         "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"$npm_execpath generate-block-types\"",


### PR DESCRIPTION
## Old

NODE_OPTIONS where passed to dotenv (which is a node script itself), when attaching the debugger to 9230 you connected to the dotenv script, not the site script. The --max-old-space-size also had no effect.

## Now

As we start node ourself (without wrapper) we simply give the options directly to node.
