### PR TITLE
Set names of stories correctly

### DIFF
--- a/storybook/src/admin/clipboard/clipboard.stories.tsx
+++ b/storybook/src/admin/clipboard/clipboard.stories.tsx
@@ -46,4 +46,4 @@ export const ClipboardFallbackSizeLimit = function () {
     );
 };
 
-ClipboardFallbackSizeLimit.storyName = "Clipboard fallback size limit";
+ClipboardFallbackSizeLimit.name = "Clipboard fallback size limit";

--- a/storybook/src/admin/common/dialog/Dialog.stories.tsx
+++ b/storybook/src/admin/common/dialog/Dialog.stories.tsx
@@ -36,4 +36,4 @@ export const DialogStory: Story = {
         );
     },
 };
-DialogStory.storyName = "Dialog";
+DialogStory.name = "Dialog";

--- a/storybook/src/admin/edit-dialog/NestedEditDialogInStack.stories.tsx
+++ b/storybook/src/admin/edit-dialog/NestedEditDialogInStack.stories.tsx
@@ -106,4 +106,4 @@ export const NestedEditDialogInStack = function Story() {
     );
 };
 
-NestedEditDialogInStack.storyName = "Nested Edit Dialog in Stack";
+NestedEditDialogInStack.name = "Nested Edit Dialog in Stack";

--- a/storybook/src/admin/form/DependentAsyncSelects.stories.tsx
+++ b/storybook/src/admin/form/DependentAsyncSelects.stories.tsx
@@ -82,4 +82,4 @@ export const DependentAsyncSelects = function () {
     );
 };
 
-DependentAsyncSelects.storyName = "Dependent async selects";
+DependentAsyncSelects.name = "Dependent async selects";

--- a/storybook/src/admin/inlineAlert/InlineAlert.stories.tsx
+++ b/storybook/src/admin/inlineAlert/InlineAlert.stories.tsx
@@ -23,7 +23,7 @@ export default config;
  * Demonstrates the base appearance of the error component.
  */
 export const InlineAlertStory: Story = {};
-InlineAlertStory.storyName = "InlineAlert";
+InlineAlertStory.name = "InlineAlert";
 
 /**
  * Displays the `InlineAlert` component with a warning variant.

--- a/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.stories.tsx
+++ b/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.stories.tsx
@@ -60,4 +60,4 @@ export const OptionalDimensions = function () {
     );
 };
 
-OptionalDimensions.storyName = "Optional dimensions";
+OptionalDimensions.name = "Optional dimensions";

--- a/storybook/src/cms-admin/ContentScopeSelect.stories.tsx
+++ b/storybook/src/cms-admin/ContentScopeSelect.stories.tsx
@@ -55,7 +55,7 @@ export const MultipleDimensions = function () {
     );
 };
 
-MultipleDimensions.storyName = "Multiple dimensions";
+MultipleDimensions.name = "Multiple dimensions";
 
 export const Searchable = function () {
     const [value, setValue] = useState({ domain: "main", language: "en" });
@@ -115,7 +115,7 @@ export const CustomIcon = function () {
     );
 };
 
-CustomIcon.storyName = "Custom icon";
+CustomIcon.name = "Custom icon";
 
 export const CustomRenderOption = function () {
     const [value, setValue] = useState({ domain: "main", language: "en" });
@@ -149,7 +149,7 @@ export const CustomRenderOption = function () {
     );
 };
 
-CustomRenderOption.storyName = "Custom renderOption";
+CustomRenderOption.name = "Custom renderOption";
 
 export const CustomRenderOptionWithSearchHighlighting = {
     render: () => {
@@ -213,7 +213,7 @@ export const CustomRenderSelectedOption = function () {
     );
 };
 
-CustomRenderSelectedOption.storyName = "Custom renderSelectedOption";
+CustomRenderSelectedOption.name = "Custom renderSelectedOption";
 
 export const ThreeDimensions = function () {
     const [value, setValue] = useState({ company: "a-inc", country: "at", language: "de" });
@@ -259,7 +259,7 @@ export const ThreeDimensions = function () {
     );
 };
 
-ThreeDimensions.storyName = "Three dimensions";
+ThreeDimensions.name = "Three dimensions";
 
 export const GroupingWithOptionalScopeParts = function () {
     const [value, setValue] = useState({ country: "at" });
@@ -324,4 +324,4 @@ export const GroupingWithOptionalScopeParts = function () {
     );
 };
 
-GroupingWithOptionalScopeParts.storyName = "Grouping with optional scope parts";
+GroupingWithOptionalScopeParts.name = "Grouping with optional scope parts";


### PR DESCRIPTION
## Description

Avoids this warning from storybook:

```
Unexpected usage of "storyName" in "x". Please use "name" instead.
```
