### PR TITLE
Fix lib imports in story files

### DIFF
--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -25,6 +25,7 @@ export { useSplitButtonContext } from "./common/buttons/split/useSplitButtonCont
 export { ClearInputAdornmentClassKey } from "./common/ClearInputAdornment";
 export { ClearInputAdornment, ClearInputAdornmentProps } from "./common/ClearInputAdornment";
 export { CometLogo } from "./common/CometLogo";
+export { DeleteDialog } from "./common/DeleteDialog";
 export { Dialog, DialogClassKey, DialogProps } from "./common/Dialog";
 export { FieldSet, FieldSetClassKey, FieldSetProps } from "./common/FieldSet";
 export { FillSpace, FillSpaceClassKey, FillSpaceProps } from "./common/FillSpace";

--- a/packages/admin/cms-admin/src/dam/mediaAlternatives/MediaAlternativesGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/mediaAlternatives/MediaAlternativesGrid.tsx
@@ -2,6 +2,7 @@ import { gql, useApolloClient, useQuery } from "@apollo/client";
 import {
     Button,
     DataGridToolbar,
+    DeleteDialog,
     FillSpace,
     GridCellContent,
     type GridColDef,
@@ -15,7 +16,6 @@ import {
     useEditDialog,
     usePersistentColumnState,
 } from "@comet/admin";
-import { DeleteDialog } from "@comet/admin/lib/common/DeleteDialog";
 import { Add as AddIcon, Delete as DeleteIcon, Edit as EditIcon } from "@comet/admin-icons";
 import { DialogContent, IconButton } from "@mui/material";
 import { DataGrid, type GridSlotsComponent, GridToolbarQuickFilter } from "@mui/x-data-grid";

--- a/storybook/src/admin/edit-dialog/MultipleEditDialogs.stories.tsx
+++ b/storybook/src/admin/edit-dialog/MultipleEditDialogs.stories.tsx
@@ -1,5 +1,5 @@
 import { Button, SubRoute, useEditDialog } from "@comet/admin";
-import { Add, Edit } from "@comet/admin-icons/lib";
+import { Add, Edit } from "@comet/admin-icons";
 import { Stack, Typography } from "@mui/material";
 
 import { storyRouterDecorator } from "../../story-router.decorator";

--- a/storybook/src/docs/form/components/FinalForm.stories.tsx
+++ b/storybook/src/docs/form/components/FinalForm.stories.tsx
@@ -1,7 +1,6 @@
 import { gql, useApolloClient } from "@apollo/client";
 import { MockedProvider, type MockedResponse } from "@apollo/client/testing";
-import { Field, FinalForm, FinalFormInput, FormSection, SaveButton } from "@comet/admin";
-import { useFormApiRef } from "@comet/admin/lib/FinalForm";
+import { Field, FinalForm, FinalFormInput, FormSection, SaveButton, useFormApiRef } from "@comet/admin";
 import { type VoidFunctionComponent } from "react";
 
 export default {


### PR DESCRIPTION
### Description

Some story files were importing directly from `@comet/admin/lib...`, which should not be done. 

This change updates those imports to use the proper package entry points instead. 