### PR TITLE
Renovate: group MSW dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -110,6 +110,10 @@
             "matchPackageNames": ["/^lodash.*/", "/^@types/lodash.*/"]
         },
         {
+            "groupName": "msw",
+            "matchPackageNames": ["msw", "@graphql-mocks/network-msw"]
+        },
+        {
             "groupName": "node",
             "matchPackageNames": ["node"],
             "rangeStrategy": "widen"


### PR DESCRIPTION
## Description

groups `msw` dependencies (`msw`, `@graphql-mocks/network-msw`) in `renovate.json` configuration