### PR TITLE
refactor: improve prop typings for TextField

### DIFF
--- a/packages/admin/admin/src/form/FinalFormInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormInput.tsx
@@ -9,13 +9,22 @@ import { Tooltip } from "../common/Tooltip";
 import { PlainTextTranslationDialog } from "../translator/PlainTextTranslationDialog";
 import { useContentTranslationService } from "../translator/useContentTranslationService";
 
-export type FinalFormInputProps = InputBaseProps &
-    FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement> & {
-        clearable?: boolean;
-        disableContentTranslation?: boolean;
-    };
+export type FinalFormInputProps = InputBaseProps & {
+    clearable?: boolean;
+    disableContentTranslation?: boolean;
+};
 
-export function FinalFormInput({ meta, input, innerRef, endAdornment, clearable, disableContentTranslation, ...props }: FinalFormInputProps) {
+type FinalFormInputInternalProps = FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
+
+export function FinalFormInput({
+    meta,
+    input,
+    innerRef,
+    endAdornment,
+    clearable,
+    disableContentTranslation,
+    ...props
+}: FinalFormInputProps & FinalFormInputInternalProps) {
     const type = props.type ?? input.type ?? "text";
     const { enabled: translationEnabled, showApplyTranslationDialog, translate } = useContentTranslationService();
     const isTranslatable = translationEnabled && !disableContentTranslation && type === "text" && !props.disabled;

--- a/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
+++ b/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
@@ -2,6 +2,7 @@ import { Search } from "@comet/admin-icons";
 import { InputAdornment } from "@mui/material";
 import { useThemeProps } from "@mui/material/styles";
 import { type ReactNode } from "react";
+import type { FieldRenderProps } from "react-final-form";
 import { useIntl } from "react-intl";
 
 import { ClearInputAdornment } from "../common/ClearInputAdornment";
@@ -12,12 +13,14 @@ export interface FinalFormSearchTextFieldProps extends FinalFormInputProps {
     clearable?: boolean;
 }
 
+type FinalFormSearchTextFieldInternalProps = FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
+
 /**
  * Final Form-compatible SearchTextField component.
  *
  * @see {@link SearchField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
-export function FinalFormSearchTextField(inProps: FinalFormSearchTextFieldProps) {
+export function FinalFormSearchTextField(inProps: FinalFormSearchTextFieldProps & FinalFormSearchTextFieldInternalProps) {
     const {
         icon = <Search />,
         placeholder,

--- a/packages/admin/admin/src/form/fields/TextField.tsx
+++ b/packages/admin/admin/src/form/fields/TextField.tsx
@@ -1,8 +1,7 @@
 import { Field, type FieldProps } from "../Field";
-import { FinalFormInput } from "../FinalFormInput";
+import { FinalFormInput, type FinalFormInputProps } from "../FinalFormInput";
 
-export type TextFieldProps = FieldProps<string, HTMLInputElement>;
-
+export type TextFieldProps = FieldProps<string, HTMLInputElement> & FinalFormInputProps;
 export const TextField = (props: TextFieldProps) => {
     return <Field component={FinalFormInput} {...props} />;
 };

--- a/storybook/src/admin/form/TextField.stories.tsx
+++ b/storybook/src/admin/form/TextField.stories.tsx
@@ -1,0 +1,67 @@
+import { Alert, FinalForm, TextField } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof TextField>;
+const config: Meta<typeof TextField> = {
+    component: TextField,
+    title: "@comet/admin/form/TextField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <TextField name="value" label="Textfield" fullWidth variant="horizontal" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const Clearable: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <TextField clearable name="value" label="Textfield" fullWidth variant="horizontal" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request improves typescript types for `TextField` props.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  <img width="1374" height="210" alt="Screenshot 2025-08-05 at 10 22 49" src="https://github.com/user-attachments/assets/aa703c49-cb2f-40e6-a5a2-a6b7beb9027e" />   |  <img width="1835" height="505" alt="Screenshot 2025-08-05 at 10 21 47" src="https://github.com/user-attachments/assets/ce1cb919-c06a-453e-b3a5-cbc74bcb51cd" />  |
| TextField is hiding props of the `FinalFormInput` Adapter, but it is forwarding those props. |  TextFieldProps now expose `FinalFormInput` props.  |

These changes makes it clear to the developer which properties can be used on the `TextField`

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
