### PR TITLE
Demo: Add TextImageBlock to AccordionBlock and ColumnsBlock

### DIFF
--- a/demo/admin/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/admin/src/common/blocks/AccordionItemBlock.tsx
@@ -14,6 +14,8 @@ import { StandaloneCallToActionListBlock } from "@src/common/blocks/StandaloneCa
 import { StandaloneHeadingBlock } from "@src/common/blocks/StandaloneHeadingBlock";
 import { FormattedMessage } from "react-intl";
 
+import { TextImageBlock } from "./TextImageBlock";
+
 const AccordionContentBlock = createBlocksBlock({
     name: "AccordionContent",
     supportedBlocks: {
@@ -21,6 +23,7 @@ const AccordionContentBlock = createBlocksBlock({
         space: SpaceBlock,
         heading: StandaloneHeadingBlock,
         callToActionList: StandaloneCallToActionListBlock,
+        textImage: TextImageBlock,
     },
 });
 

--- a/demo/admin/src/documents/pages/blocks/ColumnsBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/ColumnsBlock.tsx
@@ -13,6 +13,7 @@ import { SpaceBlock } from "@src/common/blocks/SpaceBlock";
 import { StandaloneCallToActionListBlock } from "@src/common/blocks/StandaloneCallToActionListBlock";
 import { StandaloneHeadingBlock } from "@src/common/blocks/StandaloneHeadingBlock";
 import { StandaloneMediaBlock } from "@src/common/blocks/StandaloneMediaBlock";
+import { TextImageBlock } from "@src/common/blocks/TextImageBlock";
 import { FormattedMessage } from "react-intl";
 
 const oneColumnLayouts = [
@@ -122,6 +123,7 @@ const ColumnsContentBlock = createBlocksBlock({
         callToActionList: StandaloneCallToActionListBlock,
         media: StandaloneMediaBlock,
         mediaGallery: MediaGalleryBlock,
+        textImage: TextImageBlock,
     },
 });
 

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -86,7 +86,8 @@
                                 "richtext": "RichText",
                                 "heading": "StandaloneHeading",
                                 "space": "Space",
-                                "callToActionList": "StandaloneCallToActionList"
+                                "callToActionList": "StandaloneCallToActionList",
+                                "textImage": "TextImage"
                             },
                             "nullable": false
                         }
@@ -123,7 +124,8 @@
                                 "richtext": "RichText",
                                 "heading": "StandaloneHeading",
                                 "space": "Space",
-                                "callToActionList": "StandaloneCallToActionList"
+                                "callToActionList": "StandaloneCallToActionList",
+                                "textImage": "TextImage"
                             },
                             "nullable": false
                         }

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -534,7 +534,8 @@
                                 "heading": "StandaloneHeading",
                                 "callToActionList": "StandaloneCallToActionList",
                                 "media": "StandaloneMedia",
-                                "mediaGallery": "MediaGallery"
+                                "mediaGallery": "MediaGallery",
+                                "textImage": "TextImage"
                             },
                             "nullable": false
                         }
@@ -575,7 +576,8 @@
                                 "heading": "StandaloneHeading",
                                 "callToActionList": "StandaloneCallToActionList",
                                 "media": "StandaloneMedia",
-                                "mediaGallery": "MediaGallery"
+                                "mediaGallery": "MediaGallery",
+                                "textImage": "TextImage"
                             },
                             "nullable": false
                         }

--- a/demo/api/src/common/blocks/accordion-item.block.ts
+++ b/demo/api/src/common/blocks/accordion-item.block.ts
@@ -17,6 +17,8 @@ import { StandaloneCallToActionListBlock } from "@src/common/blocks/standalone-c
 import { StandaloneHeadingBlock } from "@src/common/blocks/standalone-heading.block";
 import { IsBoolean, IsString } from "class-validator";
 
+import { TextImageBlock } from "./text-image.block";
+
 export const AccordionContentBlock = createBlocksBlock(
     {
         supportedBlocks: {
@@ -24,6 +26,7 @@ export const AccordionContentBlock = createBlocksBlock(
             heading: StandaloneHeadingBlock,
             space: SpaceBlock,
             callToActionList: StandaloneCallToActionListBlock,
+            textImage: TextImageBlock,
         },
     },
     "AccordionContent",

--- a/demo/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
@@ -8,6 +8,7 @@ import { BlockFixture } from "../block-fixture";
 import { StandaloneCallToActionListBlockFixtureService } from "../navigation/standalone-call-to-action-list-block-fixture.service";
 import { RichTextBlockFixtureService } from "../text-and-content/rich-text-block-fixture.service";
 import { StandaloneHeadingBlockFixtureService } from "../text-and-content/standalone-heading-block-fixture.service";
+import { TextImageBlockFixtureService } from "../text-and-content/text-image-block-fixture.service";
 import { SpaceBlockFixtureService } from "./space-block-fixture.service";
 
 @Injectable()
@@ -17,6 +18,7 @@ export class AccordionBlockFixtureService {
         private readonly headingBlockFixtureService: StandaloneHeadingBlockFixtureService,
         private readonly spaceBlockFixtureService: SpaceBlockFixtureService,
         private readonly callToActionListBlockFixtureService: StandaloneCallToActionListBlockFixtureService,
+        private readonly textImageBlockFixtureService: TextImageBlockFixtureService,
     ) {}
 
     async generateAccordionContentBlock(): Promise<ExtractBlockInputFactoryProps<typeof AccordionContentBlock>> {
@@ -26,6 +28,7 @@ export class AccordionBlockFixtureService {
             heading: this.headingBlockFixtureService,
             space: this.spaceBlockFixtureService,
             callToActionList: this.callToActionListBlockFixtureService,
+            textImage: this.textImageBlockFixtureService,
         };
 
         for (const block of Object.entries(blockCfg)) {

--- a/demo/api/src/db/fixtures/generators/blocks/layout/columns-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/layout/columns-block-fixture.service.ts
@@ -9,6 +9,7 @@ import { StandaloneMediaBlockFixtureService } from "../media/standalone-media-bl
 import { StandaloneCallToActionListBlockFixtureService } from "../navigation/standalone-call-to-action-list-block-fixture.service";
 import { RichTextBlockFixtureService } from "../text-and-content/rich-text-block-fixture.service";
 import { StandaloneHeadingBlockFixtureService } from "../text-and-content/standalone-heading-block-fixture.service";
+import { TextImageBlockFixtureService } from "../text-and-content/text-image-block-fixture.service";
 import { AccordionBlockFixtureService } from "./accordion-block-fixture.service";
 import { SpaceBlockFixtureService } from "./space-block-fixture.service";
 
@@ -24,6 +25,7 @@ export class ColumnsBlockFixtureService {
         private readonly mediaGalleryBlockFixtureService: MediaGalleryBlockFixtureService,
         private readonly spaceBlockFixtureService: SpaceBlockFixtureService,
         private readonly standaloneMediaBlockFixtureService: StandaloneMediaBlockFixtureService,
+        private readonly textImageBlockFixtureService: TextImageBlockFixtureService,
     ) {}
 
     async generateColumnsContentBlock(): Promise<ExtractBlockInputFactoryProps<typeof ColumnsContentBlock>> {
@@ -38,6 +40,7 @@ export class ColumnsBlockFixtureService {
             mediaGallery: this.mediaGalleryBlockFixtureService,
             richtext: this.richtextBlockFixtureService,
             space: this.spaceBlockFixtureService,
+            textImage: this.textImageBlockFixtureService,
         };
 
         for (const block of Object.entries(blockCfg)) {

--- a/demo/api/src/documents/pages/blocks/columns.block.ts
+++ b/demo/api/src/documents/pages/blocks/columns.block.ts
@@ -6,6 +6,7 @@ import { SpaceBlock } from "@src/common/blocks/space.block";
 import { StandaloneCallToActionListBlock } from "@src/common/blocks/standalone-call-to-action-list.block";
 import { StandaloneHeadingBlock } from "@src/common/blocks/standalone-heading.block";
 import { StandaloneMediaBlock } from "@src/common/blocks/standalone-media.block";
+import { TextImageBlock } from "@src/common/blocks/text-image.block";
 
 export const ColumnsContentBlock = createBlocksBlock(
     {
@@ -18,6 +19,7 @@ export const ColumnsContentBlock = createBlocksBlock(
             callToActionList: StandaloneCallToActionListBlock,
             media: StandaloneMediaBlock,
             mediaGallery: MediaGalleryBlock,
+            textImage: TextImageBlock,
         },
     },
     { name: "ColumnsContent" },

--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -9,12 +9,14 @@ import { useId } from "react";
 import styled, { css } from "styled-components";
 
 import { Typography } from "../components/Typography";
+import { TextImageBlock } from "./TextImageBlock";
 
 const supportedBlocks: SupportedBlocks = {
     richtext: (props) => <RichTextBlock data={props} />,
     heading: (props) => <StandaloneHeadingBlock data={props} />,
     space: (props) => <SpaceBlock data={props} />,
     callToActionList: (props) => <StandaloneCallToActionListBlock data={props} />,
+    textImage: (props) => <TextImageBlock data={props} />,
 };
 
 const AccordionContentBlock = withPreview(

--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -8,7 +8,7 @@ import styled, { css } from "styled-components";
 import { DamImageBlock } from "./DamImageBlock";
 import { RichTextBlock } from "./RichTextBlock";
 
-const TextImageBlock = withPreview(
+export const TextImageBlock = withPreview(
     ({ data: { text, image, imageAspectRatio, imagePosition } }: PropsWithData<TextImageBlockData>) => {
         return (
             <Root $imagePosition={imagePosition}>

--- a/demo/site/src/documents/pages/blocks/ColumnsBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/ColumnsBlock.tsx
@@ -8,6 +8,7 @@ import { SpaceBlock } from "@src/common/blocks/SpaceBlock";
 import { StandaloneCallToActionListBlock } from "@src/common/blocks/StandaloneCallToActionListBlock";
 import { StandaloneHeadingBlock } from "@src/common/blocks/StandaloneHeadingBlock";
 import { StandaloneMediaBlock } from "@src/common/blocks/StandaloneMediaBlock";
+import { TextImageBlock } from "@src/common/blocks/TextImageBlock";
 import { PageLayout } from "@src/layout/PageLayout";
 import styled, { css } from "styled-components";
 
@@ -20,6 +21,7 @@ const supportedBlocks: SupportedBlocks = {
     callToActionList: (props) => <StandaloneCallToActionListBlock data={props} />,
     media: (props) => <StandaloneMediaBlock data={props} />,
     mediaGallery: (props) => <MediaGalleryBlock data={props} />,
+    textImage: (props) => <TextImageBlock data={props} />,
 };
 
 const ColumnsContentBlock = withPreview(


### PR DESCRIPTION
## Description

The `TextImageBlock` was previously only used within the `PageContentTextImageBlock`, which appears in `PageContent` and `NewsContent`. This MR extends its usage by making the `TextImageBlock` also available in the `AccordionBlock` and ColumnsBlock.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

### TextImageBlock in AccordionBlock

| Admin | Site |
| ------ | ----- |
| https://github.com/user-attachments/assets/adcb9cbf-b5e0-467f-b06c-869241f927f2 |  https://github.com/user-attachments/assets/c00a5764-12ef-409f-9e11-9414d55c848a  |

### TextImageBlock in ColumnsBlock

| Admin | Site |
| ------ | ----- |
| https://github.com/user-attachments/assets/32221dc8-f527-4ccb-9090-be0b777a1603 | <img width="1514" height="436" alt="Bildschirmfoto 2025-08-06 um 09 38 24" src="https://github.com/user-attachments/assets/90c61bc4-2c62-495b-ac0a-eece767bf71c" /> |

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-2163
- https://github.com/vivid-planet/comet/pull/3804#discussion_r2068226249
