### PR TITLE
Demo Site: add reset for fieldset and legend to CSS reset

### DIFF
--- a/demo/site/src/app/GlobalStyle.ts
+++ b/demo/site/src/app/GlobalStyle.ts
@@ -81,6 +81,19 @@ export const GlobalStyle = createGlobalStyle`
         max-width: 100%;
     }
 
+    /* Fieldset CSS Reset */
+    fieldset {
+        border: 0;
+        margin: 0;
+        padding: 0;
+        min-width: 0;
+    }
+    
+    legend {
+        padding: 0;
+        margin-bottom: 0;
+    }
+
     /* Create a root stacking context: https://www.joshwcomeau.com/css/custom-css-reset/#eight-root-stacking-context-9 */
     /* stylelint-disable selector-id-pattern */
     #root,


### PR DESCRIPTION
## Description
CSS reset for fieldset and legend

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts
https://github.com/user-attachments/assets/29bbd70e-b292-4110-ba6d-970a4f922ab5

Explanation for "min-width: 0": 

https://github.com/user-attachments/assets/a5f70802-1463-4881-bf02-8e348a92c111


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2161
