### PR TITLE
Fix changeset for icons in `BlockPreviewContent`

### DIFF
--- a/.changeset/clever-planets-leave.md
+++ b/.changeset/clever-planets-leave.md
@@ -1,5 +1,5 @@
 ---
-"@comet/blocks-admin": minor
+"@comet/cms-admin": minor
 ---
 
 Enable displaying icons in `BlockPreviewContent`


### PR DESCRIPTION
## Description

Incorrectly referenced the now removed `@comet/blocks-admin` package.