### PR TITLE
Fix missing "Crop image" button in `PixelImageBlock`

### DIFF
--- a/.changeset/violet-items-cover.md
+++ b/.changeset/violet-items-cover.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix missing "Crop image" button in `PixelImageBlock`

--- a/packages/admin/cms-admin/src/form/file/FileField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileField.tsx
@@ -45,7 +45,7 @@ const FileField = ({ buttonText, input, allowedMimetypes, preview, menuActions }
     const damFile = input.value;
 
     if (damFile) {
-        const showMenu = Boolean(entityDependencyMap["DamFile"]);
+        const showMenu = Boolean(entityDependencyMap["DamFile"]) || (menuActions !== undefined && menuActions.length > 0);
         return (
             <>
                 <BlockAdminComponentPaper disablePadding>
@@ -81,21 +81,23 @@ const FileField = ({ buttonText, input, allowedMimetypes, preview, menuActions }
                 </BlockAdminComponentPaper>
                 {showMenu && (
                     <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleMenuClose}>
-                        <MenuItem
-                            onClick={async () => {
-                                const path = await entityDependencyMap["DamFile"].resolvePath({
-                                    apolloClient,
-                                    id: damFile.id,
-                                });
-                                const url = contentScope.match.url + path;
-                                window.open(url, "_blank");
-                            }}
-                        >
-                            <ListItemIcon>
-                                <OpenNewTab />
-                            </ListItemIcon>
-                            <ListItemText primary={<FormattedMessage id="comet.form.file.openInDam" defaultMessage="Open in DAM" />} />
-                        </MenuItem>
+                        {entityDependencyMap["DamFile"] && (
+                            <MenuItem
+                                onClick={async () => {
+                                    const path = await entityDependencyMap["DamFile"].resolvePath({
+                                        apolloClient,
+                                        id: damFile.id,
+                                    });
+                                    const url = contentScope.match.url + path;
+                                    window.open(url, "_blank");
+                                }}
+                            >
+                                <ListItemIcon>
+                                    <OpenNewTab />
+                                </ListItemIcon>
+                                <ListItemText primary={<FormattedMessage id="comet.form.file.openInDam" defaultMessage="Open in DAM" />} />
+                            </MenuItem>
+                        )}
                         {menuActions &&
                             menuActions.map((item, index) => {
                                 if (!item) return null;


### PR DESCRIPTION
## Description

Regression introduced with https://github.com/vivid-planet/comet/pull/3988. The menu was only shown when dependencies are configured in the application. Add an additional check for `menuActions` to resolve the issue.