### PR TITLE
Demo API: Activate dependency injection in console

### DIFF
--- a/demo/api/src/console.ts
+++ b/demo/api/src/console.ts
@@ -1,37 +1,37 @@
-import { NestFactory } from "@nestjs/core";
-import type { NestExpressApplication } from "@nestjs/platform-express";
+import { AppModule } from "@src/app.module";
 import { useContainer } from "class-validator";
 import { CommandFactory } from "nest-commander";
 
-import { AppModule } from "./app.module";
 import { createConfig } from "./config/config";
 
 const config = createConfig(process.env);
+const appModule = AppModule.forRoot(config);
 
 async function bootstrap() {
-    const appModule = AppModule.forRoot(config);
-
-    // class-validator should use Nest for dependency injection.
-    // See https://github.com/nestjs/nest/issues/528,
-    //     https://github.com/typestack/class-validator#using-service-container.
-    const app = await NestFactory.create<NestExpressApplication>(appModule);
-    useContainer(app.select(AppModule), { fallbackOnErrors: true });
+    const app = await CommandFactory.createWithoutRunning(appModule, {
+        logger: ["error", "warn", "log"],
+        serviceErrorHandler: async (error) => {
+            console.error(error);
+            process.exit(1);
+        },
+    });
 
     try {
-        await CommandFactory.run(appModule, {
-            logger: ["error", "warn", "log"],
-            serviceErrorHandler: async (error) => {
-                // Log the error and rethrow to be caught below
-                console.error(error);
-                throw error;
-            },
-        });
+        await app.init();
+
+        // class-validator should use Nest for dependency injection.
+        // See https://github.com/nestjs/nest/issues/528,
+        //     https://github.com/typestack/class-validator#using-service-container.
+        useContainer(app.select(appModule), { fallbackOnErrors: true });
+
+        await CommandFactory.runApplication(app);
+        process.exit(0);
+    } catch (e) {
+        console.error(e);
+        process.exit(1);
     } finally {
         await app.close();
     }
 }
 
-bootstrap().catch((err) => {
-    console.error(err);
-    process.exit(1);
-});
+bootstrap();


### PR DESCRIPTION
# Problem

When a `class-validator` class uses NestJS's dependency injection (for example to be able to use the `EntityManager`), these dependencies are not injected when this validator is used in a console-command.

# Solution

This pull request updates the `demo/api/src/console.ts` file to ensure that `class-validator` uses NestJS's dependency injection container, improving validation and dependency management in the CLI context. It also ensures that the NestJS application is properly closed after command execution.

Dependency injection improvements:

* Configured `class-validator` to use the NestJS dependency injection container by creating the Nest application and calling `useContainer`, which helps with custom validators that depend on injected services. [[1]](diffhunk://#diff-64ecd3cbc6b3057d5e779b74540bc555a567b471783dd060d73e6a6392a4e9e9R1-R3) [[2]](diffhunk://#diff-64ecd3cbc6b3057d5e779b74540bc555a567b471783dd060d73e6a6392a4e9e9R14-R27)

Resource management:

* Ensured the NestJS application is properly closed after running CLI commands by calling `app.close()`.