### PR TITLE
Type-safe form field paths with FilePath

### DIFF
--- a/packages/admin/admin-color-picker/src/ColorField.tsx
+++ b/packages/admin/admin-color-picker/src/ColorField.tsx
@@ -2,8 +2,8 @@ import { Field, type FieldProps } from "@comet/admin";
 
 import { FinalFormColorPicker } from "./FinalFormColorPicker";
 
-export type ColorFieldProps = FieldProps<string, HTMLInputElement>;
+export type ColorFieldProps<FormValues> = FieldProps<FormValues, string, HTMLInputElement>;
 
-export const ColorField = ({ ...restProps }: ColorFieldProps) => {
+export function ColorField<FormValues>({ ...restProps }: ColorFieldProps<FormValues>) {
     return <Field component={FinalFormColorPicker} {...restProps} />;
-};
+}

--- a/packages/admin/admin-date-time/src/datePicker/DateField.tsx
+++ b/packages/admin/admin-date-time/src/datePicker/DateField.tsx
@@ -2,11 +2,11 @@ import { Field, type FieldProps } from "@comet/admin";
 
 import { FinalFormDatePicker } from "./FinalFormDatePicker";
 
-export type DateFieldProps = FieldProps<Date, HTMLInputElement>;
+export type DateFieldProps<FormValues> = FieldProps<FormValues, Date, HTMLInputElement>;
 
 /**
  * @deprecated `DateField` from `@comet/admin-date-time` will be replaced by `DatePickerField` (currently `Future_DatePickerField`) from `@comet/admin` in a future major release.
  */
-export const DateField = ({ ...restProps }: DateFieldProps) => {
+export function DateField<FormValues>({ ...restProps }: DateFieldProps<FormValues>) {
     return <Field component={FinalFormDatePicker} {...restProps} />;
-};
+}

--- a/packages/admin/admin-date-time/src/dateRangePicker/DateRangeField.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/DateRangeField.tsx
@@ -3,8 +3,8 @@ import { Field, type FieldProps } from "@comet/admin";
 import { type DateRange } from "./DateRangePicker";
 import { FinalFormDateRangePicker } from "./FinalFormDateRangePicker";
 
-export type DateRangeFieldProps = FieldProps<DateRange, HTMLInputElement>;
+export type DateRangeFieldProps<FormValues> = FieldProps<FormValues, DateRange, HTMLInputElement>;
 
-export const DateRangeField = ({ ...restProps }: DateRangeFieldProps) => {
+export function DateRangeField<FormValues>({ ...restProps }: DateRangeFieldProps<FormValues>) {
     return <Field component={FinalFormDateRangePicker} {...restProps} />;
-};
+}

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimeField.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimeField.tsx
@@ -2,8 +2,8 @@ import { Field, type FieldProps } from "@comet/admin";
 
 import { FinalFormDateTimePicker } from "./FinalFormDateTimePicker";
 
-export type DateTimeFieldProps = FieldProps<Date, HTMLInputElement>;
+export type DateTimeFieldProps<FormValues> = FieldProps<FormValues, Date, HTMLInputElement>;
 
-export const DateTimeField = ({ ...restProps }: DateTimeFieldProps) => {
+export function DateTimeField<FormValues>({ ...restProps }: DateTimeFieldProps<FormValues>) {
     return <Field component={FinalFormDateTimePicker} {...restProps} />;
-};
+}

--- a/packages/admin/admin-date-time/src/timePicker/TimeField.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/TimeField.tsx
@@ -2,8 +2,8 @@ import { Field, type FieldProps } from "@comet/admin";
 
 import { FinalFormTimePicker } from "./FinalFormTimePicker";
 
-export type TimeFieldProps = FieldProps<string, HTMLInputElement>;
+export type TimeFieldProps<FormValues> = FieldProps<FormValues, string, HTMLInputElement>;
 
-export const TimeField = ({ ...restProps }: TimeFieldProps) => {
+export function TimeField<FormValues>({ ...restProps }: TimeFieldProps<FormValues>) {
     return <Field component={FinalFormTimePicker} {...restProps} />;
-};
+}

--- a/packages/admin/admin-date-time/src/timeRangePicker/TimeRangeField.tsx
+++ b/packages/admin/admin-date-time/src/timeRangePicker/TimeRangeField.tsx
@@ -3,8 +3,8 @@ import { Field, type FieldProps } from "@comet/admin";
 import { FinalFormTimeRangePicker } from "./FinalFormTimeRangePicker";
 import { type TimeRange } from "./TimeRangePicker";
 
-export type TimeRangeFieldProps = FieldProps<TimeRange, HTMLInputElement>;
+export type TimeRangeFieldProps<FormValues> = FieldProps<FormValues, TimeRange, HTMLInputElement>;
 
-export const TimeRangeField = ({ ...restProps }: TimeRangeFieldProps) => {
+export function TimeRangeField<FormValues>({ ...restProps }: TimeRangeFieldProps<FormValues>) {
     return <Field component={FinalFormTimeRangePicker} {...restProps} />;
-};
+}

--- a/packages/admin/admin/src/form/Field.tsx
+++ b/packages/admin/admin/src/form/Field.tsx
@@ -18,8 +18,23 @@ const composeValidators =
     (value: any, allValues: object) =>
         validators.reduce((error, validator) => error || validator(value, allValues), undefined);
 
-export interface FieldProps<FieldValue = any, T extends HTMLElement = HTMLElement> {
-    name: string;
+/**
+ * Type that extracts all possible paths from a type, handling nested objects with dot notation
+ */
+export type FilePath<T> = T extends object
+    ? {
+          [K in keyof T]: K extends string
+              ? T[K] extends Array<any>
+                  ? K | `${K}[${number}]` | `${K}[${number}].${FilePath<T[K][number]>}`
+                  : T[K] extends object
+                    ? K | `${K}.${FilePath<T[K]>}`
+                    : K
+              : never;
+      }[keyof T]
+    : never;
+
+export interface FieldProps<FormValues = any, FieldValue = any, T extends HTMLElement = HTMLElement> {
+    name: FilePath<FormValues>;
     label?: ReactNode;
     helperText?: ReactNode;
     component?: ComponentType<any> | string;
@@ -35,7 +50,7 @@ export interface FieldProps<FieldValue = any, T extends HTMLElement = HTMLElemen
     [otherProp: string]: any;
 }
 
-export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLElement>({
+export function Field<FormValues = any, FieldValue = any, FieldElement extends HTMLElement = HTMLElement>({
     children,
     component,
     name,
@@ -48,7 +63,7 @@ export function Field<FieldValue = any, FieldElement extends HTMLElement = HTMLE
     shouldShowWarning: passedShouldShowWarning,
     shouldScrollTo: passedShouldScrollTo,
     ...otherProps
-}: FieldProps<FieldValue, FieldElement>) {
+}: FieldProps<FormValues, FieldValue, FieldElement>) {
     const { disabled, variant, fullWidth } = otherProps;
 
     const { mutators } = useForm();

--- a/packages/admin/admin/src/form/fields/AsyncAutocompleteField.tsx
+++ b/packages/admin/admin/src/form/fields/AsyncAutocompleteField.tsx
@@ -4,21 +4,23 @@ import { Field, type FieldProps } from "../Field";
 import { FinalFormAsyncAutocomplete } from "../FinalFormAsyncAutocomplete";
 
 export type AsyncAutocompleteFieldProps<
+    FormValues,
     T extends Record<string, any>,
     Multiple extends boolean | undefined,
     DisableClearable extends boolean | undefined,
     FreeSolo extends boolean | undefined,
-> = FieldProps<T, HTMLInputElement | HTMLTextAreaElement> & {
+> = FieldProps<FormValues, T, HTMLInputElement | HTMLTextAreaElement> & {
     loadOptions: () => Promise<T[]>;
 } & Omit<AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>, "options" | "renderInput"> & {
         clearable?: boolean;
     };
 
 export function AsyncAutocompleteField<
+    FormValues,
     T extends Record<string, any>,
     Multiple extends boolean | undefined,
     DisableClearable extends boolean | undefined,
     FreeSolo extends boolean | undefined,
->(props: AsyncAutocompleteFieldProps<T, Multiple, DisableClearable, FreeSolo>) {
+>(props: AsyncAutocompleteFieldProps<FormValues, T, Multiple, DisableClearable, FreeSolo>) {
     return <Field component={FinalFormAsyncAutocomplete} {...props} />;
 }

--- a/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
+++ b/packages/admin/admin/src/form/fields/AsyncSelectField.tsx
@@ -3,7 +3,7 @@ import { type ReactNode } from "react";
 import { Field, type FieldProps } from "../Field";
 import { FinalFormAsyncSelect } from "../FinalFormAsyncSelect";
 
-export interface AsyncSelectFieldProps<Option> extends FieldProps<Option, HTMLSelectElement> {
+export interface AsyncSelectFieldProps<FormValues, Option> extends FieldProps<FormValues, Option, HTMLSelectElement> {
     loadOptions: () => Promise<Option[]>;
     noOptionsLabel?: ReactNode;
     errorLabel?: ReactNode;
@@ -12,6 +12,6 @@ export interface AsyncSelectFieldProps<Option> extends FieldProps<Option, HTMLSe
     clearable?: boolean;
 }
 
-export function AsyncSelectField<Option>(props: AsyncSelectFieldProps<Option>) {
+export function AsyncSelectField<FormValues, Option>(props: AsyncSelectFieldProps<FormValues, Option>) {
     return <Field component={FinalFormAsyncSelect} {...props} />;
 }

--- a/packages/admin/admin/src/form/fields/AutocompleteField.tsx
+++ b/packages/admin/admin/src/form/fields/AutocompleteField.tsx
@@ -5,21 +5,23 @@ import { FinalFormAutocomplete } from "../Autocomplete";
 import { Field, type FieldProps } from "../Field";
 
 export type AutocompleteFieldProps<
+    FormValues,
     T extends Record<string, any>,
     Multiple extends boolean | undefined,
     DisableClearable extends boolean | undefined,
     FreeSolo extends boolean | undefined,
-> = FieldProps<T, HTMLInputElement | HTMLTextAreaElement> &
+> = FieldProps<FormValues, T, HTMLInputElement | HTMLTextAreaElement> &
     Partial<AsyncOptionsProps<T>> &
     Omit<AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>, "renderInput"> & {
         clearable?: boolean;
     };
 
 export function AutocompleteField<
+    FormValues,
     T extends Record<string, any>,
     Multiple extends boolean | undefined,
     DisableClearable extends boolean | undefined,
     FreeSolo extends boolean | undefined,
->(props: AutocompleteFieldProps<T, Multiple, DisableClearable, FreeSolo>) {
+>(props: AutocompleteFieldProps<FormValues, T, Multiple, DisableClearable, FreeSolo>) {
     return <Field component={FinalFormAutocomplete} {...props} />;
 }

--- a/packages/admin/admin/src/form/fields/CheckboxField.tsx
+++ b/packages/admin/admin/src/form/fields/CheckboxField.tsx
@@ -4,7 +4,7 @@ import { type ReactNode } from "react";
 import { FinalFormCheckbox, type FinalFormCheckboxProps } from "../Checkbox";
 import { Field, type FieldProps } from "../Field";
 
-export interface CheckboxFieldProps extends FieldProps<string, HTMLInputElement> {
+export interface CheckboxFieldProps<FormValues> extends FieldProps<FormValues, string, HTMLInputElement> {
     fieldLabel?: ReactNode;
     componentsProps?: {
         formControlLabel?: FormControlLabelProps;
@@ -12,7 +12,7 @@ export interface CheckboxFieldProps extends FieldProps<string, HTMLInputElement>
     };
 }
 
-export const CheckboxField = ({ fieldLabel, label, componentsProps = {}, ...restProps }: CheckboxFieldProps) => {
+export function CheckboxField<FormValues>({ fieldLabel, label, componentsProps = {}, ...restProps }: CheckboxFieldProps<FormValues>) {
     const { formControlLabel: formControlLabelProps, finalFormCheckbox: finalFormCheckboxProps } = componentsProps;
     return (
         <Field type="checkbox" label={fieldLabel} {...restProps}>
@@ -21,4 +21,4 @@ export const CheckboxField = ({ fieldLabel, label, componentsProps = {}, ...rest
             )}
         </Field>
     );
-};
+}

--- a/packages/admin/admin/src/form/fields/CheckboxListField.tsx
+++ b/packages/admin/admin/src/form/fields/CheckboxListField.tsx
@@ -9,14 +9,19 @@ type CheckboxListFieldOption<Value extends string> = {
     disabled?: boolean;
 };
 
-export type CheckboxListFieldProps<Value extends string> = FieldProps<[Value], HTMLInputElement> & {
+export type CheckboxListFieldProps<FormValues, Value extends string> = FieldProps<FormValues, [Value], HTMLInputElement> & {
     options: CheckboxListFieldOption<Value>[];
     layout?: "row" | "column";
 };
 
-export const CheckboxListField = <Value extends string>({ options, layout = "row", required, ...restProps }: CheckboxListFieldProps<Value>) => {
+export function CheckboxListField<FormValues, Value extends string>({
+    options,
+    layout = "row",
+    required,
+    ...restProps
+}: CheckboxListFieldProps<FormValues, Value>) {
     return (
-        <Field<[Value]> required={required} {...restProps}>
+        <Field<FormValues, [Value]> required={required} {...restProps}>
             {({ input: { value, onBlur, onFocus, onChange, name, ...restInput } }) => (
                 <FormGroup row={layout === "row"} {...restInput}>
                     {options.map((option) => (
@@ -43,4 +48,4 @@ export const CheckboxListField = <Value extends string>({ options, layout = "row
             )}
         </Field>
     );
-};
+}

--- a/packages/admin/admin/src/form/fields/NumberField.tsx
+++ b/packages/admin/admin/src/form/fields/NumberField.tsx
@@ -1,8 +1,8 @@
 import { Field, type FieldProps } from "../Field";
 import { FinalFormNumberInput } from "../FinalFormNumberInput";
 
-export type NumberFieldProps = FieldProps<number, HTMLInputElement>;
+export type NumberFieldProps<FormValues> = FieldProps<FormValues, number, HTMLInputElement>;
 
-export const NumberField = ({ ...restProps }: NumberFieldProps) => {
+export function NumberField<FormValues>({ ...restProps }: NumberFieldProps<FormValues>) {
     return <Field component={FinalFormNumberInput} {...restProps} />;
-};
+}

--- a/packages/admin/admin/src/form/fields/RadioGroupField.tsx
+++ b/packages/admin/admin/src/form/fields/RadioGroupField.tsx
@@ -10,14 +10,18 @@ type RadioGroupFieldOption<Value extends string> = {
     disabled?: boolean;
 };
 
-export type RadioGroupFieldProps<Value extends string> = FieldProps<Value, HTMLInputElement> & {
+export type RadioGroupFieldProps<FormValues, Value extends string> = FieldProps<FormValues, Value, HTMLInputElement> & {
     options: RadioGroupFieldOption<Value>[];
     layout?: "row" | "column";
 };
 
-export const RadioGroupField = <Value extends string>({ options, layout = "row", ...restProps }: RadioGroupFieldProps<Value>) => {
+export const RadioGroupField = <FormValues, Value extends string>({
+    options,
+    layout = "row",
+    ...restProps
+}: RadioGroupFieldProps<FormValues, Value>) => {
     return (
-        <Field<Value> {...restProps}>
+        <Field<FormValues, Value> {...restProps}>
             {({ input: { checked, value, onBlur, onFocus, ...restInput } }) => (
                 <RadioGroup {...restInput} row={layout === "row"} value={value}>
                     {options.map(({ value, label, disabled }) => (

--- a/packages/admin/admin/src/form/fields/SearchField.tsx
+++ b/packages/admin/admin/src/form/fields/SearchField.tsx
@@ -1,8 +1,8 @@
 import { Field, type FieldProps } from "../Field";
 import { FinalFormSearchTextField } from "../FinalFormSearchTextField";
 
-export type SearchFieldProps = FieldProps<string, HTMLInputElement>;
+export type SearchFieldProps<FormValues> = FieldProps<FormValues, string, HTMLInputElement>;
 
-export const SearchField = ({ ...restProps }: SearchFieldProps) => {
+export function SearchField<FormValues>({ ...restProps }: SearchFieldProps<FormValues>) {
     return <Field component={FinalFormSearchTextField} {...restProps} />;
-};
+}

--- a/packages/admin/admin/src/form/fields/SelectField.tsx
+++ b/packages/admin/admin/src/form/fields/SelectField.tsx
@@ -10,22 +10,30 @@ export type SelectFieldOption<Value extends string | number = string | number> =
     disabled?: boolean;
 };
 
-type SelectFieldPropsToExtendFrom<Value extends string | number> = FieldProps<Value, HTMLSelectElement>;
+type SelectFieldPropsToExtendFrom<FormValues, Value extends string | number> = FieldProps<FormValues, Value, HTMLSelectElement>;
 
 // Remove `children` from the interface. Omit cannot be used here because `FieldProps` contains an index signature.
-type SelectFieldPropsToExtendFromWithoutChildren<Value extends string | number> = {
-    [K in keyof SelectFieldPropsToExtendFrom<Value> as K extends "children" ? never : K]: SelectFieldPropsToExtendFrom<Value>[K];
+type SelectFieldPropsToExtendFromWithoutChildren<FormValues, Value extends string | number> = {
+    [K in keyof SelectFieldPropsToExtendFrom<FormValues, Value> as K extends "children" ? never : K]: SelectFieldPropsToExtendFrom<
+        FormValues,
+        Value
+    >[K];
 };
 
-export interface SelectFieldProps<Value extends string | number> extends SelectFieldPropsToExtendFromWithoutChildren<Value> {
-    children?: ReturnType<Required<SelectFieldPropsToExtendFrom<Value>>["children"]>;
+export interface SelectFieldProps<FormValues, Value extends string | number> extends SelectFieldPropsToExtendFromWithoutChildren<FormValues, Value> {
+    children?: ReturnType<Required<SelectFieldPropsToExtendFrom<FormValues, Value>>["children"]>;
     options?: SelectFieldOption<Value>[];
     componentsProps?: {
         finalFormSelect?: Partial<ComponentProps<typeof FinalFormSelect<Value>>>;
     };
 }
 
-export function SelectField<Value extends string | number>({ componentsProps = {}, children, options, ...restProps }: SelectFieldProps<Value>) {
+export function SelectField<FormValues, Value extends string | number>({
+    componentsProps = {},
+    children,
+    options,
+    ...restProps
+}: SelectFieldProps<FormValues, Value>) {
     const { finalFormSelect: finalFormSelectProps } = componentsProps;
     return (
         <Field {...restProps}>

--- a/packages/admin/admin/src/form/fields/SwitchField.tsx
+++ b/packages/admin/admin/src/form/fields/SwitchField.tsx
@@ -4,20 +4,20 @@ import { type ReactNode } from "react";
 import { Field, type FieldProps } from "../Field";
 import { FinalFormSwitch, type FinalFormSwitchProps } from "../Switch";
 
-export interface SwitchFieldProps extends Omit<FieldProps<string, HTMLInputElement>, "label"> {
-    name: string;
+export type SwitchFieldProps<FormValues> = Omit<FieldProps<FormValues, string, HTMLInputElement>, "label" | "name"> & {
+    name: FieldProps<FormValues, string, HTMLInputElement>["name"];
     fieldLabel?: ReactNode;
     label?: ReactNode | ((checked?: boolean) => ReactNode);
     componentsProps?: {
         formControlLabel?: FormControlLabelProps;
         finalFormSwitch?: FinalFormSwitchProps;
     };
-}
+};
 
-export const SwitchField = ({ fieldLabel, label, componentsProps = {}, ...restProps }: SwitchFieldProps) => {
+export function SwitchField<FormValues>({ fieldLabel, label, componentsProps = {}, ...restProps }: SwitchFieldProps<FormValues>) {
     const { formControlLabel: formControlLabelProps, finalFormSwitch: finalFormSwitchProps } = componentsProps;
     return (
-        <Field type="checkbox" label={fieldLabel} {...restProps}>
+        <Field<FormValues> type="checkbox" label={fieldLabel} {...restProps}>
             {(props) => (
                 <FormControlLabel
                     label={typeof label === "function" ? label(props.input.checked) : label}
@@ -27,4 +27,4 @@ export const SwitchField = ({ fieldLabel, label, componentsProps = {}, ...restPr
             )}
         </Field>
     );
-};
+}

--- a/packages/admin/admin/src/form/fields/TextAreaField.tsx
+++ b/packages/admin/admin/src/form/fields/TextAreaField.tsx
@@ -1,8 +1,8 @@
 import { Field, type FieldProps } from "../Field";
 import { FinalFormInput } from "../FinalFormInput";
 
-export type TextAreaFieldProps = FieldProps<string, HTMLTextAreaElement>;
+export type TextAreaFieldProps<FormValues> = FieldProps<FormValues, string, HTMLTextAreaElement>;
 
-export const TextAreaField = ({ ...restProps }: TextAreaFieldProps) => {
+export function TextAreaField<FormValues>({ ...restProps }: TextAreaFieldProps<FormValues>) {
     return <Field type="textarea" multiline rows={3} component={FinalFormInput} {...restProps} />;
-};
+}

--- a/packages/admin/admin/src/form/fields/TextField.tsx
+++ b/packages/admin/admin/src/form/fields/TextField.tsx
@@ -1,7 +1,7 @@
 import { Field, type FieldProps } from "../Field";
 import { FinalFormInput, type FinalFormInputProps } from "../FinalFormInput";
 
-export type TextFieldProps = FieldProps<string, HTMLInputElement> & FinalFormInputProps;
-export const TextField = (props: TextFieldProps) => {
-    return <Field component={FinalFormInput} {...props} />;
-};
+export type TextFieldProps<FormValues> = FieldProps<FormValues, string, HTMLInputElement> & FinalFormInputProps;
+export function TextField<FormValues>(props: TextFieldProps<FormValues>) {
+    return <Field<FormValues> component={FinalFormInput} {...props} />;
+}

--- a/packages/admin/admin/src/form/fields/ToggleButtonGroupField.tsx
+++ b/packages/admin/admin/src/form/fields/ToggleButtonGroupField.tsx
@@ -1,7 +1,7 @@
 import { Field, type FieldProps } from "../Field";
 import { FinalFormToggleButtonGroup, type FinalFormToggleButtonGroupProps } from "../FinalFormToggleButtonGroup";
 
-export type ToggleButtonGroupFieldProps<FieldValue> = FieldProps<FieldValue, HTMLSelectElement> &
+export type ToggleButtonGroupFieldProps<FormValues, FieldValue> = FieldProps<FormValues, FieldValue, HTMLSelectElement> &
     Omit<FinalFormToggleButtonGroupProps<FieldValue>, "input" | "meta">;
 
 /**
@@ -10,7 +10,11 @@ export type ToggleButtonGroupFieldProps<FieldValue> = FieldProps<FieldValue, HTM
  * This is especially useful when the user needs to choose between different types
  * of input for the same conceptual field — for example, selecting between an address or coordinate.
  */
-export function ToggleButtonGroupField<FieldValue = unknown>({ options, optionsPerRow, ...restProps }: ToggleButtonGroupFieldProps<FieldValue>) {
+export function ToggleButtonGroupField<FormValues, FieldValue = unknown>({
+    options,
+    optionsPerRow,
+    ...restProps
+}: ToggleButtonGroupFieldProps<FormValues, FieldValue>) {
     return (
         <Field {...restProps}>
             {(fieldProps) => {

--- a/packages/admin/cms-admin/src/blocks/createSeoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createSeoBlock.tsx
@@ -330,7 +330,8 @@ export function createSeoBlock(
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 interface FieldWithContentGenerationProps<FieldValue = any, FieldElement extends HTMLElement = HTMLElement>
-    extends FieldProps<FieldValue, FieldElement> {
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    extends FieldProps<any, FieldValue, FieldElement> {
     name: SeoTag;
     generateSeoTag: (tag: SeoTag, currentValue: string | undefined) => Promise<string>;
 }

--- a/packages/admin/cms-admin/src/blocks/helpers/createCompositeBlockSelectField.tsx
+++ b/packages/admin/cms-admin/src/blocks/helpers/createCompositeBlockSelectField.tsx
@@ -4,13 +4,13 @@ import { BlocksFinalForm } from "../form/BlocksFinalForm";
 import { type BlockMethods } from "../types";
 import { createCompositeBlockField } from "./composeBlocks/createCompositeBlockField";
 
-interface Options<T extends string | number> extends Partial<SelectFieldProps<T>> {
+interface Options<T extends string | number> extends Partial<SelectFieldProps<unknown, T>> {
     defaultValue: T;
     options: Array<SelectFieldOption<T>>;
     /**
      * @deprecated Set the props directly instead of nesting inside fieldProps
      */
-    fieldProps?: Partial<SelectFieldProps<T>>;
+    fieldProps?: Partial<SelectFieldProps<unknown, T>>;
     extractTextContents?: BlockMethods["extractTextContents"];
 }
 

--- a/packages/admin/cms-admin/src/blocks/helpers/createCompositeBlockSwitchField.tsx
+++ b/packages/admin/cms-admin/src/blocks/helpers/createCompositeBlockSwitchField.tsx
@@ -4,7 +4,7 @@ import { BlocksFinalForm } from "../form/BlocksFinalForm";
 import { type BlockMethods } from "../types";
 import { createCompositeBlockField } from "./composeBlocks/createCompositeBlockField";
 
-interface Options extends Partial<SwitchFieldProps> {
+interface Options extends Partial<SwitchFieldProps<unknown>> {
     defaultValue?: boolean;
     extractTextContents?: BlockMethods["extractTextContents"];
 }

--- a/packages/admin/cms-admin/src/blocks/helpers/createCompositeBlockTextField.tsx
+++ b/packages/admin/cms-admin/src/blocks/helpers/createCompositeBlockTextField.tsx
@@ -4,12 +4,12 @@ import { BlocksFinalForm } from "../form/BlocksFinalForm";
 import { type BlockMethods } from "../types";
 import { createCompositeBlockField } from "./composeBlocks/createCompositeBlockField";
 
-interface Options extends Partial<TextFieldProps> {
+interface Options extends Partial<TextFieldProps<unknown>> {
     defaultValue?: string;
     /**
      * @deprecated Set the props directly instead of nesting inside fieldProps
      */
-    fieldProps?: Partial<TextFieldProps>;
+    fieldProps?: Partial<TextFieldProps<unknown>>;
     extractTextContents?: BlockMethods["extractTextContents"];
 }
 

--- a/packages/admin/cms-admin/src/dam/DataGrid/filter/DamTableFilter.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/filter/DamTableFilter.tsx
@@ -42,7 +42,8 @@ export const DamTableFilter = ({ filterApi, hideArchiveFilter }: DamTableFilterP
                         />
                     </FilterBarPopoverFilter>
                 )}
-                <Field<ISortInformation> name="sort">
+                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                <Field<any, ISortInformation> name="sort">
                     {({ input }) => {
                         return <DamSortPopover onChoose={input.onChange} currentSort={input.value} />;
                     }}

--- a/packages/admin/cms-admin/src/form/file/FileUploadField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileUploadField.tsx
@@ -3,23 +3,37 @@ import { Field, type FieldProps } from "@comet/admin";
 import { FinalFormFileUpload, type FinalFormFileUploadProps } from "./FinalFormFileUpload";
 import { type GQLFinalFormFileUploadDownloadableFragment, type GQLFinalFormFileUploadFragment } from "./FinalFormFileUpload.generated";
 
-type SingleFileUploadProps = FieldProps<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment, HTMLInputElement> &
+type SingleFileUploadProps<FormValues> = FieldProps<
+    FormValues,
+    GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment,
+    HTMLInputElement
+> &
     Partial<FinalFormFileUploadProps<false>> & {
         multiple?: false;
         maxFiles?: 1;
     };
 
-type MultipleFileUploadProps = FieldProps<Array<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment>, HTMLInputElement> &
+type MultipleFileUploadProps<FormValues> = FieldProps<
+    FormValues,
+    Array<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment>,
+    HTMLInputElement
+> &
     Partial<FinalFormFileUploadProps<true>> & {
         multiple: true;
         maxFiles?: number;
     };
 
-export type FileUploadFieldProps<Multiple extends boolean | undefined> = Multiple extends true ? MultipleFileUploadProps : SingleFileUploadProps;
+export type FileUploadFieldProps<FormValues, Multiple extends boolean | undefined> = Multiple extends true
+    ? MultipleFileUploadProps<FormValues>
+    : SingleFileUploadProps<FormValues>;
 
-export const FileUploadField = <Multiple extends boolean | undefined>({ name, ...restProps }: FileUploadFieldProps<Multiple>) => {
+export const FileUploadField = <FormValues, Multiple extends boolean | undefined>({
+    name,
+    ...restProps
+}: FileUploadFieldProps<FormValues, Multiple>) => {
     return (
         <Field<
+            FormValues,
             Multiple extends true
                 ? Array<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment>
                 : GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment

--- a/storybook/src/admin/form/TextField.stories.tsx
+++ b/storybook/src/admin/form/TextField.stories.tsx
@@ -24,7 +24,7 @@ export const Default: Story = {
                 {({ values }) => {
                     return (
                         <>
-                            <TextField name="value" label="Textfield" fullWidth variant="horizontal" />
+                            <TextField<FormValues> name="value" label="Textfield" fullWidth variant="horizontal" />
 
                             <Alert title="FormState">
                                 <pre>{JSON.stringify(values, null, 2)}</pre>

--- a/storybook/src/admin/form/ToggleButtonGroupField.stories.tsx
+++ b/storybook/src/admin/form/ToggleButtonGroupField.stories.tsx
@@ -49,7 +49,7 @@ export const ToggleButtonFieldStory: Story = {
                 {({ values }) => {
                     return (
                         <>
-                            <ToggleButtonGroupField<SampleType>
+                            <ToggleButtonGroupField<FormValues, SampleType>
                                 label="Sample Type"
                                 name="type"
                                 options={[
@@ -111,7 +111,7 @@ export const MultipleRowsExample: Story = {
                 {({ values }) => {
                     return (
                         <>
-                            <ToggleButtonGroupField<SampleType>
+                            <ToggleButtonGroupField<FormValues, SampleType>
                                 label="Sample Type"
                                 name="type"
                                 optionsPerRow={3}
@@ -202,7 +202,7 @@ export const ToggleButtonFieldAddressSample: Story = {
                 {({ values }) => {
                     return (
                         <Box display="flex" gap={2} flexDirection="column">
-                            <ToggleButtonGroupField<AddressType>
+                            <ToggleButtonGroupField<FormValues, AddressType>
                                 label="AddressType"
                                 name="type"
                                 options={[
@@ -264,7 +264,7 @@ export const MediaType: Story = {
                 {({ values }) => {
                     return (
                         <>
-                            <ToggleButtonGroupField<SampleType>
+                            <ToggleButtonGroupField<FormValues, SampleType>
                                 label="Media Type"
                                 name="type"
                                 options={[
@@ -322,7 +322,7 @@ export const MediaTypeWithText: Story = {
                 {({ values }) => {
                     return (
                         <>
-                            <ToggleButtonGroupField<SampleType>
+                            <ToggleButtonGroupField<FormValues, SampleType>
                                 label="Media Type"
                                 name="type"
                                 options={[


### PR DESCRIPTION
**‼️ Breaking change**

## Description

This update improves type safety for form fields by changing the `name` prop type in `Field` components from a generic `string` to a `FilePath<FormValues>`. This ensures that all field names are validated against the actual FormValues interface at compile time.


## Problems

Previously, the `name` prop accepted any `string`, which allowed:
- **Typos** in field names that were only caught at runtime.
- **Missing autocomplete**, forcing developers to remember exact field paths.
- **Refactoring issues**: When renaming fields in the form’s value object (or due to api changes), related name props could be forgotten and remain incorrect without compiler errors.


## Change

Updated `Field` component’s `name` prop type:

```diff
- name: string
+ name: FilePath<FormValues>
```

- Now the `name` prop is type-checked against the `FormValues` structure. FormValues can be passed optionally
- Works for nested paths (`address.street`) and array paths (`contacts[0].email`), as well.

## New Type `FilePath`

Introduced the `FilePath<T>` utility type for extracting all valid property paths from a type, supporting nested objects and arrays with proper dot/bracket notation:

## Example Migration


```diff
interface FormValues {
    value: string;
}

// Before
- <TextField name="value" label="Textfield"/>

// After
+ <TextField<FormValues> name="value" label="Textfield" />
```


## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  <img width="1066" height="710" alt="Screenshot 2025-08-08 at 08 27 15" src="https://github.com/user-attachments/assets/4f93d56b-b0dd-4e24-9a56-e48d2f626a4c" />  |  <img width="1166" height="703" alt="Screenshot 2025-08-08 at 08 26 02" src="https://github.com/user-attachments/assets/20e707c7-a9ca-4356-a0c2-d12731b1952b" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
