### PR TITLE
Implement new `TimePicker` and `TimePickerField`

### DIFF
--- a/.changeset/ninety-results-fall.md
+++ b/.changeset/ninety-results-fall.md
@@ -1,0 +1,53 @@
+---
+"@comet/admin": minor
+"@comet/admin-date-time": minor
+---
+
+Add new `Future_TimePicker` and `Future_TimePickerField` components
+
+These will replace the existing `TimePicker`, `FinalFormTimePicker` and `TimeField` components from `@comet/admin-date-time` as a mostly drop-in replacement, the existing components have been deprecated.
+
+The new components are based on the `@mui/x-date-pickers` package, so you can refer to the [MUI documentation](https://v7.mui.com/x/react-date-pickers/time-picker/) for more details.
+Unlike the MUI components, these components use a 24h `string` (`HH:mm`) as the value, instead of `Date`, just like the existing components from `@comet/admin-date-time`.
+
+**Using the new `TimePicker`**
+
+```diff
+-import { FieldContainer } from "@comet/admin";
+-import { TimePicker } from "@comet/admin-date-time";
++import { Future_TimePicker as TimePicker, FieldContainer } from "@comet/admin";
+ import { useState } from "react";
+
+ export const Example = () => {
+     const [timeValue, setTimeValue] = useState<string | undefined>();
+
+     return (
+         <FieldContainer label="Time Picker">
+             <TimePicker value={timeValue} onChange={setTimeValue} />
+         </FieldContainer>
+     );
+ };
+```
+
+**Using the new `TimePickerField` in Final Form**
+
+```diff
+-import { TimeField } from "@comet/admin-date-time";
++import { Future_TimePickerField as TimePickerField } from "@comet/admin";
+ import { Form } from "react-final-form";
+
+ type Values = {
+     time: string;
+ };
+
+ export const Example = () => {
+     return (
+         <Form<Values> initialValues={{ time: "11:30" }} onSubmit={() => {}}>
+             {() => (
+-                <TimeField name="time" label="Time Picker" />
++                <TimePickerField name="time" label="Time Picker" />
+             )}
+         </Form>
+     );
+ };
+```

--- a/packages/admin/admin-date-time/src/timePicker/FinalFormTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/FinalFormTimePicker.tsx
@@ -5,6 +5,8 @@ import { TimePicker, type TimePickerProps } from "./TimePicker";
 export type FinalFormTimePickerProps = TimePickerProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
 
 /**
+ * @deprecated `FinalFormTimePicker` from `@comet/admin-date-time` will be replaced by `TimePickerField` (currently `Future_TimePickerField`) from `@comet/admin` in a future major release.
+ *
  * Final Form-compatible TimePicker component.
  *
  * @see {@link TimeField} – preferred for typical form use. Use this only if no Field wrapper is needed.

--- a/packages/admin/admin-date-time/src/timePicker/TimeField.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/TimeField.tsx
@@ -4,6 +4,9 @@ import { FinalFormTimePicker } from "./FinalFormTimePicker";
 
 export type TimeFieldProps = FieldProps<string, HTMLInputElement>;
 
+/**
+ * @deprecated `TimeField` from `@comet/admin-date-time` will be replaced by `TimePickerField` (currently `Future_TimePickerField`) from `@comet/admin` in a future major release.
+ */
 export const TimeField = ({ ...restProps }: TimeFieldProps) => {
     return <Field component={FinalFormTimePicker} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/timePicker/TimePicker.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/TimePicker.tsx
@@ -59,6 +59,9 @@ export interface TimePickerProps extends Omit<InputWithPopperProps, "children" |
     slotProps?: SlotProps;
 }
 
+/**
+ * @deprecated `TimePicker` from `@comet/admin-date-time` will be replaced by `TimePicker` (currently `Future_TimePicker`) from `@comet/admin` in a future major release.
+ */
 export const TimePicker = (inProps: TimePickerProps) => {
     const {
         onChange,

--- a/packages/admin/admin/src/common/OpenPickerAdornment.tsx
+++ b/packages/admin/admin/src/common/OpenPickerAdornment.tsx
@@ -1,0 +1,91 @@
+import { type ComponentsOverrides, css, IconButton, InputAdornment, type InputAdornmentProps, type Theme, useThemeProps } from "@mui/material";
+
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+
+export type OpenPickerAdornmentClassKey = "root" | "openPickerButton" | "inputIsDisabled";
+
+export type OpenPickerAdornmentProps = ThemedComponentBaseProps<{
+    root: typeof InputAdornment;
+    openPickerButton: typeof IconButton;
+}> & {
+    inputIsDisabled?: boolean;
+    inputIsReadOnly?: boolean;
+    onClick?: () => void;
+    position?: InputAdornmentProps["position"];
+} & Omit<InputAdornmentProps, "position">;
+
+type OwnerState = {
+    inputIsDisabled: boolean;
+};
+
+export const OpenPickerAdornment = (inProps: OpenPickerAdornmentProps) => {
+    const {
+        inputIsDisabled,
+        inputIsReadOnly,
+        onClick,
+        position = "start",
+        slotProps,
+        children,
+        ...restProps
+    } = useThemeProps({
+        props: inProps,
+        name: "CometAdminOpenPickerAdornment",
+    });
+
+    const ownerState: OwnerState = {
+        inputIsDisabled: Boolean(inputIsDisabled),
+    };
+
+    return (
+        <Root position={position} ownerState={ownerState} {...slotProps?.root} {...restProps}>
+            <OpenPickerButton
+                onClick={onClick}
+                disabled={inputIsDisabled || inputIsReadOnly}
+                ownerState={ownerState}
+                {...slotProps?.openPickerButton}
+            >
+                {children}
+            </OpenPickerButton>
+        </Root>
+    );
+};
+
+const Root = createComponentSlot(InputAdornment)<OpenPickerAdornmentClassKey, OwnerState>({
+    componentName: "OpenPickerAdornment",
+    slotName: "root",
+    classesResolver(ownerState) {
+        return [ownerState.inputIsDisabled && "inputIsDisabled"];
+    },
+})();
+
+const OpenPickerButton = createComponentSlot(IconButton)<OpenPickerAdornmentClassKey, OwnerState>({
+    componentName: "OpenPickerAdornment",
+    slotName: "openPickerButton",
+})(
+    ({ theme, ownerState: { inputIsDisabled } }) => css`
+        ${!inputIsDisabled &&
+        css`
+            &.Mui-disabled {
+                color: ${theme.palette.text.primary};
+            }
+        `}
+    `,
+);
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminOpenPickerAdornment: OpenPickerAdornmentProps;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminOpenPickerAdornment: OpenPickerAdornmentClassKey;
+    }
+
+    interface Components {
+        CometAdminOpenPickerAdornment?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminOpenPickerAdornment"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminOpenPickerAdornment"];
+        };
+    }
+}

--- a/packages/admin/admin/src/common/OpenPickerAdornment.tsx
+++ b/packages/admin/admin/src/common/OpenPickerAdornment.tsx
@@ -3,9 +3,9 @@ import { type ComponentsOverrides, css, IconButton, InputAdornment, type InputAd
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
-export type OpenPickerAdornmentClassKey = "root" | "openPickerButton" | "inputIsDisabled";
+type OpenPickerAdornmentClassKey = "root" | "openPickerButton" | "inputIsDisabled";
 
-export type OpenPickerAdornmentProps = ThemedComponentBaseProps<{
+type OpenPickerAdornmentProps = ThemedComponentBaseProps<{
     root: typeof InputAdornment;
     openPickerButton: typeof IconButton;
 }> & {

--- a/packages/admin/admin/src/common/ReadOnlyAdornment.tsx
+++ b/packages/admin/admin/src/common/ReadOnlyAdornment.tsx
@@ -1,0 +1,61 @@
+import { Lock } from "@comet/admin-icons";
+import { type ComponentsOverrides, css, InputAdornment, type InputAdornmentProps, type Theme, useThemeProps } from "@mui/material";
+
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+
+export type ReadOnlyAdornmentClassKey = "root";
+
+export type ReadOnlyAdornmentProps = ThemedComponentBaseProps<{
+    root: typeof InputAdornment;
+}> & {
+    position?: InputAdornmentProps["position"];
+    inputIsReadOnly: boolean;
+} & Omit<InputAdornmentProps, "position">;
+
+export const ReadOnlyAdornment = (inProps: ReadOnlyAdornmentProps) => {
+    const {
+        position = "end",
+        children = <Lock fontSize="inherit" />,
+        inputIsReadOnly,
+        slotProps,
+        ...restProps
+    } = useThemeProps({
+        props: inProps,
+        name: "CometAdminReadOnlyAdornment",
+    });
+
+    if (!inputIsReadOnly) {
+        return null;
+    }
+
+    return (
+        <Root position={position} {...slotProps?.root} {...restProps}>
+            {children}
+        </Root>
+    );
+};
+
+const Root = createComponentSlot(InputAdornment)<ReadOnlyAdornmentClassKey>({
+    componentName: "ReadOnlyAdornment",
+    slotName: "root",
+})(css`
+    font-size: 12px;
+`);
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminReadOnlyAdornment: ReadOnlyAdornmentProps;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminReadOnlyAdornment: ReadOnlyAdornmentClassKey;
+    }
+
+    interface Components {
+        CometAdminReadOnlyAdornment?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminReadOnlyAdornment"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminReadOnlyAdornment"];
+        };
+    }
+}

--- a/packages/admin/admin/src/common/ReadOnlyAdornment.tsx
+++ b/packages/admin/admin/src/common/ReadOnlyAdornment.tsx
@@ -4,9 +4,9 @@ import { type ComponentsOverrides, css, InputAdornment, type InputAdornmentProps
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
-export type ReadOnlyAdornmentClassKey = "root";
+type ReadOnlyAdornmentClassKey = "root";
 
-export type ReadOnlyAdornmentProps = ThemedComponentBaseProps<{
+type ReadOnlyAdornmentProps = ThemedComponentBaseProps<{
     root: typeof InputAdornment;
 }> & {
     position?: InputAdornmentProps["position"];

--- a/packages/admin/admin/src/dateTime/DatePicker.tsx
+++ b/packages/admin/admin/src/dateTime/DatePicker.tsx
@@ -2,7 +2,7 @@ import { Calendar, Lock } from "@comet/admin-icons";
 import { type ComponentsOverrides, css, IconButton, InputAdornment, inputLabelClasses, type Theme, useThemeProps } from "@mui/material";
 import { DatePicker as MuiDatePicker, type DatePickerProps as MuiDatePickerProps, pickersInputBaseClasses } from "@mui/x-date-pickers";
 import { format } from "date-fns";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import { ClearInputAdornment as CometClearInputAdornment } from "../common/ClearInputAdornment";
 import { createComponentSlot } from "../helpers/createComponentSlot";
@@ -26,8 +26,8 @@ export type Future_DatePickerProps = ThemedComponentBaseProps<{
     value?: string;
     onChange?: (date: string | undefined) => void;
     iconMapping?: {
-        openPicker?: React.ReactNode;
-        readOnly?: React.ReactNode;
+        openPicker?: ReactNode;
+        readOnly?: ReactNode;
     };
 } & Omit<MuiDatePickerProps<Date, true>, "value" | "onChange" | "slotProps">;
 

--- a/packages/admin/admin/src/dateTime/DatePicker.tsx
+++ b/packages/admin/admin/src/dateTime/DatePicker.tsx
@@ -1,10 +1,12 @@
-import { Calendar, Lock } from "@comet/admin-icons";
-import { type ComponentsOverrides, css, IconButton, InputAdornment, inputLabelClasses, type Theme, useThemeProps } from "@mui/material";
+import { Calendar } from "@comet/admin-icons";
+import { type ComponentsOverrides, css, type InputAdornment, inputLabelClasses, type Theme, useThemeProps } from "@mui/material";
 import { DatePicker as MuiDatePicker, type DatePickerProps as MuiDatePickerProps, pickersInputBaseClasses } from "@mui/x-date-pickers";
 import { format } from "date-fns";
 import { type ReactNode, useState } from "react";
 
 import { ClearInputAdornment as CometClearInputAdornment } from "../common/ClearInputAdornment";
+import { OpenPickerAdornment } from "../common/OpenPickerAdornment";
+import { ReadOnlyAdornment } from "../common/ReadOnlyAdornment";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
@@ -12,14 +14,13 @@ const getIsoDateString = (date: Date) => {
     return format(date, "yyyy-MM-dd");
 };
 
-export type Future_DatePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdornment" | "openPickerAdornment" | "openPickerButton";
+export type Future_DatePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdornment" | "openPickerAdornment";
 
 export type Future_DatePickerProps = ThemedComponentBaseProps<{
     root: typeof MuiDatePicker<Date, true>;
     clearInputAdornment: typeof CometClearInputAdornment;
     readOnlyAdornment: typeof InputAdornment;
-    openPickerAdornment: typeof InputAdornment;
-    openPickerButton: typeof IconButton;
+    openPickerAdornment: typeof OpenPickerAdornment;
 }> & {
     fullWidth?: boolean;
     required?: boolean;
@@ -27,7 +28,6 @@ export type Future_DatePickerProps = ThemedComponentBaseProps<{
     onChange?: (date: string | undefined) => void;
     iconMapping?: {
         openPicker?: ReactNode;
-        readOnly?: ReactNode;
     };
 } & Omit<MuiDatePickerProps<Date, true>, "value" | "onChange" | "slotProps">;
 
@@ -63,31 +63,7 @@ export const Future_DatePicker = (inProps: Future_DatePickerProps) => {
     const [open, setOpen] = useState(false);
     const dateValue = getDateValue(stringValue);
 
-    const { openPicker: openPickerIcon = <Calendar color="inherit" />, readOnly: readOnlyIcon = <Lock fontSize="inherit" /> } = iconMapping;
-
-    const clearButtonEndAdornment =
-        !required && !disabled && !readOnly ? (
-            <ClearInputAdornment
-                position="end"
-                hasClearableContent={Boolean(dateValue)}
-                onClick={() => onChange?.(undefined)}
-                {...slotProps?.clearInputAdornment}
-            />
-        ) : null;
-
-    const readOnlyAdornment = readOnly ? (
-        <ReadOnlyAdornment position="end" {...slotProps?.readOnlyAdornment}>
-            {readOnlyIcon}
-        </ReadOnlyAdornment>
-    ) : null;
-
-    const openPickerAdornment = (
-        <OpenPickerAdornment position="start" {...slotProps?.openPickerAdornment}>
-            <OpenPickerButton onClick={() => setOpen(true)} disabled={disabled || readOnly} {...slotProps?.openPickerButton}>
-                {openPickerIcon}
-            </OpenPickerButton>
-        </OpenPickerAdornment>
-    );
+    const { openPicker: openPickerIcon = <Calendar color="inherit" /> } = iconMapping;
 
     return (
         <Root
@@ -97,7 +73,7 @@ export const Future_DatePicker = (inProps: Future_DatePickerProps) => {
             open={open}
             onOpen={() => setOpen(true)}
             onClose={() => setOpen(false)}
-            disableOpenPicker={true}
+            disableOpenPicker
             value={dateValue}
             onChange={(date) => onChange?.(date ? getIsoDateString(date) : undefined)}
             {...slotProps?.root}
@@ -118,15 +94,27 @@ export const Future_DatePicker = (inProps: Future_DatePickerProps) => {
                             ...textFieldProps?.InputProps,
                             startAdornment: (
                                 <>
-                                    {openPickerAdornment}
+                                    <OpenPickerAdornment
+                                        inputIsDisabled={disabled}
+                                        inputIsReadOnly={readOnly}
+                                        onClick={() => setOpen(true)}
+                                        {...slotProps?.openPickerAdornment}
+                                    >
+                                        {openPickerIcon}
+                                    </OpenPickerAdornment>
                                     {textFieldProps?.InputProps?.startAdornment}
                                 </>
                             ),
                             endAdornment: (
                                 <>
                                     {textFieldProps?.InputProps?.endAdornment}
-                                    {readOnlyAdornment}
-                                    {clearButtonEndAdornment}
+                                    <ReadOnlyAdornment inputIsReadOnly={Boolean(readOnly)} {...slotProps?.readOnlyAdornment} />
+                                    <ClearInputAdornment
+                                        position="end"
+                                        hasClearableContent={dateValue !== null && !required && !disabled && !readOnly}
+                                        onClick={() => onChange?.(undefined)}
+                                        {...slotProps?.clearInputAdornment}
+                                    />
                                 </>
                             ),
                         },
@@ -157,23 +145,6 @@ const Root = createComponentSlot(MuiDatePicker<Date, true>)<Future_DatePickerCla
 const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<Future_DatePickerClassKey>({
     componentName: "Future_DatePicker",
     slotName: "clearInputAdornment",
-})();
-
-const ReadOnlyAdornment = createComponentSlot(InputAdornment)<Future_DatePickerClassKey>({
-    componentName: "Future_DatePicker",
-    slotName: "readOnlyAdornment",
-})(css`
-    font-size: 12px;
-`);
-
-const OpenPickerAdornment = createComponentSlot(InputAdornment)<Future_DatePickerClassKey>({
-    componentName: "Future_DatePicker",
-    slotName: "openPickerAdornment",
-})();
-
-const OpenPickerButton = createComponentSlot(IconButton)<Future_DatePickerClassKey>({
-    componentName: "Future_DatePicker",
-    slotName: "openPickerButton",
 })();
 
 declare module "@mui/material/styles" {

--- a/packages/admin/admin/src/dateTime/TimePicker.tsx
+++ b/packages/admin/admin/src/dateTime/TimePicker.tsx
@@ -2,7 +2,7 @@ import { Lock, Time } from "@comet/admin-icons";
 import { type ComponentsOverrides, css, IconButton, InputAdornment, inputLabelClasses, type Theme, useThemeProps } from "@mui/material";
 import { pickersInputBaseClasses, TimePicker as MuiTimePicker, type TimePickerProps as MuiTimePickerProps } from "@mui/x-date-pickers";
 import { format, parse } from "date-fns";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import { ClearInputAdornment as CometClearInputAdornment } from "../common/ClearInputAdornment";
 import { createComponentSlot } from "../helpers/createComponentSlot";
@@ -22,8 +22,8 @@ export type Future_TimePickerProps = ThemedComponentBaseProps<{
     value?: string;
     onChange?: (time: string | undefined) => void;
     iconMapping?: {
-        openPicker?: React.ReactNode;
-        readOnly?: React.ReactNode;
+        openPicker?: ReactNode;
+        readOnly?: ReactNode;
     };
 } & Omit<MuiTimePickerProps<Date, true>, "value" | "onChange" | "slotProps">;
 
@@ -98,7 +98,7 @@ export const Future_TimePicker = (inProps: Future_TimePickerProps) => {
             open={open}
             onOpen={() => setOpen(true)}
             onClose={() => setOpen(false)}
-            disableOpenPicker={true}
+            disableOpenPicker
             value={dateValue}
             onChange={(date) => {
                 if (!date) {

--- a/packages/admin/admin/src/dateTime/TimePicker.tsx
+++ b/packages/admin/admin/src/dateTime/TimePicker.tsx
@@ -1,0 +1,202 @@
+import { Lock, Time } from "@comet/admin-icons";
+import { type ComponentsOverrides, css, IconButton, InputAdornment, inputLabelClasses, type Theme, useThemeProps } from "@mui/material";
+import { pickersInputBaseClasses, TimePicker as MuiTimePicker, type TimePickerProps as MuiTimePickerProps } from "@mui/x-date-pickers";
+import { format, parse } from "date-fns";
+import { useState } from "react";
+
+import { ClearInputAdornment as CometClearInputAdornment } from "../common/ClearInputAdornment";
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+
+export type Future_TimePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdornment" | "openPickerAdornment" | "openPickerButton";
+
+export type Future_TimePickerProps = ThemedComponentBaseProps<{
+    root: typeof MuiTimePicker<Date, true>;
+    clearInputAdornment: typeof CometClearInputAdornment;
+    readOnlyAdornment: typeof InputAdornment;
+    openPickerAdornment: typeof InputAdornment;
+    openPickerButton: typeof IconButton;
+}> & {
+    fullWidth?: boolean;
+    required?: boolean;
+    value?: string;
+    onChange?: (time: string | undefined) => void;
+    iconMapping?: {
+        openPicker?: React.ReactNode;
+        readOnly?: React.ReactNode;
+    };
+} & Omit<MuiTimePickerProps<Date, true>, "value" | "onChange" | "slotProps">;
+
+const getTimeString = (date: Date) => {
+    return format(date, "HH:mm");
+};
+
+const getDateFromTimeString = (value: string | undefined): Date | null => {
+    if (!value) {
+        return null;
+    }
+
+    const parsedDate = parse(value, "HH:mm", new Date());
+    const isValid = !isNaN(parsedDate.getTime());
+
+    if (!isValid) {
+        throw new Error(`Invalid time value: "${value}", must be a 24h time in format HH:mm`);
+    }
+
+    return parsedDate;
+};
+
+export const Future_TimePicker = (inProps: Future_TimePickerProps) => {
+    const {
+        iconMapping = {},
+        fullWidth,
+        required,
+        slotProps,
+        disabled,
+        value: stringValue,
+        onChange,
+        readOnly,
+        ...restProps
+    } = useThemeProps({
+        props: inProps,
+        name: "CometAdminFutureTimePicker",
+    });
+    const [open, setOpen] = useState(false);
+    const dateValue = getDateFromTimeString(stringValue);
+
+    const { openPicker: openPickerIcon = <Time color="inherit" />, readOnly: readOnlyIcon = <Lock fontSize="inherit" /> } = iconMapping;
+
+    const clearButtonEndAdornment =
+        !required && !disabled && !readOnly ? (
+            <ClearInputAdornment
+                position="end"
+                hasClearableContent={Boolean(dateValue)}
+                onClick={() => onChange?.(undefined)}
+                {...slotProps?.clearInputAdornment}
+            />
+        ) : null;
+
+    const readOnlyAdornment = readOnly ? (
+        <ReadOnlyAdornment position="end" {...slotProps?.readOnlyAdornment}>
+            {readOnlyIcon}
+        </ReadOnlyAdornment>
+    ) : null;
+
+    const openPickerAdornment = (
+        <OpenPickerAdornment position="start" {...slotProps?.openPickerAdornment}>
+            <OpenPickerButton onClick={() => setOpen(true)} disabled={disabled || readOnly} {...slotProps?.openPickerButton}>
+                {openPickerIcon}
+            </OpenPickerButton>
+        </OpenPickerAdornment>
+    );
+
+    return (
+        <Root
+            enableAccessibleFieldDOMStructure
+            disabled={disabled}
+            readOnly={readOnly}
+            open={open}
+            onOpen={() => setOpen(true)}
+            onClose={() => setOpen(false)}
+            disableOpenPicker={true}
+            value={dateValue}
+            onChange={(date) => {
+                if (!date) {
+                    onChange?.(undefined);
+                    return;
+                }
+
+                onChange?.(getTimeString(date));
+            }}
+            {...slotProps?.root}
+            {...restProps}
+            slotProps={{
+                ...slotProps?.root?.slotProps,
+                textField: (ownerState) => {
+                    const textFieldProps = {
+                        ...slotProps?.root?.slotProps?.textField,
+                        ownerState,
+                    };
+
+                    return {
+                        fullWidth,
+                        required,
+                        ...textFieldProps,
+                        InputProps: {
+                            ...textFieldProps?.InputProps,
+                            startAdornment: (
+                                <>
+                                    {openPickerAdornment}
+                                    {textFieldProps?.InputProps?.startAdornment}
+                                </>
+                            ),
+                            endAdornment: (
+                                <>
+                                    {textFieldProps?.InputProps?.endAdornment}
+                                    {readOnlyAdornment}
+                                    {clearButtonEndAdornment}
+                                </>
+                            ),
+                        },
+                    };
+                },
+            }}
+        />
+    );
+};
+
+const Root = createComponentSlot(MuiTimePicker<Date, true>)<Future_TimePickerClassKey>({
+    componentName: "Future_TimePicker",
+    slotName: "root",
+})(css`
+    .${inputLabelClasses.root} {
+        display: none;
+
+        & + .${pickersInputBaseClasses.root} {
+            margin-top: 0;
+        }
+    }
+
+    .MuiPickersInputBase-root.Mui-readOnly .CometAdminFutureTimePicker-openPickerButton:disabled {
+        color: inherit;
+    }
+`);
+
+const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<Future_TimePickerClassKey>({
+    componentName: "Future_TimePicker",
+    slotName: "clearInputAdornment",
+})();
+
+const ReadOnlyAdornment = createComponentSlot(InputAdornment)<Future_TimePickerClassKey>({
+    componentName: "Future_TimePicker",
+    slotName: "readOnlyAdornment",
+})(css`
+    font-size: 12px;
+`);
+
+const OpenPickerAdornment = createComponentSlot(InputAdornment)<Future_TimePickerClassKey>({
+    componentName: "Future_TimePicker",
+    slotName: "openPickerAdornment",
+})();
+
+const OpenPickerButton = createComponentSlot(IconButton)<Future_TimePickerClassKey>({
+    componentName: "Future_TimePicker",
+    slotName: "openPickerButton",
+})();
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminFutureTimePicker: Future_TimePickerProps;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminFutureTimePicker: Future_TimePickerClassKey;
+    }
+
+    interface Components {
+        CometAdminFutureTimePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminFutureTimePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFutureTimePicker"];
+        };
+    }
+}

--- a/packages/admin/admin/src/dateTime/TimePicker.tsx
+++ b/packages/admin/admin/src/dateTime/TimePicker.tsx
@@ -1,21 +1,22 @@
-import { Lock, Time } from "@comet/admin-icons";
-import { type ComponentsOverrides, css, IconButton, InputAdornment, inputLabelClasses, type Theme, useThemeProps } from "@mui/material";
+import { Time } from "@comet/admin-icons";
+import { type ComponentsOverrides, css, type InputAdornment, inputLabelClasses, type Theme, useThemeProps } from "@mui/material";
 import { pickersInputBaseClasses, TimePicker as MuiTimePicker, type TimePickerProps as MuiTimePickerProps } from "@mui/x-date-pickers";
 import { format, parse } from "date-fns";
 import { type ReactNode, useState } from "react";
 
 import { ClearInputAdornment as CometClearInputAdornment } from "../common/ClearInputAdornment";
+import { OpenPickerAdornment } from "../common/OpenPickerAdornment";
+import { ReadOnlyAdornment } from "../common/ReadOnlyAdornment";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
-export type Future_TimePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdornment" | "openPickerAdornment" | "openPickerButton";
+export type Future_TimePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdornment" | "openPickerAdornment";
 
 export type Future_TimePickerProps = ThemedComponentBaseProps<{
     root: typeof MuiTimePicker<Date, true>;
     clearInputAdornment: typeof CometClearInputAdornment;
     readOnlyAdornment: typeof InputAdornment;
-    openPickerAdornment: typeof InputAdornment;
-    openPickerButton: typeof IconButton;
+    openPickerAdornment: typeof OpenPickerAdornment;
 }> & {
     fullWidth?: boolean;
     required?: boolean;
@@ -23,7 +24,6 @@ export type Future_TimePickerProps = ThemedComponentBaseProps<{
     onChange?: (time: string | undefined) => void;
     iconMapping?: {
         openPicker?: ReactNode;
-        readOnly?: ReactNode;
     };
 } & Omit<MuiTimePickerProps<Date, true>, "value" | "onChange" | "slotProps">;
 
@@ -64,31 +64,7 @@ export const Future_TimePicker = (inProps: Future_TimePickerProps) => {
     const [open, setOpen] = useState(false);
     const dateValue = getDateFromTimeString(stringValue);
 
-    const { openPicker: openPickerIcon = <Time color="inherit" />, readOnly: readOnlyIcon = <Lock fontSize="inherit" /> } = iconMapping;
-
-    const clearButtonEndAdornment =
-        !required && !disabled && !readOnly ? (
-            <ClearInputAdornment
-                position="end"
-                hasClearableContent={Boolean(dateValue)}
-                onClick={() => onChange?.(undefined)}
-                {...slotProps?.clearInputAdornment}
-            />
-        ) : null;
-
-    const readOnlyAdornment = readOnly ? (
-        <ReadOnlyAdornment position="end" {...slotProps?.readOnlyAdornment}>
-            {readOnlyIcon}
-        </ReadOnlyAdornment>
-    ) : null;
-
-    const openPickerAdornment = (
-        <OpenPickerAdornment position="start" {...slotProps?.openPickerAdornment}>
-            <OpenPickerButton onClick={() => setOpen(true)} disabled={disabled || readOnly} {...slotProps?.openPickerButton}>
-                {openPickerIcon}
-            </OpenPickerButton>
-        </OpenPickerAdornment>
-    );
+    const { openPicker: openPickerIcon = <Time color="inherit" /> } = iconMapping;
 
     return (
         <Root
@@ -126,15 +102,27 @@ export const Future_TimePicker = (inProps: Future_TimePickerProps) => {
                             ...textFieldProps?.InputProps,
                             startAdornment: (
                                 <>
-                                    {openPickerAdornment}
+                                    <OpenPickerAdornment
+                                        inputIsDisabled={disabled}
+                                        inputIsReadOnly={readOnly}
+                                        onClick={() => setOpen(true)}
+                                        {...slotProps?.openPickerAdornment}
+                                    >
+                                        {openPickerIcon}
+                                    </OpenPickerAdornment>
                                     {textFieldProps?.InputProps?.startAdornment}
                                 </>
                             ),
                             endAdornment: (
                                 <>
                                     {textFieldProps?.InputProps?.endAdornment}
-                                    {readOnlyAdornment}
-                                    {clearButtonEndAdornment}
+                                    <ReadOnlyAdornment inputIsReadOnly={Boolean(readOnly)} {...slotProps?.readOnlyAdornment} />
+                                    <ClearInputAdornment
+                                        position="end"
+                                        hasClearableContent={dateValue !== null && !required && !disabled && !readOnly}
+                                        onClick={() => onChange?.(undefined)}
+                                        {...slotProps?.clearInputAdornment}
+                                    />
                                 </>
                             ),
                         },
@@ -156,32 +144,11 @@ const Root = createComponentSlot(MuiTimePicker<Date, true>)<Future_TimePickerCla
             margin-top: 0;
         }
     }
-
-    .MuiPickersInputBase-root.Mui-readOnly .CometAdminFutureTimePicker-openPickerButton:disabled {
-        color: inherit;
-    }
 `);
 
 const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<Future_TimePickerClassKey>({
     componentName: "Future_TimePicker",
     slotName: "clearInputAdornment",
-})();
-
-const ReadOnlyAdornment = createComponentSlot(InputAdornment)<Future_TimePickerClassKey>({
-    componentName: "Future_TimePicker",
-    slotName: "readOnlyAdornment",
-})(css`
-    font-size: 12px;
-`);
-
-const OpenPickerAdornment = createComponentSlot(InputAdornment)<Future_TimePickerClassKey>({
-    componentName: "Future_TimePicker",
-    slotName: "openPickerAdornment",
-})();
-
-const OpenPickerButton = createComponentSlot(IconButton)<Future_TimePickerClassKey>({
-    componentName: "Future_TimePicker",
-    slotName: "openPickerButton",
 })();
 
 declare module "@mui/material/styles" {

--- a/packages/admin/admin/src/dateTime/TimePickerField.tsx
+++ b/packages/admin/admin/src/dateTime/TimePickerField.tsx
@@ -1,0 +1,14 @@
+import { type FieldRenderProps } from "react-final-form";
+
+import { Field, type FieldProps } from "../form/Field";
+import { Future_TimePicker as TimePicker, type Future_TimePickerProps as TimePickerProps } from "./TimePicker";
+
+const FinalFormTimePicker = ({ meta, input, ...restProps }: TimePickerProps & FieldRenderProps<string, HTMLInputElement>) => {
+    return <TimePicker {...input} {...restProps} />;
+};
+
+export type Future_TimePickerFieldProps = FieldProps<string, HTMLInputElement>;
+
+export const Future_TimePickerField = (props: Future_TimePickerFieldProps) => {
+    return <Field component={FinalFormTimePicker} {...props} />;
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -93,6 +93,8 @@ export { useDataGridRemote } from "./dataGrid/useDataGridRemote";
 export { usePersistentColumnState } from "./dataGrid/usePersistentColumnState";
 export { Future_DatePicker, Future_DatePickerClassKey, Future_DatePickerProps } from "./dateTime/DatePicker";
 export { Future_DatePickerField, Future_DatePickerFieldProps } from "./dateTime/DatePickerField";
+export { Future_TimePicker, Future_TimePickerClassKey, Future_TimePickerProps } from "./dateTime/TimePicker";
+export { Future_TimePickerField, Future_TimePickerFieldProps } from "./dateTime/TimePickerField";
 export { DeleteMutation } from "./DeleteMutation";
 export { EditDialog, useEditDialog } from "./EditDialog";
 export { EditDialogApiContext, IEditDialogApi, useEditDialogApi } from "./EditDialogApiContext";

--- a/packages/admin/admin/src/theme/componentsTheme/MuiPickersPopper.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiPickersPopper.ts
@@ -2,10 +2,10 @@ import { type Components, type Theme } from "@mui/material/styles";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 
-export const getMuiDateCalendar = (component: Components["MuiDateCalendar"], theme: Theme): Components["MuiDateCalendar"] => ({
+export const getMuiPickersPopper = (component: Components["MuiPickersPopper"], theme: Theme): Components["MuiPickersPopper"] => ({
     ...component,
     styleOverrides: mergeOverrideStyles(component?.styleOverrides, {
-        root: {
+        paper: {
             boxShadow: theme.shadows[1],
         },
     }),

--- a/packages/admin/admin/src/theme/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/getComponentsTheme.ts
@@ -15,7 +15,6 @@ import { getMuiCardHeader } from "./MuiCardHeader";
 import { getMuiCheckbox } from "./MuiCheckbox";
 import { getMuiChip } from "./MuiChip";
 import { getMuiDataGrid } from "./MuiDataGrid";
-import { getMuiDateCalendar } from "./MuiDateCalendar";
 import { getMuiDialog } from "./MuiDialog";
 import { getMuiDialogActions } from "./MuiDialogActions";
 import { getMuiDialogContent } from "./MuiDialogContent";
@@ -42,6 +41,7 @@ import { getMuiMenuItem } from "./MuiMenuItem";
 import { getMuiNativeSelect } from "./MuiNativeSelect";
 import { getMuiPaper } from "./MuiPaper";
 import { getMuiPickersInputBase } from "./MuiPickersInputBase";
+import { getMuiPickersPopper } from "./MuiPickersPopper";
 import { getMuiPickersTextField } from "./MuiPickersTextField";
 import { getMuiPopover } from "./MuiPopover";
 import { getMuiRadio } from "./MuiRadio";
@@ -121,6 +121,6 @@ export const getComponentsTheme = (components: Components, theme: Theme): ThemeO
     MuiTooltip: getMuiTooltip(components.MuiTooltip, theme),
     MuiTypography: getMuiTypography(components.MuiTypography, theme),
     MuiTablePagination: getMuiTablePagination(components.MuiTablePagination, theme),
-    MuiDateCalendar: getMuiDateCalendar(components.MuiDateCalendar, theme),
+    MuiPickersPopper: getMuiPickersPopper(components.MuiPickersPopper, theme),
     MuiTableFooter: getMuiTableFooter(components.MuiTableFooter, theme),
 });

--- a/storybook/src/admin/dateTime/TimePicker.stories.tsx
+++ b/storybook/src/admin/dateTime/TimePicker.stories.tsx
@@ -1,0 +1,91 @@
+import { FieldContainer, Future_TimePicker as TimePicker, Future_TimePickerField as TimePickerField } from "@comet/admin";
+import { Grid } from "@mui/material";
+import { type Meta, type StoryObj } from "@storybook/react-webpack5";
+import { useState } from "react";
+import { Form } from "react-final-form";
+
+type Story = StoryObj<typeof TimePicker>;
+
+const config: Meta<typeof TimePicker> = {
+    component: TimePicker,
+    title: "@comet/admin/dateTime/TimePicker",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        const [time, setTime] = useState<string | undefined>("11:30");
+        const [requiredTime, setRequiredTime] = useState<string | undefined>(undefined);
+        const [disabledTime, setDisabledTime] = useState<string | undefined>(undefined);
+        const [readOnlyTime, setReadOnlyTime] = useState<string | undefined>("11:30");
+
+        return (
+            <Grid container spacing={4}>
+                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                    <FieldContainer label="Time Picker" fullWidth>
+                        <TimePicker value={time} onChange={setTime} fullWidth />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                    <FieldContainer label="Required Time Picker" fullWidth required>
+                        <TimePicker value={requiredTime} onChange={setRequiredTime} fullWidth required />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                    <FieldContainer label="Disabled Time Picker" fullWidth disabled>
+                        <TimePicker value={disabledTime} onChange={setDisabledTime} fullWidth disabled />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                    <FieldContainer label="ReadOnly Time Picker" fullWidth>
+                        <TimePicker value={readOnlyTime} onChange={setReadOnlyTime} fullWidth readOnly />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12 }}>
+                    <pre>{`values: ${JSON.stringify({ time, requiredTime, disabledTime, readOnlyTime }, null, 2)}`}</pre>
+                </Grid>
+            </Grid>
+        );
+    },
+};
+
+export const FinalForm: Story = {
+    render: () => {
+        type Values = {
+            time: string;
+            requiredTime: string;
+            disabledTime: string;
+            readOnlyTime: string;
+        };
+
+        return (
+            <Form<Values>
+                initialValues={{
+                    time: "11:30",
+                    readOnlyTime: "11:30",
+                }}
+                onSubmit={() => {}}
+            >
+                {({ values }) => (
+                    <Grid container spacing={4}>
+                        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                            <TimePickerField name="time" label="Time Picker" fullWidth />
+                        </Grid>
+                        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                            <TimePickerField name="requiredTime" label="Required Time Picker" fullWidth required />
+                        </Grid>
+                        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                            <TimePickerField name="disabledTime" label="Disabled Time Picker" fullWidth disabled />
+                        </Grid>
+                        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                            <TimePickerField name="readOnlyTime" label="ReadOnly Time Picker" fullWidth readOnly />
+                        </Grid>
+                        <Grid size={{ xs: 12 }}>
+                            <pre>{`values: ${JSON.stringify(values, null, 2)}`}</pre>
+                        </Grid>
+                    </Grid>
+                )}
+            </Form>
+        );
+    },
+};


### PR DESCRIPTION
## Description

Add new `TimePicker` and `TimePickerField` components, based on MUI's [V7 TimePicker](https://v7.mui.com/x/api/date-pickers/time-picker/).
This enables better accessibility and allows keyboard input.

The design/styling doesn't yet match the Comet Design, that can be done in a future PR.

### New helper components

This also adds new helper-components for internal use in the new picker components. 
As there currently doesn't seem to be a need to use those components in Comet projects or other packages, they are currently not being exported by the library. 

- `OpenPickerAdornment`: Renders and styles the `IconButton` to open the picker
- `ReadOnlyAdornment`: Renders and styles the read-only icon when the input is set to `readOnly`

### Breaking changes

Due to the use of the new helper components, the `ClassKey` and `SlotProps` of `Future_DatePicker` have technically changed. Since these changes likely won't affect anything in practice and the component is prefixed with `Future_`, we can ignore this imo. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Existing from `@comet/admin-date-time` | New from `@comet/admin`
| ------ | ----- |
| <img width="303" height="398" alt="Existing TimePicker" src="https://github.com/user-attachments/assets/438a3055-baec-43b0-b400-cc64769946b8" />   | <img width="303" height="398" alt="New TimePicker" src="https://github.com/user-attachments/assets/db1a7bf5-029e-4d24-858b-0c8bb10a0ef2" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2202
