### PR TITLE
fix: remove CometDigitalExperienceLogo from All Icon overview

### DIFF
--- a/storybook/src/docs/icons/AllIcons.stories.tsx
+++ b/storybook/src/docs/icons/AllIcons.stories.tsx
@@ -5,6 +5,8 @@ import { styled } from "@mui/material/styles";
 import { useState } from "react";
 import { useDebounce } from "use-debounce";
 
+const iconBlockList = ["CometDigitalExperienceLogo"];
+
 const matchesSearchQuery = (str: string, query: string): boolean => {
     if (!query.length) return true;
 
@@ -41,7 +43,9 @@ const IconWrapper = styled("div")`
 const SearchIcon = imports.Search;
 
 const iconsWithSearchTerms = Object.keys(imports)
-    .filter((key) => !key.endsWith("SearchTerms") && key !== "__esModule")
+    .filter((key) => {
+        return !key.endsWith("SearchTerms") && key !== "__esModule" && !iconBlockList.includes(key);
+    })
     .map((key) => ({
         name: key,
         Icon: imports[key as keyof typeof imports],


### PR DESCRIPTION
## Description

Remove CometDigitalExperienceLogo from All Icons overview.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  <img width="939" height="687" alt="Screenshot 2025-08-11 at 07 09 26" src="https://github.com/user-attachments/assets/b107ad12-4bb7-476c-828f-8a946bcdc8ae" />    |   <img width="975" height="862" alt="Screenshot 2025-08-11 at 07 06 55" src="https://github.com/user-attachments/assets/33849d76-8d5f-40d6-a760-abc1bffc8cd0" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2222
