### PR TITLE
Improve prop typings for ColorField

### DIFF
--- a/packages/admin/admin-color-picker/src/ColorField.tsx
+++ b/packages/admin/admin-color-picker/src/ColorField.tsx
@@ -1,8 +1,8 @@
 import { Field, type FieldProps } from "@comet/admin";
 
-import { FinalFormColorPicker } from "./FinalFormColorPicker";
+import { FinalFormColorPicker, type FinalFormColorPickerProps } from "./FinalFormColorPicker";
 
-export type ColorFieldProps = FieldProps<string, HTMLInputElement>;
+export type ColorFieldProps = FieldProps<string, HTMLInputElement> & FinalFormColorPickerProps;
 
 export const ColorField = ({ ...restProps }: ColorFieldProps) => {
     return <Field component={FinalFormColorPicker} {...restProps} />;

--- a/packages/admin/admin-color-picker/src/FinalFormColorPicker.tsx
+++ b/packages/admin/admin-color-picker/src/FinalFormColorPicker.tsx
@@ -2,13 +2,14 @@ import { type FieldRenderProps } from "react-final-form";
 
 import { ColorPicker, type ColorPickerProps } from "./ColorPicker";
 
-export type FinalFormColorPickerProps = ColorPickerProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
+export type FinalFormColorPickerProps = ColorPickerProps;
 
+type FinalFormColorPickerInternalProps = FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
 /**
  * Final Form-compatible ColorPicker component.
  *
  * @see {@link ColorField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
-export const FinalFormColorPicker = ({ meta, input, ...restProps }: FinalFormColorPickerProps) => {
+export const FinalFormColorPicker = ({ meta, input, ...restProps }: FinalFormColorPickerProps & FinalFormColorPickerInternalProps) => {
     return <ColorPicker {...input} {...restProps} />;
 };

--- a/storybook/src/admin-color-picker/ColorField.stories.tsx
+++ b/storybook/src/admin-color-picker/ColorField.stories.tsx
@@ -1,0 +1,201 @@
+import { Alert, FinalForm } from "@comet/admin";
+import { ColorField } from "@comet/admin-color-picker";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof ColorField>;
+const config: Meta<typeof ColorField> = {
+    component: ColorField,
+    title: "@comet/admin-color-picker/ColorField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <ColorField name="value" label="Colorfield" fullWidth variant="horizontal" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const WithColorPalette: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <ColorField
+                                name="value"
+                                label="Colorfield"
+                                fullWidth
+                                variant="horizontal"
+                                colorPalette={[
+                                    "#E63946",
+                                    "#F4A261",
+                                    "#FFD166",
+                                    "#A8DADC",
+                                    "#457B9D",
+                                    "#3A0CA3",
+                                    "#B892FF",
+                                    "#FFB5A7",
+                                    "#8D99AE",
+                                    "#2B2D42",
+                                ]}
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const HiddenPicker: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <ColorField name="value" label="Colorfield" fullWidth variant="horizontal" hidePicker />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const HiddenHeader: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <ColorField name="value" label="Colorfield" fullWidth variant="horizontal" hideHeader />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const HiddenFooter: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <ColorField name="value" label="Colorfield" fullWidth variant="horizontal" hideFooter />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const CustomTitle: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <ColorField name="value" label="Colorfield" fullWidth variant="horizontal" titleText="Custom pick a color" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request improves typescript types for `ColorField` props.

## Screenshots/screencasts


| Before | After |
| ------ | ----- |
| <img width="1197" height="479" alt="Screenshot 2025-08-11 at 07 37 11" src="https://github.com/user-attachments/assets/2bb16cf1-cf04-4364-9534-5eb30357def9" />  |  <img width="1152" height="412" alt="Screenshot 2025-08-11 at 07 36 55" src="https://github.com/user-attachments/assets/1605bd3c-ccc2-4c7c-bd23-c3e1dc651e7b" /> |

These changes makes it clear to the developer which

 properties can be used on the `ColorField`

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
