### PR TITLE
Remove invalidIndicatorCharacter from 

### DIFF
--- a/packages/admin/admin-color-picker/src/ColorPicker.tsx
+++ b/packages/admin/admin-color-picker/src/ColorPicker.tsx
@@ -57,7 +57,6 @@ export interface ColorPickerProps extends Omit<InputWithPopperProps, "children" 
     fullWidth?: boolean;
     startAdornment?: InputBaseProps["startAdornment"];
     endAdornment?: InputBaseProps["endAdornment"];
-    invalidIndicatorCharacter?: string;
     required?: boolean;
     titleText?: ReactNode;
     clearButtonText?: ReactNode;


### PR DESCRIPTION
## Description


`invalidIndicatorCharacter` prop got introduced in https://github.com/vivid-planet/comet/pull/597 on `ColorPickerProps`, but is not used.

