### PR TITLE
Improve prop typings for DateRangeField

### DIFF
--- a/packages/admin/admin-date-time/src/dateRangePicker/DateRangeField.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/DateRangeField.tsx
@@ -1,9 +1,9 @@
 import { Field, type FieldProps } from "@comet/admin";
 
 import { type DateRange } from "./DateRangePicker";
-import { FinalFormDateRangePicker } from "./FinalFormDateRangePicker";
+import { FinalFormDateRangePicker, type FinalFormDateRangePickerProps } from "./FinalFormDateRangePicker";
 
-export type DateRangeFieldProps = FieldProps<DateRange, HTMLInputElement>;
+export type DateRangeFieldProps = FieldProps<DateRange, HTMLInputElement> & FinalFormDateRangePickerProps;
 
 export const DateRangeField = ({ ...restProps }: DateRangeFieldProps) => {
     return <Field component={FinalFormDateRangePicker} {...restProps} />;

--- a/packages/admin/admin-date-time/src/dateRangePicker/FinalFormDateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/FinalFormDateRangePicker.tsx
@@ -2,13 +2,14 @@ import { type FieldRenderProps } from "react-final-form";
 
 import { type DateRange, DateRangePicker, type DateRangePickerProps } from "./DateRangePicker";
 
-export type FinalFormDateRangePickerProps = DateRangePickerProps & FieldRenderProps<DateRange, HTMLInputElement | HTMLTextAreaElement>;
+export type FinalFormDateRangePickerProps = DateRangePickerProps;
+type FinalFormDateRangePickerInternalProps = FieldRenderProps<DateRange, HTMLInputElement | HTMLTextAreaElement>;
 
 /**
  * Final Form-compatible DateRangerPicker component.
  *
  * @see {@link DateRangeField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
-export const FinalFormDateRangePicker = ({ meta, input, ...restProps }: FinalFormDateRangePickerProps) => {
+export const FinalFormDateRangePicker = ({ meta, input, ...restProps }: FinalFormDateRangePickerProps & FinalFormDateRangePickerInternalProps) => {
     return <DateRangePicker {...input} {...restProps} />;
 };

--- a/storybook/src/admin-date-time/dateRangePicker/DateRangePicker.stories.tsx
+++ b/storybook/src/admin-date-time/dateRangePicker/DateRangePicker.stories.tsx
@@ -1,0 +1,75 @@
+import { Alert, FinalForm } from "@comet/admin";
+import { DateRangeField } from "@comet/admin-date-time";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof DateRangeField>;
+const config: Meta<typeof DateRangeField> = {
+    component: DateRangeField,
+    title: "@comet/admin-date-time/dateRangePicker/DateRangeField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <DateRangeField name="value" label="Date Range Field" fullWidth variant="horizontal" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const MinMaxDate: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <DateRangeField
+                                name="value"
+                                label="Date Range Field"
+                                fullWidth
+                                variant="horizontal"
+                                minDate={new Date(2025, 0, 1)}
+                                maxDate={new Date(2025, 11, 31)}
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request improves typescript types for `DateRangeField` props.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1166" height="170" alt="Screenshot 2025-08-11 at 08 57 13" src="https://github.com/user-attachments/assets/77861d97-9b29-4cd1-887c-d33824c1d1f1" />  |  <img width="1139" height="370" alt="Screenshot 2025-08-11 at 08 57 51" src="https://github.com/user-attachments/assets/cf770987-dd1c-4c1b-8007-00ec90d687d7" /> |



These changes makes it clear to the developer which properties can be used on the `DateRangeField`

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
