### PR TITLE
Improve prop typings for TimeField

### DIFF
--- a/packages/admin/admin-date-time/src/timePicker/FinalFormTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/FinalFormTimePicker.tsx
@@ -2,13 +2,14 @@ import { type FieldRenderProps } from "react-final-form";
 
 import { TimePicker, type TimePickerProps } from "./TimePicker";
 
-export type FinalFormTimePickerProps = TimePickerProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
+export type FinalFormTimePickerProps = TimePickerProps;
+type FinalFormTimePickerInternalProps = FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
 
 /**
  * Final Form-compatible TimePicker component.
  *
  * @see {@link TimeField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
-export const FinalFormTimePicker = ({ meta, input, ...restProps }: FinalFormTimePickerProps) => {
+export const FinalFormTimePicker = ({ meta, input, ...restProps }: FinalFormTimePickerProps & FinalFormTimePickerInternalProps) => {
     return <TimePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/timePicker/TimeField.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/TimeField.tsx
@@ -1,8 +1,8 @@
 import { Field, type FieldProps } from "@comet/admin";
 
-import { FinalFormTimePicker } from "./FinalFormTimePicker";
+import { FinalFormTimePicker, type FinalFormTimePickerProps } from "./FinalFormTimePicker";
 
-export type TimeFieldProps = FieldProps<string, HTMLInputElement>;
+export type TimeFieldProps = FieldProps<string, HTMLInputElement> & FinalFormTimePickerProps;
 
 export const TimeField = ({ ...restProps }: TimeFieldProps) => {
     return <Field component={FinalFormTimePicker} {...restProps} />;

--- a/storybook/src/admin-date-time/timePicker/TimeField.stories.tsx
+++ b/storybook/src/admin-date-time/timePicker/TimeField.stories.tsx
@@ -1,0 +1,68 @@
+import { Alert, FinalForm } from "@comet/admin";
+import { TimeField } from "@comet/admin-date-time";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof TimeField>;
+const config: Meta<typeof TimeField> = {
+    component: TimeField,
+    title: "@comet/admin-date-time/timePicker/TimeField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <TimeField name="value" label="Time Field" fullWidth variant="horizontal" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const MinuteStep: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <TimeField name="value" label="Time Field" fullWidth variant="horizontal" minuteStep={5} />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request improves typescript types for `TimeField` props.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|   <img width="1120" height="119" alt="Screenshot 2025-08-11 at 09 18 28" src="https://github.com/user-attachments/assets/7e8f223f-3871-46e4-a49f-876d80f9cf77" />  |  <img width="420" height="89" alt="Screenshot 2025-08-11 at 09 27 08" src="https://github.com/user-attachments/assets/0a25a19c-6935-4522-871a-46e7a5e2c976" />
 | 


These changes makes it clear to the developer which properties can be used on the `TimeField`

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
