### PR TITLE
Improve prop typings for TimeRangeField

### DIFF
--- a/packages/admin/admin-date-time/src/timeRangePicker/FinalFormTimeRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/timeRangePicker/FinalFormTimeRangePicker.tsx
@@ -2,13 +2,14 @@ import { type FieldRenderProps } from "react-final-form";
 
 import { type TimeRange, TimeRangePicker, type TimeRangePickerProps } from "./TimeRangePicker";
 
-export type FinalFormTimeRangePickerProps = TimeRangePickerProps & FieldRenderProps<TimeRange, HTMLInputElement | HTMLTextAreaElement>;
+export type FinalFormTimeRangePickerProps = TimeRangePickerProps;
+type FinalFormTimeRangePickerInternalProps = FieldRenderProps<TimeRange, HTMLInputElement | HTMLTextAreaElement>;
 
 /**
  * Final Form-compatible TimeRangePicker component.
  *
  * @see {@link TimeRangeField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
-export const FinalFormTimeRangePicker = ({ meta, input, ...restProps }: FinalFormTimeRangePickerProps) => {
+export const FinalFormTimeRangePicker = ({ meta, input, ...restProps }: FinalFormTimeRangePickerProps & FinalFormTimeRangePickerInternalProps) => {
     return <TimeRangePicker {...input} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/timeRangePicker/TimeRangeField.tsx
+++ b/packages/admin/admin-date-time/src/timeRangePicker/TimeRangeField.tsx
@@ -1,9 +1,9 @@
 import { Field, type FieldProps } from "@comet/admin";
 
-import { FinalFormTimeRangePicker } from "./FinalFormTimeRangePicker";
+import { FinalFormTimeRangePicker, type FinalFormTimeRangePickerProps } from "./FinalFormTimeRangePicker";
 import { type TimeRange } from "./TimeRangePicker";
 
-export type TimeRangeFieldProps = FieldProps<TimeRange, HTMLInputElement>;
+export type TimeRangeFieldProps = FieldProps<TimeRange, HTMLInputElement> & FinalFormTimeRangePickerProps;
 
 export const TimeRangeField = ({ ...restProps }: TimeRangeFieldProps) => {
     return <Field component={FinalFormTimeRangePicker} {...restProps} />;

--- a/storybook/src/admin-date-time/timeRangePicker/TimeRangeField.stories.tsx
+++ b/storybook/src/admin-date-time/timeRangePicker/TimeRangeField.stories.tsx
@@ -1,0 +1,68 @@
+import { Alert, FinalForm } from "@comet/admin";
+import { TimeRangeField } from "@comet/admin-date-time";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof TimeRangeField>;
+const config: Meta<typeof TimeRangeField> = {
+    component: TimeRangeField,
+    title: "@comet/admin-date-time/timeRangePicker/TimeRangeField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <TimeRangeField name="value" label="Time Range Field" fullWidth variant="horizontal" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const MinuteStep: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <TimeRangeField name="value" label="Time Range Field" fullWidth variant="horizontal" minuteStep={5} />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request improves typescript types for `TimeRangeField` props.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1187" height="143" alt="Screenshot 2025-08-11 at 09 34 10" src="https://github.com/user-attachments/assets/1d852c05-ea69-46aa-9e46-072d7bcd9aa2" />  |   <img width="1262" height="146" alt="Screenshot 2025-08-11 at 09 34 54" src="https://github.com/user-attachments/assets/d0358245-afb9-42e4-9a43-69435a08d594" /> |


These changes makes it clear to the developer which properties can be used on the `TimeRangeField`

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
