### PR TITLE
Best Practices: Fix scrolling of `DataGrid` inside `Dialog`

### DIFF
--- a/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
+++ b/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
@@ -930,7 +930,6 @@ export const GridWithSelectionInDialog = {
                         loading={loading}
                         slots={{ toolbar: GridToolbar }}
                         checkboxSelection
-                        autoHeight
                         rowSelectionModel={selectionModel}
                         onRowSelectionModelChange={setSelectionModel}
                     />


### PR DESCRIPTION
## Description

Scrolling inside the `DataGrid`/`Dialog` was not possible, likely since either the Comet V8 or DataGrid V7 update. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <video width="375" src="https://github.com/user-attachments/assets/8f8d88af-31ad-4618-b60f-e9a3d1985b8c" /> | <video width="375" src="https://github.com/user-attachments/assets/7c560834-f31a-455f-b2bf-52658e0c1316" /> |


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1948
