### PR TITLE
Improve prop typings for NumberField

### DIFF
--- a/packages/admin/admin/src/form/FinalFormNumberInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormNumberInput.tsx
@@ -5,18 +5,27 @@ import { useIntl } from "react-intl";
 
 import { ClearInputAdornment } from "../common/ClearInputAdornment";
 
-export type FinalFormNumberInputProps = InputBaseProps &
-    FieldRenderProps<number> & {
-        clearable?: boolean;
-        decimals?: number;
-    };
+export type FinalFormNumberInputProps = InputBaseProps & {
+    clearable?: boolean;
+    decimals?: number;
+};
+
+type FinalFormNumberInputInternalProps = FieldRenderProps<number>;
 
 /**
  * Final Form-compatible NumberInput component.
  *
  * @see {@link NumberField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
-export function FinalFormNumberInput({ meta, input, innerRef, clearable, endAdornment, decimals = 0, ...props }: FinalFormNumberInputProps) {
+export function FinalFormNumberInput({
+    meta,
+    input,
+    innerRef,
+    clearable,
+    endAdornment,
+    decimals = 0,
+    ...props
+}: FinalFormNumberInputProps & FinalFormNumberInputInternalProps) {
     const intl = useIntl();
 
     const [formattedNumberValue, setFormattedNumberValue] = useState("");

--- a/packages/admin/admin/src/form/fields/NumberField.tsx
+++ b/packages/admin/admin/src/form/fields/NumberField.tsx
@@ -1,7 +1,7 @@
 import { Field, type FieldProps } from "../Field";
-import { FinalFormNumberInput } from "../FinalFormNumberInput";
+import { FinalFormNumberInput, type FinalFormNumberInputProps } from "../FinalFormNumberInput";
 
-export type NumberFieldProps = FieldProps<number, HTMLInputElement>;
+export type NumberFieldProps = FieldProps<number, HTMLInputElement> & FinalFormNumberInputProps;
 
 export const NumberField = ({ ...restProps }: NumberFieldProps) => {
     return <Field component={FinalFormNumberInput} {...restProps} />;

--- a/storybook/src/admin/form/NumberField.stories.tsx
+++ b/storybook/src/admin/form/NumberField.stories.tsx
@@ -1,0 +1,38 @@
+import { Alert, FinalForm, NumberField } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof NumberField>;
+const config: Meta<typeof NumberField> = {
+    component: NumberField,
+    title: "@comet/admin/form/NumberField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            value: number;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <NumberField name="value" label="Number Field" fullWidth variant="horizontal" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request improves typescript types for `NumberField` props.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1139" height="214" alt="Screenshot 2025-08-11 at 09 58 02" src="https://github.com/user-attachments/assets/4c475da8-0911-485a-bb0f-e9b394a2be34" />  | <img width="1138" height="173" alt="Screenshot 2025-08-11 at 09 59 20" src="https://github.com/user-attachments/assets/c99ec1d6-75aa-4c83-97eb-8a3a760f34cc" />  |


These changes makes it clear to the developer which properties can be used on the `NumberField`

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
