### PR TITLE
Improve prop typings for SearchField

### DIFF
--- a/packages/admin/admin/src/form/fields/SearchField.tsx
+++ b/packages/admin/admin/src/form/fields/SearchField.tsx
@@ -1,7 +1,7 @@
 import { Field, type FieldProps } from "../Field";
-import { FinalFormSearchTextField } from "../FinalFormSearchTextField";
+import { FinalFormSearchTextField, type FinalFormSearchTextFieldProps } from "../FinalFormSearchTextField";
 
-export type SearchFieldProps = FieldProps<string, HTMLInputElement>;
+export type SearchFieldProps = FieldProps<string, HTMLInputElement> & FinalFormSearchTextFieldProps;
 
 export const SearchField = ({ ...restProps }: SearchFieldProps) => {
     return <Field component={FinalFormSearchTextField} {...restProps} />;

--- a/storybook/src/admin/form/SearchField.stories.tsx
+++ b/storybook/src/admin/form/SearchField.stories.tsx
@@ -1,0 +1,38 @@
+import { Alert, FinalForm, SearchField } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof SearchField>;
+const config: Meta<typeof SearchField> = {
+    component: SearchField,
+    title: "@comet/admin/form/SearchField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <SearchField name="value" label="Search Field" fullWidth variant="horizontal" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request improves typescript types for `SearchField` props.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1129" height="134" alt="Screenshot 2025-08-11 at 10 07 42" src="https://github.com/user-attachments/assets/5bc278e3-b531-45c3-b061-96b6c3256ba4" />   |  <img width="1211" height="144" alt="Screenshot 2025-08-11 at 10 07 20" src="https://github.com/user-attachments/assets/7e5ac20d-ade8-468c-bfac-643147a8e008" />  |


These changes makes it clear to the developer which properties can be used on the `SearchField`

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
