### PR TITLE
refactor: improve prop typings for CheckboxField

### DIFF
--- a/packages/admin/admin/src/form/Checkbox.tsx
+++ b/packages/admin/admin/src/form/Checkbox.tsx
@@ -1,13 +1,19 @@
 import MuiCheckbox, { type CheckboxProps } from "@mui/material/Checkbox";
 import { type FieldRenderProps } from "react-final-form";
 
-export type FinalFormCheckboxProps = FieldRenderProps<string, HTMLInputElement> & CheckboxProps;
+export type FinalFormCheckboxProps = CheckboxProps;
+
+type FinalFormCheckboxInternalProps = FieldRenderProps<string, HTMLInputElement>;
 
 /**
  * Final Form-compatible Checkbox component.
  *
  * @see {@link CheckboxField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
-export const FinalFormCheckbox = ({ input: { checked, name, onChange, ...restInput }, meta, ...rest }: FinalFormCheckboxProps) => {
+export const FinalFormCheckbox = ({
+    input: { checked, name, onChange, ...restInput },
+    meta,
+    ...rest
+}: FinalFormCheckboxProps & FinalFormCheckboxInternalProps) => {
     return <MuiCheckbox {...rest} name={name} inputProps={restInput} onChange={onChange} checked={checked} />;
 };

--- a/storybook/src/admin/form/CheckboxField.stories.tsx
+++ b/storybook/src/admin/form/CheckboxField.stories.tsx
@@ -1,0 +1,37 @@
+import { Alert, CheckboxField, FinalForm } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof CheckboxField>;
+const config: Meta<typeof CheckboxField> = {
+    component: CheckboxField,
+    title: "@comet/admin/form/CheckboxField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <CheckboxField name="value" label="Checkbox Field" fullWidth variant="horizontal" />
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request improves typescript types for `CheckboxField` props.

Setting the componentsProps, and the`finalFormCheckbox` is currently not possible without providing `meta` and `input` which came from `FieldRenderProps<string, HTMLInputElement>`. Both variables are expected to be injected in the FinalForm Adapter from the Field component, but should not be required to be set outside of the field.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="832" height="455" alt="Screenshot 2025-08-11 at 10 33 47" src="https://github.com/user-attachments/assets/b03f083a-f207-442b-b805-e0d6b8f15540" />   |  <img width="315" height="268" alt="Screenshot 2025-08-11 at 10 34 12" src="https://github.com/user-attachments/assets/b027cc4e-cfa0-4e7d-b7c9-cdfb415726a7" /> |


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
