### PR TITLE
RFC: fieldLabel on CheckboxField / SwitchField

### DIFF
--- a/packages/admin/admin/src/form/fields/CheckboxField.tsx
+++ b/packages/admin/admin/src/form/fields/CheckboxField.tsx
@@ -5,19 +5,23 @@ import { FinalFormCheckbox, type FinalFormCheckboxProps } from "../Checkbox";
 import { Field, type FieldProps } from "../Field";
 
 export interface CheckboxFieldProps extends FieldProps<string, HTMLInputElement> {
-    fieldLabel?: ReactNode;
+    checkboxLabel?: ReactNode;
     componentsProps?: {
         formControlLabel?: FormControlLabelProps;
         finalFormCheckbox?: FinalFormCheckboxProps;
     };
 }
 
-export const CheckboxField = ({ fieldLabel, label, componentsProps = {}, ...restProps }: CheckboxFieldProps) => {
+export const CheckboxField = ({ checkboxLabel, componentsProps = {}, ...restProps }: CheckboxFieldProps) => {
     const { formControlLabel: formControlLabelProps, finalFormCheckbox: finalFormCheckboxProps } = componentsProps;
     return (
-        <Field type="checkbox" label={fieldLabel} {...restProps}>
+        <Field type="checkbox" {...restProps}>
             {(props) => (
-                <FormControlLabel label={label} control={<FinalFormCheckbox {...props} {...finalFormCheckboxProps} />} {...formControlLabelProps} />
+                <FormControlLabel
+                    label={checkboxLabel}
+                    control={<FinalFormCheckbox {...props} {...finalFormCheckboxProps} />}
+                    {...formControlLabelProps}
+                />
             )}
         </Field>
     );


### PR DESCRIPTION
## Description

While reviewing the codebase, I noticed inconsistent usage of the label prop across form fields.

`FieldProps` already defines a `label` prop intended to label the entire field. Most field components (e.g., `TextField`, `NumberField`, …) correctly forward this label to the `Field`. For example:

```tsx
<TextField name="value" label="Label" fullWidth variant="horizontal" />
```

However, `CheckboxField` and `SwitchField` introduce a second prop, `fieldLabel`, which is used as the field label, while the `label` from `FieldProps` is instead forwarded to FormControlLabel. 


```tsx
<CheckboxField
  name="value"
  label="Label"
  fieldLabel="FieldLabel"
  fullWidth
  variant="horizontal"
/>
```


This breaks consistency with other fields and makes label behave differently depending on the field type, which can be confusing for developers.

Screenshots for comparison:

### TextField

<img width="924" height="338" alt="Screenshot 2025-08-11 at 10 53 54" src="https://github.com/user-attachments/assets/7ec0b36a-0248-46d2-99ed-8e55fdb2768d" />

### CheckboxField

<img width="948" height="348" alt="Screenshot 2025-08-11 at 10 53 47" src="https://github.com/user-attachments/assets/8f2ef5e2-a0b6-4eeb-8c44-5f767b26d541" />

