### PR TITLE
Improve prop typings for SwitchField

### DIFF
--- a/packages/admin/admin/src/form/Switch.tsx
+++ b/packages/admin/admin/src/form/Switch.tsx
@@ -1,13 +1,18 @@
 import MuiSwitch, { type SwitchProps } from "@mui/material/Switch";
 import { type FieldRenderProps } from "react-final-form";
 
-export type FinalFormSwitchProps = SwitchProps & FieldRenderProps<string, HTMLInputElement>;
+export type FinalFormSwitchProps = SwitchProps;
+type FinalFormSwitchInternalProps = FieldRenderProps<string, HTMLInputElement>;
 
 /**
  * Final Form-compatible Switch component.
  *
  * @see {@link SwitchField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
-export const FinalFormSwitch = ({ input: { checked, name, onChange, ...restInput }, meta, ...rest }: FinalFormSwitchProps) => {
+export const FinalFormSwitch = ({
+    input: { checked, name, onChange, ...restInput },
+    meta,
+    ...rest
+}: FinalFormSwitchProps & FinalFormSwitchInternalProps) => {
     return <MuiSwitch {...rest} name={name} inputProps={restInput} onChange={onChange} checked={checked} />;
 };

--- a/storybook/src/admin/form/SwitchField.stories.tsx
+++ b/storybook/src/admin/form/SwitchField.stories.tsx
@@ -1,0 +1,38 @@
+import { Alert, FinalForm, SwitchField } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof SwitchField>;
+const config: Meta<typeof SwitchField> = {
+    component: SwitchField,
+    title: "@comet/admin/form/SwitchField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <SwitchField name="value" label="Switch Field" fullWidth variant="horizontal" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request improves typescript types for `SwitchField` props.

Setting the componentsProps, and the`finalFormSwitch` is currently not possible without providing `meta` and `input` which came from `FieldRenderProps<string, HTMLInputElement>`. Both variables are expected to be injected in the FinalForm Adapter from the Field component, but should not be required to be set outside of the field.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="712" height="454" alt="Screenshot 2025-08-11 at 11 20 57" src="https://github.com/user-attachments/assets/ca25ac20-f7f2-478a-9eb9-db58c03a1108" />  |   <img width="380" height="243" alt="Screenshot 2025-08-11 at 11 21 45" src="https://github.com/user-attachments/assets/86aae835-0716-4f70-a3ab-aee0083bfb4b" /> |



## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
