### PR TITLE
refactor: improve prop typings for TextAreaField

### DIFF
--- a/packages/admin/admin/src/form/fields/TextAreaField.tsx
+++ b/packages/admin/admin/src/form/fields/TextAreaField.tsx
@@ -1,7 +1,7 @@
 import { Field, type FieldProps } from "../Field";
-import { FinalFormInput } from "../FinalFormInput";
+import { FinalFormInput, type FinalFormInputProps } from "../FinalFormInput";
 
-export type TextAreaFieldProps = FieldProps<string, HTMLTextAreaElement>;
+export type TextAreaFieldProps = FieldProps<string, HTMLTextAreaElement> & FinalFormInputProps;
 
 export const TextAreaField = ({ ...restProps }: TextAreaFieldProps) => {
     return <Field type="textarea" multiline rows={3} component={FinalFormInput} {...restProps} />;

--- a/storybook/src/admin/form/TextAreaField.stories.tsx
+++ b/storybook/src/admin/form/TextAreaField.stories.tsx
@@ -1,0 +1,38 @@
+import { Alert, FinalForm, TextAreaField } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof TextAreaField>;
+const config: Meta<typeof TextAreaField> = {
+    component: TextAreaField,
+    title: "@comet/admin/form/TextAreaField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            value: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <TextAreaField name="value" label="Text Area Field" fullWidth variant="horizontal" />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request improves typescript types for `TextAreaField` props.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  <img width="1175" height="124" alt="Screenshot 2025-08-11 at 13 33 25" src="https://github.com/user-attachments/assets/efed6833-8d1f-4584-98a8-f6fd6896b7d1" />  |  <img width="1231" height="180" alt="Screenshot 2025-08-11 at 13 41 54" src="https://github.com/user-attachments/assets/aab2c4fd-da2c-4bef-91fe-8d10a44ebe8d" /> |




These changes makes it clear to the developer which properties can be used on the `TextAreaField`

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2205
