### PR TITLE
`TableBlock` fixes for updates to Comet V8 and DataGrid V7

### DIFF
--- a/demo/api/src/db/fixtures/generators/page-content-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/page-content-block-fixture.service.ts
@@ -56,7 +56,8 @@ export class PageContentBlockFixtureService {
         type SupportedBlocks = (typeof blocks)[number]["type"];
 
         // TODO add fixtures for newsDetail and newsList
-        const fixtures: Record<Exclude<SupportedBlocks, "newsDetail" | "newsList">, [BlockCategory, BlockFixture]> = {
+        // TODO: Add table fixture (https://vivid-planet.atlassian.net/browse/COM-2227)
+        const fixtures: Record<Exclude<SupportedBlocks, "newsDetail" | "newsList" | "table">, [BlockCategory, BlockFixture]> = {
             accordion: ["layout", this.accordionBlockFixtureService],
             columns: ["layout", this.columnsBlockFixtureService],
             contentGroup: ["layout", this.contentGroupBlockFixtureService],

--- a/knip.json
+++ b/knip.json
@@ -58,7 +58,8 @@
         "packages/admin/cms-admin": {
             "entry": ["./src/index.ts", "./src/generator/generate.ts"],
             "project": ["./src/**/*.{ts,tsx}"],
-            "ignore": ["**/*.generated.ts"]
+            "ignore": ["**/*.generated.ts"],
+            "ignoreDependencies": ["@mui/x-data-grid-pro"]
         },
         "packages/admin/admin-generator": {
             "entry": ["./src/adminGenerator.ts", "./src/index.ts"],

--- a/packages/admin/cms-admin/src/blocks/table/ActionsCell.tsx
+++ b/packages/admin/cms-admin/src/blocks/table/ActionsCell.tsx
@@ -1,12 +1,12 @@
 import { Alert, readClipboardText, RowActionsItem, RowActionsMenu, useSnackbarApi, writeClipboardText } from "@comet/admin";
 import { Add, ArrowDown, ArrowUp, Copy, Delete, Duplicate, Paste, Remove } from "@comet/admin-icons";
-import { DispatchSetStateAction } from "@comet/blocks-admin";
 import { Divider, Snackbar } from "@mui/material";
+import { type Dispatch, type SetStateAction } from "react";
 import { FormattedMessage } from "react-intl";
 import { v4 as uuid } from "uuid";
 import { z } from "zod";
 
-import { TableBlockData } from "../../blocks.generated";
+import { type TableBlockData } from "../../blocks.generated";
 import { getNewColumn, getNewRow } from "./utils";
 
 const clipboardRowSchema = z.object({
@@ -18,12 +18,13 @@ type ClipboardRow = z.infer<typeof clipboardRowSchema>;
 
 type Props = {
     row: Record<string, unknown> & { id: string };
-    updateState: DispatchSetStateAction<TableBlockData>;
+    updateState: Dispatch<SetStateAction<TableBlockData>>;
     state: TableBlockData;
 };
 
 export const ActionsCell = ({ row, updateState, state }: Props) => {
     const snackbarApi = useSnackbarApi();
+    const stateRow = state.rows.find((rowInState) => rowInState.id === row.id);
 
     const insertRow = (where: "above" | "below") => {
         updateState((state) => {
@@ -179,12 +180,12 @@ export const ActionsCell = ({ row, updateState, state }: Props) => {
         <RowActionsMenu>
             <RowActionsMenu>
                 <RowActionsItem
-                    icon={row.highlighted ? <Remove /> : <Add />}
+                    icon={stateRow?.highlighted ? <Remove /> : <Add />}
                     onClick={() => {
                         toggleRowHighlight();
                     }}
                 >
-                    {row.highlighted ? (
+                    {stateRow?.highlighted ? (
                         <FormattedMessage id="comet.tableBlock.removeHighlighting" defaultMessage="Remove highlighting" />
                     ) : (
                         <FormattedMessage id="comet.tableBlock.highlightRow" defaultMessage="Highlight row" />

--- a/packages/admin/cms-admin/src/blocks/table/CellValue.tsx
+++ b/packages/admin/cms-admin/src/blocks/table/CellValue.tsx
@@ -1,5 +1,5 @@
-import { styled } from "@mui/material";
-import { ReactNode } from "react";
+import { styled } from "@mui/material/styles";
+import { type ReactNode } from "react";
 
 type Props = {
     highlighted: boolean;
@@ -8,23 +8,23 @@ type Props = {
 
 export const CellValue = ({ highlighted, value }: Props) => {
     return (
-        <>
+        <CellValueContainer $highlighted={highlighted}>
             <TextValue $highlighted={highlighted}>{value}</TextValue>
-            <CellBackground $highlighted={highlighted} />
-        </>
+        </CellValueContainer>
     );
 };
+
+const CellValueContainer = styled("div")<{ $highlighted: boolean }>(({ $highlighted, theme }) => ({
+    backgroundColor: $highlighted ? theme.palette.grey[50] : "transparent",
+    marginLeft: theme.spacing(-2),
+    marginRight: theme.spacing(-2),
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+}));
 
 const TextValue = styled("div")<{ $highlighted: boolean }>(({ $highlighted }) => ({
     overflow: "hidden",
     whiteSpace: "nowrap",
     textOverflow: "ellipsis",
     fontWeight: $highlighted ? 700 : 400,
-}));
-
-const CellBackground = styled("div")<{ $highlighted: boolean }>(({ $highlighted, theme }) => ({
-    position: "absolute",
-    inset: 0,
-    zIndex: -1,
-    backgroundColor: $highlighted ? theme.palette.grey[50] : "white",
 }));

--- a/packages/admin/cms-admin/src/blocks/table/ColumnHeader.tsx
+++ b/packages/admin/cms-admin/src/blocks/table/ColumnHeader.tsx
@@ -1,20 +1,20 @@
 import { Alert, RowActionsItem, RowActionsMenu, useSnackbarApi } from "@comet/admin";
 import { Add, Copy, Delete, DensityStandard, DragIndicator, Duplicate, Paste, PinLeft, PinRight, Remove } from "@comet/admin-icons";
-import { DispatchSetStateAction } from "@comet/blocks-admin";
-import { ButtonBase, Divider, Snackbar, styled } from "@mui/material";
-import { GridColumnHeaderParams } from "@mui/x-data-grid";
-import { ReactNode } from "react";
+import { ButtonBase, Divider, Snackbar } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import { type GridColumnHeaderParams } from "@mui/x-data-grid";
+import { type Dispatch, type ReactNode, type SetStateAction } from "react";
 import { FormattedMessage } from "react-intl";
 import { v4 as uuid } from "uuid";
 
-import { TableBlockData } from "../../blocks.generated";
-import { ColumnSize } from "./TableBlockGrid";
+import { type TableBlockData } from "../../blocks.generated";
+import { type ColumnSize } from "./TableBlockGrid";
 import { getNewColumn } from "./utils";
 
 type Props = GridColumnHeaderParams & {
     columnSize: ColumnSize;
     highlighted: boolean;
-    updateState: DispatchSetStateAction<TableBlockData>;
+    updateState: Dispatch<SetStateAction<TableBlockData>>;
     columnIndex: number;
 };
 

--- a/packages/admin/cms-admin/src/blocks/table/EditCell.tsx
+++ b/packages/admin/cms-admin/src/blocks/table/EditCell.tsx
@@ -1,8 +1,9 @@
-import { InputBase, InputBaseProps, Paper, Popper, styled } from "@mui/material";
-import { GridRenderEditCellParams, useGridApiContext } from "@mui/x-data-grid-pro";
+import { InputBase, type InputBaseProps, Paper, Popper } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import { type GridRenderEditCellParams, useGridApiContext } from "@mui/x-data-grid-pro";
 import { useCallback, useState } from "react";
 
-export const EditCell = ({ id, field, value, colDef }: GridRenderEditCellParams<string>) => {
+export const EditCell = ({ id, field, value, colDef }: GridRenderEditCellParams) => {
     const [valueState, setValueState] = useState(value);
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>();
     const apiRef = useGridApiContext();
@@ -33,7 +34,6 @@ export const EditCell = ({ id, field, value, colDef }: GridRenderEditCellParams<
     return (
         <>
             <EditCellHandle ref={handleRef} />
-            {/* @ts-expect-error Fixed with MUI v6 (`onResize` and `onResizeCapture` props required according to TS but not actually needed) */}
             <EditPopper open={!!anchorEl} anchorEl={anchorEl} placement="bottom-start">
                 <EditPaper elevation={1}>
                     <EditInput

--- a/packages/admin/cms-admin/src/blocks/table/TableBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/table/TableBlock.tsx
@@ -1,10 +1,13 @@
-import { OkayButton, useStackApi } from "@comet/admin";
-import { BlockCategory, BlockInterface, BlocksFinalForm, createBlockSkeleton, SelectPreviewComponent } from "@comet/blocks-admin";
-import { Dialog, DialogActions, DialogTitle } from "@mui/material";
+import { Dialog, OkayButton, useStackApi } from "@comet/admin";
+import { DialogActions } from "@mui/material";
 import { useState } from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
-import { TableBlockData, TableBlockInput } from "../../blocks.generated";
+import { type TableBlockData, type TableBlockInput } from "../../blocks.generated";
+import { BlocksFinalForm } from "../form/BlocksFinalForm";
+import { createBlockSkeleton } from "../helpers/createBlockSkeleton";
+import { SelectPreviewComponent } from "../iframebridge/SelectPreviewComponent";
+import { BlockCategory, type BlockInterface } from "../types";
 import { TableBlockGrid } from "./TableBlockGrid";
 import { getInitialTableData } from "./utils";
 
@@ -16,6 +19,7 @@ export const TableBlock: BlockInterface<TableBlockData, TableBlockData, TableBlo
     category: BlockCategory.TextAndContent,
     AdminComponent: ({ state, updateState }) => {
         const stackApi = useStackApi();
+        const intl = useIntl();
         const [showDialog, setShowDialog] = useState(true);
 
         const closeTableBlock = () => {
@@ -26,10 +30,13 @@ export const TableBlock: BlockInterface<TableBlockData, TableBlockData, TableBlo
         return (
             <SelectPreviewComponent>
                 <BlocksFinalForm<TableBlockData> onSubmit={updateState} initialValues={state}>
-                    <Dialog open={showDialog} maxWidth="xl" onClose={closeTableBlock}>
-                        <DialogTitle>
-                            <FormattedMessage id="comet.blocks.table.displayName" defaultMessage="Table" />
-                        </DialogTitle>
+                    <Dialog
+                        open={showDialog}
+                        maxWidth="xl"
+                        onClose={closeTableBlock}
+                        title={intl.formatMessage({ id: "comet.blocks.table.displayName", defaultMessage: "Table" })}
+                        PaperProps={{ sx: { height: "100%", maxHeight: 880 } }}
+                    >
                         <TableBlockGrid state={state} updateState={updateState} />
                         <DialogActions>
                             <OkayButton onClick={closeTableBlock} />

--- a/packages/admin/cms-admin/src/blocks/table/dataGridStyles.ts
+++ b/packages/admin/cms-admin/src/blocks/table/dataGridStyles.ts
@@ -1,7 +1,8 @@
-import { SxProps, Theme } from "@mui/material";
+import { type SxProps, type Theme } from "@mui/material";
 
+// TODO: Can we remove the `!important`s?
 export const dataGridStyles: SxProps<Theme> = (theme) => ({
-    minHeight: "min(740px, calc(100vh - 40px))",
+    "--DataGrid-rowBorderColor": theme.palette.grey[100],
     borderLeft: 0,
     borderRight: 0,
 
@@ -9,52 +10,64 @@ export const dataGridStyles: SxProps<Theme> = (theme) => ({
         width: "100%",
         justifyContent: "flex-end",
     },
-    ".MuiDataGrid-columnHeader": {
-        borderBottom: `1px solid ${theme.palette.grey[100]}`,
-    },
-    ".MuiDataGrid-cell": {
-        position: "relative",
-        borderBottom: `1px solid ${theme.palette.grey[100]} !important`, // TODO: Can we fix this?
-        borderTop: "none",
-    },
-    ".MuiDataGrid-cell:not(:last-child), .MuiDataGrid-columnHeader:not(:last-child)": {
-        borderRight: `1px solid ${theme.palette.grey[100]}`,
-    },
-    '.MuiDataGrid-cell[data-field="actions"]': {
-        padding: 0,
-        justifyContent: "center",
-    },
-    ".MuiDataGrid-columnSeparator": {
+
+    ".MuiDataGrid-columnHeaders .MuiDataGrid-filler[role='presentation']": {
         display: "none",
     },
-    ".MuiDataGrid-columnHeaders, .MuiDataGrid-cell": {
-        borderBottom: "none",
-    },
-    ".MuiDataGrid-rowReorderCell": {
-        height: "100%",
-    },
-    ".MuiDataGrid-pinnedColumns": {
-        boxShadow: "none",
 
-        "&--left .MuiDataGrid-cell": {
+    ".MuiDataGrid-columnHeader": {
+        borderRight: `1px solid ${theme.palette.grey[100]}`,
+
+        "&.MuiDataGrid-columnHeader--pinnedLeft.MuiDataGrid-columnHeader--withRightBorder": {
             borderRight: `1px solid ${theme.palette.grey[100]}`,
-            paddingLeft: 0,
-            paddingRight: 0,
+            boxShadow: "none",
         },
 
-        "&--right .MuiDataGrid-cell": {
+        "&.MuiDataGrid-columnHeader--pinnedRight.MuiDataGrid-columnHeader--withLeftBorder": {
             borderLeft: `1px solid ${theme.palette.grey[100]}`,
+            boxShadow: "none",
+        },
+
+        "&:nth-last-child(4)": {
+            // The last non-pinned cell should not have a border, as the pinned column already has one
+            borderRight: "none",
         },
     },
-    ".MuiDataGrid-pinnedColumnHeaders": {
-        boxShadow: "none",
 
-        "&--left .MuiDataGrid-columnHeader": {
-            borderRight: `1px solid ${theme.palette.grey[100]}`,
+    ".MuiDataGrid-cell": {
+        borderBottom: `1px solid ${theme.palette.grey[100]}`,
+        borderRight: `1px solid ${theme.palette.grey[100]}`,
+        borderTop: "none",
+
+        "&.MuiDataGrid-cellEmpty[role='presentation']": {
+            display: "none",
         },
 
-        "&--right .MuiDataGrid-columnHeader": {
-            borderLeft: `1px solid ${theme.palette.grey[100]}`,
+        "&.MuiDataGrid-cell--pinnedLeft.MuiDataGrid-cell--withRightBorder": {
+            borderRightWidth: 1,
+            boxShadow: "none",
         },
+
+        "&.MuiDataGrid-cell--pinnedRight.MuiDataGrid-cell--withLeftBorder": {
+            borderLeftWidth: 1,
+            boxShadow: "none",
+        },
+
+        "&:nth-last-child(3)": {
+            // The last non-pinned cell should not have a border, as the pinned column already has one
+            borderRight: "none",
+        },
+
+        '&[data-field="actions"]': {
+            display: "flex",
+            borderRight: "none",
+            justifyContent: "center",
+            alignItems: "center",
+            padding: 0,
+        },
+    },
+
+    ".MuiDataGrid-columnSeparator": {
+        display: "none",
     },
 });

--- a/packages/admin/cms-admin/src/blocks/table/utils.ts
+++ b/packages/admin/cms-admin/src/blocks/table/utils.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from "uuid";
 
-import { TableBlockData } from "../../blocks.generated";
+import { type TableBlockData } from "../../blocks.generated";
 
 export const getNewColumn = (): TableBlockData["columns"][number] => {
     return { id: uuid(), highlighted: false, size: "standard" };

--- a/packages/api/cms-api/src/blocks/table.block.ts
+++ b/packages/api/cms-api/src/blocks/table.block.ts
@@ -1,6 +1,8 @@
-import { BlockData, BlockField, BlockInput, createBlock, inputToData } from "@comet/blocks-api";
 import { plainToInstance, Type } from "class-transformer";
 import { IsArray, IsBoolean, IsEnum, IsString } from "class-validator";
+
+import { BlockData, BlockInput, blockInputToData, createBlock } from "./block";
+import { BlockField } from "./decorators/field";
 
 enum ColumnSize {
     extraSmall = "extraSmall",
@@ -35,7 +37,7 @@ class TableBlockColumnInput extends BlockInput {
     highlighted: boolean;
 
     transformToBlockData(): TableBlockColumnData {
-        return inputToData(TableBlockColumnData, this);
+        return blockInputToData(TableBlockColumnData, this);
     }
 }
 
@@ -57,7 +59,7 @@ class TableBlockRowColumnValueInput extends BlockInput {
     value: string;
 
     transformToBlockData(): TableBlockRowColumnValueData {
-        return inputToData(TableBlockRowColumnValueData, this);
+        return blockInputToData(TableBlockRowColumnValueData, this);
     }
 }
 
@@ -87,11 +89,11 @@ class TableBlockRowInput extends BlockInput {
     cellValues: TableBlockRowColumnValueInput[] = [];
 
     transformToBlockData(): TableBlockRowData {
-        return inputToData(TableBlockRowData, this);
+        return blockInputToData(TableBlockRowData, this);
     }
 }
 
-export class TableBlockData extends BlockData {
+class TableBlockData extends BlockData {
     @BlockField(TableBlockColumnData)
     @Type(() => TableBlockColumnData)
     columns: TableBlockColumnData[] = [];
@@ -101,7 +103,7 @@ export class TableBlockData extends BlockData {
     rows: TableBlockRowData[] = [];
 }
 
-export class TableBlockInput extends BlockInput {
+class TableBlockInput extends BlockInput {
     @BlockField(TableBlockColumnInput)
     @IsArray()
     @Type(() => TableBlockColumnInput)


### PR DESCRIPTION
## Description

Fixes typescript, lint and functionality of the `TableBlock` after merging `main` into the feature-branch. 

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1948
-   Follow-up task for fixtures [COM-2227](https://vivid-planet.atlassian.net/browse/COM-2227)
-   Relates to https://github.com/vivid-planet/comet/pull/4241

[COM-2227]: https://vivid-planet.atlassian.net/browse/COM-2227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ