### PR TITLE
Use storybook/react-vite for storybook package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2489,16 +2489,13 @@ importers:
         version: 0.4.4(graphql-mocks@0.10.0(graphql@15.10.1))(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))
       '@storybook/addon-docs':
         specifier: ^9.0.16
-        version: 9.1.1(@types/react@18.3.23)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))
-      '@storybook/addon-webpack5-compiler-babel':
-        specifier: ^3.0.6
-        version: 3.0.6(webpack@5.101.0)
+        version: 9.1.1(@types/react@18.3.23)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))
       '@storybook/react':
         specifier: ^9.0.16
-        version: 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3)
-      '@storybook/react-webpack5':
-        specifier: ^9.0.16
-        version: 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3)
+        version: 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))(typescript@5.7.3)
+      '@storybook/react-vite':
+        specifier: 9.0.16
+        version: 9.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))(typescript@5.7.3)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
       '@types/draft-js':
         specifier: ^0.11.18
         version: 0.11.18
@@ -2537,7 +2534,7 @@ importers:
         version: 9.30.1(jiti@2.5.1)
       eslint-plugin-storybook:
         specifier: ^9.0.16
-        version: 9.0.16(eslint@9.30.1(jiti@2.5.1))(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3)
+        version: 9.0.16(eslint@9.30.1(jiti@2.5.1))(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))(typescript@5.7.3)
       graphql-mocks:
         specifier: ^0.10.0
         version: 0.10.0(graphql@15.10.1)
@@ -2565,15 +2562,18 @@ importers:
       react-router-dom:
         specifier: ^5.3.4
         version: 5.3.4(react@18.3.1)
-      remark-gfm:
-        specifier: ^4.0.1
-        version: 4.0.1
       storybook:
         specifier: ^9.0.16
-        version: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
+        version: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
+      storybook-addon-tag-badges:
+        specifier: ^2.0.1
+        version: 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
+      vite:
+        specifier: ^7.0.6
+        version: 7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)
 
 packages:
 
@@ -5867,6 +5867,15 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1':
+    resolution: {integrity: sha512-J4BaTocTOYFkMHIra1JDWrMWpNmBl4EkplIwHEsV8aeUOtdWjwSnln9U7twjMFTAEB7mptNtSKyVi1Y2W9sDJw==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@jridgewell/gen-mapping@0.1.1':
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
@@ -7991,23 +8000,16 @@ packages:
     peerDependencies:
       storybook: ^9.1.1
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.6':
-    resolution: {integrity: sha512-J4uVxEfkd2iAxPxcT90iebt5wuLSd0EYuMJa94t1jVUGlvZZAvnmqXAqscRITNU37nOr0c9yZ2YVS/sFOZyOVw==}
-    engines: {node: '>=18'}
-
-  '@storybook/builder-webpack5@9.1.1':
-    resolution: {integrity: sha512-4yAF0KHgwqtsiBcgu3FEmctmk3kYALry+YCxi8nLKxi5Qh0laiR7NBKnZ7PsQ5545rAAkGTRu7axYn7y4Dg6jg==}
+  '@storybook/builder-vite@9.0.16':
+    resolution: {integrity: sha512-zXockUexeRy3ABG7DFLEvJqJe4mGL0JkI7FMrpwiKaHCQNaD87vR0xkRVeh0a3B8GKUNxoYtpYKvdzc9DobQHQ==}
     peerDependencies:
-      storybook: ^9.1.1
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      storybook: ^9.0.16
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/core-webpack@9.1.1':
-    resolution: {integrity: sha512-z/SFjtZWiKkW66NzKikIGGCnuB3otqL1Q/XrX3AcAAU3UoRXD2cykRC0LwRHF8byxoQe1ZMg5L7/pibMNKORDg==}
+  '@storybook/csf-plugin@9.0.16':
+    resolution: {integrity: sha512-MSmfPwI0j1mMAc+R3DVkVBQf2KLzaVn2SLdEwweesx63Nh9j3zu9CqKEa0zOuDX1lR2M0DZU0lV6K4sc2EYI4A==}
     peerDependencies:
-      storybook: ^9.1.1
+      storybook: ^9.0.16
 
   '@storybook/csf-plugin@9.1.1':
     resolution: {integrity: sha512-MwdtvzzFpkard06pCfDrgRXZiBfWAQICdKh7kzpv1L8SwewsRgUr5WZQuEAVfYdSvCFJbWnNN4KirzPhe5ENCg==}
@@ -8024,23 +8026,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
-  '@storybook/preset-react-webpack@9.1.1':
-    resolution: {integrity: sha512-dfCiNubGUpVnMjtL+1benBcBAAoLlNxSw3yKz+TULl5fV6aLoiAqoazQPaRA9WwMTFlH+1iW7Q3PEBNEs9Mk5g==}
-    engines: {node: '>=20.0.0'}
+  '@storybook/react-dom-shim@9.0.16':
+    resolution: {integrity: sha512-5aIK+31R41mRUvDB4vmBv8hwh3IVHIk/Zbs6kkWF2a+swOsB2+a06aLX21lma4/0T/AuFVXHWat0+inQ4nrXRg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.1.1
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0':
-    resolution: {integrity: sha512-KUqXC3oa9JuQ0kZJLBhVdS4lOneKTOopnNBK4tUAgoxWQ3u/IjzdueZjFr7gyBrXMoU6duutk3RQR9u8ZpYJ4Q==}
-    peerDependencies:
-      typescript: '>= 4.x'
-      webpack: '>= 4'
+      storybook: ^9.0.16
 
   '@storybook/react-dom-shim@9.1.1':
     resolution: {integrity: sha512-L+HCOXvOP+PwKrVS8od9aF+F4hO7zA0Nt1vnpbg2LeAHCxYghrjFVtioe7gSlzrlYdozQrPLY98a4OkDB7KGrw==}
@@ -8049,13 +8040,22 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^9.1.1
 
-  '@storybook/react-webpack5@9.1.1':
-    resolution: {integrity: sha512-IunfvKQh48F1wW3MRxaF4UOvQB6qp25aHUazHYpJ90mfFB09RZKmqcX/JkJF+S7H8l4zrsuwpNLJuVSER9GHGw==}
+  '@storybook/react-vite@9.0.16':
+    resolution: {integrity: sha512-a+UsoymyvPH4bJJVI+asj02N8U2wlkGyzhUqF6LUM9gXzixRMxoRHkchCKLdqLhE+//STrwC0YFF3GG6Y5oMEg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.1.1
+      storybook: ^9.0.16
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@storybook/react@9.0.16':
+    resolution: {integrity: sha512-1jk9fBe8vEoZrba9cK19ZDdZgYMXUNl3Egjj5RsTMYMc1L2mtIu9o56VyK/1V4Q52N9IyawHvmIIuxc5pCZHkQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^9.0.16
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       typescript:
@@ -8752,9 +8752,6 @@ packages:
 
   '@types/sax@1.2.4':
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
-
-  '@types/semver@7.7.0':
-    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
   '@types/send@0.17.4':
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
@@ -9760,10 +9757,6 @@ packages:
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
 
-  case-sensitive-paths-webpack-plugin@2.4.0:
-    resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
-    engines: {node: '>=4'}
-
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
@@ -10091,9 +10084,6 @@ packages:
   common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
-
-  commondir@1.0.1:
-    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
@@ -10746,9 +10736,6 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
-  dedent@0.7.0:
-    resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
-
   dedent@1.5.3:
     resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
     peerDependencies:
@@ -11124,9 +11111,6 @@ packages:
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
-
-  endent@2.1.0:
-    resolution: {integrity: sha512-r8VyPX7XL8U01Xgnb1CjZ3XV+z90cXIJ9JPE/R9SEC9vpw2P6CfsRPJmp20DppC5N7ZAMCmjYkJIa744Iyg96w==}
 
   enhanced-resolve@5.18.0:
     resolution: {integrity: sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==}
@@ -11628,9 +11612,6 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-json-parse@1.0.3:
-    resolution: {integrity: sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==}
-
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -11678,6 +11659,14 @@ packages:
 
   fdir@6.4.4:
     resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.4.6:
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -11778,10 +11767,6 @@ packages:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
 
-  find-cache-dir@3.3.2:
-    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
-    engines: {node: '>=8'}
-
   find-cache-dir@4.0.0:
     resolution: {integrity: sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==}
     engines: {node: '>=14.16'}
@@ -11809,10 +11794,6 @@ packages:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
     engines: {node: '>=18'}
 
-  flat-cache@3.2.0:
-    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -11827,9 +11808,6 @@ packages:
 
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
-
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
   follow-redirects@1.15.9:
     resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
@@ -11850,13 +11828,6 @@ packages:
 
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
-
-  fork-ts-checker-webpack-plugin@8.0.0:
-    resolution: {integrity: sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==}
-    engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
-    peerDependencies:
-      typescript: '>3.6.0'
-      webpack: ^5.11.0
 
   fork-ts-checker-webpack-plugin@9.1.0:
     resolution: {integrity: sha512-mpafl89VFPJmhnJ1ssH+8wmM2b50n+Rew5x42NeI2U78aRWgtkEtGmctp7iT16UjquJTjorEmIfESj3DxdW84Q==}
@@ -11940,9 +11911,6 @@ packages:
 
   fs-monkey@1.0.3:
     resolution: {integrity: sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==}
-
-  fs-monkey@1.1.0:
-    resolution: {integrity: sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==}
 
   fs-readdir-recursive@1.1.0:
     resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
@@ -12344,9 +12312,6 @@ packages:
 
   html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
-
-  html-entities@2.6.0:
-    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -13795,10 +13760,6 @@ packages:
     resolution: {integrity: sha512-omTM41g3Skpvx5dSYeZIbXKcXoAVc/AoMNwn9TKx++L/gaen/+4TTttmu8ZSch5vfVJ8uJvGbroTsIlslRg6lg==}
     engines: {node: '>= 4.0.0'}
 
-  memfs@3.5.3:
-    resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
-    engines: {node: '>= 4.0.0'}
-
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
@@ -14381,9 +14342,6 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
-
-  objectorarray@1.0.5:
-    resolution: {integrity: sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==}
 
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
@@ -15501,9 +15459,9 @@ packages:
     peerDependencies:
       typescript: '>= 4.3.x'
 
-  react-docgen@7.1.1:
-    resolution: {integrity: sha512-hlSJDQ2synMPKFZOsKo9Hi8WWZTC7POR8EmWvTSjow+VDgKzkmjQvFm2fk0tmRw+f0vTOIYKlarR0iL4996pdg==}
-    engines: {node: '>=16.14.0'}
+  react-docgen@8.0.0:
+    resolution: {integrity: sha512-kmob/FOTwep7DUWf9KjuenKX0vyvChr3oTdvvPt09V60Iz75FJp+T/0ZeHMbAfJj2WaVWqAPP5Hmm3PYzSPPKg==}
+    engines: {node: ^20.9.0 || >=22}
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -15908,10 +15866,6 @@ packages:
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
-    hasBin: true
-
-  resolve@1.22.8:
-    resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
 
   resolve@2.0.0-next.5:
@@ -16442,6 +16396,12 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  storybook-addon-tag-badges@2.0.2:
+    resolution: {integrity: sha512-vttxTOAg6p6jdcPQ/6egJMPEwG40j4AY6eyMjpID1UaDLl2o99k8wHR2UJT6E6DWeEvVx8x5nMIlcr1mBXvT2w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      storybook: ^9.0.0
+
   storybook@9.1.1:
     resolution: {integrity: sha512-q6GaGZdVZh6rjOdGnc+4hGTu8ECyhyjQDw4EZNxKtQjDO8kqtuxbFm8l/IP2l+zLVJAatGWKkaX9Qcd7QZxz+Q==}
     hasBin: true
@@ -16607,12 +16567,6 @@ packages:
   strtok3@7.1.1:
     resolution: {integrity: sha512-mKX8HA/cdBqMKUr0MMZAFssCkIGoZeSCMXgnt79yKxNFguMLVFgRe6wB+fsL0NmoHDbeyZXczy7vEPSoo3rkzg==}
     engines: {node: '>=16'}
-
-  style-loader@3.3.4:
-    resolution: {integrity: sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      webpack: ^5.0.0
 
   style-to-object@1.0.8:
     resolution: {integrity: sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==}
@@ -16838,6 +16792,10 @@ packages:
 
   tinyglobby@0.2.13:
     resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -17430,6 +17388,46 @@ packages:
       terser:
         optional: true
 
+  vite@7.1.2:
+    resolution: {integrity: sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -17522,15 +17520,6 @@ packages:
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
 
-  webpack-dev-middleware@6.1.3:
-    resolution: {integrity: sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-
   webpack-dev-server@4.15.2:
     resolution: {integrity: sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==}
     engines: {node: '>= 12.13.0'}
@@ -17543,9 +17532,6 @@ packages:
         optional: true
       webpack-cli:
         optional: true
-
-  webpack-hot-middleware@2.26.1:
-    resolution: {integrity: sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==}
 
   webpack-merge@5.10.0:
     resolution: {integrity: sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==}
@@ -18983,8 +18969,8 @@ snapshots:
 
   '@babel/generator@7.27.5':
     dependencies:
-      '@babel/parser': 7.27.7
-      '@babel/types': 7.27.7
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
       jsesc: 3.0.2
@@ -18999,15 +18985,15 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.18.6':
     dependencies:
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
@@ -19091,13 +19077,13 @@ snapshots:
   '@babel/helper-function-name@7.22.5':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-member-expression-to-functions@7.20.7':
     dependencies:
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
@@ -19138,7 +19124,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.18.6':
     dependencies:
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-optimise-call-expression@7.25.9':
     dependencies:
@@ -19170,7 +19156,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
@@ -19194,25 +19180,25 @@ snapshots:
 
   '@babel/helper-skip-transparent-expression-wrappers@7.20.0':
     dependencies:
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
       '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-split-export-declaration@7.22.6':
     dependencies:
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -19237,7 +19223,7 @@ snapshots:
 
   '@babel/parser@7.27.7':
     dependencies:
-      '@babel/types': 7.27.7
+      '@babel/types': 7.28.2
 
   '@babel/parser@7.28.0':
     dependencies:
@@ -19998,7 +19984,7 @@ snapshots:
       '@babel/generator': 7.27.5
       '@babel/parser': 7.27.7
       '@babel/template': 7.27.2
-      '@babel/types': 7.27.7
+      '@babel/types': 7.28.2
       debug: 4.4.1
       globals: 11.12.0
     transitivePeerDependencies:
@@ -23055,6 +23041,15 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.7.3)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))':
+    dependencies:
+      glob: 10.4.5
+      magic-string: 0.30.17
+      react-docgen-typescript: 2.4.0(typescript@5.7.3)
+      vite: 7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)
+    optionalDependencies:
+      typescript: 5.7.3
+
   '@jridgewell/gen-mapping@0.1.1':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -25056,7 +25051,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.46.2
 
@@ -25684,62 +25679,34 @@ snapshots:
       '@smithy/types': 4.3.1
       tslib: 2.8.1
 
-  '@storybook/addon-docs@9.1.1(@types/react@18.3.23)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))':
+  '@storybook/addon-docs@9.1.1(@types/react@18.3.23)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@18.3.23)(react@18.3.1)
-      '@storybook/csf-plugin': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))
+      '@storybook/csf-plugin': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))
       '@storybook/icons': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))
+      '@storybook/react-dom-shim': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.6(webpack@5.101.0)':
+  '@storybook/builder-vite@9.0.16(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))':
     dependencies:
-      '@babel/core': 7.28.0
-      babel-loader: 9.2.1(@babel/core@7.28.0)(webpack@5.101.0)
-    transitivePeerDependencies:
-      - supports-color
-      - webpack
-
-  '@storybook/builder-webpack5@9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3)':
-    dependencies:
-      '@storybook/core-webpack': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      cjs-module-lexer: 1.4.3
-      css-loader: 6.11.0(webpack@5.101.0)
-      es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.7.3)(webpack@5.101.0)
-      html-webpack-plugin: 5.6.3(webpack@5.101.0)
-      magic-string: 0.30.17
-      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
-      style-loader: 3.3.4(webpack@5.101.0)
-      terser-webpack-plugin: 5.3.14(webpack@5.101.0)
+      '@storybook/csf-plugin': 9.0.16(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
       ts-dedent: 2.2.0
-      webpack: 5.101.0
-      webpack-dev-middleware: 6.1.3(webpack@5.101.0)
-      webpack-hot-middleware: 2.26.1
-      webpack-virtual-modules: 0.6.2
-    optionalDependencies:
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-      - webpack-cli
+      vite: 7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)
 
-  '@storybook/core-webpack@9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))':
+  '@storybook/csf-plugin@9.0.16(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))':
     dependencies:
-      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
-      ts-dedent: 2.2.0
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
+      unplugin: 1.16.1
 
-  '@storybook/csf-plugin@9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))':
+  '@storybook/csf-plugin@9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))':
     dependencies:
-      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -25749,75 +25716,55 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/preset-react-webpack@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3)':
+  '@storybook/react-dom-shim@9.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))':
     dependencies:
-      '@storybook/core-webpack': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.7.3)(webpack@5.101.0)
-      '@types/semver': 7.7.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
+
+  '@storybook/react-dom-shim@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
+
+  '@storybook/react-vite@9.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))(typescript@5.7.3)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.7.3)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
+      '@rollup/pluginutils': 5.1.4(rollup@4.46.2)
+      '@storybook/builder-vite': 9.0.16(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
+      '@storybook/react': 9.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))(typescript@5.7.3)
       find-up: 7.0.0
       magic-string: 0.30.17
       react: 18.3.1
-      react-docgen: 7.1.1
+      react-docgen: 8.0.0
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.10
-      semver: 7.7.2
-      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
       tsconfig-paths: 4.2.0
-      webpack: 5.101.0
-    optionalDependencies:
-      typescript: 5.7.3
+      vite: 7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)
     transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
+      - rollup
       - supports-color
-      - uglify-js
-      - webpack-cli
+      - typescript
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.7.3)(webpack@5.101.0)':
-    dependencies:
-      debug: 4.4.1
-      endent: 2.1.0
-      find-cache-dir: 3.3.2
-      flat-cache: 3.2.0
-      micromatch: 4.0.8
-      react-docgen-typescript: 2.4.0(typescript@5.7.3)
-      tslib: 2.8.1
-      typescript: 5.7.3
-      webpack: 5.101.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@storybook/react-dom-shim@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
-
-  '@storybook/react-webpack5@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3)':
-    dependencies:
-      '@storybook/builder-webpack5': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3)
-      '@storybook/preset-react-webpack': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3)
-      '@storybook/react': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
-    optionalDependencies:
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - esbuild
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  '@storybook/react@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3)':
+  '@storybook/react@9.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))(typescript@5.7.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))
+      '@storybook/react-dom-shim': 9.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
+    optionalDependencies:
+      typescript: 5.7.3
+
+  '@storybook/react@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))(typescript@5.7.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
     optionalDependencies:
       typescript: 5.7.3
 
@@ -26594,8 +26541,6 @@ snapshots:
     dependencies:
       '@types/node': 22.17.0
 
-  '@types/semver@7.7.0': {}
-
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
@@ -26828,14 +26773,14 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))':
+  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.4(@types/node@22.17.0)(typescript@5.7.3)
-      vite: 5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)
+      vite: 7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -27460,13 +27405,6 @@ snapshots:
       schema-utils: 4.3.2
       webpack: 5.101.0(@swc/core@1.13.3)
 
-  babel-loader@9.2.1(@babel/core@7.28.0)(webpack@5.101.0):
-    dependencies:
-      '@babel/core': 7.28.0
-      find-cache-dir: 4.0.0
-      schema-utils: 4.3.2
-      webpack: 5.101.0
-
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
       object.assign: 4.1.7
@@ -27492,7 +27430,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.0
       cosmiconfig: 7.1.0
-      resolve: 1.22.8
+      resolve: 1.22.10
 
   babel-plugin-polyfill-corejs2@0.4.12(@babel/core@7.28.0):
     dependencies:
@@ -27887,8 +27825,6 @@ snapshots:
       tslib: 2.8.1
       upper-case-first: 2.0.2
 
-  case-sensitive-paths-webpack-plugin@2.4.0: {}
-
   caseless@0.12.0: {}
 
   ccount@2.0.1: {}
@@ -28244,8 +28180,6 @@ snapshots:
 
   common-tags@1.8.2: {}
 
-  commondir@1.0.1: {}
-
   compare-versions@6.1.1: {}
 
   compress-commons@4.1.2:
@@ -28598,19 +28532,6 @@ snapshots:
       semver: 7.7.2
     optionalDependencies:
       webpack: 5.101.0(@swc/core@1.13.3)
-
-  css-loader@6.11.0(webpack@5.101.0):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
-      postcss-value-parser: 4.2.0
-      semver: 7.7.2
-    optionalDependencies:
-      webpack: 5.101.0
 
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.101.0(@swc/core@1.13.3)):
     dependencies:
@@ -29018,8 +28939,6 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  dedent@0.7.0: {}
-
   dedent@1.5.3(babel-plugin-macros@3.1.0):
     optionalDependencies:
       babel-plugin-macros: 3.1.0
@@ -29357,12 +29276,6 @@ snapshots:
   end-of-stream@1.4.4:
     dependencies:
       once: 1.4.0
-
-  endent@2.1.0:
-    dependencies:
-      dedent: 0.7.0
-      fast-json-parse: 1.0.3
-      objectorarray: 1.0.5
 
   enhanced-resolve@5.18.0:
     dependencies:
@@ -29811,11 +29724,11 @@ snapshots:
     dependencies:
       eslint: 9.30.1(jiti@2.5.1)
 
-  eslint-plugin-storybook@9.0.16(eslint@9.30.1(jiti@2.5.1))(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)))(typescript@5.7.3):
+  eslint-plugin-storybook@9.0.16(eslint@9.30.1(jiti@2.5.1))(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)))(typescript@5.7.3):
     dependencies:
       '@typescript-eslint/utils': 8.24.1(eslint@9.30.1(jiti@2.5.1))(typescript@5.7.3)
       eslint: 9.30.1(jiti@2.5.1)
-      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -30151,8 +30064,6 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-json-parse@1.0.3: {}
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -30219,6 +30130,10 @@ snapshots:
   fdir@6.4.4(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.4.6(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   feed@4.2.2:
     dependencies:
@@ -30329,12 +30244,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-cache-dir@3.3.2:
-    dependencies:
-      commondir: 1.0.1
-      make-dir: 3.1.0
-      pkg-dir: 4.2.0
-
   find-cache-dir@4.0.0:
     dependencies:
       common-path-prefix: 3.0.0
@@ -30367,12 +30276,6 @@ snapshots:
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
 
-  flat-cache@3.2.0:
-    dependencies:
-      flatted: 3.3.3
-      keyv: 4.5.4
-      rimraf: 3.0.2
-
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.3.2
@@ -30386,8 +30289,6 @@ snapshots:
   flat@5.0.2: {}
 
   flatted@3.3.2: {}
-
-  flatted@3.3.3: {}
 
   follow-redirects@1.15.9(debug@4.4.0):
     optionalDependencies:
@@ -30403,23 +30304,6 @@ snapshots:
       signal-exit: 4.1.0
 
   forever-agent@0.6.1: {}
-
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.7.3)(webpack@5.101.0):
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cosmiconfig: 7.1.0
-      deepmerge: 4.3.1
-      fs-extra: 10.1.0
-      memfs: 3.5.3
-      minimatch: 3.1.2
-      node-abort-controller: 3.1.1
-      schema-utils: 3.3.0
-      semver: 7.7.2
-      tapable: 2.2.2
-      typescript: 5.7.3
-      webpack: 5.101.0
 
   fork-ts-checker-webpack-plugin@9.1.0(typescript@5.8.3)(webpack@5.99.6(@swc/core@1.13.3)):
     dependencies:
@@ -30512,8 +30396,6 @@ snapshots:
       universalify: 0.1.2
 
   fs-monkey@1.0.3: {}
-
-  fs-monkey@1.1.0: {}
 
   fs-readdir-recursive@1.1.0: {}
 
@@ -31057,8 +30939,6 @@ snapshots:
 
   html-entities@2.3.3: {}
 
-  html-entities@2.6.0: {}
-
   html-escaper@2.0.2: {}
 
   html-minifier-terser@6.1.0:
@@ -31094,16 +30974,6 @@ snapshots:
       tapable: 2.2.2
     optionalDependencies:
       webpack: 5.101.0(@swc/core@1.13.3)
-
-  html-webpack-plugin@5.6.3(webpack@5.101.0):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.21
-      pretty-error: 4.0.0
-      tapable: 2.2.2
-    optionalDependencies:
-      webpack: 5.101.0
 
   htmlparser2@3.10.1:
     dependencies:
@@ -32065,7 +31935,7 @@ snapshots:
       '@babel/generator': 7.28.0
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.28.0)
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.28.0)
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.2
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -32945,10 +32815,6 @@ snapshots:
     dependencies:
       fs-monkey: 1.0.3
 
-  memfs@3.5.3:
-    dependencies:
-      fs-monkey: 1.1.0
-
   memoize-one@5.2.1: {}
 
   memorystream@0.3.1: {}
@@ -33700,8 +33566,6 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
-
-  objectorarray@1.0.5: {}
 
   obuf@1.1.2: {}
 
@@ -34887,7 +34751,7 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  react-docgen@7.1.1:
+  react-docgen@8.0.0:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/traverse': 7.28.0
@@ -35433,12 +35297,6 @@ snapshots:
   resolve.exports@2.0.2: {}
 
   resolve@1.22.10:
-    dependencies:
-      is-core-module: 2.16.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
-  resolve@1.22.8:
     dependencies:
       is-core-module: 2.16.1
       path-parse: 1.0.7
@@ -36105,13 +35963,21 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1)):
+  storybook-addon-tag-badges@2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))):
+    dependencies:
+      '@storybook/icons': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  storybook@9.1.1(@testing-library/dom@10.4.1)(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.4
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(vite@5.4.19(@types/node@22.17.0)(sass@1.89.2)(terser@5.43.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@22.17.0)(typescript@5.7.3))(vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.8
@@ -36312,10 +36178,6 @@ snapshots:
       '@tokenizer/token': 0.3.0
       peek-readable: 5.4.2
 
-  style-loader@3.3.4(webpack@5.101.0):
-    dependencies:
-      webpack: 5.101.0
-
   style-to-object@1.0.8:
     dependencies:
       inline-style-parser: 0.2.4
@@ -36506,15 +36368,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.13.3
 
-  terser-webpack-plugin@5.3.14(webpack@5.101.0):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
-      jest-worker: 27.5.1
-      schema-utils: 4.3.2
-      serialize-javascript: 6.0.2
-      terser: 5.43.1
-      webpack: 5.101.0
-
   terser@5.36.0:
     dependencies:
       '@jridgewell/source-map': 0.3.6
@@ -36567,6 +36420,11 @@ snapshots:
     dependencies:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinyglobby@0.2.14:
+    dependencies:
+      fdir: 6.4.6(picomatch@4.0.3)
+      picomatch: 4.0.3
 
   tinypool@1.1.1: {}
 
@@ -37203,6 +37061,22 @@ snapshots:
       sass: 1.89.2
       terser: 5.43.1
 
+  vite@7.1.2(@types/node@22.17.0)(jiti@2.5.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.7.1):
+    dependencies:
+      esbuild: 0.25.8
+      fdir: 6.4.6(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.46.2
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 22.17.0
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      sass: 1.89.2
+      terser: 5.43.1
+      yaml: 2.7.1
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -37326,16 +37200,6 @@ snapshots:
       schema-utils: 4.3.2
       webpack: 5.101.0(@swc/core@1.13.3)
 
-  webpack-dev-middleware@6.1.3(webpack@5.101.0):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 3.5.3
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.3.2
-    optionalDependencies:
-      webpack: 5.101.0
-
   webpack-dev-server@4.15.2(webpack@5.101.0(@swc/core@1.13.3)):
     dependencies:
       '@types/bonjour': 3.5.10
@@ -37376,12 +37240,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-hot-middleware@2.26.1:
-    dependencies:
-      ansi-html-community: 0.0.8
-      html-entities: 2.6.0
-      strip-ansi: 6.0.1
-
   webpack-merge@5.10.0:
     dependencies:
       clone-deep: 4.0.1
@@ -37401,38 +37259,6 @@ snapshots:
   webpack-sources@3.3.3: {}
 
   webpack-virtual-modules@0.6.2: {}
-
-  webpack@5.101.0:
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.25.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.2
-      es-module-lexer: 1.7.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.2
-      tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(webpack@5.101.0)
-      watchpack: 2.4.4
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   webpack@5.101.0(@swc/core@1.13.3):
     dependencies:

--- a/storybook/.storybook/decorators/ThemeProvider.decorator.tsx
+++ b/storybook/.storybook/decorators/ThemeProvider.decorator.tsx
@@ -1,6 +1,6 @@
 import { createCometTheme, MuiThemeProvider } from "@comet/admin";
 import { createTheme as createMuiTheme, CssBaseline } from "@mui/material";
-import { type Decorator } from "@storybook/react-webpack5";
+import { type Decorator } from "@storybook/react-vite";
 
 export enum ThemeOption {
     Comet = "comet",

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -1,23 +1,23 @@
-import type { StorybookConfig } from "@storybook/react-webpack5";
-import remarkGfm from "remark-gfm";
+import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-    framework: "@storybook/react-webpack5",
+    framework: {
+        name: "@storybook/react-vite",
+        options: {},
+    },
     stories: ["../src/**/*.@(mdx|stories.tsx)"],
-    addons: [
-        {
-            name: "@storybook/addon-docs",
-            options: {
-                mdxPluginOptions: {
-                    mdxCompileOptions: {
-                        remarkPlugins: [remarkGfm],
-                    },
-                },
-            },
-        },
-        "@storybook/addon-webpack5-compiler-babel",
-    ],
+    addons: ["@storybook/addon-docs", "storybook-addon-tag-badges"],
     staticDirs: ["../public"],
+    async viteFinal(config) {
+        // Merge custom configuration into the default config
+        const { mergeConfig } = await import("vite");
+
+        return mergeConfig(config, {
+            optimizeDeps: {
+                include: ["@comet/admin", "@comet/admin-icons", "@comet/admin-date-time", "@emotion/react"],
+            },
+        });
+    },
 };
 
 export default config;

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import "@fontsource-variable/roboto-flex/full.css";
 
-import type { Preview } from "@storybook/react-webpack5";
+import type { Preview } from "@storybook/react-vite";
 import { type GlobalTypes } from "storybook/internal/csf";
 
 import { IntlDecorator, LocaleOption } from "./decorators/IntlProvider.decorator";

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -53,9 +53,8 @@
         "@faker-js/faker": "^9.9.0",
         "@graphql-mocks/network-msw": "^0.4.4",
         "@storybook/addon-docs": "^9.0.16",
-        "@storybook/addon-webpack5-compiler-babel": "^3.0.6",
         "@storybook/react": "^9.0.16",
-        "@storybook/react-webpack5": "^9.0.16",
+        "@storybook/react-vite": "9.0.16",
         "@types/draft-js": "^0.11.18",
         "@types/history": "^4.7.11",
         "@types/qs": "^6.14.0",
@@ -78,9 +77,10 @@
         "react-dnd-html5-backend": "^16.0.1",
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
-        "remark-gfm": "^4.0.1",
         "storybook": "^9.0.16",
-        "typescript": "^5.7.3"
+        "storybook-addon-tag-badges": "^2.0.1",
+        "typescript": "^5.7.3",
+        "vite": "^7.0.6"
     },
     "msw": {
         "workerDirectory": "public"

--- a/storybook/src/admin-component-docs/Button.stories.tsx
+++ b/storybook/src/admin-component-docs/Button.stories.tsx
@@ -2,7 +2,7 @@ import { Button } from "@comet/admin";
 import { ArrowRight } from "@comet/admin-icons";
 import { Box, Chip, Stack } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { componentDocsDecorator } from "./utils/componentDocsDecorator";
 import { DocsPage } from "./utils/DocsPage";

--- a/storybook/src/admin-component-docs/ColorField.stories.tsx
+++ b/storybook/src/admin-component-docs/ColorField.stories.tsx
@@ -2,7 +2,7 @@ import { FinalForm } from "@comet/admin";
 import { ColorField } from "@comet/admin-color-picker";
 import { ArrowRight } from "@comet/admin-icons";
 import { InputAdornment } from "@mui/material";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { argTypes } from "./ColorPicker.stories";
 import { commonFieldComponentArgTypes } from "./utils/commonArgTypes";

--- a/storybook/src/admin-component-docs/ColorPicker.stories.tsx
+++ b/storybook/src/admin-component-docs/ColorPicker.stories.tsx
@@ -2,7 +2,7 @@ import { FieldContainer } from "@comet/admin";
 import { ColorPicker } from "@comet/admin-color-picker";
 import { ArrowRight } from "@comet/admin-icons";
 import { InputAdornment } from "@mui/material";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { componentDocsDecorator } from "./utils/componentDocsDecorator";
 import { DocsPage } from "./utils/DocsPage";

--- a/storybook/src/admin-component-docs/FieldSet.stories.tsx
+++ b/storybook/src/admin-component-docs/FieldSet.stories.tsx
@@ -1,6 +1,6 @@
 import { FieldSet } from "@comet/admin";
 import { Chip } from "@mui/material";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { componentDocsDecorator } from "./utils/componentDocsDecorator";
 import { DocsPage } from "./utils/DocsPage";

--- a/storybook/src/admin-component-docs/InlineAlert.stories.tsx
+++ b/storybook/src/admin-component-docs/InlineAlert.stories.tsx
@@ -1,7 +1,7 @@
 import { Button, InlineAlert } from "@comet/admin";
 import { ArrowRight, Clear, CometColor, InfoFilled, Reload, RemoveFilled, WarningSolid } from "@comet/admin-icons";
 import { Box } from "@mui/material";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { componentDocsDecorator } from "./utils/componentDocsDecorator";
 import { DocsPage } from "./utils/DocsPage";

--- a/storybook/src/admin-component-docs/NumberField.stories.tsx
+++ b/storybook/src/admin-component-docs/NumberField.stories.tsx
@@ -1,5 +1,5 @@
 import { FinalForm, NumberField } from "@comet/admin";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { commonFieldComponentArgTypes } from "./utils/commonArgTypes";
 import { componentDocsDecorator } from "./utils/componentDocsDecorator";

--- a/storybook/src/admin-component-docs/Typography.stories.tsx
+++ b/storybook/src/admin-component-docs/Typography.stories.tsx
@@ -1,5 +1,5 @@
 import { Typography } from "@mui/material";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { componentDocsDecorator } from "./utils/componentDocsDecorator";
 import { DocsPage } from "./utils/DocsPage";

--- a/storybook/src/admin/common/dialog/Dialog.stories.tsx
+++ b/storybook/src/admin/common/dialog/Dialog.stories.tsx
@@ -1,6 +1,6 @@
 import { Button, Dialog } from "@comet/admin";
 import { Box } from "@mui/material";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 
 type Story = StoryObj<typeof Dialog>;

--- a/storybook/src/admin/dateTime/DatePicker.stories.tsx
+++ b/storybook/src/admin/dateTime/DatePicker.stories.tsx
@@ -1,6 +1,6 @@
 import { FieldContainer, Future_DatePicker as DatePicker, Future_DatePickerField as DatePickerField } from "@comet/admin";
 import { Grid } from "@mui/material";
-import { type Meta, type StoryObj } from "@storybook/react-webpack5";
+import { type Meta, type StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 import { Form } from "react-final-form";
 

--- a/storybook/src/admin/error-handling/ErrorBoundary.stories.tsx
+++ b/storybook/src/admin/error-handling/ErrorBoundary.stories.tsx
@@ -1,6 +1,6 @@
 import { Alert, ErrorBoundary } from "@comet/admin";
 import { Box, Card, CardContent, Link, Typography } from "@mui/material";
-import { type Meta } from "@storybook/react-webpack5";
+import { type Meta } from "@storybook/react-vite";
 
 const ViewWithNoError = () => {
     return (

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -1,7 +1,7 @@
 import { gql, useApolloClient } from "@apollo/client";
 import { Alert, AsyncSelectField, FinalForm } from "@comet/admin";
 import { Info, WarningSolid } from "@comet/admin-icons";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { Manufacturer } from "../../../.storybook/mocks/handlers";
 import { apolloStoryDecorator } from "../../apollo-story.decorator";

--- a/storybook/src/admin/form/FormValidation.stories.tsx
+++ b/storybook/src/admin/form/FormValidation.stories.tsx
@@ -1,5 +1,5 @@
 import { Alert, FinalForm, SaveBoundary, SaveBoundarySaveButton, TextField } from "@comet/admin";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 type Story = StoryObj;
 const config: Meta = {

--- a/storybook/src/admin/form/TextField.stories.tsx
+++ b/storybook/src/admin/form/TextField.stories.tsx
@@ -1,5 +1,5 @@
 import { Alert, FinalForm, TextField } from "@comet/admin";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 type Story = StoryObj<typeof TextField>;
 const config: Meta<typeof TextField> = {

--- a/storybook/src/admin/form/ToggleButtonGroupField.stories.tsx
+++ b/storybook/src/admin/form/ToggleButtonGroupField.stories.tsx
@@ -17,7 +17,7 @@ import {
 } from "@comet/admin-icons";
 import { Box, Divider } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 type Story = StoryObj<typeof ToggleButtonGroupField>;
 const config: Meta<typeof ToggleButtonGroupField> = {

--- a/storybook/src/admin/form/file/FileDropzone.stories.tsx
+++ b/storybook/src/admin/form/file/FileDropzone.stories.tsx
@@ -1,6 +1,6 @@
 import { FileDropzone, type FileDropzoneProps } from "@comet/admin";
 import { Card, CardContent, Stack } from "@mui/material";
-import { type Meta } from "@storybook/react-webpack5";
+import { type Meta } from "@storybook/react-vite";
 import { useState } from "react";
 
 type FileRejections = Parameters<Required<FileDropzoneProps>["onDropRejected"]>[0];

--- a/storybook/src/admin/form/file/FileSelect.stories.tsx
+++ b/storybook/src/admin/form/file/FileSelect.stories.tsx
@@ -1,6 +1,6 @@
 import { FileSelect, type FileSelectItem } from "@comet/admin";
 import { Card, CardContent, Stack } from "@mui/material";
-import { type Meta } from "@storybook/react-webpack5";
+import { type Meta } from "@storybook/react-vite";
 
 export default {
     title: "@comet/admin/form/File",

--- a/storybook/src/admin/form/file/FileSelectListItem.stories.tsx
+++ b/storybook/src/admin/form/file/FileSelectListItem.stories.tsx
@@ -1,6 +1,6 @@
 import { type FileSelectItem, FileSelectListItem } from "@comet/admin";
 import { Card, CardContent, Stack } from "@mui/material";
-import { type Meta } from "@storybook/react-webpack5";
+import { type Meta } from "@storybook/react-vite";
 
 const fileSize = 1.8 * 1024 * 1024; // 1.8 MB
 

--- a/storybook/src/admin/inlineAlert/InlineAlert.stories.tsx
+++ b/storybook/src/admin/inlineAlert/InlineAlert.stories.tsx
@@ -1,7 +1,7 @@
 import { Button, InlineAlert } from "@comet/admin";
 import { Clear, CometColor, InfoFilled, Reload, RemoveFilled, WarningSolid } from "@comet/admin-icons";
 import { Box } from "@mui/material";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 type Story = StoryObj<typeof InlineAlert>;
 

--- a/storybook/src/apollo-rest-story.decorator.tsx
+++ b/storybook/src/apollo-rest-story.decorator.tsx
@@ -1,5 +1,5 @@
 import { ApolloClient, ApolloLink, ApolloProvider, InMemoryCache } from "@apollo/client";
-import { type Decorator } from "@storybook/react-webpack5";
+import { type Decorator } from "@storybook/react-vite";
 import { RestLink } from "apollo-link-rest";
 
 export function apolloRestStoryDecorator(options?: { uri?: string; responseTransformer?: RestLink.ResponseTransformer }): Decorator {

--- a/storybook/src/apollo-story.decorator.tsx
+++ b/storybook/src/apollo-story.decorator.tsx
@@ -1,6 +1,6 @@
 import { ApolloClient, ApolloLink, ApolloProvider, createHttpLink, InMemoryCache } from "@apollo/client";
 import { createErrorDialogApolloLink } from "@comet/admin";
-import { type Decorator } from "@storybook/react-webpack5";
+import { type Decorator } from "@storybook/react-vite";
 
 const createApolloClient = (uri: string) => {
     const link = ApolloLink.from([

--- a/storybook/src/cms-admin/ContentScopeSelect.stories.tsx
+++ b/storybook/src/cms-admin/ContentScopeSelect.stories.tsx
@@ -2,7 +2,7 @@ import { AppHeader, AppHeaderMenuButton, CometLogo, FillSpace } from "@comet/adm
 import { Domain, Language } from "@comet/admin-icons";
 import { ContentScopeSelect, findTextMatches, MarkedMatches } from "@comet/cms-admin";
 import { ListItemIcon, ListItemText } from "@mui/material";
-import { type Meta } from "@storybook/react-webpack5";
+import { type Meta } from "@storybook/react-vite";
 import { useState } from "react";
 
 export default {

--- a/storybook/src/cms-admin/dashboard/widgets/DashboardWidgetRoot.stories.tsx
+++ b/storybook/src/cms-admin/dashboard/widgets/DashboardWidgetRoot.stories.tsx
@@ -1,7 +1,7 @@
 import { InfoFilled } from "@comet/admin-icons";
 import { DashboardWidgetRoot } from "@comet/cms-admin";
 import { Grid } from "@mui/material";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 type Story = StoryObj<typeof DashboardWidgetRoot>;
 

--- a/storybook/src/dnd.decorator.tsx
+++ b/storybook/src/dnd.decorator.tsx
@@ -1,4 +1,4 @@
-import { type Decorator } from "@storybook/react-webpack5";
+import { type Decorator } from "@storybook/react-vite";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 

--- a/storybook/src/docs/components/EditDialog/editDialog.decorator.tsx
+++ b/storybook/src/docs/components/EditDialog/editDialog.decorator.tsx
@@ -1,6 +1,6 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { RouterMemoryRouter } from "@comet/admin";
-import { type Decorator } from "@storybook/react-webpack5";
+import { type Decorator } from "@storybook/react-vite";
 
 export function editDialogDecorator(): Decorator {
     return (Story) => {

--- a/storybook/src/docs/components/ErrorHandling/ErrorDialog/error-dialog-provider.decorator.tsx
+++ b/storybook/src/docs/components/ErrorHandling/ErrorDialog/error-dialog-provider.decorator.tsx
@@ -1,5 +1,5 @@
 import { ErrorDialogHandler } from "@comet/admin";
-import { type Decorator } from "@storybook/react-webpack5";
+import { type Decorator } from "@storybook/react-vite";
 
 export function errorDialogStoryProviderDecorator(): Decorator {
     return (Story) => {

--- a/storybook/src/docs/components/FileDropzone/FileDropzone.stories.tsx
+++ b/storybook/src/docs/components/FileDropzone/FileDropzone.stories.tsx
@@ -1,6 +1,6 @@
 import { FileDropzone } from "@comet/admin";
 import { Card, CardContent, Stack } from "@mui/material";
-import { type Meta } from "@storybook/react-webpack5";
+import { type Meta } from "@storybook/react-vite";
 
 export default {
     title: "Docs/Components/FileDropzone",

--- a/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
+++ b/storybook/src/docs/components/FileSelect/FileSelect.stories.tsx
@@ -1,6 +1,6 @@
 import { FileSelect, type FileSelectItem } from "@comet/admin";
 import { Card, CardContent } from "@mui/material";
-import { type Meta } from "@storybook/react-webpack5";
+import { type Meta } from "@storybook/react-vite";
 
 export default {
     title: "Docs/Components/FileSelect",

--- a/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.tsx
+++ b/storybook/src/docs/components/FileSelectListItem/FileSelectListItem.stories.tsx
@@ -1,6 +1,6 @@
 import { FileSelectListItem } from "@comet/admin";
 import { Box, Card, CardContent } from "@mui/material";
-import { type Meta } from "@storybook/react-webpack5";
+import { type Meta } from "@storybook/react-vite";
 
 export default {
     title: "Docs/Components/FileSelectListItem",

--- a/storybook/src/docs/components/RowActions/RowActions.stories.tsx
+++ b/storybook/src/docs/components/RowActions/RowActions.stories.tsx
@@ -1,7 +1,7 @@
 import { RowActionsItem, RowActionsMenu } from "@comet/admin";
 import { Copy, Delete, Edit, Online, Paste, Settings } from "@comet/admin-icons";
 import { Divider, Paper } from "@mui/material";
-import { type Meta } from "@storybook/react-webpack5";
+import { type Meta } from "@storybook/react-vite";
 
 export default {
     title: "Docs/Components/RowActions",

--- a/storybook/src/docs/components/Snackbar/snackbar.decorator.tsx
+++ b/storybook/src/docs/components/Snackbar/snackbar.decorator.tsx
@@ -1,5 +1,5 @@
 import { SnackbarProvider } from "@comet/admin";
-import { type Decorator } from "@storybook/react-webpack5";
+import { type Decorator } from "@storybook/react-vite";
 
 export function snackbarDecorator(): Decorator {
     return (Story) => {

--- a/storybook/src/docs/components/Toolbar/toolbar.decorator.tsx
+++ b/storybook/src/docs/components/Toolbar/toolbar.decorator.tsx
@@ -1,5 +1,5 @@
 import { Stack, StackPage, StackPageTitle, StackSwitch } from "@comet/admin";
-import { type Decorator } from "@storybook/react-webpack5";
+import { type Decorator } from "@storybook/react-vite";
 
 export function toolbarDecorator(): Decorator {
     return (Story) => {

--- a/storybook/src/docs/icons/CometLogo.stories.tsx
+++ b/storybook/src/docs/icons/CometLogo.stories.tsx
@@ -1,5 +1,5 @@
 import { CometDigitalExperienceLogo } from "@comet/admin-icons";
-import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 type Story = StoryObj;
 

--- a/storybook/src/story-router.decorator.tsx
+++ b/storybook/src/story-router.decorator.tsx
@@ -1,5 +1,5 @@
 import { RouterMemoryRouter } from "@comet/admin";
-import { type Decorator } from "@storybook/react-webpack5";
+import { type Decorator } from "@storybook/react-vite";
 import { type Action, type History, type UnregisterCallback } from "history";
 import { type PropsWithChildren, type ReactNode, useEffect } from "react";
 import { type MemoryRouterProps, Route, type RouteComponentProps } from "react-router";


### PR DESCRIPTION
## Description

This Pull Request changes the Storybook framework from [react-webpack5](https://storybook.js.org/docs/get-started/frameworks/react-webpack5?renderer=react) to [react-vite](https://storybook.js.org/docs/get-started/frameworks/react-vite?renderer=react)

## Performance improvements

| Description | Before | After |
|---- | ------ | ----- |
| | `@storybook/react-webpack5`   | `@storybook/react-vite`  |
| Development Server |   <img width="343" height="130" alt="Screenshot 2025-08-13 at 07 58 01" src="https://github.com/user-attachments/assets/7bd996c7-9257-4315-8746-983274ed5f3b" />  | <img width="356" height="142" alt="Screenshot 2025-08-13 at 07 53 33" src="https://github.com/user-attachments/assets/9daeb7c3-2485-4a69-abce-5fb52159d2eb" /> |
| Development Server time | 39.1 s | 1.7s | 
| Build Storybook |  <img width="937" height="633" alt="Screenshot 2025-08-13 at 08 01 29" src="https://github.com/user-attachments/assets/12a65288-5d75-49ab-a1ef-2dd5317a16a2" />  | tba.  |
| Build Time |  120.5s  | tba. | 

## Open TODOs

- [x] `@comet's` Mono repo dependencies must be optimized for development server
-   [ ] Build problem `pnpm run build-storybook` ends in 

<img width="1543" height="186" alt="Screenshot 2025-08-13 at 07 55 42" src="https://github.com/user-attachments/assets/08cf1724-1c0b-47fa-80c0-6d6f969ec90c" />

 
(looks like optimizations, like done for development server do not work and must be configured differently)


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2233
