### PR TITLE
Hide generated files in GitHub diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+**/generated/** linguist-generated=true
+**/__snapshots__/** linguist-generated=true


### PR DESCRIPTION
## Description

This Pull Request adds `.gitattributes` to mark specific directories as generated code so that GitHub excludes them from diffs by default.

### Changes
- marks `/generated/**`  as hidden by default
- marks `/__snapshots__/**` as  hidden by default

Github Docs: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

### Example

This Examples shows how files in a `generated/` or `__snapshots__` directory will be shown in Github diffs, and how they could be viewed.

![Screen Recording 2025-08-13 at 10 45 39](https://github.com/user-attachments/assets/d2252669-27ab-4d27-b2a9-6fbb4fde4e0c)

