### PR TITLE
Fix Incorrect false value in generated ToolbarProps when only excelExport is enabled

### DIFF
--- a/.changeset/heavy-rings-pump.md
+++ b/.changeset/heavy-rings-pump.md
@@ -1,0 +1,16 @@
+---
+"@comet/admin-generator": patch
+---
+
+Fix generated `ToolbarProps` for `excelExport`-only case
+
+When generating `ToolbarProps` with `forwardToolbarAction = false` and `excelExport = true`, the generator previously inserted `false` into the generated interface, causing invalid TypeScript output.
+
+**Example broken output**
+
+```ts
+interface BooksGridToolbarToolbarProps extends GridToolbarProps {
+    false;
+    exportApi: ExportApi;
+}
+```

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/__snapshots__/generateGridToolbar.test.ts.snap
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/__snapshots__/generateGridToolbar.test.ts.snap
@@ -72,3 +72,34 @@ exports[`generateGridToolbar generates toolbar with minimal features 1`] = `
         );
     }"
 `;
+
+exports[`generateGridToolbar generates valid Toolbar props for only excelExport enabled 1`] = `
+"interface BooksGridToolbarToolbarProps extends GridToolbarProps {
+         false
+         exportApi: ExportApi;
+}
+    function BooksGridToolbar({
+        exportApi
+    }: BooksGridToolbarToolbarProps) {
+        return (
+            <DataGridToolbar>
+                <FillSpace />
+        <CrudMoreActionsMenu
+        slotProps={{
+            button: {
+                responsive: true
+            }
+        }}
+        overallActions={[
+            {
+                        label: <FormattedMessage {...messages.downloadAsExcel} />,
+                        icon: exportApi.loading ? <CircularProgress size={20} /> : <ExcelIcon />,
+                        onClick: () => exportApi.exportGrid(),
+                        disabled: exportApi.loading,
+                    }
+        ]}
+    />
+            </DataGridToolbar>
+        );
+    }"
+`;

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/__snapshots__/generateGridToolbar.test.ts.snap
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/__snapshots__/generateGridToolbar.test.ts.snap
@@ -75,7 +75,6 @@ exports[`generateGridToolbar generates toolbar with minimal features 1`] = `
 
 exports[`generateGridToolbar generates valid Toolbar props for only excelExport enabled 1`] = `
 "interface BooksGridToolbarToolbarProps extends GridToolbarProps {
-         false
          exportApi: ExportApi;
 }
     function BooksGridToolbar({

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/generateGridToolbar.test.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/generateGridToolbar.test.ts
@@ -68,4 +68,21 @@ describe("generateGridToolbar", () => {
 
         expect(output).toMatchSnapshot();
     });
+
+    it("generates valid Toolbar props for only excelExport enabled", () => {
+        const output = generateGridToolbar({
+            componentName: "BooksGridToolbar",
+            forwardToolbarAction: false,
+            hasSearch: false,
+            hasFilter: false,
+            excelExport: true,
+            allowAdding: false,
+            instanceGqlType: "booksMessages",
+            gqlType: "Book",
+            newEntryText: undefined,
+            fragmentName: "bookFragment",
+        });
+
+        expect(output).toMatchSnapshot();
+    });
 });

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGridToolbar.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGridToolbar.ts
@@ -126,7 +126,7 @@ const renderToolbarActions = ({ forwardToolbarAction, addItemText, excelExport, 
 const renderToolbarProps = (componentName: string, forwardToolbarAction: boolean | undefined, exportApi: boolean) => {
     if (forwardToolbarAction || exportApi) {
         return `interface ${componentName}ToolbarProps extends GridToolbarProps {
-         ${forwardToolbarAction && "toolbarAction: ReactNode;"}
+         ${forwardToolbarAction ? "toolbarAction: ReactNode;" : ""}
          ${exportApi ? "exportApi: ExportApi;" : ""}
 }`;
     }


### PR DESCRIPTION
## Description

Previously, when generating `ToolbarProps` with `forwardToolbarAction = false` and `excelExport = true`, the `admin-generator` incorrectly wrote `false` into the generated interface.
This caused a syntax error in the generated TypeScript file.

### Example of broken output:

```ts
interface BooksGridToolbarToolbarProps extends GridToolbarProps {
         false
         exportApi: ExportApi;
}
```

### What’s changed:
- Updated `renderToolbarProps` to not falsly add false to the ToolbarProps.
- Added a new snaptshot test case to cover the scenario where only excelExport is enabled and forwardToolbarAction is false.



<img width="983" height="247" alt="Screenshot 2025-08-13 at 11 25 41" src="https://github.com/user-attachments/assets/5ccf5152-d351-449a-9632-f8a7ac8703ea" />

see: https://github.com/vivid-planet/comet/commit/d6c7ec6911715208e09e0cee469c8333136da7d6
