### PR TITLE
New `DateTimePicker` and `DateTimePickerField` components

### DIFF
--- a/.changeset/ninety-corners-fold.md
+++ b/.changeset/ninety-corners-fold.md
@@ -1,0 +1,52 @@
+---
+"@comet/admin": minor
+"@comet/admin-date-time": minor
+---
+
+Add new `Future_DateTimePicker` and `Future_DateTimePickerField` components
+
+These will replace the existing `DateTimePicker`, `FinalFormDateTimePicker` and `DateTimeField` components from `@comet/admin-date-time` as a mostly drop-in replacement, the existing components have been deprecated.
+
+The new components are based on the `@mui/x-date-pickers` package, so you can refer to the [MUI documentation](https://v7.mui.com/x/react-date-pickers/date-time-picker/) for more details.
+
+**Using the new `DateTimePicker`**
+
+```diff
+-import { FieldContainer } from "@comet/admin";
+-import { DateTimePicker } from "@comet/admin-date-time";
++import { Future_DateTimePicker as DateTimePicker, FieldContainer } from "@comet/admin";
+ import { useState } from "react";
+
+ export const Example = () => {
+     const [dateTime, setDateTime] = useState<Date | undefined>();
+
+     return (
+         <FieldContainer label="Date-Time Picker">
+             <DateTimePicker value={dateTime} onChange={setDateTime} />
+         </FieldContainer>
+     );
+ };
+```
+
+**Using the new `DateTimePickerField` in Final Form**
+
+```diff
+-import { DateTimeField } from "@comet/admin-date-time";
++import { Future_DateTimePickerField as DateTimePickerField } from "@comet/admin";
+ import { Form } from "react-final-form";
+
+ type Values = {
+     dateTime: Date;
+ };
+
+ export const Example = () => {
+     return (
+         <Form<Values> initialValues={{ dateTime: new Date("2025-07-23 14:30") }} onSubmit={() => {}}>
+             {() => (
+-                <DateTimeField name="dateTime" label="Date-Time Picker" />
++                <DateTimePickerField name="dateTime" label="Date-Time Picker" />
+             )}
+         </Form>
+     );
+ };
+```

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimeField.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimeField.tsx
@@ -4,6 +4,9 @@ import { FinalFormDateTimePicker, type FinalFormDateTimePickerProps } from "./Fi
 
 export type DateTimeFieldProps = FieldProps<Date, HTMLInputElement> & FinalFormDateTimePickerProps;
 
+/**
+ * @deprecated `DateTimeField` from `@comet/admin-date-time` will be replaced by `DateTimePickerField` (currently `Future_DateTimePickerField`) from `@comet/admin` in a future major release.
+ */
 export const DateTimeField = ({ ...restProps }: DateTimeFieldProps) => {
     return <Field component={FinalFormDateTimePicker} {...restProps} />;
 };

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
@@ -92,6 +92,9 @@ export interface DateTimePickerProps
     onFocus?: InputBaseProps["onFocus"];
 }
 
+/**
+ * @deprecated `DateTimePicker` from `@comet/admin-date-time` will be replaced by `DateTimePicker` (currently `Future_DateTimePicker`) from `@comet/admin` in a future major release.
+ */
 export const DateTimePicker = (inProps: DateTimePickerProps) => {
     const { onChange, value, required, disabled, slotProps, onBlur, onFocus, ...restProps } = useThemeProps({
         props: inProps,

--- a/packages/admin/admin-date-time/src/dateTimePicker/FinalFormDateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/FinalFormDateTimePicker.tsx
@@ -6,6 +6,8 @@ export type FinalFormDateTimePickerProps = DateTimePickerProps;
 type FinalFormDateTimePickerInternalProps = FieldRenderProps<Date, HTMLInputElement | HTMLTextAreaElement>;
 
 /**
+ * @deprecated `FinalFormDateTimePicker` from `@comet/admin-date-time` will be replaced by `DateTimePickerField` (currently `Future_DateTimePickerField`) from `@comet/admin` in a future major release.
+ *
  * Final Form-compatible DateTimePicker component.
  *
  * @see {@link DateTimeField} – preferred for typical form use. Use this only if no Field wrapper is needed.

--- a/packages/admin/admin/src/dateTime/DateTimePicker.tsx
+++ b/packages/admin/admin/src/dateTime/DateTimePicker.tsx
@@ -1,0 +1,152 @@
+import { Calendar } from "@comet/admin-icons";
+import { type ComponentsOverrides, css, inputLabelClasses, type Theme, useThemeProps } from "@mui/material";
+import {
+    DateTimePicker as MuiDateTimePicker,
+    type DateTimePickerProps as MuiDateTimePickerProps,
+    pickersInputBaseClasses,
+} from "@mui/x-date-pickers";
+import { type ReactNode, useState } from "react";
+
+import { ClearInputAdornment as CometClearInputAdornment } from "../common/ClearInputAdornment";
+import { OpenPickerAdornment } from "../common/OpenPickerAdornment";
+import { ReadOnlyAdornment } from "../common/ReadOnlyAdornment";
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+
+export type Future_DateTimePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdornment" | "openPickerAdornment";
+
+export type Future_DateTimePickerProps = ThemedComponentBaseProps<{
+    root: typeof MuiDateTimePicker<Date, true>;
+    clearInputAdornment: typeof CometClearInputAdornment;
+    readOnlyAdornment: typeof ReadOnlyAdornment;
+    openPickerAdornment: typeof OpenPickerAdornment;
+}> & {
+    fullWidth?: boolean;
+    required?: boolean;
+    value?: Date;
+    onChange?: (dateTime: Date | undefined) => void;
+    iconMapping?: {
+        openPicker?: ReactNode;
+    };
+} & Omit<MuiDateTimePickerProps<Date, true>, "value" | "onChange">;
+
+export const Future_DateTimePicker = (inProps: Future_DateTimePickerProps) => {
+    const {
+        iconMapping = {},
+        fullWidth,
+        required,
+        slotProps,
+        disabled,
+        value = null,
+        onChange,
+        readOnly,
+        ...restProps
+    } = useThemeProps({
+        props: inProps,
+        name: "CometAdminFutureDateTimePicker",
+    });
+    const [open, setOpen] = useState(false);
+
+    const { openPicker: openPickerIcon = <Calendar color="inherit" /> } = iconMapping;
+
+    return (
+        <Root
+            enableAccessibleFieldDOMStructure
+            disabled={disabled}
+            readOnly={readOnly}
+            open={open}
+            onOpen={() => setOpen(true)}
+            onClose={() => setOpen(false)}
+            disableOpenPicker
+            value={value}
+            onChange={(date) => {
+                const dateIsInvalid = date !== null && isNaN(date.getTime());
+                if (dateIsInvalid) {
+                    return;
+                }
+
+                onChange?.(date || undefined);
+            }}
+            {...slotProps?.root}
+            {...restProps}
+            slotProps={{
+                ...slotProps?.root?.slotProps,
+                textField: (ownerState) => {
+                    const textFieldProps = {
+                        ...slotProps?.root?.slotProps?.textField,
+                        ownerState,
+                    };
+
+                    return {
+                        fullWidth,
+                        required,
+                        ...textFieldProps,
+                        InputProps: {
+                            ...textFieldProps?.InputProps,
+                            startAdornment: (
+                                <>
+                                    <OpenPickerAdornment
+                                        inputIsDisabled={disabled}
+                                        inputIsReadOnly={readOnly}
+                                        onClick={() => setOpen(true)}
+                                        {...slotProps?.openPickerAdornment}
+                                    >
+                                        {openPickerIcon}
+                                    </OpenPickerAdornment>
+                                    {textFieldProps?.InputProps?.startAdornment}
+                                </>
+                            ),
+                            endAdornment: (
+                                <>
+                                    {textFieldProps?.InputProps?.endAdornment}
+                                    <ReadOnlyAdornment inputIsReadOnly={Boolean(readOnly)} {...slotProps?.readOnlyAdornment} />
+                                    <ClearInputAdornment
+                                        position="end"
+                                        hasClearableContent={value !== null && !required && !disabled && !readOnly}
+                                        onClick={() => onChange?.(undefined)}
+                                        {...slotProps?.clearInputAdornment}
+                                    />
+                                </>
+                            ),
+                        },
+                    };
+                },
+            }}
+        />
+    );
+};
+
+const Root = createComponentSlot(MuiDateTimePicker<Date, true>)<Future_DateTimePickerClassKey>({
+    componentName: "Future_DateTimePicker",
+    slotName: "root",
+})(css`
+    .${inputLabelClasses.root} {
+        display: none;
+
+        & + .${pickersInputBaseClasses.root} {
+            margin-top: 0;
+        }
+    }
+`);
+
+const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<Future_DateTimePickerClassKey>({
+    componentName: "Future_DateTimePicker",
+    slotName: "clearInputAdornment",
+})();
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminFutureDateTimePicker: Future_DateTimePickerProps;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminFutureDateTimePicker: Future_DateTimePickerClassKey;
+    }
+
+    interface Components {
+        CometAdminFutureDateTimePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminFutureDateTimePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFutureDateTimePicker"];
+        };
+    }
+}

--- a/packages/admin/admin/src/dateTime/DateTimePickerField.tsx
+++ b/packages/admin/admin/src/dateTime/DateTimePickerField.tsx
@@ -1,0 +1,14 @@
+import { type FieldRenderProps } from "react-final-form";
+
+import { Field, type FieldProps } from "../form/Field";
+import { Future_DateTimePicker as DateTimePicker, type Future_DateTimePickerProps as DateTimePickerProps } from "./DateTimePicker";
+
+const FinalFormDateTimePicker = ({ meta, input, ...restProps }: DateTimePickerProps & FieldRenderProps<Date, HTMLInputElement>) => {
+    return <DateTimePicker {...input} {...restProps} />;
+};
+
+export type Future_DateTimePickerFieldProps = FieldProps<Date, HTMLInputElement>;
+
+export const Future_DateTimePickerField = (props: Future_DateTimePickerFieldProps) => {
+    return <Field component={FinalFormDateTimePicker} {...props} />;
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -95,6 +95,8 @@ export { Future_DatePicker, Future_DatePickerClassKey, Future_DatePickerProps } 
 export { Future_DatePickerField, Future_DatePickerFieldProps } from "./dateTime/DatePickerField";
 export { type DateRange, Future_DateRangePicker, Future_DateRangePickerClassKey, Future_DateRangePickerProps } from "./dateTime/DateRangePicker";
 export { Future_DateRangePickerField, Future_DateRangePickerFieldProps } from "./dateTime/DateRangePickerField";
+export { Future_DateTimePicker, Future_DateTimePickerClassKey, Future_DateTimePickerProps } from "./dateTime/DateTimePicker";
+export { Future_DateTimePickerField, Future_DateTimePickerFieldProps } from "./dateTime/DateTimePickerField";
 export { Future_TimePicker, Future_TimePickerClassKey, Future_TimePickerProps } from "./dateTime/TimePicker";
 export { Future_TimePickerField, Future_TimePickerFieldProps } from "./dateTime/TimePickerField";
 export { DeleteMutation } from "./DeleteMutation";

--- a/storybook/src/admin/dateTime/DateTimePicker.stories.tsx
+++ b/storybook/src/admin/dateTime/DateTimePicker.stories.tsx
@@ -1,0 +1,91 @@
+import { FieldContainer, Future_DateTimePicker as DateTimePicker, Future_DateTimePickerField as DateTimePickerField } from "@comet/admin";
+import { Grid } from "@mui/material";
+import { type Meta, type StoryObj } from "@storybook/react-webpack5";
+import { useState } from "react";
+import { Form } from "react-final-form";
+
+type Story = StoryObj<typeof DateTimePicker>;
+
+const config: Meta<typeof DateTimePicker> = {
+    component: DateTimePicker,
+    title: "@comet/admin/dateTime/DateTimePicker",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        const [dateTime, setDateTime] = useState<Date | undefined>(new Date("2025-07-23 14:30"));
+        const [requiredDateTime, setRequiredDateTime] = useState<Date | undefined>(undefined);
+        const [disabledDateTime, setDisabledDateTime] = useState<Date | undefined>(undefined);
+        const [readOnlyDateTime, setReadOnlyDateTime] = useState<Date | undefined>(new Date("2025-07-23 14:30"));
+
+        return (
+            <Grid container spacing={4}>
+                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                    <FieldContainer label="Date-Time Picker" fullWidth>
+                        <DateTimePicker value={dateTime} onChange={setDateTime} fullWidth />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                    <FieldContainer label="Required Date-Time Picker" fullWidth required>
+                        <DateTimePicker value={requiredDateTime} onChange={setRequiredDateTime} fullWidth required />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                    <FieldContainer label="Disabled Date-Time Picker" fullWidth disabled>
+                        <DateTimePicker value={disabledDateTime} onChange={setDisabledDateTime} fullWidth disabled />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                    <FieldContainer label="ReadOnly Date-Time Picker" fullWidth>
+                        <DateTimePicker value={readOnlyDateTime} onChange={setReadOnlyDateTime} fullWidth readOnly />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12 }}>
+                    <pre>{`values: ${JSON.stringify({ dateTime, requiredDateTime, disabledDateTime, readOnlyDateTime }, null, 2)}`}</pre>
+                </Grid>
+            </Grid>
+        );
+    },
+};
+
+export const FinalForm: Story = {
+    render: () => {
+        type Values = {
+            dateTime: Date;
+            requiredDateTime: Date;
+            disabledDateTime: Date;
+            readOnlyDateTime: Date;
+        };
+
+        return (
+            <Form<Values>
+                initialValues={{
+                    dateTime: new Date("2025-07-23 14:30"),
+                    readOnlyDateTime: new Date("2025-07-23 14:30"),
+                }}
+                onSubmit={() => {}}
+            >
+                {({ values }) => (
+                    <Grid container spacing={4}>
+                        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                            <DateTimePickerField name="dateTime" label="Date-Time Picker" fullWidth />
+                        </Grid>
+                        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                            <DateTimePickerField name="requiredDateTime" label="Required Date-Time Picker" fullWidth required />
+                        </Grid>
+                        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                            <DateTimePickerField name="disabledDateTime" label="Disabled Date-Time Picker" fullWidth disabled />
+                        </Grid>
+                        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                            <DateTimePickerField name="readOnlyDateTime" label="ReadOnly Date-Time Picker" fullWidth readOnly />
+                        </Grid>
+                        <Grid size={{ xs: 12 }}>
+                            <pre>{`values: ${JSON.stringify(values, null, 2)}`}</pre>
+                        </Grid>
+                    </Grid>
+                )}
+            </Form>
+        );
+    },
+};


### PR DESCRIPTION
## Description

Add new `DateTimePicker` and `DateTimePickerField` components, based on MUI's [V7 DateRangePicker](https://v7.mui.com/x/react-date-pickers/date-time-picker/). 
This enables better accessibility and allows keyboard input.

The design/styling doesn't yet match the Comet Design, that can be done in a future PR.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Existing from `@comet/admin-date-time` | New from `@comet/admin`
| ------ | ----- |
| <img width="540" height="381" alt="Previous DateTimePicker while selecting the date" src="https://github.com/user-attachments/assets/33eaaa8e-e344-4928-8580-a5fc250ff833" /><br><img width="540" height="381" alt="Previous DateTimePicker while selecting the time" src="https://github.com/user-attachments/assets/44b544ab-2acd-4ea0-807c-5951130805ec" />  | <img width="540" height="517" alt="New DateTimePicker" src="https://github.com/user-attachments/assets/fa6e0dab-fc48-4055-b8fb-73a51ed77ecc" />  |

## Open TODOs/questions

-   [x] Add changeset
-   [ ] Merge parent #4296 

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2201
