### PR TITLE
Add ActionLogShowVersion component

### DIFF
--- a/packages/admin/cms-admin/src/actionLog/actionLog.utils.test.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLog.utils.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultFilterOutKeys, filterOutKeys } from "./actionLog.utils";
+
+describe("filterOutKeys", () => {
+    it("removes a specified key from a flat object", () => {
+        const result = filterOutKeys({ id: 1, title: "Page", createdAt: "2024-01-01" }, ["createdAt"]);
+
+        expect(result).toEqual({ id: 1, title: "Page" });
+    });
+
+    it("removes multiple keys", () => {
+        const result = filterOutKeys({ id: 1, title: "Page", createdAt: "2024-01-01", updatedAt: "2024-01-02" }, ["createdAt", "updatedAt"]);
+
+        expect(result).toEqual({ id: 1, title: "Page" });
+    });
+
+    it("removes keys recursively from nested objects", () => {
+        const result = filterOutKeys(
+            {
+                id: 1,
+                createdAt: "2024-01-01",
+                author: { id: 2, name: "Alice", createdAt: "2023-01-01" },
+            },
+            ["createdAt"],
+        );
+
+        expect(result).toEqual({
+            id: 1,
+            author: { id: 2, name: "Alice" },
+        });
+    });
+
+    it("removes keys from objects inside arrays", () => {
+        const result = filterOutKeys(
+            {
+                items: [
+                    { id: 1, createdAt: "2024-01-01" },
+                    { id: 2, createdAt: "2024-01-02" },
+                ],
+            },
+            ["createdAt"],
+        );
+
+        expect(result).toEqual({
+            items: [{ id: 1 }, { id: 2 }],
+        });
+    });
+
+    it("walks deeply nested mixes of objects and arrays", () => {
+        const result = filterOutKeys(
+            {
+                page: {
+                    blocks: [
+                        { type: "text", content: "hi", createdAt: "x" },
+                        { type: "list", items: [{ label: "a", createdAt: "y" }] },
+                    ],
+                    createdAt: "z",
+                },
+            },
+            ["createdAt"],
+        );
+
+        expect(result).toEqual({
+            page: {
+                blocks: [
+                    { type: "text", content: "hi" },
+                    { type: "list", items: [{ label: "a" }] },
+                ],
+            },
+        });
+    });
+
+    it("leaves primitives unchanged", () => {
+        expect(filterOutKeys("hello", ["createdAt"])).toBe("hello");
+        expect(filterOutKeys(42, ["createdAt"])).toBe(42);
+        expect(filterOutKeys(true, ["createdAt"])).toBe(true);
+        expect(filterOutKeys(null, ["createdAt"])).toBe(null);
+    });
+
+    it("preserves empty objects and arrays", () => {
+        expect(filterOutKeys({}, ["createdAt"])).toEqual({});
+        expect(filterOutKeys([], ["createdAt"])).toEqual([]);
+    });
+
+    it("returns the input unchanged when no keys match", () => {
+        const input = { id: 1, title: "Page", nested: { value: 2 } };
+
+        expect(filterOutKeys(input, ["nonExistent"])).toEqual(input);
+    });
+
+    it("does not mutate the input", () => {
+        const input = { id: 1, createdAt: "2024-01-01", nested: { createdAt: "x" } };
+        const snapshot = JSON.parse(JSON.stringify(input));
+
+        filterOutKeys(input, ["createdAt"]);
+
+        expect(input).toEqual(snapshot);
+    });
+
+    it("removes the default keys (createdAt, updatedAt)", () => {
+        const result = filterOutKeys({ id: 1, title: "Page", createdAt: "x", updatedAt: "y" }, defaultFilterOutKeys);
+
+        expect(result).toEqual({ id: 1, title: "Page" });
+    });
+});

--- a/packages/admin/cms-admin/src/actionLog/actionLog.utils.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLog.utils.ts
@@ -1,0 +1,15 @@
+export const defaultFilterOutKeys = ["updatedAt", "createdAt"];
+
+export function filterOutKeys<T>(value: T, keysToBeRemoved: readonly string[]): T {
+    if (Array.isArray(value)) {
+        return value.map((item) => filterOutKeys(item, keysToBeRemoved)) as T;
+    }
+    if (value !== null && typeof value === "object") {
+        return Object.fromEntries(
+            Object.entries(value as Record<string, unknown>)
+                .filter(([key]) => !keysToBeRemoved.includes(key))
+                .map(([key, v]) => [key, filterOutKeys(v, keysToBeRemoved)]),
+        ) as T;
+    }
+    return value;
+}

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.tsx
@@ -107,7 +107,7 @@ export const ActionLogGrid: FunctionComponent<ActionLogGridProps> = ({
                 action={
                     <Typography variant="caption">
                         <FormattedMessage
-                            defaultMessage="Es können jeweils nur 2 Versionen verglichen werden."
+                            defaultMessage="You can only compare 2 versions at a time."
                             id="actionLog.actionLogGrid.info.onlyCompare2Versions"
                         />
                     </Typography>

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.gql.ts
@@ -1,0 +1,12 @@
+import { gql } from "@apollo/client";
+
+export const actionLogShowVersionFragment = gql`
+    fragment ActionLogShowVersionFragment on ActionLog {
+        id
+        version
+        snapshot
+        createdAt
+        userId
+        entityName
+    }
+`;

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.styles.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.styles.ts
@@ -1,0 +1,17 @@
+import { Box, Paper } from "@mui/material";
+import { styled } from "@mui/material/styles";
+
+export const Root = styled(Box)`
+    padding: ${({ theme }) => theme.spacing(8)};
+`;
+
+export const DiffViewerContainer = styled(Paper)`
+    padding: ${({ theme }) => theme.spacing(1)};
+    border-radius: 4px;
+`;
+export const LoadingContainer = styled(Box)`
+    display: flex;
+    min-height: 100px;
+    justify-content: center;
+    align-items: center;
+`;

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.tsx
@@ -1,0 +1,97 @@
+import { Button, InlineAlert, Loading } from "@comet/admin";
+import { ArrowLeft } from "@comet/admin-icons";
+import { Box } from "@mui/material";
+import type { FunctionComponent } from "react";
+import { FormattedMessage } from "react-intl";
+
+import { defaultFilterOutKeys, filterOutKeys } from "../actionLog.utils";
+import { DiffHeader } from "../components/DiffHeader";
+import { DiffViewer } from "../components/diffViewer/DiffViewer";
+import { ActionLogHeader } from "../components/header/ActionLogHeader";
+import type { GQLActionLogShowVersionFragmentFragment } from "./ActionLogShowVersion.gql.generated";
+import { DiffViewerContainer, LoadingContainer, Root } from "./ActionLogShowVersion.styles";
+
+type ActionLogShowVersionProps = {
+    actionLog: GQLActionLogShowVersionFragmentFragment | undefined;
+    error?: boolean;
+    filterKeys?: string[];
+    id: string;
+    loading: boolean;
+    /**
+     * Latest name of the actual object, displayed in the title
+     */
+    name?: string;
+    onClickShowVersionHistory: () => void;
+};
+
+export const ActionLogShowVersion: FunctionComponent<ActionLogShowVersionProps> = ({
+    actionLog: version,
+    error,
+    filterKeys: passedFilterKeys,
+    id,
+    loading,
+    name,
+    onClickShowVersionHistory,
+}) => {
+    const filterKeys = passedFilterKeys != null ? [...passedFilterKeys, ...defaultFilterOutKeys] : defaultFilterOutKeys;
+
+    const filteredVersionSnapshot = filterOutKeys(version?.snapshot, filterKeys);
+
+    const versionLabel = version?.version ?? <FormattedMessage defaultMessage="Unknown" id="actionLog.actionLogShowVersion.unknownVersion" />;
+
+    const title =
+        name != null ? (
+            <FormattedMessage
+                defaultMessage="Version {version} – {name}"
+                id="actionLog.actionLogShowVersion.titleWithName"
+                values={{ name, version: versionLabel }}
+            />
+        ) : (
+            <FormattedMessage defaultMessage="Version {version}" id="actionLog.actionLogShowVersion.title" values={{ version: versionLabel }} />
+        );
+
+    return (
+        <Root>
+            <Box marginBottom={4}>
+                <Button onClick={onClickShowVersionHistory} startIcon={<ArrowLeft />} variant="primary">
+                    <FormattedMessage defaultMessage="Show Version History" id="actionLog.actionLogCompare.showVersionHistory" />
+                </Button>
+            </Box>
+
+            <ActionLogHeader dbTypes={version?.entityName ? [version.entityName] : []} id={id} title={title} />
+
+            {loading && (
+                <LoadingContainer>
+                    <Loading behavior="auto" />
+                </LoadingContainer>
+            )}
+
+            {error && <InlineAlert />}
+
+            {version != null && (
+                <DiffViewerContainer>
+                    <DiffViewer
+                        leftTitle={<DiffHeader createdAt={version.createdAt} userId={version.userId} version={version.version} />}
+                        newValue={JSON.stringify(filteredVersionSnapshot, null, 8)}
+                        oldValue={JSON.stringify(filteredVersionSnapshot, null, 8)}
+                        showDiffOnly={false}
+                        splitView={false}
+                    />
+                </DiffViewerContainer>
+            )}
+            {!loading && !error && version == null && (
+                <InlineAlert
+                    title={<FormattedMessage id="actionLog.actionLogShowVersion.notFound.title" defaultMessage="Version not found" />}
+                    description={
+                        <FormattedMessage
+                            id="actionLog.actionLogShowVersion.notFound.description"
+                            defaultMessage="The requested version could not be found."
+                        />
+                    }
+                />
+            )}
+        </Root>
+    );
+};
+
+export { actionLogShowVersionFragment } from "./ActionLogShowVersion.gql";

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/__stories__/ActionLogShowVersion.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/__stories__/ActionLogShowVersion.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter } from "react-router";
+
+import { ActionLogShowVersion } from "../ActionLogShowVersion";
+
+const mockActionLog = {
+    __typename: "ActionLog" as const,
+    id: "log1",
+    version: 1,
+    snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
+    createdAt: "2023-10-01T12:00:00Z",
+    userId: "system-user",
+    entityName: "TestEntity",
+};
+
+type Story = StoryObj<typeof ActionLogShowVersion>;
+const meta: Meta<typeof ActionLogShowVersion> = {
+    component: ActionLogShowVersion,
+    decorators: [
+        (Story) => (
+            <MemoryRouter>
+                <Story />
+            </MemoryRouter>
+        ),
+    ],
+    tags: ["!autodocs"],
+    title: "Action log/Action log show version",
+    args: {
+        onClickShowVersionHistory: () => undefined,
+    },
+};
+export default meta;
+
+export const Standard: Story = {
+    args: {
+        actionLog: mockActionLog,
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        loading: false,
+        name: "My Page",
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        actionLog: undefined,
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        loading: true,
+    },
+};
+
+export const NotFound: Story = {
+    args: {
+        actionLog: undefined,
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        loading: false,
+    },
+};
+
+export const Error: Story = {
+    args: {
+        actionLog: undefined,
+        error: true,
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        loading: false,
+    },
+};

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -1,4 +1,5 @@
 export { ActionLogGrid, actionLogGridFragment } from "./actionLog/actionLogGrid/ActionLogGrid";
+export { ActionLogShowVersion, actionLogShowVersionFragment } from "./actionLog/actionLogShowVersion/ActionLogShowVersion";
 export { DiffHeader, type DiffHeaderProps } from "./actionLog/components/DiffHeader";
 export { DiffViewer, type DiffViewerProps } from "./actionLog/components/diffViewer/DiffViewer";
 export { ActionLogHeader, type ActionLogHeaderProps } from "./actionLog/components/header/ActionLogHeader";


### PR DESCRIPTION
## Description

This Pull Request introduces a new `ActionLogShowVersion` component which can display one version of an `ActionLog`.

### Default

<img width="1000" height="442" alt="Screenshot 2025-08-18 at 15 52 52" src="https://github.com/user-attachments/assets/6fae7b40-f424-4468-af53-e1cfb0908230" />

### Error - unexpected error

<img width="1006" height="497" alt="Screenshot 2025-08-18 at 15 52 02" src="https://github.com/user-attachments/assets/b65b3b10-e15c-49ef-9ddc-babee99d77f3" />

### Error - no version found

<img width="1004" height="435" alt="Screenshot 2025-08-18 at 15 40 15" src="https://github.com/user-attachments/assets/906d32e0-805e-412b-af35-b332c3a848ce" />


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2226
