### PR TITLE
Add ActionLogCompare component

### DIFF
--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.gql.ts
@@ -1,0 +1,12 @@
+import { gql } from "@apollo/client";
+
+export const actionLogCompareFragment = gql`
+    fragment ActionLogCompareFragment on ActionLog {
+        id
+        version
+        snapshot
+        createdAt
+        userId
+        entityName
+    }
+`;

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.styles.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.styles.ts
@@ -1,0 +1,18 @@
+import { Box, Paper } from "@mui/material";
+import { styled } from "@mui/material/styles";
+
+export const Root = styled(Box)`
+    padding: ${({ theme }) => theme.spacing(8)};
+`;
+
+export const PaperStyled = styled(Paper)`
+    padding: ${({ theme }) => theme.spacing(1)};
+    border-radius: 4px;
+`;
+
+export const LoadingContainer = styled(Box)`
+    display: flex;
+    min-height: 100px;
+    justify-content: center;
+    align-items: center;
+`;

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.tsx
@@ -1,0 +1,133 @@
+import { Button, InlineAlert, Loading, useStoredState } from "@comet/admin";
+import { ArrowLeft } from "@comet/admin-icons";
+import { Box, FormControlLabel, Switch, useMediaQuery, useTheme } from "@mui/material";
+import type { FunctionComponent } from "react";
+import { FormattedMessage } from "react-intl";
+
+import { defaultFilterOutKeys, filterOutKeys } from "../actionLog.utils";
+import { DiffHeader } from "../components/DiffHeader";
+import { DiffViewer } from "../components/diffViewer/DiffViewer";
+import { ActionLogHeader } from "../components/header/ActionLogHeader";
+import type { GQLActionLogCompareFragmentFragment } from "./ActionLogCompare.gql.generated";
+import { LoadingContainer, PaperStyled, Root } from "./ActionLogCompare.styles";
+
+type ActionLogCompareProps = {
+    afterVersion: GQLActionLogCompareFragmentFragment | undefined;
+    beforeVersion: GQLActionLogCompareFragmentFragment | undefined;
+    error?: boolean;
+    filterKeys?: string[];
+    id: string;
+    loading: boolean;
+    /**
+     * Latest name of the actual object, displayed in the title
+     */
+    name?: string;
+    onClickShowVersionHistory: () => void;
+};
+
+export const ActionLogCompare: FunctionComponent<ActionLogCompareProps> = ({
+    afterVersion,
+    beforeVersion,
+    error,
+    filterKeys: _filterKeys,
+    id,
+    loading,
+    name,
+    onClickShowVersionHistory,
+}) => {
+    const [onlyShowChanges, setOnlyShowChanges] = useStoredState<boolean>("actionLogCompare.onlyShowChanges", false);
+    const filterKeys = _filterKeys != null ? [..._filterKeys, ...defaultFilterOutKeys] : defaultFilterOutKeys;
+
+    const theme = useTheme();
+    const smallBreakpoint = useMediaQuery(theme.breakpoints.down("md"));
+
+    const filteredSnapshotBeforeVersion = filterOutKeys(beforeVersion?.snapshot, filterKeys);
+    const filteredSnapshotAfterVersion = filterOutKeys(afterVersion?.snapshot, filterKeys);
+
+    return (
+        <Root>
+            <Box marginBottom={4}>
+                <Button onClick={onClickShowVersionHistory} startIcon={<ArrowLeft />} variant="primary">
+                    <FormattedMessage defaultMessage="Show Version History" id="actionLog.actionLogCompare.showVersionHistory" />
+                </Button>
+            </Box>
+
+            <ActionLogHeader
+                action={
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={onlyShowChanges}
+                                onChange={(event, checked) => {
+                                    setOnlyShowChanges(checked);
+                                }}
+                            />
+                        }
+                        label={<FormattedMessage defaultMessage="Show Changes Only" id="actionLog.actionLogCompare.onlyShowChanges.switchLabel" />}
+                    />
+                }
+                dbTypes={Array.from(new Set([beforeVersion?.entityName ?? "", afterVersion?.entityName ?? ""]))}
+                id={id}
+                title={
+                    <FormattedMessage
+                        defaultMessage="Content Comparison {name}"
+                        id="actionLog.actionLogCompare.title"
+                        values={{
+                            name: name != null ? `- ${name}` : "",
+                        }}
+                    />
+                }
+            />
+
+            {loading && (
+                <LoadingContainer>
+                    <Loading behavior="auto" />
+                </LoadingContainer>
+            )}
+
+            {error && <InlineAlert />}
+
+            {!loading && !error && (afterVersion == null || beforeVersion == null) && (
+                <Box margin={6}>
+                    <InlineAlert
+                        title={<FormattedMessage id="actionLog.actionLogCompare.notFound.title" defaultMessage="Versions not found" />}
+                        description={
+                            <FormattedMessage
+                                id="actionLog.actionLogCompare.notFound.description"
+                                defaultMessage="One or both of the requested versions could not be found."
+                            />
+                        }
+                    />
+                </Box>
+            )}
+            {afterVersion != null && beforeVersion != null && (
+                <PaperStyled>
+                    <DiffViewer
+                        leftTitle={
+                            smallBreakpoint ? (
+                                <>
+                                    <DiffHeader
+                                        createdAt={beforeVersion?.createdAt}
+                                        userId={beforeVersion?.userId}
+                                        version={beforeVersion?.version}
+                                    />
+
+                                    <DiffHeader createdAt={afterVersion?.createdAt} userId={afterVersion?.userId} version={afterVersion?.version} />
+                                </>
+                            ) : (
+                                <DiffHeader createdAt={beforeVersion?.createdAt} userId={beforeVersion?.userId} version={beforeVersion?.version} />
+                            )
+                        }
+                        newValue={JSON.stringify(filteredSnapshotAfterVersion, null, 8)}
+                        oldValue={JSON.stringify(filteredSnapshotBeforeVersion, null, 8)}
+                        rightTitle={<DiffHeader createdAt={afterVersion?.createdAt} userId={afterVersion?.userId} version={afterVersion?.version} />}
+                        showDiffOnly={onlyShowChanges}
+                        splitView={!smallBreakpoint}
+                    />
+                </PaperStyled>
+            )}
+        </Root>
+    );
+};
+
+export { actionLogCompareFragment } from "./ActionLogCompare.gql";

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.tsx
@@ -29,14 +29,14 @@ export const ActionLogCompare: FunctionComponent<ActionLogCompareProps> = ({
     afterVersion,
     beforeVersion,
     error,
-    filterKeys: _filterKeys,
+    filterKeys: passedFilterKeys,
     id,
     loading,
     name,
     onClickShowVersionHistory,
 }) => {
     const [onlyShowChanges, setOnlyShowChanges] = useStoredState<boolean>("actionLogCompare.onlyShowChanges", false);
-    const filterKeys = _filterKeys != null ? [..._filterKeys, ...defaultFilterOutKeys] : defaultFilterOutKeys;
+    const filterKeys = passedFilterKeys != null ? [...passedFilterKeys, ...defaultFilterOutKeys] : defaultFilterOutKeys;
 
     const theme = useTheme();
     const smallBreakpoint = useMediaQuery(theme.breakpoints.down("md"));

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/__stories__/ActionLogCompare.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/__stories__/ActionLogCompare.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter } from "react-router";
+
+import { ActionLogCompare } from "../ActionLogCompare";
+
+const mockVersion1 = {
+    __typename: "ActionLog" as const,
+    id: "log1",
+    version: 1,
+    snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
+    createdAt: "2023-10-01T12:00:00Z",
+    userId: "system-user",
+    entityName: "TestEntity",
+};
+
+const mockVersion2 = {
+    __typename: "ActionLog" as const,
+    id: "log2",
+    version: 2,
+    snapshot: { title: "My Page (updated)", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
+    createdAt: "2023-10-02T12:00:00Z",
+    userId: "user2",
+    entityName: "TestEntity",
+};
+
+type Story = StoryObj<typeof ActionLogCompare>;
+const meta: Meta<typeof ActionLogCompare> = {
+    component: ActionLogCompare,
+    decorators: [
+        (Story) => (
+            <MemoryRouter>
+                <Story />
+            </MemoryRouter>
+        ),
+    ],
+    tags: ["!autodocs"],
+    title: "Action log/Action log compare",
+    args: {
+        onClickShowVersionHistory: () => undefined,
+    },
+};
+export default meta;
+
+export const Standard: Story = {
+    args: {
+        beforeVersion: mockVersion1,
+        afterVersion: mockVersion2,
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        loading: false,
+        name: "My Page",
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        beforeVersion: undefined,
+        afterVersion: undefined,
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        loading: true,
+    },
+};
+
+export const NotFound: Story = {
+    args: {
+        beforeVersion: undefined,
+        afterVersion: undefined,
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        loading: false,
+    },
+};
+
+export const Error: Story = {
+    args: {
+        beforeVersion: undefined,
+        afterVersion: undefined,
+        error: true,
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        loading: false,
+    },
+};

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -1,3 +1,4 @@
+export { ActionLogCompare, actionLogCompareFragment } from "./actionLog/actionLogCompare/ActionLogCompare";
 export { ActionLogGrid, actionLogGridFragment } from "./actionLog/actionLogGrid/ActionLogGrid";
 export { ActionLogShowVersion, actionLogShowVersionFragment } from "./actionLog/actionLogShowVersion/ActionLogShowVersion";
 export { DiffHeader, type DiffHeaderProps } from "./actionLog/components/DiffHeader";


### PR DESCRIPTION
## Description

This Pull Request introduces a new `ActionLogCompare` component which can display the diff of two version of an ActionLog.

## Default

<img width="996" height="511" alt="Screenshot 2025-08-18 at 16 32 09" src="https://github.com/user-attachments/assets/398974b1-3d47-4a81-a0a8-26fd35134fb0" />

## Error- unexpected error

<img width="991" height="541" alt="Screenshot 2025-08-18 at 16 31 54" src="https://github.com/user-attachments/assets/3ff36490-aed6-43d0-9207-9fc9571c2b0e" />


## Error - no versions found

<img width="1002" height="472" alt="Screenshot 2025-08-18 at 16 31 03" src="https://github.com/user-attachments/assets/dd065085-7a8e-4fe4-a167-12564428ed7f" />


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2226
