### PR TITLE
Add ActionLogDialog component

### DIFF
--- a/packages/admin/cms-admin/.storybook/mocks/actionLogDialogHandler.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/actionLogDialogHandler.ts
@@ -1,0 +1,57 @@
+import { graphql, HttpResponse } from "msw";
+
+const mockGridNodes = [
+    { id: "log3", userId: "Max Mustermann", entityName: "TestEntity", version: 3, createdAt: "2023-10-03T12:00:00Z" },
+    { id: "log2", userId: "user2", entityName: "TestEntity", version: 2, createdAt: "2023-10-02T12:00:00Z" },
+    { id: "log1", userId: "system-user", entityName: "TestEntity", version: 1, createdAt: "2023-10-01T12:00:00Z" },
+];
+
+const mockVersionById: Record<string, { id: string; version: number; userId: string; entityName: string; snapshot: object; createdAt: string }> = {
+    log1: {
+        id: "log1",
+        version: 1,
+        userId: "system-user",
+        entityName: "TestEntity",
+        snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
+        createdAt: "2023-10-01T12:00:00Z",
+    },
+    log2: {
+        id: "log2",
+        version: 2,
+        userId: "user2",
+        entityName: "TestEntity",
+        snapshot: { title: "My Page (updated)", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
+        createdAt: "2023-10-02T12:00:00Z",
+    },
+    log3: {
+        id: "log3",
+        version: 3,
+        userId: "Max Mustermann",
+        entityName: "TestEntity",
+        snapshot: { title: "My Page (v3)", slug: "my-page", createdAt: "2023-10-03T12:00:00Z" },
+        createdAt: "2023-10-03T12:00:00Z",
+    },
+};
+
+export const actionLogDialogHandlers = [
+    graphql.query("ActionLogDialogGrid", () =>
+        HttpResponse.json({
+            data: { entity: { actionLogs: { nodes: mockGridNodes, totalCount: mockGridNodes.length } } },
+        }),
+    ),
+    graphql.query("ActionLogDialogShowVersion", ({ variables }) =>
+        HttpResponse.json({
+            data: { entity: { actionLog: mockVersionById[variables.versionId] ?? null } },
+        }),
+    ),
+    graphql.query("ActionLogDialogCompare", ({ variables }) =>
+        HttpResponse.json({
+            data: {
+                entity: {
+                    beforeVersion: mockVersionById[variables.beforeVersionId] ?? null,
+                    afterVersion: mockVersionById[variables.afterVersionId] ?? null,
+                },
+            },
+        }),
+    ),
+];

--- a/packages/admin/cms-admin/.storybook/mocks/actionLogDialogHandler.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/actionLogDialogHandler.ts
@@ -1,13 +1,17 @@
 import { graphql, HttpResponse } from "msw";
 
 const mockGridNodes = [
-    { id: "log3", userId: "Max Mustermann", entityName: "TestEntity", version: 3, createdAt: "2023-10-03T12:00:00Z" },
-    { id: "log2", userId: "user2", entityName: "TestEntity", version: 2, createdAt: "2023-10-02T12:00:00Z" },
-    { id: "log1", userId: "system-user", entityName: "TestEntity", version: 1, createdAt: "2023-10-01T12:00:00Z" },
+    { __typename: "ActionLog", id: "log3", userId: "Max Mustermann", entityName: "TestEntity", version: 3, createdAt: "2023-10-03T12:00:00Z" },
+    { __typename: "ActionLog", id: "log2", userId: "user2", entityName: "TestEntity", version: 2, createdAt: "2023-10-02T12:00:00Z" },
+    { __typename: "ActionLog", id: "log1", userId: "system-user", entityName: "TestEntity", version: 1, createdAt: "2023-10-01T12:00:00Z" },
 ];
 
-const mockVersionById: Record<string, { id: string; version: number; userId: string; entityName: string; snapshot: object; createdAt: string }> = {
+const mockVersionById: Record<
+    string,
+    { __typename: "ActionLog"; id: string; version: number; userId: string; entityName: string; snapshot: object; createdAt: string }
+> = {
     log1: {
+        __typename: "ActionLog",
         id: "log1",
         version: 1,
         userId: "system-user",
@@ -16,6 +20,7 @@ const mockVersionById: Record<string, { id: string; version: number; userId: str
         createdAt: "2023-10-01T12:00:00Z",
     },
     log2: {
+        __typename: "ActionLog",
         id: "log2",
         version: 2,
         userId: "user2",
@@ -24,6 +29,7 @@ const mockVersionById: Record<string, { id: string; version: number; userId: str
         createdAt: "2023-10-02T12:00:00Z",
     },
     log3: {
+        __typename: "ActionLog",
         id: "log3",
         version: 3,
         userId: "Max Mustermann",
@@ -36,18 +42,29 @@ const mockVersionById: Record<string, { id: string; version: number; userId: str
 export const actionLogDialogHandlers = [
     graphql.query("ActionLogDialogGrid", () =>
         HttpResponse.json({
-            data: { entity: { actionLogs: { nodes: mockGridNodes, totalCount: mockGridNodes.length } } },
+            data: {
+                entity: {
+                    __typename: "Manufacturer",
+                    actionLogs: { __typename: "PaginatedActionLogs", nodes: mockGridNodes, totalCount: mockGridNodes.length },
+                },
+            },
         }),
     ),
     graphql.query("ActionLogDialogShowVersion", ({ variables }) =>
         HttpResponse.json({
-            data: { entity: { actionLog: mockVersionById[variables.versionId] ?? null } },
+            data: {
+                entity: {
+                    __typename: "Manufacturer",
+                    actionLog: mockVersionById[variables.versionId] ?? null,
+                },
+            },
         }),
     ),
     graphql.query("ActionLogDialogCompare", ({ variables }) =>
         HttpResponse.json({
             data: {
                 entity: {
+                    __typename: "Manufacturer",
                     beforeVersion: mockVersionById[variables.beforeVersionId] ?? null,
                     afterVersion: mockVersionById[variables.afterVersionId] ?? null,
                 },

--- a/packages/admin/cms-admin/.storybook/mocks/handlers.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { actionLogDialogHandlers } from "./actionLogDialogHandler";
 import { currentUserHandler } from "./currentUserHandler";
 
-export const handlers = [currentUserHandler];
+export const handlers = [currentUserHandler, ...actionLogDialogHandlers];

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.gql.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const actionLogCompareFragment = gql`
-    fragment ActionLogCompareFragment on ActionLog {
+    fragment ActionLogCompare on ActionLog {
         id
         version
         snapshot

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.tsx
@@ -8,12 +8,12 @@ import { defaultFilterOutKeys, filterOutKeys } from "../actionLog.utils";
 import { DiffHeader } from "../components/DiffHeader";
 import { DiffViewer } from "../components/diffViewer/DiffViewer";
 import { ActionLogHeader } from "../components/header/ActionLogHeader";
-import type { GQLActionLogCompareFragmentFragment } from "./ActionLogCompare.gql.generated";
+import type { GQLActionLogCompareFragment } from "./ActionLogCompare.gql.generated";
 import { LoadingContainer, PaperStyled, Root } from "./ActionLogCompare.styles";
 
 type ActionLogCompareProps = {
-    afterVersion: GQLActionLogCompareFragmentFragment | undefined;
-    beforeVersion: GQLActionLogCompareFragmentFragment | undefined;
+    afterVersion: GQLActionLogCompareFragment | undefined;
+    beforeVersion: GQLActionLogCompareFragment | undefined;
     error?: boolean;
     filterKeys?: string[];
     id: string;

--- a/packages/admin/cms-admin/src/actionLog/actionLogDialog/ActionLogDialog.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogDialog/ActionLogDialog.gql.ts
@@ -2,14 +2,14 @@ import { gql } from "@apollo/client";
 import type { DocumentNode } from "graphql";
 
 import { actionLogCompareFragment } from "../actionLogCompare/ActionLogCompare";
-import type { GQLActionLogCompareFragmentFragment } from "../actionLogCompare/ActionLogCompare.gql.generated";
+import type { GQLActionLogCompareFragment } from "../actionLogCompare/ActionLogCompare.gql.generated";
 import { actionLogGridFragment } from "../actionLogGrid/ActionLogGrid";
-import type { GQLActionLogGridFragmentFragment } from "../actionLogGrid/ActionLogGrid.gql.generated";
+import type { GQLActionLogGridFragment } from "../actionLogGrid/ActionLogGrid.gql.generated";
 import { actionLogShowVersionFragment } from "../actionLogShowVersion/ActionLogShowVersion";
-import type { GQLActionLogShowVersionFragmentFragment } from "../actionLogShowVersion/ActionLogShowVersion.gql.generated";
+import type { GQLActionLogShowVersionFragment } from "../actionLogShowVersion/ActionLogShowVersion.gql.generated";
 
 export type ActionLogDialogGridQueryResult = {
-    entity: { actionLogs: { nodes: GQLActionLogGridFragmentFragment[]; totalCount: number } } | null;
+    entity: { actionLogs: { nodes: GQLActionLogGridFragment[]; totalCount: number } } | null;
 };
 
 export type ActionLogDialogGridQueryVariables = {
@@ -20,7 +20,7 @@ export type ActionLogDialogGridQueryVariables = {
 };
 
 export type ActionLogDialogShowVersionQueryResult = {
-    entity: { actionLog: GQLActionLogShowVersionFragmentFragment | null } | null;
+    entity: { actionLog: GQLActionLogShowVersionFragment | null } | null;
 };
 
 export type ActionLogDialogShowVersionQueryVariables = {
@@ -30,8 +30,8 @@ export type ActionLogDialogShowVersionQueryVariables = {
 
 export type ActionLogDialogCompareQueryResult = {
     entity: {
-        beforeVersion: GQLActionLogCompareFragmentFragment | null;
-        afterVersion: GQLActionLogCompareFragmentFragment | null;
+        beforeVersion: GQLActionLogCompareFragment | null;
+        afterVersion: GQLActionLogCompareFragment | null;
     } | null;
 };
 
@@ -46,7 +46,7 @@ export const createActionLogDialogGridQuery = (rootField: string): DocumentNode 
         entity: ${rootField}(id: $id) {
             actionLogs(offset: $offset, limit: $limit, sort: $sort) {
                 nodes {
-                    ...ActionLogGridFragment
+                    ...ActionLogGrid
                 }
                 totalCount
             }
@@ -59,7 +59,7 @@ export const createActionLogDialogShowVersionQuery = (rootField: string): Docume
     query ActionLogDialogShowVersion($id: ID!, $versionId: ID!) {
         entity: ${rootField}(id: $id) {
             actionLog(id: $versionId) {
-                ...ActionLogShowVersionFragment
+                ...ActionLogShowVersion
             }
         }
     }
@@ -70,10 +70,10 @@ export const createActionLogDialogCompareQuery = (rootField: string): DocumentNo
     query ActionLogDialogCompare($id: ID!, $beforeVersionId: ID!, $afterVersionId: ID!) {
         entity: ${rootField}(id: $id) {
             beforeVersion: actionLog(id: $beforeVersionId) {
-                ...ActionLogCompareFragment
+                ...ActionLogCompare
             }
             afterVersion: actionLog(id: $afterVersionId) {
-                ...ActionLogCompareFragment
+                ...ActionLogCompare
             }
         }
     }

--- a/packages/admin/cms-admin/src/actionLog/actionLogDialog/ActionLogDialog.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogDialog/ActionLogDialog.gql.ts
@@ -1,0 +1,81 @@
+import { gql } from "@apollo/client";
+import type { DocumentNode } from "graphql";
+
+import { actionLogCompareFragment } from "../actionLogCompare/ActionLogCompare";
+import type { GQLActionLogCompareFragmentFragment } from "../actionLogCompare/ActionLogCompare.gql.generated";
+import { actionLogGridFragment } from "../actionLogGrid/ActionLogGrid";
+import type { GQLActionLogGridFragmentFragment } from "../actionLogGrid/ActionLogGrid.gql.generated";
+import { actionLogShowVersionFragment } from "../actionLogShowVersion/ActionLogShowVersion";
+import type { GQLActionLogShowVersionFragmentFragment } from "../actionLogShowVersion/ActionLogShowVersion.gql.generated";
+
+export type ActionLogDialogGridQueryResult = {
+    entity: { actionLogs: { nodes: GQLActionLogGridFragmentFragment[]; totalCount: number } } | null;
+};
+
+export type ActionLogDialogGridQueryVariables = {
+    id: string;
+    offset: number;
+    limit: number;
+    sort: Array<{ field: string; direction: "ASC" | "DESC" }>;
+};
+
+export type ActionLogDialogShowVersionQueryResult = {
+    entity: { actionLog: GQLActionLogShowVersionFragmentFragment | null } | null;
+};
+
+export type ActionLogDialogShowVersionQueryVariables = {
+    id: string;
+    versionId: string;
+};
+
+export type ActionLogDialogCompareQueryResult = {
+    entity: {
+        beforeVersion: GQLActionLogCompareFragmentFragment | null;
+        afterVersion: GQLActionLogCompareFragmentFragment | null;
+    } | null;
+};
+
+export type ActionLogDialogCompareQueryVariables = {
+    id: string;
+    beforeVersionId: string;
+    afterVersionId: string;
+};
+
+export const createActionLogDialogGridQuery = (rootField: string): DocumentNode => gql`
+    query ActionLogDialogGrid($id: ID!, $offset: Int!, $limit: Int!, $sort: [ActionLogSort!]) {
+        entity: ${rootField}(id: $id) {
+            actionLogs(offset: $offset, limit: $limit, sort: $sort) {
+                nodes {
+                    ...ActionLogGridFragment
+                }
+                totalCount
+            }
+        }
+    }
+    ${actionLogGridFragment}
+`;
+
+export const createActionLogDialogShowVersionQuery = (rootField: string): DocumentNode => gql`
+    query ActionLogDialogShowVersion($id: ID!, $versionId: ID!) {
+        entity: ${rootField}(id: $id) {
+            actionLog(id: $versionId) {
+                ...ActionLogShowVersionFragment
+            }
+        }
+    }
+    ${actionLogShowVersionFragment}
+`;
+
+export const createActionLogDialogCompareQuery = (rootField: string): DocumentNode => gql`
+    query ActionLogDialogCompare($id: ID!, $beforeVersionId: ID!, $afterVersionId: ID!) {
+        entity: ${rootField}(id: $id) {
+            beforeVersion: actionLog(id: $beforeVersionId) {
+                ...ActionLogCompareFragment
+            }
+            afterVersion: actionLog(id: $afterVersionId) {
+                ...ActionLogCompareFragment
+            }
+        }
+    }
+    ${actionLogCompareFragment}
+`;

--- a/packages/admin/cms-admin/src/actionLog/actionLogDialog/ActionLogDialog.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogDialog/ActionLogDialog.tsx
@@ -1,63 +1,103 @@
-import { Dialog, InlineAlert, type useDataGridRemote, type usePersistentColumnState } from "@comet/admin";
-import type { FunctionComponent } from "react";
+import { useQuery } from "@apollo/client";
+import { Dialog, InlineAlert, useDataGridRemote, usePersistentColumnState } from "@comet/admin";
+import { useEffect, useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { ActionLogCompare } from "../actionLogCompare/ActionLogCompare";
-import type { GQLActionLogCompareFragmentFragment } from "../actionLogCompare/ActionLogCompare.gql.generated";
 import { ActionLogGrid } from "../actionLogGrid/ActionLogGrid";
-import type { GQLActionLogGridFragmentFragment } from "../actionLogGrid/ActionLogGrid.gql.generated";
 import { ActionLogShowVersion } from "../actionLogShowVersion/ActionLogShowVersion";
-import type { GQLActionLogShowVersionFragmentFragment } from "../actionLogShowVersion/ActionLogShowVersion.gql.generated";
+import {
+    type ActionLogDialogCompareQueryResult,
+    type ActionLogDialogCompareQueryVariables,
+    type ActionLogDialogGridQueryResult,
+    type ActionLogDialogGridQueryVariables,
+    type ActionLogDialogShowVersionQueryResult,
+    type ActionLogDialogShowVersionQueryVariables,
+    createActionLogDialogCompareQuery,
+    createActionLogDialogGridQuery,
+    createActionLogDialogShowVersionQuery,
+} from "./ActionLogDialog.gql";
 
-export type ActionLogDialogValue =
-    | (ReturnType<typeof useDataGridRemote> &
-          ReturnType<typeof usePersistentColumnState> & {
-              type: "grid";
-              actionLogs: { nodes: GQLActionLogGridFragmentFragment[]; totalCount: number } | undefined;
-              error?: boolean;
-              loading: boolean;
-          })
-    | {
-          type: "showVersion";
-          actionLog: GQLActionLogShowVersionFragmentFragment | undefined;
-          error?: boolean;
-          loading: boolean;
-      }
-    | {
-          type: "compareVersions";
-          afterVersion: GQLActionLogCompareFragmentFragment | undefined;
-          beforeVersion: GQLActionLogCompareFragmentFragment | undefined;
-          error?: boolean;
-          loading: boolean;
-      };
+type ActionLogDialogView =
+    | { type: "grid" }
+    | { type: "showVersion"; versionId: string }
+    | { type: "compareVersions"; beforeVersionId: string; afterVersionId: string };
 
-type ActionLogDialogProps = {
+/**
+ * Keys of `TQuery` whose value structurally exposes both `actionLog` and `actionLogs`
+ * (i.e. entities decorated with `@ActionLogs()`). Falls back to `string` when no generic is supplied.
+ */
+type ActionLogRootField<TQuery> = string extends keyof TQuery
+    ? string
+    : {
+          [K in keyof TQuery]: NonNullable<TQuery[K]> extends { actionLog: unknown; actionLogs: unknown } ? K : never;
+      }[keyof TQuery] &
+          string;
+
+type ActionLogDialogProps<TQuery> = {
     id: string;
+    /**
+     * GraphQL root field exposing the entity (e.g. "manufacturer", "product").
+     * The entity must expose `actionLog(id)` and `actionLogs(offset, limit, sort)` via `@ActionLogs()`.
+     *
+     * Pass your app's `GQLQuery` as the generic to constrain this to entities decorated with `@ActionLogs()`.
+     */
+    rootField: ActionLogRootField<TQuery>;
+    /**
+     * Latest name of the entity, displayed in titles.
+     */
     name?: string;
-    onClose: () => void;
-    onCompareVersionsClick: (versionId: string, versionId2: string) => void;
-    onShowVersionClick: (versionId: string) => void;
-    onShowVersionHistoryClick: () => void;
     open: boolean;
-    value: ActionLogDialogValue;
+    onClose: () => void;
 };
 
-export const ActionLogDialog: FunctionComponent<ActionLogDialogProps> = ({
-    id,
-    name,
-    onClose,
-    onCompareVersionsClick,
-    onShowVersionClick,
-    onShowVersionHistoryClick,
-    open,
-    value,
-}) => {
+export function ActionLogDialog<TQuery = Record<string, unknown>>({ id, rootField, name, open, onClose }: ActionLogDialogProps<TQuery>) {
     const intl = useIntl();
+    const [view, setView] = useState<ActionLogDialogView>({ type: "grid" });
+
+    useEffect(() => {
+        if (!open) {
+            setView({ type: "grid" });
+        }
+    }, [open]);
+
+    const dataGridRemote = useDataGridRemote({ initialSort: [{ field: "version", sort: "desc" }] });
+    const persistentColumnState = usePersistentColumnState(`ActionLogDialog-${rootField}`);
+
+    const gridQuery = useMemo(() => createActionLogDialogGridQuery(rootField), [rootField]);
+    const showVersionQuery = useMemo(() => createActionLogDialogShowVersionQuery(rootField), [rootField]);
+    const compareQuery = useMemo(() => createActionLogDialogCompareQuery(rootField), [rootField]);
+
+    const gridResult = useQuery<ActionLogDialogGridQueryResult, ActionLogDialogGridQueryVariables>(gridQuery, {
+        variables: {
+            id,
+            offset: dataGridRemote.paginationModel.page * dataGridRemote.paginationModel.pageSize,
+            limit: dataGridRemote.paginationModel.pageSize,
+            sort: dataGridRemote.sortModel.map((entry) => ({
+                field: entry.field,
+                direction: entry.sort === "desc" ? "DESC" : "ASC",
+            })),
+        },
+        skip: !open || view.type !== "grid",
+    });
+
+    const showVersionResult = useQuery<ActionLogDialogShowVersionQueryResult, ActionLogDialogShowVersionQueryVariables>(showVersionQuery, {
+        variables: { id, versionId: view.type === "showVersion" ? view.versionId : "" },
+        skip: !open || view.type !== "showVersion",
+    });
+
+    const compareResult = useQuery<ActionLogDialogCompareQueryResult, ActionLogDialogCompareQueryVariables>(compareQuery, {
+        variables:
+            view.type === "compareVersions"
+                ? { id, beforeVersionId: view.beforeVersionId, afterVersionId: view.afterVersionId }
+                : { id, beforeVersionId: "", afterVersionId: "" },
+        skip: !open || view.type !== "compareVersions",
+    });
 
     return (
         <Dialog
-            fullWidth={true}
-            maxWidth={value.type === "compareVersions" ? "xl" : "md"}
+            fullWidth
+            maxWidth={view.type === "compareVersions" ? "xl" : "md"}
             onClose={onClose}
             open={open}
             title={intl.formatMessage({
@@ -65,42 +105,47 @@ export const ActionLogDialog: FunctionComponent<ActionLogDialogProps> = ({
                 id: "actionLog.actionLogModal.title",
             })}
         >
-            {value.type === "grid" && !value.error && (
-                <ActionLogGrid
-                    {...value}
-                    id={id}
-                    name={name}
-                    onCompareVersionsClick={onCompareVersionsClick}
-                    onShowVersionClick={onShowVersionClick}
-                />
-            )}
-
-            {value.type === "grid" && value.error && (
+            {view.type === "grid" && gridResult.error && (
                 <InlineAlert title={<FormattedMessage defaultMessage="Error loading action logs" id="actionLog.actionLogDialog.gridError.title" />} />
             )}
 
-            {value.type === "showVersion" && (
-                <ActionLogShowVersion
-                    actionLog={value.actionLog}
-                    error={value.error}
+            {view.type === "grid" && !gridResult.error && (
+                <ActionLogGrid
+                    {...dataGridRemote}
+                    {...persistentColumnState}
+                    actionLogs={gridResult.data?.entity?.actionLogs ?? undefined}
                     id={id}
-                    loading={value.loading}
+                    loading={gridResult.loading}
                     name={name}
-                    onClickShowVersionHistory={onShowVersionHistoryClick}
+                    onShowVersionClick={(versionId) => setView({ type: "showVersion", versionId })}
+                    onCompareVersionsClick={(beforeVersionId, afterVersionId) =>
+                        setView({ type: "compareVersions", beforeVersionId, afterVersionId })
+                    }
                 />
             )}
 
-            {value.type === "compareVersions" && (
-                <ActionLogCompare
-                    afterVersion={value.afterVersion}
-                    beforeVersion={value.beforeVersion}
-                    error={value.error}
+            {view.type === "showVersion" && (
+                <ActionLogShowVersion
+                    actionLog={showVersionResult.data?.entity?.actionLog ?? undefined}
+                    error={Boolean(showVersionResult.error)}
                     id={id}
-                    loading={value.loading}
+                    loading={showVersionResult.loading}
                     name={name}
-                    onClickShowVersionHistory={onShowVersionHistoryClick}
+                    onClickShowVersionHistory={() => setView({ type: "grid" })}
+                />
+            )}
+
+            {view.type === "compareVersions" && (
+                <ActionLogCompare
+                    afterVersion={compareResult.data?.entity?.afterVersion ?? undefined}
+                    beforeVersion={compareResult.data?.entity?.beforeVersion ?? undefined}
+                    error={Boolean(compareResult.error)}
+                    id={id}
+                    loading={compareResult.loading}
+                    name={name}
+                    onClickShowVersionHistory={() => setView({ type: "grid" })}
                 />
             )}
         </Dialog>
     );
-};
+}

--- a/packages/admin/cms-admin/src/actionLog/actionLogDialog/ActionLogDialog.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogDialog/ActionLogDialog.tsx
@@ -1,0 +1,106 @@
+import { Dialog, InlineAlert, type useDataGridRemote, type usePersistentColumnState } from "@comet/admin";
+import type { FunctionComponent } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { ActionLogCompare } from "../actionLogCompare/ActionLogCompare";
+import type { GQLActionLogCompareFragmentFragment } from "../actionLogCompare/ActionLogCompare.gql.generated";
+import { ActionLogGrid } from "../actionLogGrid/ActionLogGrid";
+import type { GQLActionLogGridFragmentFragment } from "../actionLogGrid/ActionLogGrid.gql.generated";
+import { ActionLogShowVersion } from "../actionLogShowVersion/ActionLogShowVersion";
+import type { GQLActionLogShowVersionFragmentFragment } from "../actionLogShowVersion/ActionLogShowVersion.gql.generated";
+
+export type ActionLogDialogValue =
+    | (ReturnType<typeof useDataGridRemote> &
+          ReturnType<typeof usePersistentColumnState> & {
+              type: "grid";
+              actionLogs: { nodes: GQLActionLogGridFragmentFragment[]; totalCount: number } | undefined;
+              error?: boolean;
+              loading: boolean;
+          })
+    | {
+          type: "showVersion";
+          actionLog: GQLActionLogShowVersionFragmentFragment | undefined;
+          error?: boolean;
+          loading: boolean;
+      }
+    | {
+          type: "compareVersions";
+          afterVersion: GQLActionLogCompareFragmentFragment | undefined;
+          beforeVersion: GQLActionLogCompareFragmentFragment | undefined;
+          error?: boolean;
+          loading: boolean;
+      };
+
+type ActionLogDialogProps = {
+    id: string;
+    name?: string;
+    onClose: () => void;
+    onCompareVersionsClick: (versionId: string, versionId2: string) => void;
+    onShowVersionClick: (versionId: string) => void;
+    onShowVersionHistoryClick: () => void;
+    open: boolean;
+    value: ActionLogDialogValue;
+};
+
+export const ActionLogDialog: FunctionComponent<ActionLogDialogProps> = ({
+    id,
+    name,
+    onClose,
+    onCompareVersionsClick,
+    onShowVersionClick,
+    onShowVersionHistoryClick,
+    open,
+    value,
+}) => {
+    const intl = useIntl();
+
+    return (
+        <Dialog
+            fullWidth={true}
+            maxWidth={value.type === "compareVersions" ? "xl" : "md"}
+            onClose={onClose}
+            open={open}
+            title={intl.formatMessage({
+                defaultMessage: "Action Log",
+                id: "actionLog.actionLogModal.title",
+            })}
+        >
+            {value.type === "grid" && !value.error && (
+                <ActionLogGrid
+                    {...value}
+                    id={id}
+                    name={name}
+                    onCompareVersionsClick={onCompareVersionsClick}
+                    onShowVersionClick={onShowVersionClick}
+                />
+            )}
+
+            {value.type === "grid" && value.error && (
+                <InlineAlert title={<FormattedMessage defaultMessage="Error loading action logs" id="actionLog.actionLogDialog.gridError.title" />} />
+            )}
+
+            {value.type === "showVersion" && (
+                <ActionLogShowVersion
+                    actionLog={value.actionLog}
+                    error={value.error}
+                    id={id}
+                    loading={value.loading}
+                    name={name}
+                    onClickShowVersionHistory={onShowVersionHistoryClick}
+                />
+            )}
+
+            {value.type === "compareVersions" && (
+                <ActionLogCompare
+                    afterVersion={value.afterVersion}
+                    beforeVersion={value.beforeVersion}
+                    error={value.error}
+                    id={id}
+                    loading={value.loading}
+                    name={name}
+                    onClickShowVersionHistory={onShowVersionHistoryClick}
+                />
+            )}
+        </Dialog>
+    );
+};

--- a/packages/admin/cms-admin/src/actionLog/actionLogDialog/__stories__/ActionLogDialog.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogDialog/__stories__/ActionLogDialog.stories.tsx
@@ -1,0 +1,176 @@
+import { useDataGridRemote, usePersistentColumnState } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { MemoryRouter } from "react-router";
+
+import type { GQLActionLogGridFragmentFragment } from "../../actionLogGrid/ActionLogGrid.gql.generated";
+import { ActionLogDialog, type ActionLogDialogValue } from "../ActionLogDialog";
+
+const mockActionLogs = {
+    totalCount: 3,
+    nodes: [
+        {
+            __typename: "ActionLog" as const,
+            id: "log3",
+            userId: "Max Mustermann",
+            entityName: "TestEntity",
+            version: 3,
+            createdAt: "2023-10-03T12:00:00Z",
+        },
+        { __typename: "ActionLog" as const, id: "log2", userId: "user2", entityName: "TestEntity", version: 2, createdAt: "2023-10-02T12:00:00Z" },
+        {
+            __typename: "ActionLog" as const,
+            id: "log1",
+            userId: "system-user",
+            entityName: "TestEntity",
+            version: 1,
+            createdAt: "2023-10-01T12:00:00Z",
+        },
+    ],
+};
+
+const mockActionLog = {
+    __typename: "ActionLog" as const,
+    id: "log1",
+    version: 1,
+    snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
+    createdAt: "2023-10-01T12:00:00Z",
+    userId: "system-user",
+    entityName: "TestEntity",
+};
+
+const mockVersion1 = {
+    __typename: "ActionLog" as const,
+    id: "log1",
+    version: 1,
+    snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
+    createdAt: "2023-10-01T12:00:00Z",
+    userId: "system-user",
+    entityName: "TestEntity",
+};
+
+const mockVersion2 = {
+    __typename: "ActionLog" as const,
+    id: "log2",
+    version: 2,
+    snapshot: { title: "My Page (updated)", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
+    createdAt: "2023-10-02T12:00:00Z",
+    userId: "user2",
+    entityName: "TestEntity",
+};
+
+type Story = StoryObj<typeof ActionLogDialog>;
+const meta: Meta<typeof ActionLogDialog> = {
+    component: ActionLogDialog,
+    decorators: [
+        (Story) => (
+            <MemoryRouter>
+                <Story />
+            </MemoryRouter>
+        ),
+    ],
+    tags: ["!autodocs"],
+    title: "Action log/Action log dialog",
+    args: {
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        name: "My Page",
+        onClose: () => undefined,
+        open: true,
+    },
+};
+export default meta;
+
+const mockActionLogById: Record<string, typeof mockActionLog> = {
+    log1: mockActionLog,
+    log2: { ...mockVersion2, snapshot: mockVersion2.snapshot },
+    log3: {
+        __typename: "ActionLog",
+        id: "log3",
+        version: 3,
+        snapshot: { title: "My Page (v3)", slug: "my-page", createdAt: "2023-10-03T12:00:00Z" },
+        createdAt: "2023-10-03T12:00:00Z",
+        userId: "Max Mustermann",
+        entityName: "TestEntity",
+    },
+};
+
+type StoryValue =
+    | { type: "grid"; actionLogs: { nodes: GQLActionLogGridFragmentFragment[]; totalCount: number } | undefined; error?: boolean; loading: boolean }
+    | Exclude<ActionLogDialogValue, { type: "grid" }>;
+
+const StoryWrapper = (args: Omit<React.ComponentProps<typeof ActionLogDialog>, "value"> & { initialState: StoryValue }) => {
+    const { initialState, ...rest } = args;
+    const [storyValue, setStoryValue] = useState<StoryValue>(initialState);
+    const dataGridProps = {
+        ...useDataGridRemote({ initialSort: [{ field: "version", sort: "desc" }] }),
+        ...usePersistentColumnState("ActionLogDialogGrid"),
+    };
+    const value: ActionLogDialogValue = storyValue.type === "grid" ? { ...dataGridProps, ...storyValue } : storyValue;
+
+    return (
+        <ActionLogDialog
+            {...rest}
+            value={value}
+            onShowVersionClick={(versionId) =>
+                setStoryValue({ type: "showVersion", actionLog: mockActionLogById[versionId] ?? mockActionLog, loading: false })
+            }
+            onCompareVersionsClick={(versionId, versionId2) =>
+                setStoryValue({
+                    type: "compareVersions",
+                    beforeVersion: mockActionLogById[versionId] ?? mockVersion1,
+                    afterVersion: mockActionLogById[versionId2] ?? mockVersion2,
+                    loading: false,
+                })
+            }
+            onShowVersionHistoryClick={() => setStoryValue({ type: "grid", actionLogs: mockActionLogs, loading: false })}
+        />
+    );
+};
+
+export const Grid: Story = {
+    render: (args) => <StoryWrapper {...args} initialState={{ type: "grid", actionLogs: mockActionLogs, loading: false }} />,
+};
+
+export const GridLoading: Story = {
+    render: (args) => <StoryWrapper {...args} initialState={{ type: "grid", actionLogs: undefined, loading: true }} />,
+};
+
+export const GridError: Story = {
+    render: (args) => <StoryWrapper {...args} initialState={{ type: "grid", actionLogs: undefined, loading: false, error: true }} />,
+};
+
+export const ShowVersion: Story = {
+    render: (args) => <StoryWrapper {...args} initialState={{ type: "showVersion", actionLog: mockActionLog, loading: false }} />,
+};
+
+export const ShowVersionLoading: Story = {
+    render: (args) => <StoryWrapper {...args} initialState={{ type: "showVersion", actionLog: undefined, loading: true }} />,
+};
+
+export const CompareVersions: Story = {
+    render: (args) => (
+        <StoryWrapper
+            {...args}
+            initialState={{
+                type: "compareVersions",
+                beforeVersion: mockVersion1,
+                afterVersion: mockVersion2,
+                loading: false,
+            }}
+        />
+    ),
+};
+
+export const CompareVersionsLoading: Story = {
+    render: (args) => (
+        <StoryWrapper
+            {...args}
+            initialState={{
+                type: "compareVersions",
+                beforeVersion: undefined,
+                afterVersion: undefined,
+                loading: true,
+            }}
+        />
+    ),
+};

--- a/packages/admin/cms-admin/src/actionLog/actionLogDialog/__stories__/ActionLogDialog.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogDialog/__stories__/ActionLogDialog.stories.tsx
@@ -1,116 +1,6 @@
-import { ApolloClient, ApolloLink, ApolloProvider, InMemoryCache, Observable } from "@apollo/client";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { MemoryRouter } from "react-router";
 
 import { ActionLogDialog } from "../ActionLogDialog";
-
-const rootField = "manufacturer";
-const entityId = "550e8400-e29b-41d4-a716-446655440000";
-
-const mockGridNodes = [
-    {
-        __typename: "ActionLog" as const,
-        id: "log3",
-        userId: "Max Mustermann",
-        entityName: "TestEntity",
-        version: 3,
-        createdAt: "2023-10-03T12:00:00Z",
-    },
-    {
-        __typename: "ActionLog" as const,
-        id: "log2",
-        userId: "user2",
-        entityName: "TestEntity",
-        version: 2,
-        createdAt: "2023-10-02T12:00:00Z",
-    },
-    {
-        __typename: "ActionLog" as const,
-        id: "log1",
-        userId: "system-user",
-        entityName: "TestEntity",
-        version: 1,
-        createdAt: "2023-10-01T12:00:00Z",
-    },
-];
-
-const mockVersionById: Record<
-    string,
-    { __typename: "ActionLog"; id: string; version: number; userId: string; entityName: string; snapshot: object; createdAt: string }
-> = {
-    log1: {
-        __typename: "ActionLog",
-        id: "log1",
-        version: 1,
-        userId: "system-user",
-        entityName: "TestEntity",
-        snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
-        createdAt: "2023-10-01T12:00:00Z",
-    },
-    log2: {
-        __typename: "ActionLog",
-        id: "log2",
-        version: 2,
-        userId: "user2",
-        entityName: "TestEntity",
-        snapshot: { title: "My Page (updated)", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
-        createdAt: "2023-10-02T12:00:00Z",
-    },
-    log3: {
-        __typename: "ActionLog",
-        id: "log3",
-        version: 3,
-        userId: "Max Mustermann",
-        entityName: "TestEntity",
-        snapshot: { title: "My Page (v3)", slug: "my-page", createdAt: "2023-10-03T12:00:00Z" },
-        createdAt: "2023-10-03T12:00:00Z",
-    },
-};
-
-const mockLink = new ApolloLink(
-    (operation) =>
-        new Observable((observer) => {
-            const variables = operation.variables;
-            const operationName = operation.operationName;
-            if (operationName === "ActionLogDialogGrid") {
-                observer.next({
-                    data: {
-                        entity: {
-                            __typename: "Manufacturer",
-                            actionLogs: { __typename: "PaginatedActionLogs", nodes: mockGridNodes, totalCount: mockGridNodes.length },
-                        },
-                    },
-                });
-            } else if (operationName === "ActionLogDialogShowVersion") {
-                observer.next({
-                    data: {
-                        entity: {
-                            __typename: "Manufacturer",
-                            actionLog: mockVersionById[variables.versionId as string] ?? null,
-                        },
-                    },
-                });
-            } else if (operationName === "ActionLogDialogCompare") {
-                observer.next({
-                    data: {
-                        entity: {
-                            __typename: "Manufacturer",
-                            beforeVersion: mockVersionById[variables.beforeVersionId as string] ?? null,
-                            afterVersion: mockVersionById[variables.afterVersionId as string] ?? null,
-                        },
-                    },
-                });
-            } else {
-                observer.next({ data: null });
-            }
-            observer.complete();
-        }),
-);
-
-const mockClient = new ApolloClient({
-    link: mockLink,
-    cache: new InMemoryCache(),
-});
 
 type ActionLogDialogStoryArgs = {
     id: string;
@@ -124,20 +14,11 @@ type Story = StoryObj<ActionLogDialogStoryArgs>;
 
 const meta: Meta<ActionLogDialogStoryArgs> = {
     component: ActionLogDialog,
-    decorators: [
-        (Story) => (
-            <ApolloProvider client={mockClient}>
-                <MemoryRouter>
-                    <Story />
-                </MemoryRouter>
-            </ApolloProvider>
-        ),
-    ],
     tags: ["!autodocs"],
     title: "Action log/Action log dialog",
     args: {
-        id: entityId,
-        rootField,
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        rootField: "manufacturer",
         name: "My Page",
         open: true,
         onClose: () => undefined,

--- a/packages/admin/cms-admin/src/actionLog/actionLogDialog/__stories__/ActionLogDialog.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogDialog/__stories__/ActionLogDialog.stories.tsx
@@ -1,176 +1,149 @@
-import { useDataGridRemote, usePersistentColumnState } from "@comet/admin";
+import { ApolloClient, ApolloLink, ApolloProvider, InMemoryCache, Observable } from "@apollo/client";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
 import { MemoryRouter } from "react-router";
 
-import type { GQLActionLogGridFragmentFragment } from "../../actionLogGrid/ActionLogGrid.gql.generated";
-import { ActionLogDialog, type ActionLogDialogValue } from "../ActionLogDialog";
+import { ActionLogDialog } from "../ActionLogDialog";
 
-const mockActionLogs = {
-    totalCount: 3,
-    nodes: [
-        {
-            __typename: "ActionLog" as const,
-            id: "log3",
-            userId: "Max Mustermann",
-            entityName: "TestEntity",
-            version: 3,
-            createdAt: "2023-10-03T12:00:00Z",
-        },
-        { __typename: "ActionLog" as const, id: "log2", userId: "user2", entityName: "TestEntity", version: 2, createdAt: "2023-10-02T12:00:00Z" },
-        {
-            __typename: "ActionLog" as const,
-            id: "log1",
-            userId: "system-user",
-            entityName: "TestEntity",
-            version: 1,
-            createdAt: "2023-10-01T12:00:00Z",
-        },
-    ],
+const rootField = "manufacturer";
+const entityId = "550e8400-e29b-41d4-a716-446655440000";
+
+const mockGridNodes = [
+    {
+        __typename: "ActionLog" as const,
+        id: "log3",
+        userId: "Max Mustermann",
+        entityName: "TestEntity",
+        version: 3,
+        createdAt: "2023-10-03T12:00:00Z",
+    },
+    {
+        __typename: "ActionLog" as const,
+        id: "log2",
+        userId: "user2",
+        entityName: "TestEntity",
+        version: 2,
+        createdAt: "2023-10-02T12:00:00Z",
+    },
+    {
+        __typename: "ActionLog" as const,
+        id: "log1",
+        userId: "system-user",
+        entityName: "TestEntity",
+        version: 1,
+        createdAt: "2023-10-01T12:00:00Z",
+    },
+];
+
+const mockVersionById: Record<
+    string,
+    { __typename: "ActionLog"; id: string; version: number; userId: string; entityName: string; snapshot: object; createdAt: string }
+> = {
+    log1: {
+        __typename: "ActionLog",
+        id: "log1",
+        version: 1,
+        userId: "system-user",
+        entityName: "TestEntity",
+        snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
+        createdAt: "2023-10-01T12:00:00Z",
+    },
+    log2: {
+        __typename: "ActionLog",
+        id: "log2",
+        version: 2,
+        userId: "user2",
+        entityName: "TestEntity",
+        snapshot: { title: "My Page (updated)", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
+        createdAt: "2023-10-02T12:00:00Z",
+    },
+    log3: {
+        __typename: "ActionLog",
+        id: "log3",
+        version: 3,
+        userId: "Max Mustermann",
+        entityName: "TestEntity",
+        snapshot: { title: "My Page (v3)", slug: "my-page", createdAt: "2023-10-03T12:00:00Z" },
+        createdAt: "2023-10-03T12:00:00Z",
+    },
 };
 
-const mockActionLog = {
-    __typename: "ActionLog" as const,
-    id: "log1",
-    version: 1,
-    snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
-    createdAt: "2023-10-01T12:00:00Z",
-    userId: "system-user",
-    entityName: "TestEntity",
+const mockLink = new ApolloLink(
+    (operation) =>
+        new Observable((observer) => {
+            const variables = operation.variables;
+            const operationName = operation.operationName;
+            if (operationName === "ActionLogDialogGrid") {
+                observer.next({
+                    data: {
+                        entity: {
+                            __typename: "Manufacturer",
+                            actionLogs: { __typename: "PaginatedActionLogs", nodes: mockGridNodes, totalCount: mockGridNodes.length },
+                        },
+                    },
+                });
+            } else if (operationName === "ActionLogDialogShowVersion") {
+                observer.next({
+                    data: {
+                        entity: {
+                            __typename: "Manufacturer",
+                            actionLog: mockVersionById[variables.versionId as string] ?? null,
+                        },
+                    },
+                });
+            } else if (operationName === "ActionLogDialogCompare") {
+                observer.next({
+                    data: {
+                        entity: {
+                            __typename: "Manufacturer",
+                            beforeVersion: mockVersionById[variables.beforeVersionId as string] ?? null,
+                            afterVersion: mockVersionById[variables.afterVersionId as string] ?? null,
+                        },
+                    },
+                });
+            } else {
+                observer.next({ data: null });
+            }
+            observer.complete();
+        }),
+);
+
+const mockClient = new ApolloClient({
+    link: mockLink,
+    cache: new InMemoryCache(),
+});
+
+type ActionLogDialogStoryArgs = {
+    id: string;
+    rootField: string;
+    name?: string;
+    open: boolean;
+    onClose: () => void;
 };
 
-const mockVersion1 = {
-    __typename: "ActionLog" as const,
-    id: "log1",
-    version: 1,
-    snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
-    createdAt: "2023-10-01T12:00:00Z",
-    userId: "system-user",
-    entityName: "TestEntity",
-};
+type Story = StoryObj<ActionLogDialogStoryArgs>;
 
-const mockVersion2 = {
-    __typename: "ActionLog" as const,
-    id: "log2",
-    version: 2,
-    snapshot: { title: "My Page (updated)", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
-    createdAt: "2023-10-02T12:00:00Z",
-    userId: "user2",
-    entityName: "TestEntity",
-};
-
-type Story = StoryObj<typeof ActionLogDialog>;
-const meta: Meta<typeof ActionLogDialog> = {
+const meta: Meta<ActionLogDialogStoryArgs> = {
     component: ActionLogDialog,
     decorators: [
         (Story) => (
-            <MemoryRouter>
-                <Story />
-            </MemoryRouter>
+            <ApolloProvider client={mockClient}>
+                <MemoryRouter>
+                    <Story />
+                </MemoryRouter>
+            </ApolloProvider>
         ),
     ],
     tags: ["!autodocs"],
     title: "Action log/Action log dialog",
     args: {
-        id: "550e8400-e29b-41d4-a716-446655440000",
+        id: entityId,
+        rootField,
         name: "My Page",
-        onClose: () => undefined,
         open: true,
+        onClose: () => undefined,
     },
 };
+
 export default meta;
 
-const mockActionLogById: Record<string, typeof mockActionLog> = {
-    log1: mockActionLog,
-    log2: { ...mockVersion2, snapshot: mockVersion2.snapshot },
-    log3: {
-        __typename: "ActionLog",
-        id: "log3",
-        version: 3,
-        snapshot: { title: "My Page (v3)", slug: "my-page", createdAt: "2023-10-03T12:00:00Z" },
-        createdAt: "2023-10-03T12:00:00Z",
-        userId: "Max Mustermann",
-        entityName: "TestEntity",
-    },
-};
-
-type StoryValue =
-    | { type: "grid"; actionLogs: { nodes: GQLActionLogGridFragmentFragment[]; totalCount: number } | undefined; error?: boolean; loading: boolean }
-    | Exclude<ActionLogDialogValue, { type: "grid" }>;
-
-const StoryWrapper = (args: Omit<React.ComponentProps<typeof ActionLogDialog>, "value"> & { initialState: StoryValue }) => {
-    const { initialState, ...rest } = args;
-    const [storyValue, setStoryValue] = useState<StoryValue>(initialState);
-    const dataGridProps = {
-        ...useDataGridRemote({ initialSort: [{ field: "version", sort: "desc" }] }),
-        ...usePersistentColumnState("ActionLogDialogGrid"),
-    };
-    const value: ActionLogDialogValue = storyValue.type === "grid" ? { ...dataGridProps, ...storyValue } : storyValue;
-
-    return (
-        <ActionLogDialog
-            {...rest}
-            value={value}
-            onShowVersionClick={(versionId) =>
-                setStoryValue({ type: "showVersion", actionLog: mockActionLogById[versionId] ?? mockActionLog, loading: false })
-            }
-            onCompareVersionsClick={(versionId, versionId2) =>
-                setStoryValue({
-                    type: "compareVersions",
-                    beforeVersion: mockActionLogById[versionId] ?? mockVersion1,
-                    afterVersion: mockActionLogById[versionId2] ?? mockVersion2,
-                    loading: false,
-                })
-            }
-            onShowVersionHistoryClick={() => setStoryValue({ type: "grid", actionLogs: mockActionLogs, loading: false })}
-        />
-    );
-};
-
-export const Grid: Story = {
-    render: (args) => <StoryWrapper {...args} initialState={{ type: "grid", actionLogs: mockActionLogs, loading: false }} />,
-};
-
-export const GridLoading: Story = {
-    render: (args) => <StoryWrapper {...args} initialState={{ type: "grid", actionLogs: undefined, loading: true }} />,
-};
-
-export const GridError: Story = {
-    render: (args) => <StoryWrapper {...args} initialState={{ type: "grid", actionLogs: undefined, loading: false, error: true }} />,
-};
-
-export const ShowVersion: Story = {
-    render: (args) => <StoryWrapper {...args} initialState={{ type: "showVersion", actionLog: mockActionLog, loading: false }} />,
-};
-
-export const ShowVersionLoading: Story = {
-    render: (args) => <StoryWrapper {...args} initialState={{ type: "showVersion", actionLog: undefined, loading: true }} />,
-};
-
-export const CompareVersions: Story = {
-    render: (args) => (
-        <StoryWrapper
-            {...args}
-            initialState={{
-                type: "compareVersions",
-                beforeVersion: mockVersion1,
-                afterVersion: mockVersion2,
-                loading: false,
-            }}
-        />
-    ),
-};
-
-export const CompareVersionsLoading: Story = {
-    render: (args) => (
-        <StoryWrapper
-            {...args}
-            initialState={{
-                type: "compareVersions",
-                beforeVersion: undefined,
-                afterVersion: undefined,
-                loading: true,
-            }}
-        />
-    ),
-};
+export const Default: Story = {};

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.gql.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const actionLogGridFragment = gql`
-    fragment ActionLogGridFragment on ActionLog {
+    fragment ActionLogGrid on ActionLog {
         id
         userId
         entityName

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.tsx
@@ -7,11 +7,11 @@ import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
 
 import { ActionLogHeader } from "../components/header/ActionLogHeader";
 import { ActionGridToolbar, type ActionGridToolbarProps } from "./actionGridToolbar/ActionGridToolbar";
-import type { GQLActionLogGridFragmentFragment } from "./ActionLogGrid.gql.generated";
+import type { GQLActionLogGridFragment } from "./ActionLogGrid.gql.generated";
 import { Root } from "./ActionLogGrid.sc";
 import { UserCell } from "./userCell/UserCell";
 
-type ActionGridRow = GQLActionLogGridFragmentFragment;
+type ActionGridRow = GQLActionLogGridFragment;
 
 type ActionLogGridProps = ReturnType<typeof useDataGridRemote> &
     ReturnType<typeof usePersistentColumnState> & {

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.gql.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const actionLogShowVersionFragment = gql`
-    fragment ActionLogShowVersionFragment on ActionLog {
+    fragment ActionLogShowVersion on ActionLog {
         id
         version
         snapshot

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.tsx
@@ -8,11 +8,11 @@ import { defaultFilterOutKeys, filterOutKeys } from "../actionLog.utils";
 import { DiffHeader } from "../components/DiffHeader";
 import { DiffViewer } from "../components/diffViewer/DiffViewer";
 import { ActionLogHeader } from "../components/header/ActionLogHeader";
-import type { GQLActionLogShowVersionFragmentFragment } from "./ActionLogShowVersion.gql.generated";
+import type { GQLActionLogShowVersionFragment } from "./ActionLogShowVersion.gql.generated";
 import { DiffViewerContainer, LoadingContainer, Root } from "./ActionLogShowVersion.styles";
 
 type ActionLogShowVersionProps = {
-    actionLog: GQLActionLogShowVersionFragmentFragment | undefined;
+    actionLog: GQLActionLogShowVersionFragment | undefined;
     error?: boolean;
     filterKeys?: string[];
     id: string;

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -1,5 +1,5 @@
 export { ActionLogCompare, actionLogCompareFragment } from "./actionLog/actionLogCompare/ActionLogCompare";
-export { ActionLogDialog, type ActionLogDialogValue } from "./actionLog/actionLogDialog/ActionLogDialog";
+export { ActionLogDialog } from "./actionLog/actionLogDialog/ActionLogDialog";
 export { ActionLogGrid, actionLogGridFragment } from "./actionLog/actionLogGrid/ActionLogGrid";
 export { ActionLogShowVersion, actionLogShowVersionFragment } from "./actionLog/actionLogShowVersion/ActionLogShowVersion";
 export { DiffHeader, type DiffHeaderProps } from "./actionLog/components/DiffHeader";

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -1,4 +1,5 @@
 export { ActionLogCompare, actionLogCompareFragment } from "./actionLog/actionLogCompare/ActionLogCompare";
+export { ActionLogDialog, type ActionLogDialogValue } from "./actionLog/actionLogDialog/ActionLogDialog";
 export { ActionLogGrid, actionLogGridFragment } from "./actionLog/actionLogGrid/ActionLogGrid";
 export { ActionLogShowVersion, actionLogShowVersionFragment } from "./actionLog/actionLogShowVersion/ActionLogShowVersion";
 export { DiffHeader, type DiffHeaderProps } from "./actionLog/components/DiffHeader";


### PR DESCRIPTION
## Description

Adds a new `ActionLogDialog` component that orchestrates `ActionLogGrid`, `ActionLogShowVersion` and `ActionLogCompare` into a single Dialog. The component owns the GraphQL queries, the grid state, and view switching internally — consumers pass only the entity `id` and the `rootField` exposing it.

![Screen Recording 2025-08-18 at 16 43 18](https://github.com/user-attachments/assets/c246d584-1c73-46c6-adce-85eca9d2b48e)

## Usage

```tsx
<ActionLogDialog<GQLQuery> id={entityId} rootField="manufacturer" name={entityName} open={open} onClose={() => setOpen(false)} />
```

The entity referenced by `rootField` must expose `actionLog(id: ID!)` and `actionLogs(offset, limit, sort)` via the `@ActionLogs()` decorator.

`rootField` is type-safe: pass your app's `GQLQuery` as the generic and it is constrained to the keys whose value structurally exposes both `actionLog` and `actionLogs`. Without the generic it falls back to `string`.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-2226
