### PR TITLE
Validate MAILER_PORT correctly with class-transformer

### DIFF
--- a/demo/api/src/config/environment-variables.ts
+++ b/demo/api/src/config/environment-variables.ts
@@ -1,7 +1,7 @@
 import { BlobStorageConfig, IsUndefinable } from "@comet/cms-api";
 import { PrivateSiteConfig } from "@src/site-configs";
 import { Transform, Type } from "class-transformer";
-import { IsArray, IsBoolean, IsEmail, IsInt, IsNumber, IsOptional, IsString, IsUrl, MinLength, ValidateIf } from "class-validator";
+import { IsArray, IsBoolean, IsEmail, IsInt, IsOptional, IsString, IsUrl, MinLength, ValidateIf } from "class-validator";
 
 export class EnvironmentVariables {
     @IsString()
@@ -122,7 +122,8 @@ export class EnvironmentVariables {
     @IsString()
     MAILER_HOST: string;
 
-    @IsNumber()
+    @Type(() => Number)
+    @IsInt()
     MAILER_PORT: number;
 
     @IsUndefinable()


### PR DESCRIPTION
## Problem
The `demo-api` was failing to start with the following error:

```
Error: An instance of EnvironmentVariables has failed the validation:
 - property MAILER_PORT has failed the following constraints: isNumber
```
This issue was introduced in https://github.com/vivid-planet/comet/pull/4333 and caused `MAILER_PORT` validation to fail.

<img width="642" height="126" alt="Screenshot 2025-08-19 at 16 31 47" src="https://github.com/user-attachments/assets/a4add429-3349-452f-884d-a67628f1a35f" />

The issue occurred because environment variables are always loaded as strings, and class-validator was expecting a number for `MAILER_PORT`. 

## Solution:
Added class-transformer’s `@Type(() => Number)` decorator to ensure that `MAILER_PORT` is properly transformed into a number before validation (same like we are doing for `API_PORT` Environment variable:

```
@Type(() => Number)
@IsInt()
MAILER_PORT: number;
```


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2260
