### PR TITLE
Start admin-generator process with cms group

### DIFF
--- a/dev-pm.config.js
+++ b/dev-pm.config.js
@@ -50,7 +50,7 @@ module.exports = {
         {
             name: "admin-generator",
             script: "pnpm --filter @comet/admin-generator run dev",
-            group: ["cms-admin"],
+            group: ["cms-admin", "cms"],
             waitOn: waitOnPackages("@comet/cms-admin"),
         },
 


### PR DESCRIPTION
## Description

This pull request ensures that the admin-generator process is automatically started when running `npm run dev` by including it in the CMS group.


## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| everything got started, besides admin-generator  (also api-generator) | admin-generator gets started as well  |
|  <img width="527" height="502" alt="Screenshot 2025-08-19 at 16 51 15" src="https://github.com/user-attachments/assets/2d7a6853-f9db-49b0-8c0e-3cee0e784cc9" />   |  <img width="533" height="488" alt="Screenshot 2025-08-19 at 16 52 38" src="https://github.com/user-attachments/assets/cfda68f8-0e46-4792-ac30-8eb48aeabf4a" /> |

