### PR TITLE
Admin-Generator Grid: Remove adding props required for copy/paste, because feature does not exist anymore

### DIFF
--- a/.changeset/shy-ants-camp.md
+++ b/.changeset/shy-ants-camp.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin-generator": patch
+---
+
+Fix generating too many props for grid-component
+
+This happened if there was a required root gql-arg for the corresponding create-mutation to support copy/paste.

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/__snapshots__/generateGrid.test.ts.snap
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/__snapshots__/generateGrid.test.ts.snap
@@ -110,9 +110,11 @@ import { Excel as ExcelIcon } from "@comet/admin-icons";
         );
     }
 
-    
+    type Props = {
+            author: string;
+        };
 
-    export function BooksGrid() {
+    export function BooksGrid({author }: Props) {
         const client = useApolloClient();
         const intl = useIntl();
         const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("BooksGrid") };

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/__snapshots__/generateGrid.test.ts.snap
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/__snapshots__/generateGrid.test.ts.snap
@@ -110,11 +110,9 @@ import { Excel as ExcelIcon } from "@comet/admin-icons";
         );
     }
 
-    type Props = {
-            author: string;
-        };
+    
 
-    export function BooksGrid({author }: Props) {
+    export function BooksGrid() {
         const client = useApolloClient();
         const intl = useIntl();
         const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("BooksGrid") };

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/generateGrid.test.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/generateGrid.test.ts
@@ -51,7 +51,7 @@ describe("generateGrid", () => {
             }
 
             type Mutation {
-                createBook(input: BookInput!): Book!
+                createBook(author: ID!, input: BookInput!): Book!
                 updateBook(id: ID!, input: BookInput!): Book!
                 deleteBook(id: ID!): Boolean!
             }

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
@@ -255,7 +255,6 @@ export function generateGrid<T extends { __typename?: string }>(
 
     const gridQueryType = findQueryTypeOrThrow(gridQuery, gqlIntrospection);
 
-    const createMutationType = findMutationType(`create${gqlType}`, gqlIntrospection);
     const updateMutationType = findMutationType(`update${gqlType}`, gqlIntrospection);
 
     const hasDeleteMutation = !!findMutationType(`delete${gqlType}`, gqlIntrospection);
@@ -292,11 +291,7 @@ export function generateGrid<T extends { __typename?: string }>(
 
     const defaultActionsColumnWidth = getDefaultActionsColumnWidth(showCrudContextMenuInActionsColumn, showEditInActionsColumn);
 
-    const {
-        imports: forwardedGqlArgsImports,
-        props: forwardedGqlArgsProps,
-        gqlArgs,
-    } = getForwardedGqlArgs([gridQueryType, ...(createMutationType ? [createMutationType] : [])]);
+    const { imports: forwardedGqlArgsImports, props: forwardedGqlArgsProps, gqlArgs } = getForwardedGqlArgs([gridQueryType]);
     imports.push(...forwardedGqlArgsImports);
     props.push(...forwardedGqlArgsProps);
 


### PR DESCRIPTION
## Description

Generating a grid for a gql-type with create-mutation with required root gql args added props for those args to the generated grid.

This was a leftover of the copy/paste feature, where it was required to provide props for required root gql args needed for the create-mutation. This feature was removed so the props are not required anymore.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
