### PR TITLE
A11y improvements: Correct html tags on eyebrow in HeadingBlock

### DIFF
--- a/demo/site/src/common/blocks/HeadingBlock.tsx
+++ b/demo/site/src/common/blocks/HeadingBlock.tsx
@@ -42,9 +42,7 @@ export const HeadingBlock = withPreview(
             <>
                 {hasRichTextBlockContent(eyebrow) && (
                     <Typography variant="h400" as="p" bottomSpacing>
-                        <strong>
-                            <RichTextBlock data={eyebrow} renderers={eyebrowRenderers} />
-                        </strong>
+                        <RichTextBlock data={eyebrow} renderers={eyebrowRenderers} />
                     </Typography>
                 )}
                 <PreviewSkeleton

--- a/demo/site/src/common/blocks/HeadingBlock.tsx
+++ b/demo/site/src/common/blocks/HeadingBlock.tsx
@@ -41,8 +41,10 @@ export const HeadingBlock = withPreview(
         return (
             <>
                 {hasRichTextBlockContent(eyebrow) && (
-                    <Typography variant="h400" as="h5" bottomSpacing>
-                        <RichTextBlock data={eyebrow} renderers={eyebrowRenderers} />
+                    <Typography variant="h400" as="p" bottomSpacing>
+                        <strong>
+                            <RichTextBlock data={eyebrow} renderers={eyebrowRenderers} />
+                        </strong>
                     </Typography>
                 )}
                 <PreviewSkeleton


### PR DESCRIPTION
## Description

At the moment the `eyebrow` in the `HeadingBlock` is rendered as a `h5`. This breaks the headline order. Therefor, the eyebrow should be rendered as a <strong> tag instead.


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="960" height="320" alt="Screenshot 2025-08-20 at 14 08 46" src="https://github.com/user-attachments/assets/c365eadc-2e01-4e70-91a9-19b4da164ac1" /> | <img width="1416" height="228" alt="Screenshot 2025-08-20 at 14 35 45" src="https://github.com/user-attachments/assets/5f9a8c1e-3aee-41b0-8cbc-e969852790c2" /> |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2242
- PR in Starter: https://github.com/vivid-planet/comet-starter/pull/941
