### PR TITLE
A11y: Style links in RichTextBlock

### DIFF
--- a/demo/site/src/common/blocks/RichTextBlock.tsx
+++ b/demo/site/src/common/blocks/RichTextBlock.tsx
@@ -144,7 +144,8 @@ const InlineLink = styled(LinkBlock)`
 
     &:hover {
         color: ${({ theme }) => theme.palette.primary.dark};
-        text-decoration: none;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
     }
 `;
 

--- a/demo/site/src/common/blocks/RichTextBlock.tsx
+++ b/demo/site/src/common/blocks/RichTextBlock.tsx
@@ -144,7 +144,6 @@ const InlineLink = styled(LinkBlock)`
 
     &:hover {
         color: ${({ theme }) => theme.palette.primary.dark};
-        text-decoration: underline;
         text-decoration-thickness: 2px;
     }
 `;

--- a/demo/site/src/common/blocks/RichTextBlock.tsx
+++ b/demo/site/src/common/blocks/RichTextBlock.tsx
@@ -144,6 +144,7 @@ const InlineLink = styled(LinkBlock)`
 
     &:hover {
         color: ${({ theme }) => theme.palette.primary.dark};
+        text-decoration: none;
     }
 `;
 


### PR DESCRIPTION
## Description

For better visibility, the underline of a Link should be thicker, when hovering on it (in RichTextBlock)

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts



https://github.com/user-attachments/assets/525c912f-57e2-4051-924e-176ac9f749bf




## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2245
-  PR in Starter: https://github.com/vivid-planet/comet-starter/pull/940
