### PR TITLE
 Align FinalFormSelect props with FinalFormAutocomplete

### DIFF
--- a/.changeset/swift-baboons-rescue.md
+++ b/.changeset/swift-baboons-rescue.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": minor
+---
+
+Renamed two props of `FinalFormSelect` to align with `FinalFormAutocomplete`
+
+- `noOptionsLabel` → `noOptionsText`
+- `errorLabel` → `errorText`

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -9,8 +9,8 @@ import { type AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 import { LinearLoadingContainer, MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
 
 export interface FinalFormSelectProps<T> {
-    noOptionsLabel?: ReactNode;
-    errorLabel?: ReactNode;
+    noOptionsText?: ReactNode;
+    errorText?: ReactNode;
     getOptionLabel?: (option: T) => string;
     getOptionValue?: (option: T) => string;
     children?: ReactNode;
@@ -56,12 +56,12 @@ export const FinalFormSelect = <T,>({
         }
     },
 
-    noOptionsLabel = (
+    noOptionsText = (
         <Typography variant="body2">
             <FormattedMessage id="finalFormSelect.noOptions" defaultMessage="No options." />
         </Typography>
     ),
-    errorLabel = (
+    errorText = (
         <Typography variant="body2">
             <FormattedMessage id="finalFormSelect.error" defaultMessage="Error loading options." />
         </Typography>
@@ -158,12 +158,12 @@ export const FinalFormSelect = <T,>({
 
             {showNoOptions && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
-                    {noOptionsLabel}
+                    {noOptionsText}
                 </MenuItemDisabledOverrideOpacity>
             )}
             {showError && (
                 <MenuItemDisabledOverrideOpacity value="" disabled>
-                    {errorLabel}
+                    {errorText}
                 </MenuItemDisabledOverrideOpacity>
             )}
 

--- a/storybook/src/admin/form/AsyncSelectField.stories.tsx
+++ b/storybook/src/admin/form/AsyncSelectField.stories.tsx
@@ -232,9 +232,9 @@ export const NoOptions: Story = {
 };
 
 /**
- * If no options are available, the noOptionsLabel function can be used to customize the label.
+ * If no options are available, the noOptionsText function can be used to customize the label.
  */
-export const NoOptionsWithCustomNoOptionsLabel: Story = {
+export const NoOptionsWithCustomNoOptionsText: Story = {
     render: () => {
         interface FormValues {
             type: string;
@@ -261,7 +261,7 @@ export const NoOptionsWithCustomNoOptionsLabel: Story = {
                                 getOptionLabel={(option) => {
                                     return option;
                                 }}
-                                noOptionsLabel={
+                                noOptionsText={
                                     <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
                                         <Info color="info" />
                                         No options available at this point in time
@@ -331,7 +331,7 @@ export const ErrorLoadingOptions: Story = {
     },
 };
 
-export const ErrorLoadingOptionsWithCustomErrorLabel: Story = {
+export const ErrorLoadingOptionsWithCustomErrorText: Story = {
     render: () => {
         interface FormValues {
             type: string;
@@ -358,7 +358,7 @@ export const ErrorLoadingOptionsWithCustomErrorLabel: Story = {
                                 getOptionLabel={(option) => {
                                     return option;
                                 }}
-                                errorLabel={
+                                errorText={
                                     <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
                                         <WarningSolid color="error" />
                                         Error loading options


### PR DESCRIPTION
depends on naming of the `errorLabel / errorText` prop:

- https://github.com/vivid-planet/comet/pull/4249

## Description

This Pull Request renames two optional props of `FinalFormSelect` to align them with `FinalFormAutocomplete`:
- `noOptionsLabel` → `noOptionsText`
- `errorLabel` → `errorText`

## Breaking Change:
This is technically a breaking change. However, these props were introduced only ~2 months ago in the next branch ([#3862](https://github.com/vivid-planet/comet/pull/3862), [#3863](https://github.com/vivid-planet/comet/pull/3863)) and were just released with Comet 8. (2 weeks ago) Given the short time frame since release, it is unlikely that anyone has adopted the prop names yet.

## Why this change:

- Ensures consistency across FinalForm components.

## Further information:

discussion about align prop names started here: https://github.com/vivid-planet/comet/pull/4249#discussion_r2287215870