### PR TITLE
Admin-Generator Grid: fix wrong query var for export

### DIFF
--- a/.changeset/wet-pandas-open.md
+++ b/.changeset/wet-pandas-open.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-generator": patch
+---
+
+Admin-Generator: Fix using wrong query-var for export

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/__snapshots__/generateGrid.test.ts.snap
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/__tests__/__snapshots__/generateGrid.test.ts.snap
@@ -385,7 +385,7 @@ renderCell: (params) => {
         variables: {
             authorId, ...muiGridFilterToGql(columns, dataGridProps.filterModel)
         },
-        query: booksByAuthorQuery,
+        query: booksQuery,
         resolveQueryNodes: (data) => data.booksByAuthor.nodes,
         totalCount: data?.booksByAuthor.totalCount ?? 0,
         exportOptions: {

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
@@ -908,7 +908,7 @@ export function generateGrid<T extends { __typename?: string }>(
             !allowRowReordering ? `data?.${gridQuery}.nodes` : generateRowReorderingRows(gridQuery, fieldList, config.rowReordering?.dragPreviewField)
         } ?? [];
 
-        ${generateGridExportApi(config.excelExport, gqlTypePlural, gridQuery, gqlArgs)}
+        ${generateGridExportApi(config.excelExport, gqlTypePlural, instanceGqlTypePlural, gridQuery, gqlArgs)}
 
         return (
             <DataGridPro
@@ -985,7 +985,13 @@ const getDataGridSlotProps = (componentName: string, forwardToolbarAction: boole
     }}`;
 };
 
-const generateGridExportApi = (excelExport: boolean | undefined, gqlTypePlural: string, gridQuery: string, gqlArgs: GqlArg[]) => {
+const generateGridExportApi = (
+    excelExport: boolean | undefined,
+    gqlTypePlural: string,
+    instanceGqlTypePlural: string,
+    gridQuery: string,
+    gqlArgs: GqlArg[],
+) => {
     if (!excelExport) {
         return "";
     }
@@ -998,7 +1004,7 @@ const generateGridExportApi = (excelExport: boolean | undefined, gqlTypePlural: 
                 `...muiGridFilterToGql(columns, dataGridProps.filterModel)`,
             ].join(", ")}
         },
-        query: ${gridQuery}Query,
+        query: ${instanceGqlTypePlural}Query,
         resolveQueryNodes: (data) => data.${gridQuery}.nodes,
         totalCount: data?.${gridQuery}.totalCount ?? 0,
         exportOptions: {


### PR DESCRIPTION
## Description

If a custom query is set in grid-config `useDataGridExcelExport` was generated with the query-name and not with the query variable name. e.g. `const queryVar = gql'query MyQuery(...) { queryName {...} }';` generated 

```
const exportApi = useDataGridExcelExport<...>({
    ...
    query: queryName,
    ...
});
```

where it should have been `queryVar`

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
