### PR TITLE
A11y: Improve AccordionItemBlock by adding htmlTag to title

### DIFF
--- a/demo/admin/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/admin/src/common/blocks/AccordionItemBlock.tsx
@@ -12,9 +12,9 @@ import { type AccordionItemBlockData } from "@src/blocks.generated";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import { SpaceBlock } from "@src/common/blocks/SpaceBlock";
 import { StandaloneCallToActionListBlock } from "@src/common/blocks/StandaloneCallToActionListBlock";
-import { StandaloneHeadingBlock } from "@src/common/blocks/StandaloneHeadingBlock";
 import { FormattedMessage } from "react-intl";
 
+import { StandaloneHeadingBlock } from "./StandaloneHeadingBlock";
 import { TextImageBlock } from "./TextImageBlock";
 
 const AccordionContentBlock = createBlocksBlock({
@@ -41,15 +41,15 @@ export const AccordionItemBlock = createCompositeBlock(
             },
             htmlTag: {
                 block: createCompositeBlockSelectField<AccordionItemBlockData["htmlTag"]>({
-                    label: <FormattedMessage id="headingBlock.htmlTag" defaultMessage="HTML tag" />,
+                    label: <FormattedMessage id="accordionItem.htmlTag" defaultMessage="HTML tag" />,
                     defaultValue: "h3",
                     options: [
-                        { value: "h1", label: <FormattedMessage id="headingBlock.headline1" defaultMessage="Headline 1" /> },
-                        { value: "h2", label: <FormattedMessage id="headingBlock.headline2" defaultMessage="Headline 2" /> },
-                        { value: "h3", label: <FormattedMessage id="headingBlock.headline3" defaultMessage="Headline 3" /> },
-                        { value: "h4", label: <FormattedMessage id="headingBlock.headline4" defaultMessage="Headline 4" /> },
-                        { value: "h5", label: <FormattedMessage id="headingBlock.headline5" defaultMessage="Headline 5" /> },
-                        { value: "h6", label: <FormattedMessage id="headingBlock.headline6" defaultMessage="Headline 6" /> },
+                        { value: "h1", label: <FormattedMessage id="accordionItem.headline1" defaultMessage="Headline 1" /> },
+                        { value: "h2", label: <FormattedMessage id="accordionItem.headline2" defaultMessage="Headline 2" /> },
+                        { value: "h3", label: <FormattedMessage id="accordionItem.headline3" defaultMessage="Headline 3" /> },
+                        { value: "h4", label: <FormattedMessage id="accordionItem.headline4" defaultMessage="Headline 4" /> },
+                        { value: "h5", label: <FormattedMessage id="accordionItem.headline5" defaultMessage="Headline 5" /> },
+                        { value: "h6", label: <FormattedMessage id="accordionItem.headline6" defaultMessage="Headline 6" /> },
                     ],
                     required: true,
                 }),

--- a/demo/admin/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/admin/src/common/blocks/AccordionItemBlock.tsx
@@ -5,6 +5,7 @@ import {
     createBlocksBlock,
     createCompositeBlock,
     createCompositeBlockField,
+    createCompositeBlockSelectField,
     createCompositeBlockTextField,
 } from "@comet/cms-admin";
 import { type AccordionItemBlockData } from "@src/blocks.generated";
@@ -37,6 +38,21 @@ export const AccordionItemBlock = createCompositeBlock(
                     label: <FormattedMessage id="accordionBlock.accordionItem.title" defaultMessage="Title" />,
                 }),
                 hiddenInSubroute: true,
+            },
+            htmlTag: {
+                block: createCompositeBlockSelectField<AccordionItemBlockData["htmlTag"]>({
+                    label: <FormattedMessage id="headingBlock.htmlTag" defaultMessage="HTML tag" />,
+                    defaultValue: "h3",
+                    options: [
+                        { value: "h1", label: <FormattedMessage id="headingBlock.headline1" defaultMessage="Headline 1" /> },
+                        { value: "h2", label: <FormattedMessage id="headingBlock.headline2" defaultMessage="Headline 2" /> },
+                        { value: "h3", label: <FormattedMessage id="headingBlock.headline3" defaultMessage="Headline 3" /> },
+                        { value: "h4", label: <FormattedMessage id="headingBlock.headline4" defaultMessage="Headline 4" /> },
+                        { value: "h5", label: <FormattedMessage id="headingBlock.headline5" defaultMessage="Headline 5" /> },
+                        { value: "h6", label: <FormattedMessage id="headingBlock.headline6" defaultMessage="Headline 6" /> },
+                    ],
+                    required: true,
+                }),
             },
             content: {
                 block: AccordionContentBlock,

--- a/demo/admin/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/admin/src/common/blocks/AccordionItemBlock.tsx
@@ -43,9 +43,9 @@ export const AccordionItemBlock = createCompositeBlock(
                 block: createCompositeBlockSelectField<AccordionItemBlockData["titleHtmlTag"]>({
                     label: <FormattedMessage id="accordionItem.titleHtmlTag" defaultMessage="Title HTML tag" />,
                     defaultValue: "h3",
-                    options: ([1, 2, 3, 4, 5, 6] as const).map((number) => ({
-                        value: `h${number}`,
-                        label: <FormattedMessage id={`teaserItemBlock.headline${number}`} defaultMessage={`Headline ${number}`} />,
+                    options: ([1, 2, 3, 4, 5, 6] as const).map((level) => ({
+                        value: `h${level}`,
+                        label: <FormattedMessage id="accordionItem.headline" defaultMessage="Headline {level}" values={{ level }} />,
                     })),
                     required: true,
                 }),

--- a/demo/admin/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/admin/src/common/blocks/AccordionItemBlock.tsx
@@ -39,9 +39,9 @@ export const AccordionItemBlock = createCompositeBlock(
                 }),
                 hiddenInSubroute: true,
             },
-            htmlTag: {
-                block: createCompositeBlockSelectField<AccordionItemBlockData["htmlTag"]>({
-                    label: <FormattedMessage id="accordionItem.htmlTag" defaultMessage="HTML tag" />,
+            titleHtmlTag: {
+                block: createCompositeBlockSelectField<AccordionItemBlockData["titleHtmlTag"]>({
+                    label: <FormattedMessage id="accordionItem.titleHtmlTag" defaultMessage="Title HTML tag" />,
                     defaultValue: "h3",
                     options: [
                         { value: "h1", label: <FormattedMessage id="accordionItem.headline1" defaultMessage="Headline 1" /> },

--- a/demo/admin/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/admin/src/common/blocks/AccordionItemBlock.tsx
@@ -43,14 +43,10 @@ export const AccordionItemBlock = createCompositeBlock(
                 block: createCompositeBlockSelectField<AccordionItemBlockData["titleHtmlTag"]>({
                     label: <FormattedMessage id="accordionItem.titleHtmlTag" defaultMessage="Title HTML tag" />,
                     defaultValue: "h3",
-                    options: [
-                        { value: "h1", label: <FormattedMessage id="accordionItem.headline1" defaultMessage="Headline 1" /> },
-                        { value: "h2", label: <FormattedMessage id="accordionItem.headline2" defaultMessage="Headline 2" /> },
-                        { value: "h3", label: <FormattedMessage id="accordionItem.headline3" defaultMessage="Headline 3" /> },
-                        { value: "h4", label: <FormattedMessage id="accordionItem.headline4" defaultMessage="Headline 4" /> },
-                        { value: "h5", label: <FormattedMessage id="accordionItem.headline5" defaultMessage="Headline 5" /> },
-                        { value: "h6", label: <FormattedMessage id="accordionItem.headline6" defaultMessage="Headline 6" /> },
-                    ],
+                    options: ([1, 2, 3, 4, 5, 6] as const).map((number) => ({
+                        value: `h${number}`,
+                        label: <FormattedMessage id={`teaserItemBlock.headline${number}`} defaultMessage={`Headline ${number}`} />,
+                    })),
                     required: true,
                 }),
             },

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -155,7 +155,7 @@
                 "nullable": false
             },
             {
-                "name": "htmlTag",
+                "name": "titleHtmlTag",
                 "kind": "Enum",
                 "enum": [
                     "h1",
@@ -186,7 +186,7 @@
                 "nullable": false
             },
             {
-                "name": "htmlTag",
+                "name": "titleHtmlTag",
                 "kind": "Enum",
                 "enum": [
                     "h1",

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -153,6 +153,19 @@
                 "name": "openByDefault",
                 "kind": "Boolean",
                 "nullable": false
+            },
+            {
+                "name": "htmlTag",
+                "kind": "Enum",
+                "enum": [
+                    "h1",
+                    "h2",
+                    "h3",
+                    "h4",
+                    "h5",
+                    "h6"
+                ],
+                "nullable": false
             }
         ],
         "inputFields": [
@@ -170,6 +183,19 @@
             {
                 "name": "openByDefault",
                 "kind": "Boolean",
+                "nullable": false
+            },
+            {
+                "name": "htmlTag",
+                "kind": "Enum",
+                "enum": [
+                    "h1",
+                    "h2",
+                    "h3",
+                    "h4",
+                    "h5",
+                    "h6"
+                ],
                 "nullable": false
             }
         ]

--- a/demo/api/src/common/blocks/accordion-item.block.ts
+++ b/demo/api/src/common/blocks/accordion-item.block.ts
@@ -32,7 +32,7 @@ export const AccordionContentBlock = createBlocksBlock(
     "AccordionContent",
 );
 
-export enum AccordionItemTitleTag {
+export enum AccordionItemTitleHtmlTag {
     h1 = "h1",
     h2 = "h2",
     h3 = "h3",
@@ -51,8 +51,8 @@ class AccordionItemBlockData extends BlockData {
     @BlockField()
     openByDefault: boolean;
 
-    @BlockField({ type: "enum", enum: AccordionItemTitleTag })
-    htmlTag: AccordionItemTitleTag;
+    @BlockField({ type: "enum", enum: AccordionItemTitleHtmlTag })
+    titleHtmlTag: AccordionItemTitleHtmlTag;
 }
 
 class AccordionItemBlockInput extends BlockInput {
@@ -68,9 +68,9 @@ class AccordionItemBlockInput extends BlockInput {
     @BlockField()
     openByDefault: boolean;
 
-    @IsEnum(AccordionItemTitleTag)
-    @BlockField({ type: "enum", enum: AccordionItemTitleTag })
-    htmlTag: AccordionItemTitleTag;
+    @IsEnum(AccordionItemTitleHtmlTag)
+    @BlockField({ type: "enum", enum: AccordionItemTitleHtmlTag })
+    titleHtmlTag: AccordionItemTitleHtmlTag;
 
     transformToBlockData(): AccordionItemBlockData {
         return blockInputToData(AccordionItemBlockData, this);

--- a/demo/api/src/common/blocks/accordion-item.block.ts
+++ b/demo/api/src/common/blocks/accordion-item.block.ts
@@ -15,7 +15,7 @@ import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { SpaceBlock } from "@src/common/blocks/space.block";
 import { StandaloneCallToActionListBlock } from "@src/common/blocks/standalone-call-to-action-list.block";
 import { StandaloneHeadingBlock } from "@src/common/blocks/standalone-heading.block";
-import { IsBoolean, IsString } from "class-validator";
+import { IsBoolean, IsEnum, IsString } from "class-validator";
 
 import { TextImageBlock } from "./text-image.block";
 
@@ -32,6 +32,15 @@ export const AccordionContentBlock = createBlocksBlock(
     "AccordionContent",
 );
 
+export enum AccordionItemTitleTag {
+    h1 = "h1",
+    h2 = "h2",
+    h3 = "h3",
+    h4 = "h4",
+    h5 = "h5",
+    h6 = "h6",
+}
+
 class AccordionItemBlockData extends BlockData {
     @BlockField({ nullable: true })
     title?: string;
@@ -41,6 +50,9 @@ class AccordionItemBlockData extends BlockData {
 
     @BlockField()
     openByDefault: boolean;
+
+    @BlockField({ type: "enum", enum: AccordionItemTitleTag })
+    htmlTag: AccordionItemTitleTag;
 }
 
 class AccordionItemBlockInput extends BlockInput {
@@ -55,6 +67,10 @@ class AccordionItemBlockInput extends BlockInput {
     @IsBoolean()
     @BlockField()
     openByDefault: boolean;
+
+    @IsEnum(AccordionItemTitleTag)
+    @BlockField({ type: "enum", enum: AccordionItemTitleTag })
+    htmlTag: AccordionItemTitleTag;
 
     transformToBlockData(): AccordionItemBlockData {
         return blockInputToData(AccordionItemBlockData, this);

--- a/demo/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
@@ -2,7 +2,7 @@ import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
 import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { AccordionBlock } from "@src/common/blocks/accordion.block";
-import { AccordionContentBlock, AccordionItemBlock, AccordionItemTitleTag } from "@src/common/blocks/accordion-item.block";
+import { AccordionContentBlock, AccordionItemBlock, AccordionItemTitleHtmlTag } from "@src/common/blocks/accordion-item.block";
 
 import { BlockFixture } from "../block-fixture";
 import { StandaloneCallToActionListBlockFixtureService } from "../navigation/standalone-call-to-action-list-block-fixture.service";
@@ -54,7 +54,7 @@ export class AccordionBlockFixtureService {
             title: faker.lorem.words({ min: 3, max: 9 }),
             content: await this.generateAccordionContentBlock(),
             openByDefault: faker.datatype.boolean(),
-            htmlTag: faker.helpers.arrayElement(Object.values(AccordionItemTitleTag)),
+            titleHtmlTag: faker.helpers.arrayElement(Object.values(AccordionItemTitleHtmlTag)),
         };
     }
 

--- a/demo/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
@@ -2,7 +2,7 @@ import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
 import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { AccordionBlock } from "@src/common/blocks/accordion.block";
-import { AccordionContentBlock, AccordionItemBlock } from "@src/common/blocks/accordion-item.block";
+import { AccordionContentBlock, AccordionItemBlock, AccordionItemTitleTag } from "@src/common/blocks/accordion-item.block";
 
 import { BlockFixture } from "../block-fixture";
 import { StandaloneCallToActionListBlockFixtureService } from "../navigation/standalone-call-to-action-list-block-fixture.service";
@@ -54,6 +54,7 @@ export class AccordionBlockFixtureService {
             title: faker.lorem.words({ min: 3, max: 9 }),
             content: await this.generateAccordionContentBlock(),
             openByDefault: faker.datatype.boolean(),
+            htmlTag: faker.helpers.arrayElement(Object.values(AccordionItemTitleTag)),
         };
     }
 

--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -32,14 +32,14 @@ type AccordionItemBlockProps = PropsWithData<AccordionItemBlockData> & {
 };
 
 export const AccordionItemBlock = withPreview(
-    ({ data: { title, content, htmlTag }, isExpanded, onChange }: AccordionItemBlockProps) => {
+    ({ data: { title, content, titleHtmlTag }, isExpanded, onChange }: AccordionItemBlockProps) => {
         const headlineId = useId();
         const contentId = useId();
 
         return (
             <>
                 <TitleWrapper id={headlineId} onClick={onChange} aria-expanded={isExpanded} aria-controls={contentId}>
-                    <Typography variant="h350" as={htmlTag}>
+                    <Typography variant="h350" as={titleHtmlTag}>
                         {title}
                     </Typography>
                     <IconWrapper>

--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -32,14 +32,16 @@ type AccordionItemBlockProps = PropsWithData<AccordionItemBlockData> & {
 };
 
 export const AccordionItemBlock = withPreview(
-    ({ data: { title, content }, isExpanded, onChange }: AccordionItemBlockProps) => {
+    ({ data: { title, content, htmlTag }, isExpanded, onChange }: AccordionItemBlockProps) => {
         const headlineId = useId();
         const contentId = useId();
 
         return (
             <>
                 <TitleWrapper id={headlineId} onClick={onChange} aria-expanded={isExpanded} aria-controls={contentId}>
-                    <Typography variant="h350">{title}</Typography>
+                    <Typography variant="h350" as={htmlTag}>
+                        {title}
+                    </Typography>
                     <IconWrapper>
                         <AnimatedChevron href="/assets/icons/chevron-down.svg#root" $isExpanded={isExpanded} />
                     </IconWrapper>


### PR DESCRIPTION
## Description

The title in an AccordionItem is hardcoded as a h6. This is problematic as the headline order might be broken. 

Therefor an additional field `htmlTag` is added to the block, so that it is possible to set the html tag manually. 


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Screenshot Admin:
<img width="1452" height="494" alt="Screenshot 2025-08-22 at 11 26 05" src="https://github.com/user-attachments/assets/2254a97c-445d-4b5b-bfc6-9254e4648c41" />


Screencast Site:

![accordionitem_htmlTag](https://github.com/user-attachments/assets/465966c4-22b7-4e3d-b7f3-862d2affa58d)


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2244
