### PR TITLE
A11y: Improve TeaserItemBlock by adding htmlTag to title

### DIFF
--- a/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -36,7 +36,7 @@ export const TeaserItemBlock = createCompositeBlock(
             },
             titleHtmlTag: {
                 block: createCompositeBlockSelectField<TeaserItemBlockData["titleHtmlTag"]>({
-                    label: <FormattedMessage id="teaserItemBlock.htmlTag" defaultMessage="HTML tag" />,
+                    label: <FormattedMessage id="teaserItemBlock.titleHtmlTag" defaultMessage="Title HTML tag" />,
                     defaultValue: "h3",
                     options: ([1, 2, 3, 4, 5, 6] as const).map((number) => ({
                         value: `h${number}`,

--- a/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -1,4 +1,11 @@
-import { BlockCategory, createCompositeBlock, createCompositeBlockTextField, createRichTextBlock } from "@comet/cms-admin";
+import {
+    BlockCategory,
+    createCompositeBlock,
+    createCompositeBlockSelectField,
+    createCompositeBlockTextField,
+    createRichTextBlock,
+} from "@comet/cms-admin";
+import { type TeaserItemBlockData } from "@src/blocks.generated";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
 import { MediaBlock } from "@src/common/blocks/MediaBlock";
 import { TextLinkBlock } from "@src/common/blocks/TextLinkBlock";
@@ -25,6 +32,21 @@ export const TeaserItemBlock = createCompositeBlock(
             title: {
                 block: createCompositeBlockTextField({
                     label: <FormattedMessage id="teaserItemBlock.title" defaultMessage="Title" />,
+                }),
+            },
+            htmlTag: {
+                block: createCompositeBlockSelectField<TeaserItemBlockData["htmlTag"]>({
+                    label: <FormattedMessage id="teaserItemBlock.htmlTag" defaultMessage="HTML tag" />,
+                    defaultValue: "h3",
+                    options: [
+                        { value: "h1", label: <FormattedMessage id="teaserItemBlock.headline1" defaultMessage="Headline 1" /> },
+                        { value: "h2", label: <FormattedMessage id="teaserItemBlock.headline2" defaultMessage="Headline 2" /> },
+                        { value: "h3", label: <FormattedMessage id="teaserItemBlock.headline3" defaultMessage="Headline 3" /> },
+                        { value: "h4", label: <FormattedMessage id="teaserItemBlock.headline4" defaultMessage="Headline 4" /> },
+                        { value: "h5", label: <FormattedMessage id="teaserItemBlock.headline5" defaultMessage="Headline 5" /> },
+                        { value: "h6", label: <FormattedMessage id="teaserItemBlock.headline6" defaultMessage="Headline 6" /> },
+                    ],
+                    required: true,
                 }),
             },
             description: {

--- a/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -34,17 +34,17 @@ export const TeaserItemBlock = createCompositeBlock(
                     label: <FormattedMessage id="teaserItemBlock.title" defaultMessage="Title" />,
                 }),
             },
-            headlineLevel: {
-                block: createCompositeBlockSelectField<TeaserItemBlockData["headlineLevel"]>({
+            htmlTag: {
+                block: createCompositeBlockSelectField<TeaserItemBlockData["htmlTag"]>({
                     label: <FormattedMessage id="teaserItemBlock.htmlTag" defaultMessage="HTML tag" />,
                     defaultValue: "h3",
                     options: [
-                        { value: "h1", label: <FormattedMessage id="teaserItemBlock.level1" defaultMessage="Level 1" /> },
-                        { value: "h2", label: <FormattedMessage id="teaserItemBlock.level2" defaultMessage="Level 2" /> },
-                        { value: "h3", label: <FormattedMessage id="teaserItemBlock.level3" defaultMessage="Level 3" /> },
-                        { value: "h4", label: <FormattedMessage id="teaserItemBlock.level4" defaultMessage="Level 4" /> },
-                        { value: "h5", label: <FormattedMessage id="teaserItemBlock.level5" defaultMessage="Level 5" /> },
-                        { value: "h6", label: <FormattedMessage id="teaserItemBlock.level6" defaultMessage="Level 6" /> },
+                        { value: "h1", label: <FormattedMessage id="teaserItemBlock.headline1" defaultMessage="Headline 1" /> },
+                        { value: "h2", label: <FormattedMessage id="teaserItemBlock.headline2" defaultMessage="Headline 2" /> },
+                        { value: "h3", label: <FormattedMessage id="teaserItemBlock.headline3" defaultMessage="Headline 3" /> },
+                        { value: "h4", label: <FormattedMessage id="teaserItemBlock.headline4" defaultMessage="Headline 4" /> },
+                        { value: "h5", label: <FormattedMessage id="teaserItemBlock.headline5" defaultMessage="Headline 5" /> },
+                        { value: "h6", label: <FormattedMessage id="teaserItemBlock.headline6" defaultMessage="Headline 6" /> },
                     ],
                     required: true,
                 }),

--- a/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -38,14 +38,10 @@ export const TeaserItemBlock = createCompositeBlock(
                 block: createCompositeBlockSelectField<TeaserItemBlockData["htmlTag"]>({
                     label: <FormattedMessage id="teaserItemBlock.htmlTag" defaultMessage="HTML tag" />,
                     defaultValue: "h3",
-                    options: [
-                        { value: "h1", label: <FormattedMessage id="teaserItemBlock.headline1" defaultMessage="Headline 1" /> },
-                        { value: "h2", label: <FormattedMessage id="teaserItemBlock.headline2" defaultMessage="Headline 2" /> },
-                        { value: "h3", label: <FormattedMessage id="teaserItemBlock.headline3" defaultMessage="Headline 3" /> },
-                        { value: "h4", label: <FormattedMessage id="teaserItemBlock.headline4" defaultMessage="Headline 4" /> },
-                        { value: "h5", label: <FormattedMessage id="teaserItemBlock.headline5" defaultMessage="Headline 5" /> },
-                        { value: "h6", label: <FormattedMessage id="teaserItemBlock.headline6" defaultMessage="Headline 6" /> },
-                    ],
+                    options: ([1, 2, 3, 4, 5, 6] as const).map((number) => ({
+                        value: `h${number}`,
+                        label: <FormattedMessage id={`teaserItemBlock.headline${number}`} defaultMessage={`Headline ${number}`} />,
+                    })),
                     required: true,
                 }),
             },

--- a/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -34,8 +34,8 @@ export const TeaserItemBlock = createCompositeBlock(
                     label: <FormattedMessage id="teaserItemBlock.title" defaultMessage="Title" />,
                 }),
             },
-            htmlTag: {
-                block: createCompositeBlockSelectField<TeaserItemBlockData["htmlTag"]>({
+            titleHtmlTag: {
+                block: createCompositeBlockSelectField<TeaserItemBlockData["titleHtmlTag"]>({
                     label: <FormattedMessage id="teaserItemBlock.htmlTag" defaultMessage="HTML tag" />,
                     defaultValue: "h3",
                     options: ([1, 2, 3, 4, 5, 6] as const).map((number) => ({

--- a/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -38,9 +38,9 @@ export const TeaserItemBlock = createCompositeBlock(
                 block: createCompositeBlockSelectField<TeaserItemBlockData["titleHtmlTag"]>({
                     label: <FormattedMessage id="teaserItemBlock.titleHtmlTag" defaultMessage="Title HTML tag" />,
                     defaultValue: "h3",
-                    options: ([1, 2, 3, 4, 5, 6] as const).map((number) => ({
-                        value: `h${number}`,
-                        label: <FormattedMessage id={`teaserItemBlock.headline${number}`} defaultMessage={`Headline ${number}`} />,
+                    options: ([1, 2, 3, 4, 5, 6] as const).map((level) => ({
+                        value: `h${level}`,
+                        label: <FormattedMessage id="teaserItemBlock.headline" defaultMessage="Headline {level}" values={{ level }} />,
                     })),
                     required: true,
                 }),

--- a/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -34,17 +34,17 @@ export const TeaserItemBlock = createCompositeBlock(
                     label: <FormattedMessage id="teaserItemBlock.title" defaultMessage="Title" />,
                 }),
             },
-            htmlTag: {
-                block: createCompositeBlockSelectField<TeaserItemBlockData["htmlTag"]>({
+            headlineLevel: {
+                block: createCompositeBlockSelectField<TeaserItemBlockData["headlineLevel"]>({
                     label: <FormattedMessage id="teaserItemBlock.htmlTag" defaultMessage="HTML tag" />,
                     defaultValue: "h3",
                     options: [
-                        { value: "h1", label: <FormattedMessage id="teaserItemBlock.headline1" defaultMessage="Headline 1" /> },
-                        { value: "h2", label: <FormattedMessage id="teaserItemBlock.headline2" defaultMessage="Headline 2" /> },
-                        { value: "h3", label: <FormattedMessage id="teaserItemBlock.headline3" defaultMessage="Headline 3" /> },
-                        { value: "h4", label: <FormattedMessage id="teaserItemBlock.headline4" defaultMessage="Headline 4" /> },
-                        { value: "h5", label: <FormattedMessage id="teaserItemBlock.headline5" defaultMessage="Headline 5" /> },
-                        { value: "h6", label: <FormattedMessage id="teaserItemBlock.headline6" defaultMessage="Headline 6" /> },
+                        { value: "h1", label: <FormattedMessage id="teaserItemBlock.level1" defaultMessage="Level 1" /> },
+                        { value: "h2", label: <FormattedMessage id="teaserItemBlock.level2" defaultMessage="Level 2" /> },
+                        { value: "h3", label: <FormattedMessage id="teaserItemBlock.level3" defaultMessage="Level 3" /> },
+                        { value: "h4", label: <FormattedMessage id="teaserItemBlock.level4" defaultMessage="Level 4" /> },
+                        { value: "h5", label: <FormattedMessage id="teaserItemBlock.level5" defaultMessage="Level 5" /> },
+                        { value: "h6", label: <FormattedMessage id="teaserItemBlock.level6" defaultMessage="Level 6" /> },
                     ],
                     required: true,
                 }),

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -3175,7 +3175,7 @@
                 "nullable": false
             },
             {
-                "name": "htmlTag",
+                "name": "titleHtmlTag",
                 "kind": "Enum",
                 "enum": [
                     "h1",
@@ -3213,7 +3213,7 @@
                 "nullable": false
             },
             {
-                "name": "htmlTag",
+                "name": "titleHtmlTag",
                 "kind": "Enum",
                 "enum": [
                     "h1",

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -3175,7 +3175,7 @@
                 "nullable": false
             },
             {
-                "name": "headlineLevel",
+                "name": "htmlTag",
                 "kind": "Enum",
                 "enum": [
                     "h1",
@@ -3213,7 +3213,7 @@
                 "nullable": false
             },
             {
-                "name": "headlineLevel",
+                "name": "htmlTag",
                 "kind": "Enum",
                 "enum": [
                     "h1",

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -3175,7 +3175,7 @@
                 "nullable": false
             },
             {
-                "name": "htmlTag",
+                "name": "headlineLevel",
                 "kind": "Enum",
                 "enum": [
                     "h1",
@@ -3213,7 +3213,7 @@
                 "nullable": false
             },
             {
-                "name": "htmlTag",
+                "name": "headlineLevel",
                 "kind": "Enum",
                 "enum": [
                     "h1",

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -3173,6 +3173,19 @@
                 "kind": "Block",
                 "block": "TextLink",
                 "nullable": false
+            },
+            {
+                "name": "htmlTag",
+                "kind": "Enum",
+                "enum": [
+                    "h1",
+                    "h2",
+                    "h3",
+                    "h4",
+                    "h5",
+                    "h6"
+                ],
+                "nullable": false
             }
         ],
         "inputFields": [
@@ -3197,6 +3210,19 @@
                 "name": "link",
                 "kind": "Block",
                 "block": "TextLink",
+                "nullable": false
+            },
+            {
+                "name": "htmlTag",
+                "kind": "Enum",
+                "enum": [
+                    "h1",
+                    "h2",
+                    "h3",
+                    "h4",
+                    "h5",
+                    "h6"
+                ],
                 "nullable": false
             }
         ]

--- a/demo/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
@@ -2,7 +2,7 @@ import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
 import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { TeaserBlock } from "@src/documents/pages/blocks/teaser.block";
-import { TeaserItemBlock } from "@src/documents/pages/blocks/teaser-item.block";
+import { TeaserItemBlock, TeaserTitleTag } from "@src/documents/pages/blocks/teaser-item.block";
 
 import { MediaBlockFixtureService } from "../media/media-block.fixture.service";
 import { TextLinkBlockFixtureService } from "../navigation/text-link-block-fixture.service";
@@ -22,6 +22,7 @@ export class TeaserBlockFixtureService {
             title: faker.lorem.words({ min: 3, max: 9 }),
             description: await this.richTextBlockFixtureService.generateBlockInput(),
             link: await this.textLinkBlockFixtureService.generateBlockInput(),
+            htmlTag: faker.helpers.arrayElement(Object.values(TeaserTitleTag)),
         };
     }
 

--- a/demo/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
@@ -2,7 +2,7 @@ import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
 import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { TeaserBlock } from "@src/documents/pages/blocks/teaser.block";
-import { TeaserItemBlock, TeaserTitleTag } from "@src/documents/pages/blocks/teaser-item.block";
+import { TeaserItemBlock, TeaserItemTitleHtmlTag } from "@src/documents/pages/blocks/teaser-item.block";
 
 import { MediaBlockFixtureService } from "../media/media-block.fixture.service";
 import { TextLinkBlockFixtureService } from "../navigation/text-link-block-fixture.service";
@@ -22,7 +22,7 @@ export class TeaserBlockFixtureService {
             title: faker.lorem.words({ min: 3, max: 9 }),
             description: await this.richTextBlockFixtureService.generateBlockInput(),
             link: await this.textLinkBlockFixtureService.generateBlockInput(),
-            htmlTag: faker.helpers.arrayElement(Object.values(TeaserTitleTag)),
+            titleHtmlTag: faker.helpers.arrayElement(Object.values(TeaserItemTitleHtmlTag)),
         };
     }
 

--- a/demo/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
@@ -2,7 +2,7 @@ import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
 import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { TeaserBlock } from "@src/documents/pages/blocks/teaser.block";
-import { TeaserItemBlock, TeaserTitleTag } from "@src/documents/pages/blocks/teaser-item.block";
+import { HeadlineLevel, TeaserItemBlock } from "@src/documents/pages/blocks/teaser-item.block";
 
 import { MediaBlockFixtureService } from "../media/media-block.fixture.service";
 import { TextLinkBlockFixtureService } from "../navigation/text-link-block-fixture.service";
@@ -22,7 +22,7 @@ export class TeaserBlockFixtureService {
             title: faker.lorem.words({ min: 3, max: 9 }),
             description: await this.richTextBlockFixtureService.generateBlockInput(),
             link: await this.textLinkBlockFixtureService.generateBlockInput(),
-            htmlTag: faker.helpers.arrayElement(Object.values(TeaserTitleTag)),
+            headlineLevel: faker.helpers.arrayElement(Object.values(HeadlineLevel)),
         };
     }
 

--- a/demo/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
@@ -2,7 +2,7 @@ import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
 import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { TeaserBlock } from "@src/documents/pages/blocks/teaser.block";
-import { HeadlineLevel, TeaserItemBlock } from "@src/documents/pages/blocks/teaser-item.block";
+import { TeaserItemBlock, TeaserTitleTag } from "@src/documents/pages/blocks/teaser-item.block";
 
 import { MediaBlockFixtureService } from "../media/media-block.fixture.service";
 import { TextLinkBlockFixtureService } from "../navigation/text-link-block-fixture.service";
@@ -22,7 +22,7 @@ export class TeaserBlockFixtureService {
             title: faker.lorem.words({ min: 3, max: 9 }),
             description: await this.richTextBlockFixtureService.generateBlockInput(),
             link: await this.textLinkBlockFixtureService.generateBlockInput(),
-            headlineLevel: faker.helpers.arrayElement(Object.values(HeadlineLevel)),
+            htmlTag: faker.helpers.arrayElement(Object.values(TeaserTitleTag)),
         };
     }
 

--- a/demo/api/src/documents/pages/blocks/teaser-item.block.ts
+++ b/demo/api/src/documents/pages/blocks/teaser-item.block.ts
@@ -14,7 +14,7 @@ import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { TextLinkBlock } from "@src/common/blocks/text-link.block";
 import { IsEnum, IsString } from "class-validator";
 
-export enum HeadlineLevel {
+export enum TeaserTitleTag {
     h1 = "h1",
     h2 = "h2",
     h3 = "h3",
@@ -36,8 +36,8 @@ class TeaserItemBlockData extends BlockData {
     @ChildBlock(TextLinkBlock)
     link: BlockDataInterface;
 
-    @BlockField({ type: "enum", enum: HeadlineLevel })
-    headlineLevel: HeadlineLevel;
+    @BlockField({ type: "enum", enum: TeaserTitleTag })
+    htmlTag: TeaserTitleTag;
 }
 
 class TeaserItemBlockInput extends BlockInput {
@@ -54,9 +54,9 @@ class TeaserItemBlockInput extends BlockInput {
     @ChildBlockInput(TextLinkBlock)
     link: ExtractBlockInput<typeof TextLinkBlock>;
 
-    @IsEnum(HeadlineLevel)
-    @BlockField({ type: "enum", enum: HeadlineLevel })
-    headlineLevel: HeadlineLevel;
+    @IsEnum(TeaserTitleTag)
+    @BlockField({ type: "enum", enum: TeaserTitleTag })
+    htmlTag: TeaserTitleTag;
 
     transformToBlockData(): TeaserItemBlockData {
         return blockInputToData(TeaserItemBlockData, this);

--- a/demo/api/src/documents/pages/blocks/teaser-item.block.ts
+++ b/demo/api/src/documents/pages/blocks/teaser-item.block.ts
@@ -12,7 +12,16 @@ import {
 import { MediaBlock } from "@src/common/blocks/media.block";
 import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { TextLinkBlock } from "@src/common/blocks/text-link.block";
-import { IsString } from "class-validator";
+import { IsEnum, IsString } from "class-validator";
+
+export enum TeaserTitleTag {
+    h1 = "h1",
+    h2 = "h2",
+    h3 = "h3",
+    h4 = "h4",
+    h5 = "h5",
+    h6 = "h6",
+}
 
 class TeaserItemBlockData extends BlockData {
     @ChildBlock(MediaBlock)
@@ -26,6 +35,9 @@ class TeaserItemBlockData extends BlockData {
 
     @ChildBlock(TextLinkBlock)
     link: BlockDataInterface;
+
+    @BlockField({ type: "enum", enum: TeaserTitleTag })
+    htmlTag: TeaserTitleTag;
 }
 
 class TeaserItemBlockInput extends BlockInput {
@@ -41,6 +53,10 @@ class TeaserItemBlockInput extends BlockInput {
 
     @ChildBlockInput(TextLinkBlock)
     link: ExtractBlockInput<typeof TextLinkBlock>;
+
+    @IsEnum(TeaserTitleTag)
+    @BlockField({ type: "enum", enum: TeaserTitleTag })
+    htmlTag: TeaserTitleTag;
 
     transformToBlockData(): TeaserItemBlockData {
         return blockInputToData(TeaserItemBlockData, this);

--- a/demo/api/src/documents/pages/blocks/teaser-item.block.ts
+++ b/demo/api/src/documents/pages/blocks/teaser-item.block.ts
@@ -14,7 +14,7 @@ import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { TextLinkBlock } from "@src/common/blocks/text-link.block";
 import { IsEnum, IsString } from "class-validator";
 
-export enum TeaserTitleTag {
+export enum TeaserItemTitleHtmlTag {
     h1 = "h1",
     h2 = "h2",
     h3 = "h3",
@@ -36,8 +36,8 @@ class TeaserItemBlockData extends BlockData {
     @ChildBlock(TextLinkBlock)
     link: BlockDataInterface;
 
-    @BlockField({ type: "enum", enum: TeaserTitleTag })
-    htmlTag: TeaserTitleTag;
+    @BlockField({ type: "enum", enum: TeaserItemTitleHtmlTag })
+    titleHtmlTag: TeaserItemTitleHtmlTag;
 }
 
 class TeaserItemBlockInput extends BlockInput {
@@ -54,9 +54,9 @@ class TeaserItemBlockInput extends BlockInput {
     @ChildBlockInput(TextLinkBlock)
     link: ExtractBlockInput<typeof TextLinkBlock>;
 
-    @IsEnum(TeaserTitleTag)
-    @BlockField({ type: "enum", enum: TeaserTitleTag })
-    htmlTag: TeaserTitleTag;
+    @IsEnum(TeaserItemTitleHtmlTag)
+    @BlockField({ type: "enum", enum: TeaserItemTitleHtmlTag })
+    titleHtmlTag: TeaserItemTitleHtmlTag;
 
     transformToBlockData(): TeaserItemBlockData {
         return blockInputToData(TeaserItemBlockData, this);

--- a/demo/api/src/documents/pages/blocks/teaser-item.block.ts
+++ b/demo/api/src/documents/pages/blocks/teaser-item.block.ts
@@ -14,7 +14,7 @@ import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { TextLinkBlock } from "@src/common/blocks/text-link.block";
 import { IsEnum, IsString } from "class-validator";
 
-export enum TeaserTitleTag {
+export enum HeadlineLevel {
     h1 = "h1",
     h2 = "h2",
     h3 = "h3",
@@ -36,8 +36,8 @@ class TeaserItemBlockData extends BlockData {
     @ChildBlock(TextLinkBlock)
     link: BlockDataInterface;
 
-    @BlockField({ type: "enum", enum: TeaserTitleTag })
-    htmlTag: TeaserTitleTag;
+    @BlockField({ type: "enum", enum: HeadlineLevel })
+    headlineLevel: HeadlineLevel;
 }
 
 class TeaserItemBlockInput extends BlockInput {
@@ -54,9 +54,9 @@ class TeaserItemBlockInput extends BlockInput {
     @ChildBlockInput(TextLinkBlock)
     link: ExtractBlockInput<typeof TextLinkBlock>;
 
-    @IsEnum(TeaserTitleTag)
-    @BlockField({ type: "enum", enum: TeaserTitleTag })
-    htmlTag: TeaserTitleTag;
+    @IsEnum(HeadlineLevel)
+    @BlockField({ type: "enum", enum: HeadlineLevel })
+    headlineLevel: HeadlineLevel;
 
     transformToBlockData(): TeaserItemBlockData {
         return blockInputToData(TeaserItemBlockData, this);

--- a/demo/site/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -13,7 +13,7 @@ const descriptionRenderers: Renderers = {
 };
 
 export const TeaserItemBlock = withPreview(
-    ({ data: { media, title, description, link, htmlTag } }: PropsWithData<TeaserItemBlockData>) => (
+    ({ data: { media, title, description, link, headlineLevel } }: PropsWithData<TeaserItemBlockData>) => (
         <Link data={link.link}>
             <MediaMobile>
                 <MediaBlock data={media} aspectRatio="1x1" sizes="20vw" />
@@ -22,7 +22,7 @@ export const TeaserItemBlock = withPreview(
                 <MediaBlock data={media} aspectRatio="16x9" sizes="20vw" />
             </MediaDesktop>
             <ContentContainer>
-                <TitleTypography variant="h350" as={htmlTag}>
+                <TitleTypography variant="h350" as={headlineLevel}>
                     {title}
                 </TitleTypography>
                 <Typography variant="p200">

--- a/demo/site/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -13,7 +13,7 @@ const descriptionRenderers: Renderers = {
 };
 
 export const TeaserItemBlock = withPreview(
-    ({ data: { media, title, description, link, headlineLevel } }: PropsWithData<TeaserItemBlockData>) => (
+    ({ data: { media, title, description, link, htmlTag } }: PropsWithData<TeaserItemBlockData>) => (
         <Link data={link.link}>
             <MediaMobile>
                 <MediaBlock data={media} aspectRatio="1x1" sizes="20vw" />
@@ -22,7 +22,7 @@ export const TeaserItemBlock = withPreview(
                 <MediaBlock data={media} aspectRatio="16x9" sizes="20vw" />
             </MediaDesktop>
             <ContentContainer>
-                <TitleTypography variant="h350" as={headlineLevel}>
+                <TitleTypography variant="h350" as={htmlTag}>
                     {title}
                 </TitleTypography>
                 <Typography variant="p200">

--- a/demo/site/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -13,7 +13,7 @@ const descriptionRenderers: Renderers = {
 };
 
 export const TeaserItemBlock = withPreview(
-    ({ data: { media, title, description, link, htmlTag } }: PropsWithData<TeaserItemBlockData>) => (
+    ({ data: { media, title, description, link, titleHtmlTag } }: PropsWithData<TeaserItemBlockData>) => (
         <Link data={link.link}>
             <MediaMobile>
                 <MediaBlock data={media} aspectRatio="1x1" sizes="20vw" />
@@ -22,7 +22,7 @@ export const TeaserItemBlock = withPreview(
                 <MediaBlock data={media} aspectRatio="16x9" sizes="20vw" />
             </MediaDesktop>
             <ContentContainer>
-                <TitleTypography variant="h350" as={htmlTag}>
+                <TitleTypography variant="h350" as={titleHtmlTag}>
                     {title}
                 </TitleTypography>
                 <Typography variant="p200">

--- a/demo/site/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -13,7 +13,7 @@ const descriptionRenderers: Renderers = {
 };
 
 export const TeaserItemBlock = withPreview(
-    ({ data: { media, title, description, link } }: PropsWithData<TeaserItemBlockData>) => (
+    ({ data: { media, title, description, link, htmlTag } }: PropsWithData<TeaserItemBlockData>) => (
         <Link data={link.link}>
             <MediaMobile>
                 <MediaBlock data={media} aspectRatio="1x1" sizes="20vw" />
@@ -22,7 +22,9 @@ export const TeaserItemBlock = withPreview(
                 <MediaBlock data={media} aspectRatio="16x9" sizes="20vw" />
             </MediaDesktop>
             <ContentContainer>
-                <TitleTypography variant="h350">{title}</TitleTypography>
+                <TitleTypography variant="h350" as={htmlTag}>
+                    {title}
+                </TitleTypography>
                 <Typography variant="p200">
                     <RichTextBlock data={description} renderers={descriptionRenderers} />
                 </Typography>


### PR DESCRIPTION
## Description

The title in an TeaserItemBlock is hardcoded as a h6. This is problematic as the headline order might be broken.

Therefor an additional field htmlTag is added to the block, so that it is possible to set the html tag manually.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Admin:
<img width="1451" height="799" alt="Screenshot 2025-08-22 at 12 03 30" src="https://github.com/user-attachments/assets/bc6e9289-e4fb-43c8-8b19-a96501aa9dc5" />


Site:
![teaseritemblock_htmltag](https://github.com/user-attachments/assets/74bab73a-8eea-40a2-b1fe-ead216f67e7d)


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2243
