### PR TITLE
Create a placeholder docs-page for all non-deprecated/non-legacy admin-components

### DIFF
--- a/storybook/src/admin-component-docs/Alert.stories.tsx
+++ b/storybook/src/admin-component-docs/Alert.stories.tsx
@@ -1,0 +1,26 @@
+import { Alert } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof Alert>;
+
+const meta: Meta<typeof Alert> = {
+    component: Alert,
+    title: "Component Docs/Alert",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/AppHeader.stories.tsx
+++ b/storybook/src/admin-component-docs/AppHeader.stories.tsx
@@ -1,0 +1,26 @@
+import { AppHeader } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof AppHeader>;
+
+const meta: Meta<typeof AppHeader> = {
+    component: AppHeader,
+    title: "Component Docs/AppHeader",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/AppHeaderButton.stories.tsx
+++ b/storybook/src/admin-component-docs/AppHeaderButton.stories.tsx
@@ -1,0 +1,26 @@
+import { AppHeaderButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof AppHeaderButton>;
+
+const meta: Meta<typeof AppHeaderButton> = {
+    component: AppHeaderButton,
+    title: "Component Docs/AppHeaderButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/AppHeaderDropdown.stories.tsx
+++ b/storybook/src/admin-component-docs/AppHeaderDropdown.stories.tsx
@@ -1,0 +1,26 @@
+import { AppHeaderDropdown } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof AppHeaderDropdown>;
+
+const meta: Meta<typeof AppHeaderDropdown> = {
+    component: AppHeaderDropdown,
+    title: "Component Docs/AppHeaderDropdown",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/AppHeaderMenuButton.stories.tsx
+++ b/storybook/src/admin-component-docs/AppHeaderMenuButton.stories.tsx
@@ -1,0 +1,26 @@
+import { AppHeaderMenuButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof AppHeaderMenuButton>;
+
+const meta: Meta<typeof AppHeaderMenuButton> = {
+    component: AppHeaderMenuButton,
+    title: "Component Docs/AppHeaderMenuButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/CancelButton.stories.tsx
+++ b/storybook/src/admin-component-docs/CancelButton.stories.tsx
@@ -1,0 +1,26 @@
+import { CancelButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof CancelButton>;
+
+const meta: Meta<typeof CancelButton> = {
+    component: CancelButton,
+    title: "Component Docs/CancelButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/ClearInputAdornment.stories.tsx
+++ b/storybook/src/admin-component-docs/ClearInputAdornment.stories.tsx
@@ -1,0 +1,26 @@
+import { ClearInputAdornment } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof ClearInputAdornment>;
+
+const meta: Meta<typeof ClearInputAdornment> = {
+    component: ClearInputAdornment,
+    title: "Component Docs/ClearInputAdornment",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/ClearInputButton.stories.tsx
+++ b/storybook/src/admin-component-docs/ClearInputButton.stories.tsx
@@ -1,0 +1,26 @@
+import { ClearInputButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof ClearInputButton>;
+
+const meta: Meta<typeof ClearInputButton> = {
+    component: ClearInputButton,
+    title: "Component Docs/ClearInputButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/ContentOverflow.stories.tsx
+++ b/storybook/src/admin-component-docs/ContentOverflow.stories.tsx
@@ -1,0 +1,26 @@
+import { ContentOverflow } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof ContentOverflow>;
+
+const meta: Meta<typeof ContentOverflow> = {
+    component: ContentOverflow,
+    title: "Component Docs/ContentOverflow",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/CopyToClipboardButton.stories.tsx
+++ b/storybook/src/admin-component-docs/CopyToClipboardButton.stories.tsx
@@ -1,0 +1,26 @@
+import { CopyToClipboardButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof CopyToClipboardButton>;
+
+const meta: Meta<typeof CopyToClipboardButton> = {
+    component: CopyToClipboardButton,
+    title: "Component Docs/CopyToClipboardButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/CrudContextMenu.stories.tsx
+++ b/storybook/src/admin-component-docs/CrudContextMenu.stories.tsx
@@ -1,0 +1,26 @@
+import { CrudContextMenu } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof CrudContextMenu>;
+
+const meta: Meta<typeof CrudContextMenu> = {
+    component: CrudContextMenu,
+    title: "Component Docs/CrudContextMenu",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DataGridColumnsManagement.stories.tsx
+++ b/storybook/src/admin-component-docs/DataGridColumnsManagement.stories.tsx
@@ -1,0 +1,26 @@
+import { DataGridColumnsManagement } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DataGridColumnsManagement>;
+
+const meta: Meta<typeof DataGridColumnsManagement> = {
+    component: DataGridColumnsManagement,
+    title: "Component Docs/DataGridColumnsManagement",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DataGridColumnsManagementListItem.stories.tsx
+++ b/storybook/src/admin-component-docs/DataGridColumnsManagementListItem.stories.tsx
@@ -1,0 +1,26 @@
+import { DataGridColumnsManagementListItem } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DataGridColumnsManagementListItem>;
+
+const meta: Meta<typeof DataGridColumnsManagementListItem> = {
+    component: DataGridColumnsManagementListItem,
+    title: "Component Docs/DataGridColumnsManagementListItem",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DataGridPagination.stories.tsx
+++ b/storybook/src/admin-component-docs/DataGridPagination.stories.tsx
@@ -1,0 +1,26 @@
+import { DataGridPagination } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DataGridPagination>;
+
+const meta: Meta<typeof DataGridPagination> = {
+    component: DataGridPagination,
+    title: "Component Docs/DataGridPagination",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DataGridPaginationActions.stories.tsx
+++ b/storybook/src/admin-component-docs/DataGridPaginationActions.stories.tsx
@@ -1,0 +1,26 @@
+import { DataGridPaginationActions } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DataGridPaginationActions>;
+
+const meta: Meta<typeof DataGridPaginationActions> = {
+    component: DataGridPaginationActions,
+    title: "Component Docs/DataGridPaginationActions",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DataGridPanel.stories.tsx
+++ b/storybook/src/admin-component-docs/DataGridPanel.stories.tsx
@@ -1,0 +1,26 @@
+import { DataGridPanel } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DataGridPanel>;
+
+const meta: Meta<typeof DataGridPanel> = {
+    component: DataGridPanel,
+    title: "Component Docs/DataGridPanel",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DataGridToolbar.stories.tsx
+++ b/storybook/src/admin-component-docs/DataGridToolbar.stories.tsx
@@ -1,0 +1,26 @@
+import { DataGridToolbar } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DataGridToolbar>;
+
+const meta: Meta<typeof DataGridToolbar> = {
+    component: DataGridToolbar,
+    title: "Component Docs/DataGridToolbar",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DatePicker.stories.tsx
+++ b/storybook/src/admin-component-docs/DatePicker.stories.tsx
@@ -1,0 +1,26 @@
+import { DatePicker } from "@comet/admin-date-time";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DatePicker>;
+
+const meta: Meta<typeof DatePicker> = {
+    component: DatePicker,
+    title: "Component Docs/DatePicker",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DateRangePicker.stories.tsx
+++ b/storybook/src/admin-component-docs/DateRangePicker.stories.tsx
@@ -1,0 +1,26 @@
+import { DateRangePicker } from "@comet/admin-date-time";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DateRangePicker>;
+
+const meta: Meta<typeof DateRangePicker> = {
+    component: DateRangePicker,
+    title: "Component Docs/DateRangePicker",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DateTimePicker.stories.tsx
+++ b/storybook/src/admin-component-docs/DateTimePicker.stories.tsx
@@ -1,0 +1,26 @@
+import { DateTimePicker } from "@comet/admin-date-time";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DateTimePicker>;
+
+const meta: Meta<typeof DateTimePicker> = {
+    component: DateTimePicker,
+    title: "Component Docs/DateTimePicker",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DeleteButton.stories.tsx
+++ b/storybook/src/admin-component-docs/DeleteButton.stories.tsx
@@ -1,0 +1,26 @@
+import { DeleteButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DeleteButton>;
+
+const meta: Meta<typeof DeleteButton> = {
+    component: DeleteButton,
+    title: "Component Docs/DeleteButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/Dialog.stories.tsx
+++ b/storybook/src/admin-component-docs/Dialog.stories.tsx
@@ -1,0 +1,26 @@
+import { Dialog } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof Dialog>;
+
+const meta: Meta<typeof Dialog> = {
+    component: Dialog,
+    title: "Component Docs/Dialog",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/ErrorBoundary.stories.tsx
+++ b/storybook/src/admin-component-docs/ErrorBoundary.stories.tsx
@@ -1,0 +1,26 @@
+import { ErrorBoundary } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof ErrorBoundary>;
+
+const meta: Meta<typeof ErrorBoundary> = {
+    component: ErrorBoundary,
+    title: "Component Docs/ErrorBoundary",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/FeedbackButton.stories.tsx
+++ b/storybook/src/admin-component-docs/FeedbackButton.stories.tsx
@@ -1,0 +1,26 @@
+import { FeedbackButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof FeedbackButton>;
+
+const meta: Meta<typeof FeedbackButton> = {
+    component: FeedbackButton,
+    title: "Component Docs/FeedbackButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/FileDropzone.stories.tsx
+++ b/storybook/src/admin-component-docs/FileDropzone.stories.tsx
@@ -1,0 +1,26 @@
+import { FileDropzone } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof FileDropzone>;
+
+const meta: Meta<typeof FileDropzone> = {
+    component: FileDropzone,
+    title: "Component Docs/FileDropzone",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/FileSelect.stories.tsx
+++ b/storybook/src/admin-component-docs/FileSelect.stories.tsx
@@ -1,0 +1,26 @@
+import { FileSelect } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof FileSelect>;
+
+const meta: Meta<typeof FileSelect> = {
+    component: FileSelect,
+    title: "Component Docs/FileSelect",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/FileSelectListItem.stories.tsx
+++ b/storybook/src/admin-component-docs/FileSelectListItem.stories.tsx
@@ -1,0 +1,26 @@
+import { FileSelectListItem } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof FileSelectListItem>;
+
+const meta: Meta<typeof FileSelectListItem> = {
+    component: FileSelectListItem,
+    title: "Component Docs/FileSelectListItem",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/FillSpace.stories.tsx
+++ b/storybook/src/admin-component-docs/FillSpace.stories.tsx
@@ -1,0 +1,26 @@
+import { FillSpace } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof FillSpace>;
+
+const meta: Meta<typeof FillSpace> = {
+    component: FillSpace,
+    title: "Component Docs/FillSpace",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/FinalFormRangeInput.stories.tsx
+++ b/storybook/src/admin-component-docs/FinalFormRangeInput.stories.tsx
@@ -1,0 +1,26 @@
+import { FinalFormRangeInput } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof FinalFormRangeInput>;
+
+const meta: Meta<typeof FinalFormRangeInput> = {
+    component: FinalFormRangeInput,
+    title: "Component Docs/FinalFormRangeInput",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/FormSection.stories.tsx
+++ b/storybook/src/admin-component-docs/FormSection.stories.tsx
@@ -1,0 +1,26 @@
+import { FormSection } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof FormSection>;
+
+const meta: Meta<typeof FormSection> = {
+    component: FormSection,
+    title: "Component Docs/FormSection",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/FullHeightContent.stories.tsx
+++ b/storybook/src/admin-component-docs/FullHeightContent.stories.tsx
@@ -1,0 +1,26 @@
+import { FullHeightContent } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof FullHeightContent>;
+
+const meta: Meta<typeof FullHeightContent> = {
+    component: FullHeightContent,
+    title: "Component Docs/FullHeightContent",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/GridCellContent.stories.tsx
+++ b/storybook/src/admin-component-docs/GridCellContent.stories.tsx
@@ -1,0 +1,26 @@
+import { GridCellContent } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof GridCellContent>;
+
+const meta: Meta<typeof GridCellContent> = {
+    component: GridCellContent,
+    title: "Component Docs/GridCellContent",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/HoverActions.stories.tsx
+++ b/storybook/src/admin-component-docs/HoverActions.stories.tsx
@@ -1,0 +1,26 @@
+import { HoverActions } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof HoverActions>;
+
+const meta: Meta<typeof HoverActions> = {
+    component: HoverActions,
+    title: "Component Docs/HoverActions",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/InputWithPopper.stories.tsx
+++ b/storybook/src/admin-component-docs/InputWithPopper.stories.tsx
@@ -1,0 +1,26 @@
+import { InputWithPopper } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof InputWithPopper>;
+
+const meta: Meta<typeof InputWithPopper> = {
+    component: InputWithPopper,
+    title: "Component Docs/InputWithPopper",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/MainContent.stories.tsx
+++ b/storybook/src/admin-component-docs/MainContent.stories.tsx
@@ -1,0 +1,26 @@
+import { MainContent } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof MainContent>;
+
+const meta: Meta<typeof MainContent> = {
+    component: MainContent,
+    title: "Component Docs/MainContent",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/MainNavigation.stories.tsx
+++ b/storybook/src/admin-component-docs/MainNavigation.stories.tsx
@@ -1,0 +1,26 @@
+import { MainNavigation } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof MainNavigation>;
+
+const meta: Meta<typeof MainNavigation> = {
+    component: MainNavigation,
+    title: "Component Docs/MainNavigation",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/MainNavigationCollapsibleItem.stories.tsx
+++ b/storybook/src/admin-component-docs/MainNavigationCollapsibleItem.stories.tsx
@@ -1,0 +1,26 @@
+import { MainNavigationCollapsibleItem } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof MainNavigationCollapsibleItem>;
+
+const meta: Meta<typeof MainNavigationCollapsibleItem> = {
+    component: MainNavigationCollapsibleItem,
+    title: "Component Docs/MainNavigationCollapsibleItem",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/MainNavigationItem.stories.tsx
+++ b/storybook/src/admin-component-docs/MainNavigationItem.stories.tsx
@@ -1,0 +1,26 @@
+import { MainNavigationItem } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof MainNavigationItem>;
+
+const meta: Meta<typeof MainNavigationItem> = {
+    component: MainNavigationItem,
+    title: "Component Docs/MainNavigationItem",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/MainNavigationItemGroup.stories.tsx
+++ b/storybook/src/admin-component-docs/MainNavigationItemGroup.stories.tsx
@@ -1,0 +1,26 @@
+import { MainNavigationItemGroup } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof MainNavigationItemGroup>;
+
+const meta: Meta<typeof MainNavigationItemGroup> = {
+    component: MainNavigationItemGroup,
+    title: "Component Docs/MainNavigationItemGroup",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/MasterLayout.stories.tsx
+++ b/storybook/src/admin-component-docs/MasterLayout.stories.tsx
@@ -1,0 +1,26 @@
+import { MasterLayout } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof MasterLayout>;
+
+const meta: Meta<typeof MasterLayout> = {
+    component: MasterLayout,
+    title: "Component Docs/MasterLayout",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/OkayButton.stories.tsx
+++ b/storybook/src/admin-component-docs/OkayButton.stories.tsx
@@ -1,0 +1,26 @@
+import { OkayButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof OkayButton>;
+
+const meta: Meta<typeof OkayButton> = {
+    component: OkayButton,
+    title: "Component Docs/OkayButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/RouterConfirmationDialog.stories.tsx
+++ b/storybook/src/admin-component-docs/RouterConfirmationDialog.stories.tsx
@@ -1,0 +1,26 @@
+import { RouterConfirmationDialog } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof RouterConfirmationDialog>;
+
+const meta: Meta<typeof RouterConfirmationDialog> = {
+    component: RouterConfirmationDialog,
+    title: "Component Docs/RouterConfirmationDialog",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/RouterTabs.stories.tsx
+++ b/storybook/src/admin-component-docs/RouterTabs.stories.tsx
@@ -1,0 +1,26 @@
+import { RouterTabs } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof RouterTabs>;
+
+const meta: Meta<typeof RouterTabs> = {
+    component: RouterTabs,
+    title: "Component Docs/RouterTabs",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/Rte.stories.tsx
+++ b/storybook/src/admin-component-docs/Rte.stories.tsx
@@ -1,0 +1,26 @@
+import { Rte } from "@comet/admin-rte";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof Rte>;
+
+const meta: Meta<typeof Rte> = {
+    component: Rte,
+    title: "Component Docs/Rte",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/SaveButton.stories.tsx
+++ b/storybook/src/admin-component-docs/SaveButton.stories.tsx
@@ -1,0 +1,26 @@
+import { SaveButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof SaveButton>;
+
+const meta: Meta<typeof SaveButton> = {
+    component: SaveButton,
+    title: "Component Docs/SaveButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/StackBackButton.stories.tsx
+++ b/storybook/src/admin-component-docs/StackBackButton.stories.tsx
@@ -1,0 +1,26 @@
+import { StackBackButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof StackBackButton>;
+
+const meta: Meta<typeof StackBackButton> = {
+    component: StackBackButton,
+    title: "Component Docs/StackBackButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/StackBreadcrumbs.stories.tsx
+++ b/storybook/src/admin-component-docs/StackBreadcrumbs.stories.tsx
@@ -1,0 +1,26 @@
+import { StackBreadcrumbs } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof StackBreadcrumbs>;
+
+const meta: Meta<typeof StackBreadcrumbs> = {
+    component: StackBreadcrumbs,
+    title: "Component Docs/StackBreadcrumbs",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/TabScrollButton.stories.tsx
+++ b/storybook/src/admin-component-docs/TabScrollButton.stories.tsx
@@ -1,0 +1,26 @@
+import { TabScrollButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof TabScrollButton>;
+
+const meta: Meta<typeof TabScrollButton> = {
+    component: TabScrollButton,
+    title: "Component Docs/TabScrollButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/Tabs.stories.tsx
+++ b/storybook/src/admin-component-docs/Tabs.stories.tsx
@@ -1,0 +1,26 @@
+import { Tabs } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof Tabs>;
+
+const meta: Meta<typeof Tabs> = {
+    component: Tabs,
+    title: "Component Docs/Tabs",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/TimePicker.stories.tsx
+++ b/storybook/src/admin-component-docs/TimePicker.stories.tsx
@@ -1,0 +1,26 @@
+import { TimePicker } from "@comet/admin-date-time";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof TimePicker>;
+
+const meta: Meta<typeof TimePicker> = {
+    component: TimePicker,
+    title: "Component Docs/TimePicker",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/TimeRangePicker.stories.tsx
+++ b/storybook/src/admin-component-docs/TimeRangePicker.stories.tsx
@@ -1,0 +1,26 @@
+import { TimeRangePicker } from "@comet/admin-date-time";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof TimeRangePicker>;
+
+const meta: Meta<typeof TimeRangePicker> = {
+    component: TimeRangePicker,
+    title: "Component Docs/TimeRangePicker",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/Toolbar.stories.tsx
+++ b/storybook/src/admin-component-docs/Toolbar.stories.tsx
@@ -1,0 +1,26 @@
+import { Toolbar } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof Toolbar>;
+
+const meta: Meta<typeof Toolbar> = {
+    component: Toolbar,
+    title: "Component Docs/Toolbar",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/ToolbarActions.stories.tsx
+++ b/storybook/src/admin-component-docs/ToolbarActions.stories.tsx
@@ -1,0 +1,26 @@
+import { ToolbarActions } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof ToolbarActions>;
+
+const meta: Meta<typeof ToolbarActions> = {
+    component: ToolbarActions,
+    title: "Component Docs/ToolbarActions",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/ToolbarAutomaticTitleItem.stories.tsx
+++ b/storybook/src/admin-component-docs/ToolbarAutomaticTitleItem.stories.tsx
@@ -1,0 +1,26 @@
+import { ToolbarAutomaticTitleItem } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof ToolbarAutomaticTitleItem>;
+
+const meta: Meta<typeof ToolbarAutomaticTitleItem> = {
+    component: ToolbarAutomaticTitleItem,
+    title: "Component Docs/ToolbarAutomaticTitleItem",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/ToolbarBackButton.stories.tsx
+++ b/storybook/src/admin-component-docs/ToolbarBackButton.stories.tsx
@@ -1,0 +1,26 @@
+import { ToolbarBackButton } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof ToolbarBackButton>;
+
+const meta: Meta<typeof ToolbarBackButton> = {
+    component: ToolbarBackButton,
+    title: "Component Docs/ToolbarBackButton",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/ToolbarBreadcrumbs.stories.tsx
+++ b/storybook/src/admin-component-docs/ToolbarBreadcrumbs.stories.tsx
@@ -1,0 +1,26 @@
+import { ToolbarBreadcrumbs } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof ToolbarBreadcrumbs>;
+
+const meta: Meta<typeof ToolbarBreadcrumbs> = {
+    component: ToolbarBreadcrumbs,
+    title: "Component Docs/ToolbarBreadcrumbs",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/ToolbarItem.stories.tsx
+++ b/storybook/src/admin-component-docs/ToolbarItem.stories.tsx
@@ -1,0 +1,26 @@
+import { ToolbarItem } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof ToolbarItem>;
+
+const meta: Meta<typeof ToolbarItem> = {
+    component: ToolbarItem,
+    title: "Component Docs/ToolbarItem",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/ToolbarTitleItem.stories.tsx
+++ b/storybook/src/admin-component-docs/ToolbarTitleItem.stories.tsx
@@ -1,0 +1,26 @@
+import { ToolbarTitleItem } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof ToolbarTitleItem>;
+
+const meta: Meta<typeof ToolbarTitleItem> = {
+    component: ToolbarTitleItem,
+    title: "Component Docs/ToolbarTitleItem",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/Tooltip.stories.tsx
+++ b/storybook/src/admin-component-docs/Tooltip.stories.tsx
@@ -1,0 +1,26 @@
+import { Tooltip } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof Tooltip>;
+
+const meta: Meta<typeof Tooltip> = {
+    component: Tooltip,
+    title: "Component Docs/Tooltip",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * ⚠️ This components documentation is incomplete and will be updated in the future.
+ */
+export const Default: Story = {};


### PR DESCRIPTION
## Description

This is so we have a valid URL for each component's docs-page that can be used for reference. 
The full documentation of each component will be added in future PRs. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2229
