### PR TITLE
A11y: Fix order of elements in DOM in `Footer`

### DIFF
--- a/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
+++ b/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
@@ -13,14 +13,22 @@ export const FooterContentBlock = withPreview(
             <Root>
                 <PageLayout grid>
                     <PageLayoutContent>
-                        <TopContainer>
+                        <MobileTopContainer>
                             <ImageWrapper>
                                 <DamImageBlock data={image} aspectRatio="1/1" style={{ objectFit: "contain" }} />
                             </ImageWrapper>
                             <RichTextWrapper>
                                 <RichTextBlock data={text} disableLastBottomSpacing />
                             </RichTextWrapper>
-                        </TopContainer>
+                        </MobileTopContainer>
+                        <DesktopTopContainer>
+                            <RichTextWrapper>
+                                <RichTextBlock data={text} disableLastBottomSpacing />
+                            </RichTextWrapper>
+                            <ImageWrapper>
+                                <DamImageBlock data={image} aspectRatio="1/1" style={{ objectFit: "contain" }} />
+                            </ImageWrapper>
+                        </DesktopTopContainer>
                         <HorizontalLine />
                         <LinkCopyrightWrapper>
                             <nav>
@@ -67,7 +75,7 @@ const PageLayoutContent = styled.div`
     }
 `;
 
-const TopContainer = styled.div`
+const MobileTopContainer = styled.div`
     display: flex;
     width: 100%;
     flex-direction: column;
@@ -75,8 +83,16 @@ const TopContainer = styled.div`
     gap: ${({ theme }) => theme.spacing.D100};
 
     ${({ theme }) => theme.breakpoints.sm.mediaQuery} {
+        display: none;
+    }
+`;
+
+const DesktopTopContainer = styled.div`
+    display: none;
+
+    ${({ theme }) => theme.breakpoints.sm.mediaQuery} {
+        display: flex;
         align-self: stretch;
-        flex-direction: row-reverse;
         justify-content: space-between;
     }
 


### PR DESCRIPTION
## Description

Setting `row-reverse` on a container, alters the order of elements visually but not in the DOM, which causes assistive technologies to use the wrong other. 

--> Use separate divs for mobile and desktop styling to avoid using `row-reverse`

## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| Mobile: 
<img width="331" height="452" alt="Screenshot 2025-08-25 at 10 33 24" src="https://github.com/user-attachments/assets/4a72a8cc-9356-4bbf-aec8-3e81fbd1c490" /> 
<img width="196" height="121" alt="Screenshot 2025-08-25 at 10 37 01" src="https://github.com/user-attachments/assets/f094dfc9-a500-4915-bbfe-892b1fad7215" />  |   |

## Open TODOs/questions

-   [ ] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2248
