### PR TITLE
Disable cors for vite dev server

### DIFF
--- a/demo/admin/vite.config.mts
+++ b/demo/admin/vite.config.mts
@@ -77,6 +77,7 @@ export default defineConfig(({ mode }) => {
         server: {
             host: process.env.SERVER_HOST ?? "localhost",
             port: Number(process.env.ADMIN_PORT),
+            cors: false,
             proxy: process.env.API_URL_INTERNAL
                 ? {
                     "/api": {

--- a/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
+++ b/docs/docs/7-migration-guide/migration-from-v7-to-v8.md
@@ -1927,6 +1927,7 @@ Add the proxy to your vite config:
 //...
 server: {
     // ...
+    cors: false,
     proxy: process.env.API_URL_INTERNAL
     ? {
          "/api": {


### PR DESCRIPTION
## Description

### Problem

Requests from the site to the api via the admin domain were blocked by cors. The reason is that preflight requests aren't handled by the vite proxy but instantly blocked by the dev server's cors config. You can reproduce this using the NewsListBlock:

<img width="1077" height="264" alt="Bildschirmfoto 2025-08-26 um 09 17 48" src="https://github.com/user-attachments/assets/7dc1196e-8e88-4e88-af86-8793b59e4708" />

<img width="1080" height="249" alt="Bildschirmfoto 2025-08-26 um 09 18 00" src="https://github.com/user-attachments/assets/fad00373-1c0d-4466-9df5-3585e86fa667" />

<img width="687" height="62" alt="Bildschirmfoto 2025-08-26 um 09 18 16" src="https://github.com/user-attachments/assets/b118432a-28bc-45db-a37c-032e21bdd0ea" />

### Solution

Disable cors in the vite dev server (as mentioned in https://github.com/vitejs/vite/discussions/11516#discussioncomment-4554666):

<img width="708" height="374" alt="Bildschirmfoto 2025-08-26 um 09 29 51" src="https://github.com/user-attachments/assets/855ae042-c526-4ea8-a4a0-c3730da0d85d" />

