### PR TITLE
Fix renderStaticSelectCell support for null values

### DIFF
--- a/.changeset/silver-cows-sin.md
+++ b/.changeset/silver-cows-sin.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+Fix renderStaticSelectCell support for null values

--- a/packages/admin/admin/src/dataGrid/renderStaticSelectCell.ts
+++ b/packages/admin/admin/src/dataGrid/renderStaticSelectCell.ts
@@ -5,7 +5,7 @@ export const renderStaticSelectCell: GridColDef["renderCell"] = ({ value, colDef
     const gridColDef = colDef as GridColDef;
     if (Array.isArray(gridColDef.valueOptions)) {
         const renderCellValue = gridColDef.valueOptions.find((option) => {
-            return typeof option === "object" && option.value === value.toString();
+            return typeof option === "object" && option.value === value ? value.toString() : "";
         });
 
         if (typeof renderCellValue === "object") {


### PR DESCRIPTION
## Description

this was introduced with [eefb0546](https://github.com/vivid-planet/comet/commit/eefb0546) and probably unintentionally removed/broken in [cfa2f856](https://github.com/vivid-planet/comet/commit/cfa2f856#diff-b447b4a2e8dd9d0400465415dbc0e8ed8ef5978172c726bcf40f2c98e4eb9808L6)

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
