### PR TITLE
Fix optional peer dependency `@mui/x-date-pickers-pro` by importing it dynamically

### DIFF
--- a/packages/admin/admin/src/dateTime/DateRangePicker.tsx
+++ b/packages/admin/admin/src/dateTime/DateRangePicker.tsx
@@ -1,18 +1,14 @@
 import { Calendar } from "@comet/admin-icons";
 import { type ComponentsOverrides, css, inputLabelClasses, type Theme, useThemeProps } from "@mui/material";
-import {
-    DateRangePicker as MuiDateRangePicker,
-    type DateRangePickerProps as MuiDateRangePickerProps,
-    pickersInputBaseClasses,
-    SingleInputDateRangeField,
-} from "@mui/x-date-pickers-pro";
-import { type ReactNode, useState } from "react";
+import { type DateRangePickerProps as MuiDateRangePickerProps } from "@mui/x-date-pickers-pro";
+import { type ComponentType, type ReactNode, useMemo, useState } from "react";
 
 import { ClearInputAdornment as CometClearInputAdornment } from "../common/ClearInputAdornment";
 import { OpenPickerAdornment } from "../common/OpenPickerAdornment";
 import { ReadOnlyAdornment } from "../common/ReadOnlyAdornment";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+import { useMuiDatePickersProModule } from "./useMuiDatePickersProModule";
 import { getDateValue, getIsoDateString } from "./utils";
 
 export type DateRange = {
@@ -23,7 +19,7 @@ export type DateRange = {
 export type Future_DateRangePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdornment" | "openPickerAdornment";
 
 export type Future_DateRangePickerProps = ThemedComponentBaseProps<{
-    root: typeof MuiDateRangePicker<Date, true>;
+    root: ComponentType<MuiDateRangePickerProps<Date, true>>;
     clearInputAdornment: typeof CometClearInputAdornment;
     readOnlyAdornment: typeof ReadOnlyAdornment;
     openPickerAdornment: typeof OpenPickerAdornment;
@@ -57,10 +53,44 @@ export const Future_DateRangePicker = (inProps: Future_DateRangePickerProps) => 
         name: "CometAdminFutureDateRangePicker",
     });
     const [open, setOpen] = useState(false);
+
     const dateRangeValue = getDateRangeValue(stringDateRangeValue);
     const hasDateRangeValue = dateRangeValue.some((date) => date !== null);
 
     const { openPicker: openPickerIcon = <Calendar color="inherit" /> } = iconMapping;
+
+    const {
+        module: muiDatePickersProModule,
+        loading: muiDateRangePickerModuleLoading,
+        error: muiDateRangePickerModuleError,
+    } = useMuiDatePickersProModule();
+
+    const Root = useMemo(() => {
+        if (!muiDatePickersProModule || muiDateRangePickerModuleLoading) {
+            return null;
+        }
+
+        return createComponentSlot(muiDatePickersProModule.DateRangePicker)<Future_DateRangePickerClassKey>({
+            componentName: "Future_DateRangePicker",
+            slotName: "root",
+        })(css`
+            .${inputLabelClasses.root} {
+                display: none;
+
+                & + .${muiDatePickersProModule.pickersInputBaseClasses.root} {
+                    margin-top: 0;
+                }
+            }
+        `);
+    }, [muiDateRangePickerModuleLoading, muiDatePickersProModule]);
+
+    if (muiDateRangePickerModuleError) {
+        throw new Error(muiDateRangePickerModuleError);
+    }
+
+    if (!muiDatePickersProModule || !Root) {
+        return null;
+    }
 
     return (
         <Root
@@ -129,25 +159,12 @@ export const Future_DateRangePicker = (inProps: Future_DateRangePickerProps) => 
                 },
             }}
             slots={{
-                field: SingleInputDateRangeField,
+                field: muiDatePickersProModule.SingleInputDateRangeField,
                 ...slotProps?.root?.slots,
             }}
         />
     );
 };
-
-const Root = createComponentSlot(MuiDateRangePicker<Date, true>)<Future_DateRangePickerClassKey>({
-    componentName: "Future_DateRangePicker",
-    slotName: "root",
-})(css`
-    .${inputLabelClasses.root} {
-        display: none;
-
-        & + .${pickersInputBaseClasses.root} {
-            margin-top: 0;
-        }
-    }
-`);
 
 const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<Future_DateRangePickerClassKey>({
     componentName: "Future_DateRangePicker",

--- a/packages/admin/admin/src/dateTime/useMuiDatePickersProModule.tsx
+++ b/packages/admin/admin/src/dateTime/useMuiDatePickersProModule.tsx
@@ -1,0 +1,90 @@
+import { type DateRangePickerProps, type PickersInputBaseClasses, type SingleInputDateRangeFieldProps } from "@mui/x-date-pickers-pro";
+import { type ComponentType, useEffect, useState } from "react";
+
+type Module = {
+    DateRangePicker: ComponentType<DateRangePickerProps<Date, boolean>>;
+    pickersInputBaseClasses: Record<keyof PickersInputBaseClasses, string>;
+    SingleInputDateRangeField: ComponentType<SingleInputDateRangeFieldProps<Date, boolean>>;
+};
+
+let module: Module | null = null;
+let modulePromise: Promise<Module> | null = null;
+
+const importModule = async () => {
+    if (module) {
+        return module;
+    }
+
+    if (modulePromise) {
+        return modulePromise;
+    }
+
+    modulePromise = (async () => {
+        try {
+            const { DateRangePicker, pickersInputBaseClasses, SingleInputDateRangeField } = await import("@mui/x-date-pickers-pro");
+            module = {
+                DateRangePicker,
+                pickersInputBaseClasses,
+                SingleInputDateRangeField,
+            };
+            return module;
+        } catch {
+            throw new Error("Failed to import '@mui/x-date-pickers-pro', make sure it's installed.");
+        }
+    })();
+
+    return modulePromise;
+};
+
+type SuccessReturnValue = {
+    error: null;
+    loading: false;
+    module: Module;
+};
+
+type ErrorReturnValue = {
+    error: string;
+    loading: false;
+    module: null;
+};
+
+type LoadingReturnValue = {
+    error: null;
+    loading: true;
+    module: null;
+};
+
+export const useMuiDatePickersProModule = (): SuccessReturnValue | ErrorReturnValue | LoadingReturnValue => {
+    const [loaded, setLoaded] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        importModule()
+            .then(() => setLoaded(true))
+            .catch((error) => {
+                setError(error.message);
+            });
+    }, []);
+
+    if (loaded && module) {
+        return {
+            error: null,
+            loading: false,
+            module,
+        };
+    }
+
+    if (error) {
+        return {
+            error,
+            loading: false,
+            module: null,
+        };
+    }
+
+    return {
+        error: null,
+        loading: true,
+        module: null,
+    };
+};


### PR DESCRIPTION
## Description

In #4296, the `@mui/x-date-pickers-pro` package was added as an optional peer-dependency, while the imports were static. This caused an error when a project did not install the package, even though it's optional. 

Now, with dynamic imports, the project works without the package installed and only throws an error, when trying to use the components that use these imports. 

We still need to add the package to the `ignoreDependencies` of knip, due to the type-imports. 

This was tested in [Comet Starter](https://github.com/vivid-planet/comet-starter) using `wml`.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots

| Package installed | Package not installed |
| --- | --- |
| <img width="340" height="561" alt="Screenshot 2025-08-26 at 10 29 23" src="https://github.com/user-attachments/assets/5b71bdb8-6e07-40a4-881e-353a89761d5d" /> | <img width="635" height="124" alt="image" src="https://github.com/user-attachments/assets/a52fc355-e524-4d68-879c-4d4f1a65c46e" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2387
