### PR TITLE
Excel Export: Add support for real boolean columns

### DIFF
--- a/.changeset/wide-cycles-wish.md
+++ b/.changeset/wide-cycles-wish.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Allow exporting columns with value type boolean

--- a/packages/admin/admin/src/dataGrid/excelExport/generateExcelFile.ts
+++ b/packages/admin/admin/src/dataGrid/excelExport/generateExcelFile.ts
@@ -53,7 +53,13 @@ export function generateExcelFile<Row extends GridValidRowModel>(
                         value = column.valueFormatter(value, row) ?? "";
                     }
 
-                    if (typeof value !== "string" && typeof value !== "number" && value !== null && !(value instanceof Date)) {
+                    if (
+                        typeof value !== "string" &&
+                        typeof value !== "boolean" &&
+                        typeof value !== "number" &&
+                        value !== null &&
+                        !(value instanceof Date)
+                    ) {
                         throw new Error(`The type of the provided value "${typeof value}" is not supported for excel export.`);
                     }
 


### PR DESCRIPTION
## Description

Currently an error was thrown if value was a boolean. But the used library already supports this column type. This allows better usage of the exported file.
Note: admin-generator export for boolean columns only works because it's converted to a string value for export. (I'm going to fix this in a follow-up [PR](https://github.com/vivid-planet/comet/pull/4395))

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts
<img width="295" height="221" alt="Screenshot 2025-08-27 at 14 46 09" src="https://github.com/user-attachments/assets/23ac55c0-00d7-4c9d-aae3-fe69e0fb0c75" />
