### PR TITLE
Admin Generator: Export boolean columns as real boolean columns

### DIFF
--- a/.changeset/blue-brooms-kiss.md
+++ b/.changeset/blue-brooms-kiss.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-generator": minor
+---
+
+Admin Generator: support export boolean column as real boolean column

--- a/demo/admin/src/products/generator/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/generator/generated/ProductsGrid.tsx
@@ -163,7 +163,6 @@ export function ProductsGrid({ filter, toolbarAction, rowAction, actionsColumnWi
         { field: "inStock",
             headerName: intl.formatMessage({ id: "product.inStock", defaultMessage: "In stock" }),
             type: "boolean",
-            valueFormatter: (value, row) => typeof row.inStock === "boolean" ? row.inStock.toString() : "",
             flex: 1,
             visible: theme.breakpoints.up('md'),
             minWidth: 80, },

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
@@ -417,7 +417,6 @@ export function generateGrid<T extends { __typename?: string }>(
             }`;
         } else if (type == "boolean") {
             gridType = "boolean";
-            valueFormatter = `(value, row) => typeof row.${name} === "boolean" ? row.${name}.toString() : ""`;
         } else if (column.type == "block") {
             renderCell = `(params) => {
                     return <BlockPreviewContent block={${column.block.name}} input={params.row.${name}} />;


### PR DESCRIPTION
## Description

Currently boolean columns were converted to string columns. As [generateExcelFile](https://github.com/vivid-planet/comet/blob/main/packages/admin/admin/src/dataGrid/excelExport/generateExcelFile.ts) does now support boolean columns this is not required anymore. If it's required to differently render the boolean columns in admin it's still possible to implement `renderCell`. If we really want to support exporting a boolean column/field as string we should consider allow implementing/defining `valueFormatter` in grid config.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Merge #4394 
