### PR TITLE
Admin Generator: Add `queryFields` support to action column

### DIFF
--- a/.changeset/dark-humans-worry.md
+++ b/.changeset/dark-humans-worry.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-generator": minor
+---
+
+Admin Generator: Allow fetching additional fields for action columns

--- a/demo/admin/src/products/ProductsGridPreviewAction.tsx
+++ b/demo/admin/src/products/ProductsGridPreviewAction.tsx
@@ -32,7 +32,7 @@ export const ProductsGridPreviewAction = ({ row }: Props) => {
                 </DialogTitle>
                 <DialogContent>
                     <Typography variant="h3" gutterBottom>
-                        {row.title}
+                        {row.title}/{row.slug}
                     </Typography>
                     <Typography>{row.description}</Typography>
                 </DialogContent>

--- a/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
+++ b/demo/admin/src/products/generator/ProductsGrid.cometGen.tsx
@@ -141,6 +141,7 @@ export default defineConfig<GQLProduct>({
         },
         {
             type: "actions",
+            queryFields: ["slug"],
             component: ProductsGridPreviewAction,
         },
     ],

--- a/demo/admin/src/products/generator/generated/ProductsGrid.tsx
+++ b/demo/admin/src/products/generator/generated/ProductsGrid.tsx
@@ -47,7 +47,7 @@ import { Education as EducationIcon } from "@comet/admin-icons";
 const productsFragment = gql`
         fragment ProductsGridFuture on Product {
             id
-            category { title } title description price inStock type availableSince createdAt manufacturer { name } tags { title } variants { name }
+            category { title } title description price inStock type availableSince createdAt manufacturer { name } tags { title } variants { name } slug
         }
     `;
 const productsQuery = gql`

--- a/packages/admin/admin-generator/src/commands/generate/generate-command.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generate-command.ts
@@ -213,7 +213,11 @@ export type GridColumnConfig<T extends GridValidRowModel> = (
       }
 ) & { name: UsableFields<T>; filterOperators?: GridFilterOperator[] } & BaseColumnConfig;
 
-export type ActionsGridColumnConfig = { type: "actions"; component?: ComponentType<GridCellParams> } & BaseColumnConfig;
+export type ActionsGridColumnConfig<T> = {
+    type: "actions";
+    queryFields?: UsableFields<T, true>[];
+    component?: ComponentType<GridCellParams>;
+} & BaseColumnConfig;
 export type VirtualGridColumnConfig<T extends GridValidRowModel> = {
     type: "virtual";
     name: string;
@@ -228,7 +232,7 @@ type InitialFilterConfig = {
 };
 
 // Additional type is necessary to avoid "TS2589: Type instantiation is excessively deep and possibly infinite."
-type GridConfigGridColumnDef<T extends { __typename?: string }> = GridColumnConfig<T> | ActionsGridColumnConfig | VirtualGridColumnConfig<T>;
+type GridConfigGridColumnDef<T extends { __typename?: string }> = GridColumnConfig<T> | ActionsGridColumnConfig<T> | VirtualGridColumnConfig<T>;
 
 export type GridConfig<T extends { __typename?: string }> = {
     type: "grid";

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGqlFieldList.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGqlFieldList.ts
@@ -22,7 +22,13 @@ const recursiveStringify = (obj: FieldsObjectType): string => {
 
 export function generateGqlFieldList<T extends { __typename?: string }>({ columns }: { columns: GridConfig<T>["columns"] }) {
     const fieldsObject: FieldsObjectType = columns.reduce<FieldsObjectType>((acc, field) => {
-        if (field.type !== "actions") {
+        if (field.type === "actions") {
+            if ("queryFields" in field) {
+                field.queryFields?.forEach((queryField) => {
+                    objectPath.set(acc, queryField, true);
+                });
+            }
+        } else {
             let hasCustomFields = false;
 
             if ("labelField" in field && field.labelField) {

--- a/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateGrid/generateGrid.ts
@@ -228,7 +228,7 @@ export function generateGrid<T extends { __typename?: string }>(
 
     const fieldList = generateGqlFieldList({
         // exclude id because it's always required
-        columns: config.columns.filter((column) => column.type !== "actions" && column.name !== "id"),
+        columns: config.columns.filter((column) => column.type === "actions" || column.name !== "id"),
     });
 
     // all root blocks including those we don't have columns for (required for copy/paste)
@@ -362,7 +362,7 @@ export function generateGrid<T extends { __typename?: string }>(
         | undefined;
     if (!schemaEntity) throw new Error("didn't find entity in schema types");
 
-    const actionsColumnConfig = config.columns.find((column) => column.type === "actions") as ActionsGridColumnConfig;
+    const actionsColumnConfig = config.columns.find((column) => column.type === "actions") as ActionsGridColumnConfig<any>;
     const {
         component: actionsColumnComponent,
         type: actionsColumnType,
@@ -370,6 +370,8 @@ export function generateGrid<T extends { __typename?: string }>(
         pinned: actionsColumnPinned = "right",
         width: actionsColumnWidth = defaultActionsColumnWidth,
         visible: actionsColumnVisible = undefined,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        queryFields: actionsColumnQueryFields = [], // not needed here, but needs to be removed from restActionsColumnConfig because it's directly used in to generate component props in tsCodeRecordToString
         ...restActionsColumnConfig
     } = actionsColumnConfig ?? {};
     if (actionsColumnComponent) {


### PR DESCRIPTION
## Description
This allows to fetch additional fields e.g. needed to implement a row-action or some special action component.

Note: action column was explicitly filtered in `generateGqlFieldList` call because of missing name-prop (to allow check for name="id") and additionally handled in `generateGqlFieldList` also because of missing name-prop. Had to adapt those.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Slack: https://vividplanet.slack.com/archives/C046HD77Y1Y/p1755848533177319
