### PR TITLE
Add `SectionHeadline` admin component

### DIFF
--- a/.changeset/salty-bananas-know.md
+++ b/.changeset/salty-bananas-know.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Add new admin component `SectionHeadline`

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -204,6 +204,7 @@ export {
     useSaveBoundaryState,
 } from "./saveBoundary/SaveBoundary";
 export { SaveBoundarySaveButton } from "./saveBoundary/SaveBoundarySaveButton";
+export { SectionHeadline, SectionHeadlineClassKey, SectionHeadlineProps } from "./section/SectionHeadline";
 export { Selected } from "./Selected";
 export { ISelectionRenderPropArgs, Selection, useSelection } from "./Selection";
 export { ISelectionApi } from "./SelectionApi";

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from "../common/Tooltip";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
-export type SectionHeadlineClassKey = "root" | "header" | "titleContainer" | "divider" | "supportText" | "infoTooltip";
+export type SectionHeadlineClassKey = "root" | "header" | "titleContainer" | "headline" | "divider" | "supportText" | "infoTooltip";
 
 const Root = createComponentSlot("div")<SectionHeadlineClassKey>({
     componentName: "SectionHeadline",
@@ -35,6 +35,11 @@ const TitleContainer = createComponentSlot("div")<SectionHeadlineClassKey>({
         align-items: center;
     `,
 );
+
+const Headline = createComponentSlot(Typography)<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "headline",
+})();
 
 const SupportText = createComponentSlot(Typography)<SectionHeadlineClassKey>({
     componentName: "SectionHeadline",
@@ -103,7 +108,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         <Root {...slotProps?.root} {...restProps}>
             <Header {...slotProps?.header}>
                 <TitleContainer {...slotProps?.titleContainer}>
-                    {children}
+                    <Headline variant="h4">{children}</Headline>
                     {infoTooltip && infoIcon && isValidElement(infoIcon) && (
                         <InfoTooltip title={infoTooltip} {...slotProps?.infoTooltip}>
                             {infoIcon}

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -67,7 +67,6 @@ const StyledDivider = createComponentSlot(Divider)<SectionHeadlineClassKey>({
 })(
     () => css`
         margin-top: 10px;
-        color: "inherit";
     `,
 );
 

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -82,8 +82,8 @@ export interface SectionHeadlineProps
     }> {
     children: ReactNode;
     divider?: boolean;
-    supportText?: string;
-    infoTooltip?: string;
+    supportText?: ReactNode;
+    infoTooltip?: ReactNode;
     iconMapping?: {
         infoIcon?: ReactNode;
     };

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -1,13 +1,13 @@
 import { Info } from "@comet/admin-icons";
 import { type ComponentsOverrides, Divider, Typography } from "@mui/material";
 import { css, type Theme, useThemeProps } from "@mui/material/styles";
-import { type ReactNode } from "react";
+import { isValidElement, type ReactNode } from "react";
 
 import { Tooltip } from "../common/Tooltip";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
-export type SectionHeadlineClassKey = "root" | "header" | "titleContainer" | "divider" | "supportText" | "infoTooltip" | "infoIcon";
+export type SectionHeadlineClassKey = "root" | "header" | "titleContainer" | "divider" | "supportText" | "infoTooltip";
 
 const Root = createComponentSlot("div")<SectionHeadlineClassKey>({
     componentName: "SectionHeadline",
@@ -65,22 +65,12 @@ const StyledDivider = createComponentSlot(Divider)<SectionHeadlineClassKey>({
     `,
 );
 
-const StyledInfoIcon = createComponentSlot(Info)<SectionHeadlineClassKey>({
-    componentName: "SectionHeadline",
-    slotName: "infoIcon",
-})(
-    () => css`
-        font-size: 12px;
-    `,
-);
-
 export interface SectionHeadlineProps
     extends ThemedComponentBaseProps<{
         root: "div";
         header: "div";
         titleContainer: "div";
         infoTooltip: typeof Tooltip;
-        infoIcon: typeof Info;
         supportText: typeof Typography;
         divider: typeof Divider;
     }> {
@@ -88,22 +78,35 @@ export interface SectionHeadlineProps
     divider?: boolean;
     supportText?: string;
     infoTooltip?: string;
+    iconMapping?: {
+        infoIcon?: ReactNode;
+    };
 }
 
 export function SectionHeadline(inProps: SectionHeadlineProps) {
-    const { children, divider, supportText, infoTooltip, slotProps, ...restProps } = useThemeProps({
+    const {
+        children,
+        divider,
+        supportText,
+        infoTooltip,
+        iconMapping = {},
+        slotProps,
+        ...restProps
+    } = useThemeProps({
         props: inProps,
         name: "CometAdminSectionHeadline",
     });
+
+    const { infoIcon = <Info color="inherit" style={{ fontSize: "12px" }} /> } = iconMapping;
 
     return (
         <Root {...slotProps?.root} {...restProps}>
             <Header {...slotProps?.header}>
                 <TitleContainer {...slotProps?.titleContainer}>
                     {children}
-                    {infoTooltip && (
+                    {infoTooltip && infoIcon && isValidElement(infoIcon) && (
                         <InfoTooltip title={infoTooltip} {...slotProps?.infoTooltip}>
-                            <StyledInfoIcon {...slotProps?.infoIcon} />
+                            {infoIcon}
                         </InfoTooltip>
                     )}
                 </TitleContainer>

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -103,7 +103,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         name: "CometAdminSectionHeadline",
     });
 
-    const { tooltip: tooltooltipIcon = <Info sx={{ fontSize: "inherit" }} /> } = iconMapping;
+    const { tooltip: tooltipIcon = <Info sx={{ fontSize: "inherit" }} /> } = iconMapping;
 
     return (
         <Root {...slotProps?.root} {...restProps}>
@@ -114,7 +114,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
                     </Headline>
                     {infoTooltipText && (
                         <InfoTooltip title={infoTooltipText} {...slotProps?.infoTooltip}>
-                            {tooltooltipIcon}
+                            {tooltipIcon}
                         </InfoTooltip>
                     )}
                 </TitleContainer>

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from "../common/Tooltip";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
-export type SectionHeadlineClassKey = "root" | "headlineWrapper" | "titleContainer" | "divider" | "supportText" | "infoTooltipText" | "infoIcon";
+export type SectionHeadlineClassKey = "root" | "headlineWrapper" | "titleContainer" | "divider" | "supportText" | "infoTooltip" | "infoIcon";
 
 const Root = createComponentSlot("div")<SectionHeadlineClassKey>({
     componentName: "SectionHeadline",
@@ -45,9 +45,9 @@ const SupportText = createComponentSlot(Typography)<SectionHeadlineClassKey>({
     `,
 );
 
-const StyledTooltip = createComponentSlot(Tooltip)<SectionHeadlineClassKey>({
+const InfoTooltip = createComponentSlot(Tooltip)<SectionHeadlineClassKey>({
     componentName: "SectionHeadline",
-    slotName: "infoTooltipText",
+    slotName: "infoTooltip",
 })(
     ({ theme }) => css`
         color: ${theme.palette.text.secondary};
@@ -79,7 +79,7 @@ export interface SectionHeadlineProps
         root: "div";
         headlineWrapper: "div";
         titleContainer: "div";
-        infoTooltipText: typeof Tooltip;
+        infoTooltip: typeof Tooltip;
         infoIcon: typeof Info;
         supportText: typeof Typography;
         divider: typeof Divider;
@@ -87,11 +87,11 @@ export interface SectionHeadlineProps
     children: ReactNode;
     divider?: boolean;
     supportText?: string;
-    infoTooltipText?: string;
+    infoTooltip?: string;
 }
 
 export function SectionHeadline(inProps: SectionHeadlineProps) {
-    const { children, divider, supportText, infoTooltipText, slotProps, ...restProps } = useThemeProps({
+    const { children, divider, supportText, infoTooltip, slotProps, ...restProps } = useThemeProps({
         props: inProps,
         name: "CometAdminSectionHeadline",
     });
@@ -101,10 +101,10 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
             <HeadlineWrapper {...slotProps?.headlineWrapper}>
                 <TitleContainer {...slotProps?.titleContainer}>
                     {children}
-                    {infoTooltipText && (
-                        <StyledTooltip title={infoTooltipText} {...slotProps?.infoTooltipText}>
+                    {infoTooltip && (
+                        <InfoTooltip title={infoTooltip} {...slotProps?.infoTooltip}>
                             <StyledInfoIcon {...slotProps?.infoIcon} />
-                        </StyledTooltip>
+                        </InfoTooltip>
                     )}
                 </TitleContainer>
 

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -7,16 +7,16 @@ import { Tooltip } from "../common/Tooltip";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
 
-export type SectionHeadlineClassKey = "root" | "headlineWrapper" | "titleContainer" | "divider" | "supportText" | "infoTooltip" | "infoIcon";
+export type SectionHeadlineClassKey = "root" | "header" | "titleContainer" | "divider" | "supportText" | "infoTooltip" | "infoIcon";
 
 const Root = createComponentSlot("div")<SectionHeadlineClassKey>({
     componentName: "SectionHeadline",
     slotName: "root",
 })();
 
-const HeadlineWrapper = createComponentSlot("div")<SectionHeadlineClassKey>({
+const Header = createComponentSlot("div")<SectionHeadlineClassKey>({
     componentName: "SectionHeadline",
-    slotName: "headlineWrapper",
+    slotName: "header",
 })(
     () => css`
         display: flex;
@@ -77,7 +77,7 @@ const StyledInfoIcon = createComponentSlot(Info)<SectionHeadlineClassKey>({
 export interface SectionHeadlineProps
     extends ThemedComponentBaseProps<{
         root: "div";
-        headlineWrapper: "div";
+        header: "div";
         titleContainer: "div";
         infoTooltip: typeof Tooltip;
         infoIcon: typeof Info;
@@ -98,7 +98,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
 
     return (
         <Root {...slotProps?.root} {...restProps}>
-            <HeadlineWrapper {...slotProps?.headlineWrapper}>
+            <Header {...slotProps?.header}>
                 <TitleContainer {...slotProps?.titleContainer}>
                     {children}
                     {infoTooltip && (
@@ -113,7 +113,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
                         {supportText}
                     </SupportText>
                 )}
-            </HeadlineWrapper>
+            </Header>
 
             {divider && <StyledDivider {...slotProps?.divider} />}
         </Root>

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -83,7 +83,7 @@ export interface SectionHeadlineProps
     children: ReactNode;
     divider?: boolean;
     supportText?: ReactNode;
-    infoTooltip?: ReactNode;
+    infoTooltipText?: ReactNode;
     iconMapping?: {
         tooltip?: ReactElement;
     };
@@ -94,7 +94,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         children,
         divider,
         supportText,
-        infoTooltip,
+        infoTooltipText,
         iconMapping = {},
         slotProps,
         ...restProps
@@ -112,8 +112,8 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
                     <Headline variant="h4" {...slotProps?.headline}>
                         {children}
                     </Headline>
-                    {infoTooltip && (
-                        <InfoTooltip title={infoTooltip} {...slotProps?.infoTooltip}>
+                    {infoTooltipText && (
+                        <InfoTooltip title={infoTooltipText} {...slotProps?.infoTooltip}>
                             {tooltip}
                         </InfoTooltip>
                     )}

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -103,7 +103,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         name: "CometAdminSectionHeadline",
     });
 
-    const { tooltip = <Info sx={{ fontSize: "inherit" }} /> } = iconMapping;
+    const { tooltip: tooltooltipIcon = <Info sx={{ fontSize: "inherit" }} /> } = iconMapping;
 
     return (
         <Root {...slotProps?.root} {...restProps}>
@@ -114,7 +114,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
                     </Headline>
                     {infoTooltipText && (
                         <InfoTooltip title={infoTooltipText} {...slotProps?.infoTooltip}>
-                            {tooltip}
+                            {tooltooltipIcon}
                         </InfoTooltip>
                     )}
                 </TitleContainer>

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -57,6 +57,7 @@ const InfoTooltip = createComponentSlot(Tooltip)<SectionHeadlineClassKey>({
     ({ theme }) => css`
         color: ${theme.palette.text.secondary};
         margin-left: 10px;
+        font-size: 12px;
     `,
 );
 
@@ -102,7 +103,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         name: "CometAdminSectionHeadline",
     });
 
-    const { infoIcon = <Info style={{ fontSize: "12px" }} /> } = iconMapping;
+    const { infoIcon = <Info sx={{ fontSize: "inherit" }} /> } = iconMapping;
 
     return (
         <Root {...slotProps?.root} {...restProps}>

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -1,7 +1,7 @@
 import { Info } from "@comet/admin-icons";
 import { type ComponentsOverrides, Divider, Typography } from "@mui/material";
 import { css, type Theme, useThemeProps } from "@mui/material/styles";
-import { isValidElement, type ReactNode } from "react";
+import { type ReactElement, type ReactNode } from "react";
 
 import { Tooltip } from "../common/Tooltip";
 import { createComponentSlot } from "../helpers/createComponentSlot";
@@ -84,7 +84,7 @@ export interface SectionHeadlineProps
     supportText?: ReactNode;
     infoTooltip?: ReactNode;
     iconMapping?: {
-        tooltip?: ReactNode;
+        tooltip?: ReactElement;
     };
 }
 
@@ -109,7 +109,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
             <Header {...slotProps?.header}>
                 <TitleContainer {...slotProps?.titleContainer}>
                     <Headline variant="h4">{children}</Headline>
-                    {infoTooltip && tooltip && isValidElement(tooltip) && (
+                    {infoTooltip && (
                         <InfoTooltip title={infoTooltip} {...slotProps?.infoTooltip}>
                             {tooltip}
                         </InfoTooltip>

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -1,0 +1,138 @@
+import { Info } from "@comet/admin-icons";
+import { type ComponentsOverrides, Divider, Typography } from "@mui/material";
+import { css, type Theme, useThemeProps } from "@mui/material/styles";
+import { type ReactNode } from "react";
+
+import { Tooltip } from "../common/Tooltip";
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+
+export type SectionHeadlineClassKey = "root" | "headlineWrapper" | "titleContainer" | "divider" | "supportText" | "infoTooltipText" | "infoIcon";
+
+const Root = createComponentSlot("div")<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "root",
+})();
+
+const HeadlineWrapper = createComponentSlot("div")<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "headlineWrapper",
+})(
+    () => css`
+        display: flex;
+        flex-direction: row;
+        align-items: flex-end;
+        justify-content: space-between;
+    `,
+);
+
+const TitleContainer = createComponentSlot("div")<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "titleContainer",
+})(
+    () => css`
+        display: flex;
+        align-items: center;
+    `,
+);
+
+const SupportText = createComponentSlot(Typography)<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "supportText",
+})(
+    ({ theme }) => css`
+        color: ${theme.palette.text.secondary};
+    `,
+);
+
+const StyledTooltip = createComponentSlot(Tooltip)<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "infoTooltipText",
+})(
+    ({ theme }) => css`
+        color: ${theme.palette.text.secondary};
+        margin-left: 10px;
+    `,
+);
+
+const StyledDivider = createComponentSlot(Divider)<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "divider",
+})(
+    () => css`
+        margin-top: 10px;
+        color: "inherit";
+    `,
+);
+
+const StyledInfoIcon = createComponentSlot(Info)<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "infoIcon",
+})(
+    () => css`
+        font-size: 12px;
+    `,
+);
+
+export interface SectionHeadlineProps
+    extends ThemedComponentBaseProps<{
+        root: "div";
+        headlineWrapper: "div";
+        titleContainer: "div";
+        infoTooltipText: typeof Tooltip;
+        infoIcon: typeof Info;
+        supportText: typeof Typography;
+        divider: typeof Divider;
+    }> {
+    children: ReactNode;
+    divider?: boolean;
+    supportText?: string;
+    infoTooltipText?: string;
+}
+
+export function SectionHeadline(inProps: SectionHeadlineProps) {
+    const { children, divider, supportText, infoTooltipText, slotProps, ...restProps } = useThemeProps({
+        props: inProps,
+        name: "CometAdminSectionHeadline",
+    });
+
+    return (
+        <Root {...slotProps?.root} {...restProps}>
+            <HeadlineWrapper {...slotProps?.headlineWrapper}>
+                <TitleContainer {...slotProps?.titleContainer}>
+                    {children}
+                    {infoTooltipText && (
+                        <StyledTooltip title={infoTooltipText} {...slotProps?.infoTooltipText}>
+                            <StyledInfoIcon {...slotProps?.infoIcon} />
+                        </StyledTooltip>
+                    )}
+                </TitleContainer>
+
+                {supportText && (
+                    <SupportText variant="caption" {...slotProps?.supportText}>
+                        {supportText}
+                    </SupportText>
+                )}
+            </HeadlineWrapper>
+
+            {divider && <StyledDivider {...slotProps?.divider} />}
+        </Root>
+    );
+}
+
+declare module "@mui/material/styles" {
+    interface ComponentNameToClassKey {
+        CometAdminSectionHeadline: SectionHeadlineClassKey;
+    }
+
+    interface ComponentsPropsList {
+        CometAdminSectionHeadline: SectionHeadlineProps;
+    }
+
+    interface Components {
+        CometAdminSectionHeadline?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminSectionHeadline"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminSectionHeadline"];
+        };
+    }
+}

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -75,6 +75,7 @@ export interface SectionHeadlineProps
         root: "div";
         header: "div";
         titleContainer: "div";
+        headline: typeof Typography;
         infoTooltip: typeof Tooltip;
         supportText: typeof Typography;
         divider: typeof Divider;
@@ -108,7 +109,9 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         <Root {...slotProps?.root} {...restProps}>
             <Header {...slotProps?.header}>
                 <TitleContainer {...slotProps?.titleContainer}>
-                    <Headline variant="h4">{children}</Headline>
+                    <Headline variant="h4" {...slotProps?.headline}>
+                        {children}
+                    </Headline>
                     {infoTooltip && (
                         <InfoTooltip title={infoTooltip} {...slotProps?.infoTooltip}>
                             {tooltip}

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -102,7 +102,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         name: "CometAdminSectionHeadline",
     });
 
-    const { infoIcon = <Info color="inherit" style={{ fontSize: "12px" }} /> } = iconMapping;
+    const { infoIcon = <Info style={{ fontSize: "12px" }} /> } = iconMapping;
 
     return (
         <Root {...slotProps?.root} {...restProps}>

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -84,7 +84,7 @@ export interface SectionHeadlineProps
     supportText?: ReactNode;
     infoTooltip?: ReactNode;
     iconMapping?: {
-        infoIcon?: ReactNode;
+        tooltip?: ReactNode;
     };
 }
 
@@ -102,16 +102,16 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         name: "CometAdminSectionHeadline",
     });
 
-    const { infoIcon = <Info sx={{ fontSize: "inherit" }} /> } = iconMapping;
+    const { tooltip = <Info sx={{ fontSize: "inherit" }} /> } = iconMapping;
 
     return (
         <Root {...slotProps?.root} {...restProps}>
             <Header {...slotProps?.header}>
                 <TitleContainer {...slotProps?.titleContainer}>
                     <Headline variant="h4">{children}</Headline>
-                    {infoTooltip && infoIcon && isValidElement(infoIcon) && (
+                    {infoTooltip && tooltip && isValidElement(tooltip) && (
                         <InfoTooltip title={infoTooltip} {...slotProps?.infoTooltip}>
-                            {infoIcon}
+                            {tooltip}
                         </InfoTooltip>
                     )}
                 </TitleContainer>

--- a/storybook/src/admin/SectionHeadline.stories.tsx
+++ b/storybook/src/admin/SectionHeadline.stories.tsx
@@ -8,7 +8,7 @@ export default {
 export const _SectionHeadline = () => {
     return (
         <Stack spacing={15}>
-            <SectionHeadline supportText="Support Text" divider infoTooltipText="Tooltip Info Text">
+            <SectionHeadline supportText="Support Text" divider infoTooltip="Tooltip Info Text">
                 <Typography variant="h4">Section Title</Typography>
             </SectionHeadline>
 

--- a/storybook/src/admin/SectionHeadline.stories.tsx
+++ b/storybook/src/admin/SectionHeadline.stories.tsx
@@ -1,0 +1,20 @@
+import { SectionHeadline } from "@comet/admin";
+import { Stack, Typography } from "@mui/material";
+
+export default {
+    title: "@comet/admin/SectionHeadline",
+};
+
+export const _SectionHeadline = () => {
+    return (
+        <Stack spacing={15}>
+            <SectionHeadline supportText="Support Text" divider infoTooltipText="Tooltip Info Text">
+                <Typography variant="h4">Section Title</Typography>
+            </SectionHeadline>
+
+            <SectionHeadline>
+                <Typography variant="h4">Section Title</Typography>
+            </SectionHeadline>
+        </Stack>
+    );
+};

--- a/storybook/src/admin/SectionHeadline.stories.tsx
+++ b/storybook/src/admin/SectionHeadline.stories.tsx
@@ -5,7 +5,7 @@ export default {
     title: "@comet/admin/SectionHeadline",
 };
 
-export const _SectionHeadline = () => {
+export const Default = () => {
     return (
         <Stack spacing={15}>
             <SectionHeadline supportText="Support Text" divider infoTooltipText="Tooltip Info Text">

--- a/storybook/src/admin/SectionHeadline.stories.tsx
+++ b/storybook/src/admin/SectionHeadline.stories.tsx
@@ -1,5 +1,5 @@
 import { SectionHeadline } from "@comet/admin";
-import { Stack, Typography } from "@mui/material";
+import { Stack } from "@mui/material";
 
 export default {
     title: "@comet/admin/SectionHeadline",
@@ -9,12 +9,10 @@ export const _SectionHeadline = () => {
     return (
         <Stack spacing={15}>
             <SectionHeadline supportText="Support Text" divider infoTooltip="Tooltip Info Text">
-                <Typography variant="h4">Section Title</Typography>
+                Section Title
             </SectionHeadline>
 
-            <SectionHeadline>
-                <Typography variant="h4">Section Title</Typography>
-            </SectionHeadline>
+            <SectionHeadline>Section Title</SectionHeadline>
         </Stack>
     );
 };

--- a/storybook/src/admin/SectionHeadline.stories.tsx
+++ b/storybook/src/admin/SectionHeadline.stories.tsx
@@ -8,7 +8,7 @@ export default {
 export const _SectionHeadline = () => {
     return (
         <Stack spacing={15}>
-            <SectionHeadline supportText="Support Text" divider infoTooltip="Tooltip Info Text">
+            <SectionHeadline supportText="Support Text" divider infoTooltipText="Tooltip Info Text">
                 Section Title
             </SectionHeadline>
 


### PR DESCRIPTION
## Description

Add a new admin component called `SectionHeadline` and style it according to [design](https://www.figma.com/design/Swzee5YSEkPVlCXHcyL7mp/COMET-DXP-Library?node-id=1227-15666&p=f&m=dev)

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

<img width="952" height="311" alt="Screenshot 2025-08-28 at 10 37 47" src="https://github.com/user-attachments/assets/b0113bc9-3780-41f0-8a89-ae9638ff8515" />


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2272
