### PR TITLE
New `DateTimeRangePicker` and `DateTimeRangePickerField` components

### DIFF
--- a/.changeset/whole-baboons-do.md
+++ b/.changeset/whole-baboons-do.md
@@ -1,0 +1,49 @@
+---
+"@comet/admin": minor
+---
+
+Add new `DateTimeRangePicker` and `DateTimeRangePickerField` components
+
+The new components are based on the `@mui/x-date-pickers-pro` package, so you can refer to the [MUI documentation](https://v7.mui.com/x/api/date-pickers/date-time-range-picker/) for more details.
+Unlike the MUI components, these components use an object with `start` and `end` properties, both of which use a `Date` object as the value, instead of an array of two `Date` objects.
+
+Note: Using these components requires a [MUI X Pro license](https://v7.mui.com/x/introduction/licensing/).
+
+**Using the new `DateTimeRangePicker`**
+
+```tsx
+import { type DateTimeRange, FieldContainer, DateTimeRangePicker } from "@comet/admin";
+import { useState } from "react";
+
+export const Example = () => {
+    const [dateTimeRangeValue, setDateTimeRangeValue] = useState<DateTimeRange | undefined>();
+
+    return (
+        <FieldContainer label="Date-Time Range Picker">
+            <DateTimeRangePicker value={dateTimeRangeValue} onChange={setDateTimeRangeValue} />
+        </FieldContainer>
+    );
+};
+```
+
+**Using the new `DateTimeRangePickerField` in Final Form**
+
+```tsx
+import { type DateTimeRange, FieldContainer, DateTimeRangePicker } from "@comet/admin";
+import { useState } from "react";
+
+type Values = {
+    dateTimeRange: DateTimeRange;
+};
+
+export const Example = () => {
+    return (
+        <Form<Values>
+            initialValues={{ dateTimeRange: { start: new Date("2025-07-23 11:30:00"), end: new Date("2025-07-25 14:30:00") } }}
+            onSubmit={() => {}}
+        >
+            {() => <DateTimeRangePickerField name="dateTimeRange" label="Date-Time Range Picker" />}
+        </Form>
+    );
+};
+```

--- a/packages/admin/admin/src/dateTime/DateTimePicker.tsx
+++ b/packages/admin/admin/src/dateTime/DateTimePicker.tsx
@@ -12,6 +12,7 @@ import { OpenPickerAdornment } from "../common/OpenPickerAdornment";
 import { ReadOnlyAdornment } from "../common/ReadOnlyAdornment";
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+import { isValidDate } from "./utils";
 
 export type Future_DateTimePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdornment" | "openPickerAdornment";
 
@@ -60,7 +61,7 @@ export const Future_DateTimePicker = (inProps: Future_DateTimePickerProps) => {
             disableOpenPicker
             value={value}
             onChange={(date) => {
-                const dateIsInvalid = date !== null && isNaN(date.getTime());
+                const dateIsInvalid = date !== null && !isValidDate(date);
                 if (dateIsInvalid) {
                     return;
                 }

--- a/packages/admin/admin/src/dateTime/DateTimeRangePicker.tsx
+++ b/packages/admin/admin/src/dateTime/DateTimeRangePicker.tsx
@@ -1,0 +1,175 @@
+import { Calendar } from "@comet/admin-icons";
+import { type ComponentsOverrides, css, inputLabelClasses, type Theme, useThemeProps } from "@mui/material";
+import { type DateTimeRangePickerProps as MuiDateTimeRangePickerProps } from "@mui/x-date-pickers-pro";
+import { type ComponentType, lazy, type ReactNode, Suspense, useState } from "react";
+
+import { ClearInputAdornment as CometClearInputAdornment } from "../common/ClearInputAdornment";
+import { OpenPickerAdornment } from "../common/OpenPickerAdornment";
+import { ReadOnlyAdornment } from "../common/ReadOnlyAdornment";
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+import { isValidDate } from "./utils";
+
+export type DateTimeRange = {
+    start: Date | null;
+    end: Date | null;
+};
+
+export type DateTimeRangePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdornment" | "openPickerAdornment";
+
+export type DateTimeRangePickerProps = ThemedComponentBaseProps<{
+    root: ComponentType<MuiDateTimeRangePickerProps<Date, true>>;
+    clearInputAdornment: typeof CometClearInputAdornment;
+    readOnlyAdornment: typeof ReadOnlyAdornment;
+    openPickerAdornment: typeof OpenPickerAdornment;
+}> & {
+    fullWidth?: boolean;
+    required?: boolean;
+    value?: DateTimeRange;
+    onChange?: (date: DateTimeRange | undefined) => void;
+    iconMapping?: {
+        openPicker?: ReactNode;
+    };
+} & Omit<MuiDateTimeRangePickerProps<Date, true>, "value" | "onChange">;
+
+export const DateTimeRangePicker = (inProps: DateTimeRangePickerProps) => {
+    const {
+        iconMapping = {},
+        fullWidth,
+        required,
+        slotProps,
+        disabled,
+        value: valueObject,
+        onChange,
+        readOnly,
+        ...restProps
+    } = useThemeProps({
+        props: inProps,
+        name: "CometAdminDateTimeRangePicker",
+    });
+    const [open, setOpen] = useState(false);
+    const arrayValue: [Date | null, Date | null] = valueObject ? [valueObject.start, valueObject.end] : [null, null];
+
+    const { openPicker: openPickerIcon = <Calendar color="inherit" /> } = iconMapping;
+
+    return (
+        <Suspense>
+            <LazyRoot
+                enableAccessibleFieldDOMStructure
+                disabled={disabled}
+                readOnly={readOnly}
+                open={open}
+                onOpen={() => setOpen(true)}
+                onClose={() => setOpen(false)}
+                disableOpenPicker
+                value={arrayValue}
+                onChange={([startDate, endDate]) => {
+                    const startDateIsInvalid = startDate !== null && !isValidDate(startDate);
+                    const endDateIsInvalid = endDate !== null && !isValidDate(endDate);
+
+                    if (startDateIsInvalid || endDateIsInvalid) {
+                        return;
+                    }
+
+                    if (!startDate && !endDate) {
+                        onChange?.(undefined);
+                        return;
+                    }
+
+                    onChange?.({
+                        start: startDate,
+                        end: endDate,
+                    });
+                }}
+                {...slotProps?.root}
+                {...restProps}
+                slotProps={{
+                    ...slotProps?.root?.slotProps,
+                    textField: (ownerState) => {
+                        const textFieldProps = {
+                            ...slotProps?.root?.slotProps?.textField,
+                            ownerState,
+                        };
+
+                        return {
+                            fullWidth,
+                            required,
+                            ...textFieldProps,
+                            InputProps: {
+                                ...textFieldProps?.InputProps,
+                                startAdornment: (
+                                    <>
+                                        <OpenPickerAdornment
+                                            inputIsDisabled={disabled}
+                                            inputIsReadOnly={readOnly}
+                                            onClick={() => setOpen(true)}
+                                            {...slotProps?.openPickerAdornment}
+                                        >
+                                            {openPickerIcon}
+                                        </OpenPickerAdornment>
+                                        {textFieldProps?.InputProps?.startAdornment}
+                                    </>
+                                ),
+                                endAdornment: (
+                                    <>
+                                        {textFieldProps?.InputProps?.endAdornment}
+                                        <ReadOnlyAdornment inputIsReadOnly={Boolean(readOnly)} {...slotProps?.readOnlyAdornment} />
+                                        <ClearInputAdornment
+                                            position="end"
+                                            hasClearableContent={arrayValue.some((date) => date !== null) && !required && !disabled && !readOnly}
+                                            onClick={() => onChange?.(undefined)}
+                                            {...slotProps?.clearInputAdornment}
+                                        />
+                                    </>
+                                ),
+                            },
+                        };
+                    },
+                }}
+            />
+        </Suspense>
+    );
+};
+
+const LazyRoot = lazy(async () => {
+    const module = await import("@mui/x-date-pickers-pro");
+
+    const Root = createComponentSlot(module.DateTimeRangePicker<Date, true>)<DateTimeRangePickerClassKey>({
+        componentName: "DateTimeRangePicker",
+        slotName: "root",
+    })(css`
+        .${inputLabelClasses.root} {
+            display: none;
+
+            & + .${module.pickersInputBaseClasses.root} {
+                margin-top: 0;
+            }
+        }
+    `);
+
+    return {
+        default: (props: MuiDateTimeRangePickerProps<Date, true>) => <Root {...props} />,
+    };
+});
+
+const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<DateTimeRangePickerClassKey>({
+    componentName: "DateTimeRangePicker",
+    slotName: "clearInputAdornment",
+})();
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminDateTimeRangePicker: DateTimeRangePickerProps;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminDateTimeRangePicker: DateTimeRangePickerClassKey;
+    }
+
+    interface Components {
+        CometAdminDateTimeRangePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminDateTimeRangePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDateTimeRangePicker"];
+        };
+    }
+}

--- a/packages/admin/admin/src/dateTime/DateTimeRangePickerField.tsx
+++ b/packages/admin/admin/src/dateTime/DateTimeRangePickerField.tsx
@@ -1,0 +1,18 @@
+import { type FieldRenderProps } from "react-final-form";
+
+import { Field, type FieldProps } from "../form/Field";
+import { type DateTimeRange, DateTimeRangePicker, type DateTimeRangePickerProps } from "./DateTimeRangePicker";
+
+const FinalFormDateTimeRangePicker = ({
+    meta,
+    input,
+    ...restProps
+}: DateTimeRangePickerProps & FieldRenderProps<DateTimeRange, HTMLInputElement>) => {
+    return <DateTimeRangePicker {...input} {...restProps} />;
+};
+
+export type DateTimeRangePickerFieldProps = FieldProps<DateTimeRange, HTMLInputElement>;
+
+export const DateTimeRangePickerField = (props: DateTimeRangePickerFieldProps) => {
+    return <Field component={FinalFormDateTimeRangePicker} {...props} />;
+};

--- a/packages/admin/admin/src/dateTime/utils.ts
+++ b/packages/admin/admin/src/dateTime/utils.ts
@@ -17,3 +17,7 @@ export const getDateValue = (value: string | null | undefined): Date | null => {
 export const getIsoDateString = (date: Date) => {
     return format(date, "yyyy-MM-dd");
 };
+
+export const isValidDate = (date: Date) => {
+    return !isNaN(date.getTime());
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -97,6 +97,8 @@ export { type DateRange, Future_DateRangePicker, Future_DateRangePickerClassKey,
 export { Future_DateRangePickerField, Future_DateRangePickerFieldProps } from "./dateTime/DateRangePickerField";
 export { Future_DateTimePicker, Future_DateTimePickerClassKey, Future_DateTimePickerProps } from "./dateTime/DateTimePicker";
 export { Future_DateTimePickerField, Future_DateTimePickerFieldProps } from "./dateTime/DateTimePickerField";
+export { type DateTimeRange, DateTimeRangePicker, DateTimeRangePickerClassKey, DateTimeRangePickerProps } from "./dateTime/DateTimeRangePicker";
+export { DateTimeRangePickerField, DateTimeRangePickerFieldProps } from "./dateTime/DateTimeRangePickerField";
 export { Future_TimePicker, Future_TimePickerClassKey, Future_TimePickerProps } from "./dateTime/TimePicker";
 export { Future_TimePickerField, Future_TimePickerFieldProps } from "./dateTime/TimePickerField";
 export { DeleteMutation } from "./DeleteMutation";

--- a/storybook/src/admin-component-docs/DateTimeRangePicker.stories.tsx
+++ b/storybook/src/admin-component-docs/DateTimeRangePicker.stories.tsx
@@ -1,0 +1,42 @@
+import { DateTimeRangePicker } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DateTimeRangePicker>;
+
+const meta: Meta<typeof DateTimeRangePicker> = {
+    component: DateTimeRangePicker,
+    title: "Component Docs/DateTimeRangePicker",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+    argTypes: {
+        fullWidth: {
+            control: "boolean",
+        },
+        required: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        readOnly: {
+            control: "boolean",
+        },
+    },
+};
+
+export default meta;
+
+/**
+ * The `DateTimeRangePicker` component is used to select a date-time range in a form.
+ *
+ * For usage inside Final Form, use the `DateTimeRangePickerField` component.
+ */
+export const Default: Story = {};

--- a/storybook/src/admin-component-docs/DateTimeRangePickerField.stories.tsx
+++ b/storybook/src/admin-component-docs/DateTimeRangePickerField.stories.tsx
@@ -1,0 +1,63 @@
+import { DateTimeRangePickerField, FinalForm } from "@comet/admin";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { componentDocsDecorator } from "./utils/componentDocsDecorator";
+import { DocsPage } from "./utils/DocsPage";
+
+type Story = StoryObj<typeof DateTimeRangePickerField>;
+
+const meta: Meta<typeof DateTimeRangePickerField> = {
+    component: DateTimeRangePickerField,
+    title: "Component Docs/DateTimeRangePickerField",
+    tags: ["adminComponentDocs"],
+    decorators: [componentDocsDecorator()],
+    parameters: {
+        docs: {
+            page: () => <DocsPage defaultStory={Default} />,
+        },
+    },
+    argTypes: {
+        fullWidth: {
+            control: "boolean",
+        },
+        required: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        readOnly: {
+            control: "boolean",
+        },
+        name: {
+            control: "text",
+        },
+        label: {
+            control: "text",
+        },
+        helperText: {
+            control: "text",
+        },
+    },
+    args: {
+        name: "dateTimeRange",
+        label: "Date Time Range",
+    },
+};
+
+export default meta;
+
+/**
+ * The `DateTimeRangePickerField` component is used to select a date-time range in a Final Form.
+ *
+ * For usage outside of Final Form, use the `DateTimeRangePicker` component.
+ */
+export const Default: Story = {
+    render: ({ ...props }) => {
+        return (
+            <FinalForm mode="edit" onSubmit={() => {}}>
+                <DateTimeRangePickerField {...props} />
+            </FinalForm>
+        );
+    },
+};

--- a/storybook/src/admin/dateTime/DateTimeRangePicker.stories.tsx
+++ b/storybook/src/admin/dateTime/DateTimeRangePicker.stories.tsx
@@ -1,0 +1,97 @@
+import { type DateTimeRange, DateTimeRangePicker, DateTimeRangePickerField, FieldContainer } from "@comet/admin";
+import { Grid } from "@mui/material";
+import { type Meta, type StoryObj } from "@storybook/react-webpack5";
+import { useState } from "react";
+import { Form } from "react-final-form";
+
+type Story = StoryObj<typeof DateTimeRangePicker>;
+
+const config: Meta<typeof DateTimeRangePicker> = {
+    component: DateTimeRangePicker,
+    title: "@comet/admin/dateTime/DateTimeRangePicker",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        const [dateTimeRange, setDateTimeRange] = useState<DateTimeRange | undefined>({
+            start: new Date("2025-07-23 11:30:00"),
+            end: new Date("2025-07-25 14:30:00"),
+        });
+        const [requiredDateTimeRange, setRequiredDateTimeRange] = useState<DateTimeRange | undefined>(undefined);
+        const [disabledDateTimeRange, setDisabledDateTimeRange] = useState<DateTimeRange | undefined>(undefined);
+        const [readOnlyDateTimeRange, setReadOnlyDateTimeRange] = useState<DateTimeRange | undefined>({
+            start: new Date("2025-07-23 11:30:00"),
+            end: new Date("2025-07-25 14:30:00"),
+        });
+
+        return (
+            <Grid container spacing={4}>
+                <Grid size={{ xs: 12, md: 6 }}>
+                    <FieldContainer label="Date Time Range Picker" fullWidth>
+                        <DateTimeRangePicker value={dateTimeRange} onChange={setDateTimeRange} fullWidth />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12, md: 6 }}>
+                    <FieldContainer label="Required Date Time Range Picker" fullWidth required>
+                        <DateTimeRangePicker value={requiredDateTimeRange} onChange={setRequiredDateTimeRange} fullWidth required />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12, md: 6 }}>
+                    <FieldContainer label="Disabled Date Time Range Picker" fullWidth disabled>
+                        <DateTimeRangePicker value={disabledDateTimeRange} onChange={setDisabledDateTimeRange} fullWidth disabled />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12, md: 6 }}>
+                    <FieldContainer label="ReadOnly Date Time Range Picker" fullWidth>
+                        <DateTimeRangePicker value={readOnlyDateTimeRange} onChange={setReadOnlyDateTimeRange} fullWidth readOnly />
+                    </FieldContainer>
+                </Grid>
+                <Grid size={{ xs: 12 }}>
+                    <pre>{`values: ${JSON.stringify({ dateTimeRange, requiredDateTimeRange, disabledDateTimeRange, readOnlyDateTimeRange }, null, 2)}`}</pre>
+                </Grid>
+            </Grid>
+        );
+    },
+};
+
+export const FinalForm: Story = {
+    render: () => {
+        type Values = {
+            dateTimeRange: DateTimeRange;
+            requiredDateTimeRange: DateTimeRange;
+            disabledDateTimeRange: DateTimeRange;
+            readOnlyDateTimeRange: DateTimeRange;
+        };
+
+        return (
+            <Form<Values>
+                initialValues={{
+                    dateTimeRange: { start: new Date("2025-07-23 11:30:00"), end: new Date("2025-07-25 14:30:00") },
+                    readOnlyDateTimeRange: { start: new Date("2025-07-23 11:30:00"), end: new Date("2025-07-25 14:30:00") },
+                }}
+                onSubmit={() => {}}
+            >
+                {({ values }) => (
+                    <Grid container spacing={4}>
+                        <Grid size={{ xs: 12, md: 6 }}>
+                            <DateTimeRangePickerField name="dateTimeRange" label="Date Time Range Picker" fullWidth />
+                        </Grid>
+                        <Grid size={{ xs: 12, md: 6 }}>
+                            <DateTimeRangePickerField name="requiredDateTimeRange" label="Required Date Time Range Picker" fullWidth required />
+                        </Grid>
+                        <Grid size={{ xs: 12, md: 6 }}>
+                            <DateTimeRangePickerField name="disabledDateTimeRange" fullWidth disabled />
+                        </Grid>
+                        <Grid size={{ xs: 12, md: 6 }}>
+                            <DateTimeRangePickerField name="readOnlyDateTimeRange" label="ReadOnly Date Time Range Picker" fullWidth readOnly />
+                        </Grid>
+                        <Grid size={{ xs: 12 }}>
+                            <pre>{`values: ${JSON.stringify(values, null, 2)}`}</pre>
+                        </Grid>
+                    </Grid>
+                )}
+            </Form>
+        );
+    },
+};


### PR DESCRIPTION
## Description

Add new `DateTimeRangePicker` and `DateTimeRangePickerField` components, based on MUI's [V7 DateTimeRangePicker](https://v7.mui.com/x/api/date-pickers/date-time-range-picker/).

The design/styling doesn't yet match the Comet Design, that can be done in a future PR.

Since there is no equivalant component in the `@comet/admin-date-time` package, there is no need to deprecate any existing components or to prefix the new ones with `Future`.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Without value | With value |
| ------ | ----- |
| <img width="724" height="521" alt="DateTimeRangePicker without value" src="https://github.com/user-attachments/assets/ada600d8-028b-495b-8a08-9c8d59a6456a" />   | <img width="724" height="521" alt="DateTimeRangePicker with value" src="https://github.com/user-attachments/assets/ccac1965-b1a8-45b0-a0f4-68a9b4e729e7" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2391
