### PR TITLE
Fix styling of `DialogTitle` in `ChooseFileDialog`

### DIFF
--- a/.changeset/three-oranges-draw.md
+++ b/.changeset/three-oranges-draw.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix styling of `DialogTitle` in `ChooseFileDialog`

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseFileDialog.tsx
@@ -32,7 +32,6 @@ const StyledDialogTitle = styled(DialogTitle)`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    width: 100%;
 `;
 
 const CloseButton = styled(IconButton)`


### PR DESCRIPTION
## Description

The CloseButton in the `ChooseFileDialog` is not visible --> prevent the div from overflowing the Dialog by removing `width: 100%`

_Note: This problem occurs in Comet v7 - it was already fixed in v8_

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1645" height="786" alt="Screenshot 2025-08-28 at 13 37 22" src="https://github.com/user-attachments/assets/054115c4-0dc6-4744-a518-d5bc87225626" /> | <img width="1634" height="807" alt="Screenshot 2025-08-28 at 13 36 51" src="https://github.com/user-attachments/assets/8593d607-2610-43c4-9fa4-427b5d487dbf" /> |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2262