### PR TITLE
Allow focusing clear-button of inputs

### DIFF
--- a/.changeset/huge-shrimps-share.md
+++ b/.changeset/huge-shrimps-share.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+The clear-button, inside `ClearInputAdornment` can now be focused

--- a/packages/admin/admin/src/common/ClearInputAdornment.tsx
+++ b/packages/admin/admin/src/common/ClearInputAdornment.tsx
@@ -52,7 +52,7 @@ export const ClearInputAdornment = (inProps: ClearInputAdornmentProps) => {
     return (
         <Grow in={hasClearableContent}>
             <Root position={position} ownerState={ownerState} {...slotProps?.root} {...restProps}>
-                <Button tabIndex={-1} onClick={onClick} {...slotProps?.buttonBase}>
+                <Button onClick={onClick} focusRipple {...slotProps?.buttonBase}>
                     {icon}
                 </Button>
             </Root>


### PR DESCRIPTION
## Description

Originally, the clear-button was not supposed to be focusable to allow faster navigation from one input to the next. 
We are now changing this for improved accessibility. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="320" height="101" alt="Textfield with non-focused clear-button" src="https://github.com/user-attachments/assets/669e5e97-7c90-4c1d-bc78-98e07d1c7793" />   | <img width="320" height="101" alt="Textfield with focused clear-button" src="https://github.com/user-attachments/assets/7d7ccbc3-b2e9-41a9-9291-2b36e8deb4ab" />  |

## Open TODOs/questions

-   [x] Add changeset
-   [x] Add screenshots
-   [x] Check with UX about focus-styling

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2268
