### PR TITLE
Move Toolbar outside of DataGrid component in `ContentScopeGrid`

### DIFF
--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/ContentScopeGrid.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/ContentScopeGrid.tsx
@@ -37,6 +37,15 @@ interface ToolbarProps extends GridToolbarProps {
     toolbarAction?: ReactNode;
 }
 
+function ContentScopeGridToolbar({ toolbarAction }: ToolbarProps) {
+    return (
+        <DataGridToolbar>
+            <FillSpace />
+            {toolbarAction}
+        </DataGridToolbar>
+    );
+}
+
 export const ContentScopeGrid = ({ userId }: { userId: string }) => {
     const intl = useIntl();
     const [open, setOpen] = useState(false);
@@ -64,15 +73,6 @@ export const ContentScopeGrid = ({ userId }: { userId: string }) => {
     }
 
     const columns: GridColDef<ContentScope>[] = generateGridColumnsFromContentScopeProperties(data.availableContentScopes);
-
-    function ContentScopeGridToolbar({ toolbarAction }: ToolbarProps) {
-        return (
-            <DataGridToolbar>
-                <FillSpace />
-                {toolbarAction}
-            </DataGridToolbar>
-        );
-    }
 
     const toolbarSlotProps: ToolbarProps = {
         toolbarAction: (


### PR DESCRIPTION
## Description

Move Toolbar outside of DataGrid component in `ContentScopeGrid` as React components should not be defined in another component. 

(Fix for: https://github.com/vivid-planet/comet/pull/4347/files#r2307322405) 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset

## Further information

-  Task: https://vivid-planet.atlassian.net/browse/COM-2234
