### PR TITLE
Use constants for metadata keys in Decorators and Reflect calls

### DIFF
--- a/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { type CrudGeneratorOptions, getCrudSearchFieldsFromMetadata, hasCrudFieldFeature } from "@comet/cms-api";
+import { CRUD_GENERATOR_METADATA_KEY } from "@comet/cms-api/lib/common/decorators/crud-generator.decorator";
 import { SCOPED_ENTITY_METADATA_KEY } from "@comet/cms-api/lib/user-permissions/decorators/scoped-entity.decorator";
 import { type EntityMetadata, ReferenceKind } from "@mikro-orm/postgresql";
 import * as path from "path";
@@ -1302,7 +1303,7 @@ export async function generateCrud(generatorOptionsParam: CrudGeneratorOptions, 
             .filter((prop) => {
                 if (prop.kind === "1:m" && prop.orphanRemoval) {
                     if (!prop.targetMeta) throw new Error(`Target metadata not set`);
-                    const hasOwnCrudGenerator = Reflect.getMetadata(`data:crudGeneratorOptions`, prop.targetMeta.class);
+                    const hasOwnCrudGenerator = Reflect.getMetadata(CRUD_GENERATOR_METADATA_KEY, prop.targetMeta.class);
                     if (!hasOwnCrudGenerator) {
                         //generate nested resolver only if target entity has no own crud generator
                         return true;

--- a/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { type CrudGeneratorOptions, getCrudSearchFieldsFromMetadata, hasCrudFieldFeature } from "@comet/cms-api";
-import { CRUD_GENERATOR_METADATA_KEY } from "@comet/cms-api/lib/common/decorators/crud-generator.decorator";
-import { SCOPED_ENTITY_METADATA_KEY } from "@comet/cms-api/lib/user-permissions/decorators/scoped-entity.decorator";
+import {
+    CRUD_GENERATOR_METADATA_KEY,
+    type CrudGeneratorOptions,
+    getCrudSearchFieldsFromMetadata,
+    hasCrudFieldFeature,
+    SCOPED_ENTITY_METADATA_KEY,
+} from "@comet/cms-api";
 import { type EntityMetadata, ReferenceKind } from "@mikro-orm/postgresql";
 import * as path from "path";
 import { singular } from "pluralize";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { type CrudGeneratorOptions, getCrudSearchFieldsFromMetadata, hasCrudFieldFeature } from "@comet/cms-api";
+import { SCOPED_ENTITY_METADATA_KEY } from "@comet/cms-api/lib/user-permissions/decorators/scoped-entity.decorator";
 import { type EntityMetadata, ReferenceKind } from "@mikro-orm/postgresql";
 import * as path from "path";
 import { singular } from "pluralize";
@@ -88,7 +89,7 @@ export function buildOptions(metadata: EntityMetadata<any>, generatorOptions: Cr
         : [];
     const positionGroupProps = hasPositionProp ? metadata.props.filter((prop) => positionGroupPropNames.includes(prop.name)) : [];
 
-    const scopedEntity = Reflect.getMetadata("scopedEntity", metadata.class);
+    const scopedEntity = Reflect.getMetadata(SCOPED_ENTITY_METADATA_KEY, metadata.class);
     const skipScopeCheck = !scopeProp && !scopedEntity;
 
     const argsClassName = `${classNameSingular != classNamePlural ? classNamePlural : `${classNamePlural}List`}Args`;

--- a/packages/api/api-generator/src/commands/generate/generateFiles.ts
+++ b/packages/api/api-generator/src/commands/generate/generateFiles.ts
@@ -1,6 +1,7 @@
 import console from "node:console";
 
 import type { CrudGeneratorOptions, CrudSingleGeneratorOptions } from "@comet/cms-api";
+import { CRUD_GENERATOR_METADATA_KEY, CRUD_SINGLE_GENERATOR_METADATA_KEY } from "@comet/cms-api/lib/common/decorators/crud-generator.decorator";
 import { CLIHelper } from "@mikro-orm/cli";
 import { type MikroORM } from "@mikro-orm/core";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
@@ -42,7 +43,7 @@ export const generateFiles = async (
             }
             if (file == null || entity.path === `./${file}`) {
                 {
-                    const generatorOptions = Reflect.getMetadata(`data:crudGeneratorOptions`, entity.class) as CrudGeneratorOptions | undefined;
+                    const generatorOptions = Reflect.getMetadata(CRUD_GENERATOR_METADATA_KEY, entity.class) as CrudGeneratorOptions | undefined;
                     if (generatorOptions) {
                         console.log(`🚀 start generateCrud for Entity ${entity.path}`);
                         const files = await generateCrud(generatorOptions, entity);
@@ -50,7 +51,7 @@ export const generateFiles = async (
                     }
                 }
                 {
-                    const generatorOptions = Reflect.getMetadata(`data:crudSingleGeneratorOptions`, entity.class) as
+                    const generatorOptions = Reflect.getMetadata(CRUD_SINGLE_GENERATOR_METADATA_KEY, entity.class) as
                         | CrudSingleGeneratorOptions
                         | undefined;
                     if (generatorOptions) {

--- a/packages/api/api-generator/src/commands/generate/generateFiles.ts
+++ b/packages/api/api-generator/src/commands/generate/generateFiles.ts
@@ -1,7 +1,11 @@
 import console from "node:console";
 
-import type { CrudGeneratorOptions, CrudSingleGeneratorOptions } from "@comet/cms-api";
-import { CRUD_GENERATOR_METADATA_KEY, CRUD_SINGLE_GENERATOR_METADATA_KEY } from "@comet/cms-api/lib/common/decorators/crud-generator.decorator";
+import {
+    CRUD_GENERATOR_METADATA_KEY,
+    CRUD_SINGLE_GENERATOR_METADATA_KEY,
+    type CrudGeneratorOptions,
+    type CrudSingleGeneratorOptions,
+} from "@comet/cms-api";
 import { CLIHelper } from "@mikro-orm/cli";
 import { type MikroORM } from "@mikro-orm/core";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";

--- a/packages/api/cms-api/src/auth/decorators/disable-comet-guards.decorator.ts
+++ b/packages/api/cms-api/src/auth/decorators/disable-comet-guards.decorator.ts
@@ -1,5 +1,7 @@
 import { type CustomDecorator, SetMetadata } from "@nestjs/common";
 
+export const DISABLE_COMET_GUARDS_METADATA_KEY = "disableCometGuards";
+
 export const DisableCometGuards = (): CustomDecorator<string> => {
-    return SetMetadata("disableCometGuards", true);
+    return SetMetadata(DISABLE_COMET_GUARDS_METADATA_KEY, true);
 };

--- a/packages/api/cms-api/src/auth/guards/comet.guard.ts
+++ b/packages/api/cms-api/src/auth/guards/comet.guard.ts
@@ -7,6 +7,7 @@ import { CurrentUser } from "../../user-permissions/dto/current-user";
 import { User } from "../../user-permissions/interfaces/user";
 import { UserPermissionsService } from "../../user-permissions/user-permissions.service";
 import { SystemUser } from "../../user-permissions/user-permissions.types";
+import { DISABLE_COMET_GUARDS_METADATA_KEY } from "../decorators/disable-comet-guards.decorator";
 import { AuthServiceInterface, SKIP_AUTH_SERVICE } from "../util/auth-service.interface";
 
 @Injectable()
@@ -26,7 +27,7 @@ export class CometAuthGuard implements CanActivate {
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const request = this.getRequest(context);
 
-        const disableCometGuard = this.reflector.getAllAndOverride("disableCometGuards", [context.getHandler(), context.getClass()]);
+        const disableCometGuard = this.reflector.getAllAndOverride(DISABLE_COMET_GUARDS_METADATA_KEY, [context.getHandler(), context.getClass()]);
         const hasIncludeInvisibleContentHeader = !!request.headers["x-include-invisible-content"];
         if (disableCometGuard && !hasIncludeInvisibleContentHeader) {
             return true;

--- a/packages/api/cms-api/src/blocks/decorators/field.ts
+++ b/packages/api/cms-api/src/blocks/decorators/field.ts
@@ -32,7 +32,9 @@ type BlockFieldOptions =
           block: Block;
       };
 
+/** @knipignore */
 export const BLOCK_FIELD_METADATA_KEY = "data:fieldType";
+/** @knipignore */
 export const BLOCK_FIELD_KEYS_METADATA_KEY = "keys:field";
 
 export function BlockField(

--- a/packages/api/cms-api/src/blocks/decorators/field.ts
+++ b/packages/api/cms-api/src/blocks/decorators/field.ts
@@ -32,10 +32,8 @@ type BlockFieldOptions =
           block: Block;
       };
 
-/** @knipignore */
-export const BLOCK_FIELD_METADATA_KEY = "data:fieldType";
-/** @knipignore */
-export const BLOCK_FIELD_KEYS_METADATA_KEY = "keys:field";
+const BLOCK_FIELD_METADATA_KEY = "data:fieldType";
+const BLOCK_FIELD_KEYS_METADATA_KEY = "keys:field";
 
 export function BlockField(
     type?:

--- a/packages/api/cms-api/src/blocks/decorators/field.ts
+++ b/packages/api/cms-api/src/blocks/decorators/field.ts
@@ -32,6 +32,9 @@ type BlockFieldOptions =
           block: Block;
       };
 
+export const BLOCK_FIELD_METADATA_KEY = "data:fieldType";
+export const BLOCK_FIELD_KEYS_METADATA_KEY = "keys:field";
+
 export function BlockField(
     type?:
         | Block
@@ -42,11 +45,13 @@ export function BlockField(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return function (ctorPrototype: any, propertyKey: string | symbol): void {
         if (type) {
-            Reflect.defineMetadata(`data:fieldType`, type, ctorPrototype, propertyKey);
+            Reflect.defineMetadata(BLOCK_FIELD_METADATA_KEY, type, ctorPrototype, propertyKey);
         }
-        const propertyKeys = Reflect.getOwnMetadata(`keys:field`, ctorPrototype) || (Reflect.getMetadata(`keys:field`, ctorPrototype) || []).slice(0);
+        const propertyKeys =
+            Reflect.getOwnMetadata(BLOCK_FIELD_KEYS_METADATA_KEY, ctorPrototype) ||
+            (Reflect.getMetadata(BLOCK_FIELD_KEYS_METADATA_KEY, ctorPrototype) || []).slice(0);
         propertyKeys.push(propertyKey);
-        Reflect.defineMetadata(`keys:field`, propertyKeys, ctorPrototype);
+        Reflect.defineMetadata(BLOCK_FIELD_KEYS_METADATA_KEY, propertyKeys, ctorPrototype);
     };
 }
 
@@ -67,7 +72,7 @@ export function getBlockFieldData(ctor: { prototype: any }, propertyKey: string)
     const designType = Reflect.getMetadata(`design:type`, ctor.prototype, propertyKey);
     let ret: BlockFieldData | undefined = undefined;
 
-    const fieldType = Reflect.getMetadata(`data:fieldType`, ctor.prototype, propertyKey);
+    const fieldType = Reflect.getMetadata(BLOCK_FIELD_METADATA_KEY, ctor.prototype, propertyKey);
 
     const nullable = !!(fieldType && fieldType.nullable);
     const array: boolean | undefined = fieldType?.array ?? undefined;
@@ -133,7 +138,7 @@ export function getBlockFieldData(ctor: { prototype: any }, propertyKey: string)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getFieldKeys(ctor: { prototype: any }): string[] {
-    return (Reflect.getMetadata(`keys:field`, ctor.prototype) || []) as string[];
+    return (Reflect.getMetadata(BLOCK_FIELD_KEYS_METADATA_KEY, ctor.prototype) || []) as string[];
 }
 
 export class AnnotationBlockMeta implements BlockMetaInterface {

--- a/packages/api/cms-api/src/blocks/decorators/root-block-entity.ts
+++ b/packages/api/cms-api/src/blocks/decorators/root-block-entity.ts
@@ -3,9 +3,12 @@ import { type AnyEntity } from "@mikro-orm/postgresql";
 export interface RootBlockEntityOptions<Entity extends AnyEntity = AnyEntity> {
     isVisible?: (entity: Entity) => boolean;
 }
+
+export const ROOT_BLOCK_ENTITY_METADATA_KEY = "data:rootBlockEntityOptions";
+
 export function RootBlockEntity<Entity extends AnyEntity = AnyEntity>(options: RootBlockEntityOptions<Entity> = {}): ClassDecorator {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     return function (target: Function) {
-        Reflect.defineMetadata(`data:rootBlockEntityOptions`, options, target);
+        Reflect.defineMetadata(ROOT_BLOCK_ENTITY_METADATA_KEY, options, target);
     };
 }

--- a/packages/api/cms-api/src/blocks/decorators/root-block.ts
+++ b/packages/api/cms-api/src/blocks/decorators/root-block.ts
@@ -1,12 +1,17 @@
 import { type Block } from "../block";
 
+export const ROOT_BLOCK_METADATA_KEY = "data:rootBlock";
+export const ROOT_BLOCK_KEYS_METADATA_KEY = "keys:rootBlock";
+
 export function RootBlock(block: Block): PropertyDecorator {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return function (target: any, propertyKey: string | symbol) {
-        Reflect.defineMetadata(`data:rootBlock`, block, target, propertyKey);
+        Reflect.defineMetadata(ROOT_BLOCK_METADATA_KEY, block, target, propertyKey);
 
-        const propertyKeys = Reflect.getOwnMetadata(`keys:rootBlock`, target) || (Reflect.getMetadata(`keys:rootBlock`, target) || []).slice(0);
+        const propertyKeys =
+            Reflect.getOwnMetadata(ROOT_BLOCK_KEYS_METADATA_KEY, target) ||
+            (Reflect.getMetadata(ROOT_BLOCK_KEYS_METADATA_KEY, target) || []).slice(0);
         propertyKeys.push(propertyKey);
-        Reflect.defineMetadata(`keys:rootBlock`, propertyKeys, target);
+        Reflect.defineMetadata(ROOT_BLOCK_KEYS_METADATA_KEY, propertyKeys, target);
     };
 }

--- a/packages/api/cms-api/src/common/decorators/crud-generator.decorator.ts
+++ b/packages/api/cms-api/src/common/decorators/crud-generator.decorator.ts
@@ -11,6 +11,8 @@ export interface CrudGeneratorOptions {
     position?: { groupByFields: string[] };
 }
 
+export const CRUD_GENERATOR_METADATA_KEY = "data:crudGeneratorOptions";
+
 export function CrudGenerator({
     targetDirectory,
     requiredPermission,
@@ -24,7 +26,7 @@ export function CrudGenerator({
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     return function (target: Function) {
         Reflect.defineMetadata(
-            `data:crudGeneratorOptions`,
+            CRUD_GENERATOR_METADATA_KEY,
             { targetDirectory, requiredPermission, create, update, delete: deleteMutation, list, single, position },
             target,
         );
@@ -36,10 +38,12 @@ export interface CrudSingleGeneratorOptions {
     requiredPermission: Permission | Permission[];
 }
 
+export const CRUD_SINGLE_GENERATOR_METADATA_KEY = "data:crudSingleGeneratorOptions";
+
 export function CrudSingleGenerator(options: CrudSingleGeneratorOptions): ClassDecorator {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     return function (target: Function) {
-        Reflect.defineMetadata(`data:crudSingleGeneratorOptions`, options, target);
+        Reflect.defineMetadata(CRUD_SINGLE_GENERATOR_METADATA_KEY, options, target);
     };
 }
 
@@ -52,6 +56,8 @@ export interface CrudFieldOptions {
     input?: boolean;
 }
 
+export const CRUD_FIELD_METADATA_KEY = "data:crudField";
+
 export function CrudField({
     resolveField = true,
     dedicatedResolverArg = false,
@@ -63,7 +69,7 @@ export function CrudField({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return function (target: any, propertyKey: string | symbol) {
         Reflect.defineMetadata(
-            `data:crudField`,
+            CRUD_FIELD_METADATA_KEY,
             { resolveField, dedicatedResolverArg, search, filter, sort, input },
             target.constructor,
             propertyKey,

--- a/packages/api/cms-api/src/common/entityInfo/entity-info.decorator.ts
+++ b/packages/api/cms-api/src/common/entityInfo/entity-info.decorator.ts
@@ -13,9 +13,11 @@ export interface EntityInfoServiceInterface<Entity extends AnyEntity = AnyEntity
 
 export type EntityInfoGetter<Entity extends AnyEntity = AnyEntity> = GetEntityInfo<Entity> | Type<EntityInfoServiceInterface<Entity>>;
 
+export const ENTITY_INFO_METADATA_KEY = "data:entityInfo";
+
 export function EntityInfo<Entity extends AnyEntity = AnyEntity>(entityInfoGetter: EntityInfoGetter<Entity>): ClassDecorator {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     return (target: Function) => {
-        Reflect.defineMetadata(`data:entityInfo`, entityInfoGetter, target);
+        Reflect.defineMetadata(ENTITY_INFO_METADATA_KEY, entityInfoGetter, target);
     };
 }

--- a/packages/api/cms-api/src/common/entityInfo/entity-info.service.ts
+++ b/packages/api/cms-api/src/common/entityInfo/entity-info.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, Type } from "@nestjs/common";
 import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
 import { ModuleRef } from "@nestjs/core";
 
-import { EntityInfoGetter, EntityInfoInterface, EntityInfoServiceInterface } from "./entity-info.decorator";
+import { ENTITY_INFO_METADATA_KEY, EntityInfoGetter, EntityInfoInterface, EntityInfoServiceInterface } from "./entity-info.decorator";
 
 @Injectable()
 export class EntityInfoService {
@@ -11,7 +11,7 @@ export class EntityInfoService {
     constructor(private readonly moduleRef: ModuleRef) {}
 
     async getEntityInfo(instance: object): Promise<EntityInfoInterface | undefined> {
-        const entityInfoGetter: EntityInfoGetter | undefined = Reflect.getMetadata(`data:entityInfo`, instance.constructor);
+        const entityInfoGetter: EntityInfoGetter | undefined = Reflect.getMetadata(ENTITY_INFO_METADATA_KEY, instance.constructor);
 
         if (entityInfoGetter === undefined) {
             this.logger.warn(

--- a/packages/api/cms-api/src/common/helper/crud-generator.helper.ts
+++ b/packages/api/cms-api/src/common/helper/crud-generator.helper.ts
@@ -1,10 +1,10 @@
 import { type EntityMetadata } from "@mikro-orm/postgresql";
 
-import { type CrudFieldOptions } from "../decorators/crud-generator.decorator";
+import { CRUD_FIELD_METADATA_KEY, type CrudFieldOptions } from "../decorators/crud-generator.decorator";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function hasCrudFieldFeature(metadataClass: any, propName: string, option: keyof CrudFieldOptions): boolean {
-    const crudField = (Reflect.getMetadata(`data:crudField`, metadataClass, propName) ?? {}) as CrudFieldOptions;
+    const crudField = (Reflect.getMetadata(CRUD_FIELD_METADATA_KEY, metadataClass, propName) ?? {}) as CrudFieldOptions;
     const defaultValue = option == "dedicatedResolverArg" ? false : true;
     return !!(crudField[option] ?? defaultValue);
 }

--- a/packages/api/cms-api/src/dependencies/discover.service.ts
+++ b/packages/api/cms-api/src/dependencies/discover.service.ts
@@ -4,7 +4,8 @@ import { TypeMetadataStorage } from "@nestjs/graphql";
 import { ObjectTypeMetadata } from "@nestjs/graphql/dist/schema-builder/metadata/object-type.metadata";
 
 import { Block } from "../blocks/block";
-import { RootBlockEntityOptions } from "../blocks/decorators/root-block-entity";
+import { ROOT_BLOCK_KEYS_METADATA_KEY, ROOT_BLOCK_METADATA_KEY } from "../blocks/decorators/root-block";
+import { ROOT_BLOCK_ENTITY_METADATA_KEY, RootBlockEntityOptions } from "../blocks/decorators/root-block-entity";
 
 interface DiscoverRootBlocksResult {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,14 +43,14 @@ export class DiscoverService {
         const metadataStorage = this.orm.em.getMetadata();
 
         entities.forEach((entity) => {
-            const rootBlockEntityOptions = Reflect.getMetadata(`data:rootBlockEntityOptions`, entity);
+            const rootBlockEntityOptions = Reflect.getMetadata(ROOT_BLOCK_ENTITY_METADATA_KEY, entity);
 
             if (rootBlockEntityOptions) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const keys = Reflect.getMetadata(`keys:rootBlock`, (entity as any).prototype) || [];
+                const keys = Reflect.getMetadata(ROOT_BLOCK_KEYS_METADATA_KEY, (entity as any).prototype) || [];
                 for (const key of keys) {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    const block = Reflect.getMetadata(`data:rootBlock`, (entity as any).prototype, key);
+                    const block = Reflect.getMetadata(ROOT_BLOCK_METADATA_KEY, (entity as any).prototype, key);
                     ret.push({
                         repository: this.orm.em.getRepository(entity),
                         metadata: metadataStorage.get(entity.name),

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -117,6 +117,8 @@ export { AutoBuildStatus } from "./builds/dto/auto-build-status.object";
 export { ChangesSinceLastBuild } from "./builds/entities/changes-since-last-build.entity";
 export { SKIP_BUILD_METADATA_KEY, SkipBuild } from "./builds/skip-build.decorator";
 export {
+    CRUD_GENERATOR_METADATA_KEY,
+    CRUD_SINGLE_GENERATOR_METADATA_KEY,
     CrudField,
     CrudFieldOptions,
     CrudGenerator,
@@ -255,7 +257,7 @@ export { AzureAiTranslatorModule } from "./translation/azure-ai-translator.modul
 export { AbstractAccessControlService } from "./user-permissions/access-control.service";
 export { AffectedEntity, AffectedEntityMeta, AffectedEntityOptions } from "./user-permissions/decorators/affected-entity.decorator";
 export { DisablePermissionCheck, RequiredPermission } from "./user-permissions/decorators/required-permission.decorator";
-export { ScopedEntity, ScopedEntityMeta } from "./user-permissions/decorators/scoped-entity.decorator";
+export { SCOPED_ENTITY_METADATA_KEY, ScopedEntity, ScopedEntityMeta } from "./user-permissions/decorators/scoped-entity.decorator";
 export { CurrentUser } from "./user-permissions/dto/current-user";
 export { CurrentUserPermission } from "./user-permissions/dto/current-user";
 export { FindUsersArgs } from "./user-permissions/dto/paginated-user-list";

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
@@ -3,6 +3,7 @@ import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey } from "@mikro-o
 import { ExecutionContext } from "@nestjs/common";
 import { ModuleRef, Reflector } from "@nestjs/core";
 
+import { DISABLE_COMET_GUARDS_METADATA_KEY } from "../../auth/decorators/disable-comet-guards.decorator";
 import { AbstractAccessControlService } from "../access-control.service";
 import { ContentScopeService } from "../content-scope.service";
 import { AFFECTED_ENTITY_METADATA_KEY, AffectedEntityMeta } from "../decorators/affected-entity.decorator";
@@ -45,7 +46,7 @@ describe("UserPermissionsGuard", () => {
             if (decorator === "requiredPermission") return annotations.requiredPermission;
             if (decorator === AFFECTED_ENTITY_METADATA_KEY) return annotations.affectedEntities;
             if (decorator === SCOPED_ENTITY_METADATA_KEY) return annotations.scopedEntity;
-            if (decorator === "disableCometGuards") return annotations.disableCometGuards;
+            if (decorator === DISABLE_COMET_GUARDS_METADATA_KEY) return annotations.disableCometGuards;
             return false;
         });
     };

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
@@ -7,7 +7,7 @@ import { AbstractAccessControlService } from "../access-control.service";
 import { ContentScopeService } from "../content-scope.service";
 import { AFFECTED_ENTITY_METADATA_KEY, AffectedEntityMeta } from "../decorators/affected-entity.decorator";
 import { RequiredPermissionMetadata } from "../decorators/required-permission.decorator";
-import { ScopedEntityMeta } from "../decorators/scoped-entity.decorator";
+import { SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../decorators/scoped-entity.decorator";
 import { CurrentUser } from "../dto/current-user";
 import { Permission } from "../user-permissions.types";
 import { UserPermissionsGuard } from "./user-permissions.guard";
@@ -44,7 +44,7 @@ describe("UserPermissionsGuard", () => {
         reflector.getAllAndOverride = jest.fn().mockImplementation((decorator: string) => {
             if (decorator === "requiredPermission") return annotations.requiredPermission;
             if (decorator === AFFECTED_ENTITY_METADATA_KEY) return annotations.affectedEntities;
-            if (decorator === "scopedEntity") return annotations.scopedEntity;
+            if (decorator === SCOPED_ENTITY_METADATA_KEY) return annotations.scopedEntity;
             if (decorator === "disableCometGuards") return annotations.disableCometGuards;
             return false;
         });

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
@@ -7,7 +7,7 @@ import { DISABLE_COMET_GUARDS_METADATA_KEY } from "../../auth/decorators/disable
 import { AbstractAccessControlService } from "../access-control.service";
 import { ContentScopeService } from "../content-scope.service";
 import { AFFECTED_ENTITY_METADATA_KEY, AffectedEntityMeta } from "../decorators/affected-entity.decorator";
-import { RequiredPermissionMetadata } from "../decorators/required-permission.decorator";
+import { REQUIRED_PERMISSION_METADATA_KEY, RequiredPermissionMetadata } from "../decorators/required-permission.decorator";
 import { SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../decorators/scoped-entity.decorator";
 import { CurrentUser } from "../dto/current-user";
 import { Permission } from "../user-permissions.types";
@@ -43,7 +43,7 @@ describe("UserPermissionsGuard", () => {
         disableCometGuards?: boolean;
     }) => {
         reflector.getAllAndOverride = jest.fn().mockImplementation((decorator: string) => {
-            if (decorator === "requiredPermission") return annotations.requiredPermission;
+            if (decorator === REQUIRED_PERMISSION_METADATA_KEY) return annotations.requiredPermission;
             if (decorator === AFFECTED_ENTITY_METADATA_KEY) return annotations.affectedEntities;
             if (decorator === SCOPED_ENTITY_METADATA_KEY) return annotations.scopedEntity;
             if (decorator === DISABLE_COMET_GUARDS_METADATA_KEY) return annotations.disableCometGuards;

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
@@ -5,7 +5,7 @@ import { ModuleRef, Reflector } from "@nestjs/core";
 
 import { AbstractAccessControlService } from "../access-control.service";
 import { ContentScopeService } from "../content-scope.service";
-import { AffectedEntityMeta } from "../decorators/affected-entity.decorator";
+import { AFFECTED_ENTITY_METADATA_KEY, AffectedEntityMeta } from "../decorators/affected-entity.decorator";
 import { RequiredPermissionMetadata } from "../decorators/required-permission.decorator";
 import { ScopedEntityMeta } from "../decorators/scoped-entity.decorator";
 import { CurrentUser } from "../dto/current-user";
@@ -43,7 +43,7 @@ describe("UserPermissionsGuard", () => {
     }) => {
         reflector.getAllAndOverride = jest.fn().mockImplementation((decorator: string) => {
             if (decorator === "requiredPermission") return annotations.requiredPermission;
-            if (decorator === "affectedEntities") return annotations.affectedEntities;
+            if (decorator === AFFECTED_ENTITY_METADATA_KEY) return annotations.affectedEntities;
             if (decorator === "scopedEntity") return annotations.scopedEntity;
             if (decorator === "disableCometGuards") return annotations.disableCometGuards;
             return false;

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
@@ -5,7 +5,7 @@ import { GqlContextType, GqlExecutionContext } from "@nestjs/graphql";
 import { DISABLE_COMET_GUARDS_METADATA_KEY } from "../../auth/decorators/disable-comet-guards.decorator";
 import { getRequestFromExecutionContext } from "../../common/decorators/utils";
 import { ContentScopeService } from "../content-scope.service";
-import { DisablePermissionCheck, RequiredPermissionMetadata } from "../decorators/required-permission.decorator";
+import { DisablePermissionCheck, REQUIRED_PERMISSION_METADATA_KEY, RequiredPermissionMetadata } from "../decorators/required-permission.decorator";
 import { CurrentUser } from "../dto/current-user";
 import { ContentScope } from "../interfaces/content-scope.interface";
 import { ACCESS_CONTROL_SERVICE, USER_PERMISSIONS_OPTIONS } from "../user-permissions.constants";
@@ -23,7 +23,7 @@ export class UserPermissionsGuard implements CanActivate {
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const location = `${context.getClass().name}::${context.getHandler().name}()`;
 
-        const requiredPermission = this.getDecorator<RequiredPermissionMetadata>(context, "requiredPermission");
+        const requiredPermission = this.getDecorator<RequiredPermissionMetadata>(context, REQUIRED_PERMISSION_METADATA_KEY);
         const skipScopeCheck = requiredPermission?.options?.skipScopeCheck ?? false;
 
         let requiredContentScopes: ContentScope[][] = [];

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.ts
@@ -2,6 +2,7 @@ import { CanActivate, ExecutionContext, Inject, Injectable } from "@nestjs/commo
 import { Reflector } from "@nestjs/core";
 import { GqlContextType, GqlExecutionContext } from "@nestjs/graphql";
 
+import { DISABLE_COMET_GUARDS_METADATA_KEY } from "../../auth/decorators/disable-comet-guards.decorator";
 import { getRequestFromExecutionContext } from "../../common/decorators/utils";
 import { ContentScopeService } from "../content-scope.service";
 import { DisablePermissionCheck, RequiredPermissionMetadata } from "../decorators/required-permission.decorator";
@@ -35,7 +36,7 @@ export class UserPermissionsGuard implements CanActivate {
             request.contentScopes = this.contentScopeService.getUniqueScopes(requiredContentScopes);
         }
 
-        if (this.getDecorator(context, "disableCometGuards")) return true;
+        if (this.getDecorator(context, DISABLE_COMET_GUARDS_METADATA_KEY)) return true;
 
         const user = this.getUser(context);
         if (!user) return false;

--- a/packages/api/cms-api/src/user-permissions/content-scope.service.ts
+++ b/packages/api/cms-api/src/user-permissions/content-scope.service.ts
@@ -6,7 +6,7 @@ import { GqlExecutionContext } from "@nestjs/graphql";
 import isEqual from "lodash.isequal";
 
 import { PageTreeService } from "../page-tree/page-tree.service";
-import { EntityScopeServiceInterface, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
+import { EntityScopeServiceInterface, SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
 import { AFFECTED_ENTITY_METADATA_KEY, AffectedEntityMeta } from "./decorators/affected-entity.decorator";
 
@@ -86,7 +86,7 @@ export class ContentScopeService {
                     if (row.scope) {
                         contentScopes.push([row.scope as ContentScope]);
                     } else {
-                        const scoped = this.reflector.getAllAndOverride<ScopedEntityMeta>("scopedEntity", [affectedEntity.entity]);
+                        const scoped = this.reflector.getAllAndOverride<ScopedEntityMeta>(SCOPED_ENTITY_METADATA_KEY, [affectedEntity.entity]);
                         if (!scoped) throw new Error(`Entity ${affectedEntity.entity} is missing @ScopedEntity decorator`);
                         let scopes;
                         if (this.isService(scoped)) {

--- a/packages/api/cms-api/src/user-permissions/content-scope.service.ts
+++ b/packages/api/cms-api/src/user-permissions/content-scope.service.ts
@@ -8,7 +8,7 @@ import isEqual from "lodash.isequal";
 import { PageTreeService } from "../page-tree/page-tree.service";
 import { EntityScopeServiceInterface, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
-import { AffectedEntityMeta } from "./decorators/affected-entity.decorator";
+import { AFFECTED_ENTITY_METADATA_KEY, AffectedEntityMeta } from "./decorators/affected-entity.decorator";
 
 // TODO Remove service and move into UserPermissionsGuard once ChangesCheckerInterceptor is removed
 @Injectable()
@@ -33,7 +33,7 @@ export class ContentScopeService {
         const args = await this.getArgs(context);
         const location = `${context.getClass().name}::${context.getHandler().name}()`;
 
-        const affectedEntities = this.reflector.getAllAndOverride<AffectedEntityMeta[]>("affectedEntities", [context.getHandler()]) || [];
+        const affectedEntities = this.reflector.getAllAndOverride<AffectedEntityMeta[]>(AFFECTED_ENTITY_METADATA_KEY, [context.getHandler()]) || [];
         for (const affectedEntity of affectedEntities) {
             contentScopes.push(...(await this.getContentScopesFromEntity(affectedEntity, args, location)));
         }

--- a/packages/api/cms-api/src/user-permissions/decorators/affected-entity.decorator.ts
+++ b/packages/api/cms-api/src/user-permissions/decorators/affected-entity.decorator.ts
@@ -10,15 +10,17 @@ export type AffectedEntityMeta = {
     options: AffectedEntityOptions;
 };
 
+export const AFFECTED_ENTITY_METADATA_KEY = "affectedEntities";
+
 export const AffectedEntity = (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entity: EntityName<any>,
     { idArg, pageTreeNodeIdArg, nullable }: AffectedEntityOptions = { idArg: "id" },
 ): MethodDecorator => {
     return (target: object, key: string | symbol, descriptor: PropertyDescriptor) => {
-        const metadata = Reflect.getOwnMetadata("affectedEntities", descriptor.value) || [];
+        const metadata = Reflect.getOwnMetadata(AFFECTED_ENTITY_METADATA_KEY, descriptor.value) || [];
         metadata.push({ entity, options: { idArg, pageTreeNodeIdArg, nullable } });
-        Reflect.defineMetadata("affectedEntities", metadata, descriptor.value);
+        Reflect.defineMetadata(AFFECTED_ENTITY_METADATA_KEY, metadata, descriptor.value);
         return descriptor;
     };
 };

--- a/packages/api/cms-api/src/user-permissions/decorators/required-permission.decorator.ts
+++ b/packages/api/cms-api/src/user-permissions/decorators/required-permission.decorator.ts
@@ -14,11 +14,13 @@ export type RequiredPermissionMetadata = {
     options: RequiredPermissionOptions | undefined;
 };
 
+export const REQUIRED_PERMISSION_METADATA_KEY = "requiredPermission";
+
 export const RequiredPermission = (
     requiredPermission: Permission | Permission[] | DisablePermissionCheckType,
     options?: RequiredPermissionOptions,
 ): CustomDecorator<string> => {
-    return SetMetadata<string, RequiredPermissionMetadata>("requiredPermission", {
+    return SetMetadata<string, RequiredPermissionMetadata>(REQUIRED_PERMISSION_METADATA_KEY, {
         requiredPermission: Array.isArray(requiredPermission) ? requiredPermission : [requiredPermission],
         options,
     });

--- a/packages/api/cms-api/src/user-permissions/decorators/scoped-entity.decorator.ts
+++ b/packages/api/cms-api/src/user-permissions/decorators/scoped-entity.decorator.ts
@@ -12,6 +12,8 @@ export interface EntityScopeServiceInterface<Entity extends AnyEntity = AnyEntit
 
 export type ScopedEntityMeta<Entity extends AnyEntity = AnyEntity> = EntityScopeFunction<Entity> | Type<EntityScopeServiceInterface<Entity>>;
 
+export const SCOPED_ENTITY_METADATA_KEY = "scopedEntity";
+
 export function ScopedEntity<Entity extends AnyEntity = AnyEntity>(value: ScopedEntityMeta<Entity>): CustomDecorator<string> {
-    return SetMetadata<string, ScopedEntityMeta<Entity>>("scopedEntity", value);
+    return SetMetadata<string, ScopedEntityMeta<Entity>>(SCOPED_ENTITY_METADATA_KEY, value);
 }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -9,7 +9,7 @@ import uniqWith from "lodash.uniqwith";
 import getUuid from "uuid-by-string";
 
 import { AbstractAccessControlService } from "./access-control.service";
-import { DisablePermissionCheck, RequiredPermissionMetadata } from "./decorators/required-permission.decorator";
+import { DisablePermissionCheck, REQUIRED_PERMISSION_METADATA_KEY, RequiredPermissionMetadata } from "./decorators/required-permission.decorator";
 import { ContentScopeWithLabel } from "./dto/content-scope";
 import { CurrentUser, CurrentUserPermission } from "./dto/current-user";
 import { FindUsersArgs } from "./dto/paginated-user-list";
@@ -83,10 +83,10 @@ export class UserPermissionsService {
             this.availablePermissions = [
                 ...new Set(
                     [
-                        ...(await this.discoveryService.providerMethodsWithMetaAtKey<RequiredPermissionMetadata>("requiredPermission")),
-                        ...(await this.discoveryService.providersWithMetaAtKey<RequiredPermissionMetadata>("requiredPermission")),
-                        ...(await this.discoveryService.controllerMethodsWithMetaAtKey<RequiredPermissionMetadata>("requiredPermission")),
-                        ...(await this.discoveryService.controllersWithMetaAtKey<RequiredPermissionMetadata>("requiredPermission")),
+                        ...(await this.discoveryService.providerMethodsWithMetaAtKey<RequiredPermissionMetadata>(REQUIRED_PERMISSION_METADATA_KEY)),
+                        ...(await this.discoveryService.providersWithMetaAtKey<RequiredPermissionMetadata>(REQUIRED_PERMISSION_METADATA_KEY)),
+                        ...(await this.discoveryService.controllerMethodsWithMetaAtKey<RequiredPermissionMetadata>(REQUIRED_PERMISSION_METADATA_KEY)),
+                        ...(await this.discoveryService.controllersWithMetaAtKey<RequiredPermissionMetadata>(REQUIRED_PERMISSION_METADATA_KEY)),
                     ]
                         .flatMap((p) => p.meta.requiredPermission)
                         .concat(["prelogin"]) // Add permission to allow checking if a specific user has access to a site where preloginEnabled is true

--- a/packages/api/cms-api/src/warnings/decorators/create-warnings.decorator.ts
+++ b/packages/api/cms-api/src/warnings/decorators/create-warnings.decorator.ts
@@ -35,6 +35,8 @@ export interface CreateWarningsServiceInterface<Entity extends AnyEntity = AnyEn
 
 export type CreateWarningsMeta<Entity extends AnyEntity = AnyEntity> = CreateWarningsFunction<Entity> | Type<CreateWarningsServiceInterface<Entity>>;
 
+export const CREATE_WARNINGS_METADATA_KEY = "createWarnings";
+
 export function CreateWarnings<Entity extends AnyEntity = AnyEntity>(value: CreateWarningsMeta<Entity>): CustomDecorator<string> {
-    return SetMetadata<string, CreateWarningsMeta<Entity>>("createWarnings", value);
+    return SetMetadata<string, CreateWarningsMeta<Entity>>(CREATE_WARNINGS_METADATA_KEY, value);
 }

--- a/packages/api/cms-api/src/warnings/warning-checker.command.ts
+++ b/packages/api/cms-api/src/warnings/warning-checker.command.ts
@@ -10,7 +10,12 @@ import { FlatBlocks } from "../blocks/flat-blocks/flat-blocks";
 import { DiscoverService } from "../dependencies/discover.service";
 import { SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
-import { CreateWarningsFunction, CreateWarningsMeta, CreateWarningsServiceInterface } from "./decorators/create-warnings.decorator";
+import {
+    CREATE_WARNINGS_METADATA_KEY,
+    CreateWarningsFunction,
+    CreateWarningsMeta,
+    CreateWarningsServiceInterface,
+} from "./decorators/create-warnings.decorator";
 import { Warning } from "./entities/warning.entity";
 import { WarningService } from "./warning.service";
 
@@ -132,7 +137,7 @@ export class WarningCheckerCommand extends CommandRunner {
 
         for (const entity of entities) {
             const entityMetadata = metadataStorage.get(entity.name);
-            const createWarnings = this.reflector.getAllAndOverride<CreateWarningsMeta>("createWarnings", [entity]);
+            const createWarnings = this.reflector.getAllAndOverride<CreateWarningsMeta>(CREATE_WARNINGS_METADATA_KEY, [entity]);
             if (createWarnings) {
                 const repository = this.entityManager.getRepository(entity);
 

--- a/packages/api/cms-api/src/warnings/warning-checker.command.ts
+++ b/packages/api/cms-api/src/warnings/warning-checker.command.ts
@@ -8,7 +8,7 @@ import { Command, CommandRunner } from "nest-commander";
 import { Block, BlockData, BlockWarning, BlockWarningsServiceInterface } from "../blocks/block";
 import { FlatBlocks } from "../blocks/flat-blocks/flat-blocks";
 import { DiscoverService } from "../dependencies/discover.service";
-import { ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
+import { SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
 import { CreateWarningsFunction, CreateWarningsMeta, CreateWarningsServiceInterface } from "./decorators/create-warnings.decorator";
 import { Warning } from "./entities/warning.entity";
@@ -75,7 +75,7 @@ export class WarningCheckerCommand extends CommandRunner {
 
                         if (!scope) {
                             const entity = this.orm.getMetadata().get(className).class;
-                            const scoped = this.reflector.getAllAndOverride<ScopedEntityMeta>("scopedEntity", [entity]);
+                            const scoped = this.reflector.getAllAndOverride<ScopedEntityMeta>(SCOPED_ENTITY_METADATA_KEY, [entity]);
 
                             if (scoped) {
                                 const service = this.moduleRef.get(scoped, { strict: false });

--- a/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
+++ b/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
@@ -8,7 +8,7 @@ import { BlockWarning, BlockWarningsServiceInterface } from "src/blocks/block";
 import { FlatBlocks } from "../blocks/flat-blocks/flat-blocks";
 import { SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
-import { CreateWarningsMeta, CreateWarningsServiceInterface } from "./decorators/create-warnings.decorator";
+import { CREATE_WARNINGS_METADATA_KEY, CreateWarningsMeta, CreateWarningsServiceInterface } from "./decorators/create-warnings.decorator";
 import { WarningData } from "./dto/warning-data";
 import { WarningService } from "./warning.service";
 
@@ -30,7 +30,7 @@ export class WarningEventSubscriber implements EventSubscriber {
         const entities = this.orm.config.get("entities") as EntityClass<unknown>[];
         for (const entity of entities) {
             const rootBlockEntityOptions = Reflect.getMetadata(`data:rootBlockEntityOptions`, entity);
-            const createWarnings = this.reflector.getAllAndOverride<CreateWarningsMeta>("createWarnings", [entity]);
+            const createWarnings = this.reflector.getAllAndOverride<CreateWarningsMeta>(CREATE_WARNINGS_METADATA_KEY, [entity]);
 
             if (rootBlockEntityOptions || createWarnings) {
                 subscribedEntities.push(entity);
@@ -110,7 +110,7 @@ export class WarningEventSubscriber implements EventSubscriber {
                 }
             }
 
-            const createWarnings = this.reflector.getAllAndOverride<CreateWarningsMeta>("createWarnings", [entity]);
+            const createWarnings = this.reflector.getAllAndOverride<CreateWarningsMeta>(CREATE_WARNINGS_METADATA_KEY, [entity]);
             if (createWarnings && args.entity.id) {
                 const repository: EntityRepository<{ id: string; scope: ContentScope }> = this.entityManager.getRepository(entity);
 

--- a/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
+++ b/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
@@ -5,6 +5,8 @@ import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
 import { ModuleRef, Reflector } from "@nestjs/core";
 import { BlockWarning, BlockWarningsServiceInterface } from "src/blocks/block";
 
+import { ROOT_BLOCK_KEYS_METADATA_KEY, ROOT_BLOCK_METADATA_KEY } from "../blocks/decorators/root-block";
+import { ROOT_BLOCK_ENTITY_METADATA_KEY } from "../blocks/decorators/root-block-entity";
 import { FlatBlocks } from "../blocks/flat-blocks/flat-blocks";
 import { SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
@@ -29,7 +31,7 @@ export class WarningEventSubscriber implements EventSubscriber {
 
         const entities = this.orm.config.get("entities") as EntityClass<unknown>[];
         for (const entity of entities) {
-            const rootBlockEntityOptions = Reflect.getMetadata(`data:rootBlockEntityOptions`, entity);
+            const rootBlockEntityOptions = Reflect.getMetadata(ROOT_BLOCK_ENTITY_METADATA_KEY, entity);
             const createWarnings = this.reflector.getAllAndOverride<CreateWarningsMeta>(CREATE_WARNINGS_METADATA_KEY, [entity]);
 
             if (rootBlockEntityOptions || createWarnings) {
@@ -54,7 +56,7 @@ export class WarningEventSubscriber implements EventSubscriber {
         const definedProperties = args.meta.definedProperties;
 
         if (entity) {
-            const keys = Reflect.getMetadata(`keys:rootBlock`, entity.prototype) || [];
+            const keys = Reflect.getMetadata(ROOT_BLOCK_KEYS_METADATA_KEY, entity.prototype) || [];
             let scope: ContentScope | undefined = "scope" in definedProperties ? definedProperties.scope : undefined;
 
             if (!scope) {
@@ -72,7 +74,7 @@ export class WarningEventSubscriber implements EventSubscriber {
             }
 
             for (const key of keys) {
-                const block = Reflect.getMetadata(`data:rootBlock`, entity.prototype, key);
+                const block = Reflect.getMetadata(ROOT_BLOCK_METADATA_KEY, entity.prototype, key);
 
                 const flatBlocks = new FlatBlocks(args.entity[key], {
                     name: block.name,

--- a/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
+++ b/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
@@ -6,7 +6,7 @@ import { ModuleRef, Reflector } from "@nestjs/core";
 import { BlockWarning, BlockWarningsServiceInterface } from "src/blocks/block";
 
 import { FlatBlocks } from "../blocks/flat-blocks/flat-blocks";
-import { ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
+import { SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
 import { CreateWarningsMeta, CreateWarningsServiceInterface } from "./decorators/create-warnings.decorator";
 import { WarningData } from "./dto/warning-data";
@@ -58,7 +58,7 @@ export class WarningEventSubscriber implements EventSubscriber {
             let scope: ContentScope | undefined = "scope" in definedProperties ? definedProperties.scope : undefined;
 
             if (!scope) {
-                const scoped = this.reflector.getAllAndOverride<ScopedEntityMeta>("scopedEntity", [entity]);
+                const scoped = this.reflector.getAllAndOverride<ScopedEntityMeta>(SCOPED_ENTITY_METADATA_KEY, [entity]);
 
                 if (scoped) {
                     const service = this.moduleRef.get(scoped, { strict: false });


### PR DESCRIPTION
## Description

This PR refactors the codebase to replace hardcoded metadata key strings in decorators and Reflect calls with exported constants. This improves maintainability and reduces the risk of typos or inconsistencies. All affected decorators and usages of Reflect.defineMetadata, Reflect.getMetadata, and related methods now use the corresponding constant for each metadata key. No functional changes were made.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
