### PR TITLE
Export `SeoBlockInputInterface`

### DIFF
--- a/.changeset/shaky-cycles-smile.md
+++ b/.changeset/shaky-cycles-smile.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Export `SeoBlockInputInterface` type

--- a/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
+++ b/packages/api/cms-api/src/blocks/factories/createSeoBlock.ts
@@ -50,7 +50,7 @@ interface CreateSeoBlockOptions<ImageBlock extends Block> {
     image?: ImageBlock;
 }
 
-interface SeoBlockInputInterface<ImageBlockInput extends BlockInputInterface> extends SimpleBlockInputInterface {
+export interface SeoBlockInputInterface<ImageBlockInput extends BlockInputInterface> extends SimpleBlockInputInterface {
     htmlTitle?: string;
     metaDescription?: string;
     openGraphTitle?: string;

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -85,7 +85,7 @@ export {
 } from "./blocks/factories/createOneOfBlock";
 export { createOptionalBlock, OptionalBlockInputInterface } from "./blocks/factories/createOptionalBlock";
 export { createRichTextBlock } from "./blocks/factories/createRichTextBlock";
-export { createSeoBlock, SitemapPageChangeFrequency, SitemapPagePriority } from "./blocks/factories/createSeoBlock";
+export { createSeoBlock, type SeoBlockInputInterface, SitemapPageChangeFrequency, SitemapPagePriority } from "./blocks/factories/createSeoBlock";
 export { createSpaceBlock } from "./blocks/factories/createSpaceBlock";
 export { createTextImageBlock, ImagePosition } from "./blocks/factories/createTextImageBlock";
 export { createTextLinkBlock } from "./blocks/factories/createTextLinkBlock";


### PR DESCRIPTION
In a client project we get an error like this:

TS4023: Exported variable CometSeoBlock has or is using name SeoBlockInputInterface from external module ".../node_modules/@comet/cms-api/lib/blocks/factories/createSeoBlock" but cannot be named.

according to ChatGPT this can be fixed by exporting the SeoBlockInputInterface from cms-api

