### PR TITLE
Export `ChildBlockInfo`

### DIFF
--- a/.changeset/wise-boxes-guess.md
+++ b/.changeset/wise-boxes-guess.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Export `ChildBlockInfo`

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -37,6 +37,7 @@ export {
     BlockMetaLiteralFieldKind,
     BlockTransformerServiceInterface,
     BlockWarning,
+    ChildBlockInfo,
     createBlock,
     ExtractBlockData,
     ExtractBlockInput,


### PR DESCRIPTION
## Description

It's the return type of `childBlocksInfo()` and is used in some projects, so I think it makes sense to export it