### PR TITLE
Fix deprecation comments of `ClearInputButton`

### DIFF
--- a/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
+++ b/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
@@ -5,6 +5,9 @@ import { type ReactNode } from "react";
 
 import { createComponentSlot } from "../../../helpers/createComponentSlot";
 
+/**
+ * @deprecated Use `ClearInputAdornment` directly as the InputAdornment
+ */
 export type ClearInputButtonClassKey = "root" | "focusVisible";
 
 const Root = createComponentSlot(ButtonBase)<ClearInputButtonClassKey>({
@@ -30,10 +33,16 @@ const Root = createComponentSlot(ButtonBase)<ClearInputButtonClassKey>({
     `,
 );
 
+/**
+ * @deprecated Use `ClearInputAdornment` directly as the InputAdornment
+ */
 export interface ClearInputButtonProps extends ButtonBaseProps {
     icon?: ReactNode;
 }
 
+/**
+ * @deprecated Use `ClearInputAdornment` directly as the InputAdornment
+ */
 export function ClearInputButton(inProps: ClearInputButtonProps) {
     const { icon = <Clear />, ...restProps } = useThemeProps({
         props: inProps,
@@ -47,9 +56,8 @@ export function ClearInputButton(inProps: ClearInputButtonProps) {
 }
 
 /**
- * @deprecated Use `ClearInputAdornment` directly as the InputAdornment instead
+ * @deprecated Use `ClearInputAdornment` directly as the InputAdornment
  */
-
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
         CometAdminClearInputButton: ClearInputButtonClassKey;

--- a/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
+++ b/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
@@ -55,9 +55,6 @@ export function ClearInputButton(inProps: ClearInputButtonProps) {
     );
 }
 
-/**
- * @deprecated Use `ClearInputAdornment` directly as the InputAdornment
- */
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
         CometAdminClearInputButton: ClearInputButtonClassKey;


### PR DESCRIPTION
## Description

The component was initially deprecated in https://github.com/vivid-planet/comet/pull/628 but that was somehow broken later. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Do we need a changeset for this? 
    - We decided: no
