### PR TITLE
Disable focusing the `OpenPickerButton` and add comment for long-term fix

### DIFF
--- a/.changeset/vast-rabbits-joke.md
+++ b/.changeset/vast-rabbits-joke.md
@@ -1,0 +1,19 @@
+---
+"@comet/admin": patch
+---
+
+Prevent the `OpenPickerButton` from appearing focused while not actually being focused
+
+This was achieved by preventing the `OpenPickerButton` from being focused at all.
+The input value can still be changed in an accessible way, without using the picker.
+
+This affects the following components:
+
+- `DatePicker`
+- `DatePickerField`
+- `DateRangePicker`
+- `DateRangePickerField`
+- `DateTimePicker`
+- `DateTimePickerField`
+- `TimePicker`
+- `TimePickerField`

--- a/packages/admin/admin/src/common/OpenPickerAdornment.tsx
+++ b/packages/admin/admin/src/common/OpenPickerAdornment.tsx
@@ -40,6 +40,7 @@ export const OpenPickerAdornment = (inProps: OpenPickerAdornmentProps) => {
     return (
         <Root position={position} ownerState={ownerState} {...slotProps?.root} {...restProps}>
             <OpenPickerButton
+                tabIndex={-1}
                 onClick={onClick}
                 disabled={inputIsDisabled || inputIsReadOnly}
                 ownerState={ownerState}

--- a/packages/admin/admin/src/common/OpenPickerAdornment.tsx
+++ b/packages/admin/admin/src/common/OpenPickerAdornment.tsx
@@ -19,6 +19,9 @@ type OwnerState = {
     inputIsDisabled: boolean;
 };
 
+/**
+ * TODO: Remove this component once we can use MUI-X V8 - set `slotProps.field.openPickerButtonPosition = "start"` on each picker-component instead
+ */
 export const OpenPickerAdornment = (inProps: OpenPickerAdornmentProps) => {
     const {
         inputIsDisabled,


### PR DESCRIPTION
## Description

When focusing the `InputBase` of a picker-component, the focus is immediately moved to the `input` inside. 
We have our custom `OpenPickerButton` in the `startAdornment` of each picker-field, causing that button to be focused first and start applying the focus-ripple. 

Likely due to the focus being immediately removed, the `onBlur` of the button is called before the focus-ripple exists, causing the focus ripple to not be removed, making the no longer focused button to appear focused. 

Since MUI-X V8 adds support for the default (MUI) `OpenPickerButton` to be positioned in the `startAdornment`, where this issues has been fixed, we decided to simply disable focusing the `OpenPickerButton` for now. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

See, the `OpenPickerButton` of the second input keeps it's focus-ripple, after the focus is removed. 
(The focused element is highlighted in pink here for easier visualization)

https://github.com/user-attachments/assets/7f1d5b97-fb47-403e-9eff-dea8f5181522

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2269
