### PR TITLE
Prevent default value of `Tooltip` `slotProps.popper` from being fully overridden instead of extended

### DIFF
--- a/.changeset/twenty-sites-stick.md
+++ b/.changeset/twenty-sites-stick.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": patch
+---
+
+Fix props of `Tooltip`'s `slotProps.popper` when setting custom values
+
+When setting custom values to `slotProps.popper`, some default props would unintentionally be reset.

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -193,11 +193,11 @@ export const Tooltip = (inProps: TooltipProps) => {
             ...props.slots,
         },
         slotProps: {
+            ...props.slotProps,
             popper: {
                 ownerState,
                 ...props.slotProps?.popper,
             },
-            ...props.slotProps,
         },
     };
 


### PR DESCRIPTION
## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset