### PR TITLE
MailerModule: Fix wrong definition of recipient option

### DIFF
--- a/.changeset/easy-files-brush.md
+++ b/.changeset/easy-files-brush.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix recipient option for mailer:send-test-mail command

--- a/packages/api/cms-api/src/mailer/send-test-mail.command.ts
+++ b/packages/api/cms-api/src/mailer/send-test-mail.command.ts
@@ -22,9 +22,11 @@ export class SendTestMailCommand extends CommandRunner {
     }
 
     @Option({
-        flags: "-r, --receiver",
+        flags: "-r, --receiver [receiver]",
     })
-    parseReceiver() {}
+    parseReceiver(value: string) {
+        return value;
+    }
 
     @CreateRequestContext()
     async run(_arguments: string[], { receiver }: { receiver?: string }): Promise<void> {


### PR DESCRIPTION
## Description

recipient option of mailer:send-test-mail command did not accept a value.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
