### PR TITLE
Demo: Add CSS button reset

### DIFF
--- a/demo/site/src/styles/global.scss
+++ b/demo/site/src/styles/global.scss
@@ -128,6 +128,16 @@ sup {
     top: -0.5em;
 }
 
+button {
+    appearance: none;
+    margin: 0;
+    border: none;
+    padding: 0;
+    background: none;
+    color: inherit;
+    cursor: pointer;
+}
+
 button,
 input,
 select,


### PR DESCRIPTION
## Description

Currently, unstyled buttons inherit default browser styles. With recent a11y changes, buttons are often used purely for semantics and functionality without requiring visual styling.

Since the default styles provide no added value in our case, this MR resets all default button styles.

Styled buttons (e.g., in the `CallToActionBlock`) are not affected by this change, as shown in the screenshots.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="662" height="583" alt="Bildschirmfoto 2025-09-02 um 15 32 42" src="https://github.com/user-attachments/assets/2424866f-1317-483a-bdfc-313451e18d21" /> |  <img width="662" height="583" alt="Bildschirmfoto 2025-09-02 um 15 32 21" src="https://github.com/user-attachments/assets/6389e587-732e-4e94-87e4-1a4350f6ec7e" /> |
| <img width="1502" height="583" alt="Bildschirmfoto 2025-09-02 um 15 33 00" src="https://github.com/user-attachments/assets/2363b15d-3f3b-46c9-917e-f47c154b47a9" /> | <img width="1502" height="583" alt="Bildschirmfoto 2025-09-02 um 15 33 10" src="https://github.com/user-attachments/assets/d7802672-0f8a-4850-af78-5b43ea9206c4" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2159
