### PR TITLE
Demo Admin: add missing hiddenInSubroute to titleHtmlTag for AccordionItemBlock

### DIFF
--- a/demo/admin/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/admin/src/common/blocks/AccordionItemBlock.tsx
@@ -49,6 +49,7 @@ export const AccordionItemBlock = createCompositeBlock(
                     })),
                     required: true,
                 }),
+                hiddenInSubroute: true,
             },
             content: {
                 block: AccordionContentBlock,


### PR DESCRIPTION
## Description

titleHtmlTag was available in sub route

| Before | After |
| ------ | ----- |
|   <img width="741" height="501" alt="Screenshot 2025-09-04 at 08 22 46" src="https://github.com/user-attachments/assets/652a7dda-8340-46ed-9a4f-9cecfe58a5ff" />   |   <img width="747" height="414" alt="Screenshot 2025-09-04 at 08 23 47" src="https://github.com/user-attachments/assets/b950c047-1069-410a-b42b-b00d8e357d34" />   |
