### PR TITLE
Add a `warning` variant to `Tooltip`

### DIFF
--- a/.changeset/cold-fans-punch.md
+++ b/.changeset/cold-fans-punch.md
@@ -1,0 +1,11 @@
+---
+"@comet/admin": minor
+---
+
+Add a `warning` variant to `Tooltip`
+
+```tsx
+<Tooltip title="This is a warning" variant="warning">
+    <WarningSolid color="warning" />
+</Tooltip>
+```

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -16,7 +16,7 @@ export interface TooltipProps extends MuiTooltipProps {
     variant?: Variant;
 }
 
-type Variant = "light" | "dark" | "neutral" | "primary" | "error" | "success";
+type Variant = "light" | "dark" | "neutral" | "primary" | "error" | "success" | "warning";
 
 export type TooltipClassKey = "root" | Variant | MuiTooltipClassKey;
 
@@ -109,6 +109,17 @@ const TooltipPopper = createComponentSlot(MuiPopper)<TooltipClassKey, OwnerState
             }
             .${tooltipClasses.tooltip} {
                 background-color: ${theme.palette.success.light};
+                color: ${theme.palette.common.black};
+            }
+        `};
+
+        ${ownerState.variant === "warning" &&
+        css`
+            .${tooltipClasses.arrow} {
+                color: ${theme.palette.warning.light};
+            }
+            .${tooltipClasses.tooltip} {
+                background-color: ${theme.palette.warning.light};
                 color: ${theme.palette.common.black};
             }
         `};

--- a/storybook/src/admin/Tooltip.stories.tsx
+++ b/storybook/src/admin/Tooltip.stories.tsx
@@ -1,5 +1,6 @@
 import { Tooltip } from "@comet/admin";
-import { Add } from "@comet/admin-icons";
+import { Add, Info } from "@comet/admin-icons";
+import { Stack } from "@mui/material";
 
 export default {
     title: "@comet/admin/Tooltip",
@@ -15,4 +16,34 @@ export const IconWithTooltip = {
     },
 
     name: "Icon with Tooltip",
+};
+
+export const AllVariants = {
+    render: () => {
+        return (
+            <Stack spacing={6}>
+                <Tooltip title="Dark variant (default)" open placement="right">
+                    <Info />
+                </Tooltip>
+                <Tooltip title="Light variant" open placement="right" variant="light">
+                    <Info />
+                </Tooltip>
+                <Tooltip title="Neutral variant" open placement="right" variant="neutral">
+                    <Info />
+                </Tooltip>
+                <Tooltip title="Primary variant" open placement="right" variant="primary">
+                    <Info />
+                </Tooltip>
+                <Tooltip title="Error variant" open placement="right" variant="error">
+                    <Info />
+                </Tooltip>
+                <Tooltip title="Success variant" open placement="right" variant="success">
+                    <Info />
+                </Tooltip>
+                <Tooltip title="Warning variant" open placement="right" variant="warning">
+                    <Info />
+                </Tooltip>
+            </Stack>
+        );
+    },
 };


### PR DESCRIPTION
## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

<img width="176" height="88" alt="A tooltip with the variant set to warning" src="https://github.com/user-attachments/assets/e2e4dd6e-689b-4282-9d34-4641fd53f95a" />

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1252
