### PR TITLE
Setup MUI license key for Demo / Storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ sh install.sh
 
 _It is recommended to run `install.sh` every time you switch to the `main` branch._
 
+### MUI X Data Grid Pro License
+
+If you want to use features from `@mui/x-data-grid-pro`, you need to configure your MUI license key. Create a `.env.local` file in your project root and add your license key:
+
+`.env.local`:
+```
+MUI_LICENSE_KEY=your_license_key_here
+```
+
 ### Build packages
 
 Before starting individual development processes, build all Comet packages at least once.

--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -39,6 +39,7 @@
         "@mui/x-data-grid": "^7.29.8",
         "@mui/x-data-grid-pro": "^7.29.8",
         "@mui/x-date-pickers": "^7.29.4",
+        "@mui/x-license": "^7.29.1",
         "change-case": "^5.4.4",
         "date-fns": "^4.1.0",
         "dnd-core": "^16.0.1",

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -15,6 +15,7 @@ import {
 import { css, Global } from "@emotion/react";
 import { LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
+import { LicenseInfo } from "@mui/x-license";
 import { createApolloClient } from "@src/common/apollo/createApolloClient";
 import { createConfig } from "@src/config";
 import type { ContentScope as BaseContentScope } from "@src/site-configs";
@@ -60,6 +61,8 @@ declare module "@comet/cms-admin" {
         permission: GQLPermission;
     }
 }
+
+LicenseInfo.setLicenseKey(config.muiLicenseKey);
 
 export function App() {
     return (

--- a/demo/admin/src/config.tsx
+++ b/demo/admin/src/config.tsx
@@ -22,5 +22,6 @@ export function createConfig() {
         buildDate: environmentVariables.BUILD_DATE,
         buildNumber: environmentVariables.BUILD_NUMBER,
         commitSha: environmentVariables.COMMIT_SHA,
+        muiLicenseKey: environmentVariables.MUI_LICENSE_KEY,
     };
 }

--- a/demo/admin/src/environment.ts
+++ b/demo/admin/src/environment.ts
@@ -1,1 +1,10 @@
-export const environment = ["API_URL", "ADMIN_URL", "PREVIEW_URL", "PUBLIC_SITE_CONFIGS", "BUILD_DATE", "BUILD_NUMBER", "COMMIT_SHA"];
+export const environment = [
+    "API_URL",
+    "ADMIN_URL",
+    "PREVIEW_URL",
+    "PUBLIC_SITE_CONFIGS",
+    "BUILD_DATE",
+    "BUILD_NUMBER",
+    "COMMIT_SHA",
+    "MUI_LICENSE_KEY",
+];

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ ln -sf ../../site-configs/site-configs.d.ts ./demo/api/src/
 
 # admin DEMO
 ln -sf ../../.env ./demo/admin/.env
+ln -sf ../../.env.local ./demo/admin/.env.local
 ln -sf ../.env.site-configs ./demo/admin/.env.site-configs
 ln -sf ../api/schema.gql ./demo/admin/schema.gql
 ln -sf ../api/block-meta.json ./demo/admin/block-meta.json
@@ -47,6 +48,9 @@ ln -sf ../../.env ./demo/site-pages/.env
 ln -sf ../api/schema.gql ./demo/site-pages/schema.gql
 ln -sf ../api/block-meta.json ./demo/site-pages/block-meta.json
 ln -sf ../../api/src/comet-config.json ./demo/site-pages/src/comet-config.json
+
+# Storybook
+ln -sf ../.env.local ./storybook/.env.local
 
 # Lang install
 sh ./demo/admin/intl-update.sh

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@mui/x-date-pickers':
         specifier: ^7.29.4
         version: 7.29.4(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(date-fns@4.1.0)(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/x-license':
+        specifier: ^7.29.1
+        version: 7.29.1(@types/react@18.3.24)(react@18.3.1)
       change-case:
         specifier: ^5.4.4
         version: 5.4.4
@@ -2432,6 +2435,9 @@ importers:
       '@mui/x-date-pickers-pro':
         specifier: ^7.29.4
         version: 7.29.4(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(date-fns@4.1.0)(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/x-license':
+        specifier: ^7.29.1
+        version: 7.29.1(@types/react@18.3.24)(react@18.3.1)
       '@types/node':
         specifier: ^22.16.3
         version: 22.18.0
@@ -23662,7 +23668,7 @@ snapshots:
 
   '@mui/utils@7.1.0(@types/react@18.3.24)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.28.3
       '@mui/types': 7.4.6(@types/react@18.3.24)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
@@ -23782,7 +23788,7 @@ snapshots:
   '@mui/x-internals@7.29.0(@types/react@18.3.24)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.3
-      '@mui/utils': 7.3.1(@types/react@18.3.24)(react@18.3.1)
+      '@mui/utils': 7.3.2(@types/react@18.3.24)(react@18.3.1)
       react: 18.3.1
     transitivePeerDependencies:
       - '@types/react'
@@ -23790,7 +23796,7 @@ snapshots:
   '@mui/x-license@7.29.1(@types/react@18.3.24)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.3
-      '@mui/utils': 7.3.1(@types/react@18.3.24)(react@18.3.1)
+      '@mui/utils': 7.3.2(@types/react@18.3.24)(react@18.3.1)
       '@mui/x-internals': 7.29.0(@types/react@18.3.24)(react@18.3.1)
       react: 18.3.1
     transitivePeerDependencies:

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -17,6 +17,11 @@ const config: StorybookConfig = {
         },
         "@storybook/addon-webpack5-compiler-babel",
     ],
+
+    env: (config) => ({
+        ...config,
+        MUI_LICENSE_KEY: process.env.MUI_LICENSE_KEY || "",
+    }),
     staticDirs: ["../public"],
 };
 

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import "@fontsource-variable/roboto-flex/full.css";
 
+import { LicenseInfo } from "@mui/x-license";
 import type { Preview } from "@storybook/react-webpack5";
 import { type GlobalTypes } from "storybook/internal/csf";
 
@@ -8,6 +9,13 @@ import { IntlDecorator, LocaleOption } from "./decorators/IntlProvider.decorator
 import { LayoutDecorator, LayoutOption } from "./decorators/Layout.decorator";
 import { ThemeOption, ThemeProviderDecorator } from "./decorators/ThemeProvider.decorator";
 import { worker } from "./mocks/browser";
+
+if (process.env.MUI_LICENSE_KEY) {
+    LicenseInfo.setLicenseKey(process.env.MUI_LICENSE_KEY);
+}
+
+// Initialize MSW
+worker.start();
 
 export const globalTypes: GlobalTypes = {
     theme: {

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -14,9 +14,6 @@ if (process.env.MUI_LICENSE_KEY) {
     LicenseInfo.setLicenseKey(process.env.MUI_LICENSE_KEY);
 }
 
-// Initialize MSW
-worker.start();
-
 export const globalTypes: GlobalTypes = {
     theme: {
         description: "Global MUI Theme",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -32,6 +32,7 @@
         "@mui/x-data-grid-pro": "^7.29.8",
         "@mui/x-date-pickers": "^7.29.4",
         "@mui/x-date-pickers-pro": "^7.29.4",
+        "@mui/x-license": "^7.29.1",
         "@types/node": "^22.16.3",
         "apollo-link-rest": "^0.9.0",
         "date-fns": "^4.1.0",


### PR DESCRIPTION
## Description

This Pull Request ensures that all MUI X DataGrid components in the Demo Admin / Storybook setup have the required license key applied (when configured in `.env.local`). Previously, some grids which are using pro features, were missing the license key, which caused warnings in the console and the UI.

## Changes
- add information to Readme how to use `MUI_LICENSE_KEY`.
- Demo-Admin and Storybook will look for environment variable `MUI_LICENSE_KEY` and set License key acordingly
- Configured Netlify with environment `MUI_LICENSE_KEY` Variable for CI build

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|   <img width="1279" height="673" alt="Screenshot 2025-09-05 at 08 17 33" src="https://github.com/user-attachments/assets/20aa339f-b664-4e30-8e63-8835aaac25b9" />  |  <img width="642" height="340" alt="Screenshot 2025-09-05 at 07 57 00" src="https://github.com/user-attachments/assets/223ee5a2-d8f6-437b-b6fe-a94daf560765" />   |
| <img width="1277" height="679" alt="Screenshot 2025-09-05 at 07 33 19" src="https://github.com/user-attachments/assets/df616ef3-7a14-43a6-8e0f-3d2aff75277b" />   |  <img width="643" height="339" alt="Screenshot 2025-09-05 at 07 52 29" src="https://github.com/user-attachments/assets/a2344333-f55d-48f2-b8c3-051dae07f247" /> |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2460
