### PR TITLE
Deactivate storing scope in local storage in dev mode

### DIFF
--- a/.changeset/late-masks-read.md
+++ b/.changeset/late-masks-read.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+The most recently visited scope is no longer stored in local storage in development mode

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
@@ -131,7 +131,9 @@ export function ContentScopeSelect({
     }
 
     const handleChange = (selectedScope: ContentScope) => {
-        localStorage.setItem(contentScopeLocalStorageKey, JSON.stringify(selectedScope));
+        if (process.env.NODE_ENV !== "development") {
+            localStorage.setItem(contentScopeLocalStorageKey, JSON.stringify(selectedScope));
+        }
         onChange(selectedScope);
     };
 


### PR DESCRIPTION
## Description

Do not save scope in local storage in development mode to avoid problems while switiching projects.

## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| Link   | Link  |

## Open TODOs/questions

-   [ ] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2405
