### PR TITLE
Add GitHub action that checks if peer dependency are met

### DIFF
--- a/.github/workflows/peer-deps-check.yml
+++ b/.github/workflows/peer-deps-check.yml
@@ -1,0 +1,26 @@
+name: Check Peer Dependencies
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+        paths:
+            - "pnpm-lock.yaml"
+
+jobs:
+    check-peer-deps:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Use Node.js 22.x
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: "https://registry.npmjs.org"
+                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+
+            - name: Check peer dependencies
+              # This will fail if peer dependencies are not satisfied
+              run: pnpm install --resolution-only

--- a/.github/workflows/peer-deps-check.yml
+++ b/.github/workflows/peer-deps-check.yml
@@ -12,6 +12,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
             - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/peer-deps-check.yml
+++ b/.github/workflows/peer-deps-check.yml
@@ -23,4 +23,4 @@ jobs:
 
             - name: Check peer dependencies
               # This will fail if peer dependencies are not satisfied
-              run: pnpm install --resolution-only
+              run: pnpm install --resolution-only --no-frozen-lockfile

--- a/.github/workflows/peer-deps-check.yml
+++ b/.github/workflows/peer-deps-check.yml
@@ -5,7 +5,8 @@ on:
         branches: [main]
     pull_request:
         branches: [main]
-
+        paths:
+            - "pnpm-lock.yaml"
 jobs:
     check-peer-deps:
         runs-on: ubuntu-latest

--- a/.github/workflows/peer-deps-check.yml
+++ b/.github/workflows/peer-deps-check.yml
@@ -5,8 +5,6 @@ on:
         branches: [main]
     pull_request:
         branches: [main]
-        paths:
-            - "pnpm-lock.yaml"
 
 jobs:
     check-peer-deps:

--- a/.github/workflows/peer-deps-check.yml
+++ b/.github/workflows/peer-deps-check.yml
@@ -12,6 +12,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            - uses: pnpm/action-setup@v4
+
             - name: Use Node.js 22.x
               uses: actions/setup-node@v4
               with:


### PR DESCRIPTION
`.npmrc` already contained:

```
strict-peer-dependencies=true
auto-install-peers=false
dedupe-peer-dependents=true
```

But this setup only validates peers during dependency resolution. With an existing lockfile, peer mismatches could slip through unnoticed.

### Changed
Introduced a new lint step in CI that explicitly runs:

```
pnpm install --resolution-only --no-frozen-lockfile
```

This forces dependency resolution every time and ensures peer dependency validation is applied, when pnpm-lock.yaml file changes.


### Notes
- This lint step is CI-only and does not affect normal local `pnpm install`.
- `--resolution-only` must be combined with `--no-frozen-lockfile`, since frozen lockfiles are incompatible with forced resolution.
- If errors are raised, dependency versions must be corrected before merging.
