### PR TITLE
Replace MUI's `Dialog` with `Dialog` from `@comet/admin` in `ChooseFileDialog`

### DIFF
--- a/.changeset/busy-plums-boil.md
+++ b/.changeset/busy-plums-boil.md
@@ -1,5 +1,0 @@
----
-"@comet/cms-admin": patch
----
-
-Use `Dialog` from `@comet/admin` in `ChooseFileDialog`


### PR DESCRIPTION
## Description

Replace MUI's `Dialog` with `Dialog` from `@comet/admin` in `ChooseFileDialog` to simplify styling.


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1728" height="959" alt="Screenshot 2025-09-08 at 14 55 53" src="https://github.com/user-attachments/assets/d86cfe2e-3256-4dd5-aeb0-087499ebe428" /> | <img width="1728" height="957" alt="Screenshot 2025-09-08 at 15 08 36" src="https://github.com/user-attachments/assets/3c619f11-9f51-4cac-a7dc-5048630e361b" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2403
