### PR TITLE
Admin Generator: use SelectField instead of Field and FinalFormSelect

### DIFF
--- a/.changeset/fancy-foxes-melt.md
+++ b/.changeset/fancy-foxes-melt.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-generator": patch
+---
+
+Form Generation: `StaticSelect` with `inputType: "select"` now generates `SelectField` instead of `Field` + `FinalFormSelect`.

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/__tests__/__snapshots__/generateFormField-staticSelect.test.ts.snap
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/__tests__/__snapshots__/generateFormField-staticSelect.test.ts.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateFormField - staticSelect should generate readonly staticSelect 1`] = `
+"<SelectField
+                            
+                             fullWidth
+                                variant={"horizontal"}
+                                name="type"
+                                label={<FormattedMessage id="product.type" defaultMessage="Type" />}
+                                
+                                
+                                
+                                readOnly disabled endAdornment={<InputAdornment position="end"><Lock /></InputAdornment>}
+                                options={[{
+                                        value: "cap",
+                                        label: <FormattedMessage id="product.type.cap" defaultMessage="Cap" />
+                                    },{
+                                        value: "shirt",
+                                        label: <FormattedMessage id="product.type.shirt" defaultMessage="Shirt" />
+                                    },{
+                                        value: "tie",
+                                        label: <FormattedMessage id="product.type.tie" defaultMessage="Tie" />
+                                    }]}
+                            />"
+`;
+
+exports[`generateFormField - staticSelect should generate simple staticSelect 1`] = `
+"<RadioGroupField
+             required
+              variant="horizontal"
+             fullWidth
+             name="type"
+             label={<FormattedMessage id="product.type" defaultMessage="Type" />}
+             options={[
+                  {
+                                label: <FormattedMessage id="product.type.cap" defaultMessage="Cap" />,
+                                value: "cap",
+                            },{
+                                label: <FormattedMessage id="product.type.shirt" defaultMessage="Shirt" />,
+                                value: "shirt",
+                            },{
+                                label: <FormattedMessage id="product.type.tie" defaultMessage="Tie" />,
+                                value: "tie",
+                            }
+            ]}/>"
+`;

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/__tests__/generateFormField-staticSelect.test.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/__tests__/generateFormField-staticSelect.test.ts
@@ -1,0 +1,91 @@
+import { buildSchema, introspectionFromSchema } from "graphql";
+
+import type { FormConfig, FormFieldConfig } from "../../generate-command";
+import { generateFormField } from "../generateFormField";
+
+const schema = buildSchema(`
+            type Query {
+                products: [Product]!
+            } 
+
+            type Product {
+                id: ID!
+                type: ProductType!
+            }
+          
+            type Mutation {
+                createProduct(input: ProductInput!): Product!
+                updateProduct(id: ID!, input: ProductInput!): Product!
+            }
+
+            input ProductInput {
+                title: String
+                type: ProductType
+            }
+            
+            enum ProductType {
+              cap
+              shirt
+              tie
+            }
+        `);
+
+type GQLProduct = {
+    __typename?: "Product";
+    id: string;
+    type: GQLProductType;
+};
+
+type GQLProductType = "cap" | "shirt" | "tie";
+
+describe("generateFormField - staticSelect", () => {
+    it("should generate simple staticSelect", async () => {
+        const fieldConfig: FormFieldConfig<GQLProduct> = {
+            type: "staticSelect",
+            name: "type",
+        };
+
+        const formConfig: FormConfig<GQLProduct> = {
+            type: "form",
+            gqlType: "Product",
+            fields: [fieldConfig],
+        };
+
+        const introspection = introspectionFromSchema(schema);
+
+        const formOutput = generateFormField({
+            gqlIntrospection: introspection,
+            baseOutputFilename: "ProductForm",
+            formFragmentName: "ProductFormFragment",
+            config: fieldConfig,
+            formConfig,
+            gqlType: "Product",
+        });
+        expect(formOutput.code).toMatchSnapshot();
+    });
+    it("should generate readonly staticSelect", async () => {
+        const fieldConfig: FormFieldConfig<GQLProduct> = {
+            type: "staticSelect",
+            name: "type",
+            readOnly: true,
+        };
+
+        const formConfig: FormConfig<GQLProduct> = {
+            type: "form",
+            gqlType: "Product",
+            fields: [fieldConfig],
+        };
+
+        const introspection = introspectionFromSchema(schema);
+
+        const formOutput = generateFormField({
+            gqlIntrospection: introspection,
+            baseOutputFilename: "ProductForm",
+            formFragmentName: "ProductFormFragment",
+            config: fieldConfig,
+            formConfig,
+            gqlType: "Product",
+        });
+        expect(formOutput.code).toMatchSnapshot();
+    });
+});

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -324,33 +324,35 @@ export function generateFormField({
                       .join(",")}
             ]}/>`;
         } else {
-            code = `<Field
-            ${required ? "required" : ""}
-            variant="horizontal"
-            fullWidth
-            name="${nameWithPrefix}"
-            label={${fieldLabel}}
-            ${config.startAdornment ? `startAdornment={<InputAdornment position="start">${startAdornment.adornmentString}</InputAdornment>}` : ""}
-            ${
-                config.helperText
-                    ? `helperText={<FormattedMessage id=` +
-                      `"${formattedMessageRootId}.${name}.helperText" ` +
-                      `defaultMessage="${config.helperText}" />}`
-                    : ""
-            }
-            ${validateCode}>
-            {(props) =>
-                <FinalFormSelect ${config.readOnly ? readOnlyPropsWithLock : ""} {...props}>
-                ${values
-                    .map((value) => {
-                        const id = `${formattedMessageRootId}.${name}.${value.value.charAt(0).toLowerCase() + value.value.slice(1)}`;
-                        const label = `<FormattedMessage id="${id}" defaultMessage="${value.label}" />`;
-                        return `<MenuItem value="${value.value}">${label}</MenuItem>`;
-                    })
-                    .join("\n")}
-                </FinalFormSelect>
-            }
-        </Field>`;
+            imports.push({
+                name: "SelectField",
+                importPath: "@comet/admin",
+            });
+            code = `<SelectField
+                            ${required ? "required" : ""}
+                             fullWidth
+                                variant={"horizontal"}
+                                name="${nameWithPrefix}"
+                                label={${fieldLabel}}
+                                ${config.startAdornment ? `startAdornment={<InputAdornment position="start">${startAdornment.adornmentString}</InputAdornment>}` : ""}
+                                ${
+                                    config.helperText
+                                        ? `helperText={<FormattedMessage id=` +
+                                          `"${formattedMessageRootId}.${name}.helperText" ` +
+                                          `defaultMessage="${config.helperText}" />}`
+                                        : ""
+                                }
+                                ${validateCode}
+                                ${config.readOnly ? readOnlyPropsWithLock : ""}
+                                options={[${values.map((value) => {
+                                    const id = `${formattedMessageRootId}.${name}.${value.value.charAt(0).toLowerCase() + value.value.slice(1)}`;
+
+                                    return `{
+                                        value: "${value.value}",
+                                        label: <FormattedMessage id="${id}" defaultMessage="${value.label}" />
+                                    }`;
+                                })}]}
+                            />`;
         }
     } else {
         throw new Error(`Unsupported type`);


### PR DESCRIPTION
## Description

This Pull Request changes in the admin-generator how the form field of `type: staticSelect` - `inputType: "select"` will be generated from `<Field>` + `<FinalFormSelect>` to recommended `<SelectField/>` component.

before:
```
<Field
    variant="horizontal"
    fullWidth
    name="type"
    label={<FormattedMessage id="product.type" defaultMessage="Type" />}>
    {(props) =>
        <FinalFormSelect readOnly disabled endAdornment={<InputAdornment position="end"><Lock /></InputAdornment>} {...props}>
           <MenuItem value="cap">
                    <FormattedMessage id="product.type.cap" defaultMessage="Cap" />
           </MenuItem>
           <MenuItem value="shirt">
                    <FormattedMessage id="product.type.shirt" defaultMessage="Shirt" />
            </MenuItem>
            <MenuItem value="tie">
                    <FormattedMessage id="product.type.tie" defaultMessage="Tie" />
            </MenuItem>
       </FinalFormSelect>
    }
</Field>
```

after:
```
<SelectField
    fullWidth
    variant={"horizontal"}
    name="type"
    label={<FormattedMessage id="product.type" defaultMessage="Type" />} 
    readOnly
    disabled 
    endAdornment={<InputAdornment position="end"><Lock /></InputAdornment>}
    options={[{
         value: "cap",
         label: <FormattedMessage id="product.type.cap" defaultMessage="Cap" />
    },{
         value: "shirt",
         label: <FormattedMessage id="product.type.shirt" defaultMessage="Shirt" />
    },{
         value: "tie",
         label: <FormattedMessage id="product.type.tie" defaultMessage="Tie" />
    }]}
/>
```

### Why

- recommended to use `SelectFields` over `<Field>` usage.
- if a staticSelect configuration was set to readonly - the generated Field switches automatically to an Field + FinalFormSelect and readonly/disabled props where not forwarded correctly, and readonly state could not be recognized in UI.

| Description | before | after|
|--------|--------|--------|
| readonly staticSelect with empty value |  ![Screen Recording 2025-09-09 at 13 23 32](https://github.com/user-attachments/assets/4c21df66-ceff-4ae2-8001-b1afd322a08a) |  ![Screen Recording 2025-09-09 at 14 30 59](https://github.com/user-attachments/assets/c0484d73-3b26-41dc-ad9d-4d0bb1730608) |
| readonly staticSelect with value | ![Screen Recording 2025-09-09 at 14 28 26](https://github.com/user-attachments/assets/a1c754da-d3c3-4d5b-944e-f8d1037352be) |  ![Screen Recording 2025-09-09 at 14 30 10](https://github.com/user-attachments/assets/dc2d9bc5-40b4-49ed-9e93-8d307ea24611) |

## Note
disabled and disabled/readonly SelectFields, can still remove the value. This will be done in another Pull Request.

## Further information

-   Task:  https://vivid-planet.atlassian.net/browse/COM-1631
