### PR TITLE
SelectField / FinalFormSelect: readonly select field should not show clear button

### DIFF
--- a/.changeset/many-bats-unite.md
+++ b/.changeset/many-bats-unite.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+ySelectField / FinalFormSelect: The clear button is now always hidden when the field is disabled.

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -20,7 +20,10 @@ export interface FinalFormSelectProps<T> {
 
 type FinalFormSelectInternalProps<T> = FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement>;
 
-const getHasClearableContent = (value: unknown, multiple: boolean | undefined) => {
+const getHasClearableContent = (value: unknown, multiple: boolean | undefined, disabled: boolean | undefined) => {
+    if (disabled) {
+        return false;
+    }
     if (multiple && Array.isArray(value)) {
         return value.length > 0;
     }
@@ -66,6 +69,7 @@ export const FinalFormSelect = <T,>({
             <FormattedMessage id="finalFormSelect.error" defaultMessage="Error loading options." />
         </Typography>
     ),
+    disabled,
     children,
     required,
     ...rest
@@ -78,7 +82,7 @@ export const FinalFormSelect = <T,>({
     const endAdornment = !required ? (
         <ClearInputAdornment
             position="end"
-            hasClearableContent={getHasClearableContent(value, multiple)}
+            hasClearableContent={getHasClearableContent(value, multiple, disabled)}
             onClick={() => onChange(multiple ? [] : undefined)}
         />
     ) : null;
@@ -86,6 +90,7 @@ export const FinalFormSelect = <T,>({
     const selectProps = {
         ...rest,
         multiple,
+        disabled,
         endAdornment,
         name,
         onChange,

--- a/storybook/src/admin/form/SelectField.stories.tsx
+++ b/storybook/src/admin/form/SelectField.stories.tsx
@@ -1,0 +1,116 @@
+import { Alert, FinalForm, SelectField } from "@comet/admin";
+import { Lock } from "@comet/admin-icons";
+import { InputAdornment } from "@mui/material";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+type Story = StoryObj<typeof SelectField>;
+const config: Meta<typeof SelectField> = {
+    component: SelectField,
+    title: "@comet/admin/form/SelectField",
+};
+export default config;
+
+export const Default: Story = {
+    render: () => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{ type: "value-1" }}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <SelectField
+                                name="type"
+                                label="SelectField"
+                                fullWidth
+                                variant="horizontal"
+                                options={[
+                                    {
+                                        value: "value-1",
+                                        label: "Value 1",
+                                    },
+                                    {
+                                        value: "value-2",
+                                        label: "Value 2",
+                                    },
+                                    {
+                                        value: "value-3",
+                                        label: "Value 3",
+                                    },
+                                ]}
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+export const Readonly: Story = {
+    render: () => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{ type: "value-1" }}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <SelectField
+                                name="type"
+                                label="SelectField"
+                                fullWidth
+                                variant="horizontal"
+                                readOnly
+                                disabled
+                                endAdornment={
+                                    <InputAdornment position="end">
+                                        <Lock />
+                                    </InputAdornment>
+                                }
+                                options={[
+                                    {
+                                        value: "value-1",
+                                        label: "Value 1",
+                                    },
+                                    {
+                                        value: "value-2",
+                                        label: "Value 2",
+                                    },
+                                    {
+                                        value: "value-3",
+                                        label: "Value 3",
+                                    },
+                                ]}
+                            />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};


### PR DESCRIPTION
## Description

This Pull Request changes the SelectField / FinalFormSelect behaviour. If the SelectField is disabled, the Clear Button will never be shown.

### Why

If we are disabling the `SelectField` - it would be possible to clear the value, also in the form state.  In the Demo App (if configured accordingly) it would also enable (because the formstate changes) the Save Button.

![Screen Recording 2025-09-09 at 16 51 28](https://github.com/user-attachments/assets/13af61ba-7ff6-45e0-baa4-3a64dfa42a6b)

 
## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| ![Screen Recording 2025-09-09 at 14 54 52](https://github.com/user-attachments/assets/f6bbcfaf-ac9d-446b-adfe-a4bfa3096b2b)   |  ![Screen Recording 2025-09-09 at 14 54 31](https://github.com/user-attachments/assets/186c76e2-dbe8-4698-8d41-02f8c1b8ae60)  |

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1631
