### PR TITLE
A11y: Improve font-sizes of `<sub>` and `<sup>` elements

### DIFF
--- a/demo/site/src/styles/global.scss
+++ b/demo/site/src/styles/global.scss
@@ -114,7 +114,7 @@ p {
 /* Prevent sub and sup elements from affecting the line height in all browsers */
 sub,
 sup {
-    font-size: 75%;
+    font-size: max(12px, 75%);
     line-height: 0;
     position: relative;
     vertical-align: baseline;


### PR DESCRIPTION
## Description

Text should have at least a size of 12px to be accessible. 

Problem: the font-size of `<sub>` and `<sup>` elements is given with 75% of its parent, which can lead to values smaller than 12px, e.g. in the RichTextBlock using the "Paragraph small" variant.

To fix this, a minimum value of 12px is set to those elements globally using the max() function. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Example is from the RichTextBlock, where the font-size of the parent is 15px.

| Before | After |
| ------ | ----- |
| <img width="270" height="231" alt="Screenshot 2025-09-10 at 10 36 23" src="https://github.com/user-attachments/assets/8d982feb-9ca0-4e87-af25-64a2cfa5426c" /> | <img width="319" height="274" alt="Screenshot 2025-09-10 at 10 36 45" src="https://github.com/user-attachments/assets/cc61da5d-bc15-4e4f-92e2-a39e5306d641" />|

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2255
-   PR in starter:  https://github.com/vivid-planet/comet-starter/pull/962
