### PR TITLE
Admin Generator: use Future_DatePickerField instead of FinalFormDatePicker

### DIFF
--- a/.changeset/fancy-clowns-invent.md
+++ b/.changeset/fancy-clowns-invent.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-generator": minor
+---
+
+Use Future_DatePickerField instead of FinalFormDatePicker

--- a/.changeset/fancy-clowns-invent.md
+++ b/.changeset/fancy-clowns-invent.md
@@ -2,4 +2,4 @@
 "@comet/admin-generator": minor
 ---
 
-Use Future_DatePickerField instead of FinalFormDatePicker
+Use `Future_DatePickerField` instead of `FinalFormDatePicker`

--- a/demo/admin/src/news/generated/NewsForm.tsx
+++ b/demo/admin/src/news/generated/NewsForm.tsx
@@ -12,7 +12,6 @@ import { RadioGroupField } from "@comet/admin";
 import { TextField } from "@comet/admin";
 import { useFormApiRef } from "@comet/admin";
 import { useStackSwitchApi } from "@comet/admin";
-import { FinalFormDatePicker } from "@comet/admin-date-time";
 import { BlockState } from "@comet/cms-admin";
 import { createFinalFormBlock } from "@comet/cms-admin";
 import { queryUpdatedAt } from "@comet/cms-admin";
@@ -23,6 +22,7 @@ import { useMemo } from "react";
 import { GQLNewsContentScopeInput } from "@src/graphql.generated";
 import { DamImageBlock } from "@comet/cms-admin";
 import { NewsContentBlock } from "../blocks/NewsContentBlock";
+import { Future_DatePickerField } from "@comet/admin";
 import { newsFormFragment } from "./NewsForm.gql";
 import { GQLNewsFormFragment } from "./NewsForm.gql.generated";
 import { newsQuery } from "./NewsForm.gql";
@@ -118,7 +118,7 @@ export function NewsForm({ id, scope }: FormProps) {
 
         <TextField required variant="horizontal" fullWidth name="title" label={<FormattedMessage id="news.title" defaultMessage="Title"/>}/>
 
-            <Field required variant="horizontal" fullWidth name="date" component={FinalFormDatePicker} label={<FormattedMessage id="news.date" defaultMessage="Date"/>}/>
+            <Future_DatePickerField required variant="horizontal" fullWidth name="date" label={<FormattedMessage id="news.date" defaultMessage="Date"/>}/>
         <RadioGroupField required variant="horizontal" fullWidth name="category" label={<FormattedMessage id="news.category" defaultMessage="Category"/>} options={[
                 {
                     label: <FormattedMessage id="news.category.events" defaultMessage="Events"/>,

--- a/demo/admin/src/products/generator/generated/CreateCapProductForm.tsx
+++ b/demo/admin/src/products/generator/generated/CreateCapProductForm.tsx
@@ -12,7 +12,6 @@ import { TextAreaField } from "@comet/admin";
 import { TextField } from "@comet/admin";
 import { useFormApiRef } from "@comet/admin";
 import { useStackSwitchApi } from "@comet/admin";
-import { FinalFormDatePicker } from "@comet/admin-date-time";
 import { BlockState } from "@comet/cms-admin";
 import { createFinalFormBlock } from "@comet/cms-admin";
 import { InputAdornment } from "@mui/material";
@@ -23,6 +22,7 @@ import { validateTitle } from "../validateTitle";
 import { GQLProductCategoriesSelectQuery } from "./CreateCapProductForm.generated";
 import { GQLProductCategoriesSelectQueryVariables } from "./CreateCapProductForm.generated";
 import { CalendarToday as CalendarTodayIcon } from "@comet/admin-icons";
+import { Future_DatePickerField } from "@comet/admin";
 import { GQLCreateCapProductFormDetailsFragment } from "./CreateCapProductForm.gql.generated";
 import { createProductMutation } from "./CreateCapProductForm.gql";
 import { GQLCreateProductMutation } from "./CreateCapProductForm.gql.generated";
@@ -87,7 +87,7 @@ export function CreateCapProductForm({ type }: FormProps) {
             }} getOptionLabel={(option) => option.title}/>
         <CheckboxField label={<FormattedMessage id="product.inStock" defaultMessage="In Stock"/>} name="inStock" fullWidth variant="horizontal"/>
 
-            <Field variant="horizontal" fullWidth name="availableSince" component={FinalFormDatePicker} label={<FormattedMessage id="product.availableSince" defaultMessage="Available Since"/>} startAdornment={<InputAdornment position="start"><CalendarTodayIcon /></InputAdornment>}/>
+            <Future_DatePickerField variant="horizontal" fullWidth name="availableSince" label={<FormattedMessage id="product.availableSince" defaultMessage="Available Since"/>} startAdornment={<InputAdornment position="start"><CalendarTodayIcon /></InputAdornment>}/>
         <Field name="image" isEqual={isEqual} label={<FormattedMessage id="product.image" defaultMessage="Image"/>} variant="horizontal" fullWidth>
             {createFinalFormBlock(rootBlocks.image)}
         </Field>

--- a/demo/admin/src/products/generator/generated/ProductForm.tsx
+++ b/demo/admin/src/products/generator/generated/ProductForm.tsx
@@ -20,7 +20,6 @@ import { useFormApiRef } from "@comet/admin";
 import { useStackSwitchApi } from "@comet/admin";
 import { Lock } from "@comet/admin-icons";
 import { DateTimeField } from "@comet/admin-date-time";
-import { FinalFormDatePicker } from "@comet/admin-date-time";
 import { BlockState } from "@comet/cms-admin";
 import { createFinalFormBlock } from "@comet/cms-admin";
 import { queryUpdatedAt } from "@comet/cms-admin";
@@ -33,6 +32,7 @@ import { useMemo } from "react";
 import { DamImageBlock } from "@comet/cms-admin";
 import { GQLFinalFormFileUploadFragment } from "@comet/cms-admin";
 import { GQLFinalFormFileUploadDownloadableFragment } from "@comet/cms-admin";
+import { Future_DatePickerField } from "@comet/admin";
 import { GQLProductCategoriesSelectQuery } from "./ProductForm.generated";
 import { GQLProductCategoriesSelectQueryVariables } from "./ProductForm.generated";
 import { FinalFormSwitch } from "@comet/admin";
@@ -154,7 +154,7 @@ export function ProductForm({ manufacturerCountry, id }: FormProps) {
 
         <TextField required variant="horizontal" fullWidth name="slug" label={<FormattedMessage id="product.slug" defaultMessage="Slug"/>}/>
 
-            <Field readOnly disabled endAdornment={<InputAdornment position="end"><Lock /></InputAdornment>} variant="horizontal" fullWidth name="createdAt" component={FinalFormDatePicker} label={<FormattedMessage id="product.createdAt" defaultMessage="Created"/>}/>
+            <Future_DatePickerField readOnly disabled endAdornment={<InputAdornment position="end"><Lock /></InputAdornment>} variant="horizontal" fullWidth name="createdAt" label={<FormattedMessage id="product.createdAt" defaultMessage="Created"/>}/>
 
         <TextAreaField variant="horizontal" fullWidth name="description" label={<FormattedMessage id="product.description" defaultMessage="Description"/>}/>
         <RadioGroupField required variant="horizontal" fullWidth name="type" label={<FormattedMessage id="product.type" defaultMessage="Type"/>} options={[
@@ -215,7 +215,7 @@ export function ProductForm({ manufacturerCountry, id }: FormProps) {
             }} getOptionLabel={(option) => option.name}/>
         <CheckboxField label={<FormattedMessage id="product.inStock" defaultMessage="In Stock"/>} name="inStock" fullWidth variant="horizontal"/>
 
-            <Field variant="horizontal" fullWidth name="availableSince" component={FinalFormDatePicker} label={<FormattedMessage id="product.availableSince" defaultMessage="Available Since"/>} startAdornment={<InputAdornment position="start"><CalendarTodayIcon /></InputAdornment>}/>
+            <Future_DatePickerField variant="horizontal" fullWidth name="availableSince" label={<FormattedMessage id="product.availableSince" defaultMessage="Available Since"/>} startAdornment={<InputAdornment position="start"><CalendarTodayIcon /></InputAdornment>}/>
         <FutureProductNotice />
         <Field name="image" isEqual={isEqual} label={<FormattedMessage id="product.image" defaultMessage="Image"/>} variant="horizontal" fullWidth>
             {createFinalFormBlock(rootBlocks.image)}

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/__tests__/__snapshots__/generateFormField-date.test.ts.snap
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/__tests__/__snapshots__/generateFormField-date.test.ts.snap
@@ -2,13 +2,12 @@
 
 exports[`generateFormField - datePicker should generate simple date field with LocalType scalar 1`] = `
 "
-            <Field
+            <Future_DatePickerField
                 
                 
                 variant="horizontal"
                 fullWidth
                 name="availableSince"
-                component={FinalFormDatePicker}
                 label={<FormattedMessage id="product.availableSince" defaultMessage="Available Since" />}
                 
                 

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/__tests__/__snapshots__/generateFormField-date.test.ts.snap
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/__tests__/__snapshots__/generateFormField-date.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateFormField - datePicker should generate simple date field with LocalType scalar 1`] = `
+"
+            <Field
+                
+                
+                variant="horizontal"
+                fullWidth
+                name="availableSince"
+                component={FinalFormDatePicker}
+                label={<FormattedMessage id="product.availableSince" defaultMessage="Available Since" />}
+                
+                
+                
+                
+            />"
+`;

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/__tests__/generateFormField-date.test.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/__tests__/generateFormField-date.test.ts
@@ -1,0 +1,63 @@
+import { buildSchema, introspectionFromSchema } from "graphql";
+
+import type { FormConfig, FormFieldConfig } from "../../generate-command";
+import { generateFormField } from "../generateFormField";
+
+const schema = buildSchema(`
+            """
+            A local date string (i.e., with no associated timezone) in \`YYYY-MM-DD\` format, e.g. \`2020-01-01\`.
+            """
+            scalar LocalDate
+
+            type Query {
+                products: [Product]!
+            } 
+
+            type Product {
+                id: ID!
+                availableSince: LocalDate
+            }
+          
+            type Mutation {
+                createProduct(input: ProductInput!): Product!
+                updateProduct(id: ID!, input: ProductInput!): Product!
+            }
+
+            input ProductInput {
+                title: String
+                availableSince: LocalDate = null
+            }
+        `);
+
+type GQLProduct = {
+    __typename?: "Product";
+    id: string;
+    availableSince: string | null;
+};
+
+describe("generateFormField - datePicker", () => {
+    it("should generate simple date field with LocalType scalar", async () => {
+        const fieldConfig: FormFieldConfig<GQLProduct> = {
+            type: "date",
+            name: "availableSince",
+        };
+
+        const formConfig: FormConfig<GQLProduct> = {
+            type: "form",
+            gqlType: "Product",
+            fields: [fieldConfig],
+        };
+
+        const introspection = introspectionFromSchema(schema);
+
+        const formOutput = generateFormField({
+            gqlIntrospection: introspection,
+            baseOutputFilename: "ProductForm",
+            formFragmentName: "ProductFormFragment",
+            config: fieldConfig,
+            formConfig,
+            gqlType: "Product",
+        });
+        expect(formOutput.code).toMatchSnapshot();
+    });
+});

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -201,13 +201,12 @@ export function generateFormField({
         ];
     } else if (config.type == "date") {
         code = `
-            <Field
+            <Future_DatePickerField
                 ${required ? "required" : ""}
                 ${config.readOnly ? readOnlyPropsWithLock : ""}
                 variant="horizontal"
                 fullWidth
                 name="${nameWithPrefix}"
-                component={FinalFormDatePicker}
                 label={${fieldLabel}}
                 ${config.startAdornment ? `startAdornment={<InputAdornment position="start">${startAdornment.adornmentString}</InputAdornment>}` : ""}
                 ${config.endAdornment ? `endAdornment={<InputAdornment position="end">${endAdornment.adornmentString}</InputAdornment>}` : ""}

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -200,6 +200,10 @@ export function generateFormField({
             },
         ];
     } else if (config.type == "date") {
+        imports.push({
+            name: "Future_DatePickerField",
+            importPath: "@comet/admin",
+        });
         code = `
             <Future_DatePickerField
                 ${required ? "required" : ""}


### PR DESCRIPTION
## Description

This Pull Request changes the generated code from the admin-generator. The `Future_DatePickerField` will be used instead of the `FinalFormDatePicker` component.

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
|  ![Screen Recording 2025-09-12 at 07 25 32](https://github.com/user-attachments/assets/6335973c-1cd3-428b-a669-2412d2a1ea9c)   | ![Screen Recording 2025-09-12 at 07 29 52](https://github.com/user-attachments/assets/0364cf99-0146-4978-9f2f-c1cb1b7f86ab) |

