### PR TITLE
Add stories for status-indicator

### DIFF
--- a/storybook/src/admin/Tooltip.stories.tsx
+++ b/storybook/src/admin/Tooltip.stories.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from "@comet/admin";
-import { Add, Info } from "@comet/admin-icons";
+import { Add, Info, StatusErrorSolid, StatusSuccessSolid, StatusWarningSolid } from "@comet/admin-icons";
 import { Stack } from "@mui/material";
 
 export default {
@@ -16,6 +16,24 @@ export const IconWithTooltip = {
     },
 
     name: "Icon with Tooltip",
+};
+
+export const StatusIndicators = {
+    render: () => {
+        return (
+            <Stack py={5} spacing={5}>
+                <Tooltip title="Success variant" placement="top-start" variant="success">
+                    <StatusSuccessSolid color="success" />
+                </Tooltip>
+                <Tooltip title="Warning variant" placement="top-start" variant="warning">
+                    <StatusWarningSolid color="warning" />
+                </Tooltip>
+                <Tooltip title="Error variant" placement="top-start" variant="error">
+                    <StatusErrorSolid color="error" />
+                </Tooltip>
+            </Stack>
+        );
+    },
 };
 
 export const AllVariants = {


### PR DESCRIPTION
## Description

Originally we decided to create a `StatusIndicator` component with `icon` and `color` props and a `state` prop to pre-define a combination of `icon` and `color`. It would also have included an optional `tooltipText` prop to add a `Tooltip`. 

Since we have existing icons that exactly match the design, I decided that a new component is overkill and we can just use these icons, with a color, and optionally wrap that with a Tooltip, as demonstrated in this story. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

https://github.com/user-attachments/assets/aa720001-ec99-4fa0-87e5-ff80b960bc52

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2475
