### PR TITLE
Add stories for all `Tooltip` variants defined in design

### DIFF
--- a/storybook/src/admin/Tooltip.stories.tsx
+++ b/storybook/src/admin/Tooltip.stories.tsx
@@ -1,6 +1,8 @@
 import { Tooltip } from "@comet/admin";
-import { Add, Info, StatusErrorSolid, StatusSuccessSolid, StatusWarningSolid } from "@comet/admin-icons";
-import { Stack } from "@mui/material";
+import { Add, StatusErrorSolid, StatusSuccessSolid, StatusWarningSolid } from "@comet/admin-icons";
+import { Box, Chip, Stack, Typography } from "@mui/material";
+import { type Decorator } from "@storybook/react-webpack5";
+import { useEffect, useState } from "react";
 
 export default {
     title: "@comet/admin/Tooltip",
@@ -36,30 +38,116 @@ export const StatusIndicators = {
     },
 };
 
-export const AllVariants = {
+// Makes it easier to see the light variant of the tooltip
+const lightGrayBackgroundDecorator: Decorator = (Story) => (
+    <Box sx={{ backgroundColor: "#f0f0f0", margin: "-40px -30px", padding: "40px 30px" }}>
+        <Story />
+    </Box>
+);
+
+export const StackedTooltipsFromDesign = {
+    decorators: [lightGrayBackgroundDecorator],
     render: () => {
+        const [showTooltips, setShowTooltips] = useState(false);
+
+        useEffect(() => {
+            setTimeout(() => {
+                // Delay showing tooltips to prevent them being rendered in the wrong place due to the underlying element not being rendered properly yet.
+                setShowTooltips(true);
+            }, 1000);
+        }, []);
+
         return (
-            <Stack spacing={6}>
-                <Tooltip title="Dark variant (default)" open placement="right">
-                    <Info />
+            <Stack pb={8} spacing={16} direction="row">
+                <Tooltip
+                    title={
+                        <>
+                            <Typography variant="subtitle2" sx={{ minWidth: 180 }}>
+                                Title
+                            </Typography>
+                            <Typography variant="body2">Notification Text</Typography>
+                        </>
+                    }
+                    variant="light"
+                    placement="bottom-start"
+                    open={showTooltips}
+                >
+                    <Chip label="Light" sx={{ width: 140 }} />
                 </Tooltip>
-                <Tooltip title="Light variant" open placement="right" variant="light">
-                    <Info />
+                <Tooltip
+                    title={
+                        <>
+                            <Typography variant="subtitle2" sx={{ minWidth: 180 }}>
+                                Title
+                            </Typography>
+                            <Typography variant="body2">Notification Text</Typography>
+                        </>
+                    }
+                    variant="dark"
+                    placement="bottom-start"
+                    open={showTooltips}
+                >
+                    <Chip label="Dark" sx={{ width: 140 }} />
                 </Tooltip>
-                <Tooltip title="Neutral variant" open placement="right" variant="neutral">
-                    <Info />
+                <Tooltip
+                    title={
+                        <>
+                            <Typography variant="subtitle2" sx={{ minWidth: 180 }}>
+                                Title
+                            </Typography>
+                            <Typography variant="body2">Notification Text</Typography>
+                        </>
+                    }
+                    variant="neutral"
+                    placement="bottom-start"
+                    open={showTooltips}
+                >
+                    <Chip label="Neutral (deprecated)" sx={{ width: 140 }} />
                 </Tooltip>
-                <Tooltip title="Primary variant" open placement="right" variant="primary">
-                    <Info />
+                <Tooltip
+                    title={
+                        <>
+                            <Typography variant="subtitle2" sx={{ minWidth: 180 }}>
+                                Title
+                            </Typography>
+                            <Typography variant="body2">Notification Text</Typography>
+                        </>
+                    }
+                    variant="primary"
+                    placement="bottom-start"
+                    open={showTooltips}
+                >
+                    <Chip label="Primary (deprecated)" sx={{ width: 140 }} />
                 </Tooltip>
-                <Tooltip title="Error variant" open placement="right" variant="error">
-                    <Info />
+            </Stack>
+        );
+    },
+};
+
+export const FeedbackTooltipsFromDesign = {
+    render: () => {
+        const [showTooltips, setShowTooltips] = useState(false);
+
+        useEffect(() => {
+            setTimeout(() => {
+                // Delay showing tooltips to prevent them being rendered in the wrong place due to the underlying element not being rendered properly yet.
+                setShowTooltips(true);
+            }, 1000);
+        }, []);
+
+        return (
+            <Stack pb={8} spacing={10} direction="row">
+                <Tooltip title="Notification text" variant="dark" placement="bottom-start" open={showTooltips}>
+                    <Chip label="Dark" sx={{ width: 70 }} />
                 </Tooltip>
-                <Tooltip title="Success variant" open placement="right" variant="success">
-                    <Info />
+                <Tooltip title="Notification text" variant="success" placement="bottom-start" open={showTooltips}>
+                    <Chip label="Success" sx={{ width: 70 }} />
                 </Tooltip>
-                <Tooltip title="Warning variant" open placement="right" variant="warning">
-                    <Info />
+                <Tooltip title="Notification text" variant="error" placement="bottom-start" open={showTooltips}>
+                    <Chip label="Error" sx={{ width: 70 }} />
+                </Tooltip>
+                <Tooltip title="Notification text" variant="warning" placement="bottom-start" open={showTooltips}>
+                    <Chip label="Warning" sx={{ width: 70 }} />
                 </Tooltip>
             </Stack>
         );


### PR DESCRIPTION
## Description

These stories will be used to demonstrate the before and after of the design and API changes. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Title | Screenshot |
|--------|--------|
| Stories | <img width="1039" height="433" alt="New Stories" src="https://github.com/user-attachments/assets/cce9f96a-121e-4d30-b397-902b846e22be" /> |
| Design (Stacked) | <img width="1071" height="161" alt="Design of Stacked Tooltip variant" src="https://github.com/user-attachments/assets/674bfa74-6aa7-4eb9-8d39-7a7572f2dae8" /> |
| Design (Feedback) | <img width="217" height="409" alt="Design of Feedback Tooltip variant" src="https://github.com/user-attachments/assets/2a11dd20-cea7-4305-afeb-ba641ac004e8" /> | 

## Open TODOs/questions

-   [x] Merge parent and rebase #4485 

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2454
