### PR TITLE
Improve API of `Tooltip`

### DIFF
--- a/.changeset/rich-clubs-enjoy.md
+++ b/.changeset/rich-clubs-enjoy.md
@@ -1,0 +1,24 @@
+---
+"@comet/admin": major
+---
+
+Rename `variant` prop of `Tooltip` to `color` and remove the `neutral` and `primary` options
+
+```diff
+ <Tooltip
+     title="Title"
+-    variant="light"
++    color="light"
+ >
+     <Info />
+ </Tooltip>
+```
+
+```diff
+ <Tooltip
+     title="Title"
+-    variant="neutral"
+ >
+     <Info />
+ </Tooltip>
+```

--- a/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
+++ b/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
@@ -1,0 +1,48 @@
+---
+title: Migrating from v8 to v9
+sidebar_position: -9
+---
+
+# Migrating from v8 to v9
+
+## Admin
+
+### Tooltip-related Changes
+
+#### 🤖 Replace the `variant` prop with `color` in `Tooltip`
+
+:::note Execute the following upgrade script:
+
+    ```sh
+    npx @comet/upgrade@latest v9/admin/after-install/tooltip-replace-variant-prop.ts
+    ```
+
+:::
+
+<details>
+
+The `variant` prop has been renamed to color and the options `neutral` and `primary` have been removed.
+Change the usage of `variant` to `color` and remove or replace the values `neutral` and `primary`.
+
+Example:
+
+```diff
+ <Tooltip
+     title="Title"
+-    variant="light"
++    color="light"
+ >
+     <Info />
+ </Tooltip>
+```
+
+```diff
+ <Tooltip
+     title="Title"
+-    variant="neutral"
+ >
+     <Info />
+ </Tooltip>
+```
+
+</details>

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -22,7 +22,7 @@ type SlotProps = MuiTooltipProps["slotProps"] &
     }>["slotProps"];
 
 export interface TooltipProps extends Omit<MuiTooltipProps, "slotProps" | "title"> {
-    variant?: Variant;
+    color?: Color;
     title?: ReactNode;
     description?: ReactNode;
     customContent?: ReactNode;
@@ -30,13 +30,13 @@ export interface TooltipProps extends Omit<MuiTooltipProps, "slotProps" | "title
 }
 
 type Slot = "root" | "title" | "text";
-type Variant = "light" | "dark" | "neutral" | "primary" | "error" | "success" | "warning";
+type Color = "light" | "dark" | "error" | "success" | "warning";
 type ComponentState = "hasTitleOnly";
 
-export type TooltipClassKey = Slot | Variant | ComponentState | MuiTooltipClassKey;
+export type TooltipClassKey = Slot | Color | ComponentState | MuiTooltipClassKey;
 
 type OwnerState = {
-    variant: Variant;
+    color: Color;
     disableInteractive: boolean | undefined;
     arrow: boolean | undefined;
     isRtl: boolean;
@@ -53,7 +53,7 @@ const TooltipPopper = createComponentSlot(MuiPopper)<TooltipClassKey, OwnerState
     slotName: "popper",
     classesResolver(ownerState) {
         return [
-            ownerState.variant,
+            ownerState.color,
             // Copied the following from MUIs default TooltipPopper: https://github.com/mui/material-ui/blob/a13c0c026692aafc303756998a78f1d6c2dd707d/packages/mui-material/src/Tooltip/Tooltip.js#L48
             !ownerState.disableInteractive && "popperInteractive",
             ownerState.arrow && "popperArrow",
@@ -61,21 +61,17 @@ const TooltipPopper = createComponentSlot(MuiPopper)<TooltipClassKey, OwnerState
         ];
     },
 })(({ theme, ownerState }) => {
-    const variantToTextColor: Record<Variant, string> = {
+    const colorPropToTextColor: Record<Color, string> = {
         light: theme.palette.grey[900],
         dark: theme.palette.common.white,
-        neutral: theme.palette.grey[900],
-        primary: theme.palette.grey[900],
         error: theme.palette.common.white,
         success: theme.palette.common.black,
         warning: theme.palette.common.black,
     };
 
-    const variantToBackgroundColor: Record<Variant, string> = {
+    const colorPropToBackgroundColor: Record<Color, string> = {
         light: theme.palette.common.white,
         dark: ownerState.hasTitleOnly ? theme.palette.grey[500] : theme.palette.grey[900],
-        neutral: theme.palette.grey[100],
-        primary: theme.palette.primary.light,
         error: theme.palette.error.light,
         success: theme.palette.success.light,
         warning: theme.palette.warning.light,
@@ -91,8 +87,8 @@ const TooltipPopper = createComponentSlot(MuiPopper)<TooltipClassKey, OwnerState
             box-shadow: ${theme.shadows[3]};
             border-radius: 4px;
             padding: 3px 6px;
-            color: ${variantToTextColor[ownerState.variant]};
-            background-color: ${variantToBackgroundColor[ownerState.variant]};
+            color: ${colorPropToTextColor[ownerState.color]};
+            background-color: ${colorPropToBackgroundColor[ownerState.color]};
             line-height: 0; // Custom content may include space-caracters, due to code indentation. Removing the line-height prevents these from adding unintended whitespace.
 
             ${!ownerState.hasTitleOnly &&
@@ -102,7 +98,7 @@ const TooltipPopper = createComponentSlot(MuiPopper)<TooltipClassKey, OwnerState
         }
 
         .${tooltipClasses.arrow} {
-            color: ${variantToBackgroundColor[ownerState.variant]};
+            color: ${colorPropToBackgroundColor[ownerState.color]};
         }
 
         // Copied the following from MUIs default TooltipPopper: https://github.com/mui/material-ui/blob/a13c0c026692aafc303756998a78f1d6c2dd707d/packages/mui-material/src/Tooltip/Tooltip.js#L55
@@ -178,7 +174,7 @@ const Text = createComponentSlot(Typography)<TooltipClassKey>({
 
 export const Tooltip = (inProps: TooltipProps) => {
     const props = useThemeProps({ props: inProps, name: "CometAdminTooltip" });
-    const { variant = "dark", disableInteractive, arrow, children, title, description, customContent, slotProps = {}, ...restProps } = props;
+    const { color = "dark", disableInteractive, arrow, children, title, description, customContent, slotProps = {}, ...restProps } = props;
     const theme = useTheme();
 
     if (customContent && (title || description)) {
@@ -190,7 +186,7 @@ export const Tooltip = (inProps: TooltipProps) => {
     }
 
     const ownerState: OwnerState = {
-        variant,
+        color,
         disableInteractive,
         arrow,
         isRtl: theme.direction === "rtl",

--- a/packages/admin/admin/src/common/buttons/feedback/FeedbackButton.tsx
+++ b/packages/admin/admin/src/common/buttons/feedback/FeedbackButton.tsx
@@ -75,14 +75,14 @@ export function FeedbackButton(inProps: FeedbackButtonProps) {
 
     const isUncontrolled = loading === undefined && hasErrors === undefined;
 
-    const resolveTooltipForDisplayState = (displayState: FeedbackButtonDisplayState) => {
+    const resolveTooltipColorForDisplayState = (displayState: FeedbackButtonDisplayState) => {
         switch (displayState) {
             case "error":
                 return "error";
             case "success":
                 return "success";
             default:
-                return "neutral";
+                return "light";
         }
     };
 
@@ -143,7 +143,7 @@ export function FeedbackButton(inProps: FeedbackButtonProps) {
             title={displayState === "error" ? tooltipErrorMessage : displayState === "success" ? tooltipSuccessMessage : ""}
             open={displayState === "error" || displayState === "success"}
             placement={endIcon && !startIcon ? "top-end" : "top-start"}
-            variant={resolveTooltipForDisplayState(displayState)}
+            color={resolveTooltipColorForDisplayState(displayState)}
             {...slotProps?.tooltip}
         >
             <span>{startIcon || endIcon}</span>

--- a/packages/admin/admin/src/rowActions/RowActionsIconItem.tsx
+++ b/packages/admin/admin/src/rowActions/RowActionsIconItem.tsx
@@ -1,7 +1,7 @@
-import { IconButton, type IconButtonProps, type TooltipProps } from "@mui/material";
+import { IconButton, type IconButtonProps } from "@mui/material";
 import { forwardRef, type ReactNode } from "react";
 
-import { Tooltip } from "../common/Tooltip";
+import { Tooltip, type TooltipProps } from "../common/Tooltip";
 import { type CommonRowActionItemProps } from "./RowActionsItem";
 
 export interface RowActionsIconItemComponentsProps {

--- a/storybook/src/admin/FormSection.stories.tsx
+++ b/storybook/src/admin/FormSection.stories.tsx
@@ -42,7 +42,7 @@ export const InfoTooltipExamples = {
                     infoTooltip={{
                         title: "Hello",
                         description: "Lorem ipsum",
-                        variant: "light",
+                        color: "light",
                     }}
                 >
                     <Typography>Using infoTooltip prop, using object for title, description and variant</Typography>

--- a/storybook/src/admin/SectionHeadline.stories.tsx
+++ b/storybook/src/admin/SectionHeadline.stories.tsx
@@ -39,7 +39,7 @@ export const InfoTooltipExamples = () => {
                 infoTooltip={{
                     title: "Hello",
                     description: "Lorem ipsum",
-                    variant: "light",
+                    color: "light",
                 }}
             >
                 Using infoTooltip prop, using object for title, description and variant

--- a/storybook/src/admin/Tooltip.stories.tsx
+++ b/storybook/src/admin/Tooltip.stories.tsx
@@ -24,13 +24,13 @@ export const StatusIndicators = {
     render: () => {
         return (
             <Stack py={5} spacing={5}>
-                <Tooltip title="Success variant" placement="top-start" variant="success">
+                <Tooltip title="Success variant" placement="top-start" color="success">
                     <StatusSuccessSolid color="success" />
                 </Tooltip>
-                <Tooltip title="Warning variant" placement="top-start" variant="warning">
+                <Tooltip title="Warning variant" placement="top-start" color="warning">
                     <StatusWarningSolid color="warning" />
                 </Tooltip>
-                <Tooltip title="Error variant" placement="top-start" variant="error">
+                <Tooltip title="Error variant" placement="top-start" color="error">
                     <StatusErrorSolid color="error" />
                 </Tooltip>
             </Stack>
@@ -59,17 +59,11 @@ export const StackedTooltipsFromDesign = {
 
         return (
             <Stack pb={12} spacing={16} direction="row">
-                <Tooltip title="Title" description="Notification Text" variant="light" placement="bottom-start" open={showTooltips}>
+                <Tooltip title="Title" description="Notification Text" color="light" placement="bottom-start" open={showTooltips}>
                     <Chip label="Light" sx={{ width: 140 }} />
                 </Tooltip>
-                <Tooltip title="Title" description="Notification Text" variant="dark" placement="bottom-start" open={showTooltips}>
+                <Tooltip title="Title" description="Notification Text" color="dark" placement="bottom-start" open={showTooltips}>
                     <Chip label="Dark" sx={{ width: 140 }} />
-                </Tooltip>
-                <Tooltip title="Title" description="Notification Text" variant="neutral" placement="bottom-start" open={showTooltips}>
-                    <Chip label="Neutral (deprecated)" sx={{ width: 140 }} />
-                </Tooltip>
-                <Tooltip title="Title" description="Notification Text" variant="primary" placement="bottom-start" open={showTooltips}>
-                    <Chip label="Primary (deprecated)" sx={{ width: 140 }} />
                 </Tooltip>
             </Stack>
         );
@@ -89,16 +83,16 @@ export const FeedbackTooltipsFromDesign = {
 
         return (
             <Stack pb={8} spacing={12} direction="row">
-                <Tooltip title="Notification text" variant="dark" placement="bottom-start" open={showTooltips}>
+                <Tooltip title="Notification text" color="dark" placement="bottom-start" open={showTooltips}>
                     <Chip label="Dark" sx={{ width: 70 }} />
                 </Tooltip>
-                <Tooltip title="Notification text" variant="success" placement="bottom-start" open={showTooltips}>
+                <Tooltip title="Notification text" color="success" placement="bottom-start" open={showTooltips}>
                     <Chip label="Success" sx={{ width: 70 }} />
                 </Tooltip>
-                <Tooltip title="Notification text" variant="error" placement="bottom-start" open={showTooltips}>
+                <Tooltip title="Notification text" color="error" placement="bottom-start" open={showTooltips}>
                     <Chip label="Error" sx={{ width: 70 }} />
                 </Tooltip>
-                <Tooltip title="Notification text" variant="warning" placement="bottom-start" open={showTooltips}>
+                <Tooltip title="Notification text" color="warning" placement="bottom-start" open={showTooltips}>
                     <Chip label="Warning" sx={{ width: 70 }} />
                 </Tooltip>
             </Stack>
@@ -156,13 +150,13 @@ export const TooltipsWithCustomContent = {
 
         return (
             <Stack pb={32} spacing={24} direction="row">
-                <Tooltip customContent={customElementsContent} variant="light" open={showTooltips}>
+                <Tooltip customContent={customElementsContent} color="light" open={showTooltips}>
                     <Chip label="Custom elements" sx={{ width: 150 }} />
                 </Tooltip>
-                <Tooltip customContent={imageContent} variant="light" open={showTooltips}>
+                <Tooltip customContent={imageContent} color="light" open={showTooltips}>
                     <Chip label="Image" sx={{ width: 150 }} />
                 </Tooltip>
-                <Tooltip customContent={imageWithDescriptionContent} variant="light" open={showTooltips}>
+                <Tooltip customContent={imageWithDescriptionContent} color="light" open={showTooltips}>
                     <Chip label="Image with description" sx={{ width: 150 }} />
                 </Tooltip>
             </Stack>

--- a/storybook/src/docs/components/Tooltip/Tooltip.mdx
+++ b/storybook/src/docs/components/Tooltip/Tooltip.mdx
@@ -14,12 +14,12 @@ The Comet Admin `Tooltip` extends [Material UI's `Tooltip`](https://mui.com/mate
 
 #### Props
 
-| Name    | Type                                             | Description                            |
-| :------ | :----------------------------------------------- | :------------------------------------- |
-| variant | "light", "dark", "neutral", "primary" (optional) | Defines the color scheme of a tooltip. |
+| Name  | Type                                                      | Description                            |
+| :---- | :-------------------------------------------------------- | :------------------------------------- |
+| color | "light", "dark", "error", "success", "warning" (optional) | Defines the color scheme of a tooltip. |
 
 In addition to its own props, the Tooltip component also accepts all props from the Material UI Tooltip component.
 
-#### Example variant
+#### Color examples
 
-<Canvas of={TooltipStories.TooltipVariant} />
+<Canvas of={TooltipStories.TooltipColors} />

--- a/storybook/src/docs/components/Tooltip/Tooltip.stories.tsx
+++ b/storybook/src/docs/components/Tooltip/Tooltip.stories.tsx
@@ -21,28 +21,33 @@ export const BasicTooltip = {
     name: "BasicTooltip",
 };
 
-export const TooltipVariant = {
+export const TooltipColors = {
     render: () => {
         return (
             <Grid container justifyContent="center" spacing={4}>
                 <Grid>
-                    <Tooltip title="This is a light tooltip" variant="light">
+                    <Tooltip title="This is a light tooltip" color="light">
                         <div>Hover over me - light</div>
                     </Tooltip>
                 </Grid>
                 <Grid>
-                    <Tooltip title="This is a dark tooltip" variant="dark">
+                    <Tooltip title="This is a dark tooltip" color="dark">
                         <div>Hover over me - dark</div>
                     </Tooltip>
                 </Grid>
                 <Grid>
-                    <Tooltip title="This is a neutral tooltip" variant="neutral">
-                        <div>Hover over me - neutral</div>
+                    <Tooltip title="This is a error tooltip" color="error">
+                        <div>Hover over me - error</div>
                     </Tooltip>
                 </Grid>
                 <Grid>
-                    <Tooltip title="This is a primary tooltip" variant="primary">
-                        <div>Hover over me - primary</div>
+                    <Tooltip title="This is a success tooltip" color="success">
+                        <div>Hover over me - success</div>
+                    </Tooltip>
+                </Grid>
+                <Grid>
+                    <Tooltip title="This is a warning tooltip" color="warning">
+                        <div>Hover over me - warning</div>
                     </Tooltip>
                 </Grid>
             </Grid>


### PR DESCRIPTION
## Description

The `variant` prop was renamed, as `color` more accurately describes what it does. 
The `neutral` and `primary` options have been removed, as there is no use-case, according to UX. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Should we do this?
-   [x] Fix pipeline
-   [x] Add a migration guide entry
-   [x] Add an upgrade-script
-   [x] Change target to `next` once parent is merged #4487

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2454
-   Upgrade script PR: https://github.com/vivid-planet/comet-upgrade/pull/111
