### PR TITLE
Use `SectionHeadline` as the title for `FormSection`

### DIFF
--- a/.changeset/heavy-colts-occur.md
+++ b/.changeset/heavy-colts-occur.md
@@ -3,3 +3,5 @@
 ---
 
 The title of `FormSection` now matches the Comet design
+
+The prop `disableTypography` has been deprecated, use `slotProps.title` for custom styling or for setting a custom `variant` on the underlying `Typography` component.

--- a/.changeset/heavy-colts-occur.md
+++ b/.changeset/heavy-colts-occur.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": patch
+---
+
+The title of `FormSection` now matches the Comet design

--- a/.changeset/violet-rules-show.md
+++ b/.changeset/violet-rules-show.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": patch
+---
+
+Deprecate `SectionHeadline`
+
+The component is only meant to be used internally, inside `FormSection`.
+Use the `FormSection` component with it's `title` prop to create sections in forms.

--- a/packages/admin/admin/src/form/FormSection.tsx
+++ b/packages/admin/admin/src/form/FormSection.tsx
@@ -1,9 +1,10 @@
-import { type ComponentsOverrides, Typography } from "@mui/material";
+import { type ComponentsOverrides } from "@mui/material";
 import { css, type Theme, useThemeProps } from "@mui/material/styles";
 import { type ReactNode } from "react";
 
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+import { SectionHeadline } from "../section/SectionHeadline";
 
 export type FormSectionClassKey = "root" | "disableMarginBottom" | "title" | "children";
 
@@ -24,7 +25,17 @@ const Root = createComponentSlot("div")<FormSectionClassKey, OwnerState>({
     `,
 );
 
-const Title = createComponentSlot("div")<FormSectionClassKey>({
+const Title = createComponentSlot(SectionHeadline)<FormSectionClassKey>({
+    componentName: "FormSection",
+    slotName: "title",
+})(
+    ({ theme }) => css`
+        margin-bottom: ${theme.spacing(4)};
+    `,
+);
+
+// TODO: Remove this slot once the `disableTypography` prop has been removed
+const LegacyTitle = createComponentSlot("div")<FormSectionClassKey>({
     componentName: "FormSection",
     slotName: "title",
 })(
@@ -41,12 +52,15 @@ const Children = createComponentSlot("div")<FormSectionClassKey>({
 export interface FormSectionProps
     extends ThemedComponentBaseProps<{
         root: "div";
-        title: "div";
+        title: typeof SectionHeadline;
         children: "div";
     }> {
     children: ReactNode;
     title?: ReactNode;
     disableMarginBottom?: boolean;
+    /**
+     * @deprecated Use `slotProps.title` for custom styling or for setting a custom `variant` on the underlying `Typography` component.
+     */
     disableTypography?: boolean;
 }
 
@@ -62,7 +76,18 @@ export function FormSection(inProps: FormSectionProps) {
 
     return (
         <Root ownerState={ownerState} {...slotProps?.root} {...restProps}>
-            {title && <Title {...slotProps?.title}>{disableTypography ? title : <Typography variant="h3">{title}</Typography>}</Title>}
+            {title && (
+                <>
+                    {disableTypography ? (
+                        <LegacyTitle {...slotProps?.title}>{title}</LegacyTitle>
+                    ) : (
+                        <Title {...slotProps?.title} divider>
+                            {title}
+                        </Title>
+                    )}
+                </>
+            )}
+
             <Children {...slotProps?.children}>{children}</Children>
         </Root>
     );

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -207,7 +207,12 @@ export {
     useSaveBoundaryState,
 } from "./saveBoundary/SaveBoundary";
 export { SaveBoundarySaveButton } from "./saveBoundary/SaveBoundarySaveButton";
-export { SectionHeadline, SectionHeadlineClassKey, SectionHeadlineProps } from "./section/SectionHeadline";
+export {
+    /** @deprecated Use the `FormSection` component with it's `title` prop to create sections in forms. SectionHeadline is only meant for internal use. */
+    SectionHeadline,
+    SectionHeadlineClassKey,
+    SectionHeadlineProps,
+} from "./section/SectionHeadline";
 export { Selected } from "./Selected";
 export { ISelectionRenderPropArgs, Selection, useSelection } from "./Selection";
 export { ISelectionApi } from "./SelectionApi";


### PR DESCRIPTION
## Description

This makes the title of `FormSection` match the Comet design. 
The export of `SectionHeadline` was deprecated as there is no use-case outside of `FormSection`, according to UX. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="700" height="1002" alt="Dialog with form sections previously" src="https://github.com/user-attachments/assets/ddb169d6-bf17-43d2-a7fc-fdb708f9fc62" />   | <img width="700" height="1002" alt="Dialog with form sections now" src="https://github.com/user-attachments/assets/4ac129fe-971e-428e-9efc-788e29db5130" />  |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2474
