### PR TITLE
Add SEO "title" property to PixelImageBlock and SvgImageBlock

### DIFF
--- a/.changeset/new-toes-drive.md
+++ b/.changeset/new-toes-drive.md
@@ -1,0 +1,6 @@
+---
+"@comet/site-nextjs": patch
+"@comet/site-react": patch
+---
+
+Add SEO `title` property to PixelImageBlock and SvgImageBlock

--- a/packages/site/site-nextjs/src/blocks/PixelImageBlock.tsx
+++ b/packages/site/site-nextjs/src/blocks/PixelImageBlock.tsx
@@ -72,6 +72,7 @@ export const PixelImageBlock = withPreview(
                 placeholder="blur"
                 blurDataURL={blurDataUrl}
                 alt={damFile.altText ?? ""}
+                title={damFile.title ?? ""}
                 {...nextImageProps}
             />
         );

--- a/packages/site/site-react/src/blocks/SvgImageBlock.tsx
+++ b/packages/site/site-react/src/blocks/SvgImageBlock.tsx
@@ -19,6 +19,7 @@ export const SvgImageBlock = withPreview(
                 width={width === "auto" ? undefined : width}
                 height={height === "auto" ? undefined : height}
                 alt={damFile.altText ?? ""}
+                title={damFile.title ?? ""}
             />
         );
     },


### PR DESCRIPTION
## Description

This adds the missing `title` prop to the image in `PixelImageBlock` and `SvgImageBlock` by passing the title specified in the SEO settings for an asset.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Admin | 
| ------ | 
| <img width="2547" height="1385" alt="Screenshot 2025-09-15 at 10 40 33" src="https://github.com/user-attachments/assets/f0f14fc4-f57f-4dbc-b630-289cd727d8c7" />| 

| Before | After |
| ------ | ----- |
| <img width="2547" height="1385" alt="Screenshot 2025-09-15 at 10 41 18" src="https://github.com/user-attachments/assets/83b78eb1-5c64-4ddb-a41f-defa0c1aed41" />  | <img width="2547" height="1385" alt="Screenshot 2025-09-15 at 10 46 35" src="https://github.com/user-attachments/assets/ba1e5a91-c521-416c-b8f9-5433037053fe" /> |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/PHSB2C-8373
