### PR TITLE
Demo: Move app.close before process.exit

### DIFF
--- a/demo/api/src/console.ts
+++ b/demo/api/src/console.ts
@@ -25,12 +25,14 @@ async function bootstrap() {
         useContainer(app.select(appModule), { fallbackOnErrors: true });
 
         await CommandFactory.runApplication(app);
+
+        await app.close();
         process.exit(0);
     } catch (e) {
         console.error(e);
-        process.exit(1);
-    } finally {
+
         await app.close();
+        process.exit(1);
     }
 }
 


### PR DESCRIPTION
## Description

I just noticed that `app.close` is never called in finally because process.exit is called before.
