### PR TITLE
Fix `react/jsx-no-literals` due to `/` character

### DIFF
--- a/demo/admin/src/products/ProductsGridPreviewAction.tsx
+++ b/demo/admin/src/products/ProductsGridPreviewAction.tsx
@@ -32,7 +32,11 @@ export const ProductsGridPreviewAction = ({ row }: Props) => {
                 </DialogTitle>
                 <DialogContent>
                     <Typography variant="h3" gutterBottom>
-                        {row.title}/{row.slug}
+                        <FormattedMessage
+                            id="productsGrid.detailsDialog.description"
+                            defaultMessage="{title}/{slug}"
+                            values={{ title: row.title, slug: row.slug }}
+                        />
                     </Typography>
                     <Typography>{row.description}</Typography>
                 </DialogContent>

--- a/demo/admin/src/products/ProductsGridPreviewAction.tsx
+++ b/demo/admin/src/products/ProductsGridPreviewAction.tsx
@@ -32,11 +32,8 @@ export const ProductsGridPreviewAction = ({ row }: Props) => {
                 </DialogTitle>
                 <DialogContent>
                     <Typography variant="h3" gutterBottom>
-                        <FormattedMessage
-                            id="productsGrid.detailsDialog.description"
-                            defaultMessage="{title}/{slug}"
-                            values={{ title: row.title, slug: row.slug }}
-                        />
+                        {/* eslint-disable-next-line react/jsx-no-literals */}
+                        {row.title}/{row.slug}
                     </Typography>
                     <Typography>{row.description}</Typography>
                 </DialogContent>


### PR DESCRIPTION
## Description

Regression introduced with https://github.com/vivid-planet/comet/pull/4336.