### PR TITLE
Demo: Use the Comet `Dialog` for a consistent UI

### DIFF
--- a/demo/admin/src/dam/ImportFromPicsum.tsx
+++ b/demo/admin/src/dam/ImportFromPicsum.tsx
@@ -1,14 +1,7 @@
-import { Button, CancelButton, Loading, SaveButton } from "@comet/admin";
+import { Button, CancelButton, Dialog, Loading, SaveButton } from "@comet/admin";
 import { Reload } from "@comet/admin-icons";
 import { useCurrentDamFolder, useDamAcceptedMimeTypes, useDamFileUpload } from "@comet/cms-admin";
-import {
-    Box,
-    // eslint-disable-next-line no-restricted-imports
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogTitle,
-} from "@mui/material";
+import { Box, DialogActions, DialogContent } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { useState } from "react";
 import { FormattedMessage } from "react-intl";
@@ -57,11 +50,12 @@ export const ImportFromPicsum = () => {
             <Button variant="textDark" startIcon={<PicsumIcon />} onClick={handleOpenDialog}>
                 <FormattedMessage id="pages.dam.importFromPicsum" defaultMessage="Import from Picsum" />
             </Button>
-            <Dialog open={isOpen} onClose={handleCloseDialog}>
-                <div>
-                    <DialogTitle>
-                        <FormattedMessage id="pages.dam.importFromPicsum" defaultMessage="Import from Picsum" />
-                    </DialogTitle>
+            <Dialog
+                open={isOpen}
+                onClose={handleCloseDialog}
+                title={<FormattedMessage id="pages.dam.importFromPicsum" defaultMessage="Import from Picsum" />}
+            >
+                <>
                     <DialogContent>
                         <Box sx={{ aspectRatio: "16/9", lineHeight: 0 }}>
                             {picsumImage ? <ImagePreview src={picsumImage?.url} alt="image" /> : <Loading behavior="fillParent" />}
@@ -79,7 +73,7 @@ export const ImportFromPicsum = () => {
                             }}
                         />
                     </DialogActions>
-                </div>
+                </>
             </Dialog>
         </>
     );

--- a/demo/admin/src/products/ProductsGridPreviewAction.tsx
+++ b/demo/admin/src/products/ProductsGridPreviewAction.tsx
@@ -1,13 +1,6 @@
-import { Tooltip } from "@comet/admin";
+import { Dialog, Tooltip } from "@comet/admin";
 import { View } from "@comet/admin-icons";
-import {
-    // eslint-disable-next-line no-restricted-imports
-    Dialog,
-    DialogContent,
-    DialogTitle,
-    IconButton,
-    Typography,
-} from "@mui/material";
+import { DialogContent, IconButton, Typography } from "@mui/material";
 import { type GridCellParams } from "@mui/x-data-grid-pro";
 import { type GQLProductsGridFutureFragment } from "@src/products/generator/generated/ProductsGrid.generated";
 import { useState } from "react";
@@ -26,10 +19,11 @@ export const ProductsGridPreviewAction = ({ row }: Props) => {
                     <View />
                 </IconButton>
             </Tooltip>
-            <Dialog open={showDetails} onClose={() => setShowDetails(false)}>
-                <DialogTitle>
-                    <FormattedMessage id="productsGrid.detailsDialog.title" defaultMessage="Product Details" />
-                </DialogTitle>
+            <Dialog
+                open={showDetails}
+                onClose={() => setShowDetails(false)}
+                title={<FormattedMessage id="productsGrid.detailsDialog.title" defaultMessage="Product Details" />}
+            >
                 <DialogContent>
                     <Typography variant="h3" gutterBottom>
                         {/* eslint-disable-next-line react/jsx-no-literals */}

--- a/demo/admin/src/userGroups/UserGroupContextMenuItem.tsx
+++ b/demo/admin/src/userGroups/UserGroupContextMenuItem.tsx
@@ -1,14 +1,6 @@
-import { CancelButton, OkayButton, SelectField } from "@comet/admin";
+import { CancelButton, Dialog, OkayButton, SelectField } from "@comet/admin";
 import { Account } from "@comet/admin-icons";
-import {
-    // eslint-disable-next-line no-restricted-imports
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogTitle,
-    ListItemIcon,
-    MenuItem,
-} from "@mui/material";
+import { DialogActions, DialogContent, ListItemIcon, MenuItem } from "@mui/material";
 import { type GQLUserGroup } from "@src/graphql.generated";
 import { useState } from "react";
 import { Form } from "react-final-form";
@@ -62,10 +54,8 @@ function UserGroupContextMenuItem({ item, onChange, onMenuClose }: Props): JSX.E
                     setDialogOpen(false);
                     onMenuClose();
                 }}
+                title={<FormattedMessage id="pageContentBlock.userGroup.dialogTitle" defaultMessage="Visibility rules" />}
             >
-                <DialogTitle>
-                    <FormattedMessage id="pageContentBlock.userGroup.dialogTitle" defaultMessage="Visibility rules" />
-                </DialogTitle>
                 <Form<FormValues> onSubmit={handleSubmit} initialValues={{ userGroup: item.userGroup }}>
                     {({ handleSubmit }) => (
                         <form onSubmit={handleSubmit}>


### PR DESCRIPTION
## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="740" height="622" alt="Picsum Dialog Previously" src="https://github.com/user-attachments/assets/ba94e852-dcb6-419e-bad6-3e81f476a95b" />  | <img width="740" height="622" alt="Picsum Dialog Now" src="https://github.com/user-attachments/assets/5d79cafc-7798-44d2-b676-dd818256dbcc" />  |
