### PR TITLE
API Generator: Refactoring

### DIFF
--- a/packages/api/api-generator/src/commands/generate/generateCrud/build-options.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/build-options.ts
@@ -5,23 +5,8 @@ import { buildNameVariants } from "../utils/build-name-variants";
 import { integerTypes } from "../utils/constants";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function buildOptions(metadata: EntityMetadata<any>, generatorOptions: CrudGeneratorOptions) {
-    const { classNameSingular, classNamePlural, fileNameSingular, fileNamePlural } = buildNameVariants(metadata);
-
-    const dedicatedResolverArgProps = metadata.props.filter((prop) => {
-        if (hasCrudFieldFeature(metadata.class, prop.name, "dedicatedResolverArg")) {
-            if (prop.kind == "m:1") {
-                return true;
-            } else {
-                console.warn(`${metadata.className} ${prop.name} can't use dedicatedResolverArg as it's not a m:1 relation`);
-                return false;
-            }
-        }
-        return false;
-    });
-
-    const crudSearchPropNames = getCrudSearchFieldsFromMetadata(metadata);
-    const hasSearchArg = crudSearchPropNames.length > 0;
+function buildFilterProps(metadata: EntityMetadata<any>) {
+    const dedicatedResolverArgProps = buildDedicatedResolverArgProps(metadata);
 
     const crudFilterProps = metadata.props.filter(
         (prop) =>
@@ -46,7 +31,11 @@ export function buildOptions(metadata: EntityMetadata<any>, generatorOptions: Cr
                 prop.type === "uuid") &&
             !dedicatedResolverArgProps.some((dedicatedResolverArgProp) => dedicatedResolverArgProp.name == prop.name),
     );
-    const hasFilterArg = crudFilterProps.length > 0;
+    return crudFilterProps;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildSortProps(metadata: EntityMetadata<any>) {
     const crudSortProps = metadata.props.filter(
         (prop) =>
             hasCrudFieldFeature(metadata.class, prop.name, "sort") &&
@@ -65,6 +54,37 @@ export function buildOptions(metadata: EntityMetadata<any>, generatorOptions: Cr
                 prop.type === "EnumArrayType" ||
                 prop.enum),
     );
+    return crudSortProps;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildDedicatedResolverArgProps(metadata: EntityMetadata<any>) {
+    return metadata.props.filter((prop) => {
+        if (hasCrudFieldFeature(metadata.class, prop.name, "dedicatedResolverArg")) {
+            if (prop.kind == "m:1") {
+                return true;
+            } else {
+                console.warn(`${metadata.className} ${prop.name} can't use dedicatedResolverArg as it's not a m:1 relation`);
+                return false;
+            }
+        }
+        return false;
+    });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function buildOptions(metadata: EntityMetadata<any>, generatorOptions: CrudGeneratorOptions) {
+    const { classNameSingular, classNamePlural, fileNameSingular, fileNamePlural } = buildNameVariants(metadata);
+
+    const dedicatedResolverArgProps = buildDedicatedResolverArgProps(metadata);
+
+    const crudSearchPropNames = getCrudSearchFieldsFromMetadata(metadata);
+    const hasSearchArg = crudSearchPropNames.length > 0;
+
+    const crudFilterProps = buildFilterProps(metadata);
+    const hasFilterArg = crudFilterProps.length > 0;
+
+    const crudSortProps = buildSortProps(metadata);
     const hasSortArg = crudSortProps.length > 0;
 
     const hasSlugProp = metadata.props.some((prop) => prop.name == "slug");

--- a/packages/api/api-generator/src/commands/generate/generateCrud/build-options.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/build-options.ts
@@ -1,0 +1,111 @@
+import { type CrudGeneratorOptions, getCrudSearchFieldsFromMetadata, hasCrudFieldFeature, SCOPED_ENTITY_METADATA_KEY } from "@comet/cms-api";
+import { type EntityMetadata } from "@mikro-orm/core";
+
+import { buildNameVariants } from "../utils/build-name-variants";
+import { integerTypes } from "../utils/constants";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function buildOptions(metadata: EntityMetadata<any>, generatorOptions: CrudGeneratorOptions) {
+    const { classNameSingular, classNamePlural, fileNameSingular, fileNamePlural } = buildNameVariants(metadata);
+
+    const dedicatedResolverArgProps = metadata.props.filter((prop) => {
+        if (hasCrudFieldFeature(metadata.class, prop.name, "dedicatedResolverArg")) {
+            if (prop.kind == "m:1") {
+                return true;
+            } else {
+                console.warn(`${metadata.className} ${prop.name} can't use dedicatedResolverArg as it's not a m:1 relation`);
+                return false;
+            }
+        }
+        return false;
+    });
+
+    const crudSearchPropNames = getCrudSearchFieldsFromMetadata(metadata);
+    const hasSearchArg = crudSearchPropNames.length > 0;
+
+    const crudFilterProps = metadata.props.filter(
+        (prop) =>
+            hasCrudFieldFeature(metadata.class, prop.name, "filter") &&
+            !prop.name.startsWith("scope_") &&
+            prop.name != "position" &&
+            (!prop.embedded || hasCrudFieldFeature(metadata.class, prop.embedded[0], "filter")) && // the whole embeddable has filter disabled
+            (prop.enum ||
+                prop.type === "string" ||
+                prop.type === "text" ||
+                prop.type === "DecimalType" ||
+                prop.type === "number" ||
+                integerTypes.includes(prop.type) ||
+                prop.type === "BooleanType" ||
+                prop.type === "boolean" ||
+                prop.type === "DateType" ||
+                prop.type === "Date" ||
+                prop.kind === "m:1" ||
+                prop.kind === "1:m" ||
+                prop.kind === "m:n" ||
+                prop.type === "EnumArrayType" ||
+                prop.type === "uuid") &&
+            !dedicatedResolverArgProps.some((dedicatedResolverArgProp) => dedicatedResolverArgProp.name == prop.name),
+    );
+    const hasFilterArg = crudFilterProps.length > 0;
+    const crudSortProps = metadata.props.filter(
+        (prop) =>
+            hasCrudFieldFeature(metadata.class, prop.name, "sort") &&
+            !prop.name.startsWith("scope_") &&
+            (!prop.embedded || hasCrudFieldFeature(metadata.class, prop.embedded[0], "sort")) && // the whole embeddable has sort disabled
+            (prop.type === "string" ||
+                prop.type === "text" ||
+                prop.type === "DecimalType" ||
+                prop.type === "number" ||
+                integerTypes.includes(prop.type) ||
+                prop.type === "BooleanType" ||
+                prop.type === "boolean" ||
+                prop.type === "DateType" ||
+                prop.type === "Date" ||
+                prop.kind === "m:1" ||
+                prop.type === "EnumArrayType" ||
+                prop.enum),
+    );
+    const hasSortArg = crudSortProps.length > 0;
+
+    const hasSlugProp = metadata.props.some((prop) => prop.name == "slug");
+
+    const scopeProp = metadata.props.find((prop) => prop.name == "scope");
+    if (scopeProp && !scopeProp.targetMeta) throw new Error("Scope prop has no targetMeta");
+
+    const hasPositionProp = metadata.props.some((prop) => prop.name == "position");
+
+    const positionGroupPropNames: string[] = hasPositionProp
+        ? (generatorOptions.position?.groupByFields ?? [
+              ...(scopeProp ? [scopeProp.name] : []), // if there is a scope prop it's effecting position-group, if not groupByFields should be used
+          ])
+        : [];
+    const positionGroupProps = hasPositionProp ? metadata.props.filter((prop) => positionGroupPropNames.includes(prop.name)) : [];
+
+    const scopedEntity = Reflect.getMetadata(SCOPED_ENTITY_METADATA_KEY, metadata.class);
+    const skipScopeCheck = !scopeProp && !scopedEntity;
+
+    const argsClassName = `${classNameSingular != classNamePlural ? classNamePlural : `${classNamePlural}List`}Args`;
+    const argsFileName = `${fileNameSingular != fileNamePlural ? fileNamePlural : `${fileNameSingular}-list`}.args`;
+
+    const blockProps = metadata.props.filter((prop) => {
+        return hasCrudFieldFeature(metadata.class, prop.name, "input") && prop.type === "RootBlockType";
+    });
+
+    return {
+        crudSearchPropNames,
+        hasSearchArg,
+        crudFilterProps,
+        hasFilterArg,
+        crudSortProps,
+        hasSortArg,
+        hasSlugProp,
+        hasPositionProp,
+        positionGroupProps,
+        scopeProp,
+        skipScopeCheck,
+        argsClassName,
+        argsFileName,
+        blockProps,
+        dedicatedResolverArgProps,
+    };
+}

--- a/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
@@ -1,11 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-    CRUD_GENERATOR_METADATA_KEY,
-    type CrudGeneratorOptions,
-    getCrudSearchFieldsFromMetadata,
-    hasCrudFieldFeature,
-    SCOPED_ENTITY_METADATA_KEY,
-} from "@comet/cms-api";
+import { CRUD_GENERATOR_METADATA_KEY, type CrudGeneratorOptions, hasCrudFieldFeature } from "@comet/cms-api";
 import { type EntityMetadata, ReferenceKind } from "@mikro-orm/postgresql";
 import * as path from "path";
 import { singular } from "pluralize";
@@ -16,112 +10,7 @@ import { integerTypes } from "../utils/constants";
 import { generateImportsCode, type Imports } from "../utils/generate-imports-code";
 import { findBlockImportPath, findBlockName, findEnumImportPath, findEnumName } from "../utils/ts-morph-helper";
 import { type GeneratedFile } from "../utils/write-generated-files";
-
-// TODO move into own file
-export function buildOptions(metadata: EntityMetadata<any>, generatorOptions: CrudGeneratorOptions) {
-    const { classNameSingular, classNamePlural, fileNameSingular, fileNamePlural } = buildNameVariants(metadata);
-
-    const dedicatedResolverArgProps = metadata.props.filter((prop) => {
-        if (hasCrudFieldFeature(metadata.class, prop.name, "dedicatedResolverArg")) {
-            if (prop.kind == "m:1") {
-                return true;
-            } else {
-                console.warn(`${metadata.className} ${prop.name} can't use dedicatedResolverArg as it's not a m:1 relation`);
-                return false;
-            }
-        }
-        return false;
-    });
-
-    const crudSearchPropNames = getCrudSearchFieldsFromMetadata(metadata);
-    const hasSearchArg = crudSearchPropNames.length > 0;
-
-    const crudFilterProps = metadata.props.filter(
-        (prop) =>
-            hasCrudFieldFeature(metadata.class, prop.name, "filter") &&
-            !prop.name.startsWith("scope_") &&
-            prop.name != "position" &&
-            (!prop.embedded || hasCrudFieldFeature(metadata.class, prop.embedded[0], "filter")) && // the whole embeddable has filter disabled
-            (prop.enum ||
-                prop.type === "string" ||
-                prop.type === "text" ||
-                prop.type === "DecimalType" ||
-                prop.type === "number" ||
-                integerTypes.includes(prop.type) ||
-                prop.type === "BooleanType" ||
-                prop.type === "boolean" ||
-                prop.type === "DateType" ||
-                prop.type === "Date" ||
-                prop.kind === "m:1" ||
-                prop.kind === "1:m" ||
-                prop.kind === "m:n" ||
-                prop.type === "EnumArrayType" ||
-                prop.type === "uuid") &&
-            !dedicatedResolverArgProps.some((dedicatedResolverArgProp) => dedicatedResolverArgProp.name == prop.name),
-    );
-    const hasFilterArg = crudFilterProps.length > 0;
-    const crudSortProps = metadata.props.filter(
-        (prop) =>
-            hasCrudFieldFeature(metadata.class, prop.name, "sort") &&
-            !prop.name.startsWith("scope_") &&
-            (!prop.embedded || hasCrudFieldFeature(metadata.class, prop.embedded[0], "sort")) && // the whole embeddable has sort disabled
-            (prop.type === "string" ||
-                prop.type === "text" ||
-                prop.type === "DecimalType" ||
-                prop.type === "number" ||
-                integerTypes.includes(prop.type) ||
-                prop.type === "BooleanType" ||
-                prop.type === "boolean" ||
-                prop.type === "DateType" ||
-                prop.type === "Date" ||
-                prop.kind === "m:1" ||
-                prop.type === "EnumArrayType" ||
-                prop.enum),
-    );
-    const hasSortArg = crudSortProps.length > 0;
-
-    const hasSlugProp = metadata.props.some((prop) => prop.name == "slug");
-
-    const scopeProp = metadata.props.find((prop) => prop.name == "scope");
-    if (scopeProp && !scopeProp.targetMeta) throw new Error("Scope prop has no targetMeta");
-
-    const hasPositionProp = metadata.props.some((prop) => prop.name == "position");
-
-    const positionGroupPropNames: string[] = hasPositionProp
-        ? (generatorOptions.position?.groupByFields ?? [
-              ...(scopeProp ? [scopeProp.name] : []), // if there is a scope prop it's effecting position-group, if not groupByFields should be used
-          ])
-        : [];
-    const positionGroupProps = hasPositionProp ? metadata.props.filter((prop) => positionGroupPropNames.includes(prop.name)) : [];
-
-    const scopedEntity = Reflect.getMetadata(SCOPED_ENTITY_METADATA_KEY, metadata.class);
-    const skipScopeCheck = !scopeProp && !scopedEntity;
-
-    const argsClassName = `${classNameSingular != classNamePlural ? classNamePlural : `${classNamePlural}List`}Args`;
-    const argsFileName = `${fileNameSingular != fileNamePlural ? fileNamePlural : `${fileNameSingular}-list`}.args`;
-
-    const blockProps = metadata.props.filter((prop) => {
-        return hasCrudFieldFeature(metadata.class, prop.name, "input") && prop.type === "RootBlockType";
-    });
-
-    return {
-        crudSearchPropNames,
-        hasSearchArg,
-        crudFilterProps,
-        hasFilterArg,
-        crudSortProps,
-        hasSortArg,
-        hasSlugProp,
-        hasPositionProp,
-        positionGroupProps,
-        scopeProp,
-        skipScopeCheck,
-        argsClassName,
-        argsFileName,
-        blockProps,
-        dedicatedResolverArgProps,
-    };
-}
+import { buildOptions } from "./build-options";
 
 function generateFilterDto({ generatorOptions, metadata }: { generatorOptions: CrudGeneratorOptions; metadata: EntityMetadata<any> }): string {
     const { classNameSingular } = buildNameVariants(metadata);

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/generate-crud-input.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/generate-crud-input.ts
@@ -3,7 +3,7 @@ import { type EntityMetadata } from "@mikro-orm/postgresql";
 import { getMetadataStorage } from "class-validator";
 import { SyntaxKind } from "ts-morph";
 
-import { buildOptions } from "../generateCrud/generate-crud";
+import { buildOptions } from "../generateCrud/build-options";
 import { buildNameVariants } from "../utils/build-name-variants";
 import { integerTypes } from "../utils/constants";
 import { generateImportsCode, type Imports } from "../utils/generate-imports-code";


### PR DESCRIPTION
Refactor buildOptions into own file

- this file is way too long
- the helper is also used by other files

Refactor building sort and filter props into own (private) functions, for easier working on them