### PR TITLE
ESLint: Allow additional string literals in JSX

### DIFF
--- a/demo/admin/src/products/ProductsGridPreviewAction.tsx
+++ b/demo/admin/src/products/ProductsGridPreviewAction.tsx
@@ -26,7 +26,6 @@ export const ProductsGridPreviewAction = ({ row }: Props) => {
             >
                 <DialogContent>
                     <Typography variant="h3" gutterBottom>
-                        {/* eslint-disable-next-line react/jsx-no-literals */}
                         {row.title}/{row.slug}
                     </Typography>
                     <Typography>{row.description}</Typography>

--- a/packages/eslint-config/future/react.js
+++ b/packages/eslint-config/future/react.js
@@ -10,7 +10,7 @@ const config = [
             "react/jsx-no-literals": [
                 "error",
                 {
-                    allowedStrings: ["…", "€", "$", "?", "–", "—"],
+                    allowedStrings: ["…", "€", "$", "?", "–", "—", "/", "(", ")"],
                 },
             ],
         },


### PR DESCRIPTION
## Description

Allow using `/`, `(` and `)` as plain strings in JSX. IMO a FormattedMessage isn't necessary for these kind of strings.