### PR TITLE
SVGImageBlock: add support for CSS modules

### DIFF
--- a/packages/site/site-react/src/blocks/SvgImageBlock.tsx
+++ b/packages/site/site-react/src/blocks/SvgImageBlock.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { HTMLAttributes } from "react";
+
 import { type SvgImageBlockData } from "../blocks.generated";
 import { withPreview } from "../iframebridge/withPreview";
 import { PreviewSkeleton } from "../previewskeleton/PreviewSkeleton";
@@ -11,7 +13,7 @@ interface SvgImageBlockProps extends PropsWithData<SvgImageBlockData> {
 }
 
 export const SvgImageBlock = withPreview(
-    ({ data: { damFile }, width = "100%", height = "auto" }: SvgImageBlockProps) => {
+    ({ data: { damFile }, width = "100%", height = "auto", ...restProps }: SvgImageBlockProps & HTMLAttributes<HTMLImageElement>) => {
         if (!damFile) return <PreviewSkeleton type="media" hasContent={false} height={height === "auto" ? undefined : height} />;
         return (
             <img
@@ -20,6 +22,7 @@ export const SvgImageBlock = withPreview(
                 height={height === "auto" ? undefined : height}
                 alt={damFile.altText ?? ""}
                 title={damFile.title ?? ""}
+                {...restProps}
             />
         );
     },


### PR DESCRIPTION
## Description

SVGImageBlock does not accept prop for styling: `className`
