### PR TITLE
Demo: fix postgresql image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     postgres:
-        image: bitnami/postgresql:16
+        image: bitnamilegacy/postgresql:16
         pull_policy: weekly
         tty: true
         volumes:


### PR DESCRIPTION
## Description

`bitnami/postgresql:16` doesn't exist any longer, use `bitnamilegacy/postgresql:16` as a workaround.