### PR TITLE
Admin Generator: Remove virtual setting from form config

### DIFF
--- a/.changeset/big-bears-check.md
+++ b/.changeset/big-bears-check.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin-generator": minor
+---
+
+Remove virtual setting from form config

--- a/packages/admin/admin-generator/src/commands/generate/generate-command.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generate-command.ts
@@ -127,7 +127,6 @@ export type FormFieldConfig<T> = (
 ) & {
     label?: string;
     required?: boolean;
-    virtual?: boolean;
     validate?: FieldValidator<unknown>;
     helperText?: string;
     readOnly?: boolean;

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/asyncSelect/generateAsyncSelect.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/asyncSelect/generateAsyncSelect.ts
@@ -132,7 +132,7 @@ export function generateAsyncSelect({
     const required = !isFieldOptional({ config, gqlIntrospection, gqlType });
 
     const formValueConfig: GenerateFieldsReturn["formValuesConfig"][0] = {
-        destructFromFormValues: config.virtual || config.type == "asyncSelectFilter" ? name : undefined,
+        destructFromFormValues: config.type == "asyncSelectFilter" ? name : undefined,
     };
 
     let finalFormConfig: GenerateFieldsReturn["finalFormConfig"];
@@ -305,7 +305,7 @@ export function generateAsyncSelect({
         finalFormConfig = { subscription: { values: true }, renderProps: { values: true, form: true } };
     }
 
-    if (!config.virtual && config.type != "asyncSelectFilter") {
+    if (config.type != "asyncSelectFilter") {
         if (!required) {
             formValueToGqlInputCode = `${name}: formValues.${name} ? formValues.${name}.id : null,`;
         } else {

--- a/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
+++ b/packages/admin/admin-generator/src/commands/generate/generateForm/generateFormField.ts
@@ -60,10 +60,7 @@ export function generateFormField({
     const readOnlyProps = `readOnly disabled`;
     const readOnlyPropsWithLock = `${readOnlyProps} ${endAdornmentWithLockIconProp}`;
 
-    const defaultFormValuesConfig: GenerateFieldsReturn["formValuesConfig"][0] = {
-        destructFromFormValues: config.virtual ? name : undefined,
-    };
-    let formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [defaultFormValuesConfig]; // FormFields should only contain one entry
+    let formValuesConfig: GenerateFieldsReturn["formValuesConfig"] = [{}]; // FormFields should only contain one entry
 
     const gqlDocuments: GQLDocumentConfigMap = {};
     const hooksCode = "";
@@ -104,7 +101,7 @@ export function generateFormField({
             }
             ${validateCode}
         />`;
-        if (!config.virtual && !required && !config.readOnly) {
+        if (!required && !config.readOnly) {
             formValueToGqlInputCode = `${name}: formValues.${name} ?? null,`;
         }
     } else if (config.type == "number") {
@@ -133,7 +130,7 @@ export function generateFormField({
         if (isFieldOptional({ config, gqlIntrospection: gqlIntrospection, gqlType: gqlType })) {
             assignment = `formValues.${nameWithPrefix} ? ${assignment} : null`;
         }
-        formValueToGqlInputCode = !config.virtual ? `${name}: ${assignment},` : ``;
+        formValueToGqlInputCode = `${name}: ${assignment},`;
 
         let initializationAssignment = `String(data.${dataRootName}.${nameWithPrefix})`;
         if (!required) {
@@ -141,12 +138,9 @@ export function generateFormField({
         }
         formValuesConfig = [
             {
-                ...defaultFormValuesConfig,
-                ...{
-                    omitFromFragmentType: name,
-                    typeCode: `${name}${!required ? `?` : ``}: string;`,
-                    initializationCode: `${name}: ${initializationAssignment}`,
-                },
+                omitFromFragmentType: name,
+                typeCode: `${name}${!required ? `?` : ``}: string;`,
+                initializationCode: `${name}: ${initializationAssignment}`,
             },
         ];
     } else if (config.type === "numberRange") {
@@ -193,10 +187,7 @@ export function generateFormField({
                     />`;
         formValuesConfig = [
             {
-                ...defaultFormValuesConfig,
-                ...{
-                    defaultInitializationCode: `${name}: false`,
-                },
+                defaultInitializationCode: `${name}: false`,
             },
         ];
     } else if (config.type == "date") {
@@ -223,7 +214,7 @@ export function generateFormField({
                 }
                 ${validateCode}
             />`;
-        if (!config.virtual && !required && !config.readOnly) {
+        if (!required && !config.readOnly) {
             formValueToGqlInputCode = `${name}: formValues.${name} ?? null,`;
         }
     } else if (config.type == "dateTime") {
@@ -247,15 +238,12 @@ export function generateFormField({
             />`;
         formValuesConfig = [
             {
-                ...defaultFormValuesConfig,
-                ...{
-                    initializationCode: `${name}: data.${dataRootName}.${nameWithPrefix} ? new Date(data.${dataRootName}.${nameWithPrefix}) : undefined`,
-                    omitFromFragmentType: name,
-                    typeCode: `${name}${!required ? "?" : ""}: Date${!required ? " | null" : ""};`,
-                },
+                initializationCode: `${name}: data.${dataRootName}.${nameWithPrefix} ? new Date(data.${dataRootName}.${nameWithPrefix}) : undefined`,
+                omitFromFragmentType: name,
+                typeCode: `${name}${!required ? "?" : ""}: Date${!required ? " | null" : ""};`,
             },
         ];
-        if (!config.virtual && !config.readOnly) {
+        if (!config.readOnly) {
             formValueToGqlInputCode = required
                 ? `${name}: formValues.${name}.toISOString(),`
                 : `${name}: formValues.${name} ? formValues.${name}.toISOString() : null,`;
@@ -264,15 +252,12 @@ export function generateFormField({
         code = `<Field name="${nameWithPrefix}" isEqual={isEqual} label={${fieldLabel}} variant="horizontal" fullWidth>
             {createFinalFormBlock(rootBlocks.${String(config.name)})}
         </Field>`;
-        formValueToGqlInputCode = !config.virtual ? `${name}: rootBlocks.${name}.state2Output(formValues.${nameWithPrefix}),` : ``;
+        formValueToGqlInputCode = `${name}: rootBlocks.${name}.state2Output(formValues.${nameWithPrefix}),`;
         formValuesConfig = [
             {
-                ...defaultFormValuesConfig,
-                ...{
-                    typeCode: `${name}: BlockState<typeof rootBlocks.${name}>;`,
-                    initializationCode: `${name}: rootBlocks.${name}.input2State(data.${dataRootName}.${nameWithPrefix})`,
-                    defaultInitializationCode: `${name}: rootBlocks.${name}.defaultValues()`,
-                },
+                typeCode: `${name}: BlockState<typeof rootBlocks.${name}>;`,
+                initializationCode: `${name}: rootBlocks.${name}.input2State(data.${dataRootName}.${nameWithPrefix})`,
+                defaultInitializationCode: `${name}: rootBlocks.${name}.defaultValues()`,
             },
         ];
     } else if (config.type === "fileUpload") {


### PR DESCRIPTION
This virtual feature was originally intended to avoid saving filter selects (see https://github.com/vivid-planet/comet/pull/2383)

This is now done using `type="asyncSelectFilter"`, so this setting has no use case anymore.

This is theoretically breaking, but I don't think it had a single usage. 