### PR TITLE
Demo: Localization - add language parameter to getMessages

### DIFF
--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -133,7 +133,7 @@ export function App() {
             }}
         >
             <ApolloProvider client={apolloClient}>
-                <IntlProvider locale="en" messages={getMessages()}>
+                <IntlProvider locale="en" messages={getMessages("en")}>
                     <LocalizationProvider adapterLocale={enUS} dateAdapter={AdapterDateFns}>
                         <MuiThemeProvider theme={theme}>
                             <DndProvider options={HTML5toTouch}>

--- a/demo/admin/src/lang.ts
+++ b/demo/admin/src/lang.ts
@@ -20,6 +20,12 @@ export const getMessages = (language: "de" | "en"): ResolvedIntlConfig["messages
     if (import.meta.env.MODE === "development") {
         return {};
     }
+    if (language === "de") {
+        return {
+            ...cometMessages["de"],
+            ...cometDemoMessages["de"],
+        }
+    }
 
     return {
         ...cometMessages["en"],

--- a/demo/admin/src/lang.ts
+++ b/demo/admin/src/lang.ts
@@ -24,7 +24,7 @@ export const getMessages = (language: "de" | "en"): ResolvedIntlConfig["messages
         return {
             ...cometMessages["de"],
             ...cometDemoMessages["de"],
-        }
+        };
     }
 
     return {

--- a/demo/admin/src/lang.ts
+++ b/demo/admin/src/lang.ts
@@ -15,7 +15,7 @@ const cometDemoMessages = {
     de: comet_demo_messages_de,
 };
 
-export const getMessages = (): ResolvedIntlConfig["messages"] => {
+export const getMessages = (language: "de" | "en"): ResolvedIntlConfig["messages"] => {
     // in dev mode we use the default messages to have immediate changes
     if (import.meta.env.MODE === "development") {
         return {};


### PR DESCRIPTION
## Description

This PR enhances the `getMessages` function in Comet Demo to support localization. The function now accepts a language parameter and returns messages in the selected language.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2501
