### PR TITLE
Demo Site: adapt footer to updated starter design

### DIFF
--- a/demo/site/src/layout/footer/blocks/FooterContentBlock.module.scss
+++ b/demo/site/src/layout/footer/blocks/FooterContentBlock.module.scss
@@ -11,14 +11,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: var(--spacing-d400) 0;
-
-    @media (min-width: $breakpoint-lg) {
-        position: relative;
-        gap: var(--spacing-d100);
-        flex-direction: row;
-        justify-content: space-between;
-    }
+    padding: var(--spacing-d200) 0;
 }
 
 .topContainer {
@@ -26,62 +19,38 @@
     width: 100%;
     flex-direction: column;
     align-items: center;
-    gap: var(--spacing-d100);
+    gap: var(--spacing-d200);
 
     @media (min-width: $breakpoint-sm) {
-        align-self: stretch;
-        flex-direction: row-reverse;
-        justify-content: space-between;
-        reading-flow: flex-visual;
-    }
-
-    @media (min-width: $breakpoint-lg) {
+        align-self: center;
         flex-direction: row;
+        justify-content: space-between;
     }
 }
 
 .richTextWrapper {
-    width: 100%;
     text-align: center;
 
     @media (min-width: $breakpoint-sm) {
         text-align: left;
     }
-
-    @media (min-width: $breakpoint-lg) {
-        max-width: 80%;
-    }
 }
 
 .imageWrapper {
-    width: 100px;
-
-    @media (min-width: $breakpoint-lg) {
-        position: absolute;
-        width: 100%;
-        max-width: 100px;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
-    }
+    width: 160px;
+    flex-shrink: 0;
 }
 
 .linkCopyrightWrapper {
-    color: var(--palette-gray-400);
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: var(--spacing-s500);
-
-    @media (min-width: $breakpoint-lg) {
-        width: 80%;
-        align-items: flex-end;
-    }
 }
 
 .linksWrapper {
     display: flex;
-    gap: var(--spacing-s500);
+    gap: var(--spacing-s400);
     flex-wrap: wrap;
     justify-content: center;
     list-style: none;
@@ -91,10 +60,7 @@
 
 .copyrightNotice {
     text-align: center;
-
-    @media (min-width: $breakpoint-lg) {
-        text-align: right;
-    }
+    color: var(--palette-text-secondary);
 }
 
 .linkText {
@@ -108,9 +74,5 @@
     border: none;
     background-color: var(--palette-gray-600);
     color: var(--palette-gray-600);
-    margin: var(--spacing-d300) 0;
-
-    @media (min-width: $breakpoint-lg) {
-        display: none;
-    }
+    margin: var(--spacing-d200) 0;
 }

--- a/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
+++ b/demo/site/src/layout/footer/blocks/FooterContentBlock.tsx
@@ -19,7 +19,7 @@ export const FooterContentBlock = withPreview(
                             <div className={styles.imageWrapper}>
                                 <DamImageBlock
                                     data={image}
-                                    aspectRatio="1x1"
+                                    aspectRatio="inherit"
                                     style={{ objectFit: "contain" }}
                                     sizes={createImageSizes({ default: "20vw" })}
                                 />
@@ -30,8 +30,8 @@ export const FooterContentBlock = withPreview(
                         </div>
                         <hr className={styles.horizontalLine} />
                         <div className={styles.linkCopyrightWrapper}>
-                            <nav>
-                                {linkList.blocks.length > 0 && (
+                            {linkList.blocks.length > 0 && (
+                                <nav>
                                     <ul className={styles.linksWrapper}>
                                         {linkList.blocks.map((block) => (
                                             <li key={block.key}>
@@ -41,8 +41,8 @@ export const FooterContentBlock = withPreview(
                                             </li>
                                         ))}
                                     </ul>
-                                )}
-                            </nav>
+                                </nav>
+                            )}
                             {copyrightNotice && (
                                 <Typography variant="p200" className={styles.copyrightNotice}>
                                     {copyrightNotice}


### PR DESCRIPTION
# Screenshots/screencasts

Desktop: 

<img width="1153" height="433" alt="Screenshot 2025-09-22 at 15 29 18" src="https://github.com/user-attachments/assets/c8834561-afd4-49a9-a9ae-99976766a9ed" />

Mobile:

<img width="430" height="406" alt="Screenshot 2025-09-22 at 15 29 32" src="https://github.com/user-attachments/assets/9874ca05-2786-4470-b22a-b689ee003037" />


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2492
