### PR TITLE
Update variants of ColumnsBlock

### DIFF
--- a/demo/admin/src/documents/pages/blocks/ColumnsBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/ColumnsBlock.tsx
@@ -42,7 +42,7 @@ const oneColumnLayouts = [
         ),
     },
     {
-        name: "9-6-9",
+        name: "6-12-6",
         columns: 1,
         label: <FormattedMessage id="columnsBlock.center.small" defaultMessage="Center small" />,
         preview: (

--- a/demo/api/src/documents/pages/blocks/columns.block.ts
+++ b/demo/api/src/documents/pages/blocks/columns.block.ts
@@ -27,7 +27,7 @@ export const ColumnsContentBlock = createBlocksBlock(
 
 export const ColumnsBlock = ColumnsBlockFactory.create(
     {
-        layouts: [{ name: "2-20-2" }, { name: "4-16-4" }, { name: "9-6-9" }, { name: "9-9" }, { name: "12-6" }, { name: "6-12" }],
+        layouts: [{ name: "2-20-2" }, { name: "4-16-4" }, { name: "6-12-6" }, { name: "9-9" }, { name: "12-6" }, { name: "6-12" }],
         contentBlock: ColumnsContentBlock,
     },
     "Columns",

--- a/demo/site-pages/src/documents/pages/blocks/ColumnsBlock.tsx
+++ b/demo/site-pages/src/documents/pages/blocks/ColumnsBlock.tsx
@@ -46,7 +46,7 @@ const Column = styled.div<{ $layout: string }>`
     grid-column: 3 / -3;
 
     ${({ $layout, theme }) =>
-        $layout === "9-6-9" &&
+        $layout === "6-12-6" &&
         css`
             grid-column: 5 / -5;
 

--- a/demo/site/src/documents/pages/blocks/ColumnsBlock.module.scss
+++ b/demo/site/src/documents/pages/blocks/ColumnsBlock.module.scss
@@ -4,20 +4,11 @@
     grid-column: 3 / -3;
 }
 
-.layout-9-6-9 {
-    grid-column: 5 / -5;
+.layout-6-12-6 {
+    grid-column: 4 / -4;
 
     @media (min-width: $breakpoint-sm) {
         grid-column: 7 / -7;
-    }
-    @media (min-width: $breakpoint-md) {
-        grid-column: 8 / -8;
-    }
-    @media (min-width: $breakpoint-lg) {
-        grid-column: 9 / -9;
-    }
-    @media (min-width: $breakpoint-xl) {
-        grid-column: 10 / -10;
     }
 }
 


### PR DESCRIPTION
## Description

The variants of the ColumnsBlock were revised by UX.

- The `9-6-9`(small) variant is changed to a `6-12-6` grid layout (except mobile it is 3-18-3)

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

New desktop:
<img width="1478" height="637" alt="Screenshot 2025-09-22 at 16 10 42" src="https://github.com/user-attachments/assets/a200e394-09d0-49a5-99f0-59738d24fafb" />

New mobile:
<img width="416" height="418" alt="Screenshot 2025-09-22 at 16 10 13" src="https://github.com/user-attachments/assets/fc5bfbcb-985b-4cef-9214-07bcca22dbdf" />


Admin:
<img width="1419" height="750" alt="Screenshot 2025-09-22 at 16 12 15" src="https://github.com/user-attachments/assets/42bed03b-795d-4c3a-8fc9-7c345ebcdc58" />


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2485