### PR TITLE
Warnings Module: make warnings feature truly optional

### DIFF
--- a/.changeset/modern-zoos-check.md
+++ b/.changeset/modern-zoos-check.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Warnings Module: make warnings feature truly optional

--- a/packages/api/cms-api/src/dam/dam.module.ts
+++ b/packages/api/cms-api/src/dam/dam.module.ts
@@ -2,7 +2,7 @@ import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { DynamicModule, Global, Module, Type, ValueProvider } from "@nestjs/common";
 import { TypeMetadataStorage } from "@nestjs/graphql";
 
-import { BlobStorageModule, damDefaultAcceptedMimetypes, DependentsResolverFactory, WarningsModule } from "..";
+import { BlobStorageModule, damDefaultAcceptedMimetypes, DependentsResolverFactory } from "..";
 import { FileValidationService } from "../file-utils/file-validation.service";
 import { ImgproxyModule } from "../imgproxy/imgproxy.module";
 import { DamFileDownloadLinkBlockTransformerService } from "./blocks/dam-file-download-link-block-transformer.service";
@@ -103,12 +103,7 @@ export class DamModule {
 
         return {
             module: DamModule,
-            imports: [
-                MikroOrmModule.forFeature([File, Folder, DamFileImage, ImageCropArea, DamMediaAlternative]),
-                BlobStorageModule,
-                ImgproxyModule,
-                WarningsModule,
-            ],
+            imports: [MikroOrmModule.forFeature([File, Folder, DamFileImage, ImageCropArea, DamMediaAlternative]), BlobStorageModule, ImgproxyModule],
             providers: [
                 damConfigProvider,
                 DamItemsResolver,


### PR DESCRIPTION
## Description

The `WarningsModule` was incorrectly imported into the `DamModule`, resulting in generating warnings even if the module wasn't initialized in the application. The import in the DamModule isn't needed because it only uses the WarningsModule's types.