### PR TITLE
Renovate: fix OpenTelemetry group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -105,7 +105,7 @@
         },
         {
             "groupName": "OpenTelemetry",
-            "matchPackageNames": ["/^open-telemetry/*/"]
+            "matchPackageNames": ["/^opentelemetry/*/"]
         },
         {
             "groupName": "lodash",


### PR DESCRIPTION
## Description

It's `@opentelemetry/*` without a dash.
