### PR TITLE
Demo: Load translated messages also in local development

### DIFF
--- a/demo/admin/src/lang.ts
+++ b/demo/admin/src/lang.ts
@@ -16,10 +16,6 @@ const cometDemoMessages = {
 };
 
 export const getMessages = (language: "de" | "en"): ResolvedIntlConfig["messages"] => {
-    // in dev mode we use the default messages to have immediate changes
-    if (import.meta.env.MODE === "development") {
-        return {};
-    }
     if (language === "de") {
         return {
             ...cometMessages["de"],


### PR DESCRIPTION
## Description

This Pull Request aligns translation handling across environments and local development by making the Demo load translated messages also in local development, just like in production, pipeline, and other non-prod environments.

Previously, Demo short-circuited to `defaultMessages` in local development. 

This PR removes that behavior so that all environments (also local development) use translated messages (with defaultMessages only as a fallback when a key is missing). This matches also the Starter project.

## Further information

-   Task: http://vivid-planet.atlassian.net/browse/COM-2508
