### PR TITLE
Update preview icon in admin in ColumnsBlock

### DIFF
--- a/demo/admin/src/documents/pages/blocks/ColumnsBlock.tsx
+++ b/demo/admin/src/documents/pages/blocks/ColumnsBlock.tsx
@@ -47,9 +47,9 @@ const oneColumnLayouts = [
         label: <FormattedMessage id="columnsBlock.center.small" defaultMessage="Center small" />,
         preview: (
             <ColumnsLayoutPreview>
-                <ColumnsLayoutPreviewSpacing width={9} />
-                <ColumnsLayoutPreviewContent width={6} />
-                <ColumnsLayoutPreviewSpacing width={9} />
+                <ColumnsLayoutPreviewSpacing width={6} />
+                <ColumnsLayoutPreviewContent width={12} />
+                <ColumnsLayoutPreviewSpacing width={6} />
             </ColumnsLayoutPreview>
         ),
     },


### PR DESCRIPTION
## Description

The preview icon of the new `6-12-6` columns variant in admin is updated (in addition to https://github.com/vivid-planet/comet/pull/4551).

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="373" height="347" alt="Bildschirmfoto 2025-09-25 um 10 20 32" src="https://github.com/user-attachments/assets/e2deb163-05b8-4ee6-92de-894a9406ce89" />   | <img width="374" height="356" alt="Bildschirmfoto 2025-09-25 um 10 17 56" src="https://github.com/user-attachments/assets/1a0ec7b2-0fa4-4b82-931b-f197ef94dcde" />  |

## Further information

Task: https://vivid-planet.atlassian.net/browse/COM-2485