### PR TITLE
Fix Demo Site rewrite loop

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,8 @@
 # node
 NODE_ENV=development
 
-SERVER_HOST=127.0.0.1 # change me to 0.0.0.0 if you want to access the server from other devices
+# enable me if you want to access the server from other devices
+# SERVER_HOST=0.0.0.0 
 
 # project
 PROJECT_NAME=comet-demo

--- a/demo/api/src/config/config.ts
+++ b/demo/api/src/config/config.ts
@@ -27,7 +27,7 @@ export function createConfig(processEnv: NodeJS.ProcessEnv) {
     return {
         ...cometConfig,
         debug: processEnv.NODE_ENV !== "production",
-        serverHost: processEnv.SERVER_HOST ?? "localhost",
+        serverHost: processEnv.SERVER_HOST ?? "127.0.0.1",
         helmRelease: envVars.HELM_RELEASE,
         apiUrl: envVars.API_URL,
         apiPort: envVars.API_PORT,


### PR DESCRIPTION
## Description

Changing `SERVER_HOST` to `127.0.0.1` in https://github.com/vivid-planet/comet/pull/4301 caused the site to run into an infinite domain rewrite loop resulting in a `431 Request Header Fields Too Large` error. I've spent quite some time trying to solve this but it seems to me that this is a bug in Next.js, not our middleware.

I've then tried to understand why the change to `127.0.0.1` is necessary at all. Since calling the API at http://localhost:4001/ (mitmproxy) didn't work, I figured this may be related to running mitmproxy in Docker, where `localhost` apparently behaves different than `127.0.0.1`. I then tried to change `SERVER_HOST` only for the API and – et voilà – everything works just fine.