### PR TITLE
Refactor service detection to use shared isInjectableService helper across codebase

### DIFF
--- a/packages/api/cms-api/src/blocks/blocks-transformer.ts
+++ b/packages/api/cms-api/src/blocks/blocks-transformer.ts
@@ -1,15 +1,9 @@
-import { Scope, type Type } from "@nestjs/common";
-import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
+import { Scope } from "@nestjs/common";
 import { type ContextId, type ModuleRef } from "@nestjs/core";
 import opentelemetry from "@opentelemetry/api";
 
-import {
-    type BlockContext,
-    type BlockDataInterface,
-    type BlockTransformerServiceInterface,
-    isBlockDataInterface,
-    type TraversableTransformBlockResponse,
-} from "./block";
+import { isInjectableService } from "../common/helper/is-injectable-service.helper";
+import { type BlockContext, type BlockDataInterface, type BlockTransformerServiceInterface, isBlockDataInterface } from "./block";
 
 const tracer = opentelemetry.trace.getTracer("@comet/cms-api");
 
@@ -29,7 +23,7 @@ export async function transformToPlain(
                 if (isBlockDataInterface(json)) {
                     const transformResponse = await json.transformToPlain(blockContext);
 
-                    if (isBlockTransformerService(transformResponse)) {
+                    if (isInjectableService(transformResponse)) {
                         let service: BlockTransformerServiceInterface;
 
                         if (moduleRef.introspect(transformResponse).scope === Scope.DEFAULT) {
@@ -57,10 +51,4 @@ export async function transformToPlain(
         span.end();
         return result;
     });
-}
-
-function isBlockTransformerService(
-    transformResponse: Type<BlockTransformerServiceInterface> | TraversableTransformBlockResponse,
-): transformResponse is Type<BlockTransformerServiceInterface> {
-    return Reflect.hasMetadata(INJECTABLE_WATERMARK, transformResponse);
 }

--- a/packages/api/cms-api/src/common/entityInfo/entity-info.service.ts
+++ b/packages/api/cms-api/src/common/entityInfo/entity-info.service.ts
@@ -1,8 +1,8 @@
-import { Injectable, Logger, Type } from "@nestjs/common";
-import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
+import { Injectable, Logger } from "@nestjs/common";
 import { ModuleRef } from "@nestjs/core";
 
-import { ENTITY_INFO_METADATA_KEY, EntityInfoGetter, EntityInfoInterface, EntityInfoServiceInterface } from "./entity-info.decorator";
+import { isInjectableService } from "../helper/is-injectable-service.helper";
+import { ENTITY_INFO_METADATA_KEY, EntityInfoGetter, EntityInfoInterface } from "./entity-info.decorator";
 
 @Injectable()
 export class EntityInfoService {
@@ -20,7 +20,7 @@ export class EntityInfoService {
             return undefined;
         }
 
-        if (this.isService(entityInfoGetter)) {
+        if (isInjectableService(entityInfoGetter)) {
             const service = this.moduleRef.get(entityInfoGetter, { strict: false });
             const { name, secondaryInformation } = await service.getEntityInfo(instance);
             return { name, secondaryInformation };
@@ -28,10 +28,5 @@ export class EntityInfoService {
             const { name, secondaryInformation } = await entityInfoGetter(instance);
             return { name, secondaryInformation };
         }
-    }
-
-    private isService(entityInfoGetter: EntityInfoGetter): entityInfoGetter is Type<EntityInfoServiceInterface> {
-        // Check if class has @Injectable() decorator -> if true it's a service class else it's a function
-        return Reflect.hasMetadata(INJECTABLE_WATERMARK, entityInfoGetter);
     }
 }

--- a/packages/api/cms-api/src/common/helper/is-injectable-service.helper.ts
+++ b/packages/api/cms-api/src/common/helper/is-injectable-service.helper.ts
@@ -1,0 +1,6 @@
+import { type Type } from "@nestjs/common";
+import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
+
+export function isInjectableService<T>(target: object): target is Type<T> {
+    return Reflect.hasMetadata(INJECTABLE_WATERMARK, target);
+}

--- a/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
+++ b/packages/api/cms-api/src/warnings/warning-event-subscriber.ts
@@ -1,13 +1,13 @@
 import { EntityName, EventArgs, EventSubscriber } from "@mikro-orm/core";
 import { EntityClass, EntityManager, EntityRepository, MikroORM } from "@mikro-orm/postgresql";
-import { Injectable, Type } from "@nestjs/common";
-import { INJECTABLE_WATERMARK } from "@nestjs/common/constants";
+import { Injectable } from "@nestjs/common";
 import { ModuleRef, Reflector } from "@nestjs/core";
 import { BlockWarning, BlockWarningsServiceInterface } from "src/blocks/block";
 
 import { ROOT_BLOCK_KEYS_METADATA_KEY, ROOT_BLOCK_METADATA_KEY } from "../blocks/decorators/root-block";
 import { ROOT_BLOCK_ENTITY_METADATA_KEY } from "../blocks/decorators/root-block-entity";
 import { FlatBlocks } from "../blocks/flat-blocks/flat-blocks";
+import { isInjectableService } from "../common/helper/is-injectable-service.helper";
 import { SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
 import { CREATE_WARNINGS_METADATA_KEY, CreateWarningsMeta } from "./decorators/create-warnings.decorator";
@@ -65,7 +65,7 @@ export class WarningEventSubscriber implements EventSubscriber {
                 if (scoped) {
                     let scopedEntityScope: ContentScope | ContentScope[];
 
-                    if (this.isService(scoped)) {
+                    if (isInjectableService(scoped)) {
                         const service = this.moduleRef.get(scoped, { strict: false });
                         scopedEntityScope = await service.getEntityScope(args.entity);
                     } else {
@@ -93,7 +93,7 @@ export class WarningEventSubscriber implements EventSubscriber {
                     const warningsOrWarningsService = await node.block.warnings();
                     let warnings: BlockWarning[] = [];
 
-                    if (this.isService(warningsOrWarningsService)) {
+                    if (isInjectableService(warningsOrWarningsService)) {
                         const warningsService = warningsOrWarningsService;
                         const service: BlockWarningsServiceInterface = await this.moduleRef.get(warningsService, { strict: false });
 
@@ -126,7 +126,7 @@ export class WarningEventSubscriber implements EventSubscriber {
                 const row = await repository.findOneOrFail(args.entity.id);
 
                 let warnings: WarningData[] = [];
-                if (this.isService(createWarnings)) {
+                if (isInjectableService(createWarnings)) {
                     const service = this.moduleRef.get(createWarnings, { strict: false });
                     warnings = await service.createWarnings(row);
                 } else {
@@ -146,10 +146,5 @@ export class WarningEventSubscriber implements EventSubscriber {
                 await this.warningService.deleteOutdatedWarnings({ date: startDate, sourceInfo });
             }
         }
-    }
-
-    private isService(target: object): target is Type {
-        // Check if class has @Injectable() decorator -> if true it's a service class else it's a function
-        return Reflect.hasMetadata(INJECTABLE_WATERMARK, target);
     }
 }


### PR DESCRIPTION
## Description

This pull request refactors multiple services and modules to use the new isInjectableService helper for detecting @Injectable classes. It replaces various local isService implementations with a single, shared utility, improving code consistency and maintainability across the codebase. No functional changes were made.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)
