### PR TITLE
Adapt Button styling in Demo Site

### DIFF
--- a/demo/site/src/common/components/Button.module.scss
+++ b/demo/site/src/common/components/Button.module.scss
@@ -29,8 +29,9 @@
     border: 1px solid var(--palette-primary-main);
 
     &:hover {
-        background-color: var(--palette-primary-dark);
+        color: var(--palette-primary-dark);
         border-color: var(--palette-primary-dark);
+        background-color: var(--palette-primary-contrastText);
     }
 
     &:disabled {
@@ -46,7 +47,8 @@
     border: 1px solid var(--palette-primary-main);
 
     &:hover {
-        color: var(--palette-primary-dark);
+        background-color: var(--palette-primary-dark);
+        color: var(--palette-primary-contrastText);
         border-color: var(--palette-primary-dark);
     }
 
@@ -60,9 +62,12 @@
     background-color: transparent;
     color: var(--palette-primary-main);
     border: 1px solid transparent;
+    text-decoration: underline;
+    text-underline-offset: 3px;
 
     &:hover {
         color: var(--palette-primary-dark);
+        text-decoration-thickness: 2px;
     }
 
     &:disabled {


### PR DESCRIPTION
## Description

The styling of the Button was updated by UX. Changes were made for the hover state of all variants. Additionally the `text" variant is underlined now.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

https://github.com/user-attachments/assets/b3a97452-4d33-4b88-8f31-43fb813b7194

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2484
