### PR TITLE
Remove `@babel/plugin-proposal-class-properties`

### DIFF
--- a/packages/admin/admin-babel-preset/index.js
+++ b/packages/admin/admin-babel-preset/index.js
@@ -35,7 +35,6 @@ module.exports = function () {
                     },
                 },
             ],
-            "@babel/plugin-proposal-class-properties",
         ],
     };
 };

--- a/packages/admin/admin-babel-preset/package.json
+++ b/packages/admin/admin-babel-preset/package.json
@@ -13,7 +13,6 @@
     "dependencies": {
         "@babel/cli": "^7.28.0",
         "@babel/core": "^7.28.0",
-        "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/preset-env": "^7.28.0",
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1058,9 +1058,6 @@ importers:
       '@babel/core':
         specifier: ^7.28.0
         version: 7.28.4
-      '@babel/plugin-proposal-class-properties':
-        specifier: ^7.18.6
-        version: 7.18.6(@babel/core@7.28.4)
       '@babel/preset-env':
         specifier: ^7.28.0
         version: 7.28.3(@babel/core@7.28.4)


### PR DESCRIPTION
## Description

Found this while trying to fix https://github.com/vivid-planet/comet/pull/4573. [@babel/plugin-proposal-class-properties](https://www.npmjs.com/package/@babel/plugin-proposal-class-properties) was deprecated in favor of [@babel/plugin-transform-class-properties](https://www.npmjs.com/package/@babel/plugin-transform-class-properties), which is included in `@babel/preset-env`.

To verify that this doesn't break anything, I compared the output of [Breadcrumb.tsx](https://github.com/vivid-planet/comet/blob/remove-babel-plugin-proposal-class-properties/packages/admin/admin/src/stack/Breadcrumb.tsx) before and after removing the plugin, which stayed the same. So I believe this change should be non-breaking.
