### PR TITLE
Add `pull_policy: weekly` to mailhog image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
 
     mailhog:
         image: mailhog/mailhog
+        pull_policy: weekly
         ports:
             - "127.0.0.1:1025:1025"
             - "127.0.0.1:8025:8025"


### PR DESCRIPTION
Missed in original implementation. All other services use it already for automated image updates.