### PR TITLE
Demo: use environment variable for database user

### DIFF
--- a/demo/api/src/config/environment-variables.ts
+++ b/demo/api/src/config/environment-variables.ts
@@ -23,9 +23,8 @@ export class EnvironmentVariables {
     @IsString()
     POSTGRESQL_DB: string;
 
-    @IsOptional()
     @IsString()
-    POSTGRESQL_USER?: string;
+    POSTGRESQL_USER: string;
 
     @IsString()
     POSTGRESQL_PWD: string;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         ports:
             - "127.0.0.1:${POSTGRESQL_PORT}:5432"
         environment:
-            POSTGRESQL_USER: postgres
+            POSTGRESQL_USER: ${POSTGRESQL_USER}
             POSTGRESQL_PASSWORD: ${POSTGRESQL_PWD_DECODED}
             POSTGRESQL_DATABASE: ${POSTGRESQL_DB}
         networks:


### PR DESCRIPTION
## Description

Noticed this while reviewing https://github.com/vivid-planet/comet/pull/4587: We have an environment variable for the user which we use in the API, but not for Docker Compose. Now using the variable everywhere.
