### PR TITLE
Fix DAM not rendering all items and its scrolling behavior when rendered in a Dialog

### DIFF
--- a/.changeset/wide-bikes-peel.md
+++ b/.changeset/wide-bikes-peel.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix DAM not rendering all items and its scrolling behavior when rendered in a Dialog

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -62,14 +62,7 @@ const Folder = ({ id, filterApi, renderWithFullHeightMainContent, ...props }: Fo
     });
 
     const folderDataGridNode = (
-        <FolderDataGrid
-            id={id}
-            breadcrumbs={stackApi?.breadCrumbs}
-            selectionApi={selectionApi}
-            filterApi={filterApi}
-            renderWithFullHeightMainContent={renderWithFullHeightMainContent}
-            {...props}
-        />
+        <FolderDataGrid id={id} breadcrumbs={stackApi?.breadCrumbs} selectionApi={selectionApi} filterApi={filterApi} {...props} />
     );
 
     return (

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.sc.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.sc.tsx
@@ -14,6 +14,7 @@ export const FolderOuterHoverHighlight = styled("div", { shouldForwardProp: (pro
     flex-direction: column;
     justify-content: flex-start;
     height: 100%;
+    overflow: hidden;
 
     ${({ isHovered, theme }) =>
         isHovered &&

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -77,7 +77,6 @@ interface FolderDataGridProps extends DamConfig {
     breadcrumbs?: BreadcrumbItem[];
     filterApi: IFilterApi<DamFilter>;
     selectionApi: ISelectionApi;
-    renderWithFullHeightMainContent?: boolean;
 }
 
 type FolderDataGridToolbarProps = {
@@ -141,7 +140,6 @@ const FolderDataGrid = ({
     hideArchiveFilter,
     hideMultiselect,
     renderDamLabel,
-    renderWithFullHeightMainContent,
     ...props
 }: FolderDataGridProps) => {
     const intl = useIntl();
@@ -637,7 +635,6 @@ const FolderDataGrid = ({
                     checkboxSelection={!hideMultiselect}
                     rowSelectionModel={Array.from(damSelectionActionsApi.selectionMap.keys())}
                     onRowSelectionModelChange={handleSelectionModelChange}
-                    autoHeight={!renderWithFullHeightMainContent}
                     initialState={{ columns: { columnVisibilityModel: { importSourceType: importSources !== undefined } } }}
                     columnVisibilityModel={{
                         contextMenu: !hideContextMenu,


### PR DESCRIPTION
## Description

By preventing the height of the DataGrid's wrapper element from growing larger than the Dialog's available space, the scrolling is now handled by the DataGrid itself, instead of the Dialog. This is generally the default behavior. 

This resolves the following issues, as seen in the video below:

- Not all DataGrid rows were visible, even when scrolling, due to the DataGrid itself not being scrollable when overflowing. 
- The Dialog's header and the DataGrid's header and footer were not sticky, causing these elements to be hidden, depending on the scroll position. 
- The Toolbar above the DataGrid would overlay the DataGrid when scrolling. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/6564b66b-0c11-49df-a981-095e08494841" alt="Select from DAM Previously" />   | <video src="https://github.com/user-attachments/assets/3a09ed7d-4183-4ba3-b8a7-c3b724032c9b" alt="Select from DAM Now" />  |


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2513
