### PR TITLE
Fix an ESM issue with react-diff-viewer

### DIFF
--- a/demo/admin/vite.config.mts
+++ b/demo/admin/vite.config.mts
@@ -98,6 +98,8 @@ export default defineConfig(({ mode }) => {
             "process.env.NODE_ENV": mode === "production" ? "'production'" : "'development'",
         },
         optimizeDeps: {
+            force: true,
+
             esbuildOptions: {
                 // Node.js global to browser globalThis. https://github.com/vitejs/vite/discussions/5912
                 // "global is not defined" occurs directly after loading. Used by draft-is package
@@ -105,9 +107,17 @@ export default defineConfig(({ mode }) => {
                     global: "globalThis",
                 },
             },
-            include: ["@comet/admin", "@comet/admin-rte", "@comet/admin-date-time", "@comet/admin-icons", "@comet/cms-admin"],
+            include: [
+                "@comet/admin",
+                "@comet/admin-rte",
+                "@comet/admin-date-time",
+                "@comet/admin-icons",
+                "@comet/cms-admin",
+            ],
         },
         resolve: {
+            conditions: ["module", "import", "browser"],
+            mainFields: ["module", "browser", "exports", "main"],
             alias: {
                 "@src": resolve(__dirname, "./src"),
             },

--- a/demo/admin/vite.config.mts
+++ b/demo/admin/vite.config.mts
@@ -98,8 +98,6 @@ export default defineConfig(({ mode }) => {
             "process.env.NODE_ENV": mode === "production" ? "'production'" : "'development'",
         },
         optimizeDeps: {
-            force: true,
-
             esbuildOptions: {
                 // Node.js global to browser globalThis. https://github.com/vitejs/vite/discussions/5912
                 // "global is not defined" occurs directly after loading. Used by draft-is package
@@ -107,17 +105,10 @@ export default defineConfig(({ mode }) => {
                     global: "globalThis",
                 },
             },
-            include: [
-                "@comet/admin",
-                "@comet/admin-rte",
-                "@comet/admin-date-time",
-                "@comet/admin-icons",
-                "@comet/cms-admin",
-            ],
+            include: ["@comet/admin", "@comet/admin-rte", "@comet/admin-date-time", "@comet/admin-icons", "@comet/cms-admin"],
         },
         resolve: {
-            conditions: ["module", "import", "browser"],
-            mainFields: ["module", "browser", "exports", "main"],
+            conditions: ["import"],
             alias: {
                 "@src": resolve(__dirname, "./src"),
             },


### PR DESCRIPTION
## Description

Demo Admin ends with the following ESM errors:

```
at ../../node_modules/.pnpm/react-diff-viewer-continued@4.0.6_@types+react@18.3.24_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/react-diff-viewer-continued/lib/cjs/src/compute-hidden-blocks.js (@comet_cms-admin.js?v=10a733b8:389:27)
```

Adjusting the `vite.config.mts` fixes the problem.
