### PR TITLE
Improve API for setting info-tooltips of SectionHeadline and FormSection

### DIFF
--- a/.changeset/yellow-parks-tie.md
+++ b/.changeset/yellow-parks-tie.md
@@ -1,0 +1,16 @@
+---
+"@comet/admin": patch
+---
+
+Allow overriding the `divider` value of the `title` slot of `FormSection` using `slotProps`
+
+```tsx
+<FormSection
+    title="Title of the FormSection"
+    slotProps={{
+        title: { divider: false },
+    }}
+>
+    {/* ... */}
+</FormSection>
+```

--- a/.changeset/young-goats-yawn.md
+++ b/.changeset/young-goats-yawn.md
@@ -1,0 +1,28 @@
+---
+"@comet/admin": minor
+---
+
+Simplify adding an info-icon with a tooltip in `FormSection` using the new `infoTooltip` prop
+
+Either set the props value to a string or `FormattedMessage` directly:
+
+```tsx
+<FormSection title="Title of the FormSection" infoTooltip="Title of the info tooltip">
+    {/* ... */}
+</FormSection>
+```
+
+Or use an object for a more detailed definition:
+
+```tsx
+<FormSection
+    title="FormSection"
+    infoTooltip={{
+        title: "Title of the info tooltip",
+        description: "Description of the info tooltip",
+        variant: "light",
+    }}
+>
+    {/* ... */}
+</FormSection>
+```

--- a/packages/admin/admin/src/form/FormSection.tsx
+++ b/packages/admin/admin/src/form/FormSection.tsx
@@ -43,7 +43,7 @@ export function FormSection(inProps: FormSectionProps) {
                     {disableTypography ? (
                         <LegacyTitle {...slotProps?.title}>{title}</LegacyTitle>
                     ) : (
-                        <Title infoTooltip={infoTooltip} {...slotProps?.title} divider>
+                        <Title infoTooltip={infoTooltip} divider {...slotProps?.title}>
                             {title}
                         </Title>
                     )}

--- a/packages/admin/admin/src/form/FormSection.tsx
+++ b/packages/admin/admin/src/form/FormSection.tsx
@@ -1,6 +1,6 @@
 import { type ComponentsOverrides } from "@mui/material";
 import { css, type Theme, useThemeProps } from "@mui/material/styles";
-import { type ReactNode } from "react";
+import { type ComponentProps, type ReactNode } from "react";
 
 import { createComponentSlot } from "../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
@@ -19,6 +19,7 @@ export interface FormSectionProps
     children: ReactNode;
     title?: ReactNode;
     disableMarginBottom?: boolean;
+    infoTooltip?: ComponentProps<typeof Title>["infoTooltip"];
     /**
      * @deprecated Use `slotProps.title` for custom styling or for setting a custom `variant` on the underlying `Typography` component.
      */
@@ -26,7 +27,7 @@ export interface FormSectionProps
 }
 
 export function FormSection(inProps: FormSectionProps) {
-    const { children, title, disableMarginBottom, disableTypography, slotProps, ...restProps } = useThemeProps({
+    const { children, title, disableMarginBottom, disableTypography, slotProps, infoTooltip, ...restProps } = useThemeProps({
         props: inProps,
         name: "CometAdminFormSection",
     });
@@ -42,7 +43,7 @@ export function FormSection(inProps: FormSectionProps) {
                     {disableTypography ? (
                         <LegacyTitle {...slotProps?.title}>{title}</LegacyTitle>
                     ) : (
-                        <Title {...slotProps?.title} divider>
+                        <Title infoTooltip={infoTooltip} {...slotProps?.title} divider>
                             {title}
                         </Title>
                     )}

--- a/packages/admin/admin/src/form/FormSection.tsx
+++ b/packages/admin/admin/src/form/FormSection.tsx
@@ -10,45 +10,6 @@ export type FormSectionClassKey = "root" | "disableMarginBottom" | "title" | "ch
 
 type OwnerState = Pick<FormSectionProps, "disableMarginBottom">;
 
-const Root = createComponentSlot("div")<FormSectionClassKey, OwnerState>({
-    componentName: "FormSection",
-    slotName: "root",
-    classesResolver(ownerState) {
-        return [ownerState.disableMarginBottom && "disableMarginBottom"];
-    },
-})(
-    ({ theme, ownerState }) => css`
-        ${!ownerState.disableMarginBottom &&
-        css`
-            margin-bottom: ${theme.spacing(12)};
-        `}
-    `,
-);
-
-const Title = createComponentSlot(SectionHeadline)<FormSectionClassKey>({
-    componentName: "FormSection",
-    slotName: "title",
-})(
-    ({ theme }) => css`
-        margin-bottom: ${theme.spacing(4)};
-    `,
-);
-
-// TODO: Remove this slot once the `disableTypography` prop has been removed
-const LegacyTitle = createComponentSlot("div")<FormSectionClassKey>({
-    componentName: "FormSection",
-    slotName: "title",
-})(
-    ({ theme }) => css`
-        margin-bottom: ${theme.spacing(4)};
-    `,
-);
-
-const Children = createComponentSlot("div")<FormSectionClassKey>({
-    componentName: "FormSection",
-    slotName: "children",
-})();
-
 export interface FormSectionProps
     extends ThemedComponentBaseProps<{
         root: "div";
@@ -92,6 +53,45 @@ export function FormSection(inProps: FormSectionProps) {
         </Root>
     );
 }
+
+const Root = createComponentSlot("div")<FormSectionClassKey, OwnerState>({
+    componentName: "FormSection",
+    slotName: "root",
+    classesResolver(ownerState) {
+        return [ownerState.disableMarginBottom && "disableMarginBottom"];
+    },
+})(
+    ({ theme, ownerState }) => css`
+        ${!ownerState.disableMarginBottom &&
+        css`
+            margin-bottom: ${theme.spacing(12)};
+        `}
+    `,
+);
+
+const Title = createComponentSlot(SectionHeadline)<FormSectionClassKey>({
+    componentName: "FormSection",
+    slotName: "title",
+})(
+    ({ theme }) => css`
+        margin-bottom: ${theme.spacing(4)};
+    `,
+);
+
+// TODO: Remove this slot once the `disableTypography` prop has been removed
+const LegacyTitle = createComponentSlot("div")<FormSectionClassKey>({
+    componentName: "FormSection",
+    slotName: "title",
+})(
+    ({ theme }) => css`
+        margin-bottom: ${theme.spacing(4)};
+    `,
+);
+
+const Children = createComponentSlot("div")<FormSectionClassKey>({
+    componentName: "FormSection",
+    slotName: "children",
+})();
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -1,7 +1,7 @@
 import { Info } from "@comet/admin-icons";
 import { type ComponentsOverrides, Divider, Typography } from "@mui/material";
 import { css, type Theme, useThemeProps } from "@mui/material/styles";
-import { type ReactElement, type ReactNode } from "react";
+import { type ComponentProps, isValidElement, type ReactElement, type ReactNode } from "react";
 
 import { Tooltip } from "../common/Tooltip";
 import { createComponentSlot } from "../helpers/createComponentSlot";
@@ -22,6 +22,10 @@ export interface SectionHeadlineProps
     children: ReactNode;
     divider?: boolean;
     supportText?: ReactNode;
+    infoTooltip?: ReactNode | Omit<ComponentProps<typeof InfoTooltip>, "children">;
+    /*
+     * @deprecated Use the `infoTooltip` prop instead
+     */
     infoTooltipText?: ReactNode;
     iconMapping?: {
         tooltip?: ReactElement;
@@ -33,6 +37,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         children,
         divider,
         supportText,
+        infoTooltip,
         infoTooltipText,
         iconMapping = {},
         slotProps,
@@ -43,6 +48,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
     });
 
     const { tooltip: tooltipIcon = <Info sx={{ fontSize: "inherit" }} /> } = iconMapping;
+    const infoTooltipProps = getTooltipProps(infoTooltip);
 
     return (
         <Root {...slotProps?.root} {...restProps}>
@@ -51,8 +57,8 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
                     <Headline variant="h4" {...slotProps?.headline}>
                         {children}
                     </Headline>
-                    {(infoTooltipText || slotProps?.infoTooltip?.title !== undefined) && (
-                        <InfoTooltip title={infoTooltipText} {...slotProps?.infoTooltip}>
+                    {(infoTooltipText || infoTooltipProps || slotProps?.infoTooltip?.title !== undefined) && (
+                        <InfoTooltip title={infoTooltipText} {...infoTooltipProps} {...slotProps?.infoTooltip}>
                             {tooltipIcon}
                         </InfoTooltip>
                     )}
@@ -69,6 +75,22 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         </Root>
     );
 }
+
+const getTooltipProps = (infoTooltip: SectionHeadlineProps["infoTooltip"]) => {
+    if (!infoTooltip) return null;
+
+    if (isValidElement(infoTooltip) || typeof infoTooltip === "string") {
+        return {
+            title: infoTooltip,
+        };
+    }
+
+    if (typeof infoTooltip === "object") {
+        return infoTooltip;
+    }
+
+    return null;
+};
 
 const Root = createComponentSlot("div")<SectionHeadlineClassKey>({
     componentName: "SectionHeadline",

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -9,67 +9,6 @@ import { type ThemedComponentBaseProps } from "../helpers/ThemedComponentBasePro
 
 export type SectionHeadlineClassKey = "root" | "header" | "titleContainer" | "headline" | "divider" | "supportText" | "infoTooltip";
 
-const Root = createComponentSlot("div")<SectionHeadlineClassKey>({
-    componentName: "SectionHeadline",
-    slotName: "root",
-})();
-
-const Header = createComponentSlot("div")<SectionHeadlineClassKey>({
-    componentName: "SectionHeadline",
-    slotName: "header",
-})(
-    () => css`
-        display: flex;
-        flex-direction: row;
-        align-items: flex-end;
-        justify-content: space-between;
-    `,
-);
-
-const TitleContainer = createComponentSlot("div")<SectionHeadlineClassKey>({
-    componentName: "SectionHeadline",
-    slotName: "titleContainer",
-})(
-    () => css`
-        display: flex;
-        align-items: center;
-    `,
-);
-
-const Headline = createComponentSlot(Typography)<SectionHeadlineClassKey>({
-    componentName: "SectionHeadline",
-    slotName: "headline",
-})();
-
-const SupportText = createComponentSlot(Typography)<SectionHeadlineClassKey>({
-    componentName: "SectionHeadline",
-    slotName: "supportText",
-})(
-    ({ theme }) => css`
-        color: ${theme.palette.text.secondary};
-    `,
-);
-
-const InfoTooltip = createComponentSlot(Tooltip)<SectionHeadlineClassKey>({
-    componentName: "SectionHeadline",
-    slotName: "infoTooltip",
-})(
-    ({ theme }) => css`
-        color: ${theme.palette.text.secondary};
-        margin-left: 10px;
-        font-size: 12px;
-    `,
-);
-
-const StyledDivider = createComponentSlot(Divider)<SectionHeadlineClassKey>({
-    componentName: "SectionHeadline",
-    slotName: "divider",
-})(
-    () => css`
-        margin-top: 10px;
-    `,
-);
-
 export interface SectionHeadlineProps
     extends ThemedComponentBaseProps<{
         root: "div";
@@ -130,6 +69,61 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         </Root>
     );
 }
+
+const Root = createComponentSlot("div")<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "root",
+})();
+
+const Header = createComponentSlot("div")<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "header",
+})(css`
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+`);
+
+const TitleContainer = createComponentSlot("div")<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "titleContainer",
+})(css`
+    display: flex;
+    align-items: center;
+`);
+
+const Headline = createComponentSlot(Typography)<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "headline",
+})();
+
+const SupportText = createComponentSlot(Typography)<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "supportText",
+})(
+    ({ theme }) => css`
+        color: ${theme.palette.text.secondary};
+    `,
+);
+
+const InfoTooltip = createComponentSlot(Tooltip)<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "infoTooltip",
+})(
+    ({ theme }) => css`
+        color: ${theme.palette.text.secondary};
+        margin-left: 10px;
+        font-size: 12px;
+    `,
+);
+
+const StyledDivider = createComponentSlot(Divider)<SectionHeadlineClassKey>({
+    componentName: "SectionHeadline",
+    slotName: "divider",
+})(css`
+    margin-top: 10px;
+`);
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/PermissionDialog.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/PermissionDialog.tsx
@@ -152,25 +152,19 @@ export const PermissionDialog = ({ userId, permissionId, handleDialogClose }: Fo
                             </FormSection>
                             <FormSection
                                 title={<FormattedMessage id="comet.userPermissions.validityDuration" defaultMessage="Validity duration" />}
-                                slotProps={{
-                                    title: {
-                                        slotProps: {
-                                            infoTooltip: {
-                                                title: (
-                                                    <FormattedMessage
-                                                        id="comet.userPermission.validityDuration.tooltip.title"
-                                                        defaultMessage="Validity duration"
-                                                    />
-                                                ),
-                                                description: (
-                                                    <FormattedMessage
-                                                        id="comet.userPermission.validityDuration.tooltip.content"
-                                                        defaultMessage="Leave empty for unlimited validity"
-                                                    />
-                                                ),
-                                            },
-                                        },
-                                    },
+                                infoTooltip={{
+                                    title: (
+                                        <FormattedMessage
+                                            id="comet.userPermission.validityDuration.tooltip.title"
+                                            defaultMessage="Validity duration"
+                                        />
+                                    ),
+                                    description: (
+                                        <FormattedMessage
+                                            id="comet.userPermission.validityDuration.tooltip.content"
+                                            defaultMessage="Leave empty for unlimited validity"
+                                        />
+                                    ),
                                 }}
                             >
                                 <DatePickerField

--- a/storybook/src/admin/FormSection.stories.tsx
+++ b/storybook/src/admin/FormSection.stories.tsx
@@ -1,0 +1,66 @@
+import { FormSection } from "@comet/admin";
+import { Typography } from "@mui/material";
+import { FormattedMessage } from "react-intl";
+
+export default {
+    title: "@comet/admin/FormSection",
+};
+
+export const InfoTooltipExamples = {
+    render: () => {
+        return (
+            <>
+                <FormSection
+                    title="FormSection"
+                    slotProps={{
+                        title: { infoTooltipText: "Hello" },
+                    }}
+                >
+                    <Typography>
+                        Using <strong>deprecated</strong> infoTooltipText prop through slotProps.title
+                    </Typography>
+                </FormSection>
+                <FormSection title="FormSection" infoTooltip="Hello">
+                    <Typography>Using infoTooltip prop, using string directly</Typography>
+                </FormSection>
+                <FormSection
+                    title="FormSection"
+                    infoTooltip={<FormattedMessage id="stories.formSectionl.infoTooltipExamples.hello" defaultMessage="Hello" />}
+                >
+                    <Typography>Using infoTooltip prop, using FormattedMessage directly</Typography>
+                </FormSection>
+                <FormSection
+                    title="FormSection"
+                    infoTooltip={{
+                        title: "Hello",
+                    }}
+                >
+                    <Typography>Using infoTooltip prop, using object for title only</Typography>
+                </FormSection>
+                <FormSection
+                    title="FormSection"
+                    infoTooltip={{
+                        title: "Hello",
+                        description: "Lorem ipsum",
+                        variant: "light",
+                    }}
+                >
+                    <Typography>Using infoTooltip prop, using object for title, description and variant</Typography>
+                </FormSection>
+                <FormSection
+                    title="FormSection"
+                    infoTooltip={{
+                        customContent: (
+                            <>
+                                <Typography variant="subtitle1">Hello</Typography>
+                                <Typography variant="body1">Lorem ipsum</Typography>
+                            </>
+                        ),
+                    }}
+                >
+                    <Typography>Using infoTooltip prop, using object for custom content</Typography>
+                </FormSection>
+            </>
+        );
+    },
+};

--- a/storybook/src/admin/SectionHeadline.stories.tsx
+++ b/storybook/src/admin/SectionHeadline.stories.tsx
@@ -1,5 +1,6 @@
 import { SectionHeadline } from "@comet/admin";
-import { Stack } from "@mui/material";
+import { Stack, Typography } from "@mui/material";
+import { FormattedMessage } from "react-intl";
 
 export default {
     title: "@comet/admin/SectionHeadline",
@@ -13,6 +14,48 @@ export const Default = () => {
             </SectionHeadline>
 
             <SectionHeadline>Section Title</SectionHeadline>
+        </Stack>
+    );
+};
+
+export const InfoTooltipExamples = () => {
+    return (
+        <Stack spacing={4}>
+            <SectionHeadline infoTooltipText="Hello">
+                Using <strong>deprecated</strong> infoTooltipText prop
+            </SectionHeadline>
+            <SectionHeadline infoTooltip="Hello">Using infoTooltip prop, using string directly</SectionHeadline>
+            <SectionHeadline infoTooltip={<FormattedMessage id="stories.formSectionl.infoTooltipExamples.hello" defaultMessage="Hello" />}>
+                Using infoTooltip prop, using FormattedMessage directly
+            </SectionHeadline>
+            <SectionHeadline
+                infoTooltip={{
+                    title: "Hello",
+                }}
+            >
+                Using infoTooltip prop, using object for title only
+            </SectionHeadline>
+            <SectionHeadline
+                infoTooltip={{
+                    title: "Hello",
+                    description: "Lorem ipsum",
+                    variant: "light",
+                }}
+            >
+                Using infoTooltip prop, using object for title, description and variant
+            </SectionHeadline>
+            <SectionHeadline
+                infoTooltip={{
+                    customContent: (
+                        <>
+                            <Typography variant="subtitle1">Hello</Typography>
+                            <Typography variant="body1">Lorem ipsum</Typography>
+                        </>
+                    ),
+                }}
+            >
+                Using infoTooltip prop, using object for custom content
+            </SectionHeadline>
         </Stack>
     );
 };


### PR DESCRIPTION
## Description

You can simply set the `infoTooltip` prop to either the title directly, or to an object of props for more control. 
This works the same in `SectionHeadline` and `FormSection` which uses the `SectionHeadline` internally. 

```tsx
<FormSection
    title="Title of the FormSection"
    infoTooltip="Title of the info tooltip"
>
    {/* ... */}
</FormSection>
```

```tsx
<FormSection
    title="FormSection"
    infoTooltip={{
        title: "Title of the info tooltip",
        description: "Description of the info tooltip",
        variant: "light",
    }}
>
    {/* ... */}
</FormSection>
```

Additionally: 
- Refactoring: Move styles below component definition for consistency with other components.
- Allow overriding the `divider` value of the `title` slot of `FormSection` using `slotProps`
- Deprecate the `infoTooltipText` prop of `SectionHeadline` as it's replaced by the `infoTooltip` prop. 
- I did not add a changesets for `SectionHeadline`, as the export of the component is deprecated. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2474
