### PR TITLE
Renovate: add dedicated group for Next.js

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,7 +45,8 @@
         },
         {
             "groupName": "eslint",
-            "matchPackageNames": ["/^eslint/"]
+            "matchPackageNames": ["/^eslint/"],
+            "excludePackagePatterns": ["eslint-config-next"]
         },
         {
             "groupName": "prettier",
@@ -132,6 +133,10 @@
         {
             "groupName": "SWC",
             "matchPackageNames": ["@swc/plugin-emotion", "@vitejs/plugin-react-swc"]
+        },
+        {
+            "groupName": "Next.js",
+            "matchPackageNames": ["next", "@next/bundle-analyzer", "@next/eslint-plugin-next", "eslint-config-next"]
         }
     ],
     "lockFileMaintenance": { "enabled": true },


### PR DESCRIPTION
## Description

Group `next` and all related dependencies. Also, exclude `eslint-config-next` from ESLint group.
