### PR TITLE
Fix preview skeleton for `AccordionContentBlock`

### DIFF
--- a/demo/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionItemBlock.tsx
@@ -1,4 +1,4 @@
-import { BlocksBlock, type PropsWithData, type SupportedBlocks, withPreview } from "@comet/site-nextjs";
+import { BlocksBlock, PreviewSkeleton, type PropsWithData, type SupportedBlocks, withPreview } from "@comet/site-nextjs";
 import { type AccordionContentBlockData, type AccordionItemBlockData } from "@src/blocks.generated";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import { SpaceBlock } from "@src/common/blocks/SpaceBlock";
@@ -53,7 +53,9 @@ export const AccordionItemBlock = withPreview(
                     className={clsx(styles.contentWrapper, isExpanded && styles.contentWrapperExpanded)}
                 >
                     <div className={styles.contentWrapperInner}>
-                        <AccordionContentBlock data={content} />
+                        <PreviewSkeleton hasContent={isExpanded}>
+                            <AccordionContentBlock data={content} />
+                        </PreviewSkeleton>
                     </div>
                 </section>
             </>


### PR DESCRIPTION
## Description

If an `AccordionItem` is closed, the preview skeleton still overlaps the following content. To solve this, a `PreviewSkeleton` wrapper was added, that renders the preview skeleton depending on the state of the AccordionItem. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1060" height="618" alt="Bildschirmfoto 2025-10-02 um 13 23 24" src="https://github.com/user-attachments/assets/302b4b0d-c35a-4845-960f-b945160a662b" /> | ![preview](https://github.com/user-attachments/assets/a14d1b26-6633-427a-abd2-73e465786445) |

## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2274
- PR in Starter: https://github.com/vivid-planet/comet-starter/pull/1053
