### PR TITLE
Fix file replacement by id

### DIFF
--- a/.changeset/better-bats-train.md
+++ b/.changeset/better-bats-train.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix file replacement by id

--- a/packages/api/cms-api/src/dam/files/files.controller.ts
+++ b/packages/api/cms-api/src/dam/files/files.controller.ts
@@ -166,8 +166,10 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             @GetCurrentUser() user: CurrentUser,
             @Headers("x-preview-dam-urls") previewDamUrls: string | undefined,
         ): Promise<Omit<FileInterface, keyof BaseEntity> & { fileUrl: string }> {
-            const { fileId, ...transformedBody } = plainToInstance(ReplaceFileByIdBody, body);
+            const transformedBody = plainToInstance(ReplaceFileByIdBody, body);
             const errors = await validate(transformedBody, { whitelist: true, forbidNonWhitelisted: true });
+
+            const { fileId, ...restBody } = transformedBody;
 
             if (errors.length > 0) {
                 throw new CometValidationException("Validation failed", errors);
@@ -181,7 +183,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                 throw new ForbiddenException();
             }
 
-            const replacedFile = await this.filesService.replace(fileToReplace, file, transformedBody);
+            const replacedFile = await this.filesService.replace(fileToReplace, file, restBody);
 
             const fileUrl = await this.filesService.createFileUrl(replacedFile, {
                 previewDamUrls: Boolean(previewDamUrls),


### PR DESCRIPTION
## Description

Previously, file replacement caused a validation error

I'm unsure how this ever worked. Maybe it broke because of the class-validator update but I didn't try to validate this.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screencast

### Before


https://github.com/user-attachments/assets/a7917a57-3a94-4993-a363-df3ffadb033b


### After


https://github.com/user-attachments/assets/6d752a78-5d79-447a-b118-b27c935b041b



## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2528
