### PR TITLE
Allow percentage sign string literal in eslint-config future/react.js

### DIFF
--- a/.changeset/chubby-hounds-appear.md
+++ b/.changeset/chubby-hounds-appear.md
@@ -1,0 +1,5 @@
+---
+"@comet/eslint-config": patch
+---
+
+Allow `%` as a string literal in `future/react.js`

--- a/packages/eslint-config/future/react.js
+++ b/packages/eslint-config/future/react.js
@@ -10,7 +10,7 @@ const config = [
             "react/jsx-no-literals": [
                 "error",
                 {
-                    allowedStrings: ["…", "€", "$", "?", "–", "—", "/", "(", ")"],
+                    allowedStrings: ["…", "€", "$", "?", "–", "—", "/", "(", ")", "%"],
                 },
             ],
         },


### PR DESCRIPTION
## Description

This Pull Request updates `@comet/eslint-config` the `/future/react.js` config, to allow the `%` character as a valid string literal.

