### PR TITLE
Prevent a refresh of `block_index_dependencies` within 5 minutes of the last refresh

### DIFF
--- a/.changeset/brave-pigs-listen.md
+++ b/.changeset/brave-pigs-listen.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Prevent a refresh of `block_index_dependencies` within 5 minutes of the last refresh
+
+This was already the desired behavior, but the previous implementation was not working correctly.

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -138,7 +138,7 @@ export class DependenciesService {
 
             await forkedEntityManager.execute(`REFRESH MATERIALIZED VIEW ${options?.concurrently ? "CONCURRENTLY" : ""} block_index_dependencies`);
 
-            await forkedEntityManager.persistAndFlush(Object.assign(blockIndexRefresh, { finishedAt: subMinutes(new Date(), 5) }));
+            await forkedEntityManager.persistAndFlush(Object.assign(blockIndexRefresh, { finishedAt: new Date() }));
             console.timeEnd(`refresh materialized block dependency ${id}`);
         };
 


### PR DESCRIPTION
## Description

### Problem

I noticed that the DAM page is very slow since we added the usages column, so I started investigating. I saw that the block index is refreshed every time the GraphQL query is executed.

The desired behavior is:

Within 5 minutes -> Don't refresh (except on force)
Within 15 minutes -> Refresh non-blocking
After 15 minutes -> Refresh blocking

### Solution

The finish time of the refresh was moved 5 minutes to the past before saving it 🤦‍♂️

<img width="641" height="385" alt="Bildschirmfoto 2025-10-03 um 09 43 10" src="https://github.com/user-attachments/assets/776355aa-8679-44bf-93a1-02188518b557" />

I have no idea how I missed this during the initial implementation 😅

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

