### PR TITLE
Add help prop to Toolbar

### DIFF
--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -1,13 +1,25 @@
-import { type ComponentsOverrides, Paper, Toolbar as MuiToolbar } from "@mui/material";
+import { QuestionMark } from "@comet/admin-icons";
+import { type ComponentsOverrides, DialogContent, IconButton, Paper, Toolbar as MuiToolbar } from "@mui/material";
 import { css, type Theme, useThemeProps } from "@mui/material/styles";
-import { type ReactNode, useContext } from "react";
+import { type ReactNode, useContext, useState } from "react";
 
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import { type ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
 import { MasterLayoutContext } from "../../mui/MasterLayoutContext";
+import { Dialog } from "../Dialog";
+import { FillSpace } from "../FillSpace";
 import { ToolbarBreadcrumbs } from "./ToolbarBreadcrumbs";
 
-export type ToolbarClassKey = "root" | "topBar" | "bottomBar" | "mainContentContainer" | "breadcrumbs" | "scopeIndicator";
+export type ToolbarClassKey =
+    | "root"
+    | "topBar"
+    | "bottomBar"
+    | "mainContentContainer"
+    | "breadcrumbs"
+    | "scopeIndicator"
+    | "helpButton"
+    | "helpDialog"
+    | "helpDialogContent";
 
 export interface ToolbarProps
     extends ThemedComponentBaseProps<{
@@ -17,10 +29,18 @@ export interface ToolbarProps
         topBar: "div";
         breadcrumbs: typeof ToolbarBreadcrumbs;
         scopeIndicator: "div";
+        helpButton: typeof IconButton;
+        helpDialog: typeof Dialog;
+        helpDialogContent: typeof DialogContent;
     }> {
     elevation?: number;
     children?: ReactNode;
     scopeIndicator?: ReactNode;
+    help?: {
+        title?: ReactNode;
+        description?: ReactNode;
+    };
+
     hideTopBar?: boolean;
     /**
      * The height of the header above the toolbar. Default behaviour is to use the height of the headerHeight from the
@@ -121,6 +141,21 @@ const Breadcrumbs = createComponentSlot(ToolbarBreadcrumbs)<ToolbarClassKey>({
     slotName: "breadcrumbs",
 })();
 
+const HelpButton = createComponentSlot(IconButton)<ToolbarClassKey>({
+    componentName: "Toolbar",
+    slotName: "helpButton",
+})();
+
+const HelpDialog = createComponentSlot(Dialog)<ToolbarClassKey>({
+    componentName: "Toolbar",
+    slotName: "helpDialog",
+})();
+
+const HelpDialogContent = createComponentSlot(DialogContent)<ToolbarClassKey>({
+    componentName: "Toolbar",
+    slotName: "helpDialogContent",
+})();
+
 export const Toolbar = (inProps: ToolbarProps) => {
     const {
         children,
@@ -128,9 +163,12 @@ export const Toolbar = (inProps: ToolbarProps) => {
         elevation = 1,
         slotProps,
         scopeIndicator,
+        help,
         ...restProps
     } = useThemeProps({ props: inProps, name: "CometAdminToolbar" });
     const { headerHeight } = useContext(MasterLayoutContext);
+
+    const [showHelp, setShowHelp] = useState(false);
 
     const ownerState: OwnerState = {
         headerHeight: inProps.headerHeight ?? headerHeight,
@@ -141,6 +179,17 @@ export const Toolbar = (inProps: ToolbarProps) => {
                 <TopBar {...slotProps?.topBar}>
                     {Boolean(scopeIndicator) && <ScopeIndicator {...slotProps?.scopeIndicator}>{scopeIndicator}</ScopeIndicator>}
                     <Breadcrumbs {...slotProps?.breadcrumbs} />
+                    <FillSpace />
+                    {help && (
+                        <HelpButton
+                            onClick={() => {
+                                setShowHelp(!showHelp);
+                            }}
+                            {...slotProps?.helpButton}
+                        >
+                            <QuestionMark />
+                        </HelpButton>
+                    )}
                 </TopBar>
             )}
             {children && (
@@ -148,6 +197,16 @@ export const Toolbar = (inProps: ToolbarProps) => {
                     <MainContentContainer {...slotProps?.mainContentContainer}>{children}</MainContentContainer>
                 </BottomBar>
             )}
+            <HelpDialog
+                open={showHelp}
+                onClose={() => {
+                    setShowHelp(false);
+                }}
+                title={help?.title}
+                {...slotProps?.helpDialog}
+            >
+                <HelpDialogContent {...slotProps?.helpDialogContent}>{help?.description}</HelpDialogContent>
+            </HelpDialog>
         </Root>
     );
 };

--- a/storybook/src/admin/toolbar/Toolbar.stories.tsx
+++ b/storybook/src/admin/toolbar/Toolbar.stories.tsx
@@ -12,6 +12,7 @@ import {
     ToolbarItem,
 } from "@comet/admin";
 import { ArrowRight, Save } from "@comet/admin-icons";
+import { ContentScopeIndicator } from "@comet/cms-admin";
 import { Chip } from "@mui/material";
 import { type ReactNode } from "react";
 
@@ -66,3 +67,35 @@ export const _Toolbar = () => (
         <Story />
     </StackWrapper>
 );
+
+export const ToolbarWithHelp = () => {
+    return (
+        <Toolbar
+            scopeIndicator={<ContentScopeIndicator global />}
+            help={{
+                title: "Help",
+                description: (
+                    <div>
+                        <div
+                            style={{
+                                backgroundColor: "teal",
+                                width: "200px",
+                                height: "200px",
+                                float: "right",
+                                marginLeft: 16,
+                                alignItems: "center",
+                                justifyContent: "center",
+                                display: "flex",
+                            }}
+                        >
+                            Image Placeholder
+                        </div>
+                        <p>This is some help text. You can put whatever you want in here, for example an image to illustrate your help.</p>
+                    </div>
+                ),
+            }}
+        >
+            <ToolbarItem>Some title</ToolbarItem>
+        </Toolbar>
+    );
+};

--- a/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
+++ b/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
@@ -938,3 +938,49 @@ export const GridWithSelectionInDialog = {
         );
     },
 };
+
+export const PageWithHelpInToolbarModal = {
+    render: () => {
+        const { rows, loading } = useData();
+
+        const GridToolbar = () => {
+            console.log("GridToolbar render");
+            return (
+                <DataGridToolbar>
+                    <GridToolbarQuickFilter />
+                    <GridFilterButton />
+                </DataGridToolbar>
+            );
+        };
+
+        const columns: GridColDef[] = [
+            { field: "title", headerName: "Title", flex: 1 },
+            { field: "description", headerName: "Description", flex: 2 },
+        ];
+
+        return (
+            <>
+                <StackToolbar
+                    help={{
+                        title: "How to use this table",
+                        description: (
+                            <div>
+                                <ul>
+                                    <li>Use the quick filter to search titles or descriptions.</li>
+                                    <li>Click the filter button to refine results.</li>
+                                    <li>Columns can be resized and sorted by clicking the header.</li>
+                                </ul>
+                            </div>
+                        ),
+                    }}
+                >
+                    <ToolbarBackButton />
+                    <ToolbarAutomaticTitleItem />´
+                </StackToolbar>
+                <StackMainContent>
+                    <DataGrid columns={columns} rows={rows} loading={loading} slots={{ toolbar: GridToolbar }} autoHeight />
+                </StackMainContent>
+            </>
+        );
+    },
+};


### PR DESCRIPTION
## Description

Add optional `help` prop to `Toolbar` to show a help icon that opens a modal with customizable `title` and `description`. 

Introduces dedicated slots on Toolbar (helpButton, helpDialog, helpDialogContent) and Storybook examples.

## Why

Provides built-in contextual help for complex pages; consistent UX, themable via slots, and remains non-breaking (no icon if help is unset).

## Open Questions
- Do we want a dedicated `help` prop which handles this context sensitive logic or do we want something more generic (e.g., actions, rightContainer) to allow broader extensibility?

## Screenshots/screencasts
![Screen Recording 2025-10-03 at 10 51 42](https://github.com/user-attachments/assets/78417352-0b14-4539-a3e3-eb179c1618fe)

