### PR TITLE
Redirect to main domain if host matches with pattern or additional do…

### DIFF
--- a/demo/site/src/middleware/redirectToMainHost.ts
+++ b/demo/site/src/middleware/redirectToMainHost.ts
@@ -32,7 +32,9 @@ export function withRedirectToMainHostMiddleware(middleware: CustomMiddleware) {
                 getSiteConfigs().find((siteConfig) => matchesHostWithAdditionalDomain(siteConfig, host)) ||
                 getSiteConfigs().find((siteConfig) => matchesHostWithPattern(siteConfig, host));
             if (redirectSiteConfig) {
-                return NextResponse.redirect(redirectSiteConfig.url + request.nextUrl.pathname + request.nextUrl.search, { status: 301 });
+                return NextResponse.redirect(`https://${redirectSiteConfig.domains.main}${request.nextUrl.pathname}${request.nextUrl.search}`, {
+                    status: 301,
+                });
             }
 
             return NextResponse.json({ error: `Cannot resolve domain: ${host}` }, { status: 404 });


### PR DESCRIPTION
The current behaviour is that [getSiteConfigForHost() returns only the siteConfig if the exact domain](https://github.com/vivid-planet/comet/blob/main/demo/site/src/util/siteConfig.ts#L23) is passed. If not, a redirect occurs, as if a preliminary domain is set, [it will be used as redirect target](https://github.com/vivid-planet/comet/blob/main/packages/cli/src/commands/site-configs.ts#L42).

This PR makes that the redirect always occurs to the main host. The preliminary host however is still used for the preview in the Admin.