### PR TITLE
POC: Generic way of making Grid rows editable

### DIFF
--- a/storybook/src/admin/data-grid/ClickableRows.stories.tsx
+++ b/storybook/src/admin/data-grid/ClickableRows.stories.tsx
@@ -1,46 +1,24 @@
-import { type GridColDef, StackLink, StackPage, StackSwitch, Toolbar, ToolbarBackButton, ToolbarTitleItem, useStackSwitchApi } from "@comet/admin";
-import { Edit } from "@comet/admin-icons";
-import { IconButton } from "@mui/material";
+import { type GridColDef, StackPage, StackSwitch, Toolbar, ToolbarBackButton, ToolbarTitleItem } from "@comet/admin";
 import { DataGrid } from "@mui/x-data-grid";
+import { type StoryObj } from "@storybook/react-webpack5";
+import { expect, within } from "storybook/test";
 
 import { exampleColumns, exampleRows } from "../../helpers/ExampleDataGrid";
 import { stackRouteDecorator } from "../../helpers/storyDecorators";
 import { storyRouterDecorator } from "../../story-router.decorator";
+import { useEditGridRow } from "./utils/useEditGridRow";
 
 export default {
-    title: "@comet/admin/data-grid",
+    title: "@comet/admin/data-grid/Clickable Rows",
     decorators: [stackRouteDecorator(), storyRouterDecorator()],
 };
 
-export const ClickableRows = () => {
+export const Story = () => {
     // Grid must be a separate component to make sure the stackSwitchApi context is correct
     const Grid = () => {
-        const stackSwitchApi = useStackSwitchApi();
-
-        const columns: GridColDef[] = [
-            ...exampleColumns,
-            {
-                field: "actions",
-                type: "actions",
-                headerName: "",
-                width: 52,
-                renderCell: (params) => (
-                    <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
-                        <Edit />
-                    </IconButton>
-                ),
-            },
-        ];
-
-        return (
-            <DataGrid
-                rows={exampleRows}
-                columns={columns}
-                onRowClick={(params) => {
-                    stackSwitchApi.activatePage("edit", params.row.id);
-                }}
-            />
-        );
+        const { handleDataGridRowClick, actionsCell } = useEditGridRow();
+        const columns: GridColDef[] = [...exampleColumns, actionsCell];
+        return <DataGrid rows={exampleRows} columns={columns} onRowClick={handleDataGridRowClick} />;
     };
 
     return (
@@ -49,15 +27,60 @@ export const ClickableRows = () => {
                 <Grid />
             </StackPage>
             <StackPage name="edit">
-                {(id) => (
-                    <Toolbar>
-                        <ToolbarBackButton />
-                        <ToolbarTitleItem>
-                            Editing item with id: <code>{id}</code>
-                        </ToolbarTitleItem>
-                    </Toolbar>
-                )}
+                {(id) => {
+                    const row = exampleRows.find((row) => row.id.toString() === id);
+                    if (!row) return null;
+
+                    return (
+                        <Toolbar>
+                            <ToolbarBackButton />
+                            <ToolbarTitleItem>
+                                Editing {row.firstName} {row.lastName} (ID: {id})
+                            </ToolbarTitleItem>
+                        </Toolbar>
+                    );
+                }}
             </StackPage>
         </StackSwitch>
     );
+};
+
+export const TestClickingEditButton: StoryObj<typeof Story> = {
+    render: Story,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Click on edit button", async () => {
+            const gridRowsContainer = canvas.getByRole("rowgroup");
+            const firstRow = within(gridRowsContainer).getAllByRole("row")[0];
+            const firstCell = within(firstRow).getAllByRole("gridcell")[0];
+            const firstName = firstCell.textContent;
+
+            const editButton = within(firstRow).getByLabelText(/edit/i);
+            await userEvent.click(editButton);
+
+            const editText = await within(document.body).findByText(new RegExp(`Editing ${firstName}`));
+
+            expect(editText).toBeInTheDocument();
+            expect(firstCell).not.toBeInTheDocument();
+            expect(editButton).not.toBeInTheDocument();
+        });
+    },
+};
+
+export const TestClickingRow: StoryObj<typeof Story> = {
+    render: Story,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Click on row (first cell)", async () => {
+            const gridRowsContainer = canvas.getByRole("rowgroup");
+            const firstRow = within(gridRowsContainer).getAllByRole("row")[0];
+            const firstCell = within(firstRow).getAllByRole("gridcell")[0];
+            const firstName = firstCell.textContent;
+
+            await userEvent.click(firstCell);
+
+            const editText = await within(document.body).findByText(new RegExp(`Editing ${firstName}`));
+
+            expect(editText).toBeInTheDocument();
+            expect(firstCell).not.toBeInTheDocument();
+        });
+    },
 };

--- a/storybook/src/admin/data-grid/ClickableRowsWithInteractiveCells.stories.tsx
+++ b/storybook/src/admin/data-grid/ClickableRowsWithInteractiveCells.stories.tsx
@@ -1,0 +1,250 @@
+import { type GridColDef, StackPage, StackSwitch, Toolbar, ToolbarBackButton, ToolbarTitleItem } from "@comet/admin";
+import { Favorite } from "@comet/admin-icons";
+import { IconButton, InputBase } from "@mui/material";
+import { DataGrid } from "@mui/x-data-grid";
+import { type StoryObj } from "@storybook/react-webpack5";
+import { expect, waitFor, within } from "storybook/test";
+
+import { exampleColumns, exampleRows } from "../../helpers/ExampleDataGrid";
+import { stackRouteDecorator } from "../../helpers/storyDecorators";
+import { storyRouterDecorator } from "../../story-router.decorator";
+import { DummyTextInContentOverflow } from "./utils/DummyTextInContentOverflow";
+import { DummyVisibilitySelect } from "./utils/DummyVisibilitySelect";
+import { useEditGridRow } from "./utils/useEditGridRow";
+
+export default {
+    title: "@comet/admin/data-grid/Clickable Rows With Interactive Cells",
+    decorators: [stackRouteDecorator(), storyRouterDecorator()],
+};
+
+export const Story = () => {
+    // Grid must be a separate component to make sure the stackSwitchApi context is correct
+    const Grid = () => {
+        const { handleDataGridRowClick, EditIconButton } = useEditGridRow();
+
+        const columns: GridColDef[] = [
+            ...exampleColumns,
+            {
+                field: "input",
+                type: "actions",
+                headerName: "Input",
+                renderCell: () => <InputBase aria-label="Text Input" />,
+                flex: 1,
+            },
+            {
+                field: "description",
+                type: "actions",
+                headerName: "Description",
+                renderCell: () => <DummyTextInContentOverflow />,
+                flex: 2,
+            },
+            {
+                field: "visible",
+                type: "actions",
+                headerName: "Visible",
+                width: 120,
+                renderCell: () => <DummyVisibilitySelect />,
+            },
+            {
+                field: "actions",
+                type: "actions",
+                headerName: "",
+                width: 84,
+                renderCell: (params) => (
+                    <>
+                        <IconButton color="secondary" aria-label="Add to favorites">
+                            <Favorite />
+                        </IconButton>
+                        <EditIconButton id={params.row.id} />
+                    </>
+                ),
+            },
+        ];
+        return <DataGrid checkboxSelection rows={exampleRows} columns={columns} onRowClick={handleDataGridRowClick} />;
+    };
+
+    return (
+        <StackSwitch>
+            <StackPage name="grid">
+                <Grid />
+            </StackPage>
+            <StackPage name="edit">
+                {(id) => {
+                    const row = exampleRows.find((row) => row.id.toString() === id);
+                    if (!row) return null;
+
+                    return (
+                        <Toolbar>
+                            <ToolbarBackButton />
+                            <ToolbarTitleItem>
+                                Editing {row.firstName} {row.lastName} (ID: {id})
+                            </ToolbarTitleItem>
+                        </Toolbar>
+                    );
+                }}
+            </StackPage>
+        </StackSwitch>
+    );
+};
+
+export const TestClickingEditButton: StoryObj<typeof Story> = {
+    render: Story,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Click on edit button", async () => {
+            const gridRowsContainer = canvas.getByRole("rowgroup");
+            const firstRow = within(gridRowsContainer).getAllByRole("row")[0];
+            const firstNameCell = within(firstRow).getAllByRole("gridcell")[1];
+            const firstName = firstNameCell.textContent;
+
+            const editButton = within(firstRow).getByLabelText(/edit/i);
+            await userEvent.click(editButton);
+
+            const toolbarEditText = await within(document.body).findByText(new RegExp(`Editing ${firstName}`));
+
+            expect(toolbarEditText).toBeInTheDocument();
+            expect(firstNameCell).not.toBeInTheDocument();
+            expect(editButton).not.toBeInTheDocument();
+        });
+    },
+};
+
+export const TestClickingRow: StoryObj<typeof Story> = {
+    render: Story,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Click on row (first cell)", async () => {
+            const gridRowsContainer = canvas.getByRole("rowgroup");
+            const firstRow = within(gridRowsContainer).getAllByRole("row")[0];
+            const firstNameCell = within(firstRow).getAllByRole("gridcell")[1];
+            const firstName = firstNameCell.textContent;
+
+            await userEvent.click(firstNameCell);
+
+            const toolbarEditText = await within(document.body).findByText(new RegExp(`Editing ${firstName}`));
+
+            expect(toolbarEditText).toBeInTheDocument();
+            expect(firstNameCell).not.toBeInTheDocument();
+        });
+    },
+};
+
+export const TestClickingCheckbox: StoryObj<typeof Story> = {
+    render: Story,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Click on checkbox", async () => {
+            const gridRowsContainer = canvas.getByRole("rowgroup");
+            const firstRow = within(gridRowsContainer).getAllByRole("row")[0];
+
+            const inputTypeCheckbox = within(firstRow).getByRole("checkbox");
+            await userEvent.click(inputTypeCheckbox);
+
+            expect(firstRow).toBeInTheDocument();
+            expect(inputTypeCheckbox).toBeChecked();
+
+            const toolbarEditText = within(document.body).queryByText(new RegExp(`Editing`));
+            expect(toolbarEditText).toBeNull();
+        });
+    },
+};
+
+export const TestClickingFavoriteButton: StoryObj<typeof Story> = {
+    render: Story,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Click on favorite button", async () => {
+            const gridRowsContainer = canvas.getByRole("rowgroup");
+            const firstRow = within(gridRowsContainer).getAllByRole("row")[0];
+
+            const favoriteButton = within(firstRow).getByLabelText(/add to favorites/i);
+            await userEvent.click(favoriteButton);
+
+            expect(firstRow).toBeInTheDocument();
+
+            const toolbarEditText = within(document.body).queryByText(new RegExp(`Editing`));
+            expect(toolbarEditText).toBeNull();
+        });
+    },
+};
+
+export const TestSettingInvisible: StoryObj<typeof Story> = {
+    render: Story,
+    play: async ({ canvas, userEvent, step }) => {
+        const gridRowsContainer = canvas.getByRole("rowgroup");
+        const firstRow = within(gridRowsContainer).getAllByRole("row")[0];
+        const selectVisibilityButton = within(firstRow).getByLabelText(/select visibility/i);
+
+        await step("Open visibility menu", async () => {
+            await userEvent.click(selectVisibilityButton);
+
+            expect(firstRow).toBeInTheDocument();
+            const toolbarEditText = within(document.body).queryByText(new RegExp(`Editing`));
+            expect(toolbarEditText).toBeNull();
+        });
+        await step("Click on invisible option", async () => {
+            const menu = await waitFor(() => within(document.body).getByRole("menu"), { timeout: 4000 });
+            const invisibleOption = within(menu).getByText(/invisible/i);
+            await userEvent.click(invisibleOption);
+
+            expect(firstRow).toBeInTheDocument();
+            expect(selectVisibilityButton).toHaveTextContent(/invisible/i);
+            const toolbarEditText = within(document.body).queryByText(new RegExp(`Editing`));
+            expect(toolbarEditText).toBeNull();
+        });
+    },
+};
+
+export const TestOpeningContentOverflow: StoryObj<typeof Story> = {
+    render: Story,
+    play: async ({ canvas, userEvent, step }) => {
+        const startTextOfContentOverflow = "Ornare Inceptos Egestas Bibendum";
+
+        await step("Open visibility menu", async () => {
+            const gridRowsContainer = canvas.getByRole("rowgroup");
+            const firstRow = within(gridRowsContainer).getAllByRole("row")[0];
+
+            const buttonsInRow = within(firstRow).getAllByRole("button");
+            const descriptionButton = buttonsInRow.find((button) => button.textContent?.includes(startTextOfContentOverflow));
+
+            if (!descriptionButton) {
+                throw new Error("Description button not found in row");
+            }
+
+            await userEvent.click(descriptionButton);
+
+            expect(firstRow).toBeInTheDocument();
+            const toolbarEditText = within(document.body).queryByText(new RegExp(`Editing`));
+            expect(toolbarEditText).toBeNull();
+
+            const dialog = await waitFor(() => within(document.body).getByRole("dialog"), { timeout: 4000 });
+            expect(dialog).toBeInTheDocument();
+
+            const dialogTitleText = within(dialog).queryByText(new RegExp(`${startTextOfContentOverflow}`));
+            expect(dialogTitleText).toBeInTheDocument();
+        });
+    },
+};
+
+export const TestInteractingWithInput: StoryObj<typeof Story> = {
+    render: Story,
+    play: async ({ canvas, userEvent, step }) => {
+        const gridRowsContainer = canvas.getByRole("rowgroup");
+        const firstRow = within(gridRowsContainer).getAllByRole("row")[0];
+        const inputWrapper = within(firstRow).getByLabelText(/text input/i);
+        const input = within(inputWrapper).getByRole("textbox");
+
+        await step("Click on input", async () => {
+            await userEvent.click(inputWrapper);
+            expect(input).toHaveFocus();
+            expect(firstRow).toBeInTheDocument();
+
+            const toolbarEditText = within(document.body).queryByText(new RegExp(`Editing`));
+            expect(toolbarEditText).toBeNull();
+        });
+        await step("Type in input", async () => {
+            await userEvent.type(input, "Hello");
+            expect(input).toHaveValue("Hello");
+            expect(firstRow).toBeInTheDocument();
+
+            const toolbarEditText = within(document.body).queryByText(new RegExp(`Editing`));
+            expect(toolbarEditText).toBeNull();
+        });
+    },
+};

--- a/storybook/src/admin/data-grid/utils/DummyTextInContentOverflow.tsx
+++ b/storybook/src/admin/data-grid/utils/DummyTextInContentOverflow.tsx
@@ -1,0 +1,19 @@
+import { ContentOverflow } from "@comet/admin";
+import { Typography } from "@mui/material";
+
+export const DummyTextInContentOverflow = () => {
+    const paragraphsCount = 5;
+    return (
+        <ContentOverflow>
+            <Typography fontWeight={600} gutterBottom>
+                Ornare Inceptos Egestas Bibendum
+            </Typography>
+            {Array.from({ length: paragraphsCount }).map((_, index) => (
+                <Typography key={index} variant="body2" gutterBottom={index !== paragraphsCount - 1}>
+                    Curabitur blandit tempus porttitor. Nullam id dolor id nibh ultricies vehicula ut id elit. Cras mattis consectetur purus sit amet
+                    fermentum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+                </Typography>
+            ))}
+        </ContentOverflow>
+    );
+};

--- a/storybook/src/admin/data-grid/utils/DummyVisibilitySelect.tsx
+++ b/storybook/src/admin/data-grid/utils/DummyVisibilitySelect.tsx
@@ -1,0 +1,40 @@
+import { ChevronDown, Invisible, Visible } from "@comet/admin-icons";
+import { Chip, ListItemIcon, ListItemText, Menu, MenuItem } from "@mui/material";
+import { useState } from "react";
+
+export const DummyVisibilitySelect = () => {
+    const [anchorEl, setAnchorEl] = useState<Element | null>(null);
+    const [visible, setVisible] = useState(true);
+
+    const handleMenuItemClick = (visible: boolean) => {
+        setVisible(visible);
+        setAnchorEl(null);
+    };
+
+    return (
+        <>
+            <Chip
+                component="button"
+                aria-label="Select visibility"
+                color={visible ? "success" : "default"}
+                icon={<ChevronDown />}
+                label={visible ? "Visible" : "Invisible"}
+                onClick={(event) => setAnchorEl(event.currentTarget)}
+            />
+            <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
+                <MenuItem onClick={() => handleMenuItemClick(true)}>
+                    <ListItemIcon>
+                        <Visible />
+                    </ListItemIcon>
+                    <ListItemText primary="Visible" />
+                </MenuItem>
+                <MenuItem onClick={() => handleMenuItemClick(false)}>
+                    <ListItemIcon>
+                        <Invisible />
+                    </ListItemIcon>
+                    <ListItemText primary="Invisible" />
+                </MenuItem>
+            </Menu>
+        </>
+    );
+};

--- a/storybook/src/admin/data-grid/utils/useEditGridRow.tsx
+++ b/storybook/src/admin/data-grid/utils/useEditGridRow.tsx
@@ -1,0 +1,49 @@
+import { type GridColDef, StackLink, useStackSwitchApi } from "@comet/admin";
+import { Edit } from "@comet/admin-icons";
+import { IconButton, type IconButtonProps } from "@mui/material";
+import { type GridEventListener, type GridRowId } from "@mui/x-data-grid";
+import { type FC } from "react";
+
+type EditIconButton = FC<{ id: GridRowId } & IconButtonProps>;
+
+type UseEditGridRowReturn = {
+    handleDataGridRowClick: GridEventListener<"rowClick">;
+    EditIconButton: EditIconButton;
+    actionsCell: GridColDef;
+};
+
+export const useEditGridRow = (): UseEditGridRowReturn => {
+    const stackSwitchApi = useStackSwitchApi();
+
+    const handleDataGridRowClick: GridEventListener<"rowClick"> = (params, event) => {
+        const shouldOpenLinkInNewTab = event.ctrlKey || event.metaKey;
+
+        if (shouldOpenLinkInNewTab) {
+            const url = stackSwitchApi.getTargetUrl("edit", params.row.id);
+            window.open(url, "_blank");
+            return;
+        }
+
+        stackSwitchApi.activatePage("edit", params.row.id);
+    };
+
+    const EditIconButton: EditIconButton = ({ id, children = <Edit />, ...restIconButtonProps }) => (
+        <IconButton color="primary" component={StackLink} pageName="edit" payload={id.toString()} aria-label="Edit" {...restIconButtonProps}>
+            {children}
+        </IconButton>
+    );
+
+    const actionsCell: GridColDef = {
+        field: "actions",
+        type: "actions",
+        headerName: "",
+        width: 52,
+        renderCell: (params) => <EditIconButton id={params.row.id} />,
+    };
+
+    return {
+        handleDataGridRowClick,
+        EditIconButton,
+        actionsCell,
+    };
+};


### PR DESCRIPTION
## TLDR

Allow editing rows of a DataGrid by clicking on the row directly, in addition to the edit button. 
Add tests to make sure clicking in interactive cells does not trigger the edit-action. 

## This adds a new hook `useEditGridRow`

The hook returns the following:

- `handleDataGridRowClick`: the function to be passed to `onRowClick` of the DataGrid to allow editing the row by clicking anywhere in the row.
- `EditIconButton`: The IconButton that should be rendered in the `actions` cell, which is used to edit the row. This should be used when other, additional actions should be rendered inside the actions cell. 
- `actionsCell` the full actions-cell that includes the `EditIconButton`, this should be used when the actions-cell should include only the edit button. 

## `onRowClick` and `EditIconButton` intentionally do not share a function

The IconButton uses `StackLink` to render an actual link (`<a href="..." />`), which is preferred due to it's default accessibility behavior, e.g. using `cmd+click`/`ctrl+click` or the system context-menu to open the link in a new tab.

DataGrid does not support an actual link for it's row-click, therefore we must use a function here. 
This function manually adds support for `cmd+click`/`ctrl+click` to open the link in a new tab, as this is likely a common use-case. Other accessibility-features of link are not supported when clicking the row. 

## Interactive elements within a cell

If the `onRowClick` prop is set, clicking anywhere within a cell will trigger this function.

- This correctly includes static elements like text-content.
- This incorrectly includes interactive elements such as buttons, selects, inputs. 

To avoid this, we manually set `type: "actions"` on every interactive cell, the same as we already do in the cell that includes "edit" and other icon-buttons. 

## Negatives of using `type: "actions"`

- Needs to be set on every interactive column manually
- Could break existing, generated grids: Custom, interactive columns won't include `type: "actions"`, will therefore trigger the function instead of allowing the interaction
  - We could set `type: "actions"` on all custom columns by default, as they will likely often be interactive anyway. 
  - We could omit `onRowClick` on generated grids, if they include custom columns (at least until V9)
- Columns with `type: "actions"` will not be sortable or filterable by default
  - Columns would additionally require `sortable: true` and `filterable: true`
  - This might be the desired behavior for many interactive columns
  - It may be an issue that you can't do things by default such as sort by `visible` or filter by `description`
- Would require adjusting the text-alignment of the cell and header-cell

## Alternative to `type: "actions"`

We could wrap the content of each `renderCell` with an element that does `event.stopPropagation()` when clicked. 
We could also possibly abstract this away by adding an `interactive: true` flag to `GridColDef`. 

- Requires using the wrapper-component or setting `interactive: true` on every interactive column
- Will not solve the above mentioned issue about breaking generated grids
- Will allow filtering/sorting by default
- Causes no text-alignment issue in the cell and header-cell
- Triggers `onRowClick` when clicking within the cell but not on the interactive part, e.g. 1px next to the `visible` select

```tsx
const InteractiveCellWrapper = ({ children }: { children: React.ReactNode }) => {
    return (
        <Box sx={{ display: "contents" }} onClick={(event) => event.stopPropagation()}>
            {children}
        </Box>
    );
};

const columns: GridColDef[] = [
    {
        field: "interactiveValue",
        renderCell: () => (
            <InteractiveCellWrapper>
                <SomeInteractiveElement />
            </InteractiveCellWrapper>
        ),
    },
    // ...
```

## Screenshots/screencasts

https://github.com/user-attachments/assets/4d0736d5-24d6-4047-b130-1d46d78fc912

https://github.com/user-attachments/assets/6f5669d7-b444-43fc-9ba3-8343eb843edc

## Open TODOs

-   [x] Merge parent and rebase #4933
-   [ ] If we decide to go with this method: Create tasks for the follow-up tasks

## Questions

-   [ ] Do we want `useEditGridRow` in `@comet/admin`?
-   [ ] Decide on `type: "actions"` vs. `InteractiveCellWrapper` vs. `interactive: true` flag

## Follow-up tasks

- Export `useEditGridRow` from `@comet/admin` and use it in these stories
- Document the usage, mentioning the necessary settings for interactive cells
- Use `useEditGridRow` in Admin-Generator in a way that won't break custom interactive cells (maybe set `type: "actions"` by default on all custom cells)

If we go with `type: "actions"`:

- Fix the text-alignment of the cell and header-cell when using `type: "actions"`

If we go with `InteractiveCellWrapper` or `interactive: true`:

- Implement this in `@comet/admin`


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2618
