### PR TITLE
Replace dot navigation in media gallery

### DIFF
--- a/demo/site/src/common/blocks/MediaGalleryBlock.module.scss
+++ b/demo/site/src/common/blocks/MediaGalleryBlock.module.scss
@@ -32,44 +32,6 @@
 }
 
 .swiper {
-    :global(.swiper-pagination) {
-        width: auto;
-        position: absolute;
-        bottom: 35px;
-        left: 0;
-        gap: var(--spacing-s400);
-
-        @media (min-width: $breakpoint-sm) {
-            bottom: var(--spacing-s100);
-            left: auto;
-            right: 0;
-        }
-
-        :global(.swiper-pagination-bullet) {
-            color: var(--media-gallery-dot-navigation-default);
-            margin-right: var(--spacing-s400);
-            margin-left: 0;
-
-            &:hover {
-                background-color: var(--media-gallery-dot-navigation-hover);
-            }
-
-            @media (min-width: $breakpoint-sm) {
-                bottom: var(--spacing-s100);
-                margin-left: var(--spacing-s400);
-                margin-right: 0;
-            }
-        }
-
-        :global(.swiper-pagination-bullet-active) {
-            background-color: var(--media-gallery-dot-navigation-active);
-
-            &:hover {
-                background-color: var(--media-gallery-dot-navigation-active-hover);
-            }
-        }
-    }
-
     .mediaCaption {
         opacity: 0;
         transition: opacity 0.3s linear 0s;
@@ -142,5 +104,17 @@
         &--next {
             right: -48px;
         }
+    }
+}
+
+.customPagination {
+    position: absolute;
+    bottom: 35px;
+    left: 0;
+
+    @media (min-width: $breakpoint-sm) {
+        bottom: var(--spacing-s100);
+        left: auto;
+        right: 0;
     }
 }

--- a/demo/site/src/common/blocks/MediaGalleryBlock.tsx
+++ b/demo/site/src/common/blocks/MediaGalleryBlock.tsx
@@ -76,7 +76,7 @@ export const MediaGalleryBlock = withPreview(
                         </SwiperSlide>
                     ))}
                 </BasicSwiper>
-                <Typography variant="paragraph300">
+                <Typography variant="paragraph300" className={styles.customPagination}>
                     {activeItem + 1} of {data.items.blocks.length}
                 </Typography>
                 <button

--- a/demo/site/src/common/blocks/MediaGalleryBlock.tsx
+++ b/demo/site/src/common/blocks/MediaGalleryBlock.tsx
@@ -76,7 +76,7 @@ export const MediaGalleryBlock = withPreview(
                         </SwiperSlide>
                     ))}
                 </BasicSwiper>
-                <Typography variant="paragraph300" className={styles.customPagination}>
+                <Typography variant="paragraph300" className={styles.customPagination} role="status" aria-live="polite" aria-atomic="true">
                     {activeItem + 1} of {data.items.blocks.length}
                 </Typography>
                 <button

--- a/demo/site/src/common/blocks/MediaGalleryBlock.tsx
+++ b/demo/site/src/common/blocks/MediaGalleryBlock.tsx
@@ -9,7 +9,7 @@ import { PageLayout } from "@src/layout/PageLayout";
 import clsx from "clsx";
 import { useEffect, useRef, useState } from "react";
 import { useIntl } from "react-intl";
-import { Navigation, Pagination } from "swiper/modules";
+import { Navigation } from "swiper/modules";
 import { SwiperSlide } from "swiper/react";
 import { type Swiper as SwiperClass } from "swiper/types";
 
@@ -55,8 +55,7 @@ export const MediaGalleryBlock = withPreview(
                     className={styles.swiper}
                     slidesPerView={1}
                     slidesPerGroup={1}
-                    modules={[Pagination, Navigation]}
-                    pagination={{ clickable: true }}
+                    modules={[Navigation]}
                     navigation={{ prevEl: prevButtonRef.current, nextEl: nextButtonRef.current }}
                     longSwipesRatio={0.1}
                     threshold={3}
@@ -77,6 +76,9 @@ export const MediaGalleryBlock = withPreview(
                         </SwiperSlide>
                     ))}
                 </BasicSwiper>
+                <Typography variant="paragraph300">
+                    {activeItem + 1} of {data.items.blocks.length}
+                </Typography>
                 <button
                     ref={nextButtonRef}
                     className={clsx(styles.navigationButton, styles["navigationButton--next"])}

--- a/demo/site/src/common/blocks/MediaGalleryBlock.tsx
+++ b/demo/site/src/common/blocks/MediaGalleryBlock.tsx
@@ -8,7 +8,7 @@ import { Typography } from "@src/common/components/Typography";
 import { PageLayout } from "@src/layout/PageLayout";
 import clsx from "clsx";
 import { useEffect, useRef, useState } from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { Navigation } from "swiper/modules";
 import { SwiperSlide } from "swiper/react";
 import { type Swiper as SwiperClass } from "swiper/types";
@@ -77,7 +77,11 @@ export const MediaGalleryBlock = withPreview(
                     ))}
                 </BasicSwiper>
                 <Typography variant="paragraph300" className={styles.customPagination} role="status" aria-live="polite" aria-atomic="true">
-                    {activeItem + 1} of {data.items.blocks.length}
+                    <FormattedMessage
+                        id="mediaGalleryBlock.pagination"
+                        defaultMessage="{current} of {total}"
+                        values={{ current: activeItem + 1, total: data.items.blocks.length }}
+                    />
                 </Typography>
                 <button
                     ref={nextButtonRef}


### PR DESCRIPTION
## Description

Instead of displaying the native swiper pagination using bullet points, the current page number out of the total number of pages should be used (e.g. 1 of 12).

- Remove pagination module and its styling
- Add and style page numbers instead according to design
- Add aria attributes for screen readers


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Desktop:
<img width="1183" height="621" alt="Screenshot 2026-01-12 at 17 02 45" src="https://github.com/user-attachments/assets/45d4e385-a482-4874-8535-5d7fac12441c" />


Mobile: 
<img width="446" height="884" alt="Screenshot 2026-01-12 at 17 03 05" src="https://github.com/user-attachments/assets/dfa1aadc-ab43-40e2-ba82-52902413bf01" />


## Open TODOs/questions

-   [x] Add changeset

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2734
