### PR TITLE
Demo Admin: Use ADMIN_PORT variable consistently

### DIFF
--- a/demo/admin/server/index.js
+++ b/demo/admin/server/index.js
@@ -6,7 +6,7 @@ const fs = require("fs");
 const { createProxyMiddleware } = require("http-proxy-middleware");
 
 const app = express();
-const port = process.env.APP_PORT ?? 3000;
+const port = process.env.ADMIN_PORT ?? 3000;
 const host = process.env.SERVER_HOST ?? "localhost";
 
 let indexFile = fs.readFileSync("./build/index.html", "utf8");


### PR DESCRIPTION
## Description

This came up while reviewing https://github.com/vivid-planet/comet/pull/5078: We're using API_PORT for the API, SITE_PORT for the site (after #5078 has been merged), so I'd suggest to use ADMIN_PORT instead of APP_PORT for the production Admin server.
