### PR TITLE
cms-api: Upgrade file-type dependency from v16 to v21

### DIFF
--- a/.changeset/upgrade-file-type-v21.md
+++ b/.changeset/upgrade-file-type-v21.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Upgrade `file-type` dependency from v16 to v21

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -50,7 +50,7 @@
         "date-fns": "^4.1.0",
         "exifr": "^7.1.3",
         "fast-xml-parser": "^5.7.1",
-        "file-type": "^16.5.4",
+        "file-type": "^21.3.0",
         "graphql-parse-resolve-info": "^4.14.1",
         "graphql-scalars": "^1.24.2",
         "hasha": "^5.2.2",

--- a/packages/api/cms-api/src/file-utils/files.utils.ts
+++ b/packages/api/cms-api/src/file-utils/files.utils.ts
@@ -1,5 +1,4 @@
 import { XMLParser } from "fast-xml-parser";
-import FileType from "file-type";
 import fs from "fs";
 import { unlink } from "fs/promises";
 import * as mimedb from "mime-db";
@@ -138,7 +137,8 @@ export async function createFileUploadInputFromUrl(url: string): Promise<FileUpl
         fs.copyFileSync(url, tempFile);
     }
 
-    const fileType = await FileType.fromFile(tempFile);
+    const { fileTypeFromFile } = await import("file-type");
+    const fileType = await fileTypeFromFile(tempFile);
     const stats = fs.statSync(tempFile); // TODO don't use sync
     const filenameWithoutExtension = basename(url, extname(url));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2025,8 +2025,8 @@ importers:
         specifier: ^5.7.1
         version: 5.7.1
       file-type:
-        specifier: ^16.5.4
-        version: 16.5.4
+        specifier: ^21.3.0
+        version: 21.3.0
       graphql-parse-resolve-info:
         specifier: ^4.14.1
         version: 4.14.1(graphql@16.13.2)
@@ -12199,10 +12199,6 @@ packages:
     resolution: {integrity: sha512-ZuXAqGePcSPz4JuerOY06Dzzq0hrmQ6VGoXVzGyFI1npeOfBgqGIKKpznfYWRkSLJlXutkqVC5WvGZtkFVhu9Q==}
     engines: {node: '>= 12'}
 
-  file-type@16.5.4:
-    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
-    engines: {node: '>=10'}
-
   file-type@18.7.0:
     resolution: {integrity: sha512-ihHtXRzXEziMrQ56VSgU7wkxh55iNchFkosu7Y9/S+tXHdKyrGjVK0ujbqNnsxzea+78MaLhN6PGmfYSAv1ACw==}
     engines: {node: '>=14.16'}
@@ -15265,10 +15261,6 @@ packages:
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
-  peek-readable@4.1.0:
-    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
-    engines: {node: '>=8'}
-
   peek-readable@5.4.2:
     resolution: {integrity: sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==}
     engines: {node: '>=14.16'}
@@ -17144,10 +17136,6 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
-  strtok3@6.3.0:
-    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
-    engines: {node: '>=10'}
-
   strtok3@7.1.1:
     resolution: {integrity: sha512-mKX8HA/cdBqMKUr0MMZAFssCkIGoZeSCMXgnt79yKxNFguMLVFgRe6wB+fsL0NmoHDbeyZXczy7vEPSoo3rkzg==}
     engines: {node: '>=16'}
@@ -17452,10 +17440,6 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-
-  token-types@4.2.1:
-    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
-    engines: {node: '>=10'}
 
   token-types@5.0.1:
     resolution: {integrity: sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==}
@@ -30799,12 +30783,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  file-type@16.5.4:
-    dependencies:
-      readable-web-to-node-stream: 3.0.2
-      strtok3: 6.3.0
-      token-types: 4.2.1
-
   file-type@18.7.0:
     dependencies:
       readable-web-to-node-stream: 3.0.2
@@ -34783,8 +34761,6 @@ snapshots:
 
   peberminta@0.9.0: {}
 
-  peek-readable@4.1.0: {}
-
   peek-readable@5.4.2: {}
 
   pg-cloudflare@1.2.7:
@@ -37004,11 +36980,6 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
-  strtok3@6.3.0:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      peek-readable: 4.1.0
-
   strtok3@7.1.1:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -37375,11 +37346,6 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
-
-  token-types@4.2.1:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      ieee754: 1.2.1
 
   token-types@5.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

This should resolve three [Dependabot alerts](https://github.com/vivid-planet/comet/security/dependabot?q=is%3Aopen+package%3Afile-type).

- Upgrade `file-type` from `^16.5.4` to `^21` in `@comet/cms-api`
- Use dynamic `import()` since file-type v17+ is ESM-only and the project uses CommonJS
- Update API usage from `FileType.fromFile()` (default export) to `fileTypeFromFile()` (named export)

## Test plan

- [x] Verify file upload from URL works correctly (uses `createFileUploadInputFromUrl` which calls `fileTypeFromFile`)
- [x] Verify file type detection returns correct `ext` and `mime` values

https://claude.ai/code/session_016Dxh9KRgo1UNRdMXPXc2iH