### PR TITLE
Demo API: only include src/ folder in production build

### DIFF
--- a/demo/api/tsconfig.build.json
+++ b/demo/api/tsconfig.build.json
@@ -4,6 +4,6 @@
         "sourceRoot": "/dist"
     },
     "include": ["src"],
-    "exclude": ["**/*.stories.tsx", "**/*.stories.ts", ".storybook"],
+    "exclude": ["**/*.stories.tsx", "**/*.stories.ts"],
     "extends": "./tsconfig.json"
 }

--- a/demo/api/tsconfig.build.json
+++ b/demo/api/tsconfig.build.json
@@ -3,7 +3,7 @@
         "inlineSources": true,
         "sourceRoot": "/dist"
     },
-    "include": ["src"],
     "exclude": ["**/*.stories.tsx", "**/*.stories.ts"],
-    "extends": "./tsconfig.json"
+    "extends": "./tsconfig.json",
+    "include": ["src"]
 }

--- a/demo/api/tsconfig.build.json
+++ b/demo/api/tsconfig.build.json
@@ -3,6 +3,7 @@
         "inlineSources": true,
         "sourceRoot": "/dist"
     },
+    "include": ["src"],
     "exclude": ["**/*.stories.tsx", "**/*.stories.ts", ".storybook"],
     "extends": "./tsconfig.json"
 }


### PR DESCRIPTION
Demo API includes `vitest.config.ts` in the production build, resulting in a nested `src/` folder inside `dist/`. Adding `"include": ["src"]` to the production TSConfig resolves the issue.

https://claude.ai/code/session_01184NrwVkzTMr9oBuvFJEGP