### PR TITLE
Prevent unnecessary Netlify preview deployments

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  command = "cd .. && pnpm install --frozen-lockfile && pnpm build:docs"
+  publish = "build"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- . ../storybook/ ../packages/admin/"

--- a/storybook/netlify.toml
+++ b/storybook/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  command = "cd .. && pnpm install --frozen-lockfile && pnpm build:storybook"
+  publish = "storybook-static"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- . ../packages/admin/"


### PR DESCRIPTION
Configure both Netlify deployments (Storybook, Docs) to only deploy if relevant files change. This should allow us to merge PRs faster.

**Note:** We need to configure Netlify to use the `netlify.toml` files. I'll do this after merging this PR.

https://claude.ai/code/session_011SE3iuKg9Lhn17XD3ifaKz