### PR TITLE
Add Mail-Example for two-column layout

### DIFF
--- a/packages/mail-react/.storybook/preview.ts
+++ b/packages/mail-react/.storybook/preview.ts
@@ -1,5 +1,8 @@
+import { parameters as mailParameters } from "../src/storybook/preview.ts";
+
 export { decorators, initialGlobals } from "../src/storybook/preview.ts";
 
 export const parameters = {
+    ...mailParameters,
     layout: "fullscreen",
 };

--- a/packages/mail-react/src/__stories__/examples/TwoColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/examples/TwoColumnLayout.stories.tsx
@@ -1,0 +1,102 @@
+import { MjmlColumn, MjmlSpacer } from "@faire/mjml-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MjmlSection } from "../../components/section/MjmlSection.js";
+import { MjmlText } from "../../components/text/MjmlText.js";
+import { registerStyles } from "../../styles/registerStyles.js";
+import { createTheme } from "../../theme/createTheme.js";
+import { css } from "../../utils/css.js";
+
+const config: Meta = {
+    title: "Examples/TwoColumnLayout",
+};
+
+export default config;
+
+const theme = createTheme({
+    text: {
+        defaultVariant: "body",
+        variants: {
+            heading: { fontSize: "22px", lineHeight: "28px", fontWeight: "bold" },
+            subheading: { fontSize: "16px", lineHeight: "22px", fontWeight: "bold" },
+            body: { fontSize: "14px", lineHeight: "20px" },
+        },
+    },
+});
+
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.mobile.belowMediaQuery} {
+            .twoColumnsSection__leftColumn > table > tbody > tr > td {
+                padding-right: 0 !important;
+            }
+
+            .twoColumnsSection__rightColumn > table > tbody > tr > td {
+                padding-left: 0 !important;
+            }
+
+            .twoColumnsSection__leftColumn {
+                margin-bottom: 20px;
+            }
+        }
+    `,
+);
+
+export const Default: StoryObj = {
+    parameters: { theme },
+    render: () => {
+        const TwoColumnsSection = () => {
+            const columnGap = 20;
+            const halfGap = columnGap / 2;
+
+            return (
+                <MjmlSection indent className="twoColumnsSection">
+                    <MjmlColumn className="twoColumnsSection__leftColumn" paddingRight={halfGap}>
+                        <MjmlText variant="subheading" bottomSpacing>
+                            Left column
+                        </MjmlText>
+                        <MjmlText>
+                            Minima ea distinctio quisquam. Illo reiciendis non officiis consectetur. Ratione perferendis distinctio sapiente est.
+                            Dolor consequatur qui excepturi natus.
+                        </MjmlText>
+                    </MjmlColumn>
+                    <MjmlColumn className="twoColumnsSection__rightColumn" paddingLeft={halfGap}>
+                        <MjmlText variant="subheading" bottomSpacing>
+                            Right column
+                        </MjmlText>
+                        <MjmlText>
+                            Numquam aut voluptas numquam aspernatur. Consequatur quidem omnis dolorem natus quis soluta. Est recusandae delectus sed
+                            sed deserunt velit quia.
+                        </MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            );
+        };
+
+        return (
+            <>
+                <MjmlSection indent>
+                    <MjmlColumn>
+                        <MjmlSpacer height={30} />
+                        <MjmlText variant="heading" bottomSpacing>
+                            Two column layout
+                        </MjmlText>
+                        <MjmlText>
+                            Two columns with equal widths split evenly by MJML. Each column gets half-gap padding on its inner side to create the 20px
+                            gap. No explicit width calculation is needed.
+                        </MjmlText>
+                        <MjmlSpacer height={30} />
+                    </MjmlColumn>
+                </MjmlSection>
+
+                <TwoColumnsSection />
+
+                <MjmlSection indent>
+                    <MjmlColumn>
+                        <MjmlSpacer height={30} />
+                    </MjmlColumn>
+                </MjmlSection>
+            </>
+        );
+    },
+};

--- a/packages/mail-react/src/storybook/preview.ts
+++ b/packages/mail-react/src/storybook/preview.ts
@@ -5,3 +5,26 @@ export const decorators = [MailRendererDecorator];
 export const initialGlobals = {
     usePublicImageUrls: false,
 };
+
+export const parameters = {
+    viewport: {
+        options: {
+            mobile: {
+                name: "Mobile (375px)",
+                styles: { width: "375px", height: "1024px" },
+            },
+            tablet: {
+                name: "Tablet (500px)",
+                styles: { width: "500px", height: "1024px" },
+            },
+            emailWidth: {
+                name: "Email max-width (600px)",
+                styles: { width: "600px", height: "1024px" },
+            },
+            desktop: {
+                name: "Desktop (768px)",
+                styles: { width: "768px", height: "1024px" },
+            },
+        },
+    },
+};


### PR DESCRIPTION
Also define more mail-specific viewport options for Storybook. 

| Desktop | Tablet | Mobile |
|--------|--------|--------|
| <img width="768" height="462" alt="Screenshot 2026-04-07 at 15 38 27" src="https://github.com/user-attachments/assets/cb3028e6-18de-469f-946b-79c0360ad693" /> | <img width="500" height="462" alt="Screenshot 2026-04-07 at 15 38 37" src="https://github.com/user-attachments/assets/c6b9dac6-c7dd-484e-85ea-b59ad165f384" /> | <img width="375" height="502" alt="Screenshot 2026-04-07 at 15 38 51" src="https://github.com/user-attachments/assets/7c2a2096-7b13-4f9f-ad82-8fce7fefc306" /> |

--- 

Will consider updating docs/skill with this information in a [follow-up task](https://vivid-planet.atlassian.net/browse/PHSB2C-11760).
Task: https://vivid-planet.atlassian.net/browse/PHSB2C-11720