### PR TITLE
admin: Fix end adornment wrapping below chips in multi-select AutocompleteField

### DIFF
--- a/.changeset/fix-autocomplete-clear-button-wrapping.md
+++ b/.changeset/fix-autocomplete-clear-button-wrapping.md
@@ -7,3 +7,4 @@ Fix end adornment layout in multi-select `AutocompleteField`
 Previously, the clear button could wrap below the chips and fall outside the visible field area in narrow containers.
 Now the end adornment (loading indicator, clear button, error icon, popup icon) is pinned to the top right corner of the field and the input reserves exactly the required space for the currently visible adornments, so chips can never overlap it.
 Additionally, the clear button is no longer shown for an empty multi-select, and clearing a multi-select now resets the value to an empty array instead of an empty string.
+The dropdown now opens when the input receives focus (`openOnFocus`), so clicking anywhere into the field – including next to the icons – opens it.

--- a/.changeset/fix-autocomplete-clear-button-wrapping.md
+++ b/.changeset/fix-autocomplete-clear-button-wrapping.md
@@ -1,0 +1,9 @@
+---
+"@comet/admin": patch
+---
+
+Fix end adornment layout in multi-select `AutocompleteField`
+
+Previously, the clear button could wrap below the chips and fall outside the visible field area in narrow containers.
+Now the end adornment (loading indicator, clear button, error icon, popup icon) is pinned to the top right corner of the field and the input reserves exactly the required space for the currently visible adornments, so chips can never overlap it.
+Additionally, the clear button is no longer shown for an empty multi-select, and clearing a multi-select now resets the value to an empty array instead of an empty string.

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, Error } from "@comet/admin-icons";
 import {
     Autocomplete,
+    autocompleteClasses,
     type AutocompleteProps,
     type AutocompleteRenderInputParams,
     CircularProgress,
@@ -8,12 +9,57 @@ import {
     InputBase,
     Typography,
 } from "@mui/material";
-import type { ReactNode } from "react";
+import { css, styled } from "@mui/material/styles";
+import { type ReactNode, useCallback, useRef, useState } from "react";
 import type { FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
 import { ClearInputAdornment } from "../common/ClearInputAdornment";
 import type { AsyncAutocompleteOptionsProps } from "./useAsyncAutocompleteOptionsProps";
+
+// In multi-select mode the chips and the input wrap onto multiple lines. The end adornment must never wrap below
+// the chips, so it is removed from the flex flow (`MultipleEndAdornmentContainer` is absolutely positioned) and its
+// measured width is reserved as padding instead, so the chips never render underneath it.
+const MultipleInputBase = styled(InputBase, {
+    shouldForwardProp: (prop) => prop !== "endAdornmentWidth",
+})<{ endAdornmentWidth: number }>(
+    ({ endAdornmentWidth }) => css`
+        /* Quadruple specificity to override the "hasPopupIcon" padding-right from the MuiAutocomplete theme
+           (three classes: hash + root + inputRoot). */
+        &&&& {
+            position: relative;
+            flex-wrap: wrap;
+            padding-right: ${endAdornmentWidth}px;
+        }
+    `,
+);
+
+const MultipleEndAdornmentContainer = styled("div")(
+    ({ theme }) => css`
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        display: flex;
+        align-items: center;
+        padding-left: ${theme.spacing(1)};
+        padding-right: ${theme.spacing(2)};
+        /* Clicks next to the icons must fall through to the input root, where MUI Autocomplete handles them by
+           focusing the input and opening the dropdown. */
+        pointer-events: none;
+
+        & > * {
+            pointer-events: auto;
+        }
+
+        .${autocompleteClasses.endAdornment} {
+            /* Reset MUI's absolute positioning (relative to the input root) so the popup icon stays in the
+               container's flex flow next to the other adornments. */
+            position: static;
+            transform: none;
+        }
+    `,
+);
 
 export type FinalFormAutocompleteProps<
     T extends Record<string, any>,
@@ -55,7 +101,25 @@ export const FinalFormAutocomplete = <
     ...rest
 }: FinalFormAutocompleteProps<T, Multiple, DisableClearable, FreeSolo> & FinalFormAutocompleteInternalProps<T>) => {
     const value = multiple ? (Array.isArray(incomingValue) ? incomingValue : []) : incomingValue;
+    const hasValue = Array.isArray(value) ? value.length > 0 : Boolean(value);
     const clearable = !required && !disabled && !readOnly;
+
+    const [endAdornmentWidth, setEndAdornmentWidth] = useState(0);
+    const endAdornmentResizeObserver = useRef<ResizeObserver | undefined>(undefined);
+    // The rendered adornments (loading, clear, error, popup icon) change at runtime, e.g. the clear button only
+    // renders once a value is selected, so the reserved width must be measured, not hardcoded.
+    const endAdornmentRef = useCallback((node: HTMLDivElement | null) => {
+        endAdornmentResizeObserver.current?.disconnect();
+        endAdornmentResizeObserver.current = undefined;
+
+        if (node) {
+            setEndAdornmentWidth(node.offsetWidth);
+            endAdornmentResizeObserver.current = new ResizeObserver(() => {
+                setEndAdornmentWidth(node.offsetWidth);
+            });
+            endAdornmentResizeObserver.current.observe(node);
+        }
+    }, []);
 
     return (
         <Autocomplete
@@ -92,23 +156,40 @@ export const FinalFormAutocomplete = <
             disabled={disabled}
             readOnly={readOnly}
             multiple={multiple as Multiple}
-            renderInput={(params: AutocompleteRenderInputParams) => (
-                <InputBase
-                    {...restInput}
-                    {...params}
-                    {...params.InputProps}
-                    // Disable HTML required for multiple select as the input stays empty (values are shown for example as chips) and the input is used for the autocomplete input
-                    required={multiple ? false : required}
-                    endAdornment={
-                        <InputAdornment position="end">
-                            {loading && <CircularProgress color="inherit" size={16} />}
-                            {clearable && value && <ClearInputAdornment position="end" onClick={() => onChange("")} />}
-                            {loadingError && <Error color="error" />}
-                            {params.InputProps.endAdornment}
-                        </InputAdornment>
-                    }
-                />
-            )}
+            renderInput={(params: AutocompleteRenderInputParams) => {
+                const endAdornment = (
+                    <>
+                        {loading && <CircularProgress color="inherit" size={16} />}
+                        {clearable && hasValue && <ClearInputAdornment position="end" onClick={() => onChange(multiple ? [] : "")} />}
+                        {loadingError && <Error color="error" />}
+                        {params.InputProps.endAdornment}
+                    </>
+                );
+
+                if (multiple) {
+                    return (
+                        <MultipleInputBase
+                            {...restInput}
+                            {...params}
+                            {...params.InputProps}
+                            // Disable HTML required for multiple select as the input stays empty (values are shown for example as chips) and the input is used for the autocomplete input
+                            required={false}
+                            endAdornmentWidth={endAdornmentWidth}
+                            endAdornment={<MultipleEndAdornmentContainer ref={endAdornmentRef}>{endAdornment}</MultipleEndAdornmentContainer>}
+                        />
+                    );
+                }
+
+                return (
+                    <InputBase
+                        {...restInput}
+                        {...params}
+                        {...params.InputProps}
+                        required={required}
+                        endAdornment={<InputAdornment position="end">{endAdornment}</InputAdornment>}
+                    />
+                );
+            }}
         />
     );
 };

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -24,11 +24,11 @@ const MultipleInputBase = styled(InputBase, {
     shouldForwardProp: (prop) => prop !== "endAdornmentWidth",
 })<{ endAdornmentWidth: number }>(
     ({ endAdornmentWidth }) => css`
-        /* Quadruple specificity to override the "hasPopupIcon" padding-right from the MuiAutocomplete theme
-           (three classes: hash + root + inputRoot). */
-        &&&& {
-            position: relative;
-            flex-wrap: wrap;
+        /* The second selector overrides the "hasPopupIcon" padding-right from the MuiAutocomplete theme. */
+        .${autocompleteClasses.root}
+            &.${autocompleteClasses.inputRoot},
+            .${autocompleteClasses.root}.${autocompleteClasses.hasPopupIcon}
+            &.${autocompleteClasses.inputRoot} {
             padding-right: ${endAdornmentWidth}px;
         }
     `,
@@ -44,13 +44,6 @@ const MultipleEndAdornmentContainer = styled("div")(
         align-items: center;
         padding-left: ${theme.spacing(1)};
         padding-right: ${theme.spacing(2)};
-        /* Clicks next to the icons must fall through to the input root, where MUI Autocomplete handles them by
-           focusing the input and opening the dropdown. */
-        pointer-events: none;
-
-        & > * {
-            pointer-events: auto;
-        }
 
         .${autocompleteClasses.endAdornment} {
             /* Reset MUI's absolute positioning (relative to the input root) so the popup icon stays in the
@@ -125,6 +118,9 @@ export const FinalFormAutocomplete = <
         <Autocomplete
             popupIcon={popupIcon}
             disableClearable
+            // Opens the dropdown when the (multiple) end adornment container is clicked, which focuses the input
+            // but swallows the click before it reaches the input root.
+            openOnFocus
             noOptionsText={
                 loadingError ? (
                     <Typography variant="body2" component="span">

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -24,7 +24,6 @@ const MultipleInputBase = styled(InputBase, {
     shouldForwardProp: (prop) => prop !== "endAdornmentWidth",
 })<{ endAdornmentWidth: number }>(
     ({ endAdornmentWidth }) => css`
-        /* The second selector overrides the "hasPopupIcon" padding-right from the MuiAutocomplete theme. */
         .${autocompleteClasses.root}
             &.${autocompleteClasses.inputRoot},
             .${autocompleteClasses.root}.${autocompleteClasses.hasPopupIcon}

--- a/packages/admin/admin/src/form/__stories__/AutocompleteFieldMultipleEndAdornment.stories.tsx
+++ b/packages/admin/admin/src/form/__stories__/AutocompleteFieldMultipleEndAdornment.stories.tsx
@@ -1,0 +1,165 @@
+import { Box, Typography } from "@mui/material";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { PropsWithChildren } from "react";
+
+import { FinalForm } from "../../FinalForm";
+import { AutocompleteField } from "../../form/fields/AutocompleteField";
+
+/**
+ * Layout regression test for the end adornment of a multi-select AutocompleteField.
+ *
+ * The clear button and popup icon must stay in the top right corner of the field and must never wrap below the
+ * chips or overlap them – regardless of how many chips are selected and which adornments (loading, clear, error,
+ * popup icon) are rendered. Clicking anywhere into the field must still open the dropdown.
+ * Use the container-width control to test different widths.
+ */
+const config: Meta = {
+    title: "components/form/AutocompleteField/MultipleEndAdornment",
+    argTypes: {
+        containerWidth: {
+            control: { type: "range", min: 200, max: 1000, step: 5 },
+            description: "Container width in px",
+        },
+    },
+    args: {
+        containerWidth: 505,
+    },
+};
+export default config;
+
+interface Option {
+    label: string;
+    value: string;
+}
+
+const longChip: Option = { label: "Supercalifragilisticexpialidocious Chocolate Ice Cream", value: "long" };
+const smallChips: Option[] = [
+    { label: "Chocolate", value: "chocolate" },
+    { label: "Strawberry", value: "strawberry" },
+    { label: "Vanilla", value: "vanilla" },
+];
+const manyChips: Option[] = [
+    { label: "Apple", value: "apple" },
+    { label: "Banana", value: "banana" },
+    { label: "Cherry", value: "cherry" },
+    { label: "Date", value: "date" },
+    { label: "Elderberry", value: "elderberry" },
+    { label: "Fig", value: "fig" },
+    { label: "Grape", value: "grape" },
+    { label: "Honeydew", value: "honeydew" },
+];
+const allOptions: Option[] = [longChip, ...smallChips, ...manyChips];
+
+const Case = ({ label, children }: PropsWithChildren<{ label: string }>) => {
+    return (
+        <Box sx={{ mb: 3 }}>
+            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                {label}
+            </Typography>
+            {children}
+        </Box>
+    );
+};
+
+interface MultiFieldProps {
+    initialValues: Option[];
+    required?: boolean;
+    disabled?: boolean;
+    loading?: boolean;
+    loadingError?: Error | null;
+}
+
+const MultiField = ({ initialValues, required, disabled, loading, loadingError }: MultiFieldProps) => {
+    return (
+        <FinalForm
+            mode="edit"
+            initialValues={{ field: initialValues }}
+            onSubmit={() => {
+                // not handled
+            }}
+        >
+            {() => (
+                <AutocompleteField<Option, true, false, false>
+                    name="field"
+                    multiple
+                    options={allOptions}
+                    getOptionLabel={(option) => option.label}
+                    isOptionEqualToValue={(option, value) => option.value === value.value}
+                    fullWidth
+                    required={required}
+                    disabled={disabled}
+                    loading={loading}
+                    loadingError={loadingError ?? null}
+                />
+            )}
+        </FinalForm>
+    );
+};
+
+const SingleField = ({ initialValue }: { initialValue: Option | null }) => {
+    return (
+        <FinalForm
+            mode="edit"
+            initialValues={{ field: initialValue }}
+            onSubmit={() => {
+                // not handled
+            }}
+        >
+            {() => (
+                <AutocompleteField<Option, false, false, false>
+                    name="field"
+                    options={allOptions}
+                    getOptionLabel={(option) => option.label}
+                    isOptionEqualToValue={(option, value) => option.value === value.value}
+                    fullWidth
+                />
+            )}
+        </FinalForm>
+    );
+};
+
+export const AllCases: StoryObj<{ containerWidth: number }> = {
+    render: ({ containerWidth }) => (
+        <Box sx={{ width: containerWidth, p: 2, border: "1px dashed #ccc" }}>
+            <Typography variant="caption" sx={{ display: "block", mb: 2 }}>
+                Container width: {containerWidth}px
+            </Typography>
+
+            <Case label="Case 1: One long chip">
+                <MultiField initialValues={[longChip]} />
+            </Case>
+
+            <Case label="Case 2: Multiple small chips filling the row">
+                <MultiField initialValues={smallChips} />
+            </Case>
+
+            <Case label="Case 3: Many chips wrapping to several rows">
+                <MultiField initialValues={manyChips} />
+            </Case>
+
+            <Case label="Case 4: Mixed long + short chip">
+                <MultiField initialValues={[longChip, { label: "Vanilla", value: "vanilla" }]} />
+            </Case>
+
+            <Case label="Case 5: Required (no clear button) with long chip">
+                <MultiField initialValues={[longChip]} required />
+            </Case>
+
+            <Case label="Case 6: Empty (no chips)">
+                <MultiField initialValues={[]} />
+            </Case>
+
+            <Case label="Case 7: Disabled with many chips">
+                <MultiField initialValues={manyChips} disabled />
+            </Case>
+
+            <Case label="Case 8: All end-adornment slots populated (loading + error + clear + popup)">
+                <MultiField initialValues={smallChips} loading loadingError={new Error("Failed to load")} />
+            </Case>
+
+            <Case label="Case 9: Single-select with long value">
+                <SingleField initialValue={longChip} />
+            </Case>
+        </Box>
+    ),
+};


### PR DESCRIPTION
## Problem

In narrow containers, the clear button of a multi-select `AutocompleteField` wrapped below the chips and fell outside the visible field area.

Root cause: MUI absolutely positions its own popup icon and reserves `padding-right` on `.MuiAutocomplete-inputRoot` (via the `hasPopupIcon` theme override), but Comet's clear button is a regular flex item in the wrapping input root — so it wraps below the chips. Any hardcoded padding value can't fix this reliably, because the set of end adornments changes at runtime (loading spinner, clear button, error icon, popup icon).

## Solution

- The whole end adornment (loading indicator, clear button, error icon, popup icon) is pinned to the right edge of the field (absolutely positioned, like MUI does natively), so it can never wrap — regardless of how many chips are selected.
- The input root reserves exactly the adornment's **measured** width as `padding-right` (via `ResizeObserver`), so chips never render underneath it and no space is wasted when e.g. the clear button isn't shown. No magic numbers.
- The adornment container uses `pointer-events: none` (re-enabled on the icons), so clicks next to the icons fall through to the input root and still open the dropdown.

Additionally:

- The clear button is no longer shown for an empty multi-select (an empty array is truthy, so it always rendered before).
- Clearing a multi-select now resets the value to `[]` instead of `""`.

## Example

New regression story `components/form/AutocompleteField/MultipleEndAdornment` with 9 cases (long chip, chips filling the row, many rows, required, disabled, empty, loading + error + clear + popup at once, single-select) and a container-width control to test any width.

## Screenshots

| before | after |
|--------|--------|
| <img width="1200" height="811" alt="before" src="https://github.com/user-attachments/assets/901c4c95-b135-4d7d-8005-4cee7cf890dc"/> | <img width="1200" height="811" alt="after" src="https://github.com/user-attachments/assets/acc5f81c-e8bf-458a-8a20-6ce290dc1d70"/> |


<img width="2552" height="2650" alt="Screen Recording 2026-07-14 at 08 30 16" src="https://github.com/user-attachments/assets/b121902a-216f-490b-aef9-9292a9f20714" />
