### PR TITLE
Cache getSiteConfigs and op read calls to avoid redundant execution

### DIFF
--- a/.changeset/cache-site-configs-op-read.md
+++ b/.changeset/cache-site-configs-op-read.md
@@ -1,0 +1,7 @@
+---
+"@comet/cli": patch
+---
+
+Cache `getSiteConfigs` and `op read` calls to avoid redundant execution
+
+When a template contains multiple placeholders for the same environment, `getSiteConfigs(env)` and `op read` were called repeatedly with identical arguments. Both are now cached per invocation so each unique `env` and each unique `op://` URI is resolved only once.

--- a/packages/cli/src/commands/site-configs.ts
+++ b/packages/cli/src/commands/site-configs.ts
@@ -16,6 +16,14 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
         const configFile = `${process.cwd()}/${options.siteConfigFile || "site-configs.ts"}`;
         const getSiteConfigs: (env: string) => BaseSiteConfig[] = (await import(configFile)).default;
 
+        const siteConfigsCache = new Map<string, BaseSiteConfig[]>();
+        const getCachedSiteConfigs = async (env: string): Promise<BaseSiteConfig[]> => {
+            if (!siteConfigsCache.has(env)) {
+                siteConfigsCache.set(env, await getSiteConfigs(env));
+            }
+            return siteConfigsCache.get(env)!;
+        };
+
         console.log(`inject-site-configs: Replace site-configs in ${options.inFile}`);
 
         let str = fs.readFileSync(resolve(process.cwd(), options.inFile)).toString();
@@ -45,7 +53,7 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
         };
         str = str.replace(/"({{ site:\/\/configs\/.*\/.* }})"/g, "'$1'"); // convert to single quotes
         str = await replaceAsync(str, RegExp(`{{ site://configs/(.*)/(.*) }}`, "g"), async (substr, type, env) => {
-            const siteConfigs = await getSiteConfigs(env);
+            const siteConfigs = await getCachedSiteConfigs(env);
             console.log(`inject-site-configs: - ${substr} (${siteConfigs.length} sites)`);
             if (replacerFunctions[type] == undefined) {
                 console.error(`inject-site-configs: ERROR: type must be ${Object.keys(replacerFunctions).join("|")} (got ${type})`);
@@ -61,7 +69,7 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
 
         str = str.replace(/"({{ site:\/\/domains\/.*\/.* }})"/g, "$1"); // remove quotes in array
         str = await replaceAsync(str, /{{ site:\/\/domains\/(site|prelogin)\/(.*) }}/g, async (substr, type, env) => {
-            const siteConfigs = await getSiteConfigs(env);
+            const siteConfigs = await getCachedSiteConfigs(env);
             console.log(`inject-site-domains: - ${substr} (${siteConfigs.length} sites)`);
             if (type === "site") {
                 const filteredSiteConfigs = siteConfigs.filter((d) => !d.preloginEnabled);
@@ -96,11 +104,15 @@ export const resolveOpReferences = (input: string): string => {
         );
     }
 
+    const opCache = new Map<string, string>();
     let result = input;
     for (const ref of opRefs) {
         const opUri = ref.replace("{{ ", "").replace(" }}", "");
         try {
-            const secret = execSync(`op read "${opUri}"`, { encoding: "utf-8" }).trim();
+            if (!opCache.has(opUri)) {
+                opCache.set(opUri, execSync(`op read "${opUri}"`, { encoding: "utf-8" }).trim());
+            }
+            const secret = opCache.get(opUri)!;
             console.log(`inject-site-configs: - Resolved ${ref}`);
             result = result.replace(ref, secret);
         } catch (e) {

--- a/packages/cli/src/commands/site-configs.ts
+++ b/packages/cli/src/commands/site-configs.ts
@@ -18,10 +18,12 @@ export const injectSiteConfigsCommand = new Command("inject-site-configs")
 
         const siteConfigsCache = new Map<string, BaseSiteConfig[]>();
         const getCachedSiteConfigs = async (env: string): Promise<BaseSiteConfig[]> => {
-            if (!siteConfigsCache.has(env)) {
-                siteConfigsCache.set(env, await getSiteConfigs(env));
+            let cached = siteConfigsCache.get(env);
+            if (!cached) {
+                cached = await getSiteConfigs(env);
+                siteConfigsCache.set(env, cached);
             }
-            return siteConfigsCache.get(env)!;
+            return cached;
         };
 
         console.log(`inject-site-configs: Replace site-configs in ${options.inFile}`);
@@ -109,10 +111,11 @@ export const resolveOpReferences = (input: string): string => {
     for (const ref of opRefs) {
         const opUri = ref.replace("{{ ", "").replace(" }}", "");
         try {
-            if (!opCache.has(opUri)) {
-                opCache.set(opUri, execSync(`op read "${opUri}"`, { encoding: "utf-8" }).trim());
+            let secret = opCache.get(opUri);
+            if (!secret) {
+                secret = execSync(`op read "${opUri}"`, { encoding: "utf-8" }).trim();
+                opCache.set(opUri, secret);
             }
-            const secret = opCache.get(opUri)!;
             console.log(`inject-site-configs: - Resolved ${ref}`);
             result = result.replace(ref, secret);
         } catch (e) {


### PR DESCRIPTION
When a template contains multiple placeholders for the same environment, getSiteConfigs(env) and op read were called repeatedly with identical arguments. This adds per-invocation caches for both, so each unique env and each unique op:// URI is resolved only once.