### PR TITLE
Update docs and skill with two-column symmetric layout pattern

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/5-layout-patterns.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/5-layout-patterns.md
@@ -4,13 +4,31 @@ title: Layout Patterns
 
 This page provides ready-to-use layout recipes that combine the concepts from [Email Basics](./1-email-basics.md), [Components and Theme](./2-components-and-theme.md), and [Customization](./4-customization.md) into complete, tested patterns.
 
-## Two-Column Layout
-
-The most common multi-column pattern: two equal-width columns with a gap between them, stacking vertically on mobile.
-
-### How Column Gaps Work in MJML
+## How Column Gaps Work in MJML
 
 MJML has no `gap` property. Column padding reduces the **content area inside** the column — it doesn't add space between the column cells themselves. To create a visual gap between adjacent columns, apply padding to their inner edges: `paddingRight` on the left column and `paddingLeft` on the right column. The sum of the two becomes the visible gap.
+
+Do **not** apply equal padding on all sides of every column — this adds extra spacing on the outer edges that compounds with the section's `indent` padding, pushing content inward beyond the theme's `contentIndentation`.
+
+### CSS Targeting for Column Padding
+
+MJML compiles column padding to an inner `<td>`, not the outer `<div>` that receives the `className`. To override column padding in responsive styles, target the inner cell:
+
+```css
+.myColumn > table > tbody > tr > td {
+    padding-left: 0 !important;
+}
+```
+
+Properties like `margin-bottom` that apply to the column wrapper itself use the plain class name without the table path. All responsive overrides require `!important` because MJML applies styles inline, and inline styles take precedence over `<style>` block rules.
+
+:::tip
+Use `theme.breakpoints.mobile.belowMediaQuery` (or `theme.breakpoints.default.belowMediaQuery`) instead of hardcoded media queries to keep responsive styles in sync with the theme's breakpoint configuration.
+:::
+
+## Symmetric Two-Column Layout
+
+Two equal-width columns with a gap between them, stacking vertically on mobile.
 
 ```
 ┌───────────────────────────────────────────────────────────┐
@@ -25,8 +43,6 @@ MJML has no `gap` property. Column padding reduces the **content area inside** t
 │                        ←── gap ──→                        │
 └───────────────────────────────────────────────────────────┘
 ```
-
-Do **not** apply equal padding on all sides of every column — this adds extra spacing on the outer edges that compounds with the section's `indent` padding, pushing content inward beyond the theme's `contentIndentation`.
 
 ### The Pattern
 
@@ -52,7 +68,7 @@ const TwoColumnsSection = () => {
 
 ### Responsive Stacking
 
-On mobile, the columns stack vertically. The gap padding must be reset so content stretches full-width, and a vertical margin replaces the horizontal gap:
+On mobile, the columns stack vertically. Reset the gap padding so content stretches full-width, and add a vertical margin to replace the horizontal gap:
 
 ```ts
 registerStyles(
@@ -74,12 +90,113 @@ registerStyles(
 );
 ```
 
-Three things to note:
+## Asymmetric Two-Column Layout
 
-1. **Target the inner `<td>`** for padding overrides — MJML compiles column padding to an inner `<td>`, not the outer `<div>` that receives the `className`. Use the selector `.className > table > tbody > tr > td` to reach it.
-2. **`!important` is required** — inline styles set by MJML take precedence over `<style>` block rules.
-3. **`margin-bottom` on the outer element** — this goes on the column wrapper itself (not the inner `<td>`), so the plain `.twoColumnsSection__leftColumn` selector is correct here.
+A fixed-width column paired with a fluid column that takes the remaining space. Common for image-plus-text layouts, icon rows, or sidebar patterns.
 
-:::tip
-Use `theme.breakpoints.mobile.belowMediaQuery` instead of a hardcoded media query to keep responsive styles in sync with the theme's breakpoint configuration.
-:::
+```
+┌───────────────────────────────────────────────────────────┐
+│ MjmlSection indent                                        │
+│ ┌──────────┐ ┌──────────────────────────────────────────┐ │
+│ │  120px   │ │ fluid (sectionInnerWidth - 120px)        │ │
+│ │  fixed   │ │ paddingLeft={gap}                        │ │
+│ └──────────┘ └──────────────────────────────────────────┘ │
+└───────────────────────────────────────────────────────────┘
+```
+
+### Why Explicit Widths Are Required
+
+MJML does not give columns "remaining space" when some columns have widths and others don't. It always divides the container width equally among all columns (`containerWidth / numberOfColumns`). To get a fixed-plus-fluid layout, **set explicit widths on both columns** and derive the fluid column's width from the theme:
+
+```tsx
+const SMALL_COLUMN_WIDTH = 120;
+const COLUMN_GAP = 20;
+
+const sectionIndent = getDefaultFromResponsiveValue(theme.sizes.contentIndentation);
+const sectionInnerWidth = theme.sizes.bodyWidth - 2 * sectionIndent;
+const fluidColumnWidth = sectionInnerWidth - SMALL_COLUMN_WIDTH;
+```
+
+`getDefaultFromResponsiveValue` extracts the default (desktop/inline) value from a responsive theme property like `contentIndentation`.
+
+### The Pattern
+
+The gap is created by padding on the fluid column's inner edge — the same principle as the symmetric layout, just applied to one side:
+
+```tsx
+<MjmlSection indent>
+    <MjmlColumn
+        className="imageTextLayout__smallColumn"
+        width={`${SMALL_COLUMN_WIDTH}px`}
+        verticalAlign="middle"
+    >
+        <MjmlImage src="..." alt="..." width={SMALL_COLUMN_WIDTH} />
+    </MjmlColumn>
+    <MjmlColumn
+        className="imageTextLayout__fluidColumn"
+        width={`${fluidColumnWidth}px`}
+        paddingLeft={`${COLUMN_GAP}px`}
+        verticalAlign="middle"
+    >
+        <MjmlText>Content that fills the remaining space.</MjmlText>
+    </MjmlColumn>
+</MjmlSection>
+```
+
+To place the small column on the right instead, swap the column order and move the gap padding to `paddingRight` on the fluid column.
+
+### Two-Breakpoint Responsive Behavior
+
+Fixed-width columns create an overflow problem between the desktop `bodyWidth` and the mobile stacking breakpoint — the total fixed width can exceed the viewport. The solution uses two `belowMediaQuery` breakpoints stacked via CSS cascade order:
+
+```ts
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .imageTextLayout__fluidColumn {
+                width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
+                max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
+            }
+        }
+
+        ${theme.breakpoints.mobile.belowMediaQuery} {
+            .imageTextLayout__fluidColumn {
+                width: 100% !important;
+                max-width: 100% !important;
+            }
+
+            .imageTextLayout__smallColumn {
+                margin-bottom: 10px;
+            }
+
+            .imageTextLayout__fluidColumn > table > tbody > tr > td {
+                padding-left: 0 !important;
+            }
+        }
+    `,
+);
+```
+
+The `default.belowMediaQuery` block makes the fluid column responsive via `calc()` while keeping the two-column layout intact. The `mobile.belowMediaQuery` block (later in source order) overrides it to stack columns at full width. This cascade-based approach is the idiomatic pattern — never use hardcoded `@media (min-width: X) and (max-width: Y)` range queries.
+
+### Controlling Mobile Stack Order
+
+By default, MJML stacks columns in source order on mobile. If you need a column that appears on the right on desktop to stack on top on mobile (e.g., an image that should appear above the text), use `direction="rtl"` on the section to flip the visual order on desktop while keeping the desired stacking order in the source:
+
+```tsx
+<MjmlWrapper padding={`0 ${sectionIndent}px`} backgroundColor={theme.colors.background.content}>
+    <MjmlSection direction="rtl">
+        <MjmlColumn className="layout__smallColumn" width={`${SMALL_COLUMN_WIDTH}px`}>
+            <MjmlImage src="..." alt="..." width={SMALL_COLUMN_WIDTH} />
+        </MjmlColumn>
+        <MjmlColumn className="layout__fluidColumn" width={`${fluidColumnWidth}px`} paddingRight={`${COLUMN_GAP}px`}>
+            <MjmlText>This appears on the left on desktop, below the image on mobile.</MjmlText>
+        </MjmlColumn>
+    </MjmlSection>
+</MjmlWrapper>
+```
+
+Two important details:
+
+1. **`MjmlWrapper` replaces `indent`** — when using `direction="rtl"`, applying `indent` directly on the section causes a 1px line artifact in Outlook. Instead, wrap the section in `MjmlWrapper` and apply the indentation as padding. Set the `backgroundColor` on the wrapper to match the content background.
+2. **Source order = mobile stack order** — the small column is first in the JSX, so it stacks on top on mobile. `direction="rtl"` only affects the visual (left-to-right) order on desktop.

--- a/docs/docs/3-features-modules/13-building-html-emails/5-layout-patterns.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/5-layout-patterns.md
@@ -1,0 +1,85 @@
+---
+title: Layout Patterns
+---
+
+This page provides ready-to-use layout recipes that combine the concepts from [Email Basics](./1-email-basics.md), [Components and Theme](./2-components-and-theme.md), and [Customization](./4-customization.md) into complete, tested patterns.
+
+## Two-Column Layout
+
+The most common multi-column pattern: two equal-width columns with a gap between them, stacking vertically on mobile.
+
+### How Column Gaps Work in MJML
+
+MJML has no `gap` property. Column padding reduces the **content area inside** the column — it doesn't add space between the column cells themselves. To create a visual gap between adjacent columns, apply padding to their inner edges: `paddingRight` on the left column and `paddingLeft` on the right column. The sum of the two becomes the visible gap.
+
+```
+┌───────────────────────────────────────────────────────────┐
+│ MjmlSection indent                                        │
+│ ┌──────────────────────────┐ ┌──────────────────────────┐ │
+│ │ MjmlColumn               │ │ MjmlColumn               │ │
+│ │ paddingRight={halfGap}   │ │ paddingLeft={halfGap}    │ │
+│ │                          │ │                          │ │
+│ │  content area            │ │  content area            │ │
+│ │                          │ │                          │ │
+│ └──────────────────────────┘ └──────────────────────────┘ │
+│                        ←── gap ──→                        │
+└───────────────────────────────────────────────────────────┘
+```
+
+Do **not** apply equal padding on all sides of every column — this adds extra spacing on the outer edges that compounds with the section's `indent` padding, pushing content inward beyond the theme's `contentIndentation`.
+
+### The Pattern
+
+For two equal columns, apply half the desired gap to each column's inner edge. Both columns have the same total padding (half the gap on one side), so MJML's default equal-width distribution produces equal content areas — no explicit `width` props are needed:
+
+```tsx
+const TwoColumnsSection = () => {
+    const columnGap = 20;
+    const halfGap = columnGap / 2;
+
+    return (
+        <MjmlSection indent className="twoColumnsSection">
+            <MjmlColumn className="twoColumnsSection__leftColumn" paddingRight={halfGap}>
+                <MjmlText>Left column content.</MjmlText>
+            </MjmlColumn>
+            <MjmlColumn className="twoColumnsSection__rightColumn" paddingLeft={halfGap}>
+                <MjmlText>Right column content.</MjmlText>
+            </MjmlColumn>
+        </MjmlSection>
+    );
+};
+```
+
+### Responsive Stacking
+
+On mobile, the columns stack vertically. The gap padding must be reset so content stretches full-width, and a vertical margin replaces the horizontal gap:
+
+```ts
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.mobile.belowMediaQuery} {
+            .twoColumnsSection__leftColumn > table > tbody > tr > td {
+                padding-right: 0 !important;
+            }
+
+            .twoColumnsSection__rightColumn > table > tbody > tr > td {
+                padding-left: 0 !important;
+            }
+
+            .twoColumnsSection__leftColumn {
+                margin-bottom: 20px;
+            }
+        }
+    `,
+);
+```
+
+Three things to note:
+
+1. **Target the inner `<td>`** for padding overrides — MJML compiles column padding to an inner `<td>`, not the outer `<div>` that receives the `className`. Use the selector `.className > table > tbody > tr > td` to reach it.
+2. **`!important` is required** — inline styles set by MJML take precedence over `<style>` block rules.
+3. **`margin-bottom` on the outer element** — this goes on the column wrapper itself (not the inner `<td>`), so the plain `.twoColumnsSection__leftColumn` selector is correct here.
+
+:::tip
+Use `theme.breakpoints.mobile.belowMediaQuery` instead of a hardcoded media query to keep responsive styles in sync with the theme's breakpoint configuration.
+:::

--- a/docs/docs/3-features-modules/13-building-html-emails/index.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/index.md
@@ -92,3 +92,4 @@ In Storybook, the decorator handles MJML-to-HTML conversion automatically. When 
 - [**Components and Theme**](./2-components-and-theme.md) — Full theme API, text variants, responsive values, and all available components
 - [**Rendering**](./3-rendering.md) — Converting email templates to HTML with `renderMailHtml`, browser environments, and Mail Templates Module integration
 - [**Customization**](./4-customization.md) — Creating custom components, extending the theme with module augmentation, and adding responsive styles
+- [**Layout Patterns**](./5-layout-patterns.md) — Ready-to-use layout recipes including multi-column layouts with gaps and responsive stacking

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -91,7 +91,7 @@ const halfGap = columnGap / 2;
 
 On mobile, reset the gap padding so content stretches full-width, and add a vertical margin between the stacked columns. Column padding compiles to an inner `<td>`, so target it via `.className > table > tbody > tr > td`.
 
-→ For the complete two-column pattern with responsive styles, CSS targeting rules, and BEM naming conventions, read [`references/layout-patterns.md`](references/layout-patterns.md).
+→ For complete two-column patterns (equal-width and fixed+fluid) with responsive styles, CSS targeting rules, and the `direction="rtl"` technique for controlling mobile stack order, read [`references/layout-patterns.md`](references/layout-patterns.md).
 
 ### Ending Tags
 

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: comet-mail-react
-description: Guide for building HTML emails with @comet/mail-react and MJML. Use whenever working on email templates, mail markup, MJML components, email theming, email styling, responsive emails, or anything involving @comet/mail-react or HTML email development — even for seemingly simple tasks, since email client compatibility is a minefield that requires specific patterns and research before implementing.
+description: Guide for building HTML emails with @comet/mail-react and MJML. Use whenever working on email templates, mail markup, MJML components, email theming, email styling, responsive emails, column layouts, multi-column email sections, or anything involving @comet/mail-react or HTML email development — even for seemingly simple tasks like putting content side-by-side in columns, since email client compatibility is a minefield that requires specific patterns and research before implementing.
 ---
 
 # Building HTML Emails with @comet/mail-react
@@ -66,6 +66,32 @@ Content components placed outside this hierarchy produce MJML validation warning
     </MjmlColumn>
 </MjmlSection>
 ```
+
+### Multi-Column Layouts
+
+MJML has no `gap` property. Column padding reduces the content area _inside_ the column — it doesn't add space between column cells. To create a visual gap between columns, apply padding to the inner edges of adjacent columns (`paddingRight` on the left column, `paddingLeft` on the right column). Their sum becomes the visible gap.
+
+For two equal columns, apply half the desired gap to each column's inner edge. Both columns have the same total padding, so MJML's equal-width split produces equal content areas without explicit `width` props:
+
+```tsx
+const columnGap = 20;
+const halfGap = columnGap / 2;
+
+<MjmlSection indent className="twoColumnsSection">
+    <MjmlColumn className="twoColumnsSection__leftColumn" paddingRight={halfGap}>
+        <MjmlText>Left column</MjmlText>
+    </MjmlColumn>
+    <MjmlColumn className="twoColumnsSection__rightColumn" paddingLeft={halfGap}>
+        <MjmlText>Right column</MjmlText>
+    </MjmlColumn>
+</MjmlSection>;
+```
+
+**Do not** apply equal padding on all sides of every column — this adds extra outer-edge spacing that compounds with `indent`/`contentIndentation`, pushing content inward beyond the theme's intended margins.
+
+On mobile, reset the gap padding so content stretches full-width, and add a vertical margin between the stacked columns. Column padding compiles to an inner `<td>`, so target it via `.className > table > tbody > tr > td`.
+
+→ For the complete two-column pattern with responsive styles, CSS targeting rules, and BEM naming conventions, read [`references/layout-patterns.md`](references/layout-patterns.md).
 
 ### Ending Tags
 

--- a/skills/comet-mail-react/references/layout-patterns.md
+++ b/skills/comet-mail-react/references/layout-patterns.md
@@ -1,14 +1,33 @@
 # Layout Patterns
 
-## Two-Column Layout (Equal Width)
-
-Two equal-width columns with a gap between them, stacking vertically on mobile.
-
-### How Column Gaps Work
+## How Column Gaps Work
 
 MJML has no `gap` property. Column padding reduces the content area _inside_ the column — it doesn't create space between column cells. To create a visible gap, apply padding to the inner edges of adjacent columns: `paddingRight` on the left column and `paddingLeft` on the right column. Their sum becomes the gap.
 
 **Do not** apply equal padding on all sides of every column. This adds extra outer-edge spacing that compounds with `indent`/`contentIndentation`, pushing content inward.
+
+### CSS Targeting Rules
+
+- **Column padding** compiles to an inner `<td>`, not the outer `<div>` that receives `className`. Override padding via `.className > table > tbody > tr > td`.
+- **`margin-bottom`/`margin-top`** goes on the column wrapper itself (the outer `<div>`), so use the plain `.className` selector without the table path.
+- **`!important`** is required on all responsive overrides — MJML inlines styles that take precedence over `<style>` block rules.
+- Prefer `theme.breakpoints.mobile.belowMediaQuery` and `theme.breakpoints.default.belowMediaQuery` over hardcoded media queries.
+
+### BEM Class Naming
+
+Follow the BEM convention with camelCase blocks. Adapt the block name to the component context:
+
+| Element                | Example class name                                               |
+| ---------------------- | ---------------------------------------------------------------- |
+| Section/layout wrapper | `twoColumnsSection`, `imageTextLayout`                           |
+| Left/small column      | `twoColumnsSection__leftColumn`, `imageTextLayout__smallColumn`  |
+| Right/fluid column     | `twoColumnsSection__rightColumn`, `imageTextLayout__fluidColumn` |
+
+---
+
+## Symmetric Two-Column Layout (Equal Width)
+
+Two equal-width columns with a gap between them, stacking vertically on mobile.
 
 ### Pattern
 
@@ -56,21 +75,96 @@ registerStyles(
 );
 ```
 
-### CSS Targeting Rules
+---
 
-- **Column padding** compiles to an inner `<td>`, not the outer `<div>` that receives `className`. Override padding via `.className > table > tbody > tr > td`.
-- **`margin-bottom`** goes on the column wrapper itself (the outer `<div>`), so `.twoColumnsSection__leftColumn` without the table path is correct.
-- **`!important`** is required on all responsive overrides — MJML inlines styles that take precedence over `<style>` block rules.
-- Prefer `theme.breakpoints.mobile.belowMediaQuery` over hardcoded media queries.
+## Asymmetric Two-Column Layout (Fixed + Fluid)
 
-### BEM Class Naming
+A fixed-width column paired with a fluid column that takes the remaining space.
 
-Follow the BEM convention with camelCase blocks:
+### Width Computation
 
-| Element         | Class name                       |
-| --------------- | -------------------------------- |
-| Section wrapper | `twoColumnsSection`              |
-| Left column     | `twoColumnsSection__leftColumn`  |
-| Right column    | `twoColumnsSection__rightColumn` |
+MJML does not give columns "remaining space" — it always divides equally (`containerWidth / numberOfColumns`). Set explicit widths on **both** columns. Derive the fluid width from the theme:
 
-Adapt the block name to the component context (e.g., `featureComparison__leftColumn` for a feature comparison section).
+```tsx
+const SMALL_COLUMN_WIDTH = 120;
+const COLUMN_GAP = 20;
+
+const sectionIndent = getDefaultFromResponsiveValue(theme.sizes.contentIndentation);
+const sectionInnerWidth = theme.sizes.bodyWidth - 2 * sectionIndent;
+const fluidColumnWidth = sectionInnerWidth - SMALL_COLUMN_WIDTH;
+```
+
+`getDefaultFromResponsiveValue` extracts the default (desktop/inline) value from a responsive theme property like `contentIndentation`.
+
+### Pattern
+
+Gap is created by padding on the fluid column's inner edge:
+
+```tsx
+<MjmlSection indent>
+    <MjmlColumn className="imageTextLayout__smallColumn" width={`${SMALL_COLUMN_WIDTH}px`} verticalAlign="middle">
+        <MjmlImage src="..." alt="..." width={SMALL_COLUMN_WIDTH} />
+    </MjmlColumn>
+    <MjmlColumn className="imageTextLayout__fluidColumn" width={`${fluidColumnWidth}px`} paddingLeft={`${COLUMN_GAP}px`} verticalAlign="middle">
+        <MjmlText>Content that fills the remaining space.</MjmlText>
+    </MjmlColumn>
+</MjmlSection>
+```
+
+To place the small column on the right, swap column order and move padding to `paddingRight` on the fluid column.
+
+### Two-Breakpoint Responsive Behavior
+
+Fixed-width columns overflow between `bodyWidth` and the mobile stacking breakpoint. Use two stacked `belowMediaQuery` blocks — the later one overrides the earlier via cascade order:
+
+```ts
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .imageTextLayout__fluidColumn {
+                width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
+                max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
+            }
+        }
+
+        ${theme.breakpoints.mobile.belowMediaQuery} {
+            .imageTextLayout__fluidColumn {
+                width: 100% !important;
+                max-width: 100% !important;
+            }
+
+            .imageTextLayout__smallColumn {
+                margin-bottom: 10px;
+            }
+
+            .imageTextLayout__fluidColumn > table > tbody > tr > td {
+                padding-left: 0 !important;
+            }
+        }
+    `,
+);
+```
+
+This cascade-based approach is the idiomatic pattern. Never use hardcoded `@media (min-width: X) and (max-width: Y)` range queries — stacking `belowMediaQuery` blocks achieves the same result while staying in sync with the theme.
+
+### Controlling Mobile Stack Order with `direction="rtl"`
+
+MJML stacks columns in source order on mobile. To make a right-side column stack on top, use `direction="rtl"` on the section to flip the desktop visual order while keeping the source (and mobile stacking) order:
+
+```tsx
+<MjmlWrapper padding={`0 ${sectionIndent}px`} backgroundColor={theme.colors.background.content}>
+    <MjmlSection direction="rtl">
+        <MjmlColumn className="layout__smallColumn" width={`${SMALL_COLUMN_WIDTH}px`}>
+            <MjmlImage src="..." alt="..." width={SMALL_COLUMN_WIDTH} />
+        </MjmlColumn>
+        <MjmlColumn className="layout__fluidColumn" width={`${fluidColumnWidth}px`} paddingRight={`${COLUMN_GAP}px`}>
+            <MjmlText>Appears on the left on desktop, below the image on mobile.</MjmlText>
+        </MjmlColumn>
+    </MjmlSection>
+</MjmlWrapper>
+```
+
+When using `direction="rtl"`:
+
+- **Use `MjmlWrapper` instead of `indent`** — applying `indent` on a `direction="rtl"` section causes a 1px line artifact in Outlook. Wrap the section in `MjmlWrapper` with `padding={`0 ${sectionIndent}px`}` and set `backgroundColor` to match.
+- **Source order = mobile stack order** — the small column is first in the JSX, so it stacks on top on mobile. `direction="rtl"` only affects the visual left-to-right order on desktop.

--- a/skills/comet-mail-react/references/layout-patterns.md
+++ b/skills/comet-mail-react/references/layout-patterns.md
@@ -1,0 +1,76 @@
+# Layout Patterns
+
+## Two-Column Layout (Equal Width)
+
+Two equal-width columns with a gap between them, stacking vertically on mobile.
+
+### How Column Gaps Work
+
+MJML has no `gap` property. Column padding reduces the content area _inside_ the column — it doesn't create space between column cells. To create a visible gap, apply padding to the inner edges of adjacent columns: `paddingRight` on the left column and `paddingLeft` on the right column. Their sum becomes the gap.
+
+**Do not** apply equal padding on all sides of every column. This adds extra outer-edge spacing that compounds with `indent`/`contentIndentation`, pushing content inward.
+
+### Pattern
+
+Apply half the gap to each column's inner edge. Both columns have the same total padding, so MJML's default equal-width split produces equal content areas without explicit `width` props:
+
+```tsx
+const TwoColumnsSection = () => {
+    const columnGap = 20;
+    const halfGap = columnGap / 2;
+
+    return (
+        <MjmlSection indent className="twoColumnsSection">
+            <MjmlColumn className="twoColumnsSection__leftColumn" paddingRight={halfGap}>
+                <MjmlText>Left column content.</MjmlText>
+            </MjmlColumn>
+            <MjmlColumn className="twoColumnsSection__rightColumn" paddingLeft={halfGap}>
+                <MjmlText>Right column content.</MjmlText>
+            </MjmlColumn>
+        </MjmlSection>
+    );
+};
+```
+
+### Responsive Stacking
+
+On mobile, columns stack vertically. Reset the gap padding so content stretches full-width, and add a vertical margin between the stacked columns:
+
+```ts
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.mobile.belowMediaQuery} {
+            .twoColumnsSection__leftColumn > table > tbody > tr > td {
+                padding-right: 0 !important;
+            }
+
+            .twoColumnsSection__rightColumn > table > tbody > tr > td {
+                padding-left: 0 !important;
+            }
+
+            .twoColumnsSection__leftColumn {
+                margin-bottom: 20px;
+            }
+        }
+    `,
+);
+```
+
+### CSS Targeting Rules
+
+- **Column padding** compiles to an inner `<td>`, not the outer `<div>` that receives `className`. Override padding via `.className > table > tbody > tr > td`.
+- **`margin-bottom`** goes on the column wrapper itself (the outer `<div>`), so `.twoColumnsSection__leftColumn` without the table path is correct.
+- **`!important`** is required on all responsive overrides — MJML inlines styles that take precedence over `<style>` block rules.
+- Prefer `theme.breakpoints.mobile.belowMediaQuery` over hardcoded media queries.
+
+### BEM Class Naming
+
+Follow the BEM convention with camelCase blocks:
+
+| Element         | Class name                       |
+| --------------- | -------------------------------- |
+| Section wrapper | `twoColumnsSection`              |
+| Left column     | `twoColumnsSection__leftColumn`  |
+| Right column    | `twoColumnsSection__rightColumn` |
+
+Adapt the block name to the component context (e.g., `featureComparison__leftColumn` for a feature comparison section).


### PR DESCRIPTION
More layout patterns will be added in the future, primarily as reference for agents, which frequently get these things wrong for emails. E.g. the patterns added to storybook in https://github.com/vivid-planet/comet/pull/5454.