### PR TITLE
Add `hidePreviewAction` prop to `PagesPage`

### DIFF
--- a/.changeset/add-hide-preview-action-to-pages-page.md
+++ b/.changeset/add-hide-preview-action-to-pages-page.md
@@ -1,0 +1,11 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `hidePreviewAction` prop to `PagesPage`
+
+Set `hidePreviewAction` to `true` to hide the "Open preview" row action in the page tree:
+
+```tsx
+<PagesPage hidePreviewAction />
+```

--- a/packages/admin/cms-admin/src/pages/pageTree/PageActions.test.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageActions.test.tsx
@@ -1,0 +1,85 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { cleanup, render, screen } from "test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import PageActions from "./PageActions";
+import { type PageTreePage } from "./usePageTree";
+
+vi.mock("../../contentScope/Provider", () => ({
+    useContentScope: () => ({
+        match: { url: "/test" },
+    }),
+}));
+
+vi.mock("../pageTreeConfig", () => ({
+    usePageTreeConfig: () => ({
+        documentTypes: {
+            Page: {
+                displayName: "Page",
+                editComponent: () => null,
+                hasNoSitePreview: false,
+                menuIcon: () => null,
+            },
+        },
+    }),
+}));
+
+vi.mock("./usePageTreeContext", () => ({
+    usePageTreeContext: () => ({
+        tree: new Map(),
+    }),
+}));
+
+const page: PageTreePage = {
+    id: "1",
+    name: "Test Page",
+    parentId: null,
+    documentType: "Page",
+    pos: 0,
+    path: "/test-page",
+    category: "main",
+    hideInMenu: false,
+    visibility: "Published",
+    slug: "test-page",
+    selected: false,
+    expanded: null,
+    ancestorIds: [],
+    level: 0,
+    matches: [],
+};
+
+const editDialogApi = {
+    openAddDialog: vi.fn(),
+    openEditDialog: vi.fn(),
+    closeDialog: vi.fn(),
+};
+
+function renderPageActions({ hidePreviewAction }: { hidePreviewAction?: boolean } = {}) {
+    return render(
+        <MockedProvider>
+            <PageActions page={page} editDialog={editDialogApi} siteUrl="https://example.com" hidePreviewAction={hidePreviewAction} />
+        </MockedProvider>,
+    );
+}
+
+describe("PageActions", () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it("should show the preview action by default", () => {
+        renderPageActions();
+
+        const buttons = screen.getAllByRole("button");
+        // edit, preview, more menu
+        expect(buttons).toHaveLength(3);
+    });
+
+    it("should hide the preview action when hidePreviewAction is true", () => {
+        renderPageActions({ hidePreviewAction: true });
+
+        const buttons = screen.getAllByRole("button");
+        // edit, more menu
+        expect(buttons).toHaveLength(2);
+    });
+});

--- a/packages/admin/cms-admin/src/pages/pageTree/PageActions.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageActions.tsx
@@ -21,9 +21,10 @@ interface Props {
     page: PageTreePage;
     editDialog: IEditDialogApi;
     siteUrl: string;
+    hidePreviewAction?: boolean;
 }
 
-export default function PageActions({ page, editDialog, children, siteUrl }: PropsWithChildren<Props>) {
+export default function PageActions({ page, editDialog, children, siteUrl, hidePreviewAction }: PropsWithChildren<Props>) {
     const { tree } = usePageTreeContext();
     const { match: contentScopeMatch } = useContentScope();
     const { documentTypes } = usePageTreeConfig();
@@ -74,16 +75,18 @@ export default function PageActions({ page, editDialog, children, siteUrl }: Pro
                     >
                         <FormattedMessage id="comet.pages.pages.page.editContent" defaultMessage="Edit content" />
                     </RowActionsItem>,
-                    <RowActionsItem
-                        key="preview"
-                        icon={documentType.hasNoSitePreview ? <PreviewUnavailable /> : <Preview />}
-                        onClick={() => {
-                            openSitePreviewWindow(page.path, contentScopeMatch.url);
-                        }}
-                        disabled={documentType.hasNoSitePreview}
-                    >
-                        <FormattedMessage id="comet.pages.pages.page.openPreview" defaultMessage="Open preview" />
-                    </RowActionsItem>,
+                    !hidePreviewAction && (
+                        <RowActionsItem
+                            key="preview"
+                            icon={documentType.hasNoSitePreview ? <PreviewUnavailable /> : <Preview />}
+                            onClick={() => {
+                                openSitePreviewWindow(page.path, contentScopeMatch.url);
+                            }}
+                            disabled={documentType.hasNoSitePreview}
+                        >
+                            <FormattedMessage id="comet.pages.pages.page.openPreview" defaultMessage="Open preview" />
+                        </RowActionsItem>
+                    ),
                 ]}
                 <RowActionsMenu>
                     {page.visibility !== "Archived" && [

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTree.tsx
@@ -41,6 +41,7 @@ interface PageTreeProps {
     onSelectChanged: (pageId: string, value: boolean) => void;
     category: string;
     siteUrl: string;
+    hidePreviewAction?: boolean;
 }
 
 type PageTreeRefApi = { scrollToItem: List["scrollToItem"] };
@@ -92,7 +93,7 @@ const pagesCacheQuery = gql`
 const levelOffsetPx = 50;
 
 const PageTree: ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = (
-    { pages, editDialogApi, toggleExpand, onSelectChanged, category, siteUrl },
+    { pages, editDialogApi, toggleExpand, onSelectChanged, category, siteUrl, hidePreviewAction },
     ref,
 ) => {
     const client = useApolloClient();
@@ -363,6 +364,7 @@ const PageTree: ForwardRefRenderFunction<PageTreeRefApi, PageTreeProps> = (
                                                 debouncedSetHoverState={debouncedSetHoverState}
                                                 siteUrl={siteUrl}
                                                 selectedPages={selectedPages}
+                                                hidePreviewAction={hidePreviewAction}
                                             />
                                         );
                                     }}

--- a/packages/admin/cms-admin/src/pages/pageTree/PageTreeRow.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageTreeRow.tsx
@@ -39,6 +39,7 @@ interface PageTreeRowProps {
     virtualizedStyle?: CSSProperties;
     slideIn?: boolean;
     selectedPages: PageTreePage[];
+    hidePreviewAction?: boolean;
 }
 
 interface PageTreeTableRowElement extends HTMLTableRowElement {
@@ -62,6 +63,7 @@ const PageTreeRow = ({
     virtualizedStyle,
     slideIn,
     selectedPages,
+    hidePreviewAction,
 }: PageTreeRowProps) => {
     const rowRef = useRef<PageTreeTableRowElement | null>(null);
     const [hover, setHover] = useState(false);
@@ -239,7 +241,7 @@ const PageTreeRow = ({
                 <PageVisibility page={page} />
             </sc.PageVisibilityCell>
             <sc.PageActionsCell component="div">
-                <PageActions page={page} editDialog={editDialogApi} siteUrl={siteUrl} />
+                <PageActions page={page} editDialog={editDialogApi} siteUrl={siteUrl} hidePreviewAction={hidePreviewAction} />
             </sc.PageActionsCell>
             <sc.RowClickContainer onClick={onRowClick} />
 

--- a/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
+++ b/packages/admin/cms-admin/src/pages/pagesPage/PagesPage.tsx
@@ -43,6 +43,7 @@ interface Props {
     documentTypes: Record<DocumentType, DocumentInterface> | ((category: string) => Record<DocumentType, DocumentInterface>);
     editPageNode?: ComponentType<EditPageNodeProps>;
     renderContentScopeIndicator: (scope: ContentScope) => ReactNode;
+    hidePreviewAction?: boolean;
 }
 
 const DefaultEditPageNode = createEditPageNode({});
@@ -53,6 +54,7 @@ export function PagesPage({
     documentTypes: passedDocumentTypes,
     editPageNode: EditPageNode = DefaultEditPageNode,
     renderContentScopeIndicator,
+    hidePreviewAction,
 }: Props) {
     const intl = useIntl();
     const { scope, setRedirectPathAfterChange } = useContentScope();
@@ -210,6 +212,7 @@ export function PagesPage({
                                                 onSelectChanged={onSelectChanged}
                                                 category={category}
                                                 siteUrl={siteConfig.url}
+                                                hidePreviewAction={hidePreviewAction}
                                             />
                                         </>
                                     )}


### PR DESCRIPTION
We have at least two projects where we don't offer a site preview and therefore want to hide the button. This is no problem on the `EditPage` because it's custom in the project. However, you can't hide the button in the PageTree currently.

This change adds a `hidePreviewAction` to `PagesPage` that allows hiding the action button.
I also added a test since I can't showcase this in demo.

---

Open questions:

- [ ] What do you think of the prop drilling approach? Should we instead add a context to `PagesPage` that contains this config and can be accessed by `PageActions`?
- [ ] Should we add this prop to the document config instead? (The Document already has `hasNoSitePreview` prop that disables the button (for document types that don't have a preview) but doesn't hide it completely)