### PR TITLE
cms-admin: Add Chromatic deployment for Storybook

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,12 +4,14 @@ on:
     pull_request:
         paths:
             - packages/admin/admin/**
+            - packages/admin/cms-admin/**
         branches:
             - main
             - next
     push:
         paths:
             - packages/admin/admin/**
+            - packages/admin/cms-admin/**
         branches:
             - main
             - next
@@ -46,3 +48,9 @@ jobs:
               with:
                   projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN_ADMIN }}
                   workingDir: packages/admin/admin
+
+            - name: Publish comet-cms-admin to Chromatic
+              uses: chromaui/action@v1
+              with:
+                  projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN_CMS_ADMIN }}
+                  workingDir: packages/admin/cms-admin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1646,7 +1646,7 @@ importers:
         version: 8.27.2(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@mui/material@7.3.7(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mui/system@7.3.7(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(date-fns@4.1.0)(dayjs@1.11.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/addon-docs':
         specifier: ^10.2.13
-        version: 10.3.3(@types/react@19.2.10)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.4))
+        version: 10.3.3(@types/react@19.2.10)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.4))
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^4.0.0
         version: 4.0.1(webpack@5.105.4(esbuild@0.27.4))

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -31,7 +31,7 @@ const config: StorybookConfig = {
             },
             "@comet/cms-admin": {
                 title: "@comet/cms-admin",
-                url: configType === "DEVELOPMENT" ? "http://localhost:26647/" : "", // TODO: add Chromatic URL once available
+                url: configType === "DEVELOPMENT" ? "http://localhost:26647/" : "https://main--69df3371c46abe69b5199825.chromatic.com",
             },
         };
     },


### PR DESCRIPTION
- Add Chromatic deployment for `@comet/cms-admin` Storybook, mirroring the existing @comet/admin setup                                                                                          
- Update the root storybook's `@comet/cms-admin` ref to point to the Chromatic URL                                                                                                              