### PR TITLE
Add `SitePreviewAction` to `DocumentInterface`

### DIFF
--- a/.changeset/add-site-preview-action-to-document-interface.md
+++ b/.changeset/add-site-preview-action-to-document-interface.md
@@ -13,9 +13,9 @@ import { RowActionsItem } from "@comet/admin";
 import { Preview } from "@comet/admin-icons";
 import { type DocumentInterface, openSitePreviewWindow, type SitePreviewActionProps } from "@comet/cms-admin";
 
-function PageSitePreviewAction({ page }: SitePreviewActionProps) {
+function PageSitePreviewAction({ pageTreeNode }: SitePreviewActionProps) {
     // Use hooks to construct a custom preview URL
-    const previewPath = useCustomPreviewPath(page);
+    const previewPath = useCustomPreviewPath(pageTreeNode);
 
     return (
         <RowActionsItem

--- a/.changeset/add-site-preview-action-to-document-interface.md
+++ b/.changeset/add-site-preview-action-to-document-interface.md
@@ -1,0 +1,39 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `SitePreviewAction` to `DocumentInterface`
+
+Allows overriding the site preview button in the page tree row actions on a per-document-type basis. When set, the provided component replaces the default preview `RowActionsItem`, enabling custom preview URL construction (e.g., using additional GraphQL queries or scope data).
+
+**Example**
+
+```tsx
+import { RowActionsItem } from "@comet/admin";
+import { Preview } from "@comet/admin-icons";
+import { type DocumentInterface, openSitePreviewWindow, type SitePreviewActionProps } from "@comet/cms-admin";
+
+function PageSitePreviewAction({ page }: SitePreviewActionProps) {
+    // Use hooks to construct a custom preview URL
+    const previewPath = useCustomPreviewPath(page);
+
+    return (
+        <RowActionsItem
+            icon={<Preview />}
+            disabled={!previewPath}
+            onClick={() => {
+                if (previewPath) {
+                    openSitePreviewWindow(previewPath, "/custom-root");
+                }
+            }}
+        >
+            Open preview
+        </RowActionsItem>
+    );
+}
+
+export const Page: DocumentInterface = {
+    // ...
+    SitePreviewAction: PageSitePreviewAction,
+};
+```

--- a/packages/admin/cms-admin/src/documents/types.ts
+++ b/packages/admin/cms-admin/src/documents/types.ts
@@ -57,5 +57,5 @@ export type InfoTagProps<PageTreeNodeAdditionalFields extends object = object> =
 };
 
 export type SitePreviewActionProps<PageTreeNodeAdditionalFields extends object = object> = {
-    page: PageTreePage<PageTreeNodeAdditionalFields>;
+    pageTreeNode: PageTreePage<PageTreeNodeAdditionalFields>;
 };

--- a/packages/admin/cms-admin/src/documents/types.ts
+++ b/packages/admin/cms-admin/src/documents/types.ts
@@ -49,8 +49,13 @@ export interface DocumentInterface<
     dependencies: (input: DocumentInput) => BlockDependency[];
     replaceDependenciesInOutput: (output: DocumentOutput, replacements: ReplaceDependencyObject[]) => DocumentOutput;
     hasNoSitePreview?: true;
+    SitePreviewAction?: ComponentType<SitePreviewActionProps>;
 }
 
 export type InfoTagProps<PageTreeNodeAdditionalFields extends object = object> = {
+    page: PageTreePage<PageTreeNodeAdditionalFields>;
+};
+
+export type SitePreviewActionProps<PageTreeNodeAdditionalFields extends object = object> = {
     page: PageTreePage<PageTreeNodeAdditionalFields>;
 };

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -163,7 +163,7 @@ export {
     useContentGenerationConfig,
 } from "./documents/ContentGenerationConfigContext";
 export { createDocumentRootBlocksMethods } from "./documents/createDocumentRootBlocksMethods";
-export type { DocumentInterface, DocumentType, InfoTagProps } from "./documents/types";
+export type { DocumentInterface, DocumentType, InfoTagProps, SitePreviewActionProps } from "./documents/types";
 export { ChooseFileDialog } from "./form/file/chooseFile/ChooseFileDialog";
 export { FileField } from "./form/file/FileField";
 export { FileUploadField, type FileUploadFieldProps } from "./form/file/FileUploadField";

--- a/packages/admin/cms-admin/src/pages/pageTree/PageActions.test.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageActions.test.tsx
@@ -1,0 +1,130 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { cleanup, render, screen } from "test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { type DocumentInterface } from "../../documents/types";
+import PageActions from "./PageActions";
+import { type PageTreePage } from "./usePageTree";
+
+const mockActivatePage = vi.fn();
+const mockOpenSitePreviewWindow = vi.fn();
+
+vi.mock("../../contentScope/Provider", () => ({
+    useContentScope: () => ({
+        match: { url: "http://localhost:3000" },
+    }),
+}));
+
+let mockDocumentTypes: Record<string, DocumentInterface>;
+
+vi.mock("../pageTreeConfig", () => ({
+    usePageTreeConfig: () => ({
+        documentTypes: mockDocumentTypes,
+    }),
+}));
+
+vi.mock("./usePageTreeContext", () => ({
+    usePageTreeContext: () => ({
+        tree: new Map(),
+    }),
+}));
+
+vi.mock("@comet/admin", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@comet/admin")>();
+    return {
+        ...actual,
+        useStackSwitchApi: () => ({
+            activatePage: mockActivatePage,
+        }),
+    };
+});
+
+vi.mock("../../preview/openSitePreviewWindow", () => ({
+    openSitePreviewWindow: (...args: unknown[]) => mockOpenSitePreviewWindow(...args),
+}));
+
+const basePage: PageTreePage = {
+    id: "page-1",
+    name: "Test Page",
+    parentId: null,
+    documentType: "Page",
+    pos: 0,
+    path: "/test-page",
+    category: "MainNavigation",
+    hideInMenu: false,
+    visibility: "Published",
+    slug: "test-page",
+    selected: false,
+    expanded: false,
+    ancestorIds: [],
+    level: 0,
+    matches: [],
+};
+
+const baseDocumentType: DocumentInterface = {
+    displayName: "Page",
+    menuIcon: () => null,
+    anchors: () => [],
+    dependencies: () => [],
+    replaceDependenciesInOutput: (output) => output,
+};
+
+const mockEditDialog = {
+    openEditDialog: vi.fn(),
+    openAddDialog: vi.fn(),
+} as never;
+
+function renderPageActions(page: PageTreePage = basePage) {
+    return render(
+        <MockedProvider>
+            <PageActions page={page} editDialog={mockEditDialog} siteUrl="http://localhost:3000" />
+        </MockedProvider>,
+    );
+}
+
+describe("PageActions", () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    describe("SitePreviewAction", () => {
+        it("renders the custom SitePreviewAction component when provided", () => {
+            const CustomPreviewAction = ({ pageTreeNode }: { pageTreeNode: PageTreePage }) => <button>Custom preview for {pageTreeNode.name}</button>;
+
+            mockDocumentTypes = {
+                Page: {
+                    ...baseDocumentType,
+                    SitePreviewAction: CustomPreviewAction,
+                },
+            };
+
+            renderPageActions();
+
+            expect(screen.getByText("Custom preview for Test Page")).toBeTruthy();
+        });
+
+        it("does not render the custom SitePreviewAction when not provided", () => {
+            mockDocumentTypes = { Page: baseDocumentType };
+
+            renderPageActions();
+
+            expect(screen.queryByText("Custom preview for Test Page")).toBeNull();
+        });
+
+        it("passes the pageTreeNode prop to SitePreviewAction", () => {
+            const sitePreviewActionFn = vi.fn(() => <button>Custom action</button>);
+
+            mockDocumentTypes = {
+                Page: {
+                    ...baseDocumentType,
+                    SitePreviewAction: sitePreviewActionFn,
+                },
+            };
+
+            renderPageActions();
+
+            expect(sitePreviewActionFn).toHaveBeenCalledWith(expect.objectContaining({ pageTreeNode: basePage }), undefined);
+        });
+    });
+});

--- a/packages/admin/cms-admin/src/pages/pageTree/PageActions.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageActions.tsx
@@ -75,7 +75,7 @@ export default function PageActions({ page, editDialog, children, siteUrl }: Pro
                         <FormattedMessage id="comet.pages.pages.page.editContent" defaultMessage="Edit content" />
                     </RowActionsItem>,
                     documentType.SitePreviewAction ? (
-                        <documentType.SitePreviewAction key="preview" page={page} />
+                        <documentType.SitePreviewAction key="preview" pageTreeNode={page} />
                     ) : (
                         <RowActionsItem
                             key="preview"

--- a/packages/admin/cms-admin/src/pages/pageTree/PageActions.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/PageActions.tsx
@@ -74,16 +74,20 @@ export default function PageActions({ page, editDialog, children, siteUrl }: Pro
                     >
                         <FormattedMessage id="comet.pages.pages.page.editContent" defaultMessage="Edit content" />
                     </RowActionsItem>,
-                    <RowActionsItem
-                        key="preview"
-                        icon={documentType.hasNoSitePreview ? <PreviewUnavailable /> : <Preview />}
-                        onClick={() => {
-                            openSitePreviewWindow(page.path, contentScopeMatch.url);
-                        }}
-                        disabled={documentType.hasNoSitePreview}
-                    >
-                        <FormattedMessage id="comet.pages.pages.page.openPreview" defaultMessage="Open preview" />
-                    </RowActionsItem>,
+                    documentType.SitePreviewAction ? (
+                        <documentType.SitePreviewAction key="preview" page={page} />
+                    ) : (
+                        <RowActionsItem
+                            key="preview"
+                            icon={documentType.hasNoSitePreview ? <PreviewUnavailable /> : <Preview />}
+                            onClick={() => {
+                                openSitePreviewWindow(page.path, contentScopeMatch.url);
+                            }}
+                            disabled={documentType.hasNoSitePreview}
+                        >
+                            <FormattedMessage id="comet.pages.pages.page.openPreview" defaultMessage="Open preview" />
+                        </RowActionsItem>
+                    ),
                 ]}
                 <RowActionsMenu>
                     {page.visibility !== "Archived" && [


### PR DESCRIPTION
Allows overriding the site preview button in the page tree row actions on a per-document-type basis. When set, the provided component replaces the default preview `RowActionsItem`, enabling custom preview URL construction (e.g., using additional GraphQL queries or scope data).

**Example**

```tsx
import { RowActionsItem } from "@comet/admin";
import { Preview } from "@comet/admin-icons";
import { type DocumentInterface, openSitePreviewWindow, type SitePreviewActionProps } from "@comet/cms-admin";

function PageSitePreviewAction({ pageTreeNode }: SitePreviewActionProps) {
    // Use hooks to construct a custom preview URL
    const previewPath = useCustomPreviewPath(pageTreeNode);

    return (
        <RowActionsItem
            icon={<Preview />}
            disabled={!previewPath}
            onClick={() => {
                if (previewPath) {
                    openSitePreviewWindow(previewPath, "/custom-root");
                }
            }}
        >
            Open preview
        </RowActionsItem>
    );
}

export const Page: DocumentInterface = {
    // ...
    SitePreviewAction: PageSitePreviewAction,
};
```