### PR TITLE
Mail-React: Add symmetric three and four column layout patterns

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/5-layout-patterns.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/5-layout-patterns.md
@@ -90,6 +90,8 @@ registerStyles(
 );
 ```
 
+For three or more equal-width columns, see [Multi-Column Symmetric Layouts](#multi-column-symmetric-layouts).
+
 ## Asymmetric Two-Column Layout
 
 A fixed-width column paired with a fluid column that takes the remaining space. Common for image-plus-text layouts, icon rows, or sidebar patterns.
@@ -189,7 +191,11 @@ By default, MJML stacks columns in source order on mobile. If you need a column 
         <MjmlColumn className="layout__smallColumn" width={`${SMALL_COLUMN_WIDTH}px`}>
             <MjmlImage src="..." alt="..." width={SMALL_COLUMN_WIDTH} />
         </MjmlColumn>
-        <MjmlColumn className="layout__fluidColumn" width={`${fluidColumnWidth}px`} paddingRight={`${COLUMN_GAP}px`}>
+        <MjmlColumn
+            className="layout__fluidColumn"
+            width={`${fluidColumnWidth}px`}
+            paddingRight={`${COLUMN_GAP}px`}
+        >
             <MjmlText>This appears on the left on desktop, below the image on mobile.</MjmlText>
         </MjmlColumn>
     </MjmlSection>
@@ -200,3 +206,135 @@ Two important details:
 
 1. **`MjmlWrapper` replaces `indent`** — when using `direction="rtl"`, applying `indent` directly on the section causes a 1px line artifact in Outlook. Instead, wrap the section in `MjmlWrapper` and apply the indentation as padding. Set the `backgroundColor` on the wrapper to match the content background.
 2. **Source order = mobile stack order** — the small column is first in the JSX, so it stacks on top on mobile. `direction="rtl"` only affects the visual (left-to-right) order on desktop.
+
+## Multi-Column Symmetric Layouts
+
+Three or more equal-width columns use the same gap-via-inner-padding principle as the two-column layout, but require explicit `width` props: inner columns carry padding on **both** sides while outer columns only have it on one. Without compensation, the inner columns would end up with narrower content areas.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ MjmlSection indent                                              │
+│ ┌───────────────┐ ┌─────────────────┐ ┌───────────────┐         │
+│ │ outer         │ │ inner (wider)   │ │ outer         │         │
+│ │ paddingR:½gap │ │ paddingL:½gap   │ │ paddingL:½gap │         │
+│ │               │ │ paddingR:½gap   │ │               │         │
+│ └───────────────┘ └─────────────────┘ └───────────────┘         │
+│             ←── gap ──→         ←── gap ──→                     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Width Formula
+
+```tsx
+const columnGap = 20;
+const halfColumnGap = columnGap / 2;
+
+const availableContentWidth =
+    theme.sizes.bodyWidth - 2 * getDefaultFromResponsiveValue(theme.sizes.contentIndentation);
+
+const contentWidthPerColumn =
+    (availableContentWidth - (numberOfColumns - 1) * columnGap) / numberOfColumns;
+
+const outerColumnWidth = `${((contentWidthPerColumn + halfColumnGap) / availableContentWidth) * 100}%`;
+const innerColumnWidth = `${((contentWidthPerColumn + columnGap) / availableContentWidth) * 100}%`;
+```
+
+Outer columns get a width accounting for half-gap padding; inner columns are wider to absorb a full gap (half on each side). Percentages — rather than pixels — keep MJML's responsive fallback math predictable.
+
+### Pattern — Three Columns
+
+```tsx
+<MjmlSection indent className="threeColumnsSection">
+    <MjmlColumn
+        className="threeColumnsSection__column"
+        width={outerColumnWidth}
+        paddingRight={halfColumnGap}
+    >
+        <MjmlText>First</MjmlText>
+    </MjmlColumn>
+    <MjmlColumn
+        className="threeColumnsSection__column"
+        width={innerColumnWidth}
+        paddingLeft={halfColumnGap}
+        paddingRight={halfColumnGap}
+    >
+        <MjmlText>Second</MjmlText>
+    </MjmlColumn>
+    <MjmlColumn
+        className="threeColumnsSection__column"
+        width={outerColumnWidth}
+        paddingLeft={halfColumnGap}
+    >
+        <MjmlText>Third</MjmlText>
+    </MjmlColumn>
+</MjmlSection>
+```
+
+### Pattern — Four or More Columns
+
+Same formula; the inner-column is simply repeated. For four columns, the two middle columns both use `innerColumnWidth` with padding on both sides; the first and last use `outerColumnWidth` with padding only on the inner side.
+
+### Responsive Stacking
+
+Below the desktop breakpoint, the compensated inline widths no longer make sense: they were calibrated for a specific container width, and inner columns would otherwise render visibly wider than outer ones. A flex reset on the section's inner `<td>` neutralizes those widths so columns size equally.
+
+The one design decision is **when to collapse to a stack** — and that's per-component. A dense 3-column row might need to stack at mobile; a 4-column row would be too cramped below the default breakpoint.
+
+```ts
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .threeColumnsSection > table > tbody > tr > td {
+                display: flex !important;
+                gap: 20px !important;
+            }
+            .threeColumnsSection__column {
+                flex: 1 1 0% !important;
+                width: auto !important;
+                max-width: none !important;
+                display: block !important;
+            }
+            .threeColumnsSection__column > table > tbody > tr > td {
+                padding-left: 0 !important;
+                padding-right: 0 !important;
+            }
+        }
+
+        ${theme.breakpoints.mobile.belowMediaQuery} {
+            .threeColumnsSection > table > tbody > tr > td {
+                flex-direction: column !important;
+            }
+            .threeColumnsSection__column {
+                flex: none !important;
+                width: 100% !important;
+                max-width: 100% !important;
+            }
+        }
+    `,
+);
+```
+
+| Stack at           | When to use                                                              | Change from the example above                                                                      |
+| ------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| Mobile             | Columns remain readable while narrowing (typical for 3 columns).         | Use as-is.                                                                                         |
+| Default breakpoint | Columns would be too cramped below `bodyWidth` (typical for 4+ columns). | Merge the `mobile.belowMediaQuery` rules into `default.belowMediaQuery` and drop the mobile block. |
+
+### Non-Stacking Rows
+
+For short fixed-value rows — numeric data, icon strips — that remain readable even when narrow, keep columns side-by-side at every viewport. Add `disableResponsiveBehavior` on the section to suppress MJML's own mobile auto-stack:
+
+```tsx
+<MjmlSection indent disableResponsiveBehavior className="iconStrip">
+    {/* …columns as in the Three-Column pattern above… */}
+</MjmlSection>
+```
+
+The inline width compensation still needs to be neutralized so columns render at equal widths. Apply the same flex reset as in [Responsive Stacking](#responsive-stacking), with one adjustment: `disableResponsiveBehavior` wraps the columns in an `MjmlGroup` `<div>`, so the container selector goes one level deeper (`… > td > div`). Drop the `mobile.belowMediaQuery` block entirely — columns never stack.
+
+```ts
+.iconStrip > table > tbody > tr > td > div {
+    display: flex !important;
+    gap: 20px !important;
+}
+/* column rules identical to Responsive Stacking */
+```

--- a/packages/mail-react/src/__stories__/layout-patterns/SymmetricFourColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/SymmetricFourColumnLayout.stories.tsx
@@ -1,0 +1,130 @@
+import { MjmlColumn, MjmlSpacer } from "@faire/mjml-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MjmlSection } from "../../components/section/MjmlSection.js";
+import { MjmlText } from "../../components/text/MjmlText.js";
+import { registerStyles } from "../../styles/registerStyles.js";
+import { createTheme } from "../../theme/createTheme.js";
+import { getDefaultFromResponsiveValue } from "../../theme/responsiveValue.js";
+import { css } from "../../utils/css.js";
+
+const config: Meta = {
+    title: "Layout Patterns/Symmetric Four-Column Layout",
+};
+
+export default config;
+
+const theme = createTheme({
+    text: {
+        defaultVariant: "body",
+        variants: {
+            heading: { fontSize: "22px", lineHeight: "28px", fontWeight: "bold" },
+            subheading: { fontSize: "16px", lineHeight: "22px", fontWeight: "bold" },
+            body: { fontSize: "14px", lineHeight: "20px" },
+        },
+    },
+});
+
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .symmetricFourColumnsSection > table > tbody > tr > td {
+                display: flex !important;
+                flex-direction: column !important;
+                gap: 20px !important;
+            }
+
+            .symmetricFourColumnsSection__column {
+                flex: none !important;
+                width: 100% !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+
+            .symmetricFourColumnsSection__column > table > tbody > tr > td {
+                padding-left: 0 !important;
+                padding-right: 0 !important;
+            }
+        }
+    `,
+);
+
+export const Default: StoryObj = {
+    parameters: { theme },
+    render: () => {
+        const SymmetricFourColumnSection = () => {
+            const columnGap = 20;
+            const halfColumnGap = columnGap / 2;
+            const availableContentWidth = theme.sizes.bodyWidth - 2 * getDefaultFromResponsiveValue(theme.sizes.contentIndentation);
+            const contentWidthPerColumn = (availableContentWidth - 3 * columnGap) / 4;
+
+            const outerColumnWidth = `${((contentWidthPerColumn + halfColumnGap) / availableContentWidth) * 100}%`;
+            const innerColumnWidth = `${((contentWidthPerColumn + columnGap) / availableContentWidth) * 100}%`;
+
+            return (
+                <MjmlSection indent className="symmetricFourColumnsSection">
+                    <MjmlColumn width={outerColumnWidth} paddingRight={halfColumnGap} className="symmetricFourColumnsSection__column">
+                        <MjmlText variant="subheading" bottomSpacing>
+                            First
+                        </MjmlText>
+                        <MjmlText>Minima ea distinctio quisquam. Illo reiciendis non officiis consectetur.</MjmlText>
+                    </MjmlColumn>
+                    <MjmlColumn
+                        width={innerColumnWidth}
+                        paddingLeft={halfColumnGap}
+                        paddingRight={halfColumnGap}
+                        className="symmetricFourColumnsSection__column"
+                    >
+                        <MjmlText variant="subheading" bottomSpacing>
+                            Second
+                        </MjmlText>
+                        <MjmlText>Numquam aut voluptas numquam aspernatur. Consequatur quidem omnis dolorem natus.</MjmlText>
+                    </MjmlColumn>
+                    <MjmlColumn
+                        width={innerColumnWidth}
+                        paddingLeft={halfColumnGap}
+                        paddingRight={halfColumnGap}
+                        className="symmetricFourColumnsSection__column"
+                    >
+                        <MjmlText variant="subheading" bottomSpacing>
+                            Third
+                        </MjmlText>
+                        <MjmlText>Occaecati vel possimus similique reiciendis iure rerum sit architecto.</MjmlText>
+                    </MjmlColumn>
+                    <MjmlColumn width={outerColumnWidth} paddingLeft={halfColumnGap} className="symmetricFourColumnsSection__column">
+                        <MjmlText variant="subheading" bottomSpacing>
+                            Fourth
+                        </MjmlText>
+                        <MjmlText>Voluptas laudantium cupiditate aut repudiandae iste fugiat nam quas debitis.</MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            );
+        };
+
+        return (
+            <>
+                <MjmlSection indent>
+                    <MjmlColumn>
+                        <MjmlSpacer height={30} />
+                        <MjmlText variant="heading" bottomSpacing>
+                            Four column layout
+                        </MjmlText>
+                        <MjmlText>
+                            Four columns follow the same compensation pattern as three columns. The two inner columns each get a wider width to absorb
+                            their double-sided padding. On mobile, a flex reset neutralizes the desktop widths so columns can stack equally.
+                        </MjmlText>
+                        <MjmlSpacer height={30} />
+                    </MjmlColumn>
+                </MjmlSection>
+
+                <SymmetricFourColumnSection />
+
+                <MjmlSection indent>
+                    <MjmlColumn>
+                        <MjmlSpacer height={30} />
+                    </MjmlColumn>
+                </MjmlSection>
+            </>
+        );
+    },
+};

--- a/packages/mail-react/src/__stories__/layout-patterns/SymmetricThreeColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/SymmetricThreeColumnLayout.stories.tsx
@@ -1,0 +1,238 @@
+import { MjmlColumn, MjmlSpacer } from "@faire/mjml-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MjmlSection } from "../../components/section/MjmlSection.js";
+import { MjmlText } from "../../components/text/MjmlText.js";
+import { registerStyles } from "../../styles/registerStyles.js";
+import { createTheme } from "../../theme/createTheme.js";
+import { getDefaultFromResponsiveValue } from "../../theme/responsiveValue.js";
+import { css } from "../../utils/css.js";
+
+const config: Meta = {
+    title: "Layout Patterns/Symmetric Three-Column Layout",
+};
+
+export default config;
+
+const theme = createTheme({
+    text: {
+        defaultVariant: "body",
+        variants: {
+            heading: { fontSize: "22px", lineHeight: "28px", fontWeight: "bold" },
+            subheading: { fontSize: "16px", lineHeight: "22px", fontWeight: "bold" },
+            body: { fontSize: "14px", lineHeight: "20px" },
+        },
+    },
+});
+
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .symmetricThreeColumnsSection > table > tbody > tr > td {
+                display: flex !important;
+                gap: 20px !important;
+            }
+
+            .symmetricThreeColumnsSection__column {
+                flex: 1 1 0% !important;
+                width: auto !important;
+                max-width: none !important;
+                display: block !important;
+            }
+
+            .symmetricThreeColumnsSection__column > table > tbody > tr > td {
+                padding-left: 0 !important;
+                padding-right: 0 !important;
+            }
+        }
+
+        ${theme.breakpoints.mobile.belowMediaQuery} {
+            .symmetricThreeColumnsSection > table > tbody > tr > td {
+                flex-direction: column !important;
+            }
+
+            .symmetricThreeColumnsSection__column {
+                flex: none !important;
+                width: 100% !important;
+                max-width: 100% !important;
+            }
+        }
+    `,
+);
+
+export const Default: StoryObj = {
+    parameters: { theme },
+    render: () => {
+        const SymmetricThreeColumnSection = () => {
+            const columnGap = 20;
+            const halfColumnGap = columnGap / 2;
+            const availableContentWidth = theme.sizes.bodyWidth - 2 * getDefaultFromResponsiveValue(theme.sizes.contentIndentation);
+            const contentWidthPerColumn = (availableContentWidth - 2 * columnGap) / 3;
+
+            const outerColumnWidth = `${((contentWidthPerColumn + halfColumnGap) / availableContentWidth) * 100}%`;
+            const innerColumnWidth = `${((contentWidthPerColumn + columnGap) / availableContentWidth) * 100}%`;
+
+            return (
+                <MjmlSection indent className="symmetricThreeColumnsSection">
+                    <MjmlColumn width={outerColumnWidth} paddingRight={halfColumnGap} className="symmetricThreeColumnsSection__column">
+                        <MjmlText variant="subheading" bottomSpacing>
+                            First column
+                        </MjmlText>
+                        <MjmlText>
+                            Minima ea distinctio quisquam. Illo reiciendis non officiis consectetur. Ratione perferendis distinctio sapiente est.
+                        </MjmlText>
+                    </MjmlColumn>
+                    <MjmlColumn
+                        width={innerColumnWidth}
+                        paddingLeft={halfColumnGap}
+                        paddingRight={halfColumnGap}
+                        className="symmetricThreeColumnsSection__column"
+                    >
+                        <MjmlText variant="subheading" bottomSpacing>
+                            Second column
+                        </MjmlText>
+                        <MjmlText>
+                            Numquam aut voluptas numquam aspernatur. Consequatur quidem omnis dolorem natus quis soluta. Est recusandae delectus.
+                        </MjmlText>
+                    </MjmlColumn>
+                    <MjmlColumn width={outerColumnWidth} paddingLeft={halfColumnGap} className="symmetricThreeColumnsSection__column">
+                        <MjmlText variant="subheading" bottomSpacing>
+                            Third column
+                        </MjmlText>
+                        <MjmlText>
+                            Occaecati vel possimus similique reiciendis iure rerum sit architecto. Voluptas laudantium cupiditate aut repudiandae
+                            iste.
+                        </MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            );
+        };
+
+        return (
+            <>
+                <MjmlSection indent>
+                    <MjmlColumn>
+                        <MjmlSpacer height={30} />
+                        <MjmlText variant="heading" bottomSpacing>
+                            Three column layout
+                        </MjmlText>
+                        <MjmlText>
+                            Three columns require explicit width compensation. Inner columns have padding on both sides while outer columns only have
+                            it on one side, so inner columns are given a wider width to keep all content areas equal. On mobile, a flex reset
+                            neutralizes the desktop widths so columns can size equally and then stack.
+                        </MjmlText>
+                        <MjmlSpacer height={30} />
+                    </MjmlColumn>
+                </MjmlSection>
+
+                <SymmetricThreeColumnSection />
+
+                <MjmlSection indent>
+                    <MjmlColumn>
+                        <MjmlSpacer height={30} />
+                    </MjmlColumn>
+                </MjmlSection>
+            </>
+        );
+    },
+};
+
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .neverStackingThreeColumnsSection > table > tbody > tr > td > div {
+                display: flex !important;
+                gap: 20px !important;
+            }
+
+            .neverStackingThreeColumnsSection__column {
+                flex: 1 1 0% !important;
+                width: auto !important;
+                max-width: none !important;
+                display: block !important;
+            }
+
+            .neverStackingThreeColumnsSection__column > table > tbody > tr > td {
+                padding-left: 0 !important;
+                padding-right: 0 !important;
+            }
+        }
+    `,
+);
+
+export const NeverStacks: StoryObj = {
+    parameters: { theme },
+    render: () => {
+        const NeverStackingThreeColumnSection = () => {
+            const columnGap = 20;
+            const halfColumnGap = columnGap / 2;
+            const availableContentWidth = theme.sizes.bodyWidth - 2 * getDefaultFromResponsiveValue(theme.sizes.contentIndentation);
+            const contentWidthPerColumn = (availableContentWidth - 2 * columnGap) / 3;
+
+            const outerColumnWidth = `${((contentWidthPerColumn + halfColumnGap) / availableContentWidth) * 100}%`;
+            const innerColumnWidth = `${((contentWidthPerColumn + columnGap) / availableContentWidth) * 100}%`;
+
+            return (
+                <MjmlSection indent disableResponsiveBehavior className="neverStackingThreeColumnsSection">
+                    <MjmlColumn width={outerColumnWidth} paddingRight={halfColumnGap} className="neverStackingThreeColumnsSection__column">
+                        <MjmlText variant="subheading" bottomSpacing>
+                            Foo
+                        </MjmlText>
+                        <MjmlText>Lorem</MjmlText>
+                    </MjmlColumn>
+                    <MjmlColumn
+                        width={innerColumnWidth}
+                        paddingLeft={halfColumnGap}
+                        paddingRight={halfColumnGap}
+                        className="neverStackingThreeColumnsSection__column"
+                    >
+                        <MjmlText variant="subheading" bottomSpacing>
+                            Bar
+                        </MjmlText>
+                        <MjmlText>Ipsum</MjmlText>
+                    </MjmlColumn>
+                    <MjmlColumn width={outerColumnWidth} paddingLeft={halfColumnGap} className="neverStackingThreeColumnsSection__column">
+                        <MjmlText variant="subheading" bottomSpacing>
+                            Baz
+                        </MjmlText>
+                        <MjmlText>Dolor</MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            );
+        };
+
+        return (
+            <>
+                <MjmlSection indent>
+                    <MjmlColumn>
+                        <MjmlSpacer height={30} />
+                        <MjmlText variant="heading" bottomSpacing>
+                            Three columns that never stack
+                        </MjmlText>
+                        <MjmlText bottomSpacing>
+                            Same width compensation and flex-reset mechanic as the default three-column layout, without the mobile stacking override
+                            so columns stay side-by-side at every viewport.
+                        </MjmlText>
+                        <MjmlText bottomSpacing>
+                            <code>disableResponsiveBehavior</code> wraps the columns in an <code>MjmlGroup</code> internally so MJML&apos;s own mobile
+                            auto-stack is suppressed even in clients that ignore the flex CSS. Because of that wrapper, the flex reset targets one
+                            level deeper (<code>… &gt; td &gt; div</code>) than in the default layout.
+                        </MjmlText>
+                        <MjmlText>
+                            Suitable for short, fixed-value rows — metrics, numeric summaries, icon strips — that remain readable even when narrow.
+                        </MjmlText>
+                        <MjmlSpacer height={30} />
+                    </MjmlColumn>
+                </MjmlSection>
+
+                <NeverStackingThreeColumnSection />
+
+                <MjmlSection indent>
+                    <MjmlColumn>
+                        <MjmlSpacer height={30} />
+                    </MjmlColumn>
+                </MjmlSection>
+            </>
+        );
+    },
+};

--- a/skills/comet-mail-react/references/layout-patterns.md
+++ b/skills/comet-mail-react/references/layout-patterns.md
@@ -75,6 +75,124 @@ registerStyles(
 );
 ```
 
+For three or more equal-width columns, see [Multi-Column Symmetric Layouts](#multi-column-symmetric-layouts-3-columns).
+
+---
+
+## Multi-Column Symmetric Layouts (3+ columns)
+
+Three or more equal-width columns need explicit `width` props because inner columns carry padding on both sides and outer columns on only one. Without compensation, content areas are unequal.
+
+### N-Column Width Formula
+
+```ts
+const columnGap = 20;
+const halfColumnGap = columnGap / 2;
+const availableContentWidth = theme.sizes.bodyWidth - 2 * getDefaultFromResponsiveValue(theme.sizes.contentIndentation);
+const contentWidthPerColumn = (availableContentWidth - (numberOfColumns - 1) * columnGap) / numberOfColumns;
+
+const outerColumnWidth = `${((contentWidthPerColumn + halfColumnGap) / availableContentWidth) * 100}%`;
+const innerColumnWidth = `${((contentWidthPerColumn + columnGap) / availableContentWidth) * 100}%`;
+```
+
+- Outermost columns → `outerColumnWidth`, padding on their inner side only
+- All middle columns → `innerColumnWidth`, padding on both sides (`halfColumnGap` each)
+
+Scales to any N; 3 and 4 differ only in how many middle columns you repeat. Percentages — not pixels — keep MJML's fallback math predictable.
+
+### Pattern
+
+Three columns shown; for four or more, repeat the middle-column.
+
+```tsx
+<MjmlSection indent className="multiColumnSection">
+    <MjmlColumn className="multiColumnSection__column" width={outerColumnWidth} paddingRight={halfColumnGap}>
+        …
+    </MjmlColumn>
+    <MjmlColumn className="multiColumnSection__column" width={innerColumnWidth} paddingLeft={halfColumnGap} paddingRight={halfColumnGap}>
+        …
+    </MjmlColumn>
+    <MjmlColumn className="multiColumnSection__column" width={outerColumnWidth} paddingLeft={halfColumnGap}>
+        …
+    </MjmlColumn>
+</MjmlSection>
+```
+
+### Responsive Stacking — Pick Per Layout
+
+Stacking is a **design decision per component**, not a function of column count. Do not assume the user wants the storybook default — these are starting points, not rules. If it is unclear which strategy fits, infer from the content (dense text vs. short labels vs. fixed-width icons/numbers) or ask.
+
+| Strategy            | When to pick it                                                                         | How it's implemented                                                               |
+| ------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| A. Stack at mobile  | Columns stay readable while narrowing below `bodyWidth` (e.g., 3-col storybook default) | Flex reset at `default` + stack at `mobile`                                        |
+| B. Stack at default | Columns would get too cramped below `bodyWidth` (e.g., 4-col storybook default)         | Flex reset that stacks at `default`                                                |
+| C. Never stack      | Short fixed content that must remain horizontal (numeric rows, icon strips)             | `disableResponsiveBehavior` + flex reset one level deeper (targets `… > td > div`) |
+
+All three strategies share the same flex reset on the element that directly contains the columns — it neutralises the compensated inline widths so content areas stay equal at every viewport (without it, percentage widths and pixel paddings drift apart below `bodyWidth`, making columns unequal by a few pixels). For A and B the container is the section's inner `<td>`; for C it is the `MjmlGroup` wrapper `<div>` that `disableResponsiveBehavior` inserts between the `<td>` and the columns, so the selector goes one level deeper (`… > td > div`). They also differ at `mobile.belowMediaQuery`: A adds a stack override, B collapses into the `default` block and stacks immediately, C adds nothing. Strategy C additionally needs `disableResponsiveBehavior` on the section — MJML auto-stacks below its own mobile breakpoint by default, and this prop wraps the columns in an `MjmlGroup` internally so the auto-stack is suppressed even in clients that ignore the flex CSS.
+
+**Strategy A** — keep the horizontal intermediate state, stack at mobile:
+
+```ts
+${theme.breakpoints.default.belowMediaQuery} {
+    .multiColumnSection > table > tbody > tr > td {
+        display: flex !important;
+        gap: 20px !important;
+    }
+    .multiColumnSection__column {
+        flex: 1 1 0% !important;
+        width: auto !important;
+        max-width: none !important;
+        display: block !important;
+    }
+    .multiColumnSection__column > table > tbody > tr > td {
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
+}
+
+${theme.breakpoints.mobile.belowMediaQuery} {
+    .multiColumnSection > table > tbody > tr > td {
+        flex-direction: column !important;
+    }
+    .multiColumnSection__column {
+        flex: none !important;
+        width: 100% !important;
+        max-width: 100% !important;
+    }
+}
+```
+
+**Strategy B** — collapse the two blocks: put `flex-direction: column` and `width: 100%` in the `default.belowMediaQuery` block and drop the `mobile.belowMediaQuery` block.
+
+**Strategy C** — set `disableResponsiveBehavior` on the section and apply Strategy A's flex reset one level deeper (the group wrapper), dropping the `mobile.belowMediaQuery` block:
+
+```tsx
+<MjmlSection indent disableResponsiveBehavior className="multiColumnSection">
+    {/* …columns as in the pattern above… */}
+</MjmlSection>
+```
+
+```ts
+${theme.breakpoints.default.belowMediaQuery} {
+    .multiColumnSection > table > tbody > tr > td > div {
+        display: flex !important;
+        gap: 20px !important;
+    }
+    .multiColumnSection__column {
+        flex: 1 1 0% !important;
+        width: auto !important;
+        max-width: none !important;
+        display: block !important;
+    }
+    .multiColumnSection__column > table > tbody > tr > td {
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
+}
+```
+
+The only difference from Strategy A's `default.belowMediaQuery` block is the `> div` in the first selector — `disableResponsiveBehavior` wraps the columns in an `MjmlGroup` `<div>` inside the `<td>`, so the flex container has to target that wrapper instead of the `<td>` to make the columns its direct flex children. Applying flex to the `<td>` instead would give it a single flex item (the wrapper), and the block-display rule on the columns below would make them stack vertically inside that wrapper.
+
 ---
 
 ## Asymmetric Two-Column Layout (Fixed + Fluid)


### PR DESCRIPTION
| Three Columns | Four Columns | Three Columns (non-stacking) |
|--------|--------|--------|
| <img width="768" height="349" alt="3 desktop" src="https://github.com/user-attachments/assets/c3d471ce-0eb3-4a00-8da5-f9836def7f01" /> | <img width="768" height="349" alt="4 desktop" src="https://github.com/user-attachments/assets/3e996ec5-60c4-4684-8707-4bebaef3fd56" /> | <img width="768" height="382" alt="non-stacking desktop" src="https://github.com/user-attachments/assets/40573e42-e06d-489b-9094-36f19275e479" /> |
| <img width="500" height="530" alt="3 tablet" src="https://github.com/user-attachments/assets/758b8b3e-ee2f-4e51-bd1a-625fcbfd2bdc" /> | <img width="500" height="530" alt="4 tablet" src="https://github.com/user-attachments/assets/ed3eb049-7672-4eb5-bc23-26372a8dc610" /> | <img width="500" height="410" alt="non-stacking tablet" src="https://github.com/user-attachments/assets/7af991d2-f865-4a27-acda-fc558a0b281d" /> |
| <img width="375" height="585" alt="3 mobile" src="https://github.com/user-attachments/assets/12e5485c-de26-4a6a-b523-fecdea6a4482" /> | <img width="375" height="585" alt="4 mobile" src="https://github.com/user-attachments/assets/386a3865-dfba-45e7-acf7-41737831f85a" /> | <img width="375" height="475" alt="non-stacking mobile" src="https://github.com/user-attachments/assets/24d38877-1dee-4f79-bf00-d8c7d549b0f0" /> |

---

https://vivid-planet.atlassian.net/browse/PHSB2C-11720