### PR TITLE
Add setup:ci step to Netlify build commands

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,4 +1,4 @@
 [build]
-  command = "cd .. && pnpm install --frozen-lockfile && pnpm build:docs"
+  command = "cd .. && pnpm install --frozen-lockfile && pnpm setup:ci && pnpm build:docs"
   publish = "build"
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- . ../storybook/ ../packages/admin/"

--- a/storybook/netlify.toml
+++ b/storybook/netlify.toml
@@ -1,4 +1,4 @@
 [build]
-  command = "cd .. && pnpm install --frozen-lockfile && pnpm build:storybook"
+  command = "cd .. && pnpm install --frozen-lockfile && pnpm setup:ci && pnpm build:storybook"
   publish = "storybook-static"
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- . ../packages/admin/"


### PR DESCRIPTION
## Summary
Updated Netlify build configurations for both docs and storybook to include a `pnpm setup:ci` step before building, ensuring proper CI environment setup.

## Changes
- **docs/netlify.toml**: Added `pnpm setup:ci` command between install and build steps
- **storybook/netlify.toml**: Added `pnpm setup:ci` command between install and build steps

## Details
Both Netlify build configurations now execute the setup:ci task as part of their build pipeline. This ensures that any CI-specific setup requirements (such as environment configuration, dependency linking, or other initialization tasks) are properly completed before the documentation and storybook builds run.

https://claude.ai/code/session_019cmUrizSKM5kDtB6XzvjC3