### PR TITLE
Fix DataGridPagination page information not pluralizing "items"

### DIFF
--- a/.changeset/khaki-turkeys-camp.md
+++ b/.changeset/khaki-turkeys-camp.md
@@ -1,0 +1,9 @@
+---
+"@comet/admin": patch
+---
+
+Fix `DataGridPagination` page information not pluralizing "items"
+
+The default message for `comet.dataGridPagination.pageInformation` used a fixed plural form, forcing translations to follow the same shape. In languages with distinct singular/plural forms, this produced an incorrect result when `itemsTotal === 1`. The default message now uses ICU `plural` syntax so translators can branch on count.
+
+Projects that maintain their own translation of `comet.dataGridPagination.pageInformation` should update it to use `plural` with `one` and `other` branches.

--- a/packages/admin/admin/src/dataGrid/pagination/DataGridPagination.tsx
+++ b/packages/admin/admin/src/dataGrid/pagination/DataGridPagination.tsx
@@ -50,7 +50,7 @@ export const DataGridPagination: FunctionComponent<DataGridPaginationProps> = (i
             <PageInformation variant="body2" {...slotProps.pageInformation}>
                 <FormattedMessage
                     id="comet.dataGridPagination.pageInformation"
-                    defaultMessage="{itemsFrom}-{itemsTo} of {itemsTotal} items"
+                    defaultMessage="{itemsFrom}-{itemsTo} of {itemsTotal, plural, one {# item} other {# items}}"
                     values={{
                         itemsFrom:
                             paginationState.rowCount === 0 ? 0 : paginationState.paginationModel.page * paginationState.paginationModel.pageSize + 1,


### PR DESCRIPTION
## Problem

`DataGridPagination` renders the page-information string with a fixed plural noun:

```tsx
defaultMessage="{itemsFrom}-{itemsTo} of {itemsTotal} items"
```

Because the default message hard-codes the plural "items", translations inherit the same shape and can't branch on count. In languages with distinct singular/plural forms (e.g. German) this produces an incorrect form when `itemsTotal === 1`:

- **de:** `1 von 1 Elementen` (should be `1 von 1 Element`)
- **en:** `1 of 1 items` (slightly off, should be `1 of 1 item`)

## Solution

Switch the default message to ICU `plural` syntax so translators can branch on count:

```tsx
defaultMessage="{itemsFrom}-{itemsTo} of {itemsTotal, plural, one {# item} other {# items}}"
```

Downstream projects that maintain their own translation of `comet.dataGridPagination.pageInformation` can now update their JSON, e.g. for German:

```
{itemsFrom}-{itemsTo} von {itemsTotal, plural, one {# Element} other {# Elementen}}
```

Existing (non-plural) overrides continue to render — just without singular branching — so this is a non-breaking change.

## Changeset

Added (`patch` bump for `@comet/admin`).
