### PR TITLE
fix(cms-api): add .js extensions to @nestjs/graphql deep imports

### DIFF
--- a/.changeset/fix-cms-api-graphql-13-3-imports.md
+++ b/.changeset/fix-cms-api-graphql-13-3-imports.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix `MODULE_NOT_FOUND` errors caused by extensionless deep imports of `@nestjs/graphql` internals in `PartialType`. `@nestjs/graphql` 13.3.0 tightened its `exports` map so that the `"./*": "./*"` pattern no longer maps to `.js` automatically. The deep imports of `plugin-constants`, `get-fields-and-decorator.util` and `type-helpers.utils` now use explicit `.js` extensions.

--- a/.changeset/fix-cms-api-graphql-13-3-imports.md
+++ b/.changeset/fix-cms-api-graphql-13-3-imports.md
@@ -2,4 +2,4 @@
 "@comet/cms-api": patch
 ---
 
-Fix `MODULE_NOT_FOUND` errors caused by extensionless deep imports of `@nestjs/graphql` internals in `PartialType`. `@nestjs/graphql` 13.3.0 tightened its `exports` map so that the `"./*": "./*"` pattern no longer maps to `.js` automatically. The deep imports of `plugin-constants`, `get-fields-and-decorator.util` and `type-helpers.utils` now use explicit `.js` extensions.
+Fix `MODULE_NOT_FOUND` errors caused by extensionless deep imports of `@nestjs/graphql` internals. `@nestjs/graphql` 13.3.0 tightened its `exports` map so that the `"./*": "./*"` pattern no longer maps to `.js` automatically. All deep imports of `@nestjs/graphql` internals now use explicit `.js` extensions.

--- a/.cspellignore
+++ b/.cspellignore
@@ -7,6 +7,7 @@ codemods
 Embeddables
 exceljs
 exif
+extensionless
 GraphQLJSONObject
 imgproxy
 kubernetes

--- a/packages/api/cms-api/src/common/helper/partial-type.helper.ts
+++ b/packages/api/cms-api/src/common/helper/partial-type.helper.ts
@@ -3,9 +3,9 @@ import type { Type } from "@nestjs/common";
 import { isFunction } from "@nestjs/common/utils/shared.utils";
 import { Field } from "@nestjs/graphql";
 import type { ClassDecoratorFactory } from "@nestjs/graphql/dist/interfaces/class-decorator-factory.interface";
-import { METADATA_FACTORY_NAME } from "@nestjs/graphql/dist/plugin/plugin-constants";
-import { getFieldsAndDecoratorForType } from "@nestjs/graphql/dist/schema-builder/utils/get-fields-and-decorator.util";
-import { applyFieldDecorators } from "@nestjs/graphql/dist/type-helpers/type-helpers.utils";
+import { METADATA_FACTORY_NAME } from "@nestjs/graphql/dist/plugin/plugin-constants.js";
+import { getFieldsAndDecoratorForType } from "@nestjs/graphql/dist/schema-builder/utils/get-fields-and-decorator.util.js";
+import { applyFieldDecorators } from "@nestjs/graphql/dist/type-helpers/type-helpers.utils.js";
 import { inheritPropertyInitializers, inheritTransformationMetadata, inheritValidationMetadata } from "@nestjs/mapped-types";
 
 import { IsUndefinable } from "../validators/is-undefinable";

--- a/packages/api/cms-api/src/dependencies/discover.service.ts
+++ b/packages/api/cms-api/src/dependencies/discover.service.ts
@@ -1,7 +1,7 @@
 import { AnyEntity, EntityClass, EntityMetadata, EntityRepository, MikroORM } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
 import { TypeMetadataStorage } from "@nestjs/graphql";
-import { ObjectTypeMetadata } from "@nestjs/graphql/dist/schema-builder/metadata/object-type.metadata";
+import { ObjectTypeMetadata } from "@nestjs/graphql/dist/schema-builder/metadata/object-type.metadata.js";
 
 import { Block } from "../blocks/block";
 import { ROOT_BLOCK_KEYS_METADATA_KEY, ROOT_BLOCK_METADATA_KEY } from "../blocks/decorators/root-block";


### PR DESCRIPTION
## Problem

After upgrading `@nestjs/graphql` to 13.3.0, any project using `@comet/cms-api` fails to start (and tests fail to load) with:

```
Error: Cannot find module '/.../node_modules/@nestjs/graphql/dist/plugin/plugin-constants'
    at finalizeEsmResolution (node:internal/modules/cjs/loader)
    at resolveExports (node:internal/modules/cjs/loader)
  code: 'MODULE_NOT_FOUND',
  path: '/.../node_modules/@nestjs/graphql'
```

## Cause

`@nestjs/graphql` 13.3.0 tightened its `package.json` `exports` map. The subpath pattern `"./*": "./*"` no longer falls back to a `.js` extension, so extensionless deep imports go through `finalizeEsmResolution` and fail.

`packages/api/cms-api/src/common/helper/partial-type.helper.ts` does three such extensionless deep imports:

- `@nestjs/graphql/dist/plugin/plugin-constants`
- `@nestjs/graphql/dist/schema-builder/utils/get-fields-and-decorator.util`
- `@nestjs/graphql/dist/type-helpers/type-helpers.utils`

Verified with plain Node:

```
node -e "require('@nestjs/graphql/dist/plugin/metadata-loader')"     -> MODULE_NOT_FOUND
node -e "require('@nestjs/graphql/dist/plugin/metadata-loader.js')"  -> OK
```

## Fix

Append `.js` to each of those three deep imports. Resolves correctly under both 13.2.x and 13.3.x.

## Changeset

Patch bump for `@comet/cms-api`.
