### PR TITLE
CLI: Make `install-agent-skills` also install from `agentic-plugin/skills`

### DIFF
--- a/.changeset/install-agent-skills-agentic-plugin-source.md
+++ b/.changeset/install-agent-skills-agentic-plugin-source.md
@@ -1,0 +1,9 @@
+---
+"@comet/cli": minor
+---
+
+`install-agent-skills`: also install skills from `agentic-plugin/skills/`
+
+In addition to the existing `skills/` directory, the command now installs skills from `agentic-plugin/skills/`. This allows shipping agent skills as part of a Claude Code plugin (with a `.claude-plugin/plugin.json` manifest) without losing the ability to install them via `install-agent-skills`.
+
+Both directories are also fetched (via git sparse checkout) when consuming external repos listed in `agent-skills.json`. `skills/` keeps priority over `agentic-plugin/skills/`.

--- a/.cspellignore
+++ b/.cspellignore
@@ -73,3 +73,4 @@ roundrect
 arcsize
 shakability
 fulltext
+agentic

--- a/docs/docs/4-guides/5-installing-agent-skills.md
+++ b/docs/docs/4-guides/5-installing-agent-skills.md
@@ -54,7 +54,7 @@ The `SKILL.md` file contains markdown-formatted instructions that the agent foll
 
 ## Local skills
 
-Place skill folders inside `skills/` at your repo root. These have the highest priority and override any same-named skills from external repos.
+Place skill folders inside `skills/` or `agentic-plugin/skills/` at your repo root. These have the highest priority and override any same-named skills from external repos. `skills/` takes priority over `agentic-plugin/skills/`.
 
 Then run the `install-agent-skills` command to symlink them into the target directories:
 
@@ -62,7 +62,7 @@ Then run the `install-agent-skills` command to symlink them into the target dire
 npx @comet/cli install-agent-skills
 ```
 
-Local skills are **symlinked**, so edits to `skills/` are reflected immediately without re-running the command.
+Local skills are **symlinked**, so edits are reflected immediately without re-running the command.
 
 If your repo is also used as a skill source by other projects, see [Internal skills](#internal-skills) to prevent local-only skills from being installed by consumers.
 
@@ -76,7 +76,7 @@ You can install skills from external git repositories. This allows you to consum
 }
 ```
 
-Each entry is an SSH git URL, optionally followed by `#ref` to pin a branch, tag, or commit hash. Only the `skills/` folder is fetched from each repo (via git sparse checkout) — the rest of the repository is not downloaded. External skills are **copied** into the target directories.
+Each entry is an SSH git URL, optionally followed by `#ref` to pin a branch, tag, or commit hash. Only the `skills/` and `agentic-plugin/skills/` folders are fetched from each repo (via git sparse checkout) — the rest of the repository is not downloaded. External skills are **copied** into the target directories.
 
 Skills with `metadata.internal: true` in their `SKILL.md` are excluded when installing from external repos.
 
@@ -126,7 +126,7 @@ npx @comet/cli install-agent-skills --dry-run
 
 If you maintain a library, you can add agent skills to your repository so that projects using your library can pull them in via `agent-skills.json`.
 
-Place skill folders inside a `skills/` directory at your repo root:
+Place skill folders inside a `skills/` directory at your repo root (or `agentic-plugin/skills/` if you ship them as a Claude Code plugin):
 
 ```
 skills/
@@ -136,7 +136,7 @@ skills/
     └── SKILL.md
 ```
 
-When a consumer references your repo, `install-agent-skills` will sparse-fetch only the `skills/` folder — the rest of your repository is never downloaded. Their `agent-skills.json` would look like:
+When a consumer references your repo, `install-agent-skills` will sparse-fetch only the `skills/` and `agentic-plugin/skills/` folders — the rest of your repository is never downloaded. Their `agent-skills.json` would look like:
 
 ```json
 {

--- a/packages/cli/src/commands/install-agent-skills.ts
+++ b/packages/cli/src/commands/install-agent-skills.ts
@@ -27,19 +27,21 @@ function parseRepoUrl(rawUrl: string): { repoUrl: string; ref: string | undefine
     return { repoUrl: rawUrl.slice(0, hashIndex), ref: rawUrl.slice(hashIndex + 1) || undefined };
 }
 
+const SKILL_SOURCE_PATHS = ["skills", "agentic-plugin/skills"];
+
 function cloneRepo(rawUrl: string): string {
     const { repoUrl, ref } = parseRepoUrl(rawUrl);
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "comet-agent-skills-"));
 
-    // Use sparse checkout to fetch only the skills/ folder
+    // Use sparse checkout to fetch only the skill source folders
     execFileSync("git", ["init", tmpDir], { stdio: "pipe" });
     execFileSync("git", ["-C", tmpDir, "remote", "add", "origin", "--", repoUrl], { stdio: "pipe" });
     execFileSync("git", ["-C", tmpDir, "config", "core.sparseCheckout", "true"], { stdio: "pipe" });
-    fs.writeFileSync(path.join(tmpDir, ".git", "info", "sparse-checkout"), "skills/\n");
+    fs.writeFileSync(path.join(tmpDir, ".git", "info", "sparse-checkout"), SKILL_SOURCE_PATHS.map((p) => `${p}/\n`).join(""));
 
     const fetchRef = ref ?? "HEAD";
     try {
-        console.log(`Fetching ${repoUrl} ref "${fetchRef}" (sparse, skills/ only)...`);
+        console.log(`Fetching ${repoUrl} ref "${fetchRef}" (sparse, ${SKILL_SOURCE_PATHS.map((p) => `${p}/`).join(", ")} only)...`);
         execFileSync("git", ["-C", tmpDir, "fetch", "--depth", "1", "origin", fetchRef], { stdio: "pipe" });
         execFileSync("git", ["-C", tmpDir, "checkout", "FETCH_HEAD"], { stdio: "pipe" });
     } catch {
@@ -171,20 +173,26 @@ export const installAgentSkillsCommand = new Command("install-agent-skills")
             fs.mkdirSync(dir, { recursive: true });
         }
 
-        // Priority order: local skills/ > external repos (in arg order)
-        const sources: SkillSource[] = [{ label: "local skills/", directory: path.join(cwd, "skills"), symlink: true }];
+        // Priority order: local skill folders (in declared order) > external repos (in arg order)
+        const sources: SkillSource[] = SKILL_SOURCE_PATHS.map((p) => ({
+            label: `local ${p}/`,
+            directory: path.join(cwd, p),
+            symlink: true,
+        }));
 
         const tempDirs: string[] = [];
         try {
             for (const rawUrl of repos) {
                 const cloneDir = cloneRepo(rawUrl);
                 tempDirs.push(cloneDir);
-                sources.push({
-                    label: `external ${rawUrl}`,
-                    directory: path.join(cloneDir, "skills"),
-                    symlink: false,
-                    filterInternal: true,
-                });
+                for (const p of SKILL_SOURCE_PATHS) {
+                    sources.push({
+                        label: `external ${rawUrl} (${p}/)`,
+                        directory: path.join(cloneDir, p),
+                        symlink: false,
+                        filterInternal: true,
+                    });
+                }
             }
             installSkills(sources, targetDirs, { dryRun });
         } finally {


### PR DESCRIPTION
As preparation for the COMET agentic plugin (https://github.com/vivid-planet/comet/pull/5532)

---

In addition to the existing top-level `skills/` directory, the install-agent-skills command now installs skills from `agentic-plugin/skills/` as well. This allows shipping skills as a Claude Code / Copilot plugin without losing the install-agent-skills flow. Both directories are also fetched (via git sparse checkout) when consuming external repos listed in agent-skills.json.