### PR TITLE
Use nested spread instead of structuredClone in scoped theming example

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
@@ -428,9 +428,20 @@ import { MjmlColumn, MjmlSection, MjmlText, ThemeProvider } from "@comet/mail-re
 
 import { theme } from "./theme";
 
-const darkSectionTheme = structuredClone(theme);
-darkSectionTheme.colors.background.content = "#1A1A2E";
-darkSectionTheme.text.color = "#FFFFFF";
+const darkSectionTheme = {
+    ...theme,
+    colors: {
+        ...theme.colors,
+        background: {
+            ...theme.colors.background,
+            content: "#1A1A2E",
+        },
+    },
+    text: {
+        ...theme.text,
+        color: "#FFFFFF",
+    },
+};
 
 function EmailWithDarkFooter() {
     return (

--- a/skills/comet-mail-react/references/components-and-theme.md
+++ b/skills/comet-mail-react/references/components-and-theme.md
@@ -343,9 +343,20 @@ Use `!important` when setting a custom link color — the responsive reset uses 
 import { ThemeProvider } from "@comet/mail-react";
 import { theme } from "./theme";
 
-const darkSectionTheme = structuredClone(theme);
-darkSectionTheme.colors.background.content = "#1A1A2E";
-darkSectionTheme.text.color = "#FFFFFF";
+const darkSectionTheme = {
+    ...theme,
+    colors: {
+        ...theme.colors,
+        background: {
+            ...theme.colors.background,
+            content: "#1A1A2E",
+        },
+    },
+    text: {
+        ...theme.text,
+        color: "#FFFFFF",
+    },
+};
 
 function EmailWithDarkFooter() {
     return (
@@ -368,7 +379,7 @@ function EmailWithDarkFooter() {
 }
 ```
 
-`ThemeProvider` **replaces** the theme — it does not merge with the parent. Use `structuredClone` on the root theme and override only what needs to change to preserve settings like font family, variants, and breakpoints.
+`ThemeProvider` **replaces** the theme — it does not merge with the parent. Spread the root theme and override only what needs to change to preserve settings like font family, variants, and breakpoints.
 
 Theme-aware `registerStyles` entries always resolve against the **root theme** from `MjmlMailRoot`, not nested `ThemeProvider` scopes.
 


### PR DESCRIPTION
`structuredClone` may cause runtime errors when the theme carries values it cannot copy (functions, class instances, React elements). A nested spread preserves those values by reference and is functionally equivalent for overriding nested fields.