### PR TITLE
Fix `hideContextMenu` not hiding the context menu column in the DAM `DataGrid`

### DIFF
--- a/.changeset/dam-table-fix-hide-context-menu.md
+++ b/.changeset/dam-table-fix-hide-context-menu.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix `hideContextMenu` not hiding the context menu column in the DAM `DataGrid`
+
+The visibility flag was applied to a no-longer-existing `contextMenu` column id; the column had been renamed to `actions`. The flag now targets the correct column.

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -661,7 +661,7 @@ const FolderDataGrid = ({
                     disableRowSelectionExcludeModel
                     initialState={{ columns: { columnVisibilityModel: { importSourceType: importSources !== undefined } } }}
                     columnVisibilityModel={{
-                        contextMenu: !hideContextMenu,
+                        actions: !hideContextMenu,
                     }}
                     slots={{
                         toolbar: FolderDataGridToolbar as GridSlotsComponent["toolbar"],


### PR DESCRIPTION
The column was renamed from `contextMenu` to `actions` some time ago. Since then, this hasn't worked correctly.

Before:

<img width="1920" height="957" alt="Bildschirmfoto 2026-05-04 um 09 48 18" src="https://github.com/user-attachments/assets/c6f6784b-7d37-4a9e-b582-af2c3de3f5d7" />


Now:

<img width="1920" height="957" alt="Bildschirmfoto 2026-05-04 um 09 47 53" src="https://github.com/user-attachments/assets/f3355ffc-6b57-4018-86fd-6cfc9c2049c8" />
