### PR TITLE
Hide selective actions of DAM more actions menu in `ChooseDamFileDialog`

### DIFF
--- a/.changeset/cold-walls-travel.md
+++ b/.changeset/cold-walls-travel.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Hide selective actions of DAM more actions menu in `ChooseDamFileDialog`

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -85,6 +85,7 @@ export interface DamConfig {
     contentScopeIndicator?: ReactNode;
     hideMultiselect?: boolean;
     hideDamActions?: boolean;
+    hideSelectiveActions?: boolean;
     additionalToolbarItems?: ReactNode;
 }
 
@@ -99,6 +100,7 @@ export const DamTable = ({ renderWithFullHeightMainContent, ...damConfigProps }:
         hideContextMenu: false,
         hideMultiselect: false,
         hideDamActions: false,
+        hideSelectiveActions: false,
         hideArchiveFilter: false,
         ...damConfigProps,
     };

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -85,7 +85,9 @@ export interface DamConfig {
     contentScopeIndicator?: ReactNode;
     hideMultiselect?: boolean;
     hideDamActions?: boolean;
-    hideSelectiveActions?: boolean;
+    toolbarOptions?: {
+        hideSelectiveActions?: boolean;
+    };
     additionalToolbarItems?: ReactNode;
 }
 
@@ -100,7 +102,6 @@ export const DamTable = ({ renderWithFullHeightMainContent, ...damConfigProps }:
         hideContextMenu: false,
         hideMultiselect: false,
         hideDamActions: false,
-        hideSelectiveActions: false,
         hideArchiveFilter: false,
         ...damConfigProps,
     };

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -85,12 +85,14 @@ interface FolderDataGridProps extends DamConfig {
     id?: string;
     breadcrumbs?: BreadcrumbItem[];
     filterApi: IFilterApi<DamFilter>;
+    hideSelectiveActions?: boolean;
 }
 
 type FolderDataGridToolbarProps = {
     id?: string;
     filterApi: IFilterApi<DamFilter>;
     hideArchiveFilter?: boolean;
+    hideSelectiveActions?: boolean;
     additionalToolbarItems?: ReactNode;
     uploadFilters: {
         allowedMimetypes?: string[];
@@ -101,6 +103,7 @@ function FolderDataGridToolbar({
     id: currentFolderId,
     filterApi,
     hideArchiveFilter,
+    hideSelectiveActions,
     additionalToolbarItems,
     uploadFilters,
 }: FolderDataGridToolbarProps) {
@@ -131,6 +134,7 @@ function FolderDataGridToolbar({
                     }}
                     folderId={data?.damFolder.id}
                     filter={uploadFilters}
+                    hideSelectiveActions={hideSelectiveActions}
                 />
 
                 <UploadFilesButton folderId={data?.damFolder.id} filter={uploadFilters} />
@@ -145,6 +149,7 @@ const FolderDataGrid = ({
     breadcrumbs,
     hideContextMenu = false,
     hideArchiveFilter,
+    hideSelectiveActions,
     hideMultiselect,
     renderDamLabel,
     ...props
@@ -672,6 +677,7 @@ const FolderDataGrid = ({
                             breadcrumbs,
                             filterApi,
                             uploadFilters,
+                            hideSelectiveActions,
                             additionalToolbarItems: props.additionalToolbarItems,
                         } as FolderDataGridToolbarProps,
                     }}

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -85,7 +85,6 @@ interface FolderDataGridProps extends DamConfig {
     id?: string;
     breadcrumbs?: BreadcrumbItem[];
     filterApi: IFilterApi<DamFilter>;
-    hideSelectiveActions?: boolean;
 }
 
 type FolderDataGridToolbarProps = {
@@ -149,7 +148,7 @@ const FolderDataGrid = ({
     breadcrumbs,
     hideContextMenu = false,
     hideArchiveFilter,
-    hideSelectiveActions,
+    toolbarOptions,
     hideMultiselect,
     renderDamLabel,
     ...props
@@ -677,8 +676,8 @@ const FolderDataGrid = ({
                             breadcrumbs,
                             filterApi,
                             uploadFilters,
-                            hideSelectiveActions,
                             additionalToolbarItems: props.additionalToolbarItems,
+                            ...toolbarOptions,
                         } as FolderDataGridToolbarProps,
                     }}
                     showToolbar

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamMoreActions.tsx
@@ -16,9 +16,10 @@ interface DamMoreActionsProps {
     filter?: {
         allowedMimetypes?: string[];
     };
+    hideSelectiveActions?: boolean;
 }
 
-export const DamMoreActions = ({ transformOrigin, anchorOrigin, folderId, filter }: DamMoreActionsProps) => {
+export const DamMoreActions = ({ transformOrigin, anchorOrigin, folderId, filter, hideSelectiveActions }: DamMoreActionsProps) => {
     const damSelectionActionsApi = useDamSelectionApi();
     const { selectionMap, archiveSelected, deleteSelected, downloadSelected, restoreSelected, moveSelected } = damSelectionActionsApi;
     const snackbarApi = useSnackbarApi();
@@ -82,37 +83,41 @@ export const DamMoreActions = ({ transformOrigin, anchorOrigin, folderId, filter
                         icon: <AddFolderIcon />,
                     },
                 ]}
-                selectiveActions={[
-                    !onlyFoldersSelected
-                        ? {
-                              label: <FormattedMessage id="comet.dam.moreActions.downloadSelected" defaultMessage="Download" />,
-                              onClick: handleDownloadClick,
-                              icon: <Download />,
-                          }
-                        : null,
-                    {
-                        label: <FormattedMessage id="comet.dam.moreActions.moveItems" defaultMessage="Move" />,
-                        onClick: moveSelected,
-                        icon: <Move />,
-                        divider: true,
-                    },
-                    {
-                        label: <FormattedMessage id="comet.dam.moreActions.archiveItems" defaultMessage="Archive" />,
-                        onClick: archiveSelected,
-                        icon: <Archive />,
-                    },
-                    {
-                        label: <FormattedMessage id="comet.dam.moreActions.restoreItems" defaultMessage="Restore" />,
-                        onClick: restoreSelected,
-                        icon: <Restore />,
-                    },
-                    {
-                        label: <FormattedMessage id="comet.dam.moreActions.deleteItems" defaultMessage="Delete" />,
-                        onClick: deleteSelected,
-                        icon: <Delete />,
-                    },
-                ]}
-                selectionSize={selectionSize}
+                selectiveActions={
+                    hideSelectiveActions
+                        ? undefined
+                        : [
+                              !onlyFoldersSelected
+                                  ? {
+                                        label: <FormattedMessage id="comet.dam.moreActions.downloadSelected" defaultMessage="Download" />,
+                                        onClick: handleDownloadClick,
+                                        icon: <Download />,
+                                    }
+                                  : null,
+                              {
+                                  label: <FormattedMessage id="comet.dam.moreActions.moveItems" defaultMessage="Move" />,
+                                  onClick: moveSelected,
+                                  icon: <Move />,
+                                  divider: true,
+                              },
+                              {
+                                  label: <FormattedMessage id="comet.dam.moreActions.archiveItems" defaultMessage="Archive" />,
+                                  onClick: archiveSelected,
+                                  icon: <Archive />,
+                              },
+                              {
+                                  label: <FormattedMessage id="comet.dam.moreActions.restoreItems" defaultMessage="Restore" />,
+                                  onClick: restoreSelected,
+                                  icon: <Restore />,
+                              },
+                              {
+                                  label: <FormattedMessage id="comet.dam.moreActions.deleteItems" defaultMessage="Delete" />,
+                                  onClick: deleteSelected,
+                                  icon: <Delete />,
+                              },
+                          ]
+                }
+                selectionSize={hideSelectiveActions ? 0 : selectionSize}
                 slotProps={{
                     menu: {
                         transformOrigin,

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFileDialog.tsx
@@ -97,6 +97,7 @@ export const ChooseDamFileDialog = ({ open, onClose, onChooseFile, allowedMimety
                             hideMultiselect={true}
                             hideArchiveFilter={true}
                             additionalToolbarItems={damConfig.additionalToolbarItems}
+                            hideSelectiveActions
                         />
                     </SubRoute>
                 </MemoryRouter>

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFileDialog.tsx
@@ -97,7 +97,7 @@ export const ChooseDamFileDialog = ({ open, onClose, onChooseFile, allowedMimety
                             hideMultiselect={true}
                             hideArchiveFilter={true}
                             additionalToolbarItems={damConfig.additionalToolbarItems}
-                            hideSelectiveActions
+                            toolbarOptions={{ hideSelectiveActions: true }}
                         />
                     </SubRoute>
                 </MemoryRouter>


### PR DESCRIPTION
Doesn't really matter for the single select dialog, but will matter for the multi select dialog

Before:

<img width="1920" height="957" alt="Bildschirmfoto 2026-05-04 um 10 21 51" src="https://github.com/user-attachments/assets/2dc7fdd1-aece-4f37-b49c-e4aa22e92ade" />


Now:

<img width="1920" height="957" alt="Bildschirmfoto 2026-05-04 um 10 21 37" src="https://github.com/user-attachments/assets/6851cff0-d8ee-49e6-b2ec-1eac9dcf8d20" />

