### PR TITLE
Multi select `FileField`

### DIFF
--- a/.changeset/dam-files-list-ids-filter.md
+++ b/.changeset/dam-files-list-ids-filter.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Add `ids` filter to `damFilesList`
+
+`FileFilterInput` now accepts an optional `ids: [ID!]` to restrict the result set to specific files. Useful for batch-loading a known selection (e.g. after a multi-file picker confirms) in a single request.

--- a/.changeset/export-choose-dam-files-dialog.md
+++ b/.changeset/export-choose-dam-files-dialog.md
@@ -1,0 +1,13 @@
+---
+"@comet/cms-admin": minor
+---
+
+Export `ChooseDamFilesDialog`
+
+Allows building custom multi-file picker UIs on top of the DAM file dialog (e.g. bulk-adding files to a list block). Pair it with `damMultiFileFieldFragment` and a DAM file query to fetch the picked file metadata.
+
+```tsx
+import { ChooseDamFilesDialog } from "@comet/cms-admin";
+
+<ChooseDamFilesDialog open={open} onClose={onClose} onConfirm={(fileIds) => ...} initialFileIds={[]} allowedMimetypes={["image/jpeg"]} />
+```

--- a/.changeset/export-choose-dam-files-dialog.md
+++ b/.changeset/export-choose-dam-files-dialog.md
@@ -4,7 +4,7 @@
 
 Export `ChooseDamFilesDialog`
 
-Allows building custom multi-file picker UIs on top of the DAM file dialog (e.g. bulk-adding files to a list block). Pair it with `damMultiFileFieldFragment` and a DAM file query to fetch the picked file metadata.
+Allows building custom multi-file picker UIs on top of the DAM file dialog (e.g. bulk-adding files to a list block).
 
 ```tsx
 import { ChooseDamFilesDialog } from "@comet/cms-admin";

--- a/.changeset/filefield-multi-select.md
+++ b/.changeset/filefield-multi-select.md
@@ -1,0 +1,13 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `multiple` prop to `FileField` for selecting multiple DAM files
+
+`FileField` now accepts `multiple={true}` to select a list of DAM files instead of a single file. Multi-file values are typed as `GQLDamMultiFileFieldFileFragment[]` (a leaner fragment than the single-file `GQLDamFileFieldFileFragment`); the component renders a stacked list of files with per-row menu and remove actions. The picker dialog pre-checks the current selection and replaces the value on confirm. The single-file API is unchanged.
+
+**Example**
+
+```tsx
+<Field name="files" component={FileField} multiple preview={(file) => <Thumbnail fileId={file.id} />} />
+```

--- a/.changeset/filefield-multi-select.md
+++ b/.changeset/filefield-multi-select.md
@@ -4,7 +4,7 @@
 
 Add `multiple` prop to `FileField` for selecting multiple DAM files
 
-`FileField` now accepts `multiple={true}` to select a list of DAM files instead of a single file. Multi-file values are typed as `GQLDamMultiFileFieldFileFragment[]` (a leaner fragment than the single-file `GQLDamFileFieldFileFragment`); the component renders a stacked list of files with per-row menu and remove actions. The picker dialog pre-checks the current selection and replaces the value on confirm. The single-file API is unchanged.
+`FileField` now accepts `multiple={true}` to select a list of DAM files instead of a single file. Multi-file values are typed as `GQLDamFileFieldFileFragment[]` (the same fragment used in single-file mode); the component renders a stacked list of files with per-row menu and remove actions. The picker dialog pre-checks the current selection via `initialFileIds` and returns the picked file ids on confirm. The single-file API is unchanged.
 
 **Example**
 

--- a/demo/admin/src/products/ProductForm.gql.ts
+++ b/demo/admin/src/products/ProductForm.gql.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { finalFormFileUploadFragment } from "@comet/cms-admin";
+import { damMultiFileFieldFragment, finalFormFileUploadFragment } from "@comet/cms-admin";
 
 export const productFormFragment = gql`
     fragment ProductFormManual on Product {
@@ -15,6 +15,9 @@ export const productFormFragment = gql`
         }
         datasheets {
             ...FinalFormFileUpload
+        }
+        relatedImages {
+            ...DamMultiFileFieldFile
         }
         manufacturer {
             id
@@ -44,6 +47,7 @@ export const productFormFragment = gql`
         availableSince
     }
     ${finalFormFileUploadFragment}
+    ${damMultiFileFieldFragment}
 `;
 
 export const productQuery = gql`

--- a/demo/admin/src/products/ProductForm.gql.ts
+++ b/demo/admin/src/products/ProductForm.gql.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { damMultiFileFieldFragment, finalFormFileUploadFragment } from "@comet/cms-admin";
+import { damFileFieldFragment, finalFormFileUploadFragment } from "@comet/cms-admin";
 
 export const productFormFragment = gql`
     fragment ProductFormManual on Product {
@@ -17,7 +17,7 @@ export const productFormFragment = gql`
             ...FinalFormFileUpload
         }
         relatedImages {
-            ...DamMultiFileFieldFile
+            ...DamFileFieldFile
         }
         manufacturer {
             id
@@ -47,7 +47,7 @@ export const productFormFragment = gql`
         availableSince
     }
     ${finalFormFileUploadFragment}
-    ${damMultiFileFieldFragment}
+    ${damFileFieldFragment}
 `;
 
 export const productQuery = gql`

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -19,7 +19,9 @@ import {
     type BlockState,
     createFinalFormBlock,
     DamImageBlock,
+    FileField,
     FileUploadField,
+    type GQLDamMultiFileFieldFileFragment,
     type GQLFinalFormFileUploadFragment,
     queryUpdatedAt,
     resolveHasSaveConflict,
@@ -67,9 +69,10 @@ const rootBlocks = {
 };
 
 // Set types for FinalFormFileUpload manually, as they cannot be generated from the fragment in `@comet/cms-admin`
-type ProductFormManualFragment = Omit<GQLProductFormManualFragment, "priceList" | "datasheets"> & {
+type ProductFormManualFragment = Omit<GQLProductFormManualFragment, "priceList" | "datasheets" | "relatedImages"> & {
     priceList: GQLFinalFormFileUploadFragment | null;
     datasheets: Array<GQLFinalFormFileUploadFragment>;
+    relatedImages: Array<GQLDamMultiFileFieldFileFragment>;
 };
 
 type FormValues = Omit<ProductFormManualFragment, "image" | "lastCheckedAt"> & {
@@ -110,6 +113,7 @@ export function ProductForm({ id, width, onCreate }: FormProps) {
                 inStock: false,
                 additionalTypes: [],
                 tags: [],
+                relatedImages: [],
                 dimensions: width !== undefined ? { width } : undefined,
             };
         }
@@ -154,6 +158,7 @@ export function ProductForm({ id, width, onCreate }: FormProps) {
             statistics: { views: 0 },
             priceList: formValues.priceList ? formValues.priceList.id : null,
             datasheets: formValues.datasheets?.map(({ id }) => id),
+            relatedImages: formValues.relatedImages?.map(({ id }) => id) ?? [],
             manufacturer: formValues.manufacturer?.id,
             lastCheckedAt: formValues.lastCheckedAt ? formValues.lastCheckedAt.toISOString() : null,
         };
@@ -383,6 +388,14 @@ export function ProductForm({ id, width, onCreate }: FormProps) {
                         maxFileSize={1024 * 1024 * 4} // 4 MB
                         fullWidth
                         layout="grid"
+                    />
+                    <Field
+                        name="relatedImages"
+                        component={FileField}
+                        multiple
+                        fullWidth
+                        label={<FormattedMessage id="product.relatedImages" defaultMessage="Related images" />}
+                        buttonText={<FormattedMessage id="product.relatedImages.choose" defaultMessage="Choose related images" />}
                     />
                     <DateTimeField
                         label={<FormattedMessage id="product.lastCheckedAt" defaultMessage="Last checked at" />}

--- a/demo/admin/src/products/ProductForm.tsx
+++ b/demo/admin/src/products/ProductForm.tsx
@@ -21,7 +21,7 @@ import {
     DamImageBlock,
     FileField,
     FileUploadField,
-    type GQLDamMultiFileFieldFileFragment,
+    type GQLDamFileFieldFileFragment,
     type GQLFinalFormFileUploadFragment,
     queryUpdatedAt,
     resolveHasSaveConflict,
@@ -72,7 +72,7 @@ const rootBlocks = {
 type ProductFormManualFragment = Omit<GQLProductFormManualFragment, "priceList" | "datasheets" | "relatedImages"> & {
     priceList: GQLFinalFormFileUploadFragment | null;
     datasheets: Array<GQLFinalFormFileUploadFragment>;
-    relatedImages: Array<GQLDamMultiFileFieldFileFragment>;
+    relatedImages: Array<GQLDamFileFieldFileFragment>;
 };
 
 type FormValues = Omit<ProductFormManualFragment, "image" | "lastCheckedAt"> & {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -1420,6 +1420,7 @@ type Product {
   price: Float
   priceList: FileUpload
   priceRange: ProductPriceRange
+  relatedImages: [DamFile!]!
   slug: String!
   soldCount: Int
   statistics: ProductStatistics
@@ -1568,6 +1569,7 @@ input ProductFilter {
   or: [ProductFilter!]
   price: NumberFilter
   priceList: ManyToOneFilter
+  relatedImages: ManyToManyFilter
   slug: StringFilter
   soldCount: NumberFilter
   status: ProductStatusEnumFilter
@@ -1614,6 +1616,7 @@ input ProductInput {
   price: Float = null
   priceList: ID = null
   priceRange: ProductPriceRangeInput
+  relatedImages: [ID!]! = []
   slug: String!
   statistics: ProductNestedProductStatisticsInput
   status: ProductStatus! = Unpublished
@@ -1830,6 +1833,7 @@ input ProductUpdateInput {
   price: Float
   priceList: ID
   priceRange: ProductPriceRangeInput
+  relatedImages: [ID!]
   slug: String
   statistics: ProductNestedProductStatisticsInput
   status: ProductStatus

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -642,6 +642,7 @@ type EntityInfo {
 }
 
 input FileFilterInput {
+  ids: [ID!]
   mimetypes: [String!]
   searchText: String
 }

--- a/demo/api/src/dam/entities/dam-file.entity.ts
+++ b/demo/api/src/dam/entities/dam-file.entity.ts
@@ -4,3 +4,4 @@ import { DamScope } from "../dto/dam-scope";
 import { DamFolder } from "./dam-folder.entity";
 
 export const DamFile = createFileEntity({ Scope: DamScope, Folder: DamFolder });
+export type DamFile = InstanceType<typeof DamFile>;

--- a/demo/api/src/db/migrations/Migration20260504092659.ts
+++ b/demo/api/src/db/migrations/Migration20260504092659.ts
@@ -1,0 +1,19 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20260504092659 extends Migration {
+    override async up(): Promise<void> {
+        this.addSql(
+            'create table "Product_relatedImages" ("product" uuid not null, "damFile" uuid not null, constraint "Product_relatedImages_pkey" primary key ("product", "damFile"));',
+        );
+        this.addSql(
+            'alter table "Product_relatedImages" add constraint "Product_relatedImages_product_foreign" foreign key ("product") references "Product" ("id") on update cascade on delete cascade;',
+        );
+        this.addSql(
+            'alter table "Product_relatedImages" add constraint "Product_relatedImages_damFile_foreign" foreign key ("damFile") references "DamFile" ("id") on update cascade on delete cascade;',
+        );
+    }
+
+    override async down(): Promise<void> {
+        this.addSql('drop table if exists "Product_relatedImages";');
+    }
+}

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -4,6 +4,7 @@ import {
     CrudGenerator,
     DamImageBlock,
     EntityInfo,
+    FileInterface,
     FileUpload,
     ImportTargetInterface,
     RootBlock,
@@ -26,6 +27,7 @@ import {
     types,
 } from "@mikro-orm/postgresql";
 import { Field, ID, InputType, Int, ObjectType, registerEnumType } from "@nestjs/graphql";
+import { DamFile } from "@src/dam/entities/dam-file.entity";
 import { Manufacturer } from "@src/products/entities/manufacturer.entity";
 import { IsNumber } from "class-validator";
 import { GraphQLLocalDate } from "graphql-scalars";
@@ -237,4 +239,8 @@ export class Product extends BaseEntity implements ImportTargetInterface {
     @ManyToMany(() => FileUpload)
     @Field(() => [FileUpload])
     datasheets = new Collection<FileUpload>(this);
+
+    @ManyToMany(() => DamFile)
+    @Field(() => [DamFile])
+    relatedImages = new Collection<FileInterface>(this);
 }

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -4,7 +4,6 @@ import {
     CrudGenerator,
     DamImageBlock,
     EntityInfo,
-    FileInterface,
     FileUpload,
     ImportTargetInterface,
     RootBlock,
@@ -242,5 +241,5 @@ export class Product extends BaseEntity implements ImportTargetInterface {
 
     @ManyToMany(() => DamFile)
     @Field(() => [DamFile])
-    relatedImages = new Collection<FileInterface>(this);
+    relatedImages = new Collection<DamFile>(this);
 }

--- a/demo/api/src/products/generated/dto/product.filter.ts
+++ b/demo/api/src/products/generated/dto/product.filter.ts
@@ -129,6 +129,11 @@ export class ProductFilter {
     @IsOptional()
     @Type(() => ManyToManyFilter)
     datasheets?: ManyToManyFilter;
+    @Field(() => ManyToManyFilter, { nullable: true })
+    @ValidateNested()
+    @IsOptional()
+    @Type(() => ManyToManyFilter)
+    relatedImages?: ManyToManyFilter;
     @Field(() => [ProductFilter], { nullable: true })
     @Type(() => ProductFilter)
     @ValidateNested({ each: true })

--- a/demo/api/src/products/generated/dto/product.input.ts
+++ b/demo/api/src/products/generated/dto/product.input.ts
@@ -111,6 +111,10 @@ export class ProductInput {
     @IsArray()
     @IsString({ each: true })
     datasheets: string[];
+    @Field(() => [ID], { defaultValue: [] })
+    @IsArray()
+    @IsString({ each: true })
+    relatedImages: string[];
 }
 @InputType()
 export class ProductUpdateInput extends PartialType(ProductInput) {}

--- a/demo/api/src/products/generated/product.resolver.ts
+++ b/demo/api/src/products/generated/product.resolver.ts
@@ -24,6 +24,7 @@ import {
 } from "@comet/cms-api";
 import { ProductVariant } from "../entities/product-variant.entity";
 import { ProductTag } from "../entities/product-tag.entity";
+import { DamFile } from "../../dam/entities/dam-file.entity";
 import { Product } from "../entities/product.entity";
 import { ProductService } from "../product.service";
 import { ProductMutationError } from "./../product.service";
@@ -89,6 +90,7 @@ export class ProductResolver {
             tagsWithStatus: tagsWithStatusInput,
             tags: tagsInput,
             datasheets: datasheetsInput,
+            relatedImages: relatedImagesInput,
             category: categoryInput,
             manufacturer: manufacturerInput,
             priceList: priceListInput,
@@ -141,6 +143,12 @@ export class ProductResolver {
             await product.datasheets.loadItems();
             product.datasheets.set(datasheets.map((datasheet) => Reference.create(datasheet)));
         }
+        if (relatedImagesInput) {
+            const relatedImages = await this.entityManager.find(DamFile, { id: relatedImagesInput });
+            if (relatedImages.length != relatedImagesInput.length) throw new Error("Couldn't find all relatedImages that were passed as input");
+            await product.relatedImages.loadItems();
+            product.relatedImages.set(relatedImages.map((relatedImage) => Reference.create(relatedImage)));
+        }
         if (statisticsInput) {
             const statistic = new ProductStatistics();
             this.entityManager.assign(statistic, {
@@ -164,6 +172,7 @@ export class ProductResolver {
             tagsWithStatus: tagsWithStatusInput,
             tags: tagsInput,
             datasheets: datasheetsInput,
+            relatedImages: relatedImagesInput,
             category: categoryInput,
             manufacturer: manufacturerInput,
             priceList: priceListInput,
@@ -211,6 +220,12 @@ export class ProductResolver {
             if (datasheets.length != datasheetsInput.length) throw new Error("Couldn't find all datasheets that were passed as input");
             await product.datasheets.loadItems();
             product.datasheets.set(datasheets.map((datasheet) => Reference.create(datasheet)));
+        }
+        if (relatedImagesInput) {
+            const relatedImages = await this.entityManager.find(DamFile, { id: relatedImagesInput });
+            if (relatedImages.length != relatedImagesInput.length) throw new Error("Couldn't find all relatedImages that were passed as input");
+            await product.relatedImages.loadItems();
+            product.relatedImages.set(relatedImages.map((relatedImage) => Reference.create(relatedImage)));
         }
         if (statisticsInput) {
             const statistic = product.statistics ? await product.statistics.loadOrFail() : new ProductStatistics();
@@ -301,6 +316,13 @@ export class ProductResolver {
         product: Product,
     ): Promise<FileUpload[]> {
         return product.datasheets.loadItems();
+    }
+    @ResolveField(() => [DamFile])
+    async relatedImages(
+        @Parent()
+        product: Product,
+    ): Promise<DamFile[]> {
+        return product.relatedImages.loadItems();
     }
     @ResolveField(() => ProductStatistics, { nullable: true })
     async statistics(

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -8,6 +8,7 @@ import { ManualDuplicatedFilenamesHandlerContextProvider } from "./DataGrid/dupl
 import { FileUploadContextProvider } from "./DataGrid/fileUpload/FileUploadContext";
 import FolderDataGrid, {
     damFolderQuery,
+    type DamItemSelectionMap,
     type GQLDamFileTableFragment,
     type GQLDamFolderQuery,
     type GQLDamFolderQueryVariables,
@@ -89,6 +90,10 @@ export interface DamConfig {
         hideSelectiveActions?: boolean;
     };
     additionalToolbarItems?: ReactNode;
+    disableFolderSelection?: boolean;
+    keepNonExistentRowsSelected?: boolean;
+    selectionMap?: DamItemSelectionMap;
+    onSelectionChange?: (next: DamItemSelectionMap) => void;
 }
 
 type DamTableProps = DamConfig & {
@@ -103,6 +108,8 @@ export const DamTable = ({ renderWithFullHeightMainContent, ...damConfigProps }:
         hideMultiselect: false,
         hideDamActions: false,
         hideArchiveFilter: false,
+        disableFolderSelection: false,
+        keepNonExistentRowsSelected: false,
         ...damConfigProps,
     };
 

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -92,7 +92,7 @@ export interface DamConfig {
     additionalToolbarItems?: ReactNode;
     disableFolderSelection?: boolean;
     keepNonExistentRowsSelected?: boolean;
-    initialSelectionMap?: DamItemSelectionMap;
+    initialSelection?: DamItemSelectionMap;
     onSelectionChange?: (next: DamItemSelectionMap) => void;
 }
 
@@ -119,10 +119,7 @@ export const DamTable = ({ renderWithFullHeightMainContent, ...damConfigProps }:
         <Stack topLevelTitle={intl.formatMessage({ id: "comet.pages.dam.assetManager", defaultMessage: "Asset Manager" })}>
             <FileUploadContextProvider>
                 <ManualDuplicatedFilenamesHandlerContextProvider>
-                    <DamSelectionProvider
-                        initialSelectionMap={damConfigProps.initialSelectionMap}
-                        onSelectionChange={damConfigProps.onSelectionChange}
-                    >
+                    <DamSelectionProvider initialSelection={damConfigProps.initialSelection} onSelectionChange={damConfigProps.onSelectionChange}>
                         <Folder
                             filterApi={filterApi}
                             {...propsWithDefaultValues}

--- a/packages/admin/cms-admin/src/dam/DamTable.tsx
+++ b/packages/admin/cms-admin/src/dam/DamTable.tsx
@@ -92,7 +92,7 @@ export interface DamConfig {
     additionalToolbarItems?: ReactNode;
     disableFolderSelection?: boolean;
     keepNonExistentRowsSelected?: boolean;
-    selectionMap?: DamItemSelectionMap;
+    initialSelectionMap?: DamItemSelectionMap;
     onSelectionChange?: (next: DamItemSelectionMap) => void;
 }
 
@@ -119,7 +119,10 @@ export const DamTable = ({ renderWithFullHeightMainContent, ...damConfigProps }:
         <Stack topLevelTitle={intl.formatMessage({ id: "comet.pages.dam.assetManager", defaultMessage: "Asset Manager" })}>
             <FileUploadContextProvider>
                 <ManualDuplicatedFilenamesHandlerContextProvider>
-                    <DamSelectionProvider>
+                    <DamSelectionProvider
+                        initialSelectionMap={damConfigProps.initialSelectionMap}
+                        onSelectionChange={damConfigProps.onSelectionChange}
+                    >
                         <Folder
                             filterApi={filterApi}
                             {...propsWithDefaultValues}

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -170,8 +170,8 @@ const FolderDataGrid = ({
     if ((selectionMapProp !== undefined) !== (onSelectionChange !== undefined)) {
         throw new Error("DamTable: `selectionMap` and `onSelectionChange` must be provided together for controlled selection.");
     }
-    const isControlledSelection = selectionMapProp !== undefined && onSelectionChange !== undefined;
-    const effectiveSelectionMap = isControlledSelection ? selectionMapProp : damSelectionActionsApi.selectionMap;
+    const selectionMap = selectionMapProp ?? damSelectionActionsApi.selectionMap;
+    const setSelection = onSelectionChange ?? damSelectionActionsApi.setSelectionMap;
 
     const [redirectedToId, setRedirectedToId] = useStoredState<string | null>("FolderDataGrid-redirectedToId", null, window.sessionStorage);
 
@@ -619,9 +619,9 @@ const FolderDataGrid = ({
         newSelectionModel.ids.forEach((selectedId) => {
             const typedId = selectedId as string;
 
-            if (effectiveSelectionMap.has(typedId)) {
+            if (selectionMap.has(typedId)) {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                newMap.set(typedId, effectiveSelectionMap.get(typedId)!);
+                newMap.set(typedId, selectionMap.get(typedId)!);
             } else {
                 const item = dataGridData?.damItemsList.nodes.find((item) => item.id === typedId);
 
@@ -639,11 +639,7 @@ const FolderDataGrid = ({
             }
         });
 
-        if (isControlledSelection) {
-            onSelectionChange(newMap);
-        } else {
-            damSelectionActionsApi.setSelectionMap(newMap);
-        }
+        setSelection(newMap);
     };
 
     const getRowClassName = ({ row }: GridRowClassNameParams) => {
@@ -678,7 +674,7 @@ const FolderDataGrid = ({
                     checkboxSelection={!hideMultiselect}
                     keepNonExistentRowsSelected={keepNonExistentRowsSelected}
                     isRowSelectable={disableFolderSelection ? isSelectableRow : undefined}
-                    rowSelectionModel={{ type: "include", ids: new Set(effectiveSelectionMap.keys()) }}
+                    rowSelectionModel={{ type: "include", ids: new Set(selectionMap.keys()) }}
                     onRowSelectionModelChange={handleSelectionModelChange}
                     disableRowSelectionExcludeModel
                     initialState={{ columns: { columnVisibilityModel: { importSourceType: importSources !== undefined } } }}

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -87,6 +87,8 @@ interface FolderDataGridProps extends DamConfig {
     filterApi: IFilterApi<DamFilter>;
 }
 
+const isSelectableRow = ({ row }: { row: GQLDamFileTableFragment | GQLDamFolderTableFragment }) => isFile(row);
+
 type FolderDataGridToolbarProps = {
     id?: string;
     filterApi: IFilterApi<DamFilter>;
@@ -150,6 +152,10 @@ const FolderDataGrid = ({
     hideArchiveFilter,
     toolbarOptions,
     hideMultiselect,
+    disableFolderSelection,
+    keepNonExistentRowsSelected,
+    selectionMap: selectionMapProp,
+    onSelectionChange,
     renderDamLabel,
     ...props
 }: FolderDataGridProps) => {
@@ -160,6 +166,12 @@ const FolderDataGrid = ({
     const scope = useDamScope();
     const snackbarApi = useSnackbarApi();
     const { importSources, enableLicenseFeature } = useDamConfig();
+
+    if ((selectionMapProp !== undefined) !== (onSelectionChange !== undefined)) {
+        throw new Error("DamTable: `selectionMap` and `onSelectionChange` must be provided together for controlled selection.");
+    }
+    const isControlledSelection = selectionMapProp !== undefined && onSelectionChange !== undefined;
+    const effectiveSelectionMap = isControlledSelection ? selectionMapProp : damSelectionActionsApi.selectionMap;
 
     const [redirectedToId, setRedirectedToId] = useStoredState<string | null>("FolderDataGrid-redirectedToId", null, window.sessionStorage);
 
@@ -607,9 +619,9 @@ const FolderDataGrid = ({
         newSelectionModel.ids.forEach((selectedId) => {
             const typedId = selectedId as string;
 
-            if (damSelectionActionsApi.selectionMap.has(typedId)) {
+            if (effectiveSelectionMap.has(typedId)) {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                newMap.set(typedId, damSelectionActionsApi.selectionMap.get(typedId)!);
+                newMap.set(typedId, effectiveSelectionMap.get(typedId)!);
             } else {
                 const item = dataGridData?.damItemsList.nodes.find((item) => item.id === typedId);
 
@@ -627,7 +639,11 @@ const FolderDataGrid = ({
             }
         });
 
-        damSelectionActionsApi.setSelectionMap(newMap);
+        if (isControlledSelection) {
+            onSelectionChange(newMap);
+        } else {
+            damSelectionActionsApi.setSelectionMap(newMap);
+        }
     };
 
     const getRowClassName = ({ row }: GridRowClassNameParams) => {
@@ -660,7 +676,9 @@ const FolderDataGrid = ({
                     getRowClassName={getRowClassName}
                     columns={dataGridColumns}
                     checkboxSelection={!hideMultiselect}
-                    rowSelectionModel={{ type: "include", ids: new Set(damSelectionActionsApi.selectionMap.keys()) }}
+                    keepNonExistentRowsSelected={keepNonExistentRowsSelected}
+                    isRowSelectable={disableFolderSelection ? isSelectableRow : undefined}
+                    rowSelectionModel={{ type: "include", ids: new Set(effectiveSelectionMap.keys()) }}
                     onRowSelectionModelChange={handleSelectionModelChange}
                     disableRowSelectionExcludeModel
                     initialState={{ columns: { columnVisibilityModel: { importSourceType: importSources !== undefined } } }}
@@ -677,7 +695,7 @@ const FolderDataGrid = ({
                             filterApi,
                             uploadFilters,
                             additionalToolbarItems: props.additionalToolbarItems,
-                            ...toolbarOptions,
+                            hideSelectiveActions: toolbarOptions?.hideSelectiveActions,
                         } as FolderDataGridToolbarProps,
                     }}
                     showToolbar

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -154,8 +154,6 @@ const FolderDataGrid = ({
     hideMultiselect,
     disableFolderSelection,
     keepNonExistentRowsSelected,
-    selectionMap: selectionMapProp,
-    onSelectionChange,
     renderDamLabel,
     ...props
 }: FolderDataGridProps) => {
@@ -166,12 +164,6 @@ const FolderDataGrid = ({
     const scope = useDamScope();
     const snackbarApi = useSnackbarApi();
     const { importSources, enableLicenseFeature } = useDamConfig();
-
-    if ((selectionMapProp !== undefined) !== (onSelectionChange !== undefined)) {
-        throw new Error("DamTable: `selectionMap` and `onSelectionChange` must be provided together for controlled selection.");
-    }
-    const selectionMap = selectionMapProp ?? damSelectionActionsApi.selectionMap;
-    const setSelection = onSelectionChange ?? damSelectionActionsApi.setSelectionMap;
 
     const [redirectedToId, setRedirectedToId] = useStoredState<string | null>("FolderDataGrid-redirectedToId", null, window.sessionStorage);
 
@@ -619,9 +611,9 @@ const FolderDataGrid = ({
         newSelectionModel.ids.forEach((selectedId) => {
             const typedId = selectedId as string;
 
-            if (selectionMap.has(typedId)) {
+            if (damSelectionActionsApi.selectionMap.has(typedId)) {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                newMap.set(typedId, selectionMap.get(typedId)!);
+                newMap.set(typedId, damSelectionActionsApi.selectionMap.get(typedId)!);
             } else {
                 const item = dataGridData?.damItemsList.nodes.find((item) => item.id === typedId);
 
@@ -639,7 +631,7 @@ const FolderDataGrid = ({
             }
         });
 
-        setSelection(newMap);
+        damSelectionActionsApi.setSelectionMap(newMap);
     };
 
     const getRowClassName = ({ row }: GridRowClassNameParams) => {
@@ -674,7 +666,7 @@ const FolderDataGrid = ({
                     checkboxSelection={!hideMultiselect}
                     keepNonExistentRowsSelected={keepNonExistentRowsSelected}
                     isRowSelectable={disableFolderSelection ? isSelectableRow : undefined}
-                    rowSelectionModel={{ type: "include", ids: new Set(selectionMap.keys()) }}
+                    rowSelectionModel={{ type: "include", ids: new Set(damSelectionActionsApi.selectionMap.keys()) }}
                     onRowSelectionModelChange={handleSelectionModelChange}
                     disableRowSelectionExcludeModel
                     initialState={{ columns: { columnVisibilityModel: { importSourceType: importSources !== undefined } } }}

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
@@ -97,9 +97,23 @@ export const useDamSelectionApi = () => {
     return useContext(DamSelectionContext);
 };
 
-export const DamSelectionProvider = ({ children }: { children?: ReactNode }) => {
+interface DamSelectionProviderProps {
+    children?: ReactNode;
+    initialSelectionMap?: DamItemSelectionMap;
+    onSelectionChange?: (next: DamItemSelectionMap) => void;
+}
+
+export const DamSelectionProvider = ({ children, initialSelectionMap, onSelectionChange }: DamSelectionProviderProps) => {
     const apolloClient = useApolloClient();
-    const [selectionMap, setSelectionMap] = useState<DamItemSelectionMap>(new Map());
+    const [selectionMap, setMapState] = useState<DamItemSelectionMap>(() => initialSelectionMap ?? new Map());
+
+    const setSelectionMap: Dispatch<SetStateAction<DamItemSelectionMap>> = (next) => {
+        setMapState((prev) => {
+            const resolved = typeof next === "function" ? next(prev) : next;
+            onSelectionChange?.(resolved);
+            return resolved;
+        });
+    };
 
     const showError = (setError: Dispatch<SetStateAction<boolean>>) => {
         setError(true);

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
@@ -28,7 +28,7 @@ const damFileDownloadInfoFragment = gql`
 
 interface DamSelectionApi {
     selectionMap: DamItemSelectionMap;
-    setSelectionMap: Dispatch<SetStateAction<DamItemSelectionMap>>;
+    setSelectionMap: (selectionMap: DamItemSelectionMap) => void;
 
     // delete
     deleteSelected: () => void;
@@ -105,14 +105,11 @@ interface DamSelectionProviderProps {
 
 export const DamSelectionProvider = ({ children, initialSelection, onSelectionChange }: DamSelectionProviderProps) => {
     const apolloClient = useApolloClient();
-    const [selectionMap, setMapState] = useState<DamItemSelectionMap>(() => initialSelection ?? new Map());
+    const [selectionMap, setSelectionMap] = useState<DamItemSelectionMap>(() => initialSelection ?? new Map());
 
-    const setSelectionMap: Dispatch<SetStateAction<DamItemSelectionMap>> = (next) => {
-        setMapState((prev) => {
-            const resolved = typeof next === "function" ? next(prev) : next;
-            onSelectionChange?.(resolved);
-            return resolved;
-        });
+    const onSelectionMapChange = (newSelectionMap: DamItemSelectionMap) => {
+        setSelectionMap(newSelectionMap);
+        onSelectionChange?.(newSelectionMap);
     };
 
     const showError = (setError: Dispatch<SetStateAction<boolean>>) => {
@@ -292,7 +289,7 @@ export const DamSelectionProvider = ({ children, initialSelection, onSelectionCh
         <DamSelectionContext.Provider
             value={{
                 selectionMap,
-                setSelectionMap,
+                setSelectionMap: onSelectionMapChange,
 
                 deleteSelected: openDeleteDialog,
                 deleting,

--- a/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/selection/DamSelectionContext.tsx
@@ -99,13 +99,13 @@ export const useDamSelectionApi = () => {
 
 interface DamSelectionProviderProps {
     children?: ReactNode;
-    initialSelectionMap?: DamItemSelectionMap;
+    initialSelection?: DamItemSelectionMap;
     onSelectionChange?: (next: DamItemSelectionMap) => void;
 }
 
-export const DamSelectionProvider = ({ children, initialSelectionMap, onSelectionChange }: DamSelectionProviderProps) => {
+export const DamSelectionProvider = ({ children, initialSelection, onSelectionChange }: DamSelectionProviderProps) => {
     const apolloClient = useApolloClient();
-    const [selectionMap, setMapState] = useState<DamItemSelectionMap>(() => initialSelectionMap ?? new Map());
+    const [selectionMap, setMapState] = useState<DamItemSelectionMap>(() => initialSelection ?? new Map());
 
     const setSelectionMap: Dispatch<SetStateAction<DamItemSelectionMap>> = (next) => {
         setMapState((prev) => {

--- a/packages/admin/cms-admin/src/form/file/FileField.gql.ts
+++ b/packages/admin/cms-admin/src/form/file/FileField.gql.ts
@@ -1,5 +1,7 @@
 import { gql } from "@apollo/client";
 
+import { damFileThumbnailFragment } from "../../dam/DataGrid/thumbnail/DamThumbnail";
+
 const damFileFieldFragment = gql`
     fragment DamFileFieldFile on DamFile {
         id
@@ -32,4 +34,31 @@ export const damFileFieldFileQuery = gql`
         }
     }
     ${damFileFieldFragment}
+`;
+
+export const damMultiFileFieldFragment = gql`
+    fragment DamMultiFileFieldFile on DamFile {
+        id
+        name
+        size
+        mimetype
+        contentHash
+        title
+        altText
+        archived
+        image {
+            ...DamFileThumbnail
+        }
+        fileUrl
+    }
+    ${damFileThumbnailFragment}
+`;
+
+export const damMultiFileFieldFileQuery = gql`
+    query DamMultiFileFieldFile($id: ID!) {
+        damFile(id: $id) {
+            ...DamMultiFileFieldFile
+        }
+    }
+    ${damMultiFileFieldFragment}
 `;

--- a/packages/admin/cms-admin/src/form/file/FileField.gql.ts
+++ b/packages/admin/cms-admin/src/form/file/FileField.gql.ts
@@ -2,42 +2,8 @@ import { gql } from "@apollo/client";
 
 import { damFileThumbnailFragment } from "../../dam/DataGrid/thumbnail/DamThumbnail";
 
-const damFileFieldFragment = gql`
+export const damFileFieldFragment = gql`
     fragment DamFileFieldFile on DamFile {
-        id
-        name
-        size
-        mimetype
-        contentHash
-        title
-        altText
-        archived
-        image {
-            width
-            height
-            cropArea {
-                focalPoint
-                width
-                height
-                x
-                y
-            }
-        }
-        fileUrl
-    }
-`;
-
-export const damFileFieldFileQuery = gql`
-    query DamFileFieldFile($id: ID!) {
-        damFile(id: $id) {
-            ...DamFileFieldFile
-        }
-    }
-    ${damFileFieldFragment}
-`;
-
-export const damMultiFileFieldFragment = gql`
-    fragment DamMultiFileFieldFile on DamFile {
         id
         name
         size
@@ -54,11 +20,11 @@ export const damMultiFileFieldFragment = gql`
     ${damFileThumbnailFragment}
 `;
 
-export const damMultiFileFieldFileQuery = gql`
-    query DamMultiFileFieldFile($id: ID!) {
+export const damFileFieldFileQuery = gql`
+    query DamFileFieldFile($id: ID!) {
         damFile(id: $id) {
-            ...DamMultiFileFieldFile
+            ...DamFileFieldFile
         }
     }
-    ${damMultiFileFieldFragment}
+    ${damFileFieldFragment}
 `;

--- a/packages/admin/cms-admin/src/form/file/FileField.gql.ts
+++ b/packages/admin/cms-admin/src/form/file/FileField.gql.ts
@@ -28,3 +28,14 @@ export const damFileFieldFileQuery = gql`
     }
     ${damFileFieldFragment}
 `;
+
+export const damFileFieldFilesByIdsQuery = gql`
+    query DamFileFieldFilesByIds($ids: [ID!]!, $limit: Int!, $scope: DamScopeInput!) {
+        damFilesList(filter: { ids: $ids }, limit: $limit, includeArchived: true, scope: $scope) {
+            nodes {
+                ...DamFileFieldFile
+            }
+        }
+    }
+    ${damFileFieldFragment}
+`;

--- a/packages/admin/cms-admin/src/form/file/FileField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileField.tsx
@@ -1,15 +1,13 @@
 import { useApolloClient } from "@apollo/client";
 import { Alert, useSnackbarApi } from "@comet/admin";
-import { Assets, Delete, MoreVertical, OpenNewTab } from "@comet/admin-icons";
-import { Box, Divider, Grid, IconButton, List, ListItemIcon, ListItemText, Menu, MenuItem, Snackbar, Typography } from "@mui/material";
-import { type ComponentProps, isValidElement, type ReactElement, type ReactNode, useState } from "react";
+import { Assets, Delete, MoreVertical } from "@comet/admin-icons";
+import { Box, Divider, Grid, IconButton, List, Snackbar, Typography } from "@mui/material";
+import { type ReactElement, type ReactNode, useState } from "react";
 import type { FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
 import { BlockAdminComponentButton } from "../../blocks/common/BlockAdminComponentButton";
 import { BlockAdminComponentPaper } from "../../blocks/common/BlockAdminComponentPaper";
-import { useContentScope } from "../../contentScope/Provider";
-import { useDependenciesConfig } from "../../dependencies/dependenciesConfig";
 import { ChooseDamFileDialog } from "./chooseFile/ChooseDamFileDialog";
 import { ChooseDamFilesDialog } from "./chooseFile/ChooseDamFilesDialog";
 import { DamPathLazy } from "./DamPathLazy";
@@ -22,14 +20,10 @@ import type {
     GQLDamMultiFileFieldFileQuery,
     GQLDamMultiFileFieldFileQueryVariables,
 } from "./FileField.gql.generated";
+import { type ActionItem, FileFieldMenu, useHasFileFieldMenu } from "./FileFieldMenu";
 import { FileFieldRow } from "./FileFieldRow";
 
 export type { GQLDamFileFieldFileFragment, GQLDamMultiFileFieldFileFragment } from "./FileField.gql.generated";
-
-interface ActionItem extends ComponentProps<typeof MenuItem> {
-    label: ReactNode;
-    icon?: ReactNode;
-}
 
 type CommonProps = {
     buttonText?: ReactNode;
@@ -64,19 +58,12 @@ export function FileField(props: SingleFileFieldProps | MultiFileFieldProps): Re
 const SingleFileField = ({ buttonText, input, allowedMimetypes, preview, menuActions }: SingleFileFieldProps) => {
     const [chooseFileDialogOpen, setChooseFileDialogOpen] = useState<boolean>(false);
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-
-    const contentScope = useContentScope();
     const apolloClient = useApolloClient();
-    const { entityDependencyMap } = useDependenciesConfig();
-
-    const handleMenuClose = () => {
-        setAnchorEl(null);
-    };
+    const showMenu = useHasFileFieldMenu(menuActions);
 
     const damFile = input.value;
 
     if (damFile) {
-        const showMenu = Boolean(entityDependencyMap["DamFile"]) || (menuActions !== undefined && menuActions.length > 0);
         return (
             <>
                 <BlockAdminComponentPaper disablePadding>
@@ -111,44 +98,7 @@ const SingleFileField = ({ buttonText, input, allowedMimetypes, preview, menuAct
                     </BlockAdminComponentButton>
                 </BlockAdminComponentPaper>
                 {showMenu && (
-                    <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleMenuClose}>
-                        {entityDependencyMap["DamFile"] && (
-                            <MenuItem
-                                onClick={async () => {
-                                    const path = await entityDependencyMap["DamFile"].resolvePath({
-                                        apolloClient,
-                                        id: damFile.id,
-                                    });
-                                    const url = contentScope.match.url + path;
-                                    window.open(url, "_blank");
-                                }}
-                            >
-                                <ListItemIcon>
-                                    <OpenNewTab />
-                                </ListItemIcon>
-                                <ListItemText primary={<FormattedMessage id="comet.form.file.openInDam" defaultMessage="Open in DAM" />} />
-                            </MenuItem>
-                        )}
-                        {menuActions &&
-                            menuActions.map((item, index) => {
-                                if (!item) {
-                                    return null;
-                                }
-
-                                if (isValidElement(item)) {
-                                    return item;
-                                }
-
-                                const { label, icon, ...rest } = item as ActionItem;
-
-                                return (
-                                    <MenuItem key={index} {...rest}>
-                                        {!!icon && <ListItemIcon>{icon}</ListItemIcon>}
-                                        <ListItemText primary={label} />
-                                    </MenuItem>
-                                );
-                            })}
-                    </Menu>
+                    <FileFieldMenu fileId={damFile.id} anchorEl={anchorEl} onClose={() => setAnchorEl(null)} menuActions={menuActions} keepMounted />
                 )}
             </>
         );
@@ -187,23 +137,14 @@ const MultiFileField = ({ buttonText, input, allowedMimetypes, preview, menuActi
     // react-final-form may pass "" as the default when no initial value is set; fall back to [].
     const files: GQLDamMultiFileFieldFileFragment[] = Array.isArray(input.value) ? input.value : [];
 
-    const commitChange = (next: GQLDamMultiFileFieldFileFragment[]) => {
-        input.onChange(next.length === 0 ? undefined : next);
-    };
-
     const handleRemove = (id: string) => {
-        commitChange(files.filter((f) => f.id !== id));
+        input.onChange(files.filter((f) => f.id !== id));
     };
 
     const handleConfirm = async (fileIds: string[]) => {
-        const existingById = new Map<string, GQLDamMultiFileFieldFileFragment>(files.map((f) => [f.id, f]));
         try {
-            const next: GQLDamMultiFileFieldFileFragment[] = await Promise.all(
+            const next = await Promise.all(
                 fileIds.map(async (id) => {
-                    const existing = existingById.get(id);
-                    if (existing) {
-                        return existing;
-                    }
                     const { data } = await apolloClient.query<GQLDamMultiFileFieldFileQuery, GQLDamMultiFileFieldFileQueryVariables>({
                         query: damMultiFileFieldFileQuery,
                         variables: { id },
@@ -212,7 +153,7 @@ const MultiFileField = ({ buttonText, input, allowedMimetypes, preview, menuActi
                 }),
             );
 
-            commitChange(next);
+            input.onChange(next);
             setDialogOpen(false);
         } catch {
             snackbarApi.showSnackbar(
@@ -228,43 +169,39 @@ const MultiFileField = ({ buttonText, input, allowedMimetypes, preview, menuActi
         }
     };
 
-    if (files.length === 0) {
-        return (
-            <>
+    return (
+        <>
+            {files.length === 0 ? (
                 <BlockAdminComponentButton onClick={() => setDialogOpen(true)} startIcon={<Assets />} size="large">
                     {buttonText ?? <FormattedMessage id="comet.form.file.chooseFiles" defaultMessage="Choose files" />}
                 </BlockAdminComponentButton>
+            ) : (
+                <BlockAdminComponentPaper disablePadding>
+                    <List disablePadding>
+                        {files.map((file) => (
+                            <FileFieldRow
+                                key={file.id}
+                                file={file}
+                                onRemove={() => handleRemove(file.id)}
+                                preview={preview}
+                                menuActions={menuActions}
+                            />
+                        ))}
+                    </List>
+                    <Divider />
+                    <BlockAdminComponentButton startIcon={<Assets />} onClick={() => setDialogOpen(true)}>
+                        <FormattedMessage id="comet.form.file.changeSelectedFiles" defaultMessage="Change selected files" />
+                    </BlockAdminComponentButton>
+                </BlockAdminComponentPaper>
+            )}
+            {dialogOpen && (
                 <ChooseDamFilesDialog
-                    open={dialogOpen}
                     allowedMimetypes={allowedMimetypes}
-                    initialFileIds={[]}
+                    initialFileIds={files.map((f) => f.id)}
                     onClose={() => setDialogOpen(false)}
                     onConfirm={handleConfirm}
                 />
-            </>
-        );
-    }
-
-    return (
-        <>
-            <BlockAdminComponentPaper disablePadding>
-                <List disablePadding>
-                    {files.map((file) => (
-                        <FileFieldRow key={file.id} file={file} onRemove={() => handleRemove(file.id)} preview={preview} menuActions={menuActions} />
-                    ))}
-                </List>
-                <Divider />
-                <BlockAdminComponentButton startIcon={<Assets />} onClick={() => setDialogOpen(true)}>
-                    <FormattedMessage id="comet.form.file.changeSelectedFiles" defaultMessage="Change selected files" />
-                </BlockAdminComponentButton>
-            </BlockAdminComponentPaper>
-            <ChooseDamFilesDialog
-                open={dialogOpen}
-                allowedMimetypes={allowedMimetypes}
-                initialFileIds={files.map((f) => f.id)}
-                onClose={() => setDialogOpen(false)}
-                onConfirm={handleConfirm}
-            />
+            )}
         </>
     );
 };

--- a/packages/admin/cms-admin/src/form/file/FileField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileField.tsx
@@ -1,6 +1,7 @@
 import { useApolloClient } from "@apollo/client";
+import { Alert, useSnackbarApi } from "@comet/admin";
 import { Assets, Delete, MoreVertical, OpenNewTab } from "@comet/admin-icons";
-import { Box, Divider, Grid, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Typography } from "@mui/material";
+import { Box, Divider, Grid, IconButton, List, ListItemIcon, ListItemText, Menu, MenuItem, Snackbar, Typography } from "@mui/material";
 import { type ComponentProps, isValidElement, type ReactElement, type ReactNode, useState } from "react";
 import type { FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
@@ -10,28 +11,58 @@ import { BlockAdminComponentPaper } from "../../blocks/common/BlockAdminComponen
 import { useContentScope } from "../../contentScope/Provider";
 import { useDependenciesConfig } from "../../dependencies/dependenciesConfig";
 import { ChooseDamFileDialog } from "./chooseFile/ChooseDamFileDialog";
+import { ChooseDamFilesDialog } from "./chooseFile/ChooseDamFilesDialog";
 import { DamPathLazy } from "./DamPathLazy";
-import { damFileFieldFileQuery } from "./FileField.gql";
-import type { GQLDamFileFieldFileFragment, GQLDamFileFieldFileQuery, GQLDamFileFieldFileQueryVariables } from "./FileField.gql.generated";
+import { damFileFieldFileQuery, damMultiFileFieldFileQuery } from "./FileField.gql";
+import type {
+    GQLDamFileFieldFileFragment,
+    GQLDamFileFieldFileQuery,
+    GQLDamFileFieldFileQueryVariables,
+    GQLDamMultiFileFieldFileFragment,
+    GQLDamMultiFileFieldFileQuery,
+    GQLDamMultiFileFieldFileQueryVariables,
+} from "./FileField.gql.generated";
+import { FileFieldRow } from "./FileFieldRow";
 
-export type { GQLDamFileFieldFileFragment } from "./FileField.gql.generated";
+export type { GQLDamFileFieldFileFragment, GQLDamMultiFileFieldFileFragment } from "./FileField.gql.generated";
 
 interface ActionItem extends ComponentProps<typeof MenuItem> {
     label: ReactNode;
     icon?: ReactNode;
 }
 
-interface FileFieldProps extends FieldRenderProps<GQLDamFileFieldFileFragment | undefined, HTMLInputElement> {
-    buttonText?: string;
+type CommonProps = {
+    buttonText?: ReactNode;
     allowedMimetypes?: string[];
-    preview?: ReactNode;
     menuActions?: Array<ActionItem | ReactElement | null | undefined>;
+};
+
+type SingleFileFieldProps = FieldRenderProps<GQLDamFileFieldFileFragment | undefined, HTMLInputElement> &
+    CommonProps & {
+        multiple?: false;
+        preview?: ReactNode;
+    };
+
+type MultiFileFieldProps = FieldRenderProps<GQLDamMultiFileFieldFileFragment[] | undefined, HTMLInputElement> &
+    CommonProps & {
+        multiple: true;
+        preview?: (file: GQLDamMultiFileFieldFileFragment) => ReactNode;
+    };
+
+export function FileField(props: SingleFileFieldProps): ReactElement;
+export function FileField(props: MultiFileFieldProps): ReactElement;
+export function FileField(props: SingleFileFieldProps | MultiFileFieldProps): ReactElement {
+    // `react-final-form`'s `<Field>` strips `multiple` from the component's top-level props
+    // and puts it on `input.multiple`, so we have to check both locations.
+    const isMultiple = Boolean(props.multiple) || Boolean(props.input?.multiple);
+    if (isMultiple) {
+        return <MultiFileField {...(props as MultiFileFieldProps)} />;
+    }
+    return <SingleFileField {...(props as SingleFileFieldProps)} />;
 }
 
-const FileField = ({ buttonText, input, allowedMimetypes, preview, menuActions }: FileFieldProps) => {
+const SingleFileField = ({ buttonText, input, allowedMimetypes, preview, menuActions }: SingleFileFieldProps) => {
     const [chooseFileDialogOpen, setChooseFileDialogOpen] = useState<boolean>(false);
-    const client = useApolloClient();
-
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
     const contentScope = useContentScope();
@@ -134,7 +165,7 @@ const FileField = ({ buttonText, input, allowedMimetypes, preview, menuActions }
                 onClose={() => setChooseFileDialogOpen(false)}
                 onChooseFile={async (fileId) => {
                     setChooseFileDialogOpen(false);
-                    const { data } = await client.query<GQLDamFileFieldFileQuery, GQLDamFileFieldFileQueryVariables>({
+                    const { data } = await apolloClient.query<GQLDamFileFieldFileQuery, GQLDamFileFieldFileQueryVariables>({
                         query: damFileFieldFileQuery,
                         variables: {
                             id: fileId,
@@ -148,4 +179,92 @@ const FileField = ({ buttonText, input, allowedMimetypes, preview, menuActions }
     );
 };
 
-export { FileField };
+const MultiFileField = ({ buttonText, input, allowedMimetypes, preview, menuActions }: MultiFileFieldProps) => {
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const apolloClient = useApolloClient();
+    const snackbarApi = useSnackbarApi();
+
+    // react-final-form may pass "" as the default when no initial value is set; fall back to [].
+    const files: GQLDamMultiFileFieldFileFragment[] = Array.isArray(input.value) ? input.value : [];
+
+    const commitChange = (next: GQLDamMultiFileFieldFileFragment[]) => {
+        input.onChange(next.length === 0 ? undefined : next);
+    };
+
+    const handleRemove = (id: string) => {
+        commitChange(files.filter((f) => f.id !== id));
+    };
+
+    const handleConfirm = async (fileIds: string[]) => {
+        const existingById = new Map<string, GQLDamMultiFileFieldFileFragment>(files.map((f) => [f.id, f]));
+        try {
+            const next: GQLDamMultiFileFieldFileFragment[] = await Promise.all(
+                fileIds.map(async (id) => {
+                    const existing = existingById.get(id);
+                    if (existing) {
+                        return existing;
+                    }
+                    const { data } = await apolloClient.query<GQLDamMultiFileFieldFileQuery, GQLDamMultiFileFieldFileQueryVariables>({
+                        query: damMultiFileFieldFileQuery,
+                        variables: { id },
+                    });
+                    return data.damFile;
+                }),
+            );
+
+            commitChange(next);
+            setDialogOpen(false);
+        } catch {
+            snackbarApi.showSnackbar(
+                <Snackbar autoHideDuration={5000}>
+                    <Alert severity="error">
+                        <FormattedMessage
+                            id="comet.form.file.failedToLoadSelection"
+                            defaultMessage="Failed to load selected files. Please try again."
+                        />
+                    </Alert>
+                </Snackbar>,
+            );
+        }
+    };
+
+    if (files.length === 0) {
+        return (
+            <>
+                <BlockAdminComponentButton onClick={() => setDialogOpen(true)} startIcon={<Assets />} size="large">
+                    {buttonText ?? <FormattedMessage id="comet.form.file.chooseFiles" defaultMessage="Choose files" />}
+                </BlockAdminComponentButton>
+                <ChooseDamFilesDialog
+                    open={dialogOpen}
+                    allowedMimetypes={allowedMimetypes}
+                    initialFileIds={[]}
+                    onClose={() => setDialogOpen(false)}
+                    onConfirm={handleConfirm}
+                />
+            </>
+        );
+    }
+
+    return (
+        <>
+            <BlockAdminComponentPaper disablePadding>
+                <List disablePadding>
+                    {files.map((file) => (
+                        <FileFieldRow key={file.id} file={file} onRemove={() => handleRemove(file.id)} preview={preview} menuActions={menuActions} />
+                    ))}
+                </List>
+                <Divider />
+                <BlockAdminComponentButton startIcon={<Assets />} onClick={() => setDialogOpen(true)}>
+                    <FormattedMessage id="comet.form.file.changeSelectedFiles" defaultMessage="Change selected files" />
+                </BlockAdminComponentButton>
+            </BlockAdminComponentPaper>
+            <ChooseDamFilesDialog
+                open={dialogOpen}
+                allowedMimetypes={allowedMimetypes}
+                initialFileIds={files.map((f) => f.id)}
+                onClose={() => setDialogOpen(false)}
+                onConfirm={handleConfirm}
+            />
+        </>
+    );
+};

--- a/packages/admin/cms-admin/src/form/file/FileField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileField.tsx
@@ -156,8 +156,8 @@ const MultiFileFieldInner = ({ buttonText, input, allowedMimetypes, preview, men
                 variables: { ids: fileIds, limit: fileIds.length, scope: damScope },
             });
 
-            const filesById = new Map(data.damFilesList.nodes.map((file) => [file.id, file]));
-            input.onChange(fileIds.flatMap((id) => filesById.get(id) ?? []));
+            const sortedFiles = [...data.damFilesList.nodes].sort((a, b) => fileIds.indexOf(a.id) - fileIds.indexOf(b.id));
+            input.onChange(sortedFiles);
             setDialogOpen(false);
         } catch {
             snackbarApi.showSnackbar(

--- a/packages/admin/cms-admin/src/form/file/FileField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileField.tsx
@@ -11,19 +11,12 @@ import { BlockAdminComponentPaper } from "../../blocks/common/BlockAdminComponen
 import { ChooseDamFileDialog } from "./chooseFile/ChooseDamFileDialog";
 import { ChooseDamFilesDialog } from "./chooseFile/ChooseDamFilesDialog";
 import { DamPathLazy } from "./DamPathLazy";
-import { damFileFieldFileQuery, damMultiFileFieldFileQuery } from "./FileField.gql";
-import type {
-    GQLDamFileFieldFileFragment,
-    GQLDamFileFieldFileQuery,
-    GQLDamFileFieldFileQueryVariables,
-    GQLDamMultiFileFieldFileFragment,
-    GQLDamMultiFileFieldFileQuery,
-    GQLDamMultiFileFieldFileQueryVariables,
-} from "./FileField.gql.generated";
+import { damFileFieldFileQuery } from "./FileField.gql";
+import type { GQLDamFileFieldFileFragment, GQLDamFileFieldFileQuery, GQLDamFileFieldFileQueryVariables } from "./FileField.gql.generated";
 import { type ActionItem, FileFieldMenu, useHasFileFieldMenu } from "./FileFieldMenu";
 import { FileFieldRow } from "./FileFieldRow";
 
-export type { GQLDamFileFieldFileFragment, GQLDamMultiFileFieldFileFragment } from "./FileField.gql.generated";
+export type { GQLDamFileFieldFileFragment } from "./FileField.gql.generated";
 
 type CommonProps = {
     buttonText?: ReactNode;
@@ -37,10 +30,10 @@ type SingleFileFieldProps = FieldRenderProps<GQLDamFileFieldFileFragment | undef
         preview?: ReactNode;
     };
 
-type MultiFileFieldProps = FieldRenderProps<GQLDamMultiFileFieldFileFragment[] | undefined, HTMLInputElement> &
+type MultiFileFieldProps = FieldRenderProps<GQLDamFileFieldFileFragment[] | undefined, HTMLInputElement> &
     CommonProps & {
         multiple: true;
-        preview?: (file: GQLDamMultiFileFieldFileFragment) => ReactNode;
+        preview?: (file: GQLDamFileFieldFileFragment) => ReactNode;
     };
 
 export function FileField(props: SingleFileFieldProps): ReactElement;
@@ -135,7 +128,7 @@ const MultiFileField = ({ buttonText, input, allowedMimetypes, preview, menuActi
     const snackbarApi = useSnackbarApi();
 
     // react-final-form may pass "" as the default when no initial value is set; fall back to [].
-    const files: GQLDamMultiFileFieldFileFragment[] = Array.isArray(input.value) ? input.value : [];
+    const files: GQLDamFileFieldFileFragment[] = Array.isArray(input.value) ? input.value : [];
 
     const handleRemove = (id: string) => {
         input.onChange(files.filter((f) => f.id !== id));
@@ -145,8 +138,8 @@ const MultiFileField = ({ buttonText, input, allowedMimetypes, preview, menuActi
         try {
             const next = await Promise.all(
                 fileIds.map(async (id) => {
-                    const { data } = await apolloClient.query<GQLDamMultiFileFieldFileQuery, GQLDamMultiFileFieldFileQueryVariables>({
-                        query: damMultiFileFieldFileQuery,
+                    const { data } = await apolloClient.query<GQLDamFileFieldFileQuery, GQLDamFileFieldFileQueryVariables>({
+                        query: damFileFieldFileQuery,
                         variables: { id },
                     });
                     return data.damFile;

--- a/packages/admin/cms-admin/src/form/file/FileField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileField.tsx
@@ -8,11 +8,19 @@ import { FormattedMessage } from "react-intl";
 
 import { BlockAdminComponentButton } from "../../blocks/common/BlockAdminComponentButton";
 import { BlockAdminComponentPaper } from "../../blocks/common/BlockAdminComponentPaper";
+import { DamScopeProvider } from "../../dam/config/DamScopeProvider";
+import { useDamScope } from "../../dam/config/useDamScope";
 import { ChooseDamFileDialog } from "./chooseFile/ChooseDamFileDialog";
 import { ChooseDamFilesDialog } from "./chooseFile/ChooseDamFilesDialog";
 import { DamPathLazy } from "./DamPathLazy";
-import { damFileFieldFileQuery } from "./FileField.gql";
-import type { GQLDamFileFieldFileFragment, GQLDamFileFieldFileQuery, GQLDamFileFieldFileQueryVariables } from "./FileField.gql.generated";
+import { damFileFieldFileQuery, damFileFieldFilesByIdsQuery } from "./FileField.gql";
+import type {
+    GQLDamFileFieldFileFragment,
+    GQLDamFileFieldFileQuery,
+    GQLDamFileFieldFileQueryVariables,
+    GQLDamFileFieldFilesByIdsQuery,
+    GQLDamFileFieldFilesByIdsQueryVariables,
+} from "./FileField.gql.generated";
 import { type ActionItem, FileFieldMenu, useHasFileFieldMenu } from "./FileFieldMenu";
 import { FileFieldRow } from "./FileFieldRow";
 
@@ -122,10 +130,17 @@ const SingleFileField = ({ buttonText, input, allowedMimetypes, preview, menuAct
     );
 };
 
-const MultiFileField = ({ buttonText, input, allowedMimetypes, preview, menuActions }: MultiFileFieldProps) => {
+const MultiFileField = (props: MultiFileFieldProps) => (
+    <DamScopeProvider>
+        <MultiFileFieldInner {...props} />
+    </DamScopeProvider>
+);
+
+const MultiFileFieldInner = ({ buttonText, input, allowedMimetypes, preview, menuActions }: MultiFileFieldProps) => {
     const [dialogOpen, setDialogOpen] = useState(false);
     const apolloClient = useApolloClient();
     const snackbarApi = useSnackbarApi();
+    const damScope = useDamScope();
 
     // react-final-form may pass "" as the default when no initial value is set; fall back to [].
     const files: GQLDamFileFieldFileFragment[] = Array.isArray(input.value) ? input.value : [];
@@ -136,17 +151,13 @@ const MultiFileField = ({ buttonText, input, allowedMimetypes, preview, menuActi
 
     const handleConfirm = async (fileIds: string[]) => {
         try {
-            const next = await Promise.all(
-                fileIds.map(async (id) => {
-                    const { data } = await apolloClient.query<GQLDamFileFieldFileQuery, GQLDamFileFieldFileQueryVariables>({
-                        query: damFileFieldFileQuery,
-                        variables: { id },
-                    });
-                    return data.damFile;
-                }),
-            );
+            const { data } = await apolloClient.query<GQLDamFileFieldFilesByIdsQuery, GQLDamFileFieldFilesByIdsQueryVariables>({
+                query: damFileFieldFilesByIdsQuery,
+                variables: { ids: fileIds, limit: fileIds.length, scope: damScope },
+            });
 
-            input.onChange(next);
+            const filesById = new Map(data.damFilesList.nodes.map((file) => [file.id, file]));
+            input.onChange(fileIds.flatMap((id) => filesById.get(id) ?? []));
             setDialogOpen(false);
         } catch {
             snackbarApi.showSnackbar(

--- a/packages/admin/cms-admin/src/form/file/FileFieldMenu.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileFieldMenu.tsx
@@ -1,0 +1,67 @@
+import { useApolloClient } from "@apollo/client";
+import { OpenNewTab } from "@comet/admin-icons";
+import { ListItemIcon, ListItemText, Menu, MenuItem } from "@mui/material";
+import { type ComponentProps, isValidElement, type ReactElement, type ReactNode } from "react";
+import { FormattedMessage } from "react-intl";
+
+import { useContentScope } from "../../contentScope/Provider";
+import { useDependenciesConfig } from "../../dependencies/dependenciesConfig";
+
+export interface ActionItem extends ComponentProps<typeof MenuItem> {
+    label: ReactNode;
+    icon?: ReactNode;
+}
+
+interface FileFieldMenuProps {
+    fileId: string;
+    anchorEl: HTMLElement | null;
+    onClose: () => void;
+    menuActions?: Array<ActionItem | ReactElement | null | undefined>;
+    keepMounted?: boolean;
+}
+
+export const FileFieldMenu = ({ fileId, anchorEl, onClose, menuActions, keepMounted }: FileFieldMenuProps) => {
+    const contentScope = useContentScope();
+    const apolloClient = useApolloClient();
+    const { entityDependencyMap } = useDependenciesConfig();
+    const damDependency = entityDependencyMap["DamFile"];
+
+    return (
+        <Menu anchorEl={anchorEl} keepMounted={keepMounted} open={Boolean(anchorEl)} onClose={onClose}>
+            {damDependency && (
+                <MenuItem
+                    onClick={async () => {
+                        onClose();
+                        const path = await damDependency.resolvePath({ apolloClient, id: fileId });
+                        window.open(contentScope.match.url + path, "_blank");
+                    }}
+                >
+                    <ListItemIcon>
+                        <OpenNewTab />
+                    </ListItemIcon>
+                    <ListItemText primary={<FormattedMessage id="comet.form.file.openInDam" defaultMessage="Open in DAM" />} />
+                </MenuItem>
+            )}
+            {menuActions?.map((item, index) => {
+                if (!item) {
+                    return null;
+                }
+                if (isValidElement(item)) {
+                    return item;
+                }
+                const { label, icon, ...rest } = item as ActionItem;
+                return (
+                    <MenuItem key={index} {...rest}>
+                        {!!icon && <ListItemIcon>{icon}</ListItemIcon>}
+                        <ListItemText primary={label} />
+                    </MenuItem>
+                );
+            })}
+        </Menu>
+    );
+};
+
+export const useHasFileFieldMenu = (menuActions: FileFieldMenuProps["menuActions"]): boolean => {
+    const { entityDependencyMap } = useDependenciesConfig();
+    return Boolean(entityDependencyMap["DamFile"]) || (menuActions !== undefined && menuActions.length > 0);
+};

--- a/packages/admin/cms-admin/src/form/file/FileFieldRow.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileFieldRow.tsx
@@ -1,19 +1,12 @@
-import { useApolloClient } from "@apollo/client";
-import { Delete, MoreVertical, OpenNewTab } from "@comet/admin-icons";
-import { IconButton, ListItem, ListItemIcon, ListItemText, Menu, MenuItem, Stack } from "@mui/material";
-import { type ComponentProps, isValidElement, type MouseEventHandler, type ReactElement, type ReactNode, useState } from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { Delete, MoreVertical } from "@comet/admin-icons";
+import { IconButton, ListItem, ListItemText, Stack } from "@mui/material";
+import { type MouseEventHandler, type ReactElement, type ReactNode, useState } from "react";
+import { useIntl } from "react-intl";
 
-import { useContentScope } from "../../contentScope/Provider";
 import { DamThumbnail } from "../../dam/DataGrid/thumbnail/DamThumbnail";
-import { useDependenciesConfig } from "../../dependencies/dependenciesConfig";
 import { DamPathLazy } from "./DamPathLazy";
 import type { GQLDamMultiFileFieldFileFragment } from "./FileField.gql.generated";
-
-interface ActionItem extends ComponentProps<typeof MenuItem> {
-    label: ReactNode;
-    icon?: ReactNode;
-}
+import { type ActionItem, FileFieldMenu, useHasFileFieldMenu } from "./FileFieldMenu";
 
 interface FileFieldRowProps {
     file: GQLDamMultiFileFieldFileFragment;
@@ -24,17 +17,10 @@ interface FileFieldRowProps {
 
 export const FileFieldRow = ({ file, onRemove, preview, menuActions }: FileFieldRowProps) => {
     const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
-
     const intl = useIntl();
-    const contentScope = useContentScope();
-    const apolloClient = useApolloClient();
-    const { entityDependencyMap } = useDependenciesConfig();
+    const showMoreMenu = useHasFileFieldMenu(menuActions);
 
     const handleMoreClick: MouseEventHandler<HTMLElement> = (event) => setMenuAnchorEl(event.currentTarget);
-    const handleMenuClose = () => setMenuAnchorEl(null);
-
-    const damDependency = entityDependencyMap["DamFile"];
-    const showMoreMenu = Boolean(damDependency) || (menuActions !== undefined && menuActions.length > 0);
 
     return (
         <ListItem
@@ -70,37 +56,7 @@ export const FileFieldRow = ({ file, onRemove, preview, menuActions }: FileField
                 />
             </Stack>
             {showMoreMenu && (
-                <Menu anchorEl={menuAnchorEl} open={Boolean(menuAnchorEl)} onClose={handleMenuClose}>
-                    {damDependency && (
-                        <MenuItem
-                            onClick={async () => {
-                                handleMenuClose();
-                                const path = await damDependency.resolvePath({ apolloClient, id: file.id });
-                                window.open(contentScope.match.url + path, "_blank");
-                            }}
-                        >
-                            <ListItemIcon>
-                                <OpenNewTab />
-                            </ListItemIcon>
-                            <ListItemText primary={<FormattedMessage id="comet.form.file.openInDam" defaultMessage="Open in DAM" />} />
-                        </MenuItem>
-                    )}
-                    {menuActions?.map((item, itemIndex) => {
-                        if (!item) {
-                            return null;
-                        }
-                        if (isValidElement(item)) {
-                            return item;
-                        }
-                        const { label, icon, ...rest } = item as ActionItem;
-                        return (
-                            <MenuItem key={itemIndex} {...rest}>
-                                {!!icon && <ListItemIcon>{icon}</ListItemIcon>}
-                                <ListItemText primary={label} />
-                            </MenuItem>
-                        );
-                    })}
-                </Menu>
+                <FileFieldMenu fileId={file.id} anchorEl={menuAnchorEl} onClose={() => setMenuAnchorEl(null)} menuActions={menuActions} />
             )}
         </ListItem>
     );

--- a/packages/admin/cms-admin/src/form/file/FileFieldRow.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileFieldRow.tsx
@@ -1,0 +1,107 @@
+import { useApolloClient } from "@apollo/client";
+import { Delete, MoreVertical, OpenNewTab } from "@comet/admin-icons";
+import { IconButton, ListItem, ListItemIcon, ListItemText, Menu, MenuItem, Stack } from "@mui/material";
+import { type ComponentProps, isValidElement, type MouseEventHandler, type ReactElement, type ReactNode, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { useContentScope } from "../../contentScope/Provider";
+import { DamThumbnail } from "../../dam/DataGrid/thumbnail/DamThumbnail";
+import { useDependenciesConfig } from "../../dependencies/dependenciesConfig";
+import { DamPathLazy } from "./DamPathLazy";
+import type { GQLDamMultiFileFieldFileFragment } from "./FileField.gql.generated";
+
+interface ActionItem extends ComponentProps<typeof MenuItem> {
+    label: ReactNode;
+    icon?: ReactNode;
+}
+
+interface FileFieldRowProps {
+    file: GQLDamMultiFileFieldFileFragment;
+    onRemove: () => void;
+    preview?: (file: GQLDamMultiFileFieldFileFragment) => ReactNode;
+    menuActions?: Array<ActionItem | ReactElement | null | undefined>;
+}
+
+export const FileFieldRow = ({ file, onRemove, preview, menuActions }: FileFieldRowProps) => {
+    const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
+
+    const intl = useIntl();
+    const contentScope = useContentScope();
+    const apolloClient = useApolloClient();
+    const { entityDependencyMap } = useDependenciesConfig();
+
+    const handleMoreClick: MouseEventHandler<HTMLElement> = (event) => setMenuAnchorEl(event.currentTarget);
+    const handleMenuClose = () => setMenuAnchorEl(null);
+
+    const damDependency = entityDependencyMap["DamFile"];
+    const showMoreMenu = Boolean(damDependency) || (menuActions !== undefined && menuActions.length > 0);
+
+    return (
+        <ListItem
+            divider
+            secondaryAction={
+                <Stack direction="row">
+                    <IconButton
+                        size="small"
+                        onClick={onRemove}
+                        aria-label={intl.formatMessage({ id: "comet.form.file.removeFile", defaultMessage: "Remove" })}
+                    >
+                        <Delete color="action" />
+                    </IconButton>
+                    {showMoreMenu && (
+                        <IconButton
+                            size="small"
+                            onClick={handleMoreClick}
+                            aria-label={intl.formatMessage({ id: "comet.form.file.moreActions", defaultMessage: "More actions" })}
+                        >
+                            <MoreVertical color="action" />
+                        </IconButton>
+                    )}
+                </Stack>
+            }
+        >
+            <Stack direction="row" alignItems="center" spacing={2} flex={1} minWidth={0}>
+                {preview ? preview(file) : <DamThumbnail asset={{ ...file, __typename: "DamFile" }} />}
+                <ListItemText
+                    primary={file.name}
+                    secondary={<DamPathLazy fileId={file.id} />}
+                    primaryTypographyProps={{ variant: "subtitle1", noWrap: true }}
+                    secondaryTypographyProps={{ variant: "body2", color: "textSecondary", noWrap: true, component: "span" }}
+                />
+            </Stack>
+            {showMoreMenu && (
+                <Menu anchorEl={menuAnchorEl} open={Boolean(menuAnchorEl)} onClose={handleMenuClose}>
+                    {damDependency && (
+                        <MenuItem
+                            onClick={async () => {
+                                handleMenuClose();
+                                const path = await damDependency.resolvePath({ apolloClient, id: file.id });
+                                window.open(contentScope.match.url + path, "_blank");
+                            }}
+                        >
+                            <ListItemIcon>
+                                <OpenNewTab />
+                            </ListItemIcon>
+                            <ListItemText primary={<FormattedMessage id="comet.form.file.openInDam" defaultMessage="Open in DAM" />} />
+                        </MenuItem>
+                    )}
+                    {menuActions?.map((item, itemIndex) => {
+                        if (!item) {
+                            return null;
+                        }
+                        if (isValidElement(item)) {
+                            return item;
+                        }
+                        const { label, icon, ...rest } = item as ActionItem;
+                        return (
+                            <MenuItem key={itemIndex} {...rest}>
+                                {!!icon && <ListItemIcon>{icon}</ListItemIcon>}
+                                <ListItemText primary={label} />
+                            </MenuItem>
+                        );
+                    })}
+                </Menu>
+            )}
+        </ListItem>
+    );
+};

--- a/packages/admin/cms-admin/src/form/file/FileFieldRow.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileFieldRow.tsx
@@ -5,13 +5,13 @@ import { useIntl } from "react-intl";
 
 import { DamThumbnail } from "../../dam/DataGrid/thumbnail/DamThumbnail";
 import { DamPathLazy } from "./DamPathLazy";
-import type { GQLDamMultiFileFieldFileFragment } from "./FileField.gql.generated";
+import type { GQLDamFileFieldFileFragment } from "./FileField.gql.generated";
 import { type ActionItem, FileFieldMenu, useHasFileFieldMenu } from "./FileFieldMenu";
 
 interface FileFieldRowProps {
-    file: GQLDamMultiFileFieldFileFragment;
+    file: GQLDamFileFieldFileFragment;
     onRemove: () => void;
-    preview?: (file: GQLDamMultiFileFieldFileFragment) => ReactNode;
+    preview?: (file: GQLDamFileFieldFileFragment) => ReactNode;
     menuActions?: Array<ActionItem | ReactElement | null | undefined>;
 }
 

--- a/packages/admin/cms-admin/src/form/file/chooseFile/BaseChooseDamFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/BaseChooseDamFileDialog.tsx
@@ -1,0 +1,127 @@
+import { Dialog, StackLink, SubRoute } from "@comet/admin";
+import { styled } from "@mui/material/styles";
+import type { ReactNode, SyntheticEvent } from "react";
+import { MemoryRouter } from "react-router";
+
+import { useDamConfig } from "../../../dam/config/damConfig";
+import { DamScopeProvider } from "../../../dam/config/DamScopeProvider";
+import { useDamScope } from "../../../dam/config/useDamScope";
+import { DamTable } from "../../../dam/DamTable";
+import type { DamItemSelectionMap, GQLDamFileTableFragment, GQLDamFolderTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
+import DamItemLabel from "../../../dam/DataGrid/label/DamItemLabel";
+import type { RenderDamLabelOptions } from "../../../dam/DataGrid/label/DamItemLabelColumn";
+import { isFile } from "../../../dam/helpers/isFile";
+import { RedirectToPersistedDamLocation } from "./RedirectToPersistedDamLocation";
+
+const FolderStackLink = styled(StackLink)`
+    width: 100%;
+    height: 100%;
+    text-decoration: none;
+    color: ${({ theme }) => theme.palette.grey[900]};
+`;
+
+interface BaseChooseDamFileDialogProps {
+    open: boolean;
+    onClose: (event: SyntheticEvent, reason: "backdropClick" | "escapeKeyDown") => void;
+    title: ReactNode;
+    stateKey: string;
+    allowedMimetypes?: string[];
+    renderFileLabel: (file: GQLDamFileTableFragment, options: RenderDamLabelOptions) => ReactNode;
+    hideMultiselect: boolean;
+    disableFolderSelection?: boolean;
+    keepNonExistentRowsSelected?: boolean;
+    selectionMap?: DamItemSelectionMap;
+    onSelectionChange?: (map: DamItemSelectionMap) => void;
+    actions?: ReactNode;
+}
+
+type DamLabelProps = {
+    row: GQLDamFileTableFragment | GQLDamFolderTableFragment;
+    options: RenderDamLabelOptions;
+    renderFileLabel: BaseChooseDamFileDialogProps["renderFileLabel"];
+    enableLicenseFeature?: boolean;
+};
+
+const DamLabel = ({ row, options, renderFileLabel, enableLicenseFeature }: DamLabelProps) => {
+    const fullOptions = { ...options, showLicenseWarnings: enableLicenseFeature };
+    if (isFile(row)) {
+        return renderFileLabel(row, fullOptions);
+    }
+    return (
+        <FolderStackLink
+            pageName="folder"
+            payload={row.id}
+            onClick={() => {
+                options.filterApi.formApi.change("searchText", undefined);
+            }}
+        >
+            <DamItemLabel asset={row} matches={options.matches} />
+        </FolderStackLink>
+    );
+};
+
+export const BaseChooseDamFileDialog = ({
+    open,
+    onClose,
+    title,
+    stateKey,
+    allowedMimetypes,
+    renderFileLabel,
+    hideMultiselect,
+    disableFolderSelection,
+    keepNonExistentRowsSelected,
+    selectionMap,
+    onSelectionChange,
+    actions,
+}: BaseChooseDamFileDialogProps) => {
+    const damConfig = useDamConfig();
+    const scope = useDamScope();
+
+    const scopedStateKey = Object.keys(scope).length > 0 ? `${Object.values(scope).join("-")}-${stateKey}` : stateKey;
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            fullWidth
+            maxWidth="xl"
+            title={title}
+            slotProps={{
+                root: {
+                    PaperProps: {
+                        sx: { height: "100%" }, // The fixed height prevents the height of the dialog from changing when navigating between folders which may have different heights depending on the number of items in the folder
+                    },
+                },
+            }}
+        >
+            <DamScopeProvider>
+                <MemoryRouter>
+                    <SubRoute path="">
+                        <RedirectToPersistedDamLocation stateKey={scopedStateKey} />
+                        <DamTable
+                            renderDamLabel={(row, options) => (
+                                <DamLabel
+                                    row={row}
+                                    options={options}
+                                    renderFileLabel={renderFileLabel}
+                                    enableLicenseFeature={damConfig.enableLicenseFeature}
+                                />
+                            )}
+                            allowedMimetypes={allowedMimetypes}
+                            hideContextMenu={true}
+                            hideMultiselect={hideMultiselect}
+                            hideArchiveFilter={true}
+                            toolbarOptions={{ hideSelectiveActions: true }}
+                            disableFolderSelection={disableFolderSelection}
+                            keepNonExistentRowsSelected={keepNonExistentRowsSelected}
+                            selectionMap={selectionMap}
+                            onSelectionChange={onSelectionChange}
+                            additionalToolbarItems={damConfig.additionalToolbarItems}
+                        />
+                    </SubRoute>
+                </MemoryRouter>
+            </DamScopeProvider>
+            {actions}
+        </Dialog>
+    );
+};

--- a/packages/admin/cms-admin/src/form/file/chooseFile/BaseChooseDamFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/BaseChooseDamFileDialog.tsx
@@ -7,7 +7,7 @@ import { useDamConfig } from "../../../dam/config/damConfig";
 import { DamScopeProvider } from "../../../dam/config/DamScopeProvider";
 import { useDamScope } from "../../../dam/config/useDamScope";
 import { DamTable } from "../../../dam/DamTable";
-import type { DamItemSelectionMap, GQLDamFileTableFragment, GQLDamFolderTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
+import type { DamItemSelectionMap, GQLDamFileTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
 import DamItemLabel from "../../../dam/DataGrid/label/DamItemLabel";
 import type { RenderDamLabelOptions } from "../../../dam/DataGrid/label/DamItemLabelColumn";
 import { isFile } from "../../../dam/helpers/isFile";
@@ -35,31 +35,6 @@ interface BaseChooseDamFileDialogProps {
     actions?: ReactNode;
 }
 
-type DamLabelProps = {
-    row: GQLDamFileTableFragment | GQLDamFolderTableFragment;
-    options: RenderDamLabelOptions;
-    renderFileLabel: BaseChooseDamFileDialogProps["renderFileLabel"];
-    enableLicenseFeature?: boolean;
-};
-
-const DamLabel = ({ row, options, renderFileLabel, enableLicenseFeature }: DamLabelProps) => {
-    const fullOptions = { ...options, showLicenseWarnings: enableLicenseFeature };
-    if (isFile(row)) {
-        return renderFileLabel(row, fullOptions);
-    }
-    return (
-        <FolderStackLink
-            pageName="folder"
-            payload={row.id}
-            onClick={() => {
-                options.filterApi.formApi.change("searchText", undefined);
-            }}
-        >
-            <DamItemLabel asset={row} matches={options.matches} />
-        </FolderStackLink>
-    );
-};
-
 export const BaseChooseDamFileDialog = ({
     open,
     onClose,
@@ -74,7 +49,7 @@ export const BaseChooseDamFileDialog = ({
     onSelectionChange,
     actions,
 }: BaseChooseDamFileDialogProps) => {
-    const damConfig = useDamConfig();
+    const { enableLicenseFeature, additionalToolbarItems } = useDamConfig();
     const scope = useDamScope();
 
     const scopedStateKey = Object.keys(scope).length > 0 ? `${Object.values(scope).join("-")}-${stateKey}` : stateKey;
@@ -99,14 +74,22 @@ export const BaseChooseDamFileDialog = ({
                     <SubRoute path="">
                         <RedirectToPersistedDamLocation stateKey={scopedStateKey} />
                         <DamTable
-                            renderDamLabel={(row, options) => (
-                                <DamLabel
-                                    row={row}
-                                    options={options}
-                                    renderFileLabel={renderFileLabel}
-                                    enableLicenseFeature={damConfig.enableLicenseFeature}
-                                />
-                            )}
+                            renderDamLabel={(row, options) => {
+                                if (isFile(row)) {
+                                    return renderFileLabel(row, { ...options, showLicenseWarnings: enableLicenseFeature });
+                                }
+                                return (
+                                    <FolderStackLink
+                                        pageName="folder"
+                                        payload={row.id}
+                                        onClick={() => {
+                                            options.filterApi.formApi.change("searchText", undefined);
+                                        }}
+                                    >
+                                        <DamItemLabel asset={row} matches={options.matches} />
+                                    </FolderStackLink>
+                                );
+                            }}
                             allowedMimetypes={allowedMimetypes}
                             hideContextMenu={true}
                             hideMultiselect={hideMultiselect}
@@ -116,7 +99,7 @@ export const BaseChooseDamFileDialog = ({
                             keepNonExistentRowsSelected={keepNonExistentRowsSelected}
                             selectionMap={selectionMap}
                             onSelectionChange={onSelectionChange}
-                            additionalToolbarItems={damConfig.additionalToolbarItems}
+                            additionalToolbarItems={additionalToolbarItems}
                         />
                     </SubRoute>
                 </MemoryRouter>

--- a/packages/admin/cms-admin/src/form/file/chooseFile/BaseChooseDamFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/BaseChooseDamFileDialog.tsx
@@ -30,7 +30,7 @@ interface BaseChooseDamFileDialogProps {
     hideMultiselect: boolean;
     disableFolderSelection?: boolean;
     keepNonExistentRowsSelected?: boolean;
-    selectionMap?: DamItemSelectionMap;
+    initialSelectionMap?: DamItemSelectionMap;
     onSelectionChange?: (map: DamItemSelectionMap) => void;
     actions?: ReactNode;
 }
@@ -45,7 +45,7 @@ export const BaseChooseDamFileDialog = ({
     hideMultiselect,
     disableFolderSelection,
     keepNonExistentRowsSelected,
-    selectionMap,
+    initialSelectionMap,
     onSelectionChange,
     actions,
 }: BaseChooseDamFileDialogProps) => {
@@ -97,7 +97,7 @@ export const BaseChooseDamFileDialog = ({
                             toolbarOptions={{ hideSelectiveActions: true }}
                             disableFolderSelection={disableFolderSelection}
                             keepNonExistentRowsSelected={keepNonExistentRowsSelected}
-                            selectionMap={selectionMap}
+                            initialSelectionMap={initialSelectionMap}
                             onSelectionChange={onSelectionChange}
                             additionalToolbarItems={additionalToolbarItems}
                         />

--- a/packages/admin/cms-admin/src/form/file/chooseFile/BaseChooseDamFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/BaseChooseDamFileDialog.tsx
@@ -7,7 +7,7 @@ import { useDamConfig } from "../../../dam/config/damConfig";
 import { DamScopeProvider } from "../../../dam/config/DamScopeProvider";
 import { useDamScope } from "../../../dam/config/useDamScope";
 import { DamTable } from "../../../dam/DamTable";
-import type { DamItemSelectionMap, GQLDamFileTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
+import type { GQLDamFileTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
 import DamItemLabel from "../../../dam/DataGrid/label/DamItemLabel";
 import type { RenderDamLabelOptions } from "../../../dam/DataGrid/label/DamItemLabelColumn";
 import { isFile } from "../../../dam/helpers/isFile";
@@ -30,8 +30,8 @@ interface BaseChooseDamFileDialogProps {
     hideMultiselect: boolean;
     disableFolderSelection?: boolean;
     keepNonExistentRowsSelected?: boolean;
-    initialSelection?: DamItemSelectionMap;
-    onSelectionChange?: (map: DamItemSelectionMap) => void;
+    initialFileIds?: string[];
+    onFileIdsChange?: (ids: string[]) => void;
     actions?: ReactNode;
 }
 
@@ -45,8 +45,8 @@ export const BaseChooseDamFileDialog = ({
     hideMultiselect,
     disableFolderSelection,
     keepNonExistentRowsSelected,
-    initialSelection,
-    onSelectionChange,
+    initialFileIds,
+    onFileIdsChange,
     actions,
 }: BaseChooseDamFileDialogProps) => {
     const { enableLicenseFeature, additionalToolbarItems } = useDamConfig();
@@ -97,8 +97,8 @@ export const BaseChooseDamFileDialog = ({
                             toolbarOptions={{ hideSelectiveActions: true }}
                             disableFolderSelection={disableFolderSelection}
                             keepNonExistentRowsSelected={keepNonExistentRowsSelected}
-                            initialSelection={initialSelection}
-                            onSelectionChange={onSelectionChange}
+                            initialSelection={initialFileIds ? new Map(initialFileIds.map((id) => [id, "file"])) : undefined}
+                            onSelectionChange={onFileIdsChange ? (map) => onFileIdsChange(Array.from(map.keys())) : undefined}
                             additionalToolbarItems={additionalToolbarItems}
                         />
                     </SubRoute>

--- a/packages/admin/cms-admin/src/form/file/chooseFile/BaseChooseDamFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/BaseChooseDamFileDialog.tsx
@@ -30,7 +30,7 @@ interface BaseChooseDamFileDialogProps {
     hideMultiselect: boolean;
     disableFolderSelection?: boolean;
     keepNonExistentRowsSelected?: boolean;
-    initialSelectionMap?: DamItemSelectionMap;
+    initialSelection?: DamItemSelectionMap;
     onSelectionChange?: (map: DamItemSelectionMap) => void;
     actions?: ReactNode;
 }
@@ -45,7 +45,7 @@ export const BaseChooseDamFileDialog = ({
     hideMultiselect,
     disableFolderSelection,
     keepNonExistentRowsSelected,
-    initialSelectionMap,
+    initialSelection,
     onSelectionChange,
     actions,
 }: BaseChooseDamFileDialogProps) => {
@@ -97,7 +97,7 @@ export const BaseChooseDamFileDialog = ({
                             toolbarOptions={{ hideSelectiveActions: true }}
                             disableFolderSelection={disableFolderSelection}
                             keepNonExistentRowsSelected={keepNonExistentRowsSelected}
-                            initialSelectionMap={initialSelectionMap}
+                            initialSelection={initialSelection}
                             onSelectionChange={onSelectionChange}
                             additionalToolbarItems={additionalToolbarItems}
                         />

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFileDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFileDialog.tsx
@@ -1,18 +1,12 @@
-import { Button, Dialog, StackLink, SubRoute } from "@comet/admin";
+import { Button } from "@comet/admin";
 import { styled } from "@mui/material/styles";
 import type { SyntheticEvent } from "react";
 import { FormattedMessage } from "react-intl";
-import { MemoryRouter } from "react-router";
 
-import { useDamConfig } from "../../../dam/config/damConfig";
-import { DamScopeProvider } from "../../../dam/config/DamScopeProvider";
-import { useDamScope } from "../../../dam/config/useDamScope";
-import { DamTable } from "../../../dam/DamTable";
-import type { GQLDamFileTableFragment, GQLDamFolderTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
+import type { GQLDamFileTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
 import DamItemLabel from "../../../dam/DataGrid/label/DamItemLabel";
 import type { RenderDamLabelOptions } from "../../../dam/DataGrid/label/DamItemLabelColumn";
-import { isFile } from "../../../dam/helpers/isFile";
-import { RedirectToPersistedDamLocation } from "./RedirectToPersistedDamLocation";
+import { BaseChooseDamFileDialog } from "./BaseChooseDamFileDialog";
 
 const TableRowButton = styled(Button)`
     padding: 0;
@@ -24,35 +18,6 @@ const TableRowButton = styled(Button)`
     }
 `;
 
-const StyledStackLink = styled(StackLink)`
-    width: 100%;
-    height: 100%;
-    text-decoration: none;
-    color: ${({ theme }) => theme.palette.grey[900]};
-`;
-
-const renderDamLabel = (
-    row: GQLDamFileTableFragment | GQLDamFolderTableFragment,
-    onChooseFile: (fileId: string) => void,
-    { matches, filterApi, showLicenseWarnings = false }: RenderDamLabelOptions,
-) => {
-    return isFile(row) ? (
-        <TableRowButton disableRipple={true} variant="textDark" onClick={() => onChooseFile(row.id)} fullWidth>
-            <DamItemLabel asset={row} matches={matches} showLicenseWarnings={showLicenseWarnings} />
-        </TableRowButton>
-    ) : (
-        <StyledStackLink
-            pageName="folder"
-            payload={row.id}
-            onClick={() => {
-                filterApi.formApi.change("searchText", undefined);
-            }}
-        >
-            <DamItemLabel asset={row} matches={matches} />
-        </StyledStackLink>
-    );
-};
-
 interface ChooseFileDialogProps {
     open: boolean;
     onClose: (event: SyntheticEvent, reason: "backdropClick" | "escapeKeyDown") => void;
@@ -60,48 +25,27 @@ interface ChooseFileDialogProps {
     allowedMimetypes?: string[];
 }
 
+type FileLabelProps = {
+    file: GQLDamFileTableFragment;
+    onChooseFile: (fileId: string) => void;
+} & RenderDamLabelOptions;
+
+const FileLabel = ({ file, onChooseFile, matches, showLicenseWarnings }: FileLabelProps) => (
+    <TableRowButton disableRipple={true} variant="textDark" onClick={() => onChooseFile(file.id)} fullWidth>
+        <DamItemLabel asset={file} matches={matches} showLicenseWarnings={showLicenseWarnings} />
+    </TableRowButton>
+);
+
 export const ChooseDamFileDialog = ({ open, onClose, onChooseFile, allowedMimetypes }: ChooseFileDialogProps) => {
-    const damConfig = useDamConfig();
-    let stateKey = "choose-file-dam-location";
-    const scope = useDamScope();
-
-    if (Object.keys(scope).length > 0) {
-        stateKey = `${Object.values(scope).join("-")}-${stateKey}`;
-    }
-
     return (
-        <Dialog
+        <BaseChooseDamFileDialog
             open={open}
             onClose={onClose}
-            fullWidth
-            maxWidth="xl"
             title={<FormattedMessage id="comet.form.file.selectFile" defaultMessage="Select file from DAM" />}
-            slotProps={{
-                root: {
-                    PaperProps: {
-                        sx: { height: "100%" }, // The fixed height prevents the height of the dialog from changing when navigating between folders which may have different heights depending on the number of items in the folder
-                    },
-                },
-            }}
-        >
-            <DamScopeProvider>
-                <MemoryRouter>
-                    <SubRoute path="">
-                        <RedirectToPersistedDamLocation stateKey={stateKey} />
-                        <DamTable
-                            renderDamLabel={(row, { matches, filterApi }: RenderDamLabelOptions) =>
-                                renderDamLabel(row, onChooseFile, { matches, filterApi, showLicenseWarnings: damConfig.enableLicenseFeature })
-                            }
-                            allowedMimetypes={allowedMimetypes}
-                            hideContextMenu={true}
-                            hideMultiselect={true}
-                            hideArchiveFilter={true}
-                            additionalToolbarItems={damConfig.additionalToolbarItems}
-                            toolbarOptions={{ hideSelectiveActions: true }}
-                        />
-                    </SubRoute>
-                </MemoryRouter>
-            </DamScopeProvider>
-        </Dialog>
+            stateKey="choose-file-dam-location"
+            allowedMimetypes={allowedMimetypes}
+            renderFileLabel={(file, options) => <FileLabel file={file} onChooseFile={onChooseFile} {...options} />}
+            hideMultiselect={true}
+        />
     );
 };

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
@@ -1,0 +1,89 @@
+import { Button } from "@comet/admin";
+import { DialogActions } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+import { FormattedMessage } from "react-intl";
+
+import type { DamItemSelectionMap, GQLDamFileTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
+import DamItemLabel from "../../../dam/DataGrid/label/DamItemLabel";
+import type { RenderDamLabelOptions } from "../../../dam/DataGrid/label/DamItemLabelColumn";
+import { BaseChooseDamFileDialog } from "./BaseChooseDamFileDialog";
+
+interface ChooseDamFilesDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: (fileIds: string[]) => void | Promise<void>;
+    initialFileIds: string[];
+    allowedMimetypes?: string[];
+}
+
+const FileLabel = ({ file, matches, showLicenseWarnings }: { file: GQLDamFileTableFragment } & RenderDamLabelOptions) => (
+    <DamItemLabel asset={file} matches={matches} showLicenseWarnings={showLicenseWarnings} />
+);
+
+export const ChooseDamFilesDialog = ({ open, onClose, onConfirm, initialFileIds, allowedMimetypes }: ChooseDamFilesDialogProps) => {
+    const [selectionMap, setSelectionMap] = useState<DamItemSelectionMap>(new Map());
+    const [isConfirming, setIsConfirming] = useState(false);
+
+    // Seed the selection only on the false→true open transition. The parent passes a freshly-
+    // constructed `initialFileIds` array every render; depending on it here would re-seed on
+    // every parent re-render and clobber the user's in-progress checkbox changes.
+    const wasOpenRef = useRef(false);
+    useEffect(() => {
+        if (open && !wasOpenRef.current) {
+            setSelectionMap(new Map(initialFileIds.map((id) => [id, "file"] as const)));
+            setIsConfirming(false);
+        }
+        wasOpenRef.current = open;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open]);
+
+    const selectedFileIds = Array.from(selectionMap.entries())
+        .filter(([, type]) => type === "file")
+        .map(([id]) => id);
+
+    const handleConfirm = async () => {
+        setIsConfirming(true);
+        try {
+            await onConfirm(selectedFileIds);
+        } finally {
+            setIsConfirming(false);
+        }
+    };
+
+    const handleClose = () => {
+        if (isConfirming) {
+            return;
+        }
+        onClose();
+    };
+
+    return (
+        <BaseChooseDamFileDialog
+            open={open}
+            onClose={handleClose}
+            title={<FormattedMessage id="comet.form.file.selectFiles" defaultMessage="Select files from DAM" />}
+            stateKey="choose-files-dam-location"
+            allowedMimetypes={allowedMimetypes}
+            renderFileLabel={(file, options) => <FileLabel file={file} {...options} />}
+            hideMultiselect={false}
+            disableFolderSelection={true}
+            keepNonExistentRowsSelected={true}
+            selectionMap={selectionMap}
+            onSelectionChange={setSelectionMap}
+            actions={
+                <DialogActions>
+                    <Button variant="textLight" onClick={handleClose} disabled={isConfirming}>
+                        <FormattedMessage id="comet.generic.cancel" defaultMessage="Cancel" />
+                    </Button>
+                    <Button variant="primary" onClick={handleConfirm} disabled={selectedFileIds.length === 0 || isConfirming}>
+                        <FormattedMessage
+                            id="comet.form.file.applyFileSelection"
+                            defaultMessage="Select {count, plural, one {# file} other {# files}}"
+                            values={{ count: selectedFileIds.length }}
+                        />
+                    </Button>
+                </DialogActions>
+            }
+        />
+    );
+};

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@comet/admin";
 import { DialogActions } from "@mui/material";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import type { DamItemSelectionMap, GQLDamFileTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
@@ -9,7 +9,6 @@ import type { RenderDamLabelOptions } from "../../../dam/DataGrid/label/DamItemL
 import { BaseChooseDamFileDialog } from "./BaseChooseDamFileDialog";
 
 interface ChooseDamFilesDialogProps {
-    open: boolean;
     onClose: () => void;
     onConfirm: (fileIds: string[]) => void | Promise<void>;
     initialFileIds: string[];
@@ -20,26 +19,11 @@ const FileLabel = ({ file, matches, showLicenseWarnings }: { file: GQLDamFileTab
     <DamItemLabel asset={file} matches={matches} showLicenseWarnings={showLicenseWarnings} />
 );
 
-export const ChooseDamFilesDialog = ({ open, onClose, onConfirm, initialFileIds, allowedMimetypes }: ChooseDamFilesDialogProps) => {
-    const [selectionMap, setSelectionMap] = useState<DamItemSelectionMap>(new Map());
+export const ChooseDamFilesDialog = ({ onClose, onConfirm, initialFileIds, allowedMimetypes }: ChooseDamFilesDialogProps) => {
+    const [selectionMap, setSelectionMap] = useState<DamItemSelectionMap>(() => new Map(initialFileIds.map((id) => [id, "file"])));
     const [isConfirming, setIsConfirming] = useState(false);
 
-    // Seed the selection only on the false→true open transition. The parent passes a freshly-
-    // constructed `initialFileIds` array every render; depending on it here would re-seed on
-    // every parent re-render and clobber the user's in-progress checkbox changes.
-    const wasOpenRef = useRef(false);
-    useEffect(() => {
-        if (open && !wasOpenRef.current) {
-            setSelectionMap(new Map(initialFileIds.map((id) => [id, "file"] as const)));
-            setIsConfirming(false);
-        }
-        wasOpenRef.current = open;
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [open]);
-
-    const selectedFileIds = Array.from(selectionMap.entries())
-        .filter(([, type]) => type === "file")
-        .map(([id]) => id);
+    const selectedFileIds = Array.from(selectionMap.keys());
 
     const handleConfirm = async () => {
         setIsConfirming(true);
@@ -59,7 +43,7 @@ export const ChooseDamFilesDialog = ({ open, onClose, onConfirm, initialFileIds,
 
     return (
         <BaseChooseDamFileDialog
-            open={open}
+            open
             onClose={handleClose}
             title={<FormattedMessage id="comet.form.file.selectFiles" defaultMessage="Select files from DAM" />}
             stateKey="choose-files-dam-location"

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@comet/admin";
 import { DialogActions } from "@mui/material";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import type { DamItemSelectionMap, GQLDamFileTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
@@ -20,7 +20,13 @@ const FileLabel = ({ file, matches, showLicenseWarnings }: { file: GQLDamFileTab
 );
 
 export const ChooseDamFilesDialog = ({ onClose, onConfirm, initialFileIds, allowedMimetypes }: ChooseDamFilesDialogProps) => {
-    const [selectionMap, setSelectionMap] = useState<DamItemSelectionMap>(() => new Map(initialFileIds.map((id) => [id, "file"])));
+    const initialSelectionMap = useMemo<DamItemSelectionMap>(
+        () => new Map(initialFileIds.map((id) => [id, "file"])),
+        // Seeded once on mount; the parent unmounts the dialog when closed, so on next open we get a fresh mount.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [],
+    );
+    const [selectionMap, setSelectionMap] = useState<DamItemSelectionMap>(initialSelectionMap);
     const [isConfirming, setIsConfirming] = useState(false);
 
     const selectedFileIds = Array.from(selectionMap.keys());
@@ -52,7 +58,7 @@ export const ChooseDamFilesDialog = ({ onClose, onConfirm, initialFileIds, allow
             hideMultiselect={false}
             disableFolderSelection={true}
             keepNonExistentRowsSelected={true}
-            selectionMap={selectionMap}
+            initialSelectionMap={initialSelectionMap}
             onSelectionChange={setSelectionMap}
             actions={
                 <DialogActions>

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
@@ -3,7 +3,7 @@ import { DialogActions } from "@mui/material";
 import { useState } from "react";
 import { FormattedMessage } from "react-intl";
 
-import type { DamItemSelectionMap, GQLDamFileTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
+import type { GQLDamFileTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
 import DamItemLabel from "../../../dam/DataGrid/label/DamItemLabel";
 import type { RenderDamLabelOptions } from "../../../dam/DataGrid/label/DamItemLabelColumn";
 import { BaseChooseDamFileDialog } from "./BaseChooseDamFileDialog";
@@ -20,10 +20,8 @@ const FileLabel = ({ file, matches, showLicenseWarnings }: { file: GQLDamFileTab
 );
 
 export const ChooseDamFilesDialog = ({ onClose, onConfirm, initialFileIds, allowedMimetypes }: ChooseDamFilesDialogProps) => {
-    const [selectionMap, setSelectionMap] = useState<DamItemSelectionMap>(() => new Map(initialFileIds.map((id) => [id, "file"])));
+    const [selectedFileIds, setSelectedFileIds] = useState<string[]>(initialFileIds);
     const [isConfirming, setIsConfirming] = useState(false);
-
-    const selectedFileIds = Array.from(selectionMap.keys());
 
     const handleConfirm = async () => {
         setIsConfirming(true);
@@ -52,8 +50,8 @@ export const ChooseDamFilesDialog = ({ onClose, onConfirm, initialFileIds, allow
             hideMultiselect={false}
             disableFolderSelection={true}
             keepNonExistentRowsSelected={true}
-            initialSelection={selectionMap}
-            onSelectionChange={setSelectionMap}
+            initialFileIds={selectedFileIds}
+            onFileIdsChange={setSelectedFileIds}
             actions={
                 <DialogActions>
                     <Button variant="textLight" onClick={handleClose} disabled={isConfirming}>

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@comet/admin";
 import { DialogActions } from "@mui/material";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import type { DamItemSelectionMap, GQLDamFileTableFragment } from "../../../dam/DataGrid/FolderDataGrid";
@@ -20,13 +20,7 @@ const FileLabel = ({ file, matches, showLicenseWarnings }: { file: GQLDamFileTab
 );
 
 export const ChooseDamFilesDialog = ({ onClose, onConfirm, initialFileIds, allowedMimetypes }: ChooseDamFilesDialogProps) => {
-    const initialSelectionMap = useMemo<DamItemSelectionMap>(
-        () => new Map(initialFileIds.map((id) => [id, "file"])),
-        // Seeded once on mount; the parent unmounts the dialog when closed, so on next open we get a fresh mount.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [],
-    );
-    const [selectionMap, setSelectionMap] = useState<DamItemSelectionMap>(initialSelectionMap);
+    const [selectionMap, setSelectionMap] = useState<DamItemSelectionMap>(() => new Map(initialFileIds.map((id) => [id, "file"])));
     const [isConfirming, setIsConfirming] = useState(false);
 
     const selectedFileIds = Array.from(selectionMap.keys());
@@ -58,7 +52,7 @@ export const ChooseDamFilesDialog = ({ onClose, onConfirm, initialFileIds, allow
             hideMultiselect={false}
             disableFolderSelection={true}
             keepNonExistentRowsSelected={true}
-            initialSelectionMap={initialSelectionMap}
+            initialSelectionMap={selectionMap}
             onSelectionChange={setSelectionMap}
             actions={
                 <DialogActions>

--- a/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
+++ b/packages/admin/cms-admin/src/form/file/chooseFile/ChooseDamFilesDialog.tsx
@@ -52,7 +52,7 @@ export const ChooseDamFilesDialog = ({ onClose, onConfirm, initialFileIds, allow
             hideMultiselect={false}
             disableFolderSelection={true}
             keepNonExistentRowsSelected={true}
-            initialSelectionMap={selectionMap}
+            initialSelection={selectionMap}
             onSelectionChange={setSelectionMap}
             actions={
                 <DialogActions>

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -167,7 +167,9 @@ export type { DocumentInterface, DocumentType, InfoTagProps, SitePreviewActionPr
 export { ChooseDamFileDialog } from "./form/file/chooseFile/ChooseDamFileDialog";
 /** @deprecated Use `ChooseDamFileDialog` instead. */
 export { ChooseDamFileDialog as ChooseFileDialog } from "./form/file/chooseFile/ChooseDamFileDialog";
-export { FileField } from "./form/file/FileField";
+export { ChooseDamFilesDialog } from "./form/file/chooseFile/ChooseDamFilesDialog";
+export { FileField, type GQLDamFileFieldFileFragment, type GQLDamMultiFileFieldFileFragment } from "./form/file/FileField";
+export { damMultiFileFieldFragment } from "./form/file/FileField.gql";
 export { FileUploadField, type FileUploadFieldProps } from "./form/file/FileUploadField";
 export {
     FinalFormFileUpload,

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -168,8 +168,8 @@ export { ChooseDamFileDialog } from "./form/file/chooseFile/ChooseDamFileDialog"
 /** @deprecated Use `ChooseDamFileDialog` instead. */
 export { ChooseDamFileDialog as ChooseFileDialog } from "./form/file/chooseFile/ChooseDamFileDialog";
 export { ChooseDamFilesDialog } from "./form/file/chooseFile/ChooseDamFilesDialog";
-export { FileField, type GQLDamFileFieldFileFragment, type GQLDamMultiFileFieldFileFragment } from "./form/file/FileField";
-export { damMultiFileFieldFragment } from "./form/file/FileField.gql";
+export { FileField, type GQLDamFileFieldFileFragment } from "./form/file/FileField";
+export { damFileFieldFragment } from "./form/file/FileField.gql";
 export { FileUploadField, type FileUploadFieldProps } from "./form/file/FileUploadField";
 export {
     FinalFormFileUpload,

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -606,6 +606,7 @@ enum DamItemType {
 input FileFilterInput {
   searchText: String
   mimetypes: [String!]
+  ids: [ID!]
 }
 
 input ImageCropAreaInput {

--- a/packages/api/cms-api/src/dam/files/dto/file.args.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.args.ts
@@ -20,6 +20,11 @@ export class FileFilterInput {
     @IsOptional()
     @IsString({ each: true })
     mimetypes?: string[];
+
+    @Field(() => [ID], { nullable: true })
+    @IsOptional()
+    @IsUUID(4, { each: true })
+    ids?: string[];
 }
 
 export interface FileArgsInterface extends OffsetBasedPaginationArgs, SortArgs {

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -45,6 +45,7 @@ const withFilesSelect = (
     args: {
         query?: string;
         id?: string;
+        ids?: string[];
         copyOfId?: string;
         filename?: string;
         folderId?: string | null;
@@ -65,6 +66,9 @@ const withFilesSelect = (
     }
     if (args.id) {
         qb.andWhere({ id: args.id });
+    }
+    if (args.ids) {
+        qb.andWhere({ id: { $in: args.ids } });
     }
     if (args.copyOfId) {
         qb.andWhere({ copyOf: { id: args.copyOfId } });
@@ -147,6 +151,7 @@ export class FilesService {
             archived: !includeArchived ? false : undefined,
             folderId: !isSearching ? folderId || null : undefined,
             mimetypes: filter?.mimetypes,
+            ids: filter?.ids,
             query: filter?.searchText,
             sortColumnName,
             sortDirection,
@@ -164,6 +169,7 @@ export class FilesService {
             archived: !includeArchived ? false : undefined,
             folderId: !isSearching ? folderId || null : undefined,
             mimetypes: filter?.mimetypes,
+            ids: filter?.ids,
             query: filter?.searchText,
             sortColumnName,
             sortDirection,
@@ -176,6 +182,7 @@ export class FilesService {
             archived: !includeArchived ? false : undefined,
             folderId: !isSearching ? folderId || null : undefined,
             mimetypes: filter?.mimetypes,
+            ids: filter?.ids,
             query: filter?.searchText,
             sortColumnName,
             sortDirection,


### PR DESCRIPTION
## Summary

Adds a `multiple` prop to `FileField` for selecting a list of DAM files, and exposes the underlying picker (`ChooseDamFilesDialog`) so consumers can build custom multi-file UIs (e.g. bulk-adding to a list block).

**I need to backport this to v8, so it's designed to be non-breaking**

## What's new in `@comet/cms-admin`

- **`<FileField multiple>`** — picks `GQLDamFileFieldFileFragment[]`, renders a stacked `List` with per-row remove + menu actions. Single-file API unchanged.
- **`ChooseDamFilesDialog`** (exported) — multi-file picker dialog. Pre-checks the current selection via `initialFileIds`, persists across folder navigation (`keepNonExistentRowsSelected`), and returns the picked file ids on confirm.
- **`DamTable`** — new optional `initialSelectionMap` / `onSelectionChange` for seeding + observing selection, plus `disableFolderSelection`, `keepNonExistentRowsSelected`, and `toolbarOptions.hideSelectiveActions` config.

## Example

```tsx
<Field name="files" component={FileField} multiple preview={(f) => <Thumbnail fileId={f.id} />} />
```

```tsx
{
    open && (
        <ChooseDamFilesDialog onClose={onClose} onConfirm={(fileIds) => addFiles(fileIds)} initialFileIds={[]} allowedMimetypes={["image/jpeg"]} />
    );
}
```

## Demo

`Product.relatedImages` persists multiple DAM files via the new `<FileField multiple>` (demo-api migration + demo-admin form).

https://github.com/user-attachments/assets/eaae0f86-68e0-4fd2-af49-b38f76d524eb

---

Partially replaces https://github.com/vivid-planet/comet/pull/5522