### PR TITLE
API Generator: add .js extensions to @nestjs/graphql deep imports

### DIFF
--- a/.changeset/fix-api-generator-graphql-13-3-imports.md
+++ b/.changeset/fix-api-generator-graphql-13-3-imports.md
@@ -1,0 +1,5 @@
+---
+"@comet/api-generator": patch
+---
+
+Fix `MODULE_NOT_FOUND` errors caused by extensionless deep imports of `@nestjs/graphql` internals. `@nestjs/graphql` 13.3.0 tightened its `exports` map so that the `"./*": "./*"` pattern no longer maps to `.js` automatically. All deep imports of `@nestjs/graphql` internals now use explicit `.js` extensions.

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/build-options.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/build-options.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, defineConfig, Entity, ManyToOne, MikroORM, OneToOne, PrimaryKey, Property, Ref } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/deleted-at.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/deleted-at.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, defineConfig, Entity, Filter, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/filter-primary-key.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/filter-primary-key.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-dedicated-resolver-arg.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-dedicated-resolver-arg.spec.ts
@@ -1,6 +1,6 @@
 import { CrudField, CrudGenerator } from "@comet/cms-api";
 import { BaseEntity, Collection, defineConfig, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, type Ref } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-embeddable.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-embeddable.spec.ts
@@ -1,7 +1,7 @@
 import { CrudField } from "@comet/cms-api";
 import { BaseEntity, defineConfig, Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
 import { Field, InputType } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-enum-array.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-enum-array.spec.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, defineConfig, Entity, Enum, MikroORM, PrimaryKey } from "@mikro-orm/postgresql";
 import { Field, registerEnumType } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-enum-multi-use.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-enum-multi-use.spec.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, defineConfig, Entity, Enum, MikroORM, PrimaryKey } from "@mikro-orm/postgresql";
 import { Field, registerEnumType } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-enum-optional.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-enum-optional.spec.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, defineConfig, Entity, Enum, MikroORM, PrimaryKey } from "@mikro-orm/postgresql";
 import { Field, registerEnumType } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-extend-entity.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-extend-entity.spec.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
 import { Field } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-position.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-position.spec.ts
@@ -1,7 +1,7 @@
 import { CrudGenerator } from "@comet/cms-api";
 import { BaseEntity, defineConfig, Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
 import { Field, Int } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { Min } from "class-validator";
 import { v4 as uuid } from "uuid";
 

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relation-many-to-many.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relation-many-to-many.spec.ts
@@ -11,7 +11,7 @@ import {
     Ref,
     types,
 } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-id-integer.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-id-integer.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, defineConfig, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Ref } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-id-string.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-id-string.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, defineConfig, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Ref } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-multi-use.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-multi-use.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, defineConfig, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Ref } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-nested.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-nested.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, defineConfig, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Ref } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-two-levels.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-two-levels.spec.ts
@@ -11,7 +11,7 @@ import {
     Property,
     Ref,
 } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, defineConfig, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Ref } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-resolve-field.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-resolve-field.spec.ts
@@ -1,6 +1,6 @@
 import { CrudField } from "@comet/cms-api";
 import { BaseEntity, Collection, defineConfig, Entity, ManyToMany, MikroORM, PrimaryKey } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-resolve-id-integer.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-resolve-id-integer.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";
 import { generateCrud } from "../generate-crud";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-scope.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-scope.spec.ts
@@ -1,6 +1,6 @@
 import { ScopedEntity } from "@comet/cms-api";
 import { BaseEntity, defineConfig, Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-without-find.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-without-find.spec.ts
@@ -1,6 +1,6 @@
 import { CrudField } from "@comet/cms-api";
 import { BaseEntity, defineConfig, Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/position-default-sort.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/position-default-sort.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/sort-by-id.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/sort-by-id.spec.ts
@@ -1,6 +1,6 @@
 import { CrudField } from "@comet/cms-api";
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatGeneratedFiles, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-array.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-array.spec.ts
@@ -1,6 +1,6 @@
 import { ArrayType, BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
 import { Field } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatSource, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-integer.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-integer.spec.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
 import { Field, Int } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { generateCrud } from "../../generateCrud/generate-crud";

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-json-import.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-json-import.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-json.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-json.spec.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
 import { InputType } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatSource, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-no-update-input.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-no-update-input.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 
 import { formatSource, testPermission } from "../../utils/test-helper";
 import { generateCrudInput } from "../generate-crud-input";

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-relations-string.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-relations-string.spec.ts
@@ -1,7 +1,7 @@
 import { BaseEntity, defineConfig, Entity, ManyToOne, MikroORM, PrimaryKey, Ref } from "@mikro-orm/postgresql";
 import { ID } from "@nestjs/graphql";
-import { Field } from "@nestjs/graphql/dist/decorators/field.decorator";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { Field } from "@nestjs/graphql/dist/decorators/field.decorator.js";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatSource, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-relations.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-relations.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, defineConfig, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Ref } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatSource, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-type-or-columnType.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-type-or-columnType.spec.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
 import { Field, Float, Int } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { generateCrud } from "../../generateCrud/generate-crud";

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-validators.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input-validators.spec.ts
@@ -1,6 +1,6 @@
 import { IsValidRedirectSource } from "@comet/cms-api";
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import {
     IsEmail,
     IsISO8601,

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/generate-crud-input.spec.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, DateType, defineConfig, Entity, Enum, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
 import { Field, ObjectType, registerEnumType } from "@nestjs/graphql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { formatSource, parseSource, testPermission } from "../../utils/test-helper";

--- a/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/nested-two-level.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrudInput/__tests__/nested-two-level.spec.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Collection, defineConfig, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Ref } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { generateInputHandling } from "../../generateCrud/generate-crud";

--- a/packages/api/api-generator/src/commands/generate/generateFiles.ts
+++ b/packages/api/api-generator/src/commands/generate/generateFiles.ts
@@ -10,7 +10,7 @@ import {
 } from "@comet/cms-api";
 import { CLIHelper } from "@mikro-orm/cli";
 import type { MikroORM } from "@mikro-orm/core";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { format, resolveConfig } from "prettier";
 
 import { buildOptions } from "./generateCrud/build-options";

--- a/packages/api/api-generator/src/commands/generate/utils/__tests__/find-hooks-service.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/utils/__tests__/find-hooks-service.spec.ts
@@ -1,6 +1,6 @@
 import { CrudGenerator, CrudGeneratorHooksService, CurrentUser, MutationError } from "@comet/cms-api";
 import { BaseEntity, defineConfig, Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/postgresql";
-import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
 import { v4 as uuid } from "uuid";
 
 import { findHooksService } from "../find-hooks-service";


### PR DESCRIPTION
**Problem**

After upgrading `@nestjs/graphql` to 13.3.0, any project using `@comet/api-generator` fails during code generation with a module not found error:

```
Error: Cannot find module '@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage'
```

This blocks the entire lint/build pipeline because `api-generator` runs before TypeScript compilation.

**Cause**

`@nestjs/graphql` 13.3.0 tightened its `package.json` exports map by adding conditional exports for a browser shim. The `"./*": "./*"` subpath pattern now performs exact matching — it no longer falls back to trying `.js` extensions, so extensionless deep imports fail during Node.js module resolution.

`generateFiles.ts` imports `LazyMetadataStorage` directly from the internal storage path without an extension. The same extensionless import pattern is repeated across all test spec files.

Plain Node.js testing confirms the failure:

```
// fails with @nestjs/graphql ≥13.3.0
require("@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage")

// works
require("@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js")
```

**Relation to #5526**

PR #5526 applied the same fix to `@comet/cms-api`. This PR extends the fix to `@comet/api-generator`, which was not covered by that change.

**Fix**

Append `.js` to all deep `@nestjs/graphql` imports in `generateFiles.ts` and all test spec files. The fix is backward-compatible with `@nestjs/graphql` 13.2.x.

**Changeset**

Patch bump for `@comet/api-generator`.