### PR TITLE
Temporarily remove stable-v8 tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
               uses: dotansimha/changesets-action@v1.5.2
               with:
                   version: pnpm run version
-                  publish: pnpm run publish --tag=stable-v8
+                  publish: pnpm run publish
                   title: "Version Packages (v8)"
                   createGithubReleases: aggregate
                   githubReleaseName: "${{ env.PUBLISHED_VERSION }}"


### PR DESCRIPTION
While v9 isn't released yet, we still want to publish v8 under the latest tag. Publishing as stable-v8 while v9 isn't released causes problems with renovate.