### PR TITLE
Prevent links in the `TableBlock` RTE cell preview from opening when editing a cell

### DIFF
--- a/.changeset/table-block-rte-preview-no-pointer-events.md
+++ b/.changeset/table-block-rte-preview-no-pointer-events.md
@@ -1,0 +1,8 @@
+---
+"@comet/cms-admin": patch
+---
+
+Prevent links in the `TableBlock` RTE cell preview from opening when editing a cell
+
+Double-clicking a cell to edit it would open any link in the preview.
+Pointer events are now disabled on the preview, while text selection still works.

--- a/packages/admin/cms-admin/src/blocks/table/CellValue.tsx
+++ b/packages/admin/cms-admin/src/blocks/table/CellValue.tsx
@@ -64,4 +64,5 @@ const RteContentWrapper = styled("div")(({ theme }) => ({
 const RteContent = styled("div")({
     marginTop: "auto",
     marginBottom: "auto",
+    pointerEvents: "none",
 });


### PR DESCRIPTION
Double-clicking a cell to edit it would open any link in the preview.
Pointer events are now disabled on the preview, while text selection still works.

---

https://vivid-planet.atlassian.net/browse/COM-2907