### PR TITLE
Mail-React: Add Config-Context System

### DIFF
--- a/.changeset/add-mail-react-config-context.md
+++ b/.changeset/add-mail-react-config-context.md
@@ -1,0 +1,17 @@
+---
+"@comet/mail-react": minor
+---
+
+Add config context with `Config`, `ConfigProvider`, and `useConfig`
+
+`Config` is an augmentable interface for runtime configuration — intended for environment-specific data. Add custom keys via TypeScript interface declaration merging:
+
+```ts
+declare module "@comet/mail-react" {
+    interface Config {
+        myKey?: { foo: string };
+    }
+}
+```
+
+Define the config using the `config` prop on `MjmlMailRoot` or by mounting `ConfigProvider` directly. Use the `useConfig` hook to read the value.

--- a/.cspellignore
+++ b/.cspellignore
@@ -75,3 +75,4 @@ arcsize
 shakability
 fulltext
 agentic
+augmentable

--- a/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
@@ -145,6 +145,8 @@ function WelcomeEmail() {
 
 When no `theme` prop is provided, `MjmlMailRoot` uses the default theme (equivalent to `createTheme()` with no arguments).
 
+`MjmlMailRoot` also accepts an optional `config` prop that can be used to expose, e.g., environment-specific values to descendants via `useConfig`. See [Configuration](./4-customization.md#configuration).
+
 ### What MjmlMailRoot Configures
 
 From the theme, `MjmlMailRoot` automatically sets:

--- a/docs/docs/3-features-modules/13-building-html-emails/4-customization.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/4-customization.md
@@ -194,3 +194,38 @@ registerStyles(
 :::note
 MJML generates table-based HTML. When targeting nested elements inside MJML components, you may need to go through the table structure (e.g., `> table > tbody > tr > td`) to reach the element you want to style. Use the browser dev tools in Storybook to inspect the generated HTML structure.
 :::
+
+## Configuration
+
+`Config` can be used to expose, e.g., environment-specific values such as asset base URLs or per-deployment identifiers.
+
+- **`Config`** — an augmentable interface with no built-in keys. All keys are optional.
+- **`MjmlMailRoot.config`** — optional prop that exposes a `Config` value to descendants.
+- **`useConfig`** — hook that returns the nearest `Config`, or `{}` if no provider is mounted.
+- **`ConfigProvider`** — standalone provider for cases that bypass `MjmlMailRoot`.
+
+Add keys via TypeScript module augmentation:
+
+```ts title="config.ts"
+declare module "@comet/mail-react" {
+    interface Config {
+        assetBaseUrl?: string;
+    }
+}
+```
+
+Pass the value at the root and read it from any descendant:
+
+```tsx
+import { MjmlMailRoot, useConfig, type Config } from "@comet/mail-react";
+
+const config: Config = { assetBaseUrl: process.env.ASSET_BASE_URL };
+
+function WelcomeEmail() {
+    return (
+        <MjmlMailRoot config={config}>
+            {/* descendants can call useConfig() */}
+        </MjmlMailRoot>
+    );
+}
+```

--- a/packages/mail-react/openspec/changes/archive/2026-05-05-add-config-context/.openspec.yaml
+++ b/packages/mail-react/openspec/changes/archive/2026-05-05-add-config-context/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/packages/mail-react/openspec/changes/archive/2026-05-05-add-config-context/design.md
+++ b/packages/mail-react/openspec/changes/archive/2026-05-05-add-config-context/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The package already ships a `ThemeProvider` / `useTheme` pair for visual design tokens. New block-level components in the works (starting with pixel-image blocks) need different kinds of runtime data — DAM base URLs, allowed image sizes, environment-specific identifiers — that are configuration, not design. Mixing the two in `Theme` couples concerns with very different lifetimes (design tokens are static across deployments; integration data is environment-specific). A separate, additive `Config` primitive keeps both concerns clean and lets each grow independently.
+
+This change introduces the primitive only. It ships no domain-specific keys; the first consumer (`add-pixel-image-blocks`) declares its own `pixelImage` key alongside the components that read it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A single, type-safe React context for runtime configuration of `@comet/mail-react` consumers.
+- Extension model that mirrors the existing `TextVariants` pattern in `themeTypes.ts`: consumers add keys through TypeScript interface declaration merging without wrapping or shadowing the library's interface.
+- Zero-config-by-default: templates that don't need any configuration can still mount `MjmlMailRoot` with no extra setup.
+- Symmetry with `theme` so the wiring story is "pass `theme` and/or `config` to `MjmlMailRoot`", with `ConfigProvider` available for advanced cases that bypass `MjmlMailRoot`.
+
+**Non-Goals:**
+- Any specific config key. `pixelImage` and any future block-specific keys land in the proposals that introduce those blocks.
+- Strict / required configuration enforcement. The hook never throws — downstream consumers can build narrower accessors that throw when their specific key is required (as `add-pixel-image-blocks` will do via an internal `usePixelImageConfig`).
+- A merge / partial-override mechanism for nested `ConfigProvider`s. The provider replaces the value wholesale, like `ThemeProvider`. If layered configuration ever proves necessary, that's an additive change later.
+- Default config values inside `MjmlMailRoot`. Theme has `createTheme()` because design tokens have sensible defaults; config does not.
+
+## Decisions
+
+### D1. Separate context from `Theme`
+
+**Decision.** `Config` lives in its own React context, independent of `Theme`.
+
+**Why.** Different concerns, different lifetimes. Theme is design tokens that rarely change between environments; config is environment-specific integration data. Keeping them separate means a designer can tweak colors without touching DAM URLs, and an environment switch updates config without disturbing visual tokens.
+
+**Alternative considered.** Adding integration data into `Theme`. Rejected — pollutes the type, mixes concerns, and would require visual stories to know about DAM URLs.
+
+### D2. `useConfig` returns `{}` when no provider, never throws
+
+**Decision.** When no `ConfigProvider` is mounted, `useConfig()` returns an empty `Config` (`{}`). All `Config` keys are optional, so an empty object is a valid `Config`.
+
+**Why.** Most templates won't need any configuration. Forcing every consumer to wrap their root in a provider just to render an email creates friction with no benefit. Block components that genuinely *require* a key (e.g., pixel-image blocks needing `pixelImage`) build their own narrow accessor that throws — failure stays close to the offending consumer.
+
+**Alternative considered.** Mirror `useTheme`'s "throw if no provider" behavior. Rejected because `Theme` has design-token defaults via `createTheme()`, while `Config` has no library-shipped defaults — empty is the only sensible default. A `useOptionalConfig` was also considered and rejected as redundant: the regular hook already handles the no-provider case.
+
+### D3. Augmentable `Config` interface (declaration merging)
+
+**Decision.** `Config` is declared as an `interface` (not a `type`) and ships empty. Both this package's downstream changes and external consumers add keys via TypeScript interface declaration merging:
+
+```ts
+declare module "@comet/mail-react" {
+    interface Config {
+        myCustomThing?: { foo: string };
+    }
+}
+```
+
+**Why.** Mirrors the existing `TextVariants` augmentation pattern in `themeTypes.ts` — consumers already know how to extend types this way. Interface merging is the only TS mechanism that lets multiple sources contribute keys to the same name without wrapping or generic plumbing.
+
+**Note on intent vs. `TextVariants`.** `TextVariants` uses merging to *fill in* an empty type with consumer-specific names. `Config` uses the same mechanism to *additively grow* the type with new keys. Same machinery, different intent. The interface's TSDoc documents this clearly so consumers don't have to infer it.
+
+### D4. All keys optional
+
+**Decision.** Every key on `Config` is optional. Consumers (or downstream blocks) provide a key only when needed.
+
+**Why.** Required keys would force every template to fill in every block-specific config — even templates that don't render that block. Optionality keeps the cost of the primitive at zero for users who don't need it.
+
+### D5. `MjmlMailRoot` accepts an optional `config` prop and always mounts `ConfigProvider`
+
+**Decision.** Add `config?: Config` to `MjmlMailRoot`. The component always mounts `ConfigProvider` internally — with the supplied `config` when provided, and with `{}` when omitted.
+
+**Why.** Mirrors how `MjmlMailRoot` already always mounts `ThemeProvider` (using `createTheme()` as the default). Removes a conditional branch in the render path and keeps the React tree shape the same for templates with or without `config`.
+
+**Alternative considered.** Mount `ConfigProvider` only when `config` is provided, and rely on `useConfig`'s `{}` fallback otherwise. Rejected — the conditional branch is more code for no observable difference (`useConfig` returns `{}` either way), and the asymmetry with `ThemeProvider`'s always-mounted treatment was an unnecessary cost. The fallback inside `useConfig` is still required for code paths that bypass `MjmlMailRoot` entirely (raw `useConfig`, fragments, tests).
+
+### D6. Standalone `ConfigProvider` is exported
+
+**Decision.** Export `ConfigProvider` alongside `useConfig`. Consumers can mount it directly when bypassing `MjmlMailRoot` (e.g., partial fragments, custom roots, tests).
+
+**Why.** Mirrors `ThemeProvider`. The `MjmlMailRoot.config` prop is the typical path; the standalone provider covers everything else.
+
+### D7. File location: `src/config/`
+
+**Decision.** New code lives at `src/config/ConfigProvider.tsx` (provider, hook, and the `Config` interface co-located).
+
+**Why.** Top-level alongside `src/theme/`, mirroring the structural symmetry between these two contexts. Co-locating the interface with the provider/hook keeps a single import target for everything related to `Config`.
+
+## Risks / Trade-offs
+
+- *Two similar-looking augmentation patterns (`TextVariants` and `Config`) with different intents could confuse newcomers.* → TSDoc on `Config` (and on the augmentation example in the docs/skill) calls out the difference explicitly. The mechanic is identical; only the intent differs.
+- *Empty default makes mistakes silent for keys that are typed-optional but practically required by a specific block.* → Mitigated downstream: each block ships its own narrow accessor that throws when its key is missing (per the `add-pixel-image-blocks` design). The library only enforces "config is optional"; correctness of any individual key belongs to its consumer.
+- *Two contexts (`ThemeProvider` and `ConfigProvider`) at the root may feel redundant when both are needed.* → `MjmlMailRoot.config` + `MjmlMailRoot.theme` keeps the typical surface to a single component prop list. The standalone providers are escape hatches, not the default path.

--- a/packages/mail-react/openspec/changes/archive/2026-05-05-add-config-context/proposal.md
+++ b/packages/mail-react/openspec/changes/archive/2026-05-05-add-config-context/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Some block components need runtime, environment-specific values that don't belong on the visual `Theme` (DAM `baseUrl`, the API's allowed image sizes, future per-project integration data). Threading these as props at every render site is repetitive and brittle. A separate `Config` context — sibling to `Theme` — gives downstream components a single, type-safe place to read this data, and gives consumers a single place to wire it.
+
+## What Changes
+
+- Add a new `Config` interface (initially empty, augmentable by both this package and consumers via TypeScript interface declaration merging)
+- Add `ConfigProvider` for placing a `Config` value in the React tree
+- Add `useConfig` hook that returns the current `Config`, defaulting to `{}` when no provider is mounted (no provider required for templates that don't need any config)
+- Add optional `config` prop on `MjmlMailRoot` that mounts `ConfigProvider` internally, mirroring the existing `theme` prop pattern
+- Export `Config`, `ConfigProvider`, `useConfig` from `src/index.ts`
+- Add a changeset describing the new exports
+
+## Capabilities
+
+### New Capabilities
+- `config-context`: Runtime configuration context for `@comet/mail-react`. Provides an augmentable `Config` type, a `ConfigProvider`, a `useConfig` hook, and a `config` prop on `MjmlMailRoot`. Empty by default; downstream blocks and consumers add keys through TypeScript interface declaration merging.
+
+### Modified Capabilities
+<!-- None. -->
+
+## Impact
+
+- New files under `packages/mail-react/src/config/`:
+    - `ConfigProvider.tsx` (provider, hook, `Config` interface)
+- Modified file: `src/components/mailRoot/MjmlMailRoot.tsx` adds an optional `config` prop and mounts `ConfigProvider` internally
+- New exports in `src/index.ts`: `Config`, `ConfigProvider`, `useConfig`
+- New changeset under `.changeset/` at the repo root
+- **Unblocks** the `add-pixel-image-blocks` change, which augments `Config` with a `pixelImage` key and is its first consumer

--- a/packages/mail-react/openspec/changes/archive/2026-05-05-add-config-context/specs/config-context/spec.md
+++ b/packages/mail-react/openspec/changes/archive/2026-05-05-add-config-context/specs/config-context/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: `Config` interface
+
+The package SHALL export an interface named `Config` that holds runtime configuration for `@comet/mail-react` consumers. The interface ships with no built-in keys. All keys, current or future, SHALL be optional.
+
+The interface SHALL be defined as a TypeScript `interface` (not a `type` alias) so that this package's later changes and downstream consumers can add keys via TypeScript interface declaration merging:
+
+```ts
+declare module "@comet/mail-react" {
+    interface Config {
+        myKey?: { /* ... */ };
+    }
+}
+```
+
+#### Scenario: Consumer augments `Config` with a custom key
+
+- **WHEN** a consumer declares `interface Config { myKey?: { foo: string } }` via `declare module "@comet/mail-react"`
+- **THEN** `myKey` becomes an optional property on the merged `Config` type and is readable from `useConfig()` without any cast or wrapper type
+
+### Requirement: `ConfigProvider` and `useConfig`
+
+The package SHALL export:
+
+- `ConfigProvider` — a React component accepting `config: Config` and `children`, placing the given `Config` value into a React context.
+- `useConfig` — a hook returning the nearest `Config` value from context.
+
+When no `ConfigProvider` is mounted in the ancestor tree, `useConfig` SHALL return an empty `Config` (`{}`) without throwing.
+
+#### Scenario: No provider mounted
+
+- **WHEN** `useConfig()` is called in a tree without a `ConfigProvider`
+- **THEN** it returns `{}` (a valid empty `Config`) and does not throw
+
+### Requirement: `MjmlMailRoot` accepts an optional `config` prop
+
+`MjmlMailRoot` SHALL accept an optional `config?: Config` prop and SHALL mount a `ConfigProvider` internally so descendants always read a `Config` value via `useConfig`. When `config` is provided, descendants SHALL receive that value. When `config` is omitted, descendants SHALL receive an empty `Config` (`{}`).
+
+The `config` prop SHALL be additive and independent of the existing `theme` prop — passing one does not require passing the other.
+
+#### Scenario: `config` prop wires the value to descendants
+
+- **WHEN** `<MjmlMailRoot config={value}>` renders a descendant that calls `useConfig()`
+- **THEN** the descendant receives `value`
+
+#### Scenario: `config` prop omitted
+
+- **WHEN** `<MjmlMailRoot>` renders without a `config` prop and a descendant calls `useConfig()`
+- **THEN** the descendant receives `{}` (an empty `Config`) and `useConfig` does not throw

--- a/packages/mail-react/openspec/changes/archive/2026-05-05-add-config-context/tasks.md
+++ b/packages/mail-react/openspec/changes/archive/2026-05-05-add-config-context/tasks.md
@@ -1,0 +1,29 @@
+## 1. Core implementation
+
+- [x] 1.1 Create `src/config/ConfigProvider.tsx` containing: the `Config` interface (empty, with TSDoc explaining the augmentation pattern via `declare module "@comet/mail-react"`), an internal React context, the `ConfigProvider` component (accepts `config: Config` + `children`), and the `useConfig` hook (returns the nearest context value, falling back to `{}` when no provider is mounted).
+- [x] 1.2 Add TSDoc on each exported symbol: `Config` (purpose + augmentation example), `ConfigProvider` (purpose + relationship to `MjmlMailRoot.config`), `useConfig` (return value, no-provider fallback).
+
+## 2. `MjmlMailRoot` integration
+
+- [x] 2.1 Add an optional `config?: Config` prop to `MjmlMailRoot`. Always wrap children in `ConfigProvider`, falling back to `{}` when `config` is omitted. Update the component's TSDoc to mention the new prop.
+
+## 3. Public exports
+
+- [x] 3.1 Export `Config`, `ConfigProvider`, and `useConfig` from `src/index.ts`.
+
+## 4. Tests
+
+- [x] 4.1 Add `src/config/ConfigProvider.test.tsx` covering the two non-trivial behaviors: `useConfig` returns `{}` when no `ConfigProvider` is mounted (pins the no-throw fallback), and `MjmlMailRoot.config` flows the value to descendants (pins the integration contract). Plain provider→hook reads and nested-provider semantics are React `useContext` itself and are not retested here.
+
+## 5. Lint, build, verification
+
+- [x] 5.1 Run `pnpm run lint:fix` then `pnpm run lint` from `packages/mail-react/`; fix any remaining ESLint or TypeScript errors manually.
+- [x] 5.2 Run `pnpm run test` and confirm all tests pass.
+
+## 6. Changeset
+
+- [x] 6.1 Check `.changeset/` at the repo root for an existing unmerged changeset that already covers the runtime config context; update it if found, otherwise create a new minor changeset for `@comet/mail-react`. Describe the change from the consumer's perspective: a new `Config` context, an augmentable `Config` interface (with a short example), `ConfigProvider`, `useConfig`, and the optional `config` prop on `MjmlMailRoot`. Follow the formatting rules in `CONTRIBUTING.md`.
+
+## 7. Validate
+
+- [x] 7.1 Run `pnpm --filter @comet/mail-react exec openspec validate add-config-context --strict` and resolve any reported issues.

--- a/packages/mail-react/openspec/specs/config-context/spec.md
+++ b/packages/mail-react/openspec/specs/config-context/spec.md
@@ -1,7 +1,8 @@
 # config-context Specification
 
 ## Purpose
-TBD - created by archiving change add-config-context. Update Purpose after archive.
+
+Provide a runtime configuration channel for `@comet/mail-react` that is independent of the theme. Consumers extend an empty, augmentable `Config` interface via TypeScript declaration merging and read values through `useConfig()` from anywhere inside an `MjmlMailRoot`. This lets the package and its consumers expose new configurable values without widening the theme or threading props through component trees.
 ## Requirements
 ### Requirement: `Config` interface
 

--- a/packages/mail-react/openspec/specs/config-context/spec.md
+++ b/packages/mail-react/openspec/specs/config-context/spec.md
@@ -1,0 +1,54 @@
+# config-context Specification
+
+## Purpose
+TBD - created by archiving change add-config-context. Update Purpose after archive.
+## Requirements
+### Requirement: `Config` interface
+
+The package SHALL export an interface named `Config` that holds runtime configuration for `@comet/mail-react` consumers. The interface ships with no built-in keys. All keys, current or future, SHALL be optional.
+
+The interface SHALL be defined as a TypeScript `interface` (not a `type` alias) so that this package's later changes and downstream consumers can add keys via TypeScript interface declaration merging:
+
+```ts
+declare module "@comet/mail-react" {
+    interface Config {
+        myKey?: { /* ... */ };
+    }
+}
+```
+
+#### Scenario: Consumer augments `Config` with a custom key
+
+- **WHEN** a consumer declares `interface Config { myKey?: { foo: string } }` via `declare module "@comet/mail-react"`
+- **THEN** `myKey` becomes an optional property on the merged `Config` type and is readable from `useConfig()` without any cast or wrapper type
+
+### Requirement: `ConfigProvider` and `useConfig`
+
+The package SHALL export:
+
+- `ConfigProvider` — a React component accepting `config: Config` and `children`, placing the given `Config` value into a React context.
+- `useConfig` — a hook returning the nearest `Config` value from context.
+
+When no `ConfigProvider` is mounted in the ancestor tree, `useConfig` SHALL return an empty `Config` (`{}`) without throwing.
+
+#### Scenario: No provider mounted
+
+- **WHEN** `useConfig()` is called in a tree without a `ConfigProvider`
+- **THEN** it returns `{}` (a valid empty `Config`) and does not throw
+
+### Requirement: `MjmlMailRoot` accepts an optional `config` prop
+
+`MjmlMailRoot` SHALL accept an optional `config?: Config` prop and SHALL mount a `ConfigProvider` internally so descendants always read a `Config` value via `useConfig`. When `config` is provided, descendants SHALL receive that value. When `config` is omitted, descendants SHALL receive an empty `Config` (`{}`).
+
+The `config` prop SHALL be additive and independent of the existing `theme` prop — passing one does not require passing the other.
+
+#### Scenario: `config` prop wires the value to descendants
+
+- **WHEN** `<MjmlMailRoot config={value}>` renders a descendant that calls `useConfig()`
+- **THEN** the descendant receives `value`
+
+#### Scenario: `config` prop omitted
+
+- **WHEN** `<MjmlMailRoot>` renders without a `config` prop and a descendant calls `useConfig()`
+- **THEN** the descendant receives `{}` (an empty `Config`) and `useConfig` does not throw
+

--- a/packages/mail-react/openspec/specs/config-context/spec.md
+++ b/packages/mail-react/openspec/specs/config-context/spec.md
@@ -39,7 +39,7 @@ When no `ConfigProvider` is mounted in the ancestor tree, `useConfig` SHALL retu
 
 ### Requirement: `MjmlMailRoot` accepts an optional `config` prop
 
-`MjmlMailRoot` SHALL accept an optional `config?: Config` prop and SHALL mount a `ConfigProvider` internally so descendants always read a `Config` value via `useConfig`. When `config` is provided, descendants SHALL receive that value. When `config` is omitted, descendants SHALL receive an empty `Config` (`{}`).
+`MjmlMailRoot` SHALL accept an optional `config?: Config` prop. When `config` is provided, `MjmlMailRoot` SHALL mount a `ConfigProvider` internally so descendants receive that value via `useConfig`. When `config` is omitted, `MjmlMailRoot` SHALL NOT mount a `ConfigProvider`, so any `ConfigProvider` mounted in the ancestor tree remains visible to descendants; if no ancestor provider exists, `useConfig` returns `{}`.
 
 The `config` prop SHALL be additive and independent of the existing `theme` prop — passing one does not require passing the other.
 
@@ -48,8 +48,13 @@ The `config` prop SHALL be additive and independent of the existing `theme` prop
 - **WHEN** `<MjmlMailRoot config={value}>` renders a descendant that calls `useConfig()`
 - **THEN** the descendant receives `value`
 
-#### Scenario: `config` prop omitted
+#### Scenario: `config` prop omitted, no ancestor provider
 
-- **WHEN** `<MjmlMailRoot>` renders without a `config` prop and a descendant calls `useConfig()`
+- **WHEN** `<MjmlMailRoot>` renders without a `config` prop, no `ConfigProvider` is mounted in the ancestor tree, and a descendant calls `useConfig()`
 - **THEN** the descendant receives `{}` (an empty `Config`) and `useConfig` does not throw
+
+#### Scenario: `config` prop omitted, ancestor provider present
+
+- **WHEN** an outer `<ConfigProvider config={value}>` wraps `<MjmlMailRoot>` (without a `config` prop) and a descendant calls `useConfig()`
+- **THEN** the descendant receives `value` from the outer provider — `MjmlMailRoot` does not shadow it
 

--- a/packages/mail-react/src/components/mailRoot/MjmlMailRoot.tsx
+++ b/packages/mail-react/src/components/mailRoot/MjmlMailRoot.tsx
@@ -1,6 +1,7 @@
 import { Mjml, MjmlAll, MjmlAttributes, MjmlBody, MjmlBreakpoint, MjmlHead } from "@faire/mjml-react";
 import type { PropsWithChildren, ReactNode } from "react";
 
+import { type Config, ConfigProvider } from "../../config/ConfigProvider.js";
 import { Styles } from "../../styles/Styles.js";
 import { createTheme } from "../../theme/createTheme.js";
 import { ThemeProvider } from "../../theme/ThemeProvider.js";
@@ -16,6 +17,10 @@ type MjmlMailRootProps = PropsWithChildren<{
     attributes?: ReactNode;
     /** Extra content appended inside `<MjmlHead>`, after the registered styles block. */
     head?: ReactNode;
+    /**
+     * Configuration to make available to descendants via `useConfig`.
+     */
+    config?: Config;
 }>;
 
 /**
@@ -23,31 +28,33 @@ type MjmlMailRootProps = PropsWithChildren<{
  * (`<Mjml>`, `<MjmlHead>`, `<MjmlBody>`) with `<MjmlAll padding={0} />` as the
  * default attribute so all components start with zero padding.
  *
- * Accepts an optional `theme` prop that controls the body width and responsive
- * breakpoints. The theme is made available to all descendant components via
- * `useTheme()`.
+ * Accepts an optional `theme` prop that controls the body width and responsive breakpoints. The theme is made available to all descendant components via `useTheme()`.
+ *
+ * Accepts an optional `config` prop containing configuration. When provided, the value is made available to descendants via `useConfig()`.
  *
  * Direct children should be section-level components (e.g. `MjmlSection`).
  */
-export function MjmlMailRoot({ theme: themeProp, attributes, head, children }: MjmlMailRootProps): ReactNode {
+export function MjmlMailRoot({ theme: themeProp, attributes, head, config = {}, children }: MjmlMailRootProps): ReactNode {
     const theme = themeProp ?? createTheme();
 
     return (
-        <ThemeProvider theme={theme}>
-            <Mjml>
-                <MjmlHead>
-                    <MjmlAttributes>
-                        <MjmlAll padding="0" fontFamily={theme.text.fontFamily} />
-                        {attributes}
-                    </MjmlAttributes>
-                    <MjmlBreakpoint width={`${theme.breakpoints.mobile.value}px`} />
-                    <Styles />
-                    {head}
-                </MjmlHead>
-                <MjmlBody width={theme.sizes.bodyWidth} backgroundColor={theme.colors.background.body}>
-                    {children}
-                </MjmlBody>
-            </Mjml>
-        </ThemeProvider>
+        <ConfigProvider config={config}>
+            <ThemeProvider theme={theme}>
+                <Mjml>
+                    <MjmlHead>
+                        <MjmlAttributes>
+                            <MjmlAll padding="0" fontFamily={theme.text.fontFamily} />
+                            {attributes}
+                        </MjmlAttributes>
+                        <MjmlBreakpoint width={`${theme.breakpoints.mobile.value}px`} />
+                        <Styles />
+                        {head}
+                    </MjmlHead>
+                    <MjmlBody width={theme.sizes.bodyWidth} backgroundColor={theme.colors.background.body}>
+                        {children}
+                    </MjmlBody>
+                </Mjml>
+            </ThemeProvider>
+        </ConfigProvider>
     );
 }

--- a/packages/mail-react/src/components/mailRoot/MjmlMailRoot.tsx
+++ b/packages/mail-react/src/components/mailRoot/MjmlMailRoot.tsx
@@ -34,27 +34,31 @@ type MjmlMailRootProps = PropsWithChildren<{
  *
  * Direct children should be section-level components (e.g. `MjmlSection`).
  */
-export function MjmlMailRoot({ theme: themeProp, attributes, head, config = {}, children }: MjmlMailRootProps): ReactNode {
+export function MjmlMailRoot({ theme: themeProp, attributes, head, config, children }: MjmlMailRootProps): ReactNode {
     const theme = themeProp ?? createTheme();
 
-    return (
-        <ConfigProvider config={config}>
-            <ThemeProvider theme={theme}>
-                <Mjml>
-                    <MjmlHead>
-                        <MjmlAttributes>
-                            <MjmlAll padding="0" fontFamily={theme.text.fontFamily} />
-                            {attributes}
-                        </MjmlAttributes>
-                        <MjmlBreakpoint width={`${theme.breakpoints.mobile.value}px`} />
-                        <Styles />
-                        {head}
-                    </MjmlHead>
-                    <MjmlBody width={theme.sizes.bodyWidth} backgroundColor={theme.colors.background.body}>
-                        {children}
-                    </MjmlBody>
-                </Mjml>
-            </ThemeProvider>
-        </ConfigProvider>
+    const content = (
+        <ThemeProvider theme={theme}>
+            <Mjml>
+                <MjmlHead>
+                    <MjmlAttributes>
+                        <MjmlAll padding="0" fontFamily={theme.text.fontFamily} />
+                        {attributes}
+                    </MjmlAttributes>
+                    <MjmlBreakpoint width={`${theme.breakpoints.mobile.value}px`} />
+                    <Styles />
+                    {head}
+                </MjmlHead>
+                <MjmlBody width={theme.sizes.bodyWidth} backgroundColor={theme.colors.background.body}>
+                    {children}
+                </MjmlBody>
+            </Mjml>
+        </ThemeProvider>
     );
+
+    if (config) {
+        return <ConfigProvider config={config}>{content}</ConfigProvider>;
+    }
+
+    return content;
 }

--- a/packages/mail-react/src/config/ConfigProvider.test.tsx
+++ b/packages/mail-react/src/config/ConfigProvider.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { MjmlMailRoot } from "../components/mailRoot/MjmlMailRoot.js";
 import { MjmlSection } from "../components/section/MjmlSection.js";
 import { renderMailHtml } from "../server/renderMailHtml.js";
-import { useConfig } from "./ConfigProvider.js";
+import { ConfigProvider, useConfig } from "./ConfigProvider.js";
 
 declare module "./ConfigProvider.js" {
     interface Config {
@@ -41,5 +41,24 @@ describe("MjmlMailRoot config integration", () => {
 
         expect(mjmlWarnings).toEqual([]);
         expect(html).toContain('data-config-value="from-root"');
+    });
+
+    it("does not shadow an outer ConfigProvider when no config prop is passed", () => {
+        const { html, mjmlWarnings } = renderMailHtml(
+            <ConfigProvider config={{ testKey: { value: "from-outer" } }}>
+                <MjmlMailRoot>
+                    <MjmlSection>
+                        <MjmlColumn>
+                            <MjmlText>
+                                <Probe />
+                            </MjmlText>
+                        </MjmlColumn>
+                    </MjmlSection>
+                </MjmlMailRoot>
+            </ConfigProvider>,
+        );
+
+        expect(mjmlWarnings).toEqual([]);
+        expect(html).toContain('data-config-value="from-outer"');
     });
 });

--- a/packages/mail-react/src/config/ConfigProvider.test.tsx
+++ b/packages/mail-react/src/config/ConfigProvider.test.tsx
@@ -1,0 +1,45 @@
+import { MjmlColumn, MjmlText } from "@faire/mjml-react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { MjmlMailRoot } from "../components/mailRoot/MjmlMailRoot.js";
+import { MjmlSection } from "../components/section/MjmlSection.js";
+import { renderMailHtml } from "../server/renderMailHtml.js";
+import { useConfig } from "./ConfigProvider.js";
+
+declare module "./ConfigProvider.js" {
+    interface Config {
+        testKey?: { value: string };
+    }
+}
+
+function Probe() {
+    const config = useConfig();
+    return <span data-config-value={config.testKey?.value ?? "no-config"} />;
+}
+
+describe("useConfig", () => {
+    it("returns an empty Config when no ConfigProvider is mounted", () => {
+        const html = renderToStaticMarkup(<Probe />);
+        expect(html).toContain('data-config-value="no-config"');
+    });
+});
+
+describe("MjmlMailRoot config integration", () => {
+    it("makes the config value available to descendants via useConfig", () => {
+        const { html, mjmlWarnings } = renderMailHtml(
+            <MjmlMailRoot config={{ testKey: { value: "from-root" } }}>
+                <MjmlSection>
+                    <MjmlColumn>
+                        <MjmlText>
+                            <Probe />
+                        </MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            </MjmlMailRoot>,
+        );
+
+        expect(mjmlWarnings).toEqual([]);
+        expect(html).toContain('data-config-value="from-root"');
+    });
+});

--- a/packages/mail-react/src/config/ConfigProvider.tsx
+++ b/packages/mail-react/src/config/ConfigProvider.tsx
@@ -16,7 +16,7 @@ import { createContext, type PropsWithChildren, type ReactNode, useContext } fro
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface Config {}
 
-const ConfigContext = createContext<Config | null>(null);
+const ConfigContext = createContext<Config>({});
 
 /**
  * Places a `Config` value into a React context, making it available to all
@@ -30,5 +30,5 @@ export function ConfigProvider({ config, children }: PropsWithChildren<{ config:
  * Returns the nearest `Config` from context, defined by `ConfigProvider` or by the `config` prop on `MjmlMailRoot`.
  */
 export function useConfig(): Config {
-    return useContext(ConfigContext) ?? {};
+    return useContext(ConfigContext);
 }

--- a/packages/mail-react/src/config/ConfigProvider.tsx
+++ b/packages/mail-react/src/config/ConfigProvider.tsx
@@ -1,0 +1,34 @@
+import { createContext, type PropsWithChildren, type ReactNode, useContext } from "react";
+
+/**
+ * Configuration context for mails.
+ *
+ * Add custom keys via TypeScript interface declaration merging:
+ *
+ * ```ts
+ * declare module "@comet/mail-react" {
+ *     interface Config {
+ *         myKey?: { foo: string };
+ *     }
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface Config {}
+
+const ConfigContext = createContext<Config | null>(null);
+
+/**
+ * Places a `Config` value into a React context, making it available to all
+ * descendants via `useConfig`.
+ */
+export function ConfigProvider({ config, children }: PropsWithChildren<{ config: Config }>): ReactNode {
+    return <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>;
+}
+
+/**
+ * Returns the nearest `Config` from context, defined by `ConfigProvider` or by the `config` prop on `MjmlMailRoot`.
+ */
+export function useConfig(): Config {
+    return useContext(ConfigContext) ?? {};
+}

--- a/packages/mail-react/src/index.ts
+++ b/packages/mail-react/src/index.ts
@@ -15,6 +15,7 @@ export type { MjmlTextProps } from "./components/text/MjmlText.js";
 export { MjmlText } from "./components/text/MjmlText.js";
 export type { MjmlWrapperProps } from "./components/wrapper/MjmlWrapper.js";
 export { MjmlWrapper } from "./components/wrapper/MjmlWrapper.js";
+export { type Config, ConfigProvider, useConfig } from "./config/ConfigProvider.js";
 export { registerStyles } from "./styles/registerStyles.js";
 export { createBreakpoint } from "./theme/createBreakpoint.js";
 export { createTheme } from "./theme/createTheme.js";

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -231,6 +231,37 @@ Place `declare module` blocks in your theme file below the `createTheme()` call.
 
 ---
 
+## Configuration
+
+`Config` is an augmentable interface that can be used to expose, e.g., environment-specific values such as asset base URLs.
+
+- **`Config`** — augmentable interface, no built-in keys. All keys optional.
+- **`MjmlMailRoot.config`** — optional prop that exposes a `Config` value to descendants.
+- **`useConfig`** — hook returning the nearest `Config`, or `{}` if no provider is mounted.
+- **`ConfigProvider`** — standalone provider for cases that bypass `MjmlMailRoot`.
+
+Add keys via module augmentation:
+
+```ts
+declare module "@comet/mail-react" {
+    interface Config {
+        assetBaseUrl?: string;
+    }
+}
+```
+
+Wire at the root and read from any descendant:
+
+```tsx
+import { MjmlMailRoot, useConfig, type Config } from "@comet/mail-react";
+
+const config: Config = { assetBaseUrl: process.env.ASSET_BASE_URL };
+
+<MjmlMailRoot config={config}>{/* descendants can call useConfig() */}</MjmlMailRoot>;
+```
+
+---
+
 ## Components Overview
 
 ### MJML Components (Layout Level)

--- a/skills/comet-mail-react/references/components-and-theme.md
+++ b/skills/comet-mail-react/references/components-and-theme.md
@@ -159,7 +159,7 @@ Root element for every email template. Renders the full MJML skeleton (`<mjml>`,
 | Prop       | Type        | Default         | Description                                               |
 | ---------- | ----------- | --------------- | --------------------------------------------------------- |
 | `theme`    | `Theme`     | `createTheme()` | Theme for the email                                       |
-| `config`   | `Config`    | —               | Augmentable values exposed to descendants via `useConfig` |
+| `config`   | `Config`    | `{}`            | Augmentable values exposed to descendants via `useConfig` |
 | `children` | `ReactNode` | —               | Email content                                             |
 
 **What it configures from the theme:**

--- a/skills/comet-mail-react/references/components-and-theme.md
+++ b/skills/comet-mail-react/references/components-and-theme.md
@@ -159,7 +159,7 @@ Root element for every email template. Renders the full MJML skeleton (`<mjml>`,
 | Prop       | Type        | Default         | Description                                               |
 | ---------- | ----------- | --------------- | --------------------------------------------------------- |
 | `theme`    | `Theme`     | `createTheme()` | Theme for the email                                       |
-| `config`   | `Config`    | `{}`            | Augmentable values exposed to descendants via `useConfig` |
+| `config`   | `Config`    | —               | Augmentable values exposed to descendants via `useConfig` |
 | `children` | `ReactNode` | —               | Email content                                             |
 
 **What it configures from the theme:**

--- a/skills/comet-mail-react/references/components-and-theme.md
+++ b/skills/comet-mail-react/references/components-and-theme.md
@@ -156,10 +156,11 @@ Root element for every email template. Renders the full MJML skeleton (`<mjml>`,
 
 **Props:**
 
-| Prop       | Type        | Default         | Description         |
-| ---------- | ----------- | --------------- | ------------------- |
-| `theme`    | `Theme`     | `createTheme()` | Theme for the email |
-| `children` | `ReactNode` | —               | Email content       |
+| Prop       | Type        | Default         | Description                                               |
+| ---------- | ----------- | --------------- | --------------------------------------------------------- |
+| `theme`    | `Theme`     | `createTheme()` | Theme for the email                                       |
+| `config`   | `Config`    | —               | Augmentable values exposed to descendants via `useConfig` |
+| `children` | `ReactNode` | —               | Email content                                             |
 
 **What it configures from the theme:**
 


### PR DESCRIPTION
This is the preparation for implementing the Mail-Versions of the `PixelImageBlock` which requires values from the API, such as `validSizes` and `baseUrl`. 

Since these values are generally the same, across instances of the block, it makes sense to provide them globally. 
This global, extendable `Config` context allows consumers to use the same `config` object for custom values they may need for similar use-cases. 

---

Implementation with usage: https://github.com/vivid-planet/comet/pull/5552
Task: https://vivid-planet.atlassian.net/browse/PHSB2C-11716