### PR TITLE
Fix faulty changeset

### DIFF
--- a/.changeset/clear-ghosts-swim.md
+++ b/.changeset/clear-ghosts-swim.md
@@ -4,10 +4,12 @@
 
 Add fullText query support for PageTree (pageTreeFullTextSearch query)
 
-to enable add a fullText column for a PageTree document (Page or others):
+To enable add a fullText column for a PageTree document (Page or others):
 
-    @Index({ type: "fulltext" })
-    @Property<Page>({ nullable: true, type: new FullTextType(), onUpdate: (page) => blockToMikroOrmFullText(page.content) })
-    searchableContent?: string;
+```ts
+@Index({ type: "fulltext" })
+@Property<Page>({ nullable: true, type: new FullTextType(), onUpdate: (page) => blockToMikroOrmFullText(page.content) })
+searchableContent?: string;
+```
 
 and enable fullText option for PageTreeModule

--- a/packages/api/cms-api/CHANGELOG.md
+++ b/packages/api/cms-api/CHANGELOG.md
@@ -16,11 +16,13 @@
 - a50793a: Add `listFiles` method to `BlobStorageBackendService`
 - cac2b3b: Add fullText query support for PageTree (pageTreeFullTextSearch query)
 
-    to enable add a fullText column for a PageTree document (Page or others):
+    To enable add a fullText column for a PageTree document (Page or others):
 
-        @Index({ type: "fulltext" })
-        @Property<Page>({ nullable: true, type: new FullTextType(), onUpdate: (page) => blockToMikroOrmFullText(page.content) })
-        searchableContent?: string;
+    ```ts
+    @Index({ type: "fulltext" })
+    @Property<Page>({ nullable: true, type: new FullTextType(), onUpdate: (page) => blockToMikroOrmFullText(page.content) })
+    searchableContent?: string;
+    ```
 
     and enable fullText option for PageTreeModule
 


### PR DESCRIPTION
The intended code block without a code fence caused Prettier to non-idempotently reformatting cms-api's changelog file. Update the changeset and changelog to resolve the issue.