### PR TITLE
Add `head` and `attributes` props to `MjmlMailRoot`

### DIFF
--- a/.changeset/add-mjml-mail-root-head-and-attributes-slots.md
+++ b/.changeset/add-mjml-mail-root-head-and-attributes-slots.md
@@ -1,0 +1,14 @@
+---
+"@comet/mail-react": minor
+---
+
+Add `head` and `attributes` props to `MjmlMailRoot`
+
+- `head` — `ReactNode` appended inside `<MjmlHead>` after the registered styles block.
+- `attributes` — `ReactNode` appended inside `<MjmlAttributes>` after the default `<MjmlAll>`.
+
+```tsx
+<MjmlMailRoot attributes={<MjmlClass name="link" color="blue" />} head={<MjmlFont name="Foo" href="https://example.com/foo.css" />}>
+    {/* email body */}
+</MjmlMailRoot>
+```

--- a/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
@@ -155,6 +155,13 @@ From the theme, `MjmlMailRoot` automatically sets:
 - **Base font family** — from `theme.text.fontFamily`
 - **Zero default padding** — so components start with no padding
 
+### Extending `<MjmlHead>` and `<MjmlAttributes>`
+
+Two optional slot props let consumers contribute content the theme can't express:
+
+- `head` — `ReactNode` appended inside `<MjmlHead>` after the registered styles block (e.g. `<MjmlFont>`, `<MjmlConditionalComment>`, `<MjmlPreview>`)
+- `attributes` — `ReactNode` appended inside `<MjmlAttributes>` after the default `<MjmlAll>` (e.g. `<MjmlClass>` or per-element defaults)
+
 ## MjmlSection
 
 `MjmlSection` wraps the MJML section with theme integration. It automatically applies `theme.colors.background.content` as the background color — unless the section is rendered inside an [`MjmlWrapper`](#mjmlwrapper), in which case the wrapper's background is used instead. To change the default for all sections, set it in the theme:

--- a/packages/mail-react/openspec/specs/mjml-mail-root/spec.md
+++ b/packages/mail-react/openspec/specs/mjml-mail-root/spec.md
@@ -75,7 +75,7 @@ The `<MjmlHead>` SHALL contain `<MjmlAttributes><MjmlAll padding={0} fontFamily=
 
 #### Scenario: No other default attributes beyond padding and fontFamily
 
-- **WHEN** `<MjmlMailRoot>` is rendered without an `attributes` prop
+- **WHEN** `<MjmlMailRoot>` is rendered without `head` or `attributes` props
 - **THEN** the `<mj-attributes>` block contains only `<mj-all>` with `padding` and `font-family` attributes
 
 ### Requirement: Optional head and attributes slot props

--- a/packages/mail-react/openspec/specs/mjml-mail-root/spec.md
+++ b/packages/mail-react/openspec/specs/mjml-mail-root/spec.md
@@ -75,8 +75,29 @@ The `<MjmlHead>` SHALL contain `<MjmlAttributes><MjmlAll padding={0} fontFamily=
 
 #### Scenario: No other default attributes beyond padding and fontFamily
 
-- **WHEN** `<MjmlMailRoot>` is rendered
+- **WHEN** `<MjmlMailRoot>` is rendered without an `attributes` prop
 - **THEN** the `<mj-attributes>` block contains only `<mj-all>` with `padding` and `font-family` attributes
+
+### Requirement: Optional head and attributes slot props
+
+`MjmlMailRoot` SHALL accept optional `head` and `attributes` props of type `ReactNode` that let consumers contribute content into `<MjmlHead>` and `<MjmlAttributes>` respectively.
+
+When provided, `attributes` SHALL be rendered as the last children of the built-in `<MjmlAttributes>` block, after the default `<MjmlAll>` element. When provided, `head` SHALL be rendered as the last child of `<MjmlHead>`, after the built-in `<MjmlAttributes>`, `<MjmlBreakpoint>`, and the registered-styles block. The `head` placement after registered styles SHALL allow consumer-provided `<mj-style>` declarations to override registered ones via CSS source order.
+
+#### Scenario: Head slot content appears in head
+
+- **WHEN** `<MjmlMailRoot head={<MjmlFont name="Foo" href="https://example.com/foo.css" />}>` is rendered
+- **THEN** the `<mj-head>` contains the `<mj-font>` element after the registered-styles block
+
+#### Scenario: Attributes slot content appears in attributes block
+
+- **WHEN** `<MjmlMailRoot attributes={<MjmlClass name="link" color="blue" />}>` is rendered
+- **THEN** the `<mj-attributes>` block contains `<mj-class name="link" color="blue" />` after the default `<mj-all>` element
+
+#### Scenario: Slot props omitted
+
+- **WHEN** `<MjmlMailRoot>` is rendered without `head` or `attributes` props
+- **THEN** no extra elements appear in `<mj-head>` or `<mj-attributes>` beyond the built-in defaults
 
 ### Requirement: Optional theme prop
 

--- a/packages/mail-react/src/components/mailRoot/MjmlMailRoot.tsx
+++ b/packages/mail-react/src/components/mailRoot/MjmlMailRoot.tsx
@@ -12,6 +12,10 @@ type MjmlMailRootProps = PropsWithChildren<{
      * (equivalent to `createTheme()`) is used.
      */
     theme?: Theme;
+    /** Extra content appended inside the built-in `<MjmlAttributes>`, after the default `<MjmlAll>`. */
+    attributes?: ReactNode;
+    /** Extra content appended inside `<MjmlHead>`, after the registered styles block. */
+    head?: ReactNode;
 }>;
 
 /**
@@ -25,7 +29,7 @@ type MjmlMailRootProps = PropsWithChildren<{
  *
  * Direct children should be section-level components (e.g. `MjmlSection`).
  */
-export function MjmlMailRoot({ theme: themeProp, children }: MjmlMailRootProps): ReactNode {
+export function MjmlMailRoot({ theme: themeProp, attributes, head, children }: MjmlMailRootProps): ReactNode {
     const theme = themeProp ?? createTheme();
 
     return (
@@ -34,9 +38,11 @@ export function MjmlMailRoot({ theme: themeProp, children }: MjmlMailRootProps):
                 <MjmlHead>
                     <MjmlAttributes>
                         <MjmlAll padding="0" fontFamily={theme.text.fontFamily} />
+                        {attributes}
                     </MjmlAttributes>
                     <MjmlBreakpoint width={`${theme.breakpoints.mobile.value}px`} />
                     <Styles />
+                    {head}
                 </MjmlHead>
                 <MjmlBody width={theme.sizes.bodyWidth} backgroundColor={theme.colors.background.body}>
                     {children}

--- a/packages/mail-react/src/server/renderMailHtml.test.tsx
+++ b/packages/mail-react/src/server/renderMailHtml.test.tsx
@@ -1,4 +1,4 @@
-import { MjmlColumn, MjmlText } from "@faire/mjml-react";
+import { MjmlClass, MjmlColumn, MjmlText, MjmlTitle } from "@faire/mjml-react";
 import { describe, expect, it } from "vitest";
 
 import { MjmlMailRoot } from "../components/mailRoot/MjmlMailRoot.js";
@@ -80,6 +80,35 @@ describe("server/renderMailHtml", () => {
 
         expect(html).toContain(".themed");
         expect(html).toContain("width: 600px");
+    });
+
+    it("renders the head slot content inside <mj-head>", () => {
+        const titleText = "Welcome to Comet";
+        const { html } = renderMailHtml(
+            <MjmlMailRoot head={<MjmlTitle>{titleText}</MjmlTitle>}>
+                <MjmlSection>
+                    <MjmlColumn>
+                        <MjmlText>Hello</MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            </MjmlMailRoot>,
+        );
+
+        expect(html).toContain(`<title>${titleText}</title>`);
+    });
+
+    it("renders the attributes slot content inside <mj-attributes>", () => {
+        const { html } = renderMailHtml(
+            <MjmlMailRoot attributes={<MjmlClass name="cta" color="#FF0000" />}>
+                <MjmlSection>
+                    <MjmlColumn>
+                        <MjmlText mjmlClass="cta">Hello</MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            </MjmlMailRoot>,
+        );
+
+        expect(html).toContain("color:#FF0000");
     });
 
     it("produces no MJML warnings for a valid component tree", () => {

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -169,6 +169,23 @@ function MyEmail() {
 }
 ```
 
+### Contributing to `<MjmlHead>` and `<MjmlAttributes>`
+
+`MjmlMailRoot` accepts two optional slot props for content that can't be expressed via `registerStyles`:
+
+- `head` — appended inside `<MjmlHead>` after the registered-styles block. Use for `<MjmlFont>`, `<MjmlConditionalComment>`, `<MjmlPreview>`, or `<MjmlStyle>` content that depends on React context at render time.
+- `attributes` — appended inside the built-in `<MjmlAttributes>` after the default `<MjmlAll>`. Use for `<MjmlClass>` or per-element defaults (e.g. `<MjmlText fontSize="14px" />`).
+
+Pass the children directly — do not wrap them in another `<MjmlHead>` / `<MjmlAttributes>`:
+
+```tsx
+<MjmlMailRoot theme={theme} attributes={<MjmlClass name="link" color="blue" />} head={<MjmlFont name="Foo" href="https://example.com/foo.css" />}>
+    {/* email content */}
+</MjmlMailRoot>
+```
+
+For module-scoped responsive CSS that depends only on the theme, prefer `registerStyles`.
+
 ### Module Augmentation for Type-Safety
 
 `@comet/mail-react` uses TypeScript module augmentation to make custom theme tokens type-safe. Always augment these interfaces when extending the theme — TypeScript will then error on typos or unknown keys.


### PR DESCRIPTION
Some consumers require defining custom style-elements, without using `registerStyles`, such as conditional outlook-only styles. 

Additionally, it could be helpful to expose the `MjmlAttributes` feature, for global customization of default Mjml components. 

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-11757