### PR TITLE
Fix Docs Netlify build

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -2,3 +2,6 @@
   command = "cd .. && pnpm install --frozen-lockfile && pnpm setup:ci && pnpm build:docs"
   publish = "build"
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- . ../storybook/ ../packages/admin/"
+
+[build.environment]
+  NODE_OPTIONS = "--max-old-space-size=4096"


### PR DESCRIPTION
The Docs Netlify build fails since merging https://github.com/vivid-planet/comet/pull/5458. Fix it by raising Node's heap limit (max old space size) to 4 GB.