### PR TITLE
Fix Storybook preview crashing due to missing process global

### DIFF
--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -10,8 +10,8 @@ import { LayoutDecorator, LayoutOption } from "./decorators/Layout.decorator";
 import { ThemeOption, ThemeProviderDecorator } from "./decorators/ThemeProvider.decorator";
 import { worker } from "./mocks/browser";
 
-if (typeof process !== "undefined" && process.env.MUI_LICENSE_KEY) {
-    LicenseInfo.setLicenseKey(process.env.MUI_LICENSE_KEY);
+if (import.meta.env.MUI_LICENSE_KEY) {
+    LicenseInfo.setLicenseKey(import.meta.env.MUI_LICENSE_KEY);
 }
 
 export const globalTypes: GlobalTypes = {

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -10,7 +10,7 @@ import { LayoutDecorator, LayoutOption } from "./decorators/Layout.decorator";
 import { ThemeOption, ThemeProviderDecorator } from "./decorators/ThemeProvider.decorator";
 import { worker } from "./mocks/browser";
 
-if (process.env.MUI_LICENSE_KEY) {
+if (typeof process !== "undefined" && process.env.MUI_LICENSE_KEY) {
     LicenseInfo.setLicenseKey(process.env.MUI_LICENSE_KEY);
 }
 

--- a/storybook/.storybook/vendor.d.ts
+++ b/storybook/.storybook/vendor.d.ts
@@ -2,3 +2,11 @@ declare module "*.svg" {
     const content: any;
     export = content;
 }
+
+interface ImportMetaEnv {
+    readonly MUI_LICENSE_KEY?: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Problem

After updating to Vite v7, the Storybook preview crashes with an `Uncaught ReferenceError: process is not defined` error. Vite v7 no longer shims the Node.js `process` global in browser environments, so the bare `process.env.MUI_LICENSE_KEY` access in `preview.tsx` throws at runtime and prevents the preview from loading.

| Before | After |
|--------|-------|
| <img width="1275" alt="before" src="https://github.com/user-attachments/assets/69e163a1-b597-4f22-aa9c-e684c1d9489e"/> | <img width="1283" alt="after" src="https://github.com/user-attachments/assets/0c6c8ae9-2723-42e1-b478-0edc90127c1d"/> |

## Solution

Switch from `process.env.MUI_LICENSE_KEY` to the Vite-native `import.meta.env.MUI_LICENSE_KEY`. The `process.env` approach relied on a global `process` shim that Vite v7 removed. `import.meta.env` is statically replaced at compile time by Vite and works correctly in browser environments.

`ImportMeta` is extended in `vendor.d.ts` to type the `MUI_LICENSE_KEY` variable.

**Setting the key** — pass it as an environment variable when starting Storybook:
```bash
MUI_LICENSE_KEY=your-key pnpm storybook
```
Or add it to a `.env` file in the `storybook/` directory:
```
MUI_LICENSE_KEY=your-key
```