### PR TITLE
Fix Stack crash when location changes before any breadcrumb is registered

### DIFF
--- a/.changeset/fix-stack-empty-breadcrumbs.md
+++ b/.changeset/fix-stack-empty-breadcrumbs.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": patch
+---
+
+Fix `Stack` crash when location changes before any breadcrumb is registered
+
+`Stack` accessed the last entry of an empty breadcrumb array on location change, causing a `TypeError: Cannot set properties of undefined`. Guarded the update to skip when no breadcrumbs are registered yet.

--- a/packages/admin/admin/src/stack/Stack.tsx
+++ b/packages/admin/admin/src/stack/Stack.tsx
@@ -145,6 +145,9 @@ export const Stack = (props: PropsWithChildren<StackProps>) => {
     useEffect(() => {
         // execute on location change, set locationUrl for the last breadcrumb to the current location
         setBreadcrumbs((old) => {
+            if (old.length === 0) {
+                return old;
+            }
             const sorted = sortByParentId(old);
             sorted[sorted.length - 1].locationUrl = location.pathname + location.search; // modify object in place
             return [...old]; // clone (with modified object) to new array to trigger a state update


### PR DESCRIPTION
## Problem

`Stack` crashed with `TypeError: Cannot set properties of undefined` when the location changed before any breadcrumb had been registered. The `useEffect` that syncs `locationUrl` unconditionally accessed the last entry of the breadcrumbs array — which is `undefined` when the array is empty.

see broken story: https://storybook.comet-dxp.com/?path=/story/comet-admin-form--router-tabs-in-form-with-subroutes

## Solution

Guard the update in the effect: if the breadcrumbs array is empty, return early without modifying state.

## Screenshots

| Before | After |
|--------|-------|
| <img width="2571" height="1380" alt="Screenshot 2026-05-11 at 09 08 57" src="https://github.com/user-attachments/assets/10b10b7c-16db-4c03-9930-be2f2fdf4c47" />   |   <img width="2564" height="1373" alt="Screenshot 2026-05-11 at 09 09 56" src="https://github.com/user-attachments/assets/43d21fd8-a3a6-4bb5-9a36-8762588f613a" /> |
