### PR TITLE
storybook: fix BlockInFinalForm story

### DIFF
--- a/storybook/src/cms-admin/BlockInFinalForm.stories.tsx
+++ b/storybook/src/cms-admin/BlockInFinalForm.stories.tsx
@@ -1,12 +1,13 @@
 import { Field, FinalForm, SaveBoundary } from "@comet/admin";
 import { BlockAdminComponentRoot, createFinalFormBlock, createListBlock, ExternalLinkBlock } from "@comet/cms-admin";
 
+import { apolloStoryDecorator } from "../apollo-story.decorator";
 import { dndProviderDecorator } from "../dnd.decorator";
 import { snackbarDecorator } from "../docs/components/Snackbar/snackbar.decorator";
 import { storyRouterDecorator } from "../story-router.decorator";
 
 export default {
-    decorators: [snackbarDecorator(), storyRouterDecorator(), dndProviderDecorator()],
+    decorators: [apolloStoryDecorator("/graphql"), snackbarDecorator(), storyRouterDecorator(), dndProviderDecorator()],
 };
 
 export const BlockInFinalFormWithSaveBoundary = () => {


### PR DESCRIPTION
## Summary

The [BlockInFinalForm](https://storybook.comet-dxp.com/?path=/story/cms-admin-blockinfinalform--block-in-final-form-with-save-boundary) story used an Apollo client without an `ApolloProvider`. Add `apolloStoryDecorator("/graphql")` so the story renders.

<img width="2564" height="1375" alt="Screenshot 2026-05-11 at 09 40 52" src="https://github.com/user-attachments/assets/a830a96b-0523-4dc4-b9de-fbf42ea2edcd" />
