### PR TITLE
Draft: Rename mailer config options `sendAllMailsTo`/`sendAllMailsBcc` to `redirectAllMailsTo`/`bccAllMailsTo`

### DIFF
--- a/.changeset/rename-mailer-config-options.md
+++ b/.changeset/rename-mailer-config-options.md
@@ -1,0 +1,10 @@
+---
+"@comet/cms-api": minor
+---
+
+Rename `MailerModule` config options for clarity
+
+`sendAllMailsTo` is renamed to `redirectAllMailsTo` and `sendAllMailsBcc` is renamed to `bccAllMailsTo`. The old options still work but are deprecated.
+
+- `redirectAllMailsTo`: If set, all outgoing mails are redirected to these addresses instead of being delivered to the original recipients. BCCs configured via `bccAllMailsTo` are also redirected. Use case: Disable mail delivery to real customers in non-production environments.
+- `bccAllMailsTo`: If set, every outgoing mail receives an additional BCC to these addresses. Ignored when `redirectAllMailsTo` is set. Use case: In production, keep a safety copy of every outgoing mail.

--- a/demo/api/src/config/config.ts
+++ b/demo/api/src/config/config.ts
@@ -85,8 +85,8 @@ export function createConfig(processEnv: NodeJS.ProcessEnv) {
         },
         mailer: {
             defaultFrom: '"Comet Demo" <comet-demo@comet-dxp.com>',
-            sendAllMailsTo: envVars.MAILER_SEND_ALL_MAILS_TO,
-            sendAllMailsBcc: envVars.MAILER_SEND_ALL_MAILS_BCC,
+            redirectAllMailsTo: envVars.MAILER_REDIRECT_ALL_MAILS_TO,
+            bccAllMailsTo: envVars.MAILER_BCC_ALL_MAILS_TO,
 
             daysToKeepMailLog: 90,
 

--- a/demo/api/src/config/environment-variables.ts
+++ b/demo/api/src/config/environment-variables.ts
@@ -127,13 +127,13 @@ export class EnvironmentVariables {
     @IsArray()
     @Transform(({ value }) => value.split(","))
     @IsEmail({}, { each: true })
-    MAILER_SEND_ALL_MAILS_TO?: string[];
+    MAILER_REDIRECT_ALL_MAILS_TO?: string[];
 
     @IsUndefinable()
     @IsArray()
     @Transform(({ value }) => value.split(","))
     @IsEmail({}, { each: true })
-    MAILER_SEND_ALL_MAILS_BCC?: string[];
+    MAILER_BCC_ALL_MAILS_TO?: string[];
 
     @IsString()
     @ValidateIf(() => process.env.NODE_ENV === "production")

--- a/docs/docs/3-features-modules/11-mailer-module/index.md
+++ b/docs/docs/3-features-modules/11-mailer-module/index.md
@@ -16,21 +16,21 @@ MAILER_PORT: number;
 @IsArray()
 @Transform(({ value }) => value.split(","))
 @IsEmail({}, { each: true })
-MAILER_SEND_ALL_MAILS_TO?: string[];
+MAILER_REDIRECT_ALL_MAILS_TO?: string[];
 
 @IsUndefinable()
 @IsArray()
 @Transform(({ value }) => value.split(","))
 @IsEmail({}, { each: true })
-MAILER_SEND_ALL_MAILS_BCC?: string[];
+MAILER_BCC_ALL_MAILS_TO?: string[];
 ```
 
 ```ts title="/api/src/config/config.ts"
 mailer: {
     // Mailer configuration
     defaultFrom: '"Comet Demo" <comet-demo@comet-dxp.com>',
-    sendAllMailsTo: envVars.MAILER_SEND_ALL_MAILS_TO,
-    sendAllMailsBcc: envVars.MAILER_SEND_ALL_MAILS_BCC,
+    redirectAllMailsTo: envVars.MAILER_REDIRECT_ALL_MAILS_TO,
+    bccAllMailsTo: envVars.MAILER_BCC_ALL_MAILS_TO,
 
     daysToKeepMailLog: 90,
 
@@ -56,14 +56,11 @@ services:
 # mailer
 MAILER_HOST=localhost
 MAILER_PORT=1025
-MAILER_SEND_ALL_MAILS_TO=demo-leaddev@comet-dxp.com,demo-pm@comet-dxp.com
+MAILER_REDIRECT_ALL_MAILS_TO=demo-leaddev@comet-dxp.com,demo-pm@comet-dxp.com
 ```
 
 ```ts title="/api/src/app.module.ts"
-imports: [
-    ...
-    MailerModule.register(config.mailer),
-]
+imports: [...MailerModule.register(config.mailer)];
 ```
 
 ```yaml title="/deployment/helm/values.tpl.yaml"
@@ -72,7 +69,7 @@ api:
     ...
     MAILER_HOST: "localhost"
     MAILER_PORT: 25
-    MAILER_SEND_ALL_MAILS_TO: "demo-leaddev@comet-dxp.com,demo-pm@comet-dxp.com"
+    MAILER_REDIRECT_ALL_MAILS_TO: "demo-leaddev@comet-dxp.com,demo-pm@comet-dxp.com"
 ```
 
 ## Usage

--- a/packages/api/cms-api/src/mailer/mailer.module.ts
+++ b/packages/api/cms-api/src/mailer/mailer.module.ts
@@ -10,7 +10,23 @@ import { SendTestMailCommand } from "./send-test-mail.command";
 
 export type MailerModuleConfig = {
     defaultFrom: string;
+    /**
+     * If set, every outgoing mail is sent exclusively to these addresses. The original `to`, `cc`, and `bcc` recipients
+     * (including any BCCs added via `bccAllMailsTo`) are discarded.
+     *
+     * Use case: Disable mail delivery to real customers in non-production environments.
+     */
+    redirectAllMailsTo?: string[];
+    /**
+     * If set, these addresses are added as BCC to every outgoing mail.
+     * Has no effect when `redirectAllMailsTo` is set, since BCC recipients are discarded in that case.
+     *
+     * Use case: In production, keep a safety copy of every outgoing mail (e.g. sent to the sender).
+     */
+    bccAllMailsTo?: string[];
+    /** @deprecated Use `redirectAllMailsTo` instead. */
     sendAllMailsTo?: string[];
+    /** @deprecated Use `bccAllMailsTo` instead. */
     sendAllMailsBcc?: string[];
     disableMailLog?: boolean;
     /** @default 90 */

--- a/packages/api/cms-api/src/mailer/mailer.service.ts
+++ b/packages/api/cms-api/src/mailer/mailer.service.ts
@@ -38,23 +38,23 @@ export class MailerService {
             textMail = htmlToText(originMailOptions.html);
         }
 
+        const bccAllMailsTo = this.mailerConfig.bccAllMailsTo ?? this.mailerConfig.sendAllMailsBcc;
+
         return {
             ...originMailOptions,
             text: textMail,
             from: originMailOptions.from || this.mailerConfig.defaultFrom,
-            bcc: this.mailerConfig.sendAllMailsBcc
-                ? [...this.normalizeToArray(originMailOptions.bcc), ...this.mailerConfig.sendAllMailsBcc]
-                : originMailOptions.bcc,
+            bcc: bccAllMailsTo ? [...this.normalizeToArray(originMailOptions.bcc), ...bccAllMailsTo] : originMailOptions.bcc,
         };
     }
 
     /**
      * Sends a mail and logs it in the database.
-     * If mailerConfig.sendAllMailsTo is set, the mail will be sent to this address instead of the `to` address and `bcc` will be omitted. This can
+     * If mailerConfig.redirectAllMailsTo is set, the mail will be sent to that address instead, and `cc` and `bcc` will be omitted. This can
      * be used to prevent non-prod environments from sending mails to real customers.
      * @param mailTypeForLogging Mail type, e.g. order confirmation, order cancellation, etc. to filter in the mailer log
      * @param additionalData Put your additional data here, e.g. orderId, resourcePoolId, etc.
-     * @param originMailOptions `from` defaults to this.config.mailer.defaultFrom, sendAllMailsBcc is always added to `bcc`
+     * @param originMailOptions `from` defaults to this.config.mailer.defaultFrom; `bccAllMailsTo` is added to `bcc` unless `redirectAllMailsTo` is set.
      * @param logMail When set to false, the email will not be logged to the database.
      */
     async sendMail({ mailTypeForLogging, additionalData, logMail = true, ...originMailOptions }: SendMailParams): Promise<Mail> {
@@ -76,8 +76,9 @@ export class MailerService {
         }
 
         // this is needed because only on production stage we are allowed to send mails to customers
-        const mailOptions: MailOptions = this.mailerConfig.sendAllMailsTo
-            ? { ...mailOptionsWithDefaults, to: this.mailerConfig.sendAllMailsTo, cc: undefined, bcc: undefined }
+        const redirectAllMailsTo = this.mailerConfig.redirectAllMailsTo ?? this.mailerConfig.sendAllMailsTo;
+        const mailOptions: MailOptions = redirectAllMailsTo
+            ? { ...mailOptionsWithDefaults, to: redirectAllMailsTo, cc: undefined, bcc: undefined }
             : mailOptionsWithDefaults;
 
         const result = await this.mailerTransport.sendMail(mailOptions);

--- a/packages/api/cms-api/src/mailer/send-test-mail.command.ts
+++ b/packages/api/cms-api/src/mailer/send-test-mail.command.ts
@@ -30,10 +30,9 @@ export class SendTestMailCommand extends CommandRunner {
 
     @CreateRequestContext()
     async run(_arguments: string[], { receiver }: { receiver?: string }): Promise<void> {
-        const defaultReceiver = [
-            ...(this.mailerConfig.sendAllMailsTo ? this.mailerConfig.sendAllMailsTo : []),
-            ...(this.mailerConfig.sendAllMailsBcc ? this.mailerConfig.sendAllMailsBcc : []),
-        ];
+        const redirectAllMailsTo = this.mailerConfig.redirectAllMailsTo ?? this.mailerConfig.sendAllMailsTo;
+        const bccAllMailsTo = this.mailerConfig.bccAllMailsTo ?? this.mailerConfig.sendAllMailsBcc;
+        const defaultReceiver = [...(redirectAllMailsTo ?? []), ...(bccAllMailsTo ?? [])];
         if (!receiver && defaultReceiver.length === 0) {
             throw new Error(`No default receiver configured in config.mailer.receiver or config.mailer.bccReceiver. Please use --receiver.`);
         }


### PR DESCRIPTION
`sendAllMailsTo` is renamed to `redirectAllMailsTo` and `sendAllMailsBcc` is renamed to `bccAllMailsTo`. The old options still work but are deprecated.

- `redirectAllMailsTo`: If set, all outgoing mails are redirected to these addresses instead of being delivered to the original recipients. BCCs configured via `bccAllMailsTo` are also redirected. Use case: Disable mail delivery to real customers in non-production environments.
- `bccAllMailsTo`: If set, every outgoing mail receives an additional BCC to these addresses. Ignored when `redirectAllMailsTo` is set. Use case: In production, keep a safety copy of every outgoing mail.