### PR TITLE
Document `sendAllMailsTo` and `sendAllMailsBcc` mailer config

### DIFF
--- a/docs/docs/3-features-modules/11-mailer-module/index.md
+++ b/docs/docs/3-features-modules/11-mailer-module/index.md
@@ -109,6 +109,26 @@ async publishAllProducts(): Promise<boolean> {
 }
 ```
 
+### Config
+
+The `MailerModule.register` config accepts two recipient-overriding options that are designed for different environments and do not combine:
+
+#### `sendAllMailsTo`
+
+Sends every mail to the given addresses instead of the original `to`. The original `cc` and `bcc` are dropped. Intended for non-prod environments to prevent mails from reaching real users.
+
+```sh title="/.env"
+MAILER_SEND_ALL_MAILS_TO=demo-leaddev@comet-dxp.com,demo-pm@comet-dxp.com
+```
+
+#### `sendAllMailsBcc`
+
+Adds the given addresses as an additional BCC to every mail. Intended as a production backup recipient. Not applied when `sendAllMailsTo` is set.
+
+```sh title="/.env"
+MAILER_SEND_ALL_MAILS_BCC=mail-archive@comet-dxp.com,mail-backup@comet-dxp.com
+```
+
 ---
 
 ## Deleting Old Mail Logs

--- a/packages/api/cms-api/src/mailer/mailer.module.ts
+++ b/packages/api/cms-api/src/mailer/mailer.module.ts
@@ -10,7 +10,15 @@ import { SendTestMailCommand } from "./send-test-mail.command";
 
 export type MailerModuleConfig = {
     defaultFrom: string;
+    /**
+     * Send every mail to these addresses instead of the original `to`; the original `cc` and `bcc` are dropped.
+     * Intended for non-prod environments to prevent mails from reaching real users.
+     */
     sendAllMailsTo?: string[];
+    /**
+     * Add these addresses as additional BCC to every mail.
+     * Intended as a production backup recipient; not applied when `sendAllMailsTo` is set.
+     */
     sendAllMailsBcc?: string[];
     disableMailLog?: boolean;
     /** @default 90 */


### PR DESCRIPTION
Should help avoid confusion about when to use these settings and that they cannot be used together. 