### PR TITLE
cms-admin: Fix PixelImageBlock crash when selecting a DAM file

### DIFF
--- a/.changeset/fix-pixel-image-block-crash.md
+++ b/.changeset/fix-pixel-image-block-crash.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix `PixelImageBlock.AdminComponent` crash when selecting a DAM file
+
+`damFileFieldFragment` now includes `cropArea` so the Apollo cache has the required data when `PixelImageBlock` renders after a file is selected via `FileField`.

--- a/packages/admin/cms-admin/src/form/file/FileField.gql.ts
+++ b/packages/admin/cms-admin/src/form/file/FileField.gql.ts
@@ -14,6 +14,13 @@ export const damFileFieldFragment = gql`
         archived
         image {
             ...DamFileThumbnail
+            cropArea {
+                focalPoint
+                width
+                height
+                x
+                y
+            }
         }
         fileUrl
     }


### PR DESCRIPTION
**Description:**

Selecting a pixel image via `FileField` inside `PixelImageBlock.AdminComponent` (or `DamImageBlock.AdminComponent`) crashed immediately with:

```
TypeError: Cannot read properties of undefined (reading 'focalPoint')
    at createPreviewUrl (PixelImageBlock.js:52)
```

**Root cause**

`damFileFieldFragment` (used by `FileField` to populate the Apollo cache) only fetched `DamFileThumbnail` for the `image` sub-field, which contains only `thumbnailUrl`. After selecting a file, `damFile.image.cropArea` was therefore absent from the cache, and `createPreviewUrl` crashed trying to read `focalPoint` off `undefined`.

**Fix**

Add `cropArea` to `damFileFieldFragment` so the required data is in the Apollo cache when `PixelImageBlock` renders after a file selection.

**Note on the "null cropArea in database" edge case**

The issue description mentions a secondary crash path where `image.cropArea` is `null` in the database for migrated/imported files. In practice this cannot happen through the normal API: `FilesService` always writes `cropArea: { focalPoint: SMART }` on upload, and `DamFileImage` defines `cropArea` as a non-nullable embedded entity. A defensive guard for this case would be unnecessary noise, so none was added.

**Testing**

1. Add a `DamImageBlock` field to a form using `createFinalFormBlock`
2. Open the form (field empty)
3. Click **Choose image** and select any pixel image from the DAM
4. → Block renders the preview without crashing

Closes #5580
