### PR TITLE
Fix `FileField` breaking image block selection

### DIFF
--- a/.changeset/filefield-restore-image-fields.md
+++ b/.changeset/filefield-restore-image-fields.md
@@ -1,0 +1,10 @@
+---
+"@comet/cms-admin": patch
+"@comet/cms-api": patch
+---
+
+Fix `FileField` breaking image block selection
+
+The `DamFileFieldFile` fragment lost the image dimensions (`width`, `height`, `cropArea`) needed by `DamImageBlock`/`PixelImageBlock`. Selecting an image inside an image block crashed because those fields were missing. Restored them on the fragment.
+
+Composing the fragment into a parent collection (e.g. a many-to-many to `DamFile`) exposed a Mikro-ORM gotcha: `Collection.loadItems()` does not honor `eager: true`, so each loaded `DamFile` had an uninitialized `image` Reference and GraphQL threw `Cannot return null for non-nullable field DamFileImage.width`. Added an `image` `@ResolveField` on `FilesResolver` that initializes the Reference if needed, so consumers don't have to remember to populate it.

--- a/packages/admin/cms-admin/src/blocks/PixelImageBlock.fragment.ts
+++ b/packages/admin/cms-admin/src/blocks/PixelImageBlock.fragment.ts
@@ -1,0 +1,15 @@
+import { gql } from "@apollo/client";
+
+export const pixelImageBlockFragment = gql`
+    fragment PixelImageBlockImage on DamFileImage {
+        width
+        height
+        cropArea {
+            focalPoint
+            width
+            height
+            x
+            y
+        }
+    }
+`;

--- a/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/PixelImageBlock.tsx
@@ -15,6 +15,7 @@ import { BlocksFinalForm } from "./form/BlocksFinalForm";
 import { createBlockSkeleton } from "./helpers/createBlockSkeleton";
 import { SelectPreviewComponent } from "./iframebridge/SelectPreviewComponent";
 import { EditImageDialog } from "./image/EditImageDialog";
+import { pixelImageBlockFragment } from "./PixelImageBlock.fragment";
 import type { GQLImageBlockDamFileQuery, GQLImageBlockDamFileQueryVariables } from "./PixelImageBlock.generated";
 import { BlockCategory, type BlockDependency, type BlockInterface } from "./types";
 
@@ -96,19 +97,12 @@ export const PixelImageBlock: BlockInterface<PixelImageBlockData, ImageBlockStat
                         altText
                         archived
                         image {
-                            width
-                            height
-                            cropArea {
-                                focalPoint
-                                width
-                                height
-                                x
-                                y
-                            }
+                            ...PixelImageBlockImage
                         }
                         fileUrl
                     }
                 }
+                ${pixelImageBlockFragment}
             `,
             variables: { id: output.damFileId },
         });

--- a/packages/admin/cms-admin/src/form/file/FileField.gql.ts
+++ b/packages/admin/cms-admin/src/form/file/FileField.gql.ts
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 
+import { pixelImageBlockFragment } from "../../blocks/PixelImageBlock.fragment";
 import { damFileThumbnailFragment } from "../../dam/DataGrid/thumbnail/DamThumbnail";
 
 export const damFileFieldFragment = gql`
@@ -14,19 +15,12 @@ export const damFileFieldFragment = gql`
         archived
         image {
             ...DamFileThumbnail
-            width
-            height
-            cropArea {
-                focalPoint
-                width
-                height
-                x
-                y
-            }
+            ...PixelImageBlockImage
         }
         fileUrl
     }
     ${damFileThumbnailFragment}
+    ${pixelImageBlockFragment}
 `;
 
 export const damFileFieldFileQuery = gql`

--- a/packages/admin/cms-admin/src/form/file/FileField.gql.ts
+++ b/packages/admin/cms-admin/src/form/file/FileField.gql.ts
@@ -14,6 +14,15 @@ export const damFileFieldFragment = gql`
         archived
         image {
             ...DamFileThumbnail
+            width
+            height
+            cropArea {
+                focalPoint
+                width
+                height
+                x
+                y
+            }
         }
         fileUrl
     }

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -1,5 +1,5 @@
 import { InjectRepository } from "@mikro-orm/nestjs";
-import { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
+import { EntityManager, EntityRepository, wrap } from "@mikro-orm/postgresql";
 import { NotFoundException, Type } from "@nestjs/common";
 import { Args, Context, ID, Mutation, ObjectType, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { IncomingMessage } from "http";
@@ -21,6 +21,7 @@ import { FilenameInput, FilenameResponse } from "./dto/filename.args";
 import { createFindCopiesOfFileInScopeArgs, FindCopiesOfFileInScopeArgsInterface } from "./dto/find-copies-of-file-in-scope.args";
 import { UpdateDamFileArgs } from "./dto/update-dam-file.args";
 import { FileInterface } from "./entities/file.entity";
+import { DamFileImage } from "./entities/file-image.entity";
 import { FolderInterface } from "./entities/folder.entity";
 import { FilesService } from "./files.service";
 
@@ -253,6 +254,18 @@ export function createFilesResolver({
         @ResolveField(() => [DamMediaAlternative])
         async thisFileIsAlternativeFor(@Parent() file: FileInterface): Promise<DamMediaAlternative[]> {
             return file.thisFileIsAlternativeFor.loadItems();
+        }
+
+        @ResolveField(() => DamFileImage, { nullable: true })
+        async image(@Parent() file: FileInterface): Promise<DamFileImage | undefined> {
+            // Mikro-ORM's `eager: true` isn't honored when files are loaded via Collection navigation
+            // (e.g. `someEntity.files.loadItems()`), so the `image` Reference can arrive uninitialized.
+            // The `isInitialized` check skips the extra fetch when `image` was already hydrated upstream
+            // (e.g. by `FilesService.selectQueryBuilder`'s `leftJoinAndSelect`).
+            if (file.image && !wrap(file.image).isInitialized()) {
+                await wrap(file.image).init();
+            }
+            return file.image;
         }
     }
 


### PR DESCRIPTION
## Problem

#5542 slimmed down the `DamFileFieldFile` fragment and dropped `image.width/height/cropArea`. Those fields are read by `PixelImageBlock` (via `DamImageBlock`), so selecting an image inside an image block crashed.

<img width="1920" height="1077" alt="Bildschirmfoto 2026-05-11 um 14 41 21" src="https://github.com/user-attachments/assets/ddd4aac6-b6ff-4f53-bb3d-dff488360c5f" />

Simply restoring the fields exposes a second bug: when a project composes the fragment into a parent collection (e.g. the demo's `Product.relatedImages`), `Collection.loadItems()` does **not** honor the `image` relation's `eager: true` — the field arrives as an uninitialized Mikro-ORM Reference and GraphQL throws `Cannot return null for non-nullable field DamFileImage.width`.

<img width="1920" height="1077" alt="Bildschirmfoto 2026-05-11 um 14 41 57" src="https://github.com/user-attachments/assets/c20d1b33-adc1-4257-b131-7fa0ea9522d2" />

## Solution

- **`cms-admin`** — restore `width`, `height`, `cropArea` on the `DamFileFieldFile` fragment.
- **`cms-api`** — add an `image` `@ResolveField` on `FilesResolver` that initializes the Reference if needed, so projects don't have to remember `populate(['image'])` when composing the fragment.

- Image selection in PixelImageBlock works

<img width="1920" height="1077" alt="Bildschirmfoto 2026-05-11 um 14 42 34" src="https://github.com/user-attachments/assets/88b60ec1-ef9a-46ed-ba85-1ea8411639d9" />

- Multiselect FileField works for non-image files

<img width="1920" height="1077" alt="Bildschirmfoto 2026-05-11 um 14 42 18" src="https://github.com/user-attachments/assets/9113b096-845f-49e2-9654-f256fe5ff229" />

---

Closes https://github.com/vivid-planet/comet/issues/5580
