### PR TITLE
api-generator: fix missing import for nested import for manyToOne relation

### DIFF
--- a/.changeset/fix-api-generator-nested-many-to-one-import.md
+++ b/.changeset/fix-api-generator-nested-many-to-one-import.md
@@ -1,0 +1,7 @@
+---
+"@comet/api-generator": patch
+---
+
+Fix missing import for nested `ManyToOne` resolver target entities
+
+`@comet/api-generator` now imports nested `ManyToOne` target entities in generated resolvers so generated code compiles without unresolved symbol errors.

--- a/demo/api/src/products/generated/product.resolver.ts
+++ b/demo/api/src/products/generated/product.resolver.ts
@@ -5,9 +5,6 @@ import { Args, ID, Mutation, Query, Resolver, ResolveField, Parent } from "@nest
 import { ProductInput, ProductUpdateInput } from "./dto/product.input";
 import { PaginatedProducts } from "./dto/paginated-products";
 import { ProductsArgs } from "./dto/products.args";
-import { ProductColor } from "../entities/product-color.entity";
-import { ProductToTag } from "../entities/product-to-tag.entity";
-import { ProductStatistics } from "../entities/product-statistics.entity";
 import { ProductCategory } from "../entities/product-category.entity";
 import { Manufacturer } from "../entities/manufacturer.entity";
 import {
@@ -22,8 +19,11 @@ import {
     gqlArgsToMikroOrmQuery,
     gqlSortToMikroOrmOrderBy,
 } from "@comet/cms-api";
-import { ProductVariant } from "../entities/product-variant.entity";
+import { ProductColor } from "../entities/product-color.entity";
+import { ProductToTag } from "../entities/product-to-tag.entity";
 import { ProductTag } from "../entities/product-tag.entity";
+import { ProductStatistics } from "../entities/product-statistics.entity";
+import { ProductVariant } from "../entities/product-variant.entity";
 import { DamFile } from "../../dam/entities/dam-file.entity";
 import { Product } from "../entities/product.entity";
 import { ProductService } from "../product.service";

--- a/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
@@ -480,6 +480,7 @@ export function generateInputHandling(
             if (!targetMeta) {
                 throw new Error("targetMeta is not set for relation");
             }
+            imports.push(generateEntityImport(targetMeta, targetDirectory));
             return {
                 name: prop.name,
                 singularName: singular(prop.name),


### PR DESCRIPTION
## Bug

  `@comet/api-generator` emits resolver code that references a nested `m:1` target entity without importing it. The generated file fails to compile with `error TS2304: Cannot find name '<Entity>'`.

  ### Reproduction

  Given two entities joined through a junction with a `OneToMany`/`orphanRemoval` relation, e.g.:

  ```ts
  // article.entity.ts
  @OneToMany(() => ArticleToPeriodical, (atp) => atp.article, { orphanRemoval: true })
  periodicalsIncludedIn = new Collection<ArticleToPeriodical>(this);
  ```

  ```ts
  // article-to-periodical.entity.ts
  @ManyToOne(() => Periodical, { deleteRule: "cascade", ref: true })
  periodical: Ref<Periodical>;
  ```

  `comet-api-generator generate` produces the following inside `article.resolver.ts`:

  ```ts
  periodical: Reference.create(await this.entityManager.findOneOrFail(Periodical, periodicalInput)),
  ```

  …but **never imports `Periodical`**. TypeScript fails:

  ```
  src/articles/generated/article.resolver.ts(83,97): error TS2552: Cannot find name 'Periodical'.
  ```

  ## Root cause

  In `packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts`, the sibling collectors for relation props push imports for their target entities:

  - `inputRelationOneToOneProps` consumer — pushes `generateEntityImport(prop.targetMeta, …)` (line 584)
  - `inputRelationToManyProps` consumer (orphan-removal branch) — pushes `generateEntityImport(prop.targetMeta, …)` (line 541)

  But `inputRelationManyToOneProps` (lines 458–473) never pushes an import, even though its `prop.type` is interpolated into
  `findOneOrFail(${prop.type}, …)` in both the create/updateNested branch (line 527) and the update branch (line 617).

  ## Fix

  Push the entity import for each nested `m:1` relation, matching the existing pattern for `1:1` and `1:m`/`m:n` relations:

  ```diff
   const inputRelationManyToOneProps = relationManyToOneProps
       .filter((prop) => hasCrudFieldFeature(metadata.class, prop.name, "input"))
       .filter((prop) => {
           //filter out props that are dedicatedResolverArgProp
           return !dedicatedResolverArgProps.some((dedicatedResolverArgProp) => dedicatedResolverArgProp.name === prop.name);
       })
       .map((prop) => {
           const targetMeta = prop.targetMeta;
           if (!targetMeta) throw new Error("targetMeta is not set for relation");
  +        imports.push(generateEntityImport(targetMeta, generatorOptions.targetDirectory));
           return {
               name: prop.name,
               singularName: singular(prop.name),
               nullable: prop.nullable,
               type: prop.type,
           };
       });
  ```

  ## Verification

  Regenerated a downstream project that uses two `@CrudGenerator` entities joined via a junction entity. Before the fix, `npm run lint` failed with `TS2304`/`TS2552` in the generated `*.resolver.ts` files. After the fix, the generated resolvers contain the missing imports and `lint:tsc` passes.

  ## Risk

  Low. The change only adds an import for an entity whose class name is already used in the generated output, so it can never produce a worse result than the current behavior. Duplicate imports are de-duplicated by `generateImportsCode`.