### PR TITLE
cms-admin: Fix `TipTapRichTextBlock` toolbar colors to match `RichTextBlock`

### DIFF
--- a/.changeset/fix-tiptap-toolbar-colors.md
+++ b/.changeset/fix-tiptap-toolbar-colors.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix `TipTapRichTextBlock` toolbar colors to match the existing `RichTextBlock` toolbar
+
+The TipTap toolbar incorrectly used Comet's `greyPalette` (where `greyPalette[100]` is `#D9D9D9`) for the toolbar background, button icon, hover, and disabled states. This made the toolbar look noticeably darker than the existing Draft.js-based `RichTextBlock` toolbar, which uses MUI's lighter `grey` palette (`grey[100]` is `#F5F5F5`). The TipTap toolbar now uses the same MUI grey shades for these states so the two toolbars look consistent.

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -29,6 +29,7 @@ import {
     selectClasses,
     type SvgIconProps,
 } from "@mui/material";
+import { grey as muiGreyPalette } from "@mui/material/colors";
 import { type Editor, useEditorState } from "@tiptap/react";
 import { type ForwardRefExoticComponent, type MouseEvent, type ReactNode, type RefAttributes, useState } from "react";
 import { FormattedMessage } from "react-intl";
@@ -48,13 +49,13 @@ const toolbarButtonSx = {
     border: "1px solid transparent",
     boxSizing: "border-box",
     transition: "background-color 200ms, border-color 200ms, color 200ms",
-    color: greyPalette[600],
+    color: muiGreyPalette[600],
     "&:hover": {
-        backgroundColor: greyPalette[200],
-        borderColor: greyPalette[400],
+        backgroundColor: muiGreyPalette[200],
+        borderColor: muiGreyPalette[400],
     },
     "&:disabled": {
-        color: greyPalette[300],
+        color: muiGreyPalette[300],
         "&, &:hover": {
             backgroundColor: "transparent",
             borderColor: "transparent",
@@ -64,7 +65,7 @@ const toolbarButtonSx = {
 
 const toolbarButtonSelectedSx = {
     "&:not(:disabled), &:not(:disabled):hover": {
-        borderColor: greyPalette[400],
+        borderColor: muiGreyPalette[400],
         backgroundColor: "white",
     },
 } as const;
@@ -113,7 +114,7 @@ const toolbarSlotSx = {
     py: "5px",
     pr: "6px",
     mr: "5px",
-    borderRight: `1px solid ${greyPalette[300]}`,
+    borderRight: `1px solid ${greyPalette[100]}`,
     "&:last-child": {
         mr: 0,
         pr: 0,
@@ -136,7 +137,7 @@ const selectFormControlSx = {
 const selectSx = {
     [`& .${selectClasses.select}.${inputBaseClasses.input}`]: {
         minHeight: 0,
-        color: greyPalette[600],
+        color: muiGreyPalette[600],
         minWidth: 180,
         lineHeight: "24px",
         fontSize: 14,
@@ -249,7 +250,7 @@ export const TipTapToolbar = ({
                 display: "flex",
                 flexWrap: "wrap",
                 borderTop: `1px solid ${greyPalette[100]}`,
-                backgroundColor: greyPalette[100],
+                backgroundColor: muiGreyPalette[100],
                 px: "6px",
             }}
         >


### PR DESCRIPTION
## Summary

The TipTap toolbar mistakenly used Comet's `greyPalette` (where `greyPalette[100]` is `#D9D9D9`) for the toolbar background, button icon, hover, and disabled states. This made it look noticeably darker than the existing Draft.js-based `RichTextBlock` toolbar, which uses MUI's lighter `grey` palette (`grey[100]` is `#F5F5F5`). The relevant colors now use MUI's `grey` palette so the two toolbars are visually consistent.

Affected: background (`grey[100]`), button icon color (`grey[600]`), hover background/border (`grey[200]` / `grey[400]`), disabled icon (`grey[300]`), selected-state border (`grey[400]`), `Select` text color (`grey[600]`). The group-separator border was also changed from `greyPalette[300]` (`#828282`) to `greyPalette[100]` (`#D9D9D9`) to match the old toolbar's separator color.

## Screenshots

**New TipTap toolbar — before:**

<img width="902" height="438" alt="tiptap-before-v2" src="https://github.com/user-attachments/assets/29626146-cdf8-4096-b61a-eb0fbca3eebc" />


**New TipTap toolbar — after:**

<img width="902" height="438" alt="tiptap-after" src="https://github.com/user-attachments/assets/c8ee203a-02e9-4f2a-984c-4298de7f9ff5" />


**Existing Draft.js \`RichTextBlock\` toolbar (reference):**

<img width="902" height="438" alt="old-rte" src="https://github.com/user-attachments/assets/80ba6044-6456-46c6-8e66-3a00a0543f47" />


## Test plan

- [ ] Storybook: \`blocks / TipTapRichTextBlock - Default\` toolbar background is light grey (\`#F5F5F5\`), matching \`blocks / RichTextBlock - Default\`.
- [ ] Button icons render at \`grey[600]\`; hover/disabled/selected states use MUI \`grey\` shades, not Comet \`greyPalette\`.
- [ ] Group separators are visible against the lighter background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)