### PR TITLE
eslint-plugin: migrate from Jest to Vitest

### DIFF
--- a/packages/eslint-plugin/jest.config.js
+++ b/packages/eslint-plugin/jest.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-    testEnvironment: "node",
-    transform: { "^.+\\.tsx?$": "ts-jest" },
-    rootDir: "./src",
-};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -6,7 +6,7 @@
     "main": "lib/index.js",
     "license": "BSD-2-Clause",
     "scripts": {
-        "build": "pnpm run clean && tsc",
+        "build": "pnpm run clean && tsc --project ./tsconfig.build.json",
         "clean": "rimraf lib",
         "dev": "tsc --watch",
         "lint": "run-p lint:prettier lint:eslint lint:tsc",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -16,7 +16,7 @@
         "lint:fix:eslint": "pnpm run lint:eslint --fix",
         "lint:fix:prettier": "pnpm run lint:prettier --write",
         "lint:prettier": "pnpm exec prettier --check '*.{ts,js,json,md,yml,yaml}'",
-        "lint:tsc": "tsc",
+        "lint:tsc": "tsc --noEmit",
         "test": "vitest --run",
         "test:watch": "vitest --watch"
     },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -17,12 +17,11 @@
         "lint:fix:prettier": "pnpm run lint:prettier --write",
         "lint:prettier": "pnpm exec prettier --check '*.{ts,js,json,md,yml,yaml}'",
         "lint:tsc": "tsc",
-        "test": "jest",
-        "test:watch": "jest --watch"
+        "test": "vitest --run",
+        "test:watch": "vitest --watch"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@types/jest": "^29.5.14",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
@@ -32,12 +31,11 @@
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.4.1",
         "globals": "^15.15.0",
-        "jest": "^29.7.0",
         "npm-run-all2": "^8.0.4",
         "prettier": "^3.6.2",
-        "ts-jest": "^29.4.9",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.53.0"
+        "typescript-eslint": "^8.53.0",
+        "vitest": "^4.0.16"
     },
     "peerDependencies": {
         "eslint": ">=9",

--- a/packages/eslint-plugin/tsconfig.build.json
+++ b/packages/eslint-plugin/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "exclude": ["**/*.test.ts", "**/*.spec.ts", "**/__tests__/**"],
+    "extends": "./tsconfig.json"
+}

--- a/packages/eslint-plugin/vitest.config.ts
+++ b/packages/eslint-plugin/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "node",
+        reporters: ["default", "junit"],
+        outputFile: { junit: "./junit.xml" },
+        exclude: ["lib/**", "node_modules/**"],
+        setupFiles: "./vitest.setup.ts",
+    },
+});

--- a/packages/eslint-plugin/vitest.config.ts
+++ b/packages/eslint-plugin/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
         environment: "node",
         reporters: ["default", "junit"],
         outputFile: { junit: "./junit.xml" },
-        exclude: ["lib/**", "node_modules/**"],
         setupFiles: "./vitest.setup.ts",
     },
 });

--- a/packages/eslint-plugin/vitest.setup.ts
+++ b/packages/eslint-plugin/vitest.setup.ts
@@ -1,0 +1,6 @@
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;

--- a/packages/eslint-plugin/vitest.setup.ts
+++ b/packages/eslint-plugin/vitest.setup.ts
@@ -1,6 +1,8 @@
 import { RuleTester } from "eslint";
 import { describe, it } from "vitest";
 
+// Wire ESLint's RuleTester to vitest's describe/it so rule tests surface as individual test cases.
+// See https://eslint.org/docs/latest/integrate/nodejs-api#customizing-ruletester
 RuleTester.describe = describe;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1860,7 +1860,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -1990,7 +1990,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.3)(@types/node@24.12.4)(typescript@5.9.3)
@@ -2264,7 +2264,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.3)(@types/node@24.12.4)(typescript@5.9.3)
@@ -2384,9 +2384,6 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
-      '@types/jest':
-        specifier: ^29.5.14
-        version: 29.5.14
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -2414,24 +2411,21 @@ importers:
       globals:
         specifier: ^15.15.0
         version: 15.15.0
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.12.4)(typescript@5.9.3))
       npm-run-all2:
         specifier: ^8.0.4
         version: 8.0.4
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
-      ts-jest:
-        specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.53.0
         version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.2(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
 
   packages/mail-react:
     dependencies:
@@ -22448,7 +22442,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
     optionalDependencies:
-      ts-jest: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+      ts-jest: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3)
 
   '@getbrevo/brevo@3.0.4':
     dependencies:
@@ -37444,7 +37438,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-jest@29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  ts-jest@29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0


### PR DESCRIPTION
Migrate the tests for `@comet/eslint-plugin` from Jest to Vitest. Update the TS config to not include test files in the build.

https://claude.ai/code/session_014QVYpuZSVYkotZw3z7xmB4