### PR TITLE
cms-admin: Move action log stories to package storybook

### DIFF
--- a/packages/admin/cms-admin/src/actionLog/components/__stories__/DiffHeader.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/__stories__/DiffHeader.stories.tsx
@@ -1,10 +1,11 @@
-import { DiffHeader } from "@comet/cms-admin";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { DiffHeader } from "../DiffHeader";
 
 type Story = StoryObj<typeof DiffHeader>;
 const meta: Meta<typeof DiffHeader> = {
     component: DiffHeader,
-    title: "@comet/cms-admin/Action log/Components/Diff header/Diff header",
+    title: "actionLog/components/DiffHeader",
 };
 export default meta;
 

--- a/packages/admin/cms-admin/src/actionLog/components/diffViewer/__stories__/DiffViewer.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/diffViewer/__stories__/DiffViewer.stories.tsx
@@ -1,10 +1,11 @@
-import { DiffViewer } from "@comet/cms-admin";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { DiffViewer } from "../DiffViewer";
 
 type Story = StoryObj<typeof DiffViewer>;
 const meta: Meta<typeof DiffViewer> = {
     component: DiffViewer,
-    title: "@comet/cms-admin/Action log/Components/Diff viewer/Diff viewer",
+    title: "actionLog/components/diffViewer/DiffViewer",
 };
 export default meta;
 

--- a/packages/admin/cms-admin/src/actionLog/components/header/__stories__/ActionLogHeader.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/header/__stories__/ActionLogHeader.stories.tsx
@@ -1,13 +1,14 @@
-import { ActionLogHeader } from "@comet/cms-admin";
 import { Typography } from "@mui/material";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FormattedMessage } from "react-intl";
 import { v4 as uuid } from "uuid";
 
+import { ActionLogHeader } from "../ActionLogHeader";
+
 type Story = StoryObj<typeof ActionLogHeader>;
 const meta: Meta<typeof ActionLogHeader> = {
     component: ActionLogHeader,
-    title: "@comet/cms-admin/Action log/Components/Header/Action log header",
+    title: "actionLog/components/header/ActionLogHeader",
 };
 export default meta;
 


### PR DESCRIPTION
## Summary
- Moves the 3 action log component stories (`DiffHeader`, `DiffViewer`, `ActionLogHeader`) from the root storybook into `__stories__/` directories co-located with their components in `@comet/cms-admin`
- Updates imports from `@comet/cms-admin` to relative paths
- Adjusts story titles to match the directory structure (e.g. `actionLog/components/diffViewer/DiffViewer`)