### PR TITLE
cms-admin: Exclude story files from tsconfig.build.json

### DIFF
--- a/packages/admin/cms-admin/tsconfig.build.json
+++ b/packages/admin/cms-admin/tsconfig.build.json
@@ -1,4 +1,15 @@
 {
-    "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__/**", "**/__mocks__/**"],
+    "exclude": [
+        "**/*.test.tsx",
+        "**/*.test.ts",
+        "**/*.spec.tsx",
+        "**/*.spec.ts",
+        "**/__tests__/**",
+        "**/__mocks__/**",
+        "**/__stories__/**",
+        "**/*.stories.js",
+        "**/*.stories.tsx",
+        "**/*.stories.ts"
+    ],
     "extends": "./tsconfig.json"
 }


### PR DESCRIPTION
## Summary

- Adds `**/__stories__/**` and `**/*.stories.{js,ts,tsx}` to the `exclude` list in `packages/admin/cms-admin/tsconfig.build.json`
- Matches the existing exclusions already present in `packages/admin/admin/tsconfig.build.json`
- Prevents build errors when story files under `src/` import dev-only packages like `@storybook/react-vite` — without this fix, story files are compiled into `lib/` and [shipped with the package](https://www.npmjs.com/package/@comet/cms-admin/v/9.0.0-beta.3?activeTab=code) even though their imports are not listed as dependencies

<img width="1474" height="675" alt="image" src="https://github.com/user-attachments/assets/b820c0f9-4fda-4876-896c-80bae1c0fb89"/>
