### PR TITLE
storybook: fix read-only .name property on story exports

### DIFF
--- a/storybook/src/admin/clipboard/clipboard.stories.tsx
+++ b/storybook/src/admin/clipboard/clipboard.stories.tsx
@@ -46,4 +46,4 @@ export const ClipboardFallbackSizeLimit = function () {
     );
 };
 
-ClipboardFallbackSizeLimit.name = "Clipboard fallback size limit";
+ClipboardFallbackSizeLimit.storyName = "Clipboard fallback size limit";

--- a/storybook/src/admin/common/dialog/Dialog.stories.tsx
+++ b/storybook/src/admin/common/dialog/Dialog.stories.tsx
@@ -36,4 +36,4 @@ export const DialogStory: Story = {
         );
     },
 };
-DialogStory.name = "Dialog";
+DialogStory.storyName = "Dialog";

--- a/storybook/src/admin/edit-dialog/NestedEditDialogInStack.stories.tsx
+++ b/storybook/src/admin/edit-dialog/NestedEditDialogInStack.stories.tsx
@@ -106,4 +106,4 @@ export const NestedEditDialogInStack = function Story() {
     );
 };
 
-NestedEditDialogInStack.name = "Nested Edit Dialog in Stack";
+NestedEditDialogInStack.storyName = "Nested Edit Dialog in Stack";

--- a/storybook/src/admin/form/DependentAsyncSelects.stories.tsx
+++ b/storybook/src/admin/form/DependentAsyncSelects.stories.tsx
@@ -82,4 +82,4 @@ export const DependentAsyncSelects = function () {
     );
 };
 
-DependentAsyncSelects.name = "Dependent async selects";
+DependentAsyncSelects.storyName = "Dependent async selects";

--- a/storybook/src/admin/inlineAlert/InlineAlert.stories.tsx
+++ b/storybook/src/admin/inlineAlert/InlineAlert.stories.tsx
@@ -23,7 +23,7 @@ export default config;
  * Demonstrates the base appearance of the error component.
  */
 export const InlineAlertStory: Story = {};
-InlineAlertStory.name = "InlineAlert";
+InlineAlertStory.storyName = "InlineAlert";
 
 /**
  * Displays the `InlineAlert` component with a warning variant.

--- a/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.stories.tsx
+++ b/storybook/src/cms-admin/ContentScopeProvider/OptionalDimensions.stories.tsx
@@ -60,4 +60,4 @@ export const OptionalDimensions = function () {
     );
 };
 
-OptionalDimensions.name = "Optional dimensions";
+OptionalDimensions.storyName = "Optional dimensions";


### PR DESCRIPTION
## Summary

- Replace `.name` with `.storyName` on 6 story exports across the Storybook
- `function.name` is a read-only property in strict mode (ES modules), causing a `TypeError` at runtime
- Affected stories: `OptionalDimensions`, `DependentAsyncSelects`, `NestedEditDialogInStack`, `Dialog`, `ClipboardFallbackSizeLimit`, `InlineAlert`