### PR TITLE
site-nextjs: Fix `PixelImageBlock` and `Image` failing in Pages Router

### DIFF
--- a/.changeset/fix-pixel-image-block-pages-router-interop.md
+++ b/.changeset/fix-pixel-image-block-pages-router-interop.md
@@ -1,0 +1,7 @@
+---
+"@comet/site-nextjs": patch
+---
+
+Fix `PixelImageBlock` and `Image` failing to render in Next.js Pages Router with `Error: Element type is invalid ... but got: object`
+
+`@comet/site-nextjs` is published as ESM (`"type": "module"`) and the components used a default import of `next/image` (CJS). Under Next.js Pages Router the server bundler keeps node_modules ESM packages as Node-style externals, which applies Node-style ESM↔CJS interop: `import NextImage from "next/image"` yields the entire module-namespace object (`{ default, getImageProps, __esModule: true }`) instead of the component. The default import is now unwrapped at module evaluation time so the components work under both bundler-style and Node-style interop.

--- a/packages/site/site-nextjs/src/blocks/PixelImageBlock.tsx
+++ b/packages/site/site-nextjs/src/blocks/PixelImageBlock.tsx
@@ -10,10 +10,16 @@ import {
     withPreview,
 } from "@comet/site-react";
 // eslint-disable-next-line no-restricted-imports
-import NextImage, { type ImageProps } from "next/image";
+import NextImageImport, { type ImageProps } from "next/image";
 
 import type { PixelImageBlockData } from "../blocks.generated";
 import styles from "./PixelImageBlock.module.scss";
+
+// `next/image` is a CJS module; under Next.js Pages Router its default import
+// from this ESM package yields the module-namespace object instead of the
+// component (Node-style ESM↔CJS interop). Unwrap so the component works under
+// both bundler-style and Node-style interop.
+const NextImage: typeof NextImageImport = (NextImageImport as unknown as { default?: typeof NextImageImport }).default ?? NextImageImport;
 
 interface PixelImageBlockProps extends PropsWithData<PixelImageBlockData>, Omit<ImageProps, "src" | "width" | "height" | "alt"> {
     aspectRatio: string | number | "inherit";

--- a/packages/site/site-nextjs/src/image/Image.tsx
+++ b/packages/site/site-nextjs/src/image/Image.tsx
@@ -1,6 +1,12 @@
 import { generateImageUrl, parseAspectRatio } from "@comet/site-react";
 // eslint-disable-next-line no-restricted-imports
-import NextImage, { type ImageProps as NextImageProps } from "next/image";
+import NextImageImport, { type ImageProps as NextImageProps } from "next/image";
+
+// `next/image` is a CJS module; under Next.js Pages Router its default import
+// from this ESM package yields the module-namespace object instead of the
+// component (Node-style ESM↔CJS interop). Unwrap so the component works under
+// both bundler-style and Node-style interop.
+const NextImage: typeof NextImageImport = (NextImageImport as unknown as { default?: typeof NextImageImport }).default ?? NextImageImport;
 
 type Props = Omit<NextImageProps, "loader"> & { aspectRatio: string };
 


### PR DESCRIPTION
`next/image` is a CJS module; from this ESM package its default import yields the namespace object under Node-style ESM↔CJS interop (Next.js Pages Router server bundling). Unwrap the default at module load so the components render under both bundler-style and Node-style interop.