### PR TITLE
Add useActionLogDialog hook (explicit queries variant)

### DIFF
--- a/.changeset/add-use-action-log-dialog-hook.md
+++ b/.changeset/add-use-action-log-dialog-hook.md
@@ -1,0 +1,85 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `useActionLogDialog` hook
+
+A new hook that owns the dialog's open state, view state (grid / show version / compare versions), and the three Apollo queries that drive it. It returns a configured `ActionLogDialog` component (ready to render without props) and an `{ openActionLogDialog, closeActionLogDialog }` API — mirroring the `useEditDialog` pattern.
+
+The hook is **explicit about queries**: the app declares each of the three queries with the library's exported fragments (`actionLogGridFragment`, `actionLogShowVersionFragment`, `actionLogCompareFragment`) and passes them in alongside a small accessor that reads the relevant nodes out of the response. This keeps responses fully typed end-to-end via codegen and leaves room for entity-specific extras (custom variables, additional fields, etc.).
+
+**Usage**
+
+```ts
+// manufacturerActionLogQueries.ts
+import { gql } from "@apollo/client";
+import { actionLogCompareFragment, actionLogGridFragment, actionLogShowVersionFragment } from "@comet/cms-admin";
+
+export const manufacturerActionLogsQuery = gql`
+    query ManufacturerActionLogs($id: ID!, $offset: Int!, $limit: Int!, $sort: [ActionLogSort!]) {
+        manufacturer(id: $id) {
+            actionLogs(offset: $offset, limit: $limit, sort: $sort) {
+                nodes { ...ActionLogGridFragment }
+                totalCount
+            }
+        }
+    }
+    ${actionLogGridFragment}
+`;
+
+export const manufacturerActionLogShowVersionQuery = gql`
+    query ManufacturerActionLogShowVersion($id: ID!, $versionId: ID!) {
+        manufacturer(id: $id) {
+            actionLog(id: $versionId) { ...ActionLogShowVersionFragment }
+        }
+    }
+    ${actionLogShowVersionFragment}
+`;
+
+export const manufacturerActionLogCompareVersionsQuery = gql`
+    query ManufacturerActionLogCompareVersions($id: ID!, $beforeId: ID!, $afterId: ID!) {
+        manufacturer(id: $id) {
+            beforeVersion: actionLog(id: $beforeId) { ...ActionLogCompareFragment }
+            afterVersion: actionLog(id: $afterId) { ...ActionLogCompareFragment }
+        }
+    }
+    ${actionLogCompareFragment}
+`;
+```
+
+```tsx
+// ManufacturerEditToolbar.tsx
+const [ActionLogDialog, { openActionLogDialog }] = useActionLogDialog<
+    GQLManufacturerActionLogsQuery,
+    GQLManufacturerActionLogShowVersionQuery,
+    GQLManufacturerActionLogCompareVersionsQuery
+>({
+    id,
+    queries: {
+        grid: {
+            document: manufacturerActionLogsQuery,
+            getActionLogs: (data) => data.manufacturer.actionLogs,
+        },
+        showVersion: {
+            document: manufacturerActionLogShowVersionQuery,
+            getActionLog: (data) => data.manufacturer.actionLog,
+        },
+        compareVersions: {
+            document: manufacturerActionLogCompareVersionsQuery,
+            getActionLogs: (data) => ({
+                beforeVersion: data.manufacturer.beforeVersion,
+                afterVersion: data.manufacturer.afterVersion,
+            }),
+        },
+    },
+});
+
+return (
+    <>
+        <Button onClick={openActionLogDialog}>Version history</Button>
+        <ActionLogDialog />
+    </>
+);
+```
+
+Each query document must declare the variables the hook supplies (`$id, $offset, $limit, $sort` for grid; `$id, $versionId` for show; `$id, $beforeId, $afterId` for compare) and must `...` the corresponding library fragment.

--- a/demo/admin/src/products/ManufacturersPage.tsx
+++ b/demo/admin/src/products/ManufacturersPage.tsx
@@ -1,4 +1,5 @@
 import {
+    Button,
     FillSpace,
     SaveBoundary,
     SaveBoundarySaveButton,
@@ -11,12 +12,64 @@ import {
     ToolbarAutomaticTitleItem,
     ToolbarBackButton,
 } from "@comet/admin";
-import { ContentScopeIndicator } from "@comet/cms-admin";
+import { ContentScopeIndicator, useActionLogDialog } from "@comet/cms-admin";
+import {
+    manufacturerActionLogCompareVersionsQuery,
+    manufacturerActionLogShowVersionQuery,
+    manufacturerActionLogsQuery,
+} from "@src/products/manufacturerActionLogQueries";
+import type {
+    GQLManufacturerActionLogCompareVersionsQuery,
+    GQLManufacturerActionLogShowVersionQuery,
+    GQLManufacturerActionLogsQuery,
+} from "@src/products/manufacturerActionLogQueries.generated";
 import { ManufacturerForm } from "@src/products/ManufacturerForm";
 import { ManufacturersGrid } from "@src/products/ManufacturersGrid";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
-const FormToolbar = () => (
+const EditFormToolbar = ({ id }: { id: string }) => {
+    const [ActionLogDialog, { openActionLogDialog }] = useActionLogDialog<
+        GQLManufacturerActionLogsQuery,
+        GQLManufacturerActionLogShowVersionQuery,
+        GQLManufacturerActionLogCompareVersionsQuery
+    >({
+        id,
+        queries: {
+            grid: {
+                document: manufacturerActionLogsQuery,
+                getActionLogs: (data) => data.manufacturer.actionLogs,
+            },
+            showVersion: {
+                document: manufacturerActionLogShowVersionQuery,
+                getActionLog: (data) => data.manufacturer.actionLog,
+            },
+            compareVersions: {
+                document: manufacturerActionLogCompareVersionsQuery,
+                getActionLogs: (data) => ({
+                    beforeVersion: data.manufacturer.beforeVersion,
+                    afterVersion: data.manufacturer.afterVersion,
+                }),
+            },
+        },
+    });
+
+    return (
+        <StackToolbar>
+            <ToolbarBackButton />
+            <ToolbarAutomaticTitleItem />
+            <FillSpace />
+            <ToolbarActions>
+                <Button variant="textDark" onClick={openActionLogDialog}>
+                    <FormattedMessage id="manufacturer.versionHistory" defaultMessage="Version history" />
+                </Button>
+                <SaveBoundarySaveButton />
+            </ToolbarActions>
+            <ActionLogDialog />
+        </StackToolbar>
+    );
+};
+
+const AddFormToolbar = () => (
     <StackToolbar>
         <ToolbarBackButton />
         <ToolbarAutomaticTitleItem />
@@ -41,7 +94,7 @@ export function ManufacturersPage() {
                 <StackPage name="edit" title={intl.formatMessage({ id: "products.editManufacturers", defaultMessage: "Edit Manufacturers" })}>
                     {(selectedId) => (
                         <SaveBoundary>
-                            <FormToolbar />
+                            <EditFormToolbar id={selectedId} />
                             <StackMainContent>
                                 <ManufacturerForm id={selectedId} />
                             </StackMainContent>
@@ -50,7 +103,7 @@ export function ManufacturersPage() {
                 </StackPage>
                 <StackPage name="add" title={intl.formatMessage({ id: "products.addManufacturers", defaultMessage: "Add Manufacturers" })}>
                     <SaveBoundary>
-                        <FormToolbar />
+                        <AddFormToolbar />
                         <StackMainContent>
                             <ManufacturerForm />
                         </StackMainContent>

--- a/demo/admin/src/products/manufacturerActionLogQueries.ts
+++ b/demo/admin/src/products/manufacturerActionLogQueries.ts
@@ -1,0 +1,41 @@
+import { gql } from "@apollo/client";
+import { actionLogCompareFragment, actionLogGridFragment, actionLogShowVersionFragment } from "@comet/cms-admin";
+
+export const manufacturerActionLogsQuery = gql`
+    query ManufacturerActionLogs($id: ID!, $offset: Int!, $limit: Int!, $sort: [ActionLogSort!]) {
+        manufacturer(id: $id) {
+            actionLogs(offset: $offset, limit: $limit, sort: $sort) {
+                nodes {
+                    ...ActionLogGridFragment
+                }
+                totalCount
+            }
+        }
+    }
+    ${actionLogGridFragment}
+`;
+
+export const manufacturerActionLogShowVersionQuery = gql`
+    query ManufacturerActionLogShowVersion($id: ID!, $versionId: ID!) {
+        manufacturer(id: $id) {
+            actionLog(id: $versionId) {
+                ...ActionLogShowVersionFragment
+            }
+        }
+    }
+    ${actionLogShowVersionFragment}
+`;
+
+export const manufacturerActionLogCompareVersionsQuery = gql`
+    query ManufacturerActionLogCompareVersions($id: ID!, $beforeId: ID!, $afterId: ID!) {
+        manufacturer(id: $id) {
+            beforeVersion: actionLog(id: $beforeId) {
+                ...ActionLogCompareFragment
+            }
+            afterVersion: actionLog(id: $afterId) {
+                ...ActionLogCompareFragment
+            }
+        }
+    }
+    ${actionLogCompareFragment}
+`;

--- a/packages/admin/cms-admin/src/actionLog/actionLogDialog/useActionLogDialog.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogDialog/useActionLogDialog.tsx
@@ -1,0 +1,152 @@
+import { type DocumentNode, useQuery } from "@apollo/client";
+import { muiGridSortToGql, useDataGridRemote, usePersistentColumnState } from "@comet/admin";
+import { type ComponentType, useCallback, useMemo, useRef, useState } from "react";
+
+import type { GQLActionLogCompareFragmentFragment } from "../actionLogCompare/ActionLogCompare.gql.generated";
+import type { GQLActionLogGridFragmentFragment } from "../actionLogGrid/ActionLogGrid.gql.generated";
+import type { GQLActionLogShowVersionFragmentFragment } from "../actionLogShowVersion/ActionLogShowVersion.gql.generated";
+import { ActionLogDialog as ActionLogDialogComponent, type ActionLogDialogValue } from "./ActionLogDialog";
+
+type DialogView = { type: "grid" } | { type: "showVersion"; versionId: string } | { type: "compareVersions"; beforeId: string; afterId: string };
+
+type ActionLogsResult = { nodes: GQLActionLogGridFragmentFragment[]; totalCount: number };
+
+type ActionLogDialogQueries<TGridData, TShowVersionData, TCompareVersionsData> = {
+    grid: {
+        document: DocumentNode;
+        getActionLogs: (data: TGridData) => ActionLogsResult | undefined;
+    };
+    showVersion: {
+        document: DocumentNode;
+        getActionLog: (data: TShowVersionData) => GQLActionLogShowVersionFragmentFragment | undefined;
+    };
+    compareVersions: {
+        document: DocumentNode;
+        getActionLogs: (data: TCompareVersionsData) => {
+            beforeVersion: GQLActionLogCompareFragmentFragment | undefined;
+            afterVersion: GQLActionLogCompareFragmentFragment | undefined;
+        };
+    };
+};
+
+type UseActionLogDialogOptions<TGridData, TShowVersionData, TCompareVersionsData> = {
+    id: string;
+    /**
+     * Latest name of the entity, shown in the dialog title.
+     */
+    name?: string;
+    /**
+     * The three GraphQL queries that drive the dialog, paired with accessors that read the relevant nodes out of each response.
+     *
+     * - `grid.document` must declare the variables `$id: ID!, $offset: Int!, $limit: Int!, $sort: [ActionLogSort!]` and select `nodes { ...ActionLogGridFragment }, totalCount`.
+     * - `showVersion.document` must declare `$id: ID!, $versionId: ID!` and select `...ActionLogShowVersionFragment` on the version.
+     * - `compareVersions.document` must declare `$id: ID!, $beforeId: ID!, $afterId: ID!` and select the two versions with `...ActionLogCompareFragment`.
+     */
+    queries: ActionLogDialogQueries<TGridData, TShowVersionData, TCompareVersionsData>;
+    /**
+     * Storage key for the persistent grid column state.
+     */
+    columnStateStorageKey?: string;
+};
+
+type ActionLogDialogApi = {
+    openActionLogDialog: () => void;
+    closeActionLogDialog: () => void;
+};
+
+export function useActionLogDialog<TGridData, TShowVersionData, TCompareVersionsData>({
+    id,
+    name,
+    queries,
+    columnStateStorageKey = "actionLogDialogGrid",
+}: UseActionLogDialogOptions<TGridData, TShowVersionData, TCompareVersionsData>): [ComponentType, ActionLogDialogApi] {
+    const [open, setOpen] = useState(false);
+    const [view, setView] = useState<DialogView>({ type: "grid" });
+
+    const dataGridRemote = useDataGridRemote({ initialSort: [{ field: "version", sort: "desc" }] });
+    const persistentColumnState = usePersistentColumnState(columnStateStorageKey);
+
+    const gridResult = useQuery<TGridData>(queries.grid.document, {
+        skip: !open || view.type !== "grid",
+        variables: {
+            id,
+            offset: dataGridRemote.paginationModel.page * dataGridRemote.paginationModel.pageSize,
+            limit: dataGridRemote.paginationModel.pageSize,
+            sort: muiGridSortToGql(dataGridRemote.sortModel) ?? [],
+        },
+    });
+
+    const showVersionResult = useQuery<TShowVersionData>(queries.showVersion.document, {
+        skip: !open || view.type !== "showVersion",
+        variables: view.type === "showVersion" ? { id, versionId: view.versionId } : undefined,
+    });
+
+    const compareVersionsResult = useQuery<TCompareVersionsData>(queries.compareVersions.document, {
+        skip: !open || view.type !== "compareVersions",
+        variables: view.type === "compareVersions" ? { id, beforeId: view.beforeId, afterId: view.afterId } : undefined,
+    });
+
+    const value: ActionLogDialogValue = useMemo(() => {
+        if (view.type === "showVersion") {
+            return {
+                type: "showVersion",
+                actionLog: showVersionResult.data ? queries.showVersion.getActionLog(showVersionResult.data) : undefined,
+                error: !!showVersionResult.error,
+                loading: showVersionResult.loading,
+            };
+        }
+        if (view.type === "compareVersions") {
+            const versions = compareVersionsResult.data
+                ? queries.compareVersions.getActionLogs(compareVersionsResult.data)
+                : { beforeVersion: undefined, afterVersion: undefined };
+            return {
+                type: "compareVersions",
+                beforeVersion: versions.beforeVersion,
+                afterVersion: versions.afterVersion,
+                error: !!compareVersionsResult.error,
+                loading: compareVersionsResult.loading,
+            };
+        }
+        return {
+            ...dataGridRemote,
+            ...persistentColumnState,
+            type: "grid",
+            actionLogs: gridResult.data ? queries.grid.getActionLogs(gridResult.data) : undefined,
+            error: !!gridResult.error,
+            loading: gridResult.loading,
+        };
+    }, [view, dataGridRemote, persistentColumnState, gridResult, showVersionResult, compareVersionsResult, queries]);
+
+    const openActionLogDialog = useCallback(() => setOpen(true), []);
+    const closeActionLogDialog = useCallback(() => {
+        setOpen(false);
+        setView({ type: "grid" });
+    }, []);
+
+    const api = useMemo<ActionLogDialogApi>(() => ({ openActionLogDialog, closeActionLogDialog }), [openActionLogDialog, closeActionLogDialog]);
+
+    const latestPropsRef = useRef({ id, name, open, value, closeActionLogDialog });
+    latestPropsRef.current = { id, name, open, value, closeActionLogDialog };
+
+    const ActionLogDialog = useMemo<ComponentType>(
+        () =>
+            function ActionLogDialog() {
+                const { id, name, open, value, closeActionLogDialog } = latestPropsRef.current;
+                return (
+                    <ActionLogDialogComponent
+                        id={id}
+                        name={name}
+                        open={open}
+                        value={value}
+                        onClose={closeActionLogDialog}
+                        onShowVersionClick={(versionId) => setView({ type: "showVersion", versionId })}
+                        onCompareVersionsClick={(beforeId, afterId) => setView({ type: "compareVersions", beforeId, afterId })}
+                        onShowVersionHistoryClick={() => setView({ type: "grid" })}
+                    />
+                );
+            },
+        [],
+    );
+
+    return [ActionLogDialog, api];
+}

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -1,6 +1,7 @@
 export { ActionLogCompare } from "./actionLog/actionLogCompare/ActionLogCompare";
 export { actionLogCompareFragment } from "./actionLog/actionLogCompare/ActionLogCompare.gql";
 export { ActionLogDialog, type ActionLogDialogValue } from "./actionLog/actionLogDialog/ActionLogDialog";
+export { useActionLogDialog } from "./actionLog/actionLogDialog/useActionLogDialog";
 export { ActionGridToolbar } from "./actionLog/actionLogGrid/actionGridToolbar/ActionGridToolbar";
 export { ActionLogGrid } from "./actionLog/actionLogGrid/ActionLogGrid";
 export { actionLogGridFragment } from "./actionLog/actionLogGrid/ActionLogGrid.gql";


### PR DESCRIPTION
depends on:

- https://github.com/vivid-planet/comet/pull/4356

Alternative to #5618.

----

## Description

Same goal as #5618 — a `useActionLogDialog` hook that returns a configured `<ActionLogDialog />` and `{ openActionLogDialog, closeActionLogDialog }` so an app integration boils down to ~6 lines. This PR explores a different trade-off on **how the three GraphQL queries are supplied**:

| | #5618 (dynamic) | This PR (explicit) |
|---|---|---|
| Query source | Composed by the hook at runtime from a `rootField` string | App declares 3 typed `gql` documents using the library's exported fragments |
| Codegen typing | Response cast internally; only `rootField` is statically constrained | Full end-to-end typing via `TGridData`, `TShowVersionData`, `TCompareVersionsData` generics |
| Per-entity boilerplate | 0 lines | One `<entity>ActionLogQueries.ts` file (~40 lines for 3 queries) |
| Customization (extra fields, scoped variables, content language, etc.) | Not possible without escape hatch | Native — the queries are the app's |
| Hook surface | `rootField: string` | `queries: { grid, showVersion, compareVersions }` with `document` + accessor each |

The hook itself is otherwise identical to #5618: same `[ActionLogDialog, api]` tuple return, same stable component identity (ref-based, no flicker on sort/page), same internal state machine for the three views.

## Full application usage

Integrating the hook for a new entity requires two app-side files.

### 1. Three queries (one new file per entity)

The app declares the three queries using the library's exported fragments. Variable shapes are dictated by the hook (`$id, $offset, $limit, $sort` for the grid; `$id, $versionId` for show; `$id, $beforeId, $afterId` for compare).

```ts
// demo/admin/src/products/manufacturerActionLogQueries.ts
import { gql } from "@apollo/client";
import { actionLogCompareFragment, actionLogGridFragment, actionLogShowVersionFragment } from "@comet/cms-admin";

export const manufacturerActionLogsQuery = gql`
    query ManufacturerActionLogs($id: ID!, $offset: Int!, $limit: Int!, $sort: [ActionLogSort!]) {
        manufacturer(id: $id) {
            actionLogs(offset: $offset, limit: $limit, sort: $sort) {
                nodes {
                    ...ActionLogGridFragment
                }
                totalCount
            }
        }
    }
    ${actionLogGridFragment}
`;

export const manufacturerActionLogShowVersionQuery = gql`
    query ManufacturerActionLogShowVersion($id: ID!, $versionId: ID!) {
        manufacturer(id: $id) {
            actionLog(id: $versionId) {
                ...ActionLogShowVersionFragment
            }
        }
    }
    ${actionLogShowVersionFragment}
`;

export const manufacturerActionLogCompareVersionsQuery = gql`
    query ManufacturerActionLogCompareVersions($id: ID!, $beforeId: ID!, $afterId: ID!) {
        manufacturer(id: $id) {
            beforeVersion: actionLog(id: $beforeId) {
                ...ActionLogCompareFragment
            }
            afterVersion: actionLog(id: $afterId) {
                ...ActionLogCompareFragment
            }
        }
    }
    ${actionLogCompareFragment}
`;
```

> The file is intentionally named `manufacturerActionLogQueries.ts` (not `*.gql.ts`). The `*.gql.ts` suffix is reserved by `@comet/no-private-sibling-import` for queries owned by a single component of the same basename. A queries module consumed from elsewhere uses the camelCase utility-file naming.

`codegen` then emits `manufacturerActionLogQueries.generated.ts` with `GQLManufacturerActionLogsQuery`, `GQLManufacturerActionLogShowVersionQuery`, and `GQLManufacturerActionLogCompareVersionsQuery`.

### 2. Hook call + trigger (edit toolbar)

```tsx
// demo/admin/src/products/ManufacturersPage.tsx
import { Button, FillSpace, SaveBoundary, SaveBoundarySaveButton, StackToolbar, ToolbarActions, ToolbarAutomaticTitleItem, ToolbarBackButton } from "@comet/admin";
import { useActionLogDialog } from "@comet/cms-admin";
import {
    manufacturerActionLogCompareVersionsQuery,
    manufacturerActionLogShowVersionQuery,
    manufacturerActionLogsQuery,
} from "@src/products/manufacturerActionLogQueries";
import type {
    GQLManufacturerActionLogCompareVersionsQuery,
    GQLManufacturerActionLogShowVersionQuery,
    GQLManufacturerActionLogsQuery,
} from "@src/products/manufacturerActionLogQueries.generated";
import { FormattedMessage } from "react-intl";

const EditFormToolbar = ({ id }: { id: string }) => {
    const [ActionLogDialog, { openActionLogDialog }] = useActionLogDialog<
        GQLManufacturerActionLogsQuery,
        GQLManufacturerActionLogShowVersionQuery,
        GQLManufacturerActionLogCompareVersionsQuery
    >({
        id,
        queries: {
            grid: {
                document: manufacturerActionLogsQuery,
                getActionLogs: (data) => data.manufacturer.actionLogs,
            },
            showVersion: {
                document: manufacturerActionLogShowVersionQuery,
                getActionLog: (data) => data.manufacturer.actionLog,
            },
            compareVersions: {
                document: manufacturerActionLogCompareVersionsQuery,
                getActionLogs: (data) => ({
                    beforeVersion: data.manufacturer.beforeVersion,
                    afterVersion: data.manufacturer.afterVersion,
                }),
            },
        },
    });

    return (
        <StackToolbar>
            <ToolbarBackButton />
            <ToolbarAutomaticTitleItem />
            <FillSpace />
            <ToolbarActions>
                <Button variant="textDark" onClick={openActionLogDialog}>
                    <FormattedMessage id="manufacturer.versionHistory" defaultMessage="Version history" />
                </Button>
                <SaveBoundarySaveButton />
            </ToolbarActions>
            <ActionLogDialog />
        </StackToolbar>
    );
};
```

That's the full integration — three TypedDocumentNode-typed generics into the hook, three small accessors that point at where the data lives in each response, and the returned `<ActionLogDialog />` rendered prop-less. The accessors are the price for full codegen typing across the response.

## When to prefer this over the dynamic variant

- The app expects entity-specific tweaks (extra fields in `nodes`, custom scope variables, content-language args, …).
- You value codegen-typed responses and accessors over zero boilerplate.

The two variants can co-exist; we'd ship one. Discussion welcome.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-2226
- Companion PR: #5618 (dynamic `rootField` variant)
