### PR TITLE
storybook: Resolve Chromatic refs to the current PR's branch

### DIFF
--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -26,18 +26,27 @@ const config: StorybookConfig = {
         return {
             "@comet/admin": {
                 title: "@comet/admin",
-                url: configType === "DEVELOPMENT" ? "http://localhost:26646/" : "https://main--68e7b70f15b8f51dac492af6.chromatic.com", // TODO: support pull request previews,
+                url: configType === "DEVELOPMENT" ? "http://localhost:26646/" : chromaticUrl("68e7b70f15b8f51dac492af6"),
             },
             "@comet/cms-admin": {
                 title: "@comet/cms-admin",
-                url: configType === "DEVELOPMENT" ? "http://localhost:26647/" : "https://main--69df3371c46abe69b5199825.chromatic.com",
+                url: configType === "DEVELOPMENT" ? "http://localhost:26647/" : chromaticUrl("69df3371c46abe69b5199825"),
             },
             "@comet/mail-react": {
                 title: "@comet/mail-react",
-                url: configType === "DEVELOPMENT" ? "http://localhost:6066/" : "https://main--69df33e9280a36be495d6521.chromatic.com",
+                url: configType === "DEVELOPMENT" ? "http://localhost:6066/" : chromaticUrl("69df33e9280a36be495d6521"),
             },
         };
     },
 };
+
+// On Netlify deploy-previews, `HEAD` is the PR source branch; on branch-deploys, `BRANCH` is the deployed branch.
+// Chromatic publishes a build per branch at `https://<sanitized-branch>--<projectId>.chromatic.com`,
+// where the branch is lowercased and non-alphanumeric characters become `-`.
+function chromaticUrl(projectId: string): string {
+    const branch = process.env.HEAD ?? process.env.BRANCH ?? "main";
+    const sanitizedBranch = branch.toLowerCase().replace(/[^a-z0-9]/g, "-");
+    return `https://${sanitizedBranch}--${projectId}.chromatic.com`;
+}
 
 export default config;


### PR DESCRIPTION
## Summary

The Storybook composition in [storybook/.storybook/main.ts](storybook/.storybook/main.ts) hard-coded the Chromatic refs to `main--<projectId>.chromatic.com`. On Netlify deploy-previews this meant the composed sub-Storybooks (`@comet/admin`, `@comet/cms-admin`, `@comet/mail-react`) always showed stories from `main`, hiding any component changes made in the PR.

This resolves the existing `TODO: support pull request previews` by deriving the branch from Netlify's deploy env vars (`HEAD` on deploy-previews, `BRANCH` on branch-deploys, falling back to `main`) and sanitizing it for Chromatic's per-branch URL pattern (`https://<sanitized-branch>--<projectId>.chromatic.com`).

`.github/workflows/chromatic.yml` already publishes a build per PR branch to all three Chromatic projects, so the matching branch URL exists by the time the Netlify deploy-preview composes them.

## Test plan

- [ ] Open this draft PR, wait for the Netlify deploy-preview, and confirm composed sub-Storybooks load stories from this branch (not from `main`).
- [ ] Push a story change in one of the composed packages on the same branch and confirm it appears in the deploy-preview composition.
- [ ] Verify the production Netlify build (after merge to `main`) still resolves to the `main--...` URLs.