### PR TITLE
storybook: Resolve Chromatic refs to the current PR's branch

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,18 +2,10 @@ name: Chromatic
 
 on:
     pull_request:
-        paths:
-            - packages/admin/admin/**
-            - packages/admin/cms-admin/**
-            - packages/mail-react/**
         branches:
             - main
             - next
     push:
-        paths:
-            - packages/admin/admin/**
-            - packages/admin/cms-admin/**
-            - packages/mail-react/**
         branches:
             - main
             - next

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -26,18 +26,27 @@ const config: StorybookConfig = {
         return {
             "@comet/admin": {
                 title: "@comet/admin",
-                url: configType === "DEVELOPMENT" ? "http://localhost:26646/" : "https://main--68e7b70f15b8f51dac492af6.chromatic.com", // TODO: support pull request previews,
+                url: configType === "DEVELOPMENT" ? "http://localhost:26646/" : chromaticUrl("68e7b70f15b8f51dac492af6"),
             },
             "@comet/cms-admin": {
                 title: "@comet/cms-admin",
-                url: configType === "DEVELOPMENT" ? "http://localhost:26647/" : "https://main--69df3371c46abe69b5199825.chromatic.com",
+                url: configType === "DEVELOPMENT" ? "http://localhost:26647/" : chromaticUrl("69df3371c46abe69b5199825"),
             },
             "@comet/mail-react": {
                 title: "@comet/mail-react",
-                url: configType === "DEVELOPMENT" ? "http://localhost:6066/" : "https://main--69df33e9280a36be495d6521.chromatic.com",
+                url: configType === "DEVELOPMENT" ? "http://localhost:6066/" : chromaticUrl("69df33e9280a36be495d6521"),
             },
         };
     },
 };
+
+// On Netlify deploy-previews, `HEAD` is the PR source branch; on branch-deploys, `BRANCH` is the deployed branch.
+// Chromatic publishes a build per branch at `https://<sanitized-branch>--<projectId>.chromatic.com`,
+// where the branch is lowercased and non-alphanumeric characters become `-`.
+function chromaticUrl(projectId: string): string {
+    const branch = process.env.HEAD ?? process.env.BRANCH ?? "main";
+    const sanitizedBranch = branch.toLowerCase().replace(/[^a-z0-9]/g, "-");
+    return `https://${sanitizedBranch}--${projectId}.chromatic.com`;
+}
 
 export default config;

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -42,10 +42,14 @@ const config: StorybookConfig = {
 
 // On Netlify deploy-previews, `HEAD` is the PR source branch; on branch-deploys, `BRANCH` is the deployed branch.
 // Chromatic publishes a build per branch at `https://<sanitized-branch>--<projectId>.chromatic.com`,
-// where the branch is lowercased and non-alphanumeric characters become `-`.
+// where the branch is lowercased, runs of unsupported characters become a single `-`, and the
+// result is truncated to 37 characters. See https://www.chromatic.com/docs/permalinks/.
 function chromaticUrl(projectId: string): string {
     const branch = process.env.HEAD ?? process.env.BRANCH ?? "main";
-    const sanitizedBranch = branch.toLowerCase().replace(/[^a-z0-9]/g, "-");
+    const sanitizedBranch = branch
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .slice(0, 37);
     return `https://${sanitizedBranch}--${projectId}.chromatic.com`;
 }
 


### PR DESCRIPTION
## Summary

The Storybook composition in [storybook/.storybook/main.ts](storybook/.storybook/main.ts) hard-coded the Chromatic refs to `main--<projectId>.chromatic.com`. On Netlify deploy-previews this meant the composed sub-Storybooks (`@comet/admin`, `@comet/cms-admin`, `@comet/mail-react`) always showed stories from `main`, hiding any component changes made in the PR.

To keep the composition and its referenced sub-Storybooks in sync, `.github/workflows/chromatic.yml` now runs on every PR — the previous `paths:` filter skipped Chromatic for PRs that did not touch `packages/admin/admin/**`, `packages/admin/cms-admin/**`, or `packages/mail-react/**`, leaving the composition pointing at branch URLs that did not exist.

<img width="2564" height="1378" alt="Screenshot 2026-05-20 at 09 19 59" src="https://github.com/user-attachments/assets/ec9b5a45-0656-452e-b963-f547460fd0e9" />

