### PR TITLE
docs: Support deploy previews for the docusaurus navbar Storybook link

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -4,6 +4,20 @@ const { themes } = require("prism-react-renderer");
 const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
 
+// Both this docs site and the Storybook composition are deployed via Netlify with wildcard DNS
+// for `*.storybook.comet-dxp.com`. Mirror the runtime mapping in StorybookAdminComponentDocsIframe
+// so the navbar link follows the docs deploy context: a PR's deploy-preview links to its matching
+// Storybook deploy-preview, `next` to `next.storybook.comet-dxp.com`, and main to production.
+function getStorybookUrl() {
+    if (process.env.CONTEXT === "deploy-preview" && process.env.REVIEW_ID) {
+        return `https://deploy-preview-${process.env.REVIEW_ID}.storybook.comet-dxp.com/`;
+    }
+    if (process.env.BRANCH === "next") {
+        return "https://next.storybook.comet-dxp.com/";
+    }
+    return "https://storybook.comet-dxp.com/";
+}
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
     title: "COMET DXP Docs",
@@ -55,7 +69,7 @@ const config = {
                         label: "Docs",
                     },
                     {
-                        href: "https://storybook.comet-dxp.com/",
+                        href: getStorybookUrl(),
                         position: "right",
                         label: "Storybook",
                     },


### PR DESCRIPTION
## Summary

The navbar Storybook link in [docs/docusaurus.config.js](docs/docusaurus.config.js) was hard-coded to `https://storybook.comet-dxp.com/`, so PR deploy-previews of the docs always sent visitors to the `main` branch's Storybook instead of the matching deploy-preview — hiding the very component changes the PR author wanted to review.

This mirrors the runtime mapping, using Netlify's deploy env vars:

- `CONTEXT === "deploy-preview"` → `https://deploy-preview-${REVIEW_ID}.storybook.comet-dxp.com/`
- `BRANCH === "next"` → `https://next.storybook.comet-dxp.com/`
- otherwise → `https://storybook.comet-dxp.com/`

Both this docs site and the Storybook composition are deployed via Netlify with wildcard DNS for `*.storybook.comet-dxp.com`, so the deploy-preview subdomain resolves to the matching Storybook deploy-preview.

<img width="1281" height="1368" alt="Screenshot 2026-05-20 at 09 18 32" src="https://github.com/user-attachments/assets/6d84215f-d99a-45ee-ae1a-ad989086f485" />

