### PR TITLE
Add a `urlTemplate` field resolver to `FileImagesResolver`

### DIFF
--- a/.changeset/cool-streets-relax.md
+++ b/.changeset/cool-streets-relax.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": minor
+---
+
+Add a `urlTemplate` field resolver to `FileImagesResolver`

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -406,6 +406,7 @@ type DamFileImage {
   height: Int!
   id: ID!
   url(height: Int!, width: Int!): String
+  urlTemplate: String
   width: Int!
 }
 

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -134,6 +134,7 @@ type DamFileImage {
   exif: JSONObject
   dominantColor: String
   cropArea: ImageCropArea!
+  urlTemplate: String
   url(width: Int!, height: Int!): String
 }
 

--- a/packages/api/cms-api/src/dam/files/file-image.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/file-image.resolver.ts
@@ -15,6 +15,21 @@ export class FileImagesResolver {
     ) {}
 
     @ResolveField(() => String, { nullable: true })
+    async urlTemplate(@Parent() fileImage: DamFileImage, @Context("req") req: IncomingMessage): Promise<string | undefined> {
+        const file = await this.filesService.findOneByImageId(fileImage.id);
+
+        if (file) {
+            const urlTemplate = this.imagesService.createUrlTemplate(
+                { file },
+                {
+                    previewDamUrls: Boolean(req.headers["x-preview-dam-urls"]),
+                },
+            );
+            return urlTemplate;
+        }
+    }
+
+    @ResolveField(() => String, { nullable: true })
     async url(
         @Args("width", { type: () => Int }) width: number,
         @Args("height", { type: () => Int }) height: number,


### PR DESCRIPTION
Currently, the `urlTemplate` is only exposed via the PixelImageBlock (see https://github.com/vivid-planet/comet/blob/b039dcb615340d8f6b495f0777c3657822731cbe/packages/api/cms-api/src/dam/blocks/pixel-image.block.ts#L173). 

This is a problem if a DamImage is used via `FileField` (without a block). Then I don't have the possibility to use it as a responsive image because I can't get the urlTemplate with the placeholders.