### PR TITLE
Renovate: configure maximum memory

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["github>vivid-planet/comet//renovate/default"],
-    "postUpdateOptions": ["pnpmDedupe"]
+    "postUpdateOptions": ["pnpmDedupe"],
+    "toolSettings": {
+        "nodeMaxMemory": 2560
+    }
 }


### PR DESCRIPTION
Set `toolSettings.nodeMaxMemory` to 2.5 GB (as recommended [here](https://docs.renovatebot.com/mend-hosted/faq/#im-hitting-a-timeout-kernel-out-of-memory-limit-with-a-pnpmyarn-project)) in an attempt to fix Renovate frequently running into OOM errors.