### PR TITLE
Fix VimeoVideoBlock autoplay race on initial page load

### DIFF
--- a/.changeset/fix-vimeo-video-block-autoplay-race.md
+++ b/.changeset/fix-vimeo-video-block-autoplay-race.md
@@ -5,3 +5,5 @@
 Fix `VimeoVideoBlock` not autoplaying on initial page load when `autoplay` is enabled and no `previewImage` is set
 
 Without a `previewImage`, the iframe URL was missing `autoplay=1` and playback relied on a `postMessage("play")` fired from the `IntersectionObserver` callback. That message raced against the Vimeo player's initialization inside the iframe — when it arrived first the message was dropped and the video stayed paused, while the `PlayPauseButton` optimistically showed the "Pause" state, requiring two clicks to recover. `autoplay=1` is now appended whenever `autoplay` is enabled so Vimeo handles autoplay natively. The existing `muted=1` param satisfies the browser autoplay policy.
+
+The iframe is also marked with `loading="lazy"` so blocks far below the fold don't request the Vimeo player upfront.

--- a/.changeset/fix-vimeo-video-block-autoplay-race.md
+++ b/.changeset/fix-vimeo-video-block-autoplay-race.md
@@ -1,0 +1,7 @@
+---
+"@comet/site-react": patch
+---
+
+Fix `VimeoVideoBlock` not autoplaying on initial page load when `autoplay` is enabled and no `previewImage` is set
+
+Without a `previewImage`, the iframe URL was missing `autoplay=1` and playback relied on a `postMessage("play")` fired from the `IntersectionObserver` callback. That message raced against the Vimeo player's initialization inside the iframe — when it arrived first the message was dropped and the video stayed paused, while the `PlayPauseButton` optimistically showed the "Pause" state, requiring two clicks to recover. `autoplay=1` is now appended whenever `autoplay` is enabled so Vimeo handles autoplay natively. The existing `muted=1` param satisfies the browser autoplay policy.

--- a/packages/site/site-react/src/blocks/VimeoVideoBlock.tsx
+++ b/packages/site/site-react/src/blocks/VimeoVideoBlock.tsx
@@ -92,7 +92,7 @@ export const VimeoVideoBlock = withPreview(
         const identifier = parseVimeoIdentifier(vimeoIdentifier);
 
         const searchParams = new URLSearchParams();
-        if (hasPreviewImage && !showPreviewImage) {
+        if (autoplay || (hasPreviewImage && !showPreviewImage)) {
             searchParams.append("autoplay", "1");
         }
         if (autoplay) {

--- a/packages/site/site-react/src/blocks/VimeoVideoBlock.tsx
+++ b/packages/site/site-react/src/blocks/VimeoVideoBlock.tsx
@@ -142,7 +142,14 @@ export const VimeoVideoBlock = withPreview(
                         className={clsx(styles.videoContainer, fill && styles.fill)}
                         style={!fill ? { "--aspect-ratio": aspectRatio.replace("x", "/") } : undefined}
                     >
-                        <iframe ref={iframeRef} className={styles.vimeoContainer} src={vimeoUrl.toString()} allow="autoplay" allowFullScreen />
+                        <iframe
+                            ref={iframeRef}
+                            className={styles.vimeoContainer}
+                            src={vimeoUrl.toString()}
+                            allow="autoplay"
+                            allowFullScreen
+                            loading="lazy"
+                        />
                         {!showControls &&
                             (PlayPauseButtonComponent ? (
                                 <PlayPauseButtonComponent isPlaying={isPlaying} onClick={handlePlayPauseClick} />


### PR DESCRIPTION
## Problem

`VimeoVideoBlock` does not reliably autoplay on page reload when `autoplay` and `loop` are enabled and no `previewImage` is configured. The `PlayPauseButton` ends up in an inconsistent state ("Pause" icon shown, but video is actually paused). Two clicks are required to start playback.

### Reproduction

1. Place a `VimeoVideoBlock` at the top of a page (above the fold).
2. Configure: `autoplay: true`, `loop: true`, no `previewImage`.
3. Reload the page with DevTools closed.
4. Observe: video does not autoplay; `PlayPauseButton` shows "Pause" icon; first click pauses (silently); second click plays.

## Root cause

The iframe URL only received `autoplay=1` when a `previewImage` was just hidden. Without a `previewImage` the component relied on a `postMessage({ method: "play" })` from the `IntersectionObserver` callback, which races against the Vimeo player's initialization inside the iframe — if it arrives first, the message is dropped.

## Solution

Append `autoplay=1` whenever `autoplay` is enabled, so Vimeo handles autoplay natively. The existing `muted=1` param already satisfies the browser autoplay policy.

```diff
- if (hasPreviewImage && !showPreviewImage) searchParams.append("autoplay", "1");
+ if (autoplay || (hasPreviewImage && !showPreviewImage)) searchParams.append("autoplay", "1");
```
## Screencasts


| Before | After |
| --- | --- |
|  <video src='https://github.com/user-attachments/assets/03a8192b-5d04-4ada-bb42-ec6248edc4a6' />  |  <video src='https://github.com/user-attachments/assets/55f5677b-822e-4469-a7d2-6835288fa745' />  |

## Changeset

Patch bump for `@comet/site-react`.
