### PR TITLE
Remove unused @types/uuid dependency

### DIFF
--- a/packages/api/brevo-api/package.json
+++ b/packages/api/brevo-api/package.json
@@ -64,7 +64,6 @@
         "@nestjs/platform-express": "^11.1.21",
         "@types/inquirer": "^8.2.12",
         "@types/lodash.isequal": "^4.5.8",
-        "@types/uuid": "^11.0.0",
         "chokidar-cli": "^2.1.0",
         "eslint": "^9.39.4",
         "express": "^5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1946,9 +1946,6 @@ importers:
       '@types/lodash.isequal':
         specifier: ^4.5.8
         version: 4.5.8
-      '@types/uuid':
-        specifier: ^11.0.0
-        version: 11.0.0
       chokidar-cli:
         specifier: ^2.1.0
         version: 2.1.0
@@ -8977,10 +8974,6 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
-
-  '@types/uuid@11.0.0':
-    resolution: {integrity: sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==}
-    deprecated: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
@@ -26175,10 +26168,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
-
-  '@types/uuid@11.0.0':
-    dependencies:
-      uuid: 11.1.1
 
   '@types/validator@13.15.10': {}
 


### PR DESCRIPTION
## Summary
Removed the unused `@types/uuid` dev dependency from the brevo-api package.

## Changes
- Removed `@types/uuid` (^11.0.0) from devDependencies in `packages/api/brevo-api/package.json`
- Updated lockfile to reflect the removal

## Details
This dependency was not being utilized in the codebase and has been removed to reduce unnecessary package bloat and maintenance overhead.

https://claude.ai/code/session_0138JnQeDRg9NusWEE6Vja9v