### PR TITLE
Fix test report workflow

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -12,7 +12,5 @@ jobs:
               with:
                   artifact: test-results
                   name: Tests
-                  path: |
-                      packages/*/junit.xml
-                      packages/*/*/junit.xml
+                  path: "**/junit.xml"
                   reporter: jest-junit


### PR DESCRIPTION
Changing `path` from `**/junit.xml` to `packages/*/junit.xml` and `packages/**/junit.xml` in https://github.com/vivid-planet/comet/pull/5656 broke the test report workflow because files are uploaded without the packages/ prefix. Revert to `**/junit.xml` to resolve the issue. This should be fine because the test workflow only uploads package outputs.