### PR TITLE
Ignore .claude/worktrees/ to skip them during local linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ junit.xml
 .cursor/rules/
 .claude/skills/
 .claude/rules/
+.claude/worktrees/
 .github/instructions/


### PR DESCRIPTION
## Summary

- Add `.claude/worktrees/` to `.gitignore` so files inside Claude Code worktrees are not picked up by `pnpm run lint` locally.


<img width="913" height="797" alt="Screenshot 2026-05-21 at 13 22 12" src="https://github.com/user-attachments/assets/83118758-4b3a-4c29-b2dd-9d949b982835" />
