### PR TITLE
Add tests for useStoredState

### DIFF
--- a/packages/admin/admin/src/hooks/__tests__/useStoredState.test.ts
+++ b/packages/admin/admin/src/hooks/__tests__/useStoredState.test.ts
@@ -3,6 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { useStoredState } from "../useStoredState";
 
+function stored<T>(value: T): string {
+    return JSON.stringify(value);
+}
+
+function fromStorage<T>(storage: Storage, key: string): T {
+    return JSON.parse(storage.getItem(key) as string) as T;
+}
+
 function createMockStorage(initial: Record<string, string> = {}): Storage {
     const store: Record<string, string> = { ...initial };
     return {
@@ -32,13 +40,15 @@ describe("useStoredState", () => {
     it("returns the initial value when no stored value exists", () => {
         const storage = createMockStorage();
         const { result } = renderHook(() => useStoredState("my-key", "hello", storage));
-        expect(result.current[0]).toBe("hello");
+        const [value] = result.current;
+        expect(value).toBe("hello");
     });
 
     it("returns the stored value when localStorage already has a value", () => {
-        const storage = createMockStorage({ "my-key": JSON.stringify("stored") });
+        const storage = createMockStorage({ "my-key": stored("stored") });
         const { result } = renderHook(() => useStoredState("my-key", "default", storage));
-        expect(result.current[0]).toBe("stored");
+        const [value] = result.current;
+        expect(value).toBe("stored");
     });
 
     it("persists state updates to storage", () => {
@@ -46,24 +56,29 @@ describe("useStoredState", () => {
         const { result } = renderHook(() => useStoredState<string>("my-key", "initial", storage));
 
         act(() => {
-            result.current[1]("updated");
+            const [, setValue] = result.current;
+            setValue("updated");
         });
 
-        expect(result.current[0]).toBe("updated");
-        expect(JSON.parse(storage.getItem("my-key") as string)).toBe("updated");
+        const [value] = result.current;
+        expect(value).toBe("updated");
+        expect(fromStorage<string>(storage, "my-key")).toBe("updated");
     });
 
     it("skips storage when key is false", () => {
         const storage = createMockStorage();
         const { result } = renderHook(() => useStoredState<string>(false, "default-value", storage));
 
-        expect(result.current[0]).toBe("default-value");
+        const [initialValue] = result.current;
+        expect(initialValue).toBe("default-value");
 
         act(() => {
-            result.current[1]("changed");
+            const [, setValue] = result.current;
+            setValue("changed");
         });
 
-        expect(result.current[0]).toBe("changed");
+        const [updatedValue] = result.current;
+        expect(updatedValue).toBe("changed");
         expect(storage.length).toBe(0);
     });
 
@@ -72,8 +87,9 @@ describe("useStoredState", () => {
         const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
         const { result } = renderHook(() => useStoredState("bad-key", 42, storage));
+        const [value] = result.current;
 
-        expect(result.current[0]).toBe(42);
+        expect(value).toBe(42);
         expect(consoleSpy).toHaveBeenCalled();
     });
 
@@ -81,24 +97,27 @@ describe("useStoredState", () => {
         const storage = createMockStorage();
         const init = vi.fn(() => "computed");
         const { result } = renderHook(() => useStoredState("fn-key", init, storage));
+        const [value] = result.current;
 
-        expect(result.current[0]).toBe("computed");
+        expect(value).toBe("computed");
         expect(init).toHaveBeenCalledOnce();
     });
 
     it("does NOT call the initializer function when a stored value exists", () => {
-        const storage = createMockStorage({ "fn-key": JSON.stringify("from-storage") });
+        const storage = createMockStorage({ "fn-key": stored("from-storage") });
         const init = vi.fn(() => "computed");
         const { result } = renderHook(() => useStoredState("fn-key", init, storage));
+        const [value] = result.current;
 
-        expect(result.current[0]).toBe("from-storage");
+        expect(value).toBe("from-storage");
         expect(init).not.toHaveBeenCalled();
     });
 
     it("correctly returns stored boolean false (truthy string 'false' parses to false)", () => {
-        const storage = createMockStorage({ "bool-key": JSON.stringify(false) });
+        const storage = createMockStorage({ "bool-key": stored(false) });
         const { result } = renderHook(() => useStoredState("bool-key", true, storage));
-        expect(result.current[0]).toBe(false);
+        const [value] = result.current;
+        expect(value).toBe(false);
     });
 
     it("works with complex object values", () => {
@@ -108,10 +127,12 @@ describe("useStoredState", () => {
 
         const updated = { count: 1, labels: ["a", "b", "c"] };
         act(() => {
-            result.current[1](updated);
+            const [, setValue] = result.current;
+            setValue(updated);
         });
 
-        expect(result.current[0]).toEqual(updated);
-        expect(JSON.parse(storage.getItem("obj-key") as string)).toEqual(updated);
+        const [value] = result.current;
+        expect(value).toEqual(updated);
+        expect(fromStorage<typeof updated>(storage, "obj-key")).toEqual(updated);
     });
 });

--- a/packages/admin/admin/src/hooks/__tests__/useStoredState.test.ts
+++ b/packages/admin/admin/src/hooks/__tests__/useStoredState.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "test-utils";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { useStoredState } from "../useStoredState";
 
@@ -30,11 +30,6 @@ function createMockStorage(initial: Record<string, string> = {}): Storage {
         key: (index: number) => Object.keys(store)[index] ?? null,
     };
 }
-
-afterEach(() => {
-    localStorage.clear();
-    vi.restoreAllMocks();
-});
 
 describe("useStoredState", () => {
     it("returns the initial value when no stored value exists", () => {

--- a/packages/admin/admin/src/hooks/__tests__/useStoredState.test.ts
+++ b/packages/admin/admin/src/hooks/__tests__/useStoredState.test.ts
@@ -1,0 +1,117 @@
+import { act, renderHook } from "test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useStoredState } from "../useStoredState";
+
+function createMockStorage(initial: Record<string, string> = {}): Storage {
+    const store: Record<string, string> = { ...initial };
+    return {
+        getItem: (key: string) => store[key] ?? null,
+        setItem: (key: string, value: string) => {
+            store[key] = value;
+        },
+        removeItem: (key: string) => {
+            delete store[key];
+        },
+        clear: () => {
+            Object.keys(store).forEach((k) => delete store[k]);
+        },
+        get length() {
+            return Object.keys(store).length;
+        },
+        key: (index: number) => Object.keys(store)[index] ?? null,
+    };
+}
+
+afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+});
+
+describe("useStoredState", () => {
+    it("returns the initial value when no stored value exists", () => {
+        const storage = createMockStorage();
+        const { result } = renderHook(() => useStoredState("my-key", "hello", storage));
+        expect(result.current[0]).toBe("hello");
+    });
+
+    it("returns the stored value when localStorage already has a value", () => {
+        const storage = createMockStorage({ "my-key": JSON.stringify("stored") });
+        const { result } = renderHook(() => useStoredState("my-key", "default", storage));
+        expect(result.current[0]).toBe("stored");
+    });
+
+    it("persists state updates to storage", () => {
+        const storage = createMockStorage();
+        const { result } = renderHook(() => useStoredState<string>("my-key", "initial", storage));
+
+        act(() => {
+            result.current[1]("updated");
+        });
+
+        expect(result.current[0]).toBe("updated");
+        expect(JSON.parse(storage.getItem("my-key") as string)).toBe("updated");
+    });
+
+    it("skips storage when key is false", () => {
+        const storage = createMockStorage();
+        const { result } = renderHook(() => useStoredState<string>(false, "default-value", storage));
+
+        expect(result.current[0]).toBe("default-value");
+
+        act(() => {
+            result.current[1]("changed");
+        });
+
+        expect(result.current[0]).toBe("changed");
+        expect(storage.length).toBe(0);
+    });
+
+    it("falls back to initial value when stored JSON is malformed", () => {
+        const storage = createMockStorage({ "bad-key": "{ not valid json" });
+        const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+        const { result } = renderHook(() => useStoredState("bad-key", 42, storage));
+
+        expect(result.current[0]).toBe(42);
+        expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    it("accepts an initializer function instead of a plain value", () => {
+        const storage = createMockStorage();
+        const init = vi.fn(() => "computed");
+        const { result } = renderHook(() => useStoredState("fn-key", init, storage));
+
+        expect(result.current[0]).toBe("computed");
+        expect(init).toHaveBeenCalledOnce();
+    });
+
+    it("does NOT call the initializer function when a stored value exists", () => {
+        const storage = createMockStorage({ "fn-key": JSON.stringify("from-storage") });
+        const init = vi.fn(() => "computed");
+        const { result } = renderHook(() => useStoredState("fn-key", init, storage));
+
+        expect(result.current[0]).toBe("from-storage");
+        expect(init).not.toHaveBeenCalled();
+    });
+
+    it("correctly returns stored boolean false (truthy string 'false' parses to false)", () => {
+        const storage = createMockStorage({ "bool-key": JSON.stringify(false) });
+        const { result } = renderHook(() => useStoredState("bool-key", true, storage));
+        expect(result.current[0]).toBe(false);
+    });
+
+    it("works with complex object values", () => {
+        const storage = createMockStorage();
+        const initial = { count: 0, labels: ["a", "b"] };
+        const { result } = renderHook(() => useStoredState("obj-key", initial, storage));
+
+        const updated = { count: 1, labels: ["a", "b", "c"] };
+        act(() => {
+            result.current[1](updated);
+        });
+
+        expect(result.current[0]).toEqual(updated);
+        expect(JSON.parse(storage.getItem("obj-key") as string)).toEqual(updated);
+    });
+});


### PR DESCRIPTION
## What

Adds Vitest tests for `useStoredState` — a localStorage-backed state hook exported from `@comet/admin`.

## Tests added

`packages/admin/admin/src/hooks/__tests__/useStoredState.test.ts` (9 tests):

- **Happy path**: returns initial value when nothing is stored; returns stored value when key exists in storage; persists state updates back to storage
- **Edge cases**:
  - `key === false` skips all storage reads/writes (in-memory only mode)
  - Malformed JSON in storage falls back to the initial value and logs the error
  - Initializer function is called when no stored value exists, but skipped when a stored value is present
  - Stored boolean `false` (persisted as the string `"false"`) is correctly restored
  - Complex object values round-trip through JSON correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01JchRRniFQXMhHeuffeoTWz)_