### PR TITLE
Fix selecting files from folders in `FileField`

### DIFF
--- a/.changeset/fix-dam-files-list-ids-folder-bypass.md
+++ b/.changeset/fix-dam-files-list-ids-folder-bypass.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix `damFilesList` returning no files in subfolders when filtering by `ids`
+
+`damFilesList` implicitly constrains to the scope root when no `folderId` is passed. The constraint already had an escape hatch for `filter.searchText`; the same now applies to `filter.ids`. Resolving a selection via `filter: { ids: ... }` returns all matching files regardless of which folder they live in, which unblocks the admin `FileField` multi-select for files in subfolders.

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -644,8 +644,15 @@ type EntityInfo {
 }
 
 input FileFilterInput {
+  """
+  Restrict the result to files with these IDs. When a non-empty list is provided, the folder constraint is bypassed and matches are returned regardless of which folder they live in.
+  """
   ids: [ID!]
   mimetypes: [String!]
+
+  """
+  Full-text search across file names. When set, the folder constraint is bypassed and results span the whole scope.
+  """
   searchText: String
 }
 
@@ -1942,7 +1949,20 @@ type Query {
   currentUser: CurrentUser!
   damAreFilenamesOccupied(filenames: [FilenameInput!]!, scope: DamScopeInput!): [FilenameResponse!]!
   damFile(id: ID!): DamFile!
-  damFilesList(filter: FileFilterInput, folderId: ID, includeArchived: Boolean = false, limit: Int! = 25, offset: Int! = 0, scope: DamScopeInput!, sortColumnName: String, sortDirection: SortDirection! = ASC): PaginatedDamFiles!
+  damFilesList(
+    filter: FileFilterInput
+
+    """
+    Folder to list files from. When omitted, files at the scope root are returned. Ignored when filter.searchText or filter.ids is set.
+    """
+    folderId: ID
+    includeArchived: Boolean = false
+    limit: Int! = 25
+    offset: Int! = 0
+    scope: DamScopeInput!
+    sortColumnName: String
+    sortDirection: SortDirection! = ASC
+  ): PaginatedDamFiles!
   damFolder(id: ID!): DamFolder!
   damFolderByNameAndParentId(name: String!, parentId: ID, scope: DamScopeInput!): DamFolder
   damFoldersFlat(scope: DamScopeInput!): [DamFolder!]!

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -510,7 +510,20 @@ type Query {
   redirectSourceAvailable(scope: RedirectScopeInput! = {}, source: String!): Boolean!
   damItemsList(offset: Int! = 0, limit: Int! = 25, sortColumnName: String, sortDirection: SortDirection! = ASC, scope: DamScopeInput! = {}, folderId: ID, includeArchived: Boolean, filter: DamItemFilterInput): PaginatedDamItems!
   damItemListPosition(sortColumnName: String, sortDirection: SortDirection! = ASC, scope: DamScopeInput! = {}, id: ID!, type: DamItemType!, folderId: ID, includeArchived: Boolean, filter: DamItemFilterInput): Int!
-  damFilesList(offset: Int! = 0, limit: Int! = 25, sortColumnName: String, sortDirection: SortDirection! = ASC, scope: DamScopeInput! = {}, folderId: ID, includeArchived: Boolean = false, filter: FileFilterInput): PaginatedDamFiles!
+  damFilesList(
+    offset: Int! = 0
+    limit: Int! = 25
+    sortColumnName: String
+    sortDirection: SortDirection! = ASC
+    scope: DamScopeInput! = {}
+
+    """
+    Folder to list files from. When omitted, files at the scope root are returned. Ignored when filter.searchText or filter.ids is set.
+    """
+    folderId: ID
+    includeArchived: Boolean = false
+    filter: FileFilterInput
+  ): PaginatedDamFiles!
   damFile(id: ID!): DamFile!
   findCopiesOfFileInScope(id: ID!, scope: DamScopeInput! = {}, imageCropArea: ImageCropAreaInput): [DamFile!]!
   damIsFilenameOccupied(filename: String!, scope: DamScopeInput! = {}, folderId: String): Boolean!
@@ -608,8 +621,15 @@ enum DamItemType {
 }
 
 input FileFilterInput {
+  """
+  Full-text search across file names. When set, the folder constraint is bypassed and results span the whole scope.
+  """
   searchText: String
   mimetypes: [String!]
+
+  """
+  Restrict the result to files with these IDs. When a non-empty list is provided, the folder constraint is bypassed and matches are returned regardless of which folder they live in.
+  """
   ids: [ID!]
 }
 

--- a/packages/api/cms-api/src/dam/files/dto/file.args.ts
+++ b/packages/api/cms-api/src/dam/files/dto/file.args.ts
@@ -11,7 +11,10 @@ import { EmptyDamScope } from "./empty-dam-scope";
 
 @InputType()
 export class FileFilterInput {
-    @Field({ nullable: true })
+    @Field({
+        nullable: true,
+        description: "Full-text search across file names. When set, the folder constraint is bypassed and results span the whole scope.",
+    })
     @IsOptional()
     @IsString()
     searchText?: string;
@@ -21,7 +24,11 @@ export class FileFilterInput {
     @IsString({ each: true })
     mimetypes?: string[];
 
-    @Field(() => [ID], { nullable: true })
+    @Field(() => [ID], {
+        nullable: true,
+        description:
+            "Restrict the result to files with these IDs. When a non-empty list is provided, the folder constraint is bypassed and matches are returned regardless of which folder they live in.",
+    })
     @IsOptional()
     @IsUUID(4, { each: true })
     ids?: string[];
@@ -42,7 +49,11 @@ export function createFileArgs({ Scope }: { Scope: Type<DamScopeInterface> }): T
         @ValidateNested()
         scope: DamScopeInterface;
 
-        @Field(() => ID, { nullable: true })
+        @Field(() => ID, {
+            nullable: true,
+            description:
+                "Folder to list files from. When omitted, files at the scope root are returned. Ignored when filter.searchText or filter.ids is set.",
+        })
         @IsOptional()
         @IsUUID()
         folderId?: string;

--- a/packages/api/cms-api/src/dam/files/files.service.spec.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.spec.ts
@@ -1,6 +1,7 @@
 import type { EntityRepository, QueryBuilder } from "@mikro-orm/postgresql";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { FileFilterInput } from "./dto/file.args";
 import type { FileInterface } from "./entities/file.entity";
 import { FilesService } from "./files.service";
 
@@ -49,82 +50,71 @@ function createServiceWithMockQueryBuilder() {
     return { service, andWhereArgs, hasFolderConstraint };
 }
 
-describe("FilesService", () => {
-    describe("findAndCount — folder-by-default vs filter.ids", () => {
-        beforeEach(() => {
-            vi.clearAllMocks();
-        });
+type CallArgs = { folderId?: string; filter?: FileFilterInput };
 
-        it("constrains to the scope root (folder.id = null) when neither folderId nor filter.ids are provided", async () => {
-            const { service, andWhereArgs, hasFolderConstraint } = createServiceWithMockQueryBuilder();
+const callers = [
+    {
+        name: "findAll",
+        call: (service: FilesService, args: CallArgs) => service.findAll(args),
+    },
+    {
+        name: "findAndCount",
+        call: (service: FilesService, args: CallArgs) => service.findAndCount({ ...args, offset: 0, limit: 25 }),
+    },
+];
 
-            await service.findAndCount({ offset: 0, limit: 25 });
-
-            expect(hasFolderConstraint()).toBe(true);
-            expect(andWhereArgs).toContainEqual({ folder: { id: null } });
-        });
-
-        it("constrains to the given folder when folderId is provided and filter.ids is not", async () => {
-            const { service, andWhereArgs } = createServiceWithMockQueryBuilder();
-
-            await service.findAndCount({ offset: 0, limit: 25, folderId: FOLDER_ID });
-
-            expect(andWhereArgs).toContainEqual({ folder: { id: FOLDER_ID } });
-        });
-
-        it("does NOT apply any folder constraint when filter.ids is provided (fix for cross-folder lookups)", async () => {
-            const { service, andWhereArgs, hasFolderConstraint } = createServiceWithMockQueryBuilder();
-
-            await service.findAndCount({ offset: 0, limit: 25, filter: { ids: [FILE_ID_A, FILE_ID_B] } });
-
-            expect(hasFolderConstraint()).toBe(false);
-            expect(andWhereArgs).toContainEqual({ id: { $in: [FILE_ID_A, FILE_ID_B] } });
-        });
-
-        it("ignores an explicitly passed folderId when filter.ids is also provided", async () => {
-            const { service, hasFolderConstraint } = createServiceWithMockQueryBuilder();
-
-            await service.findAndCount({ offset: 0, limit: 25, folderId: FOLDER_ID, filter: { ids: [FILE_ID_A] } });
-
-            expect(hasFolderConstraint()).toBe(false);
-        });
-
-        it("still applies the folder default when filter.ids is an empty array (treated as no ids filter)", async () => {
-            const { service, andWhereArgs } = createServiceWithMockQueryBuilder();
-
-            await service.findAndCount({ offset: 0, limit: 25, filter: { ids: [] } });
-
-            expect(andWhereArgs).toContainEqual({ folder: { id: null } });
-        });
-
-        it("drops the folder constraint when searchText is provided (regression guard for existing behavior)", async () => {
-            const { service, hasFolderConstraint } = createServiceWithMockQueryBuilder();
-
-            await service.findAndCount({ offset: 0, limit: 25, filter: { searchText: "logo" } });
-
-            expect(hasFolderConstraint()).toBe(false);
-        });
+describe.each(callers)("FilesService.$name — folder-by-default vs filter.ids", ({ call }) => {
+    beforeEach(() => {
+        vi.clearAllMocks();
     });
 
-    describe("findAll — folder-by-default vs filter.ids", () => {
-        beforeEach(() => {
-            vi.clearAllMocks();
-        });
+    it("constrains to the scope root (folder.id = null) when neither folderId nor filter.ids are provided", async () => {
+        const { service, andWhereArgs, hasFolderConstraint } = createServiceWithMockQueryBuilder();
 
-        it("constrains to the scope root when neither folderId nor filter.ids are provided", async () => {
-            const { service, andWhereArgs } = createServiceWithMockQueryBuilder();
+        await call(service, {});
 
-            await service.findAll({});
+        expect(hasFolderConstraint()).toBe(true);
+        expect(andWhereArgs).toContainEqual({ folder: { id: null } });
+    });
 
-            expect(andWhereArgs).toContainEqual({ folder: { id: null } });
-        });
+    it("constrains to the given folder when folderId is provided and filter.ids is not", async () => {
+        const { service, andWhereArgs } = createServiceWithMockQueryBuilder();
 
-        it("does NOT apply any folder constraint when filter.ids is provided", async () => {
-            const { service, hasFolderConstraint } = createServiceWithMockQueryBuilder();
+        await call(service, { folderId: FOLDER_ID });
 
-            await service.findAll({ filter: { ids: [FILE_ID_A] } });
+        expect(andWhereArgs).toContainEqual({ folder: { id: FOLDER_ID } });
+    });
 
-            expect(hasFolderConstraint()).toBe(false);
-        });
+    it("does NOT apply any folder constraint when filter.ids is provided (fix for cross-folder lookups)", async () => {
+        const { service, andWhereArgs, hasFolderConstraint } = createServiceWithMockQueryBuilder();
+
+        await call(service, { filter: { ids: [FILE_ID_A, FILE_ID_B] } });
+
+        expect(hasFolderConstraint()).toBe(false);
+        expect(andWhereArgs).toContainEqual({ id: { $in: [FILE_ID_A, FILE_ID_B] } });
+    });
+
+    it("ignores an explicitly passed folderId when filter.ids is also provided", async () => {
+        const { service, hasFolderConstraint } = createServiceWithMockQueryBuilder();
+
+        await call(service, { folderId: FOLDER_ID, filter: { ids: [FILE_ID_A] } });
+
+        expect(hasFolderConstraint()).toBe(false);
+    });
+
+    it("still applies the folder default when filter.ids is an empty array (treated as no ids filter)", async () => {
+        const { service, andWhereArgs } = createServiceWithMockQueryBuilder();
+
+        await call(service, { filter: { ids: [] } });
+
+        expect(andWhereArgs).toContainEqual({ folder: { id: null } });
+    });
+
+    it("drops the folder constraint when searchText is provided (regression guard for existing behavior)", async () => {
+        const { service, hasFolderConstraint } = createServiceWithMockQueryBuilder();
+
+        await call(service, { filter: { searchText: "logo" } });
+
+        expect(hasFolderConstraint()).toBe(false);
     });
 });

--- a/packages/api/cms-api/src/dam/files/files.service.spec.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.spec.ts
@@ -1,0 +1,130 @@
+import type { EntityRepository, QueryBuilder } from "@mikro-orm/postgresql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FileInterface } from "./entities/file.entity";
+import { FilesService } from "./files.service";
+
+const FOLDER_ID = "11111111-1111-1111-1111-111111111111";
+const FILE_ID_A = "22222222-2222-2222-2222-222222222222";
+const FILE_ID_B = "33333333-3333-3333-3333-333333333333";
+
+type AndWhereArg = Parameters<QueryBuilder<FileInterface>["andWhere"]>[0];
+
+function createServiceWithMockQueryBuilder() {
+    const andWhereArgs: AndWhereArg[] = [];
+
+    const mockQb = {
+        select: vi.fn().mockReturnThis(),
+        leftJoinAndSelect: vi.fn().mockReturnThis(),
+        andWhere: vi.fn(function (this: typeof mockQb, arg: AndWhereArg) {
+            andWhereArgs.push(arg);
+            return this;
+        }),
+        orderBy: vi.fn().mockReturnThis(),
+        offset: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        getResult: vi.fn().mockResolvedValue([]),
+        getCount: vi.fn().mockResolvedValue(0),
+    };
+
+    const filesRepository = {
+        createQueryBuilder: vi.fn().mockReturnValue(mockQb),
+    } as unknown as EntityRepository<FileInterface>;
+
+    const service = new FilesService(
+        filesRepository,
+        null as never, // damMediaAlternativesRepository
+        null as never, // blobStorageBackendService
+        null as never, // foldersService
+        null as never, // DAM_CONFIG
+        null as never, // imgproxyService
+        null as never, // orm
+        null as never, // contentScopeService
+        null as never, // entityManager
+    );
+
+    const hasFolderConstraint = () =>
+        andWhereArgs.some((arg) => typeof arg === "object" && arg !== null && "folder" in (arg as Record<string, unknown>));
+
+    return { service, andWhereArgs, hasFolderConstraint };
+}
+
+describe("FilesService", () => {
+    describe("findAndCount — folder-by-default vs filter.ids", () => {
+        beforeEach(() => {
+            vi.clearAllMocks();
+        });
+
+        it("constrains to the scope root (folder.id = null) when neither folderId nor filter.ids are provided", async () => {
+            const { service, andWhereArgs, hasFolderConstraint } = createServiceWithMockQueryBuilder();
+
+            await service.findAndCount({ offset: 0, limit: 25 });
+
+            expect(hasFolderConstraint()).toBe(true);
+            expect(andWhereArgs).toContainEqual({ folder: { id: null } });
+        });
+
+        it("constrains to the given folder when folderId is provided and filter.ids is not", async () => {
+            const { service, andWhereArgs } = createServiceWithMockQueryBuilder();
+
+            await service.findAndCount({ offset: 0, limit: 25, folderId: FOLDER_ID });
+
+            expect(andWhereArgs).toContainEqual({ folder: { id: FOLDER_ID } });
+        });
+
+        it("does NOT apply any folder constraint when filter.ids is provided (fix for cross-folder lookups)", async () => {
+            const { service, andWhereArgs, hasFolderConstraint } = createServiceWithMockQueryBuilder();
+
+            await service.findAndCount({ offset: 0, limit: 25, filter: { ids: [FILE_ID_A, FILE_ID_B] } });
+
+            expect(hasFolderConstraint()).toBe(false);
+            expect(andWhereArgs).toContainEqual({ id: { $in: [FILE_ID_A, FILE_ID_B] } });
+        });
+
+        it("ignores an explicitly passed folderId when filter.ids is also provided", async () => {
+            const { service, hasFolderConstraint } = createServiceWithMockQueryBuilder();
+
+            await service.findAndCount({ offset: 0, limit: 25, folderId: FOLDER_ID, filter: { ids: [FILE_ID_A] } });
+
+            expect(hasFolderConstraint()).toBe(false);
+        });
+
+        it("still applies the folder default when filter.ids is an empty array (treated as no ids filter)", async () => {
+            const { service, andWhereArgs } = createServiceWithMockQueryBuilder();
+
+            await service.findAndCount({ offset: 0, limit: 25, filter: { ids: [] } });
+
+            expect(andWhereArgs).toContainEqual({ folder: { id: null } });
+        });
+
+        it("drops the folder constraint when searchText is provided (regression guard for existing behavior)", async () => {
+            const { service, hasFolderConstraint } = createServiceWithMockQueryBuilder();
+
+            await service.findAndCount({ offset: 0, limit: 25, filter: { searchText: "logo" } });
+
+            expect(hasFolderConstraint()).toBe(false);
+        });
+    });
+
+    describe("findAll — folder-by-default vs filter.ids", () => {
+        beforeEach(() => {
+            vi.clearAllMocks();
+        });
+
+        it("constrains to the scope root when neither folderId nor filter.ids are provided", async () => {
+            const { service, andWhereArgs } = createServiceWithMockQueryBuilder();
+
+            await service.findAll({});
+
+            expect(andWhereArgs).toContainEqual({ folder: { id: null } });
+        });
+
+        it("does NOT apply any folder constraint when filter.ids is provided", async () => {
+            const { service, hasFolderConstraint } = createServiceWithMockQueryBuilder();
+
+            await service.findAll({ filter: { ids: [FILE_ID_A] } });
+
+            expect(hasFolderConstraint()).toBe(false);
+        });
+    });
+});

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -146,10 +146,12 @@ export class FilesService {
         scope?: DamScopeInterface,
     ): Promise<FileInterface[]> {
         const isSearching = filter?.searchText !== undefined && filter.searchText.length > 0;
+        const isFilteringByIds = filter?.ids !== undefined && filter.ids.length > 0;
+        const ignoreFolder = isSearching || isFilteringByIds;
 
         return withFilesSelect(this.selectQueryBuilder(), {
             archived: !includeArchived ? false : undefined,
-            folderId: !isSearching ? folderId || null : undefined,
+            folderId: !ignoreFolder ? folderId || null : undefined,
             mimetypes: filter?.mimetypes,
             ids: filter?.ids,
             query: filter?.searchText,
@@ -164,10 +166,12 @@ export class FilesService {
         scope?: DamScopeInterface,
     ): Promise<[FileInterface[], number]> {
         const isSearching = filter?.searchText !== undefined && filter.searchText.length > 0;
+        const isFilteringByIds = filter?.ids !== undefined && filter.ids.length > 0;
+        const ignoreFolder = isSearching || isFilteringByIds;
 
         const files = await withFilesSelect(this.selectQueryBuilder(), {
             archived: !includeArchived ? false : undefined,
-            folderId: !isSearching ? folderId || null : undefined,
+            folderId: !ignoreFolder ? folderId || null : undefined,
             mimetypes: filter?.mimetypes,
             ids: filter?.ids,
             query: filter?.searchText,
@@ -180,7 +184,7 @@ export class FilesService {
 
         const totalCount = await withFilesSelect(this.selectQueryBuilder(), {
             archived: !includeArchived ? false : undefined,
-            folderId: !isSearching ? folderId || null : undefined,
+            folderId: !ignoreFolder ? folderId || null : undefined,
             mimetypes: filter?.mimetypes,
             ids: filter?.ids,
             query: filter?.searchText,


### PR DESCRIPTION
## Problem

`FileField` multi-select silently dropped any selected file that lived in a subfolder. `damFilesList` implicitly constrains to `folder.id = null` (scope root) when no `folderId` is passed, so resolving the selection via `filter: { ids: ... }` filtered out everything outside the root. An escape hatch already existed for `filter.searchText`, but not for `filter.ids`.

## Solution

Bypass the implicit folder constraint when `filter.ids` is set — mirroring the existing `searchText` behavior. Folder-browsing (default-to-root, explicit `folderId`) is unchanged.

The behavior is now documented on `FileFilterInput.searchText`, `FileFilterInput.ids`, and `FileArgs.folderId`.

## Tests

`files.service.spec.ts` covers 6 cases × `findAll` / `findAndCount` (12 tests): defaults, explicit `folderId`, the new `ids` bypass, `folderId` + `ids` together, empty `ids` array, and a regression guard for `searchText`.
