### PR TITLE
Extract shared CI setup into reusable composite action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,38 @@
+name: Setup
+description: Set up pnpm, Node.js, install dependencies, and optionally run setup:ci and build:packages.
+
+inputs:
+    node-version:
+        description: Node.js version to install.
+        default: "24"
+    setup-ci:
+        description: Whether to run `pnpm run setup:ci`.
+        default: "true"
+    build:
+        description: Whether to run `pnpm run build:packages`.
+        default: "true"
+
+runs:
+    using: composite
+    steps:
+        - uses: pnpm/action-setup@v6
+
+        - name: Use Node.js ${{ inputs.node-version }}.x
+          uses: actions/setup-node@v6
+          with:
+              node-version: ${{ inputs.node-version }}
+              registry-url: "https://registry.npmjs.org"
+              cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+
+        - shell: bash
+          run: pnpm install --frozen-lockfile
+
+        - name: Setup project for CI run
+          if: ${{ inputs.setup-ci == 'true' }}
+          shell: bash
+          run: pnpm run setup:ci
+
+        - name: Build packages
+          if: ${{ inputs.build == 'true' }}
+          shell: bash
+          run: pnpm run build:packages

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,7 +8,7 @@ inputs:
     setup-ci:
         description: Whether to run `pnpm run setup:ci`.
         default: "true"
-    build:
+    buildPackages:
         description: Whether to run `pnpm run build:packages`.
         default: "true"
 
@@ -33,6 +33,6 @@ runs:
           run: pnpm run setup:ci
 
         - name: Build packages
-          if: ${{ inputs.build == 'true' }}
+          if: ${{ inputs.buildPackages == 'true' }}
           shell: bash
           run: pnpm run build:packages

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ inputs:
         default: "true"
     buildPackages:
         description: Whether to run `pnpm run build:packages`.
-        default: "true"
+        default: "false"
 
 runs:
     using: composite

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,13 +2,10 @@ name: Setup
 description: Set up pnpm, Node.js, install dependencies, and optionally run setup:ci and build:packages.
 
 inputs:
-    node-version:
-        description: Node.js version to install.
-        default: "24"
     setup-ci:
         description: Whether to run `pnpm run setup:ci`.
         default: "true"
-    buildPackages:
+    build-packages:
         description: Whether to run `pnpm run build:packages`.
         default: "false"
 
@@ -17,10 +14,10 @@ runs:
     steps:
         - uses: pnpm/action-setup@v6
 
-        - name: Use Node.js ${{ inputs.node-version }}.x
+        - name: Use Node.js 24.x
           uses: actions/setup-node@v6
           with:
-              node-version: ${{ inputs.node-version }}
+              node-version: 24
               registry-url: "https://registry.npmjs.org"
               cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
 
@@ -33,6 +30,6 @@ runs:
           run: pnpm run setup:ci
 
         - name: Build packages
-          if: ${{ inputs.buildPackages == 'true' }}
+          if: ${{ inputs.build-packages == 'true' }}
           shell: bash
           run: pnpm run build:packages

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -27,19 +27,9 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
-            - uses: pnpm/action-setup@v6
-
-            - name: Use Node.js 24.x
-              uses: actions/setup-node@v6
+            - uses: ./.github/actions/setup
               with:
-                  node-version: 24
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-
-            - run: pnpm install --frozen-lockfile
-
-            - name: Setup project for CI run
-              run: pnpm run setup:ci
+                  build: "false"
 
             - name: Build docs
               run: pnpm build:docs

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,8 +28,6 @@ jobs:
                   ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
             - uses: ./.github/actions/setup
-              with:
-                  buildPackages: "false"
 
             - name: Build docs
               run: pnpm build:docs

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,7 +29,7 @@ jobs:
 
             - uses: ./.github/actions/setup
               with:
-                  build: "false"
+                  buildPackages: "false"
 
             - name: Build docs
               run: pnpm build:docs

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -25,7 +25,7 @@ jobs:
             - uses: ./.github/actions/setup
               with:
                   node-version: "22"
-                  build: "false"
+                  buildPackages: "false"
 
             - run: pnpm --recursive --filter '@comet/*admin*' --filter '@comet/mail-react' --filter '@comet/eslint-plugin' --filter '@comet/cli' run build
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,18 +22,10 @@ jobs:
                   ref: ${{ github.event.pull_request.head.ref || github.ref }}
                   fetch-depth: 0
 
-            - uses: pnpm/action-setup@v6
-
-            - name: Use Node.js 22.x
-              uses: actions/setup-node@v6
+            - uses: ./.github/actions/setup
               with:
-                  node-version: 22
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-
-            - run: pnpm install --frozen-lockfile
-
-            - run: pnpm setup:ci
+                  node-version: "22"
+                  build: "false"
 
             - run: pnpm --recursive --filter '@comet/*admin*' --filter '@comet/mail-react' --filter '@comet/eslint-plugin' --filter '@comet/cli' run build
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -23,9 +23,6 @@ jobs:
                   fetch-depth: 0
 
             - uses: ./.github/actions/setup
-              with:
-                  node-version: "22"
-                  buildPackages: "false"
 
             - run: pnpm --recursive --filter '@comet/*admin*' --filter '@comet/mail-react' --filter '@comet/eslint-plugin' --filter '@comet/cli' run build
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -56,15 +56,6 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   path: "demo/api/lang/comet-demo-lang"
 
-            - uses: pnpm/action-setup@v6
-
-            - name: Use Node.js 24.x
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-
             # Cache build outputs per package (before pnpm install to avoid hashing node_modules)
             # Hash patterns target source and config files, explicitly excluding lib/ build output
             - name: Cache @comet/cli build
@@ -179,7 +170,10 @@ jobs:
                   path: packages/site/site-react/lib
                   key: ${{ runner.os }}-build-site-react-${{ hashFiles('packages/site/site-react/src/**', 'packages/site/site-react/package.json', 'packages/site/site-react/tsconfig*.json', 'pnpm-lock.yaml') }}
 
-            - run: pnpm install --frozen-lockfile
+            - uses: ./.github/actions/setup
+              with:
+                  setup-ci: "false"
+                  build: "false"
 
             - name: Build @comet/cli and @comet/eslint-plugin (if not cached)
               run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -173,7 +173,7 @@ jobs:
             - uses: ./.github/actions/setup
               with:
                   setup-ci: "false"
-                  build: "false"
+                  buildPackages: "false"
 
             - name: Build @comet/cli and @comet/eslint-plugin (if not cached)
               run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -173,7 +173,6 @@ jobs:
             - uses: ./.github/actions/setup
               with:
                   setup-ci: "false"
-                  buildPackages: "false"
 
             - name: Build @comet/cli and @comet/eslint-plugin (if not cached)
               run: |

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -26,8 +26,6 @@ jobs:
                   path: "demo/admin/lang/comet-lang"
 
             - uses: ./.github/actions/setup
-              with:
-                  buildPackages: "false"
 
             - name: "Library: Extract i18n strings"
               run: |

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -27,7 +27,7 @@ jobs:
 
             - uses: ./.github/actions/setup
               with:
-                  build: "false"
+                  buildPackages: "false"
 
             - name: "Library: Extract i18n strings"
               run: |

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -25,16 +25,9 @@ jobs:
                   token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
                   path: "demo/admin/lang/comet-lang"
 
-            - uses: pnpm/action-setup@v6
-
-            - name: Use Node.js 24.x
-              uses: actions/setup-node@v6
+            - uses: ./.github/actions/setup
               with:
-                  node-version: 24
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-
-            - run: pnpm install --frozen-lockfile
+                  build: "false"
 
             - name: "Library: Extract i18n strings"
               run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
               with:
                   repository: vivid-planet/comet-demo-lang
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  path: "demo/site/lang/comet-demo-lang"
+                  path: "demo/admin/lang/comet-demo-lang"
 
             - name: "Demo Api: Clone translations"
               uses: actions/checkout@v6
@@ -55,6 +55,8 @@ jobs:
                   path: "demo/api/lang/comet-demo-lang"
 
             - uses: ./.github/actions/setup
+              with:
+                  buildPackages: "true"
 
             - name: Lint
               run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
 
             - uses: ./.github/actions/setup
               with:
-                  buildPackages: "true"
+                  build-packages: "true"
 
             - name: Lint
               run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,22 +54,7 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   path: "demo/api/lang/comet-demo-lang"
 
-            - uses: pnpm/action-setup@v6
-
-            - name: Use Node.js 24.x
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-
-            - run: pnpm install --frozen-lockfile
-
-            - name: Setup project for CI run
-              run: pnpm run setup:ci
-
-            - name: Build
-              run: pnpm run build:packages
+            - uses: ./.github/actions/setup
 
             - name: Lint
               run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
               with:
                   repository: vivid-planet/comet-demo-lang
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  path: "demo/admin/lang/comet-demo-lang"
+                  path: "demo/site/lang/comet-demo-lang"
 
             - name: "Demo Api: Clone translations"
               uses: actions/checkout@v6

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -35,8 +35,6 @@ jobs:
               uses: actions/checkout@v6
 
             - uses: ./.github/actions/setup
-              with:
-                  buildPackages: "false"
 
             - name: Get version to be published
               run: |

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -34,20 +34,9 @@ jobs:
             - name: Checkout Repo
               uses: actions/checkout@v6
 
-            - uses: pnpm/action-setup@v6
-
-            - name: Use Node.js 24.x
-              uses: actions/setup-node@v6
+            - uses: ./.github/actions/setup
               with:
-                  node-version: 24
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-
-            - name: Install Dependencies
-              run: pnpm install --frozen-lockfile
-
-            - name: Setup project for CI run
-              run: pnpm run setup:ci
+                  build: "false"
 
             - name: Get version to be published
               run: |

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -36,7 +36,7 @@ jobs:
 
             - uses: ./.github/actions/setup
               with:
-                  build: "false"
+                  buildPackages: "false"
 
             - name: Get version to be published
               run: |

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -17,8 +17,6 @@ jobs:
               uses: actions/checkout@v6
 
             - uses: ./.github/actions/setup
-              with:
-                  buildPackages: "false"
 
             - name: "Exit Prelease Mode"
               if: ${{ hashFiles('.changeset/pre.json') != '' }}

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -16,20 +16,9 @@ jobs:
             - name: Checkout Repo
               uses: actions/checkout@v6
 
-            - uses: pnpm/action-setup@v6
-
-            - name: Use Node.js 24.x
-              uses: actions/setup-node@v6
+            - uses: ./.github/actions/setup
               with:
-                  node-version: 24
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-
-            - name: Install Dependencies
-              run: pnpm install --frozen-lockfile
-
-            - name: Setup project for CI run
-              run: pnpm run setup:ci
+                  build: "false"
 
             - name: "Exit Prelease Mode"
               if: ${{ hashFiles('.changeset/pre.json') != '' }}

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -18,7 +18,7 @@ jobs:
 
             - uses: ./.github/actions/setup
               with:
-                  build: "false"
+                  buildPackages: "false"
 
             - name: "Exit Prelease Mode"
               if: ${{ hashFiles('.changeset/pre.json') != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,20 +18,9 @@ jobs:
             - name: Checkout Repo
               uses: actions/checkout@v6
 
-            - uses: pnpm/action-setup@v6
-
-            - name: Use Node.js 24.x
-              uses: actions/setup-node@v6
+            - uses: ./.github/actions/setup
               with:
-                  node-version: 24
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-
-            - name: Install Dependencies
-              run: pnpm install --frozen-lockfile
-
-            - name: Setup project for CI run
-              run: pnpm run setup:ci
+                  build: "false"
 
             - name: Get version to be published
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
             - uses: ./.github/actions/setup
               with:
-                  build: "false"
+                  buildPackages: "false"
 
             - name: Get version to be published
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
               uses: actions/checkout@v6
 
             - uses: ./.github/actions/setup
-              with:
-                  buildPackages: "false"
 
             - name: Get version to be published
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,13 @@ jobs:
 
             - name: Test
               run: pnpm run test
+
+            - name: Upload test results
+              uses: actions/upload-artifact@v7
+              if: success() || failure()
+              with:
+                  name: test-results
+                  path: |
+                      packages/*/junit.xml
+                      packages/*/*/junit.xml
+                  overwrite: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
             - uses: ./.github/actions/setup
               with:
-                  buildPackages: "true"
+                  build-packages: "true"
 
             - name: Test
               run: pnpm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,22 +26,7 @@ jobs:
                   git config user.name github-actions
                   git config user.email github-actions@github.com
 
-            - uses: pnpm/action-setup@v6
-
-            - name: Use Node.js 24.x
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-
-            - run: pnpm install --frozen-lockfile
-
-            - name: Setup project for CI run
-              run: pnpm run setup:ci
-
-            - name: Build
-              run: pnpm run build:packages
+            - uses: ./.github/actions/setup
 
             - name: Test
               run: pnpm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,16 +27,8 @@ jobs:
                   git config user.email github-actions@github.com
 
             - uses: ./.github/actions/setup
+              with:
+                  buildPackages: "true"
 
             - name: Test
               run: pnpm run test
-
-            - name: Upload test results
-              uses: actions/upload-artifact@v7
-              if: success() || failure()
-              with:
-                  name: test-results
-                  path: |
-                      packages/*/junit.xml
-                      packages/*/*/junit.xml
-                  overwrite: true


### PR DESCRIPTION
## Background

This PR addresses a discussion point in [#5561](https://github.com/vivid-planet/comet/pull/5561/files#r3272349034) about the duplicated CI setup pattern across our workflows.

## Summary

Nine workflows under `.github/workflows/` duplicated the same setup block (`pnpm/action-setup` → `setup-node@24` → `pnpm install --frozen-lockfile` → `pnpm run setup:ci` → optionally `pnpm run build:packages`). This PR extracts it into a single composite action at `.github/actions/setup` and migrates the callers.

## What the composite handles

[`.github/actions/setup/action.yml`](https://github.com/vivid-planet/comet/blob/thirsty-lamarr-7be25e/.github/actions/setup/action.yml) runs these steps in order:

| # | Step | Notes |
| --- | --- | --- |
| 1 | `pnpm/action-setup@v6` | Installs pnpm. |
| 2 | `actions/setup-node@v6` | Installs Node.js, sets `registry-url`, enables pnpm cache. Node version comes from the `node-version` input. |
| 3 | `pnpm install --frozen-lockfile` | Installs dependencies. |
| 4 | `pnpm run setup:ci` | Builds `@comet/cli` + `@comet/eslint-plugin`, runs `create-site-configs-env`, runs `copy-project-files`. Skippable via `setup-ci: "false"`. |
| 5 | `pnpm run build:packages` | Builds all packages. Opt-in via `build-packages: "true"`. |

Inputs:

| Input | Default | Notes |
| --- | --- | --- |
| `setup-ci` | `"true"` | Only `copilot-setup-steps.yml` opts out — it unrolls `setup:ci` so it can wrap the CLI / eslint-plugin builds in `actions/cache@v4`. |
| `build-packages` | `"false"` | Most workflows don't build packages; only `lint.yml` and `test.yml` opt in. |

Checkout, git config, multi-repo translation clones, `permissions:`, `concurrency:`, and any post-setup steps stay in the calling workflow.

## Per-workflow choices

| Workflow | Override | Notes |
| --- | --- | --- |
| `build-docs.yml` | — | Runs `pnpm build:docs` separately |
| `chromatic.yml` | — | Previously pinned Node 22; admin / mail-react `engines` are `>=22.0.0`, so Node 24 satisfies them. CI on this PR confirms. |
| `copilot-setup-steps.yml` | `setup-ci: "false"` | 16 `actions/cache@v4` steps moved to before the composite; the workflow intentionally unrolls `setup:ci` to wrap CLI / eslint-plugin builds in caching |
| `i18n.yml` | — | Previously skipped `setup:ci` — now runs it (closes a footgun where intl-extract could see a stale CLI build) |
| `lint.yml` | `build-packages: "true"` | |
| `release.yml` | — | NPM publish env vars stay on the changesets step |
| `release-beta.yml` | — | |
| `release-canary.yml` | — | |
| `test.yml` | `build-packages: "true"` | |

