### PR TITLE
Add ActionLogButton component

### DIFF
--- a/.changeset/add-action-log-button.md
+++ b/.changeset/add-action-log-button.md
@@ -1,0 +1,13 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `ActionLogButton`
+
+Drop-in button that opens the `ActionLogDialog` and manages its open state internally. The button label defaults to "Action Log" but can be overridden via `children`.
+
+**Example**
+
+```tsx
+<ActionLogButton<GQLQuery> id={id} rootField="manufacturer" name={manufacturer.name} />
+```

--- a/packages/admin/cms-admin/src/actionLog/actionLogButton/ActionLogButton.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogButton/ActionLogButton.tsx
@@ -1,0 +1,44 @@
+import { Button, type ButtonProps } from "@comet/admin";
+import { Time } from "@comet/admin-icons";
+import { type PropsWithChildren, useState } from "react";
+import { FormattedMessage } from "react-intl";
+
+import { ActionLogDialog } from "../actionLogDialog/ActionLogDialog";
+
+type ActionLogButtonProps<TQuery> = PropsWithChildren<
+    Omit<ButtonProps, "onClick" | "children"> & {
+        id: string;
+        /**
+         * GraphQL root field exposing the entity (e.g. "manufacturer", "product").
+         * The entity must expose `actionLog(id)` and `actionLogs(offset, limit, sort)` via `@ActionLogs()`.
+         *
+         * Pass your app's `GQLQuery` as the generic to constrain this to entities decorated with `@ActionLogs()`.
+         */
+        rootField: Parameters<typeof ActionLogDialog<TQuery>>[0]["rootField"];
+        /**
+         * Latest name of the entity, displayed in titles.
+         */
+        name?: string;
+    }
+>;
+
+export function ActionLogButton<TQuery = Record<string, unknown>>({
+    id,
+    rootField,
+    name,
+    children,
+    startIcon = <Time />,
+    variant = "textDark",
+    ...restProps
+}: ActionLogButtonProps<TQuery>) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <Button {...restProps} variant={variant} startIcon={startIcon} onClick={() => setOpen(true)}>
+                {children ?? <FormattedMessage id="comet.actionLogButton.title" defaultMessage="Action Log" />}
+            </Button>
+            <ActionLogDialog<TQuery> id={id} rootField={rootField} name={name} open={open} onClose={() => setOpen(false)} />
+        </>
+    );
+}

--- a/packages/admin/cms-admin/src/actionLog/actionLogButton/__stories__/ActionLogButton.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogButton/__stories__/ActionLogButton.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ActionLogButton } from "../ActionLogButton";
+
+type ActionLogButtonStoryArgs = {
+    id: string;
+    rootField: string;
+    name?: string;
+};
+
+type Story = StoryObj<ActionLogButtonStoryArgs>;
+
+const meta: Meta<ActionLogButtonStoryArgs> = {
+    component: ActionLogButton,
+    tags: ["!autodocs"],
+    title: "Action log/Action log button",
+    args: {
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        rootField: "manufacturer",
+        name: "My Page",
+    },
+};
+
+export default meta;
+
+export const Default: Story = {};
+
+export const CustomLabel: Story = {
+    render: (args) => <ActionLogButton {...args}>Show history</ActionLogButton>,
+};

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -1,3 +1,4 @@
+export { ActionLogButton } from "./actionLog/actionLogButton/ActionLogButton";
 export { ActionLogCompare, actionLogCompareFragment } from "./actionLog/actionLogCompare/ActionLogCompare";
 export { ActionLogDialog } from "./actionLog/actionLogDialog/ActionLogDialog";
 export { ActionLogGrid, actionLogGridFragment } from "./actionLog/actionLogGrid/ActionLogGrid";


### PR DESCRIPTION
## Summary
Introduces `ActionLogButton`, a new drop-in button component that opens the `ActionLogDialog` while managing its open state internally. This provides a convenient way to add action log functionality to entity pages without boilerplate state management.

## Changes
- **New Component**: `ActionLogButton` - A button wrapper around `ActionLogDialog` that:
  - Accepts an entity `id` and GraphQL `rootField` to query action logs
  - Manages dialog open/close state internally
  - Supports customizable button label via `children` (defaults to "Action Log")
  - Inherits standard `Button` props for styling and behavior
  - Includes TypeScript generic support for constraining `rootField` to entities decorated with `@ActionLogs()`

- **Storybook Stories**: Added documentation with Default and CustomLabel examples

- **Export**: Added `ActionLogButton` to the public API in `index.ts`

https://claude.ai/code/session_018a7yxPjGdFYAKHq65ZZdFL