### PR TITLE
Add user information to action logs

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -9,8 +9,7 @@ type ActionLog {
   id: ID!
   scope: [JSONObject!]
   snapshot: JSONObject
-  user: ActionLogUser
-  userId: ID!
+  user: ActionLogsUser!
   version: Int!
 }
 
@@ -21,13 +20,12 @@ input ActionLogSort {
 
 enum ActionLogSortField {
   createdAt
-  userId
   version
 }
 
-type ActionLogUser {
+type ActionLogsUser {
   id: ID!
-  name: String!
+  name: String
 }
 
 input AddBrevoContactsInput {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -9,6 +9,7 @@ type ActionLog {
   id: ID!
   scope: [JSONObject!]
   snapshot: JSONObject
+  user: ActionLogUser
   userId: ID!
   version: Int!
 }
@@ -22,6 +23,11 @@ enum ActionLogSortField {
   createdAt
   userId
   version
+}
+
+type ActionLogUser {
+  id: ID!
+  name: String!
 }
 
 input AddBrevoContactsInput {

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.gql.ts
@@ -6,7 +6,6 @@ export const actionLogCompareFragment = gql`
         version
         snapshot
         createdAt
-        userId
         user {
             id
             name

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.gql.ts
@@ -7,6 +7,10 @@ export const actionLogCompareFragment = gql`
         snapshot
         createdAt
         userId
+        user {
+            id
+            name
+        }
         entityName
     }
 `;

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.tsx
@@ -109,18 +109,36 @@ export const ActionLogCompare: FunctionComponent<ActionLogCompareProps> = ({
                                     <DiffHeader
                                         createdAt={beforeVersion?.createdAt}
                                         userId={beforeVersion?.userId}
+                                        userName={beforeVersion?.user?.name}
                                         version={beforeVersion?.version}
                                     />
 
-                                    <DiffHeader createdAt={afterVersion?.createdAt} userId={afterVersion?.userId} version={afterVersion?.version} />
+                                    <DiffHeader
+                                        createdAt={afterVersion?.createdAt}
+                                        userId={afterVersion?.userId}
+                                        userName={afterVersion?.user?.name}
+                                        version={afterVersion?.version}
+                                    />
                                 </>
                             ) : (
-                                <DiffHeader createdAt={beforeVersion?.createdAt} userId={beforeVersion?.userId} version={beforeVersion?.version} />
+                                <DiffHeader
+                                    createdAt={beforeVersion?.createdAt}
+                                    userId={beforeVersion?.userId}
+                                    userName={beforeVersion?.user?.name}
+                                    version={beforeVersion?.version}
+                                />
                             )
                         }
                         newValue={JSON.stringify(filteredSnapshotAfterVersion, null, 8)}
                         oldValue={JSON.stringify(filteredSnapshotBeforeVersion, null, 8)}
-                        rightTitle={<DiffHeader createdAt={afterVersion?.createdAt} userId={afterVersion?.userId} version={afterVersion?.version} />}
+                        rightTitle={
+                            <DiffHeader
+                                createdAt={afterVersion?.createdAt}
+                                userId={afterVersion?.userId}
+                                userName={afterVersion?.user?.name}
+                                version={afterVersion?.version}
+                            />
+                        }
                         showDiffOnly={onlyShowChanges}
                         splitView={!smallBreakpoint}
                     />

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/ActionLogCompare.tsx
@@ -108,23 +108,23 @@ export const ActionLogCompare: FunctionComponent<ActionLogCompareProps> = ({
                                 <>
                                     <DiffHeader
                                         createdAt={beforeVersion?.createdAt}
-                                        userId={beforeVersion?.userId}
-                                        userName={beforeVersion?.user?.name}
+                                        userId={beforeVersion?.user.id}
+                                        userName={beforeVersion?.user.name ?? undefined}
                                         version={beforeVersion?.version}
                                     />
 
                                     <DiffHeader
                                         createdAt={afterVersion?.createdAt}
-                                        userId={afterVersion?.userId}
-                                        userName={afterVersion?.user?.name}
+                                        userId={afterVersion?.user.id}
+                                        userName={afterVersion?.user.name ?? undefined}
                                         version={afterVersion?.version}
                                     />
                                 </>
                             ) : (
                                 <DiffHeader
                                     createdAt={beforeVersion?.createdAt}
-                                    userId={beforeVersion?.userId}
-                                    userName={beforeVersion?.user?.name}
+                                    userId={beforeVersion?.user.id}
+                                    userName={beforeVersion?.user.name ?? undefined}
                                     version={beforeVersion?.version}
                                 />
                             )
@@ -134,8 +134,8 @@ export const ActionLogCompare: FunctionComponent<ActionLogCompareProps> = ({
                         rightTitle={
                             <DiffHeader
                                 createdAt={afterVersion?.createdAt}
-                                userId={afterVersion?.userId}
-                                userName={afterVersion?.user?.name}
+                                userId={afterVersion?.user.id}
+                                userName={afterVersion?.user.name ?? undefined}
                                 version={afterVersion?.version}
                             />
                         }

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/__stories__/ActionLogCompare.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/__stories__/ActionLogCompare.stories.tsx
@@ -9,8 +9,7 @@ const mockVersion1 = {
     version: 1,
     snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
     createdAt: "2023-10-01T12:00:00Z",
-    userId: "1",
-    user: { __typename: "ActionLogUser" as const, id: "1", name: "Max Mustermann" },
+    user: { __typename: "ActionLogsUser" as const, id: "1", name: "Max Mustermann" },
     entityName: "TestEntity",
 };
 
@@ -20,8 +19,7 @@ const mockVersion2 = {
     version: 2,
     snapshot: { title: "My Page (updated)", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
     createdAt: "2023-10-02T12:00:00Z",
-    userId: "2",
-    user: { __typename: "ActionLogUser" as const, id: "2", name: "Jane Doe" },
+    user: { __typename: "ActionLogsUser" as const, id: "2", name: "Jane Doe" },
     entityName: "TestEntity",
 };
 

--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/__stories__/ActionLogCompare.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/__stories__/ActionLogCompare.stories.tsx
@@ -9,7 +9,8 @@ const mockVersion1 = {
     version: 1,
     snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
     createdAt: "2023-10-01T12:00:00Z",
-    userId: "system-user",
+    userId: "1",
+    user: { __typename: "ActionLogUser" as const, id: "1", name: "Max Mustermann" },
     entityName: "TestEntity",
 };
 
@@ -19,7 +20,8 @@ const mockVersion2 = {
     version: 2,
     snapshot: { title: "My Page (updated)", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
     createdAt: "2023-10-02T12:00:00Z",
-    userId: "user2",
+    userId: "2",
+    user: { __typename: "ActionLogUser" as const, id: "2", name: "Jane Doe" },
     entityName: "TestEntity",
 };
 

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.gql.ts
@@ -4,6 +4,10 @@ export const actionLogGridFragment = gql`
     fragment ActionLogGrid on ActionLog {
         id
         userId
+        user {
+            id
+            name
+        }
         entityName
         version
         createdAt

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.gql.ts
@@ -3,7 +3,6 @@ import { gql } from "@apollo/client";
 export const actionLogGridFragment = gql`
     fragment ActionLogGrid on ActionLog {
         id
-        userId
         user {
             id
             name

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.tsx
@@ -57,7 +57,7 @@ export const ActionLogGrid: FunctionComponent<ActionLogGridProps> = ({
                 headerName: intl.formatMessage({ defaultMessage: "Geändert von", id: "actionLog.actionLogGrid.columns.userId" }),
                 minWidth: 400,
                 renderCell: ({ row }) => {
-                    return <UserCell name={row.userId} />;
+                    return <UserCell id={row.userId} name={row.user?.name} />;
                 },
             },
             {

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/ActionLogGrid.tsx
@@ -53,11 +53,12 @@ export const ActionLogGrid: FunctionComponent<ActionLogGridProps> = ({
                 },
             },
             {
-                field: "userId",
-                headerName: intl.formatMessage({ defaultMessage: "Geändert von", id: "actionLog.actionLogGrid.columns.userId" }),
+                field: "user",
+                headerName: intl.formatMessage({ defaultMessage: "Geändert von", id: "actionLog.actionLogGrid.columns.user" }),
                 minWidth: 400,
+                sortable: false,
                 renderCell: ({ row }) => {
-                    return <UserCell id={row.userId} name={row.user?.name} />;
+                    return <UserCell id={row.user.id} name={row.user.name ?? undefined} />;
                 },
             },
             {

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/__stories__/ActionLogGrid.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/__stories__/ActionLogGrid.stories.tsx
@@ -7,9 +7,30 @@ import { ActionLogGrid } from "../ActionLogGrid";
 const mockActionLogs = {
     totalCount: 3,
     nodes: [
-        { id: "log3", userId: "Max Mustermann", entityName: "TestEntity", version: 3, createdAt: "2023-10-03T12:00:00Z" },
-        { id: "log2", userId: "user2", entityName: "TestEntity", version: 2, createdAt: "2023-10-02T12:00:00Z" },
-        { id: "log1", userId: "system-user", entityName: "TestEntity", version: 1, createdAt: "2023-10-01T12:00:00Z" },
+        {
+            id: "log3",
+            userId: "1",
+            user: { id: "1", name: "Max Mustermann" },
+            entityName: "TestEntity",
+            version: 3,
+            createdAt: "2023-10-03T12:00:00Z",
+        },
+        {
+            id: "log2",
+            userId: "2",
+            user: { id: "2", name: "Jane Doe" },
+            entityName: "TestEntity",
+            version: 2,
+            createdAt: "2023-10-02T12:00:00Z",
+        },
+        {
+            id: "log1",
+            userId: "deleted-user-id",
+            user: null,
+            entityName: "TestEntity",
+            version: 1,
+            createdAt: "2023-10-01T12:00:00Z",
+        },
     ],
 };
 

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/__stories__/ActionLogGrid.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/__stories__/ActionLogGrid.stories.tsx
@@ -9,7 +9,6 @@ const mockActionLogs = {
     nodes: [
         {
             id: "log3",
-            userId: "1",
             user: { id: "1", name: "Max Mustermann" },
             entityName: "TestEntity",
             version: 3,
@@ -17,7 +16,6 @@ const mockActionLogs = {
         },
         {
             id: "log2",
-            userId: "2",
             user: { id: "2", name: "Jane Doe" },
             entityName: "TestEntity",
             version: 2,
@@ -25,8 +23,7 @@ const mockActionLogs = {
         },
         {
             id: "log1",
-            userId: "deleted-user-id",
-            user: null,
+            user: { id: "deleted-user-id", name: null },
             entityName: "TestEntity",
             version: 1,
             createdAt: "2023-10-01T12:00:00Z",

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/userCell/UserCell.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/userCell/UserCell.tsx
@@ -1,29 +1,24 @@
 import { type Theme, Typography, useTheme } from "@mui/material";
 import type { FunctionComponent } from "react";
+import { FormattedMessage } from "react-intl";
 
 import { AvatarStyled, Root } from "./UserCell.sc";
 
 type UserCellProps = {
+    id: string;
     name?: string;
-    initials?: string;
-    avatarColor?: string;
 };
 
-const initialsForName = (name?: string) => {
-    if (name) {
-        const splitName = name.split(" ");
-        if (splitName.length > 1) {
-            return `${splitName[0].substring(0, 1).toUpperCase()}${splitName[1].substring(0, 1).toUpperCase()}`;
-        }
-        const dashSplitNames = name.split("-");
-        if (dashSplitNames.length > 1) {
-            return `${dashSplitNames[0].substring(0, 1).toUpperCase()}${dashSplitNames[1].substring(0, 1).toUpperCase()}`;
-        }
-
-        return name.substring(0, 2);
+const initialsForName = (name: string) => {
+    const splitName = name.split(" ");
+    if (splitName.length > 1) {
+        return `${splitName[0].substring(0, 1).toUpperCase()}${splitName[1].substring(0, 1).toUpperCase()}`;
     }
-
-    return undefined;
+    const dashSplitNames = name.split("-");
+    if (dashSplitNames.length > 1) {
+        return `${dashSplitNames[0].substring(0, 1).toUpperCase()}${dashSplitNames[1].substring(0, 1).toUpperCase()}`;
+    }
+    return name.substring(0, 2);
 };
 
 const stringToColor = (string: string) => {
@@ -44,24 +39,22 @@ const stringToColor = (string: string) => {
     return color;
 };
 
-const resolveBackgroundColor = (options: { name?: string; avatarColor?: string; theme: Theme }) => {
-    if (options.avatarColor) {
-        return options.avatarColor;
+const resolveBackgroundColor = (name: string | undefined, theme: Theme) => {
+    if (name) {
+        return stringToColor(name);
     }
-    if (options.name) {
-        return stringToColor(options.name);
-    }
-    return options.theme.palette.primary.main;
+    return theme.palette.grey[500];
 };
 
-export const UserCell: FunctionComponent<UserCellProps> = ({ name, initials = initialsForName(name), avatarColor }) => {
+export const UserCell: FunctionComponent<UserCellProps> = ({ id, name }) => {
     const theme = useTheme();
 
     return (
         <Root>
-            <AvatarStyled backgroundColor={resolveBackgroundColor({ name, avatarColor, theme })}>{initials}</AvatarStyled>
-
-            <Typography>{name}</Typography>
+            <AvatarStyled backgroundColor={resolveBackgroundColor(name, theme)}>{name ? initialsForName(name) : "?"}</AvatarStyled>
+            <Typography>
+                {name ?? <FormattedMessage defaultMessage="Unknown user ({id})" id="actionLog.actionLogGrid.userCell.unknownUser" values={{ id }} />}
+            </Typography>
         </Root>
     );
 };

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/userCell/__stories__/UserCell.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/userCell/__stories__/UserCell.stories.tsx
@@ -9,36 +9,22 @@ const meta: Meta<typeof UserCell> = {
 };
 export default meta;
 
-export const SystemUser: Story = {
-    args: {
-        name: "system-user",
-    },
-};
-
 export const MaxMustermann: Story = {
     args: {
+        id: "abc-123",
         name: "Max Mustermann",
     },
 };
 
 export const OneName: Story = {
     args: {
+        id: "abc-123",
         name: "Max",
     },
 };
 
-export const NoName: Story = {};
-
-export const RedBackgroundColor: Story = {
+export const UnknownUser: Story = {
     args: {
-        name: "Max",
-        avatarColor: "#ff0000",
-    },
-};
-
-export const CustomInitials: Story = {
-    args: {
-        name: "Max",
-        initials: "XY",
+        id: "abc-123",
     },
 };

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.gql.ts
@@ -7,6 +7,10 @@ export const actionLogShowVersionFragment = gql`
         snapshot
         createdAt
         userId
+        user {
+            id
+            name
+        }
         entityName
     }
 `;

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.gql.ts
@@ -6,7 +6,6 @@ export const actionLogShowVersionFragment = gql`
         version
         snapshot
         createdAt
-        userId
         user {
             id
             name

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.tsx
@@ -74,8 +74,8 @@ export const ActionLogShowVersion: FunctionComponent<ActionLogShowVersionProps> 
                         leftTitle={
                             <DiffHeader
                                 createdAt={version.createdAt}
-                                userId={version.userId}
-                                userName={version.user?.name}
+                                userId={version.user.id}
+                                userName={version.user.name ?? undefined}
                                 version={version.version}
                             />
                         }

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/ActionLogShowVersion.tsx
@@ -71,7 +71,14 @@ export const ActionLogShowVersion: FunctionComponent<ActionLogShowVersionProps> 
             {version != null && (
                 <DiffViewerContainer>
                     <DiffViewer
-                        leftTitle={<DiffHeader createdAt={version.createdAt} userId={version.userId} version={version.version} />}
+                        leftTitle={
+                            <DiffHeader
+                                createdAt={version.createdAt}
+                                userId={version.userId}
+                                userName={version.user?.name}
+                                version={version.version}
+                            />
+                        }
                         newValue={JSON.stringify(filteredVersionSnapshot, null, 8)}
                         oldValue={JSON.stringify(filteredVersionSnapshot, null, 8)}
                         showDiffOnly={false}

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/__stories__/ActionLogShowVersion.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/__stories__/ActionLogShowVersion.stories.tsx
@@ -9,8 +9,7 @@ const mockActionLog = {
     version: 1,
     snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
     createdAt: "2023-10-01T12:00:00Z",
-    userId: "1",
-    user: { __typename: "ActionLogUser" as const, id: "1", name: "Max Mustermann" },
+    user: { __typename: "ActionLogsUser" as const, id: "1", name: "Max Mustermann" },
     entityName: "TestEntity",
 };
 

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/__stories__/ActionLogShowVersion.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/__stories__/ActionLogShowVersion.stories.tsx
@@ -9,7 +9,8 @@ const mockActionLog = {
     version: 1,
     snapshot: { title: "My Page", slug: "my-page", createdAt: "2023-10-01T12:00:00Z" },
     createdAt: "2023-10-01T12:00:00Z",
-    userId: "system-user",
+    userId: "1",
+    user: { __typename: "ActionLogUser" as const, id: "1", name: "Max Mustermann" },
     entityName: "TestEntity",
 };
 

--- a/packages/admin/cms-admin/src/actionLog/components/DiffHeader.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/DiffHeader.tsx
@@ -6,10 +6,11 @@ import { Root } from "./DiffHeader.sc";
 export interface DiffHeaderProps {
     createdAt?: string;
     userId?: string;
+    userName?: string;
     version?: number;
 }
 
-export const DiffHeader = ({ createdAt, userId, version }: DiffHeaderProps) => {
+export const DiffHeader = ({ createdAt, userId, userName, version }: DiffHeaderProps) => {
     return (
         <Root>
             <Typography color="white" variant="subtitle1">
@@ -18,17 +19,23 @@ export const DiffHeader = ({ createdAt, userId, version }: DiffHeaderProps) => {
 
             <Typography color="textSecondary" variant="caption">
                 <FormattedMessage
-                    defaultMessage="{userId} on {date}"
-                    id="actionLog.actionLogCompare.diffHeader.userIdAndTime"
+                    defaultMessage="{user} on {date}"
+                    id="actionLog.actionLogCompare.diffHeader.userAndTime"
                     values={{
                         date: (
                             <Typography color="textSecondary" variant="overline" component="span">
                                 <FormattedDate dateStyle="short" timeStyle="short" value={createdAt} />
                             </Typography>
                         ),
-                        userId: (
+                        user: (
                             <Typography color="textSecondary" variant="overline" component="span">
-                                {userId}
+                                {userName ?? (
+                                    <FormattedMessage
+                                        defaultMessage="Unknown user ({id})"
+                                        id="actionLog.actionLogCompare.diffHeader.unknownUser"
+                                        values={{ id: userId }}
+                                    />
+                                )}
                             </Typography>
                         ),
                     }}

--- a/packages/admin/cms-admin/src/actionLog/components/__stories__/DiffHeader.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/__stories__/DiffHeader.stories.tsx
@@ -12,7 +12,16 @@ export default meta;
 export const StandardDiffHeader: Story = {
     args: {
         createdAt: "2023-10-01T12:00:00Z",
-        userId: "system-user",
+        userId: "abc-123",
+        userName: "Max Mustermann",
+        version: 1,
+    },
+};
+
+export const UnknownUser: Story = {
+    args: {
+        createdAt: "2023-10-01T12:00:00Z",
+        userId: "abc-123",
         version: 1,
     },
 };

--- a/packages/api/cms-api/generate-schema.ts
+++ b/packages/api/cms-api/generate-schema.ts
@@ -21,6 +21,7 @@ import {
     PageTreeNodeCategory,
     PaginatedPageTreeNodesFactory,
 } from "./src";
+import { ActionLogResolver } from "./src/action-logs/action-log.resolver";
 import { BuildTemplatesResolver } from "./src/builds/build-templates.resolver";
 import { GenerateAltTextResolver } from "./src/content-generation/generate-alt-text.resolver";
 import { GenerateImageTitleResolver } from "./src/content-generation/generate-image-title.resolver";
@@ -102,6 +103,7 @@ async function generateSchema(): Promise<void> {
     registerEnumType(CombinedPermission, { name: "Permission" });
 
     const schema = await gqlSchemaFactory.create([
+        ActionLogResolver,
         BuildsResolver,
         BuildTemplatesResolver,
         redirectsResolver,

--- a/packages/api/cms-api/generate-schema.ts
+++ b/packages/api/cms-api/generate-schema.ts
@@ -21,7 +21,7 @@ import {
     PageTreeNodeCategory,
     PaginatedPageTreeNodesFactory,
 } from "./src";
-import { ActionLogResolver } from "./src/action-logs/action-log.resolver";
+import { ActionLogsResolver } from "./src/action-logs/action-logs.resolver";
 import { BuildTemplatesResolver } from "./src/builds/build-templates.resolver";
 import { GenerateAltTextResolver } from "./src/content-generation/generate-alt-text.resolver";
 import { GenerateImageTitleResolver } from "./src/content-generation/generate-image-title.resolver";
@@ -103,7 +103,7 @@ async function generateSchema(): Promise<void> {
     registerEnumType(CombinedPermission, { name: "Permission" });
 
     const schema = await gqlSchemaFactory.create([
-        ActionLogResolver,
+        ActionLogsResolver,
         BuildsResolver,
         BuildTemplatesResolver,
         redirectsResolver,

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -43,21 +43,20 @@ The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](
 """
 scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
-type ActionLogUser {
+type ActionLogsUser {
   id: ID!
-  name: String!
+  name: String
 }
 
 type ActionLog {
   id: ID!
   scope: [JSONObject!]
-  userId: ID!
   entityName: String!
   entityId: ID!
   version: Int!
   snapshot: JSONObject
   createdAt: DateTime!
-  user: ActionLogUser
+  user: ActionLogsUser!
 }
 
 type ContentScopeWithLabel {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -1,24 +1,3 @@
-type ActionLog {
-  id: ID!
-  scope: [JSONObject!]
-  userId: ID!
-  entityName: String!
-  entityId: ID!
-  version: Int!
-  snapshot: JSONObject
-  createdAt: DateTime!
-}
-
-"""
-The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
-
-"""
-A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
-"""
-scalar DateTime
-
 type UserPermission {
   id: ID!
   source: UserPermissionSource!
@@ -52,6 +31,33 @@ enum Permission {
   sitePreview
   blockPreview
   fullTextSearch
+}
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
+"""
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+type ActionLogUser {
+  id: ID!
+  name: String!
+}
+
+type ActionLog {
+  id: ID!
+  scope: [JSONObject!]
+  userId: ID!
+  entityName: String!
+  entityId: ID!
+  version: Int!
+  snapshot: JSONObject
+  createdAt: DateTime!
+  user: ActionLogUser
 }
 
 type ContentScopeWithLabel {

--- a/packages/api/cms-api/src/action-logs/action-log.resolver.ts
+++ b/packages/api/cms-api/src/action-logs/action-log.resolver.ts
@@ -1,0 +1,20 @@
+import { Parent, ResolveField, Resolver } from "@nestjs/graphql";
+
+import { UserPermissionsService } from "../user-permissions/user-permissions.service";
+import { ActionLogUser } from "./dto/action-log-user";
+import { ActionLog } from "./entities/action-log.entity";
+
+@Resolver(() => ActionLog)
+export class ActionLogResolver {
+    constructor(private readonly userPermissionsService: UserPermissionsService) {}
+
+    @ResolveField(() => ActionLogUser, { nullable: true })
+    async user(@Parent() actionLog: ActionLog): Promise<ActionLogUser | null> {
+        try {
+            const user = await this.userPermissionsService.getUser(actionLog.userId);
+            return { id: user.id, name: user.name };
+        } catch {
+            return null;
+        }
+    }
+}

--- a/packages/api/cms-api/src/action-logs/action-logs.module.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.module.ts
@@ -2,6 +2,7 @@ import { MikroOrmModule } from "@mikro-orm/nestjs";
 import type { AnyEntity } from "@mikro-orm/postgresql";
 import type { DynamicModule, Type } from "@nestjs/common";
 
+import { ActionLogResolver } from "./action-log.resolver";
 import { ActionLogsResolverFactory } from "./action-logs.resolver.factory";
 import { ActionLogsService } from "./action-logs.service";
 import { ActionLogsSubscriber } from "./action-logs.subscriber";
@@ -13,7 +14,7 @@ export class ActionLogsModule {
         return {
             module: ActionLogsModule,
             imports: [MikroOrmModule.forFeature([ActionLog])],
-            providers: [ActionLogsSubscriber, ActionLogsService],
+            providers: [ActionLogsSubscriber, ActionLogsService, ActionLogResolver],
         };
     }
 

--- a/packages/api/cms-api/src/action-logs/action-logs.module.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.module.ts
@@ -2,7 +2,7 @@ import { MikroOrmModule } from "@mikro-orm/nestjs";
 import type { AnyEntity } from "@mikro-orm/postgresql";
 import type { DynamicModule, Type } from "@nestjs/common";
 
-import { ActionLogResolver } from "./action-log.resolver";
+import { ActionLogsResolver } from "./action-logs.resolver";
 import { ActionLogsResolverFactory } from "./action-logs.resolver.factory";
 import { ActionLogsService } from "./action-logs.service";
 import { ActionLogsSubscriber } from "./action-logs.subscriber";
@@ -14,7 +14,7 @@ export class ActionLogsModule {
         return {
             module: ActionLogsModule,
             imports: [MikroOrmModule.forFeature([ActionLog])],
-            providers: [ActionLogsSubscriber, ActionLogsService, ActionLogResolver],
+            providers: [ActionLogsSubscriber, ActionLogsService, ActionLogsResolver],
         };
     }
 

--- a/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
@@ -1,20 +1,20 @@
 import { Parent, ResolveField, Resolver } from "@nestjs/graphql";
 
 import { UserPermissionsService } from "../user-permissions/user-permissions.service";
-import { ActionLogUser } from "./dto/action-log-user";
+import { ActionLogsUser } from "./dto/action-logs-user";
 import { ActionLog } from "./entities/action-log.entity";
 
 @Resolver(() => ActionLog)
-export class ActionLogResolver {
+export class ActionLogsResolver {
     constructor(private readonly userPermissionsService: UserPermissionsService) {}
 
-    @ResolveField(() => ActionLogUser, { nullable: true })
-    async user(@Parent() actionLog: ActionLog): Promise<ActionLogUser | null> {
+    @ResolveField(() => ActionLogsUser)
+    async user(@Parent() actionLog: ActionLog): Promise<ActionLogsUser> {
         try {
             const user = await this.userPermissionsService.getUser(actionLog.userId);
             return { id: user.id, name: user.name };
         } catch {
-            return null;
+            return { id: actionLog.userId };
         }
     }
 }

--- a/packages/api/cms-api/src/action-logs/dto/action-log-user.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-log-user.ts
@@ -1,0 +1,10 @@
+import { Field, ID, ObjectType } from "@nestjs/graphql";
+
+@ObjectType()
+export class ActionLogUser {
+    @Field(() => ID)
+    id: string;
+
+    @Field()
+    name: string;
+}

--- a/packages/api/cms-api/src/action-logs/dto/action-log.sort.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-log.sort.ts
@@ -4,7 +4,6 @@ import { IsEnum } from "class-validator";
 import { SortDirection } from "../../common/sorting/sort-direction.enum";
 
 enum ActionLogSortField {
-    userId = "userId",
     version = "version",
     createdAt = "createdAt",
 }

--- a/packages/api/cms-api/src/action-logs/dto/action-logs-user.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-logs-user.ts
@@ -1,10 +1,10 @@
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 
 @ObjectType()
-export class ActionLogUser {
+export class ActionLogsUser {
     @Field(() => ID)
     id: string;
 
-    @Field()
-    name: string;
+    @Field({ nullable: true })
+    name?: string;
 }

--- a/packages/api/cms-api/src/action-logs/entities/action-log.entity.ts
+++ b/packages/api/cms-api/src/action-logs/entities/action-log.entity.ts
@@ -22,7 +22,6 @@ export class ActionLog extends BaseEntity {
     @Index({ type: "gin" })
     scope?: ContentScope[];
 
-    @Field(() => ID)
     @Property({ type: "text", index: true })
     userId: string;
 


### PR DESCRIPTION
## Summary
Enhanced action logs to display user information by adding a new `user` field to the `ActionLog` GraphQL type that resolves user details from the user permissions service. This allows the UI to display user names instead of raw user IDs, with a graceful fallback for deleted or unknown users.

| before | after |
|--------|--------|
| <img width="1135" height="581" alt="Screenshot 2026-05-28 at 08 59 15" src="https://github.com/user-attachments/assets/75d5928c-4739-4177-bf5b-d8d450e34991"/> | <img width="1131" height="587" alt="Screenshot 2026-05-28 at 08 49 40" src="https://github.com/user-attachments/assets/134d460d-b940-4614-b30f-20c5d972e0dd"/> |


## Key Changes

- **GraphQL Schema**:
  - Added `ActionLogsUser` type with `id: ID!` and `name: String` (name is nullable so the id is always available for the fallback).
  - Added a non-nullable `user: ActionLogsUser!` field to `ActionLog`.
  - Removed the now-redundant `ActionLog.userId` from the GraphQL schema (the DB column stays). For the same reason, `userId` was removed from `ActionLogSortField`.
- **Backend**: Added `ActionLogsResolver` with a `@ResolveField('user')` that looks up the user via `UserPermissionsService`. When the lookup fails (e.g. user was deleted), the resolver still returns `{ id: actionLog.userId }` with `name = null` so the admin can render the "Unknown user ({id})" fallback.
- **Frontend Components**:
  - Updated `UserCell` to a minimal `{ id, name? }` API. Displays the user name when known, otherwise "Unknown user ({id})" with a neutral grey avatar.
  - Updated `DiffHeader` to accept an optional `userName` alongside `userId` and apply the same fallback.
  - Updated `ActionLogGrid` to source id and name from the new `user` field.
- **GraphQL Fragments**: Updated `ActionLogGrid`, `ActionLogCompare`, and `ActionLogShowVersion` to select `user { id name }` instead of `userId`.
- **Stories**: Refreshed Storybook fixtures to use the new `user` object and added a "deleted user" example to exercise the fallback.

## Notes

- `ActionLog.user` is resolved per row, so the action log grid currently does N+1 user lookups. This is acceptable for the version-history dialog (low-traffic, ~25 rows per page) and can be improved later via a DataLoader-based batch — would require extending `UserPermissionsUserServiceInterface` with a batch lookup method.

https://claude.ai/code/session_01671MVv1jRh66RWAgLdbb8S