### PR TITLE
cms-admin: Align action log Storybook titles to directory structure

### DIFF
--- a/packages/admin/cms-admin/src/actionLog/actionLogCompare/__stories__/ActionLogCompare.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogCompare/__stories__/ActionLogCompare.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta<typeof ActionLogCompare> = {
         ),
     ],
     tags: ["!autodocs"],
-    title: "Action log/Action log compare",
+    title: "actionLog/actionLogCompare/ActionLogCompare",
     args: {
         onClickShowVersionHistory: () => undefined,
     },

--- a/packages/admin/cms-admin/src/actionLog/actionLogDialog/__stories__/ActionLogDialog.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogDialog/__stories__/ActionLogDialog.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<ActionLogDialogStoryArgs>;
 const meta: Meta<ActionLogDialogStoryArgs> = {
     component: ActionLogDialog,
     tags: ["!autodocs"],
-    title: "Action log/Action log dialog",
+    title: "actionLog/actionLogDialog/ActionLogDialog",
     args: {
         id: "550e8400-e29b-41d4-a716-446655440000",
         rootField: "manufacturer",

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/__stories__/ActionLogGrid.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/__stories__/ActionLogGrid.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof ActionLogGrid> = {
         ),
     ],
     tags: ["!autodocs"],
-    title: "Action log/Action log grid",
+    title: "actionLog/actionLogGrid/ActionLogGrid",
 };
 export default meta;
 

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/actionGridToolbar/__stories__/ActionGridToolbar.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/actionGridToolbar/__stories__/ActionGridToolbar.stories.tsx
@@ -6,7 +6,7 @@ import { ActionGridToolbar } from "../ActionGridToolbar";
 type Story = StoryFn<typeof ActionGridToolbar>;
 const config: Meta<typeof ActionGridToolbar> = {
     component: ActionGridToolbar,
-    title: "Action log/Action log grid/Action grid toolbar",
+    title: "actionLog/actionLogGrid/actionGridToolbar/ActionGridToolbar",
 };
 export default config;
 

--- a/packages/admin/cms-admin/src/actionLog/actionLogGrid/userCell/__stories__/UserCell.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogGrid/userCell/__stories__/UserCell.stories.tsx
@@ -5,7 +5,7 @@ import { UserCell } from "../UserCell";
 type Story = StoryObj<typeof UserCell>;
 const meta: Meta<typeof UserCell> = {
     component: UserCell,
-    title: "Action log/Action log grid/User cell",
+    title: "actionLog/actionLogGrid/userCell/UserCell",
 };
 export default meta;
 

--- a/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/__stories__/ActionLogShowVersion.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLogShowVersion/__stories__/ActionLogShowVersion.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof ActionLogShowVersion> = {
         ),
     ],
     tags: ["!autodocs"],
-    title: "Action log/Action log show version",
+    title: "actionLog/actionLogShowVersion/ActionLogShowVersion",
     args: {
         onClickShowVersionHistory: () => undefined,
     },


### PR DESCRIPTION
The `actionLog` stories were split across two top-level Storybook sidebar sections (`Action log/...` and `actionLog/...`). Unify them under a single `actionLog/` root with titles mirroring the source directory layout, matching the convention used elsewhere in `cms-admin` (`blocks/...`, `contentScope/...`, ...).

https://claude.ai/code/session_018Gko3uqZgSQrT3EE2zN2QX