### PR TITLE
Forbid direct MUI DataGrid imports in cms-admin and brevo-admin

### DIFF
--- a/packages/admin/brevo-admin/eslint.config.mjs
+++ b/packages/admin/brevo-admin/eslint.config.mjs
@@ -1,5 +1,13 @@
 import { defineConfig, globalIgnores } from "eslint/config";
-import eslintConfigReact from "@comet/eslint-config/future/react.js";
+import eslintConfigReact, { restrictedImportPaths } from "@comet/eslint-config/future/react.js";
+
+const dataGridImportRestrictions = ["@mui/x-data-grid", "@mui/x-data-grid-pro", "@mui/x-data-grid-premium"].flatMap((name) =>
+    ["DataGrid", "DataGridPro", "DataGridPremium"].map((importName) => ({
+        name,
+        importNames: [importName],
+        message: "Please use DataGrid from `@comet/brevo-admin` instead, which resolves the configured grid via `CometConfig`.",
+    })),
+);
 
 export default defineConfig([
     globalIgnores(["src/*.generated.ts", "lib/**", "**/*.generated.ts", "block-meta.json"]),
@@ -17,6 +25,17 @@ export default defineConfig([
     {
         rules: {
             "@comet/no-other-module-relative-import": "off",
+        },
+    },
+    {
+        ignores: ["src/dataGrid/DataGrid.tsx"],
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    paths: [...restrictedImportPaths, ...dataGridImportRestrictions],
+                },
+            ],
         },
     },
 ]);

--- a/packages/admin/brevo-admin/eslint.config.mjs
+++ b/packages/admin/brevo-admin/eslint.config.mjs
@@ -28,7 +28,6 @@ export default defineConfig([
         },
     },
     {
-        ignores: ["src/dataGrid/DataGrid.tsx"],
         rules: {
             "no-restricted-imports": [
                 "error",

--- a/packages/admin/brevo-admin/src/dataGrid/DataGrid.tsx
+++ b/packages/admin/brevo-admin/src/dataGrid/DataGrid.tsx
@@ -1,4 +1,5 @@
 import { useCometConfig } from "@comet/cms-admin";
+// eslint-disable-next-line no-restricted-imports
 import { DataGrid as MuiDataGrid, type DataGridProps, type GridValidRowModel } from "@mui/x-data-grid";
 
 export function DataGrid<R extends GridValidRowModel = GridValidRowModel>(props: DataGridProps<R>) {

--- a/packages/admin/cms-admin/eslint.config.mjs
+++ b/packages/admin/cms-admin/eslint.config.mjs
@@ -33,7 +33,6 @@ export default defineConfig([
         },
     },
     {
-        ignores: ["src/dataGrid/DataGrid.tsx"],
         rules: {
             "no-restricted-imports": [
                 "error",

--- a/packages/admin/cms-admin/eslint.config.mjs
+++ b/packages/admin/cms-admin/eslint.config.mjs
@@ -2,6 +2,14 @@ import eslintConfigReact, { restrictedImportPaths } from "@comet/eslint-config/f
 import { defineConfig, globalIgnores } from "eslint/config";
 import storybook from "eslint-plugin-storybook";
 
+const dataGridImportRestrictions = ["@mui/x-data-grid", "@mui/x-data-grid-pro", "@mui/x-data-grid-premium"].flatMap((name) =>
+    ["DataGrid", "DataGridPro", "DataGridPremium"].map((importName) => ({
+        name,
+        importNames: [importName],
+        message: "Please use DataGrid from `@comet/cms-admin` instead, which resolves the configured grid via `CometConfig`.",
+    })),
+);
+
 export default defineConfig([
     globalIgnores(["src/*.generated.ts", "lib/**", "**/*.generated.ts", "block-meta.json"]),
     ...eslintConfigReact,
@@ -22,6 +30,17 @@ export default defineConfig([
     {
         rules: {
             "@comet/no-other-module-relative-import": "off",
+        },
+    },
+    {
+        ignores: ["src/dataGrid/DataGrid.tsx"],
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    paths: [...restrictedImportPaths, ...dataGridImportRestrictions],
+                },
+            ],
         },
     },
     {

--- a/packages/admin/cms-admin/src/blocks/table/TableBlockGrid.tsx
+++ b/packages/admin/cms-admin/src/blocks/table/TableBlockGrid.tsx
@@ -2,6 +2,7 @@ import { DragIndicator } from "@comet/admin-icons";
 // eslint-disable-next-line no-restricted-imports
 import type { GridColDef, GridColumnHeaderParams, GridValidRowModel } from "@mui/x-data-grid";
 import {
+    // eslint-disable-next-line no-restricted-imports
     DataGridPro,
     GRID_REORDER_COL_DEF,
     type GridEventListener,

--- a/packages/admin/cms-admin/src/dataGrid/DataGrid.tsx
+++ b/packages/admin/cms-admin/src/dataGrid/DataGrid.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { DataGrid as MuiDataGrid, type DataGridProps, type GridValidRowModel } from "@mui/x-data-grid";
 
 import { useCometConfig } from "../config/CometConfigContext";


### PR DESCRIPTION
Follow-up to #5731 ([requested here](https://github.com/vivid-planet/comet/pull/5731#issuecomment-4562717421)).

Forbid importing `DataGrid`, `DataGridPro` and `DataGridPremium` from `@mui/x-data-grid(-pro|-premium)` in `@comet/cms-admin` and `@comet/brevo-admin`, so new code uses the `DataGrid` wrapper introduced in #5731 (which resolves the configured implementation via `CometConfig`).

Type-only imports remain allowed.

### Forbidden

```tsx
import { DataGrid } from "@mui/x-data-grid";
import { DataGridPro } from "@mui/x-data-grid-pro";
import { DataGridPremium } from "@mui/x-data-grid-premium";
```

### Allowed

```tsx
// In @comet/cms-admin
import { DataGrid } from "../dataGrid/DataGrid";

// In @comet/brevo-admin
import { DataGrid } from "../dataGrid/DataGrid";

// Type imports stay on MUI
import type { DataGridProps, GridValidRowModel } from "@mui/x-data-grid";
```
