### PR TITLE
Fix `1-NaN of NaN` pagination footer in DAM `FolderDataGrid`

### DIFF
--- a/.changeset/fix-dam-folder-data-grid-row-count.md
+++ b/.changeset/fix-dam-folder-data-grid-row-count.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix `1-NaN of NaN` pagination footer and `rowCount` warning in DAM `FolderDataGrid`
+
+The grid now routes `totalCount` through `useBufferedRowCount`, so `rowCount` stays a number across refetches instead of becoming `undefined` while data is loading.

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -12,6 +12,7 @@ import {
     ToolbarActions,
     ToolbarItem,
     Tooltip,
+    useBufferedRowCount,
     useDataGridRemote,
     useSnackbarApi,
     useStackSwitchApi,
@@ -435,6 +436,8 @@ const FolderDataGrid = ({
         },
     });
 
+    const rowCount = useBufferedRowCount(dataGridData?.damItemsList.totalCount);
+
     const { matches } = useDamSearchHighlighting({
         items: dataGridData?.damItemsList.nodes ?? [],
         query: filterApi.current.searchText ?? "",
@@ -658,7 +661,7 @@ const FolderDataGrid = ({
                     {...dataGridProps}
                     rowHeight={58}
                     rows={dataGridData?.damItemsList.nodes ?? []}
-                    rowCount={dataGridData?.damItemsList.totalCount ?? undefined}
+                    rowCount={rowCount}
                     loading={loading}
                     pageSizeOptions={[10, 20, 50]}
                     getRowClassName={getRowClassName}


### PR DESCRIPTION
## Problem

The DAM grid (`FolderDataGrid`) showed `1-NaN of NaN` in its pagination footer during loading and emitted a MUI X warning about `rowCount` being missing in `paginationMode="server"` — even though `useDataGridRemote` already sets `paginationMode: "server"`.

The real trigger was this line:

```tsx
rowCount={dataGridData?.damItemsList.totalCount ?? undefined}
```

In MUI X v8 with `paginationMode="server"`, `rowCount` must always be a number. Passing `undefined` (which happens on first render and again on every refetch) makes the grid abort its pagination calculations and produces the `NaN` footer plus the warning.

<img width="1920" height="1040" alt="Bildschirmfoto 2026-05-28 um 12 32 47" src="https://github.com/user-attachments/assets/87759bdd-15a5-4db9-85ee-d44f3d988b82" />

## Fix

Route `totalCount` through `useBufferedRowCount` so the value defaults to `0` on first render and keeps the previous count during refetches:

```tsx
const rowCount = useBufferedRowCount(dataGridData?.damItemsList.totalCount);
// …
rowCount = { rowCount };
```

<img width="1920" height="1040" alt="Bildschirmfoto 2026-05-28 um 12 30 33" src="https://github.com/user-attachments/assets/d77cc320-6dd4-4ec0-858c-ab26715ea807" />

## What this fix is based on

`FolderDataGrid` was the only server-paginated grid in `cms-admin` not using `useBufferedRowCount`. Every other grid — including its sibling `MediaAlternativesGrid` in the same DAM folder — already follows this pattern:

- `dam/mediaAlternatives/MediaAlternativesGrid.tsx:185`
- `redirects/RedirectsGrid.tsx:184`
- `warnings/WarningsGrid.tsx:224`
- `userPermissions/UserGrid.tsx:235`
- `dependencies/DependenciesList.tsx:219`, `DependentsList.tsx:217`

`useBufferedRowCount` is a small helper in `@comet/admin` that exists specifically for this case (API clients returning `undefined` while loading). `git log -S "rowCount"` on `FolderDataGrid.tsx` shows the line was never touched after the MUI X v8 upgrade — it's a leftover from before the helper became the convention, not an intentional deviation.
