### PR TITLE
mail-react: Add HtmlImage and make MjmlImage responsive by default

### DIFF
--- a/.changeset/add-html-image.md
+++ b/.changeset/add-html-image.md
@@ -1,0 +1,13 @@
+---
+"@comet/mail-react": minor
+---
+
+Add `HtmlImage` component
+
+Renders an `<img>` tag that adapts to its container width below the default breakpoint. Use within raw HTML context — HTML-only emails or MJML ending tags like `MjmlRaw`.
+
+```tsx
+import { HtmlImage } from "@comet/mail-react";
+
+<HtmlImage src="https://example.com/banner.png" width="600" height="300" alt="Banner" />;
+```

--- a/.changeset/mjml-image-responsive-by-default.md
+++ b/.changeset/mjml-image-responsive-by-default.md
@@ -1,0 +1,7 @@
+---
+"@comet/mail-react": major
+---
+
+`MjmlImage` is now responsive by default
+
+The inner `<img>` height scales to `auto` below the default breakpoint instead of staying at its declared pixel value, so the image keeps its aspect ratio as its width shrinks on narrow viewports.

--- a/packages/mail-react/README.md
+++ b/packages/mail-react/README.md
@@ -17,6 +17,7 @@ We extend `@faire/mjml-react` rather than fork it. A few rules keep that working
 - **Additive only.** A custom component must work everywhere the base did. Only add props — never remove or rename them, and don't require new providers or context. For theme access, prefer `useOptionalTheme()` over `useTheme()`.
 - **Wrap, don't reimplement.** Custom components delegate to `@faire/mjml-react`. Less to maintain, and we stay close to upstream behaviour.
 - **One export per name.** When we ship a custom version, it replaces the re-export. Consumers should never need to import from `@faire/mjml-react` directly.
+- **Public-facing documentation doesn't reference `@faire/mjml-react`.** TSDoc, story descriptions, and changeset entries describe behavior in terms of this package only. Internal places (feature READMEs, commit messages) can mention upstream when it adds maintainer context.
 
 ### Styling
 
@@ -34,6 +35,8 @@ We extend `@faire/mjml-react` rather than fork it. A few rules keep that working
 ### Storybook
 
 Every custom component has a story in `src/components/<concern>/__stories__/<Component>.stories.tsx`. Wrap non-section stories in `<MjmlSection indent>` to show a realistic indented layout.
+
+Placeholder images use the `picsum.photos` seed URL pattern — `https://picsum.photos/seed/<seed>/<width>/<height>` — so the same seed renders the same image on every build.
 
 ### Changesets
 

--- a/packages/mail-react/src/__stories__/layout-patterns/AsymmetricTwoColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/AsymmetricTwoColumnLayout.stories.tsx
@@ -1,6 +1,7 @@
-import { MjmlColumn, MjmlImage, MjmlSpacer, MjmlWrapper } from "@faire/mjml-react";
+import { MjmlColumn, MjmlSpacer, MjmlWrapper } from "@faire/mjml-react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { MjmlImage } from "../../components/image/MjmlImage.js";
 import { MjmlSection } from "../../components/section/MjmlSection.js";
 import { MjmlText } from "../../components/text/MjmlText.js";
 import { registerStyles } from "../../styles/registerStyles.js";

--- a/packages/mail-react/src/blocks/pixelImage/HtmlPixelImageBlock.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/HtmlPixelImageBlock.tsx
@@ -1,8 +1,7 @@
 import clsx from "clsx";
 import type { ComponentProps, ReactNode } from "react";
 
-import { registerStyles } from "../../styles/registerStyles.js";
-import { css } from "../../utils/css.js";
+import { HtmlImage } from "../../components/image/HtmlImage.js";
 import type { PixelImageBlockBaseProps } from "./common.js";
 import { usePixelImageBlockData } from "./usePixelImageBlockData.js";
 
@@ -30,7 +29,7 @@ export function HtmlPixelImageBlock({
     }
 
     return (
-        <img
+        <HtmlImage
             src={imageData.imageUrl}
             width={imageData.defaultRenderWidth}
             height={imageData.desktopImageHeight}
@@ -41,14 +40,3 @@ export function HtmlPixelImageBlock({
         />
     );
 }
-
-registerStyles(
-    (theme) => css`
-        ${theme.breakpoints.default.belowMediaQuery} {
-            .htmlPixelImageBlock {
-                width: 100%;
-                height: auto;
-            }
-        }
-    `,
-);

--- a/packages/mail-react/src/blocks/pixelImage/MjmlPixelImageBlock.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/MjmlPixelImageBlock.tsx
@@ -1,13 +1,11 @@
-import { type IMjmlImageProps, MjmlImage } from "@faire/mjml-react";
 import clsx from "clsx";
 import type { ReactNode } from "react";
 
-import { registerStyles } from "../../styles/registerStyles.js";
-import { css } from "../../utils/css.js";
+import { MjmlImage, type MjmlImageProps } from "../../components/image/MjmlImage.js";
 import type { PixelImageBlockBaseProps } from "./common.js";
 import { usePixelImageBlockData } from "./usePixelImageBlockData.js";
 
-export type MjmlPixelImageBlockProps = Omit<IMjmlImageProps, "src" | "width" | "height"> & PixelImageBlockBaseProps;
+export type MjmlPixelImageBlockProps = Omit<MjmlImageProps, "src" | "width" | "height"> & PixelImageBlockBaseProps;
 
 /**
  * Renders a pixel-image from the DAM as `MjmlImage`. Must be placed within an
@@ -39,14 +37,3 @@ export function MjmlPixelImageBlock({
         />
     );
 }
-
-// MJML inlines a fixed `height` on the inner <img>; !important overrides it for responsive scaling.
-registerStyles(
-    (theme) => css`
-        ${theme.breakpoints.default.belowMediaQuery} {
-            .mjmlPixelImageBlock img {
-                height: auto !important;
-            }
-        }
-    `,
-);

--- a/packages/mail-react/src/components/image/HtmlImage.tsx
+++ b/packages/mail-react/src/components/image/HtmlImage.tsx
@@ -1,0 +1,30 @@
+import clsx from "clsx";
+import type { ComponentProps, ReactNode } from "react";
+
+import { registerStyles } from "../../styles/registerStyles.js";
+import { css } from "../../utils/css.js";
+
+export type HtmlImageProps = ComponentProps<"img">;
+
+/**
+ * Renders an `<img>` tag that adapts to its container width below the default
+ * breakpoint.
+ *
+ * Use within raw HTML context — HTML-only emails or
+ * [MJML ending tags](https://documentation.mjml.io/#ending-tags) like `MjmlRaw`.
+ * For MJML context, use `MjmlImage`.
+ */
+export function HtmlImage({ className, ...restProps }: HtmlImageProps): ReactNode {
+    return <img className={clsx("htmlImage", className)} {...restProps} />;
+}
+
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .htmlImage {
+                width: 100%;
+                height: auto;
+            }
+        }
+    `,
+);

--- a/packages/mail-react/src/components/image/MjmlImage.tsx
+++ b/packages/mail-react/src/components/image/MjmlImage.tsx
@@ -1,0 +1,29 @@
+import { type IMjmlImageProps, MjmlImage as BaseMjmlImage } from "@faire/mjml-react";
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+import { registerStyles } from "../../styles/registerStyles.js";
+import { css } from "../../utils/css.js";
+
+export type MjmlImageProps = IMjmlImageProps;
+
+/**
+ * Renders an MJML image that adapts to the viewport width below the default breakpoint.
+ *
+ * Must be placed within an `MjmlColumn`. For raw HTML context (e.g. inside `MjmlRaw`),
+ * use `HtmlImage` instead.
+ */
+export function MjmlImage({ className, ...restProps }: MjmlImageProps): ReactNode {
+    return <BaseMjmlImage className={clsx("mjmlImage", className)} {...restProps} />;
+}
+
+// MJML inlines a fixed `height` on the inner <img>; !important overrides it for responsive scaling.
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .mjmlImage img {
+                height: auto !important;
+            }
+        }
+    `,
+);

--- a/packages/mail-react/src/components/image/README.md
+++ b/packages/mail-react/src/components/image/README.md
@@ -1,0 +1,3 @@
+# Image
+
+An image in an email needs to fit the viewport as it narrows below the body-width breakpoint, but the upstream MJML image inlines a fixed pixel height and the bare HTML `<img>` keeps its declared width — both produce overflowing or oversized images on mobile clients. Consumers worked around this by repeating a media-query override per image template, and the pixel-image blocks shipped with their own copy of the same override. `HtmlImage` (for raw HTML context) and `MjmlImage` (for MJML context, replacing the upstream re-export) wrap their respective base elements with a stable BEM class and the override — making responsive sizing the default for any image rendered through this package.

--- a/packages/mail-react/src/components/image/__stories__/HtmlImage.stories.tsx
+++ b/packages/mail-react/src/components/image/__stories__/HtmlImage.stories.tsx
@@ -1,0 +1,55 @@
+import { MjmlColumn, MjmlRaw } from "@faire/mjml-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { defaultTheme } from "../../../theme/defaultTheme.js";
+import { getDefaultFromResponsiveValue } from "../../../theme/responsiveValue.js";
+import { MjmlSection } from "../../section/MjmlSection.js";
+import { HtmlImage } from "../HtmlImage.js";
+
+type Story = StoryObj<typeof HtmlImage>;
+
+const sectionIndent = getDefaultFromResponsiveValue(defaultTheme.sizes.contentIndentation);
+const sectionInnerWidth = defaultTheme.sizes.bodyWidth - 2 * sectionIndent;
+
+const config: Meta<typeof HtmlImage> = {
+    title: "Components/HtmlImage",
+    component: HtmlImage,
+    tags: ["autodocs"],
+    args: {
+        src: `https://picsum.photos/seed/html-image/${sectionInnerWidth}/268`,
+        width: sectionInnerWidth,
+        height: 268,
+        alt: "Placeholder image",
+    },
+};
+
+export default config;
+
+export const Default: Story = {
+    render: (args) => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlImage {...args} />
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const FullWidth: Story = {
+    args: {
+        src: `https://picsum.photos/seed/html-image-full-width/${defaultTheme.sizes.bodyWidth}/300`,
+        width: defaultTheme.sizes.bodyWidth,
+        height: 300,
+    },
+    render: (args) => (
+        <MjmlSection>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlImage {...args} />
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};

--- a/packages/mail-react/src/components/image/__stories__/HtmlImage.stories.tsx
+++ b/packages/mail-react/src/components/image/__stories__/HtmlImage.stories.tsx
@@ -16,10 +16,12 @@ const config: Meta<typeof HtmlImage> = {
     component: HtmlImage,
     tags: ["autodocs"],
     args: {
-        src: `https://picsum.photos/seed/html-image/${sectionInnerWidth}/268`,
         width: sectionInnerWidth,
         height: 268,
         alt: "Placeholder image",
+    },
+    argTypes: {
+        src: { control: false },
     },
 };
 
@@ -30,7 +32,7 @@ export const Default: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlImage {...args} />
+                    <HtmlImage {...args} src={`https://picsum.photos/seed/html-image/${args.width}/${args.height}`} />
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -39,7 +41,6 @@ export const Default: Story = {
 
 export const FullWidth: Story = {
     args: {
-        src: `https://picsum.photos/seed/html-image-full-width/${defaultTheme.sizes.bodyWidth}/300`,
         width: defaultTheme.sizes.bodyWidth,
         height: 300,
     },
@@ -47,7 +48,7 @@ export const FullWidth: Story = {
         <MjmlSection>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlImage {...args} />
+                    <HtmlImage {...args} src={`https://picsum.photos/seed/html-image-full-width/${args.width}/${args.height}`} />
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>

--- a/packages/mail-react/src/components/image/__stories__/MjmlImage.stories.tsx
+++ b/packages/mail-react/src/components/image/__stories__/MjmlImage.stories.tsx
@@ -16,10 +16,12 @@ const config: Meta<typeof MjmlImage> = {
     component: MjmlImage,
     tags: ["autodocs"],
     args: {
-        src: `https://picsum.photos/seed/mjml-image/${sectionInnerWidth}/268`,
         width: sectionInnerWidth,
         height: 268,
         alt: "Placeholder image",
+    },
+    argTypes: {
+        src: { control: false },
     },
 };
 
@@ -29,7 +31,7 @@ export const Default: Story = {
     render: (args) => (
         <MjmlSection indent>
             <MjmlColumn>
-                <MjmlImage {...args} />
+                <MjmlImage {...args} src={`https://picsum.photos/seed/mjml-image/${args.width}/${args.height}`} />
             </MjmlColumn>
         </MjmlSection>
     ),
@@ -37,14 +39,13 @@ export const Default: Story = {
 
 export const FullWidth: Story = {
     args: {
-        src: `https://picsum.photos/seed/mjml-image-full-width/${defaultTheme.sizes.bodyWidth}/300`,
         width: defaultTheme.sizes.bodyWidth,
         height: 300,
     },
     render: (args) => (
         <MjmlSection>
             <MjmlColumn>
-                <MjmlImage {...args} />
+                <MjmlImage {...args} src={`https://picsum.photos/seed/mjml-image-full-width/${args.width}/${args.height}`} />
             </MjmlColumn>
         </MjmlSection>
     ),

--- a/packages/mail-react/src/components/image/__stories__/MjmlImage.stories.tsx
+++ b/packages/mail-react/src/components/image/__stories__/MjmlImage.stories.tsx
@@ -1,0 +1,51 @@
+import { MjmlColumn } from "@faire/mjml-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { defaultTheme } from "../../../theme/defaultTheme.js";
+import { getDefaultFromResponsiveValue } from "../../../theme/responsiveValue.js";
+import { MjmlSection } from "../../section/MjmlSection.js";
+import { MjmlImage } from "../MjmlImage.js";
+
+type Story = StoryObj<typeof MjmlImage>;
+
+const sectionIndent = getDefaultFromResponsiveValue(defaultTheme.sizes.contentIndentation);
+const sectionInnerWidth = defaultTheme.sizes.bodyWidth - 2 * sectionIndent;
+
+const config: Meta<typeof MjmlImage> = {
+    title: "Components/MjmlImage",
+    component: MjmlImage,
+    tags: ["autodocs"],
+    args: {
+        src: `https://picsum.photos/seed/mjml-image/${sectionInnerWidth}/268`,
+        width: sectionInnerWidth,
+        height: 268,
+        alt: "Placeholder image",
+    },
+};
+
+export default config;
+
+export const Default: Story = {
+    render: (args) => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlImage {...args} />
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const FullWidth: Story = {
+    args: {
+        src: `https://picsum.photos/seed/mjml-image-full-width/${defaultTheme.sizes.bodyWidth}/300`,
+        width: defaultTheme.sizes.bodyWidth,
+        height: 300,
+    },
+    render: (args) => (
+        <MjmlSection>
+            <MjmlColumn>
+                <MjmlImage {...args} />
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};

--- a/packages/mail-react/src/index.ts
+++ b/packages/mail-react/src/index.ts
@@ -8,6 +8,10 @@ export type { HtmlPixelImageBlockProps } from "./blocks/pixelImage/HtmlPixelImag
 export { HtmlPixelImageBlock } from "./blocks/pixelImage/HtmlPixelImageBlock.js";
 export type { MjmlPixelImageBlockProps } from "./blocks/pixelImage/MjmlPixelImageBlock.js";
 export { MjmlPixelImageBlock } from "./blocks/pixelImage/MjmlPixelImageBlock.js";
+export type { HtmlImageProps } from "./components/image/HtmlImage.js";
+export { HtmlImage } from "./components/image/HtmlImage.js";
+export type { MjmlImageProps } from "./components/image/MjmlImage.js";
+export { MjmlImage } from "./components/image/MjmlImage.js";
 export type { HtmlInlineLinkProps } from "./components/inlineLink/HtmlInlineLink.js";
 export { HtmlInlineLink } from "./components/inlineLink/HtmlInlineLink.js";
 export { MjmlMailRoot } from "./components/mailRoot/MjmlMailRoot.js";
@@ -81,8 +85,6 @@ export {
     type IMjmlHtmlAttributeProps as MjmlHtmlAttributeProps,
     MjmlHtmlAttributes,
     type IMjmlHtmlAttributesProps as MjmlHtmlAttributesProps,
-    MjmlImage,
-    type IMjmlImageProps as MjmlImageProps,
     MjmlInclude,
     type IMjmlIncludeProps as MjmlIncludeProps,
     MjmlNavbar,


### PR DESCRIPTION
Email images need to fit the viewport as it narrows below the body-width breakpoint, but the upstream MJML image inlines a fixed height and a bare HTML `<img>` keeps its declared width. Consumers worked around this by repeating a media-query override per image template, and the pixel-image blocks shipped with their own copy of the same override. Lifting that into reusable primitives makes responsive sizing the default.

- **No opt-out prop for non-responsive output.** The responsive default is the value; an opt-out adds API surface for an unclear need.
- **`MjmlImage` replaces the upstream re-export, prop API unchanged.** Per the package's "one export per name" rule. Only the below-breakpoint layer is added, consistent with the package's framing of `registerStyles` as progressive enhancement; the bump is major because the default rendered output differs on narrow viewports.
- **Pixel-image blocks drop their inline `registerStyles` and keep their BEM class.** The equivalent rule now lives on the inner primitive; keeping both would double-apply. The block class stays as a stable consumer styling hook.