### PR TITLE
admin: Fix `MainContent` `fullHeight` growing past viewport after scrolling on a detail page

### DIFF
--- a/.changeset/fix-main-content-full-height-after-scroll-back.md
+++ b/.changeset/fix-main-content-full-height-after-scroll-back.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": patch
+---
+
+Fix `MainContent` with `fullHeight` growing past the viewport after returning from a scrolled detail page
+
+`useTopOffset` used `getBoundingClientRect().top`, which is viewport-relative. When navigating back from a scrolled page, the browser could restore the previous scroll position before the offset was measured, producing a too-small offset and a `calc(100vh - topOffset)` larger than the viewport. The offset is now measured relative to the document by adding `window.scrollY`.

--- a/packages/admin/admin/src/helpers/useTopOffset.ts
+++ b/packages/admin/admin/src/helpers/useTopOffset.ts
@@ -6,7 +6,7 @@ export const useTopOffset = (ref: RefObject<HTMLElement | null>) => {
     useEffect(() => {
         const updateTopOffset = () => {
             if (ref.current) {
-                setTopOffset(ref.current.getBoundingClientRect().top);
+                setTopOffset(ref.current.getBoundingClientRect().top + window.scrollY);
             }
         };
 


### PR DESCRIPTION
## Problem

When navigating from a DataGrid into a detail/edit page (e.g. News), scrolling the detail page, and then going back to the grid (browser back or back button), the grid page layout becomes broken — `main` ends up taller than the viewport and the page becomes scrollable, even though the grid alone fits the screen.

| before | after |
|--------|--------|
| <img  alt="Screen Recording 2026-05-28 at 13 48 06" src="https://github.com/user-attachments/assets/2a7fde29-3e2a-4547-a91a-845bbb73b2d7" /> | <img  alt="Screen Recording 2026-05-28 at 13 44 41" src="https://github.com/user-attachments/assets/00b98762-40f5-4706-88de-30ef8a741d45" /> |

## Root cause

`MainContent` with `fullHeight` sizes itself via `height: calc(100vh - topOffset)`, where `topOffset` comes from the `useTopOffset` hook. `useTopOffset` measured the offset with `getBoundingClientRect().top`, which is **viewport-relative** and therefore affected by the current scroll position.

When navigating back, the browser can restore the previous scroll position before `useEffect` runs in the freshly mounted page. The hook then reads a too-small `top` (e.g. `100 − 75 = 25`) and the resulting `calc(100vh − 25px)` produces a `main` larger than the viewport. When the scroll then resets to `0`, the oversized `main` remains.

## Fix

Add `window.scrollY` to the measurement so the offset is document-relative and stable across scroll restoration:

```diff
- setTopOffset(ref.current.getBoundingClientRect().top);
+ setTopOffset(ref.current.getBoundingClientRect().top + window.scrollY);
```

The hook is used by `MainContent` and `FullHeightContent`; both consume the value the same way (`calc(100vh − topOffset)`).

## Verification

Reproduced in the demo at `/main/en/structured-content/news` with viewport `1280 × 600` via Playwright:

| State | Before fix | After fix |
| --- | --- | --- |
| Grid (initial) | `main` 500 / doc 600 | `main` 500 / doc 600 |
| Edit page, scrolled to `scrollY = 75` | `main` 515 / doc 675 | `main` 515 / doc 675 |
| Grid after browser back | `main` **575** / doc **675** ❌ | `main` 500 / doc 600 ✅ |

Repeated cycles all stable after the fix.

## Notes for reviewer

- The header and content wrapper above `main` are `position: static`, so document-relative top is the right value here.
- Changeset included.
