### PR TITLE
Add tests for isValidUrl

### DIFF
--- a/packages/admin/cms-admin/src/blocks/validators/__tests__/isValidUrl.test.ts
+++ b/packages/admin/cms-admin/src/blocks/validators/__tests__/isValidUrl.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidUrl } from "../isValidUrl";
+
+describe("isValidUrl", () => {
+    it("should return true for a valid https URL", () => {
+        expect(isValidUrl("https://example.com")).toBe(true);
+    });
+
+    it("should return true for a valid http URL", () => {
+        expect(isValidUrl("http://example.com")).toBe(true);
+    });
+
+    it("should return true for a URL with a path, query and fragment", () => {
+        expect(isValidUrl("https://example.com/path?foo=bar#section")).toBe(true);
+    });
+
+    it("should return false for a malformed URL", () => {
+        expect(isValidUrl("not a url")).toBe(false);
+    });
+
+    it("should return false for an empty string", () => {
+        expect(isValidUrl("")).toBe(false);
+    });
+
+    it("should return false for a relative path without a scheme", () => {
+        expect(isValidUrl("/relative/path")).toBe(false);
+    });
+
+    it("should return false for an ftp URL", () => {
+        expect(isValidUrl("ftp://files.example.com")).toBe(false);
+    });
+
+    it("should return false for a javascript: URL", () => {
+        expect(isValidUrl("javascript:alert(1)")).toBe(false);
+    });
+
+    it("should return false for a mailto: URL", () => {
+        expect(isValidUrl("mailto:user@example.com")).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

Adds Vitest tests for `isValidUrl` in `@comet/cms-admin`.

`isValidUrl` is a pure utility function exported from `packages/admin/cms-admin/src/index.ts` that validates whether a string is a valid `http:` or `https:` URL. It had no tests despite being part of the public API surface.

The new test file covers:
- Valid `https://` and `http://` URLs (happy path)
- URLs with path, query string, and fragment
- Malformed/unparseable strings
- Empty string
- Relative paths (no scheme)
- Non-http schemes: `ftp://`, `javascript:`, `mailto:`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvLoeZKwRqw1cr5Jgs15bF)_