### PR TITLE
Migrate edit-dialog stories to @comet/admin package Storybook

### DIFF
--- a/packages/admin/admin/src/editDialog/__stories__/AddDialogEditPage.stories.tsx
+++ b/packages/admin/admin/src/editDialog/__stories__/AddDialogEditPage.stories.tsx
@@ -15,12 +15,11 @@ import { DialogContent, Typography } from "@mui/material";
 import type { StoryObj } from "@storybook/react-vite";
 import { expect, waitFor, within } from "storybook/test";
 
-import { stackRouteDecorator } from "../../helpers/storyDecorators";
-import { storyRouterDecorator } from "../../story-router.decorator";
-
 export default {
-    title: "@comet/admin/edit-dialog",
-    decorators: [stackRouteDecorator(), storyRouterDecorator()],
+    title: "components/editDialog",
+    parameters: {
+        stack: { topLevelTitle: "Example Page" },
+    },
 };
 
 const Form = ({ id }: { id?: string }) => {
@@ -63,7 +62,7 @@ const Page = () => {
                 </EditDialog>
             </StackPage>
             <StackPage name="edit">
-                {(id) => (
+                {(id: string) => (
                     <SaveBoundary>
                         <StackMainContent>
                             <FieldSet title="Edit form" endAdornment={<StackBackButton />}>

--- a/packages/admin/admin/src/editDialog/__stories__/EditDialog.stories.tsx
+++ b/packages/admin/admin/src/editDialog/__stories__/EditDialog.stories.tsx
@@ -1,11 +1,8 @@
 import { Button, Field, FinalForm, FinalFormInput, useEditDialog } from "@comet/admin";
 import { DialogContent } from "@mui/material";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
-
 export default {
-    title: "@comet/admin/edit-dialog",
-    decorators: [storyRouterDecorator()],
+    title: "components/editDialog",
 };
 
 export const EditDialogStory = {

--- a/packages/admin/admin/src/editDialog/__stories__/EditDialogInDataGrid.stories.tsx
+++ b/packages/admin/admin/src/editDialog/__stories__/EditDialogInDataGrid.stories.tsx
@@ -6,11 +6,8 @@ import type { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 import { useLocation } from "react-router";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
-
 export default {
-    title: "@comet/admin/edit-dialog",
-    decorators: [storyRouterDecorator()],
+    title: "components/editDialog",
 };
 
 interface ToolbarProps extends GridToolbarProps {

--- a/packages/admin/admin/src/editDialog/__stories__/EditDialogInRouterTabs.stories.tsx
+++ b/packages/admin/admin/src/editDialog/__stories__/EditDialogInRouterTabs.stories.tsx
@@ -17,11 +17,8 @@ import { DataGrid, type GridToolbarProps } from "@mui/x-data-grid";
 import { type ReactNode, type RefObject, useRef } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
-
 export default {
-    title: "@comet/admin/edit-dialog",
-    decorators: [storyRouterDecorator()],
+    title: "components/editDialog",
 };
 
 const products = [

--- a/packages/admin/admin/src/editDialog/__stories__/EditDialogInRouterTabsWithinStack.stories.tsx
+++ b/packages/admin/admin/src/editDialog/__stories__/EditDialogInRouterTabsWithinStack.stories.tsx
@@ -27,11 +27,8 @@ import { DataGrid, type GridToolbarProps } from "@mui/x-data-grid";
 import { type ReactNode, type RefObject, useRef } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
-
 export default {
-    title: "@comet/admin/edit-dialog",
-    decorators: [storyRouterDecorator()],
+    title: "components/editDialog",
 };
 
 const products = [
@@ -223,7 +220,7 @@ export const ProductDetailsPage = ({ productId }: ProductDetailsProps) => {
                         </MainContent>
                     </StackPage>
                     <StackPage name="stocksEdit" title={intl.formatMessage({ id: "products.editStocks", defaultMessage: "Edit Stocks" })}>
-                        {(selectedStockId) => (
+                        {(selectedStockId: string) => (
                             <SaveBoundary>
                                 <MainContent fullHeight disablePadding>
                                     <StackToolbar>
@@ -303,7 +300,7 @@ export const EditDialogInRouterTabsWithinStack = {
                             </MainContent>
                         </StackPage>
                         <StackPage name="productEdit" title={intl.formatMessage({ id: "products.editProduct", defaultMessage: "Product" })}>
-                            {(productId) => (
+                            {(productId: string) => (
                                 <MainContent fullHeight disablePadding>
                                     <SaveBoundary>
                                         <StackToolbar>

--- a/packages/admin/admin/src/editDialog/__stories__/EditDialogWithFormInStack.stories.tsx
+++ b/packages/admin/admin/src/editDialog/__stories__/EditDialogWithFormInStack.stories.tsx
@@ -2,8 +2,6 @@ import { Button, Field, FinalForm, FinalFormInput, Stack, StackBreadcrumbs, Stac
 import { DialogContent } from "@mui/material";
 import { useState } from "react";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
-
 interface RootPageProps {
     counter: number;
 }
@@ -90,7 +88,7 @@ const InnerNestedStack = ({ counter }: InnerNestedStackProps) => {
                 <RootPage counter={counter} />
             </StackPage>
             <StackPage name="nested" title={`Page ${nestedCounter}`}>
-                {(counter) => {
+                {(counter: string) => {
                     setNestedCounter(Number(counter));
                     return <InnerNestedStack counter={Number(counter)} />;
                 }}
@@ -100,8 +98,7 @@ const InnerNestedStack = ({ counter }: InnerNestedStackProps) => {
 };
 
 export default {
-    title: "@comet/admin/edit-dialog",
-    decorators: [storyRouterDecorator()],
+    title: "components/editDialog",
 };
 
 export const EditDialogWithFormInStack = {

--- a/packages/admin/admin/src/editDialog/__stories__/MultipleEditDialogs.stories.tsx
+++ b/packages/admin/admin/src/editDialog/__stories__/MultipleEditDialogs.stories.tsx
@@ -2,8 +2,6 @@ import { Button, SubRoute, useEditDialog } from "@comet/admin";
 import { Add, Edit } from "@comet/admin-icons";
 import { Stack, Typography } from "@mui/material";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
-
 const FirstComponent = () => {
     const [EditDialog, selection, editDialogApi] = useEditDialog();
     return (
@@ -87,6 +85,5 @@ export const MultipleEditDialogs = () => {
 };
 
 export default {
-    title: "@comet/admin/edit-dialog",
-    decorators: [storyRouterDecorator()],
+    title: "components/editDialog",
 };

--- a/packages/admin/admin/src/editDialog/__stories__/NestedEditDialogInStack.stories.tsx
+++ b/packages/admin/admin/src/editDialog/__stories__/NestedEditDialogInStack.stories.tsx
@@ -3,8 +3,6 @@ import { Edit } from "@comet/admin-icons";
 import { DialogContent, IconButton, Typography } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
-
 const products = [
     { id: "1", name: "Product 1" },
     { id: "2", name: "Product 2" },
@@ -68,8 +66,7 @@ function ProductDetail({ id: stackSelectionId }: { id: string }) {
 }
 
 export default {
-    title: "@comet/admin/edit-dialog",
-    decorators: [storyRouterDecorator()],
+    title: "components/editDialog",
 };
 
 export const NestedEditDialogInStack = function Story() {
@@ -99,7 +96,7 @@ export const NestedEditDialogInStack = function Story() {
                     </MainContent>
                 </StackPage>
                 <StackPage name="detail" title="Edit product detail">
-                    {(productId) => <ProductDetail id={productId} />}
+                    {(productId: string) => <ProductDetail id={productId} />}
                 </StackPage>
             </StackSwitch>
         </Stack>


### PR DESCRIPTION
## Summary

Migrates all **edit-dialog** stories from the global `/storybook` directory into the `@comet/admin` package Storybook, where they live alongside the `EditDialog` source code.

**Migrated components:**
- `EditDialog` (plain edit dialog)
- `EditDialogInDataGrid`
- `EditDialogInRouterTabs`
- `EditDialogInRouterTabsWithinStack`
- `EditDialogWithFormInStack`
- `MultipleEditDialogs`
- `NestedEditDialogInStack`
- `AddDialogEditPage` (add dialog vs. edit page pattern with play function)

**Changes per story file:**
- Removed per-story `storyRouterDecorator()` decorator imports — the global `RouterDecorator` in the admin package Storybook preview already wraps every story in a `RouterMemoryRouter`
- Replaced `stackRouteDecorator()` with `parameters.stack` (`AddDialogEditPage`) — the `RouterDecorator` honours this parameter to wrap in a `<Stack>`
- Updated story titles from `"@comet/admin/edit-dialog"` → `"components/editDialog"` to match the naming convention used in the admin package Storybook
- Added explicit `string` type annotations to `StackPage` callback parameters (`noImplicitAny` is enabled in the admin package `tsconfig`)

**Target location:** `packages/admin/admin/src/editDialog/__stories__/`

https://claude.ai/code/session_012aYWtTLBHb3A8xC3BWtRpr

---
_Generated by [Claude Code](https://claude.ai/code/session_012aYWtTLBHb3A8xC3BWtRpr)_