### PR TITLE
Show archived tag on DAM file detail page

### DIFF
--- a/.changeset/dam-archived-tag-edit-file.md
+++ b/.changeset/dam-archived-tag-edit-file.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Show `ArchivedTag` next to the title on the DAM file detail page
+
+Previously the archived state was only visible in the DAM file list, which could be confusing when opening an archived file's detail page via link.

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -30,6 +30,7 @@ import type { GQLFocalPoint, GQLImageCropAreaInput, GQLLicenseInput } from "../.
 import { useUserPermissionCheck } from "../../userPermissions/hooks/currentUser";
 import { useDamConfig } from "../config/damConfig";
 import { useDamAcceptedMimeTypes } from "../config/useDamAcceptedMimeTypes";
+import { ArchivedTag } from "../DataGrid/tags/ArchivedTag";
 import { LicenseValidityTags } from "../DataGrid/tags/LicenseValidityTags";
 import { MediaAlternativesGrid } from "../mediaAlternatives/MediaAlternativesGrid";
 import Duplicates from "./Duplicates";
@@ -192,6 +193,11 @@ const EditFileInner = ({ file, id, contentScopeIndicator }: EditFileInnerProps) 
                     <Toolbar scopeIndicator={contentScopeIndicator}>
                         <ToolbarBackButton />
                         <ToolbarTitleItem>{file.name}</ToolbarTitleItem>
+                        {file.archived && (
+                            <ToolbarItem>
+                                <ArchivedTag />
+                            </ToolbarItem>
+                        )}
                         {damConfig.enableLicenseFeature &&
                             (file.license?.isNotValidYet || file.license?.expiresWithinThirtyDays || file.license?.hasExpired) && (
                                 <ToolbarItem>


### PR DESCRIPTION
The archived state was previously only visible in the DAM file list, which led to confusion when opening an archived file's detail page.

<img width="1728" height="1042" alt="Bildschirmfoto 2026-05-29 um 13 25 55" src="https://github.com/user-attachments/assets/b0f0cacb-28d8-490b-951d-5500853c9956" />
