### PR TITLE
Add tests for dateTime utils

### DIFF
--- a/packages/admin/admin/src/dateTime/__tests__/utils.test.ts
+++ b/packages/admin/admin/src/dateTime/__tests__/utils.test.ts
@@ -19,7 +19,7 @@ describe("getDateValue", () => {
         const result = getDateValue("2023-06-15");
         expect(result).toBeInstanceOf(Date);
         expect(result?.getFullYear()).toBe(2023);
-        expect(result?.getMonth()).toBe(5); // June is 0-indexed
+        expect(result?.getMonth()).toBe(5); // Month is 0-indexed -> June = 5
         expect(result?.getDate()).toBe(15);
     });
 

--- a/packages/admin/admin/src/dateTime/__tests__/utils.test.ts
+++ b/packages/admin/admin/src/dateTime/__tests__/utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { getDateValue, getIsoDateString, isValidDate } from "../utils";
+
+describe("getDateValue", () => {
+    it("should return null for null input", () => {
+        expect(getDateValue(null)).toBeNull();
+    });
+
+    it("should return null for undefined input", () => {
+        expect(getDateValue(undefined)).toBeNull();
+    });
+
+    it("should return null for empty string", () => {
+        expect(getDateValue("")).toBeNull();
+    });
+
+    it("should return a Date for a valid ISO date string", () => {
+        const result = getDateValue("2023-06-15");
+        expect(result).toBeInstanceOf(Date);
+        expect(result?.getFullYear()).toBe(2023);
+        expect(result?.getMonth()).toBe(5); // June is 0-indexed
+        expect(result?.getDate()).toBe(15);
+    });
+
+    it("should throw for an invalid date string", () => {
+        expect(() => getDateValue("not-a-date")).toThrow("Invalid date value: not-a-date");
+    });
+});
+
+describe("getIsoDateString", () => {
+    it("should format a date as yyyy-MM-dd", () => {
+        const date = new Date(2023, 5, 15); // June 15, 2023
+        expect(getIsoDateString(date)).toBe("2023-06-15");
+    });
+
+    it("should zero-pad month and day", () => {
+        const date = new Date(2023, 0, 5); // January 5, 2023
+        expect(getIsoDateString(date)).toBe("2023-01-05");
+    });
+});
+
+describe("isValidDate", () => {
+    it("should return true for a valid date", () => {
+        expect(isValidDate(new Date("2023-06-15"))).toBe(true);
+    });
+
+    it("should return false for an invalid date", () => {
+        expect(isValidDate(new Date("not-a-date"))).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

Adds Vitest tests for `getDateValue`, `getIsoDateString`, and `isValidDate` in `packages/admin/admin/src/dateTime/utils.ts`.

These utilities are used internally by the date/time picker components but had no test coverage.

**Test cases added:**

- `getDateValue`: null, undefined, and empty string all return `null`; a valid ISO date string returns the correct `Date`; an invalid string throws with a descriptive message
- `getIsoDateString`: formats a date as `yyyy-MM-dd` and zero-pads month/day
- `isValidDate`: returns `true` for valid dates and `false` for `Invalid Date` instances

---
_Generated by [Claude Code](https://claude.ai/code/session_013tRXTnLgcaVicrmwzQxXoW)_