### PR TITLE
Migrate alert, error-handling and snackbar stories to @comet/admin package Storybook

### DIFF
--- a/packages/admin/admin/src/alert/__stories__/AlertInSnackbar.stories.tsx
+++ b/packages/admin/admin/src/alert/__stories__/AlertInSnackbar.stories.tsx
@@ -1,6 +1,8 @@
-import { Alert, Button } from "@comet/admin";
 import { Snackbar } from "@mui/material";
 import { useState } from "react";
+
+import { Button } from "../../common/buttons/Button";
+import { Alert } from "../Alert";
 
 export default {
     title: "components/alert/AlertInSnackbar",

--- a/packages/admin/admin/src/alert/__stories__/AlertInSnackbar.stories.tsx
+++ b/packages/admin/admin/src/alert/__stories__/AlertInSnackbar.stories.tsx
@@ -3,7 +3,7 @@ import { Snackbar } from "@mui/material";
 import { useState } from "react";
 
 export default {
-    title: "@comet/admin/alert/Alert",
+    title: "components/alert/AlertInSnackbar",
 };
 
 export const AlertInSnackbar = {

--- a/packages/admin/admin/src/error/errorHandler/__stories__/ErrorHandlerProvider.stories.tsx
+++ b/packages/admin/admin/src/error/errorHandler/__stories__/ErrorHandlerProvider.stories.tsx
@@ -1,7 +1,10 @@
-import { Alert, ErrorBoundary, ErrorHandlerProvider } from "@comet/admin";
 import { Box, Card, CardContent, Link, List, ListItem, ListItemText, Typography } from "@mui/material";
 import type { Meta } from "@storybook/react-vite";
 import { type ErrorInfo, useState } from "react";
+
+import { Alert } from "../../../alert/Alert";
+import { ErrorBoundary } from "../../errorboundary/ErrorBoundary";
+import { ErrorHandlerProvider } from "../ErrorHandlerProvider";
 
 const ThrowingView = () => {
     throw new Error("Some error occurred");

--- a/packages/admin/admin/src/error/errorHandler/__stories__/ErrorHandlerProvider.stories.tsx
+++ b/packages/admin/admin/src/error/errorHandler/__stories__/ErrorHandlerProvider.stories.tsx
@@ -18,7 +18,7 @@ type CapturedError = {
 };
 
 export default {
-    title: "@comet/admin/error-handling/error-handler-provider",
+    title: "components/error/errorHandler/ErrorHandlerProvider",
     args: {
         renderViewWithErrors: false,
     },

--- a/packages/admin/admin/src/error/errorboundary/__stories__/ErrorBoundary.stories.tsx
+++ b/packages/admin/admin/src/error/errorboundary/__stories__/ErrorBoundary.stories.tsx
@@ -1,6 +1,8 @@
-import { Alert, ErrorBoundary } from "@comet/admin";
 import { Box, Card, CardContent, Link, Typography } from "@mui/material";
 import type { Meta } from "@storybook/react-vite";
+
+import { Alert } from "../../../alert/Alert";
+import { ErrorBoundary } from "../ErrorBoundary";
 
 const ViewWithNoError = () => {
     return (

--- a/packages/admin/admin/src/error/errorboundary/__stories__/ErrorBoundary.stories.tsx
+++ b/packages/admin/admin/src/error/errorboundary/__stories__/ErrorBoundary.stories.tsx
@@ -20,7 +20,7 @@ const ViewWithError = () => {
 };
 
 export default {
-    title: "@comet/admin/error-handling/error-boundaries",
+    title: "components/error/errorboundary/ErrorBoundary",
     args: {
         renderViewWithErrors: false,
     },

--- a/packages/admin/admin/src/error/errorboundary/__stories__/RouteWithErrorBoundary.stories.tsx
+++ b/packages/admin/admin/src/error/errorboundary/__stories__/RouteWithErrorBoundary.stories.tsx
@@ -2,8 +2,6 @@ import { Alert, MainNavigation, MainNavigationItemRouterLink, MasterLayout, Rout
 import { Card, CardContent, Typography } from "@mui/material";
 import { Redirect, Route, Switch } from "react-router";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
-
 const ViewWithNoError = () => {
     return (
         <Card variant="outlined">
@@ -39,8 +37,7 @@ function MasterMenu() {
 }
 
 export default {
-    title: "@comet/admin/error-handling/error-boundaries",
-    decorators: [storyRouterDecorator()],
+    title: "components/error/errorboundary/RouteWithErrorBoundary",
 };
 
 export const _RouteWithErrorBoundary = {

--- a/packages/admin/admin/src/error/errorboundary/__stories__/RouteWithErrorBoundary.stories.tsx
+++ b/packages/admin/admin/src/error/errorboundary/__stories__/RouteWithErrorBoundary.stories.tsx
@@ -1,6 +1,11 @@
-import { Alert, MainNavigation, MainNavigationItemRouterLink, MasterLayout, RouteWithErrorBoundary } from "@comet/admin";
 import { Card, CardContent, Typography } from "@mui/material";
 import { Redirect, Route, Switch } from "react-router";
+
+import { Alert } from "../../../alert/Alert";
+import { MainNavigationItemRouterLink } from "../../../mui/mainNavigation/ItemRouterLink";
+import { MainNavigation } from "../../../mui/mainNavigation/MainNavigation";
+import { MasterLayout } from "../../../mui/MasterLayout";
+import { RouteWithErrorBoundary } from "../RouteWithErrorBoundary";
 
 const ViewWithNoError = () => {
     return (

--- a/packages/admin/admin/src/inlineAlert/__stories__/InlineAlert.stories.tsx
+++ b/packages/admin/admin/src/inlineAlert/__stories__/InlineAlert.stories.tsx
@@ -20,21 +20,38 @@ const config: Meta<typeof InlineAlert> = {
 
 export default config;
 
+/**
+ * Renders the `InlineAlert` component with default settings.
+ * Demonstrates the base appearance of the error component.
+ */
 export const InlineAlertStory: Story = {};
 InlineAlertStory.storyName = "InlineAlert";
 
+/**
+ * Displays the `InlineAlert` component with a warning variant.
+ * This variation visually represents a warning message to the user.
+ */
 export const InlineAlertWithWarning: Story = {
     args: {
         severity: "warning",
     },
 };
 
+/**
+ * Displays the `InlineAlert` component with an info variant.
+ * This variant is used for informational messages rather than errors.
+ */
 export const InlineAlertWithInfo: Story = {
     args: {
         severity: "info",
     },
 };
 
+/**
+ * Displays the `InlineAlert` component with custom content.
+ * Includes a custom icon, title, and description to illustrate how
+ * the component can be adjusted for different use cases.
+ */
 export const InlineAlertWithCustomContent: Story = {
     args: {
         icon: <CometColor sx={{ fontSize: "32px" }} />,
@@ -43,6 +60,9 @@ export const InlineAlertWithCustomContent: Story = {
     },
 };
 
+/**
+ * Displays the `InlineAlert` component with custom icons by using `iconMapping` prop.
+ */
 export const InlineAlertWithIconMapper: Story = {
     args: {
         severity: "warning",
@@ -54,6 +74,11 @@ export const InlineAlertWithIconMapper: Story = {
     },
 };
 
+/**
+ * Displays the `InlineAlert` component with an action button.
+ * The button allows the user to retry an action when an error occurs.
+ * Clicking the button triggers an alert as an example interaction.
+ */
 export const InlineAlertWithActions: Story = {
     args: {
         actions: (
@@ -70,6 +95,11 @@ export const InlineAlertWithActions: Story = {
     },
 };
 
+/**
+ * Displays the `InlineAlert` component with multiple actions.
+ * Includes a retry button and a clear button to demonstrate
+ * how multiple interactions can be provided to the user.
+ */
 export const InlineAlertWithMultipleActions: Story = {
     args: {
         actions: (

--- a/packages/admin/admin/src/inlineAlert/__stories__/InlineAlert.stories.tsx
+++ b/packages/admin/admin/src/inlineAlert/__stories__/InlineAlert.stories.tsx
@@ -20,38 +20,21 @@ const config: Meta<typeof InlineAlert> = {
 
 export default config;
 
-/**
- * Renders the `InlineAlert` component with default settings.
- * Demonstrates the base appearance of the error component.
- */
 export const InlineAlertStory: Story = {};
 InlineAlertStory.storyName = "InlineAlert";
 
-/**
- * Displays the `InlineAlert` component with a warning variant.
- * This variation visually represents a warning message to the user.
- */
 export const InlineAlertWithWarning: Story = {
     args: {
         severity: "warning",
     },
 };
 
-/**
- * Displays the `InlineAlert` component with an info variant.
- * This variant is used for informational messages rather than errors.
- */
 export const InlineAlertWithInfo: Story = {
     args: {
         severity: "info",
     },
 };
 
-/**
- * Displays the `InlineAlert` component with custom content.
- * Includes a custom icon, title, and description to illustrate how
- * the component can be adjusted for different use cases.
- */
 export const InlineAlertWithCustomContent: Story = {
     args: {
         icon: <CometColor sx={{ fontSize: "32px" }} />,
@@ -60,9 +43,6 @@ export const InlineAlertWithCustomContent: Story = {
     },
 };
 
-/**
- * Displays the `InlineAlert` component with custom icons by using `iconMapping` prop.
- */
 export const InlineAlertWithIconMapper: Story = {
     args: {
         severity: "warning",
@@ -74,11 +54,6 @@ export const InlineAlertWithIconMapper: Story = {
     },
 };
 
-/**
- * Displays the `InlineAlert` component with an action button.
- * The button allows the user to retry an action when an error occurs.
- * Clicking the button triggers an alert as an example interaction.
- */
 export const InlineAlertWithActions: Story = {
     args: {
         actions: (
@@ -95,11 +70,6 @@ export const InlineAlertWithActions: Story = {
     },
 };
 
-/**
- * Displays the `InlineAlert` component with multiple actions.
- * Includes a retry button and a clear button to demonstrate
- * how multiple interactions can be provided to the user.
- */
 export const InlineAlertWithMultipleActions: Story = {
     args: {
         actions: (

--- a/packages/admin/admin/src/snackbar/__stories__/CustomSnackbar.stories.tsx
+++ b/packages/admin/admin/src/snackbar/__stories__/CustomSnackbar.stories.tsx
@@ -45,7 +45,7 @@ const CustomSnackbar = () => {
 };
 
 export default {
-    title: "@comet/admin/snackbar",
+    title: "components/snackbar/CustomSnackbar",
 };
 
 export const _CustomSnackbar = () => {

--- a/packages/admin/admin/src/snackbar/__stories__/CustomSnackbar.stories.tsx
+++ b/packages/admin/admin/src/snackbar/__stories__/CustomSnackbar.stories.tsx
@@ -1,5 +1,7 @@
-import { Button, SnackbarProvider, useSnackbarApi } from "@comet/admin";
 import { List, ListItem, Snackbar } from "@mui/material";
+
+import { Button } from "../../common/buttons/Button";
+import { SnackbarProvider, useSnackbarApi } from "../SnackbarProvider";
 
 let counter = 0;
 

--- a/packages/admin/admin/src/snackbar/__stories__/UndoSnackbar.stories.tsx
+++ b/packages/admin/admin/src/snackbar/__stories__/UndoSnackbar.stories.tsx
@@ -1,6 +1,8 @@
-import { SnackbarProvider, UndoSnackbar, useSnackbarApi } from "@comet/admin";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { type MouseEvent, useState } from "react";
+
+import { SnackbarProvider, useSnackbarApi } from "../SnackbarProvider";
+import { UndoSnackbar } from "../UndoSnackbar";
 
 const UndoSnackbarExample = () => {
     const [chosenOption, setChosenOption] = useState("one");

--- a/packages/admin/admin/src/snackbar/__stories__/UndoSnackbar.stories.tsx
+++ b/packages/admin/admin/src/snackbar/__stories__/UndoSnackbar.stories.tsx
@@ -34,7 +34,7 @@ const UndoSnackbarExample = () => {
 };
 
 export default {
-    title: "@comet/admin/snackbar",
+    title: "components/snackbar/UndoSnackbar",
 };
 
 export const _UndoSnackbar = () => {


### PR DESCRIPTION
## Summary

Migrates 8 stories from the global `/storybook` directory into the dedicated `@comet/admin` package Storybook (`packages/admin/admin`).

**Feature/domain:** Alerts, Error Handling & Snackbar (user feedback / notifications)

| Removed from | Moved to |
|---|---|
| `storybook/src/admin/alert/AlertInSnackbar.stories.tsx` | `packages/admin/admin/src/alert/__stories__/AlertInSnackbar.stories.tsx` |
| `storybook/src/admin/snackbar/CustomSnackbar.stories.tsx` | `packages/admin/admin/src/snackbar/__stories__/CustomSnackbar.stories.tsx` |
| `storybook/src/admin/snackbar/UndoSnackbar.stories.tsx` | `packages/admin/admin/src/snackbar/__stories__/UndoSnackbar.stories.tsx` |
| `storybook/src/admin/inlineAlert/InlineAlert.stories.tsx` | `packages/admin/admin/src/inlineAlert/__stories__/InlineAlert.stories.tsx` |
| `storybook/src/admin/fullPageAlert/ErrorPage.stories.tsx` | `packages/admin/admin/src/fullPageAlert/__stories__/ErrorPage.stories.tsx` |
| `storybook/src/admin/error-handling/ErrorBoundary.stories.tsx` | `packages/admin/admin/src/error/errorboundary/__stories__/ErrorBoundary.stories.tsx` |
| `storybook/src/admin/error-handling/ErrorHandlerProvider.stories.tsx` | `packages/admin/admin/src/error/errorHandler/__stories__/ErrorHandlerProvider.stories.tsx` |
| `storybook/src/admin/error-handling/RouteWithErrorBoundary.stories.tsx` | `packages/admin/admin/src/error/errorboundary/__stories__/RouteWithErrorBoundary.stories.tsx` |

### Changes per story

- **All stories:** Updated `title` to follow the package Storybook convention (`components/<feature>/<ComponentName>` instead of `@comet/admin/…`).
- **`RouteWithErrorBoundary`:** Removed `storyRouterDecorator()` import and decorator — the `@comet/admin` package Storybook already applies `RouterDecorator` globally via `preview.ts`.
- **`InlineAlert`:** Stripped JSDoc comments on individual stories (consistent with the package's existing story style).
- No `apolloRestStoryDecorator` was used in any of these stories — no MSW migration needed.

https://claude.ai/code/session_01W4FT8LD2Z4LF6zfKLuAc3t

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4FT8LD2Z4LF6zfKLuAc3t)_