### PR TITLE
Distinguish system users in action log

### DIFF
--- a/packages/admin/cms-admin/src/actionLog/actionLog/actionLogVersionGrid/__stories__/ActionLogVersionGrid.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLog/actionLogVersionGrid/__stories__/ActionLogVersionGrid.stories.tsx
@@ -5,8 +5,15 @@ import { MemoryRouter } from "react-router";
 import { ActionLogVersionGrid } from "../ActionLogVersionGrid";
 
 const mockActionLogs = {
-    totalCount: 3,
+    totalCount: 4,
     nodes: [
+        {
+            id: "log4",
+            user: { id: "system-user", name: "system-user" },
+            entityName: "TestEntity",
+            version: 4,
+            createdAt: "2023-10-04T12:00:00Z",
+        },
         {
             id: "log3",
             user: { id: "1", name: "Max Mustermann" },

--- a/packages/admin/cms-admin/src/actionLog/components/diffHeader/__stories__/DiffHeader.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/diffHeader/__stories__/DiffHeader.stories.tsx
@@ -18,6 +18,15 @@ export const StandardDiffHeader: Story = {
     },
 };
 
+export const SystemUser: Story = {
+    args: {
+        createdAt: "2023-10-01T12:00:00Z",
+        userId: "system-user",
+        userName: "system-user",
+        version: 1,
+    },
+};
+
 export const UnknownUser: Story = {
     args: {
         createdAt: "2023-10-01T12:00:00Z",

--- a/packages/admin/cms-admin/src/actionLog/components/userCell/__stories__/UserCell.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/userCell/__stories__/UserCell.stories.tsx
@@ -23,6 +23,13 @@ export const OneName: Story = {
     },
 };
 
+export const SystemUser: Story = {
+    args: {
+        id: "system-user",
+        name: "system-user",
+    },
+};
+
 export const UnknownUser: Story = {
     args: {
         id: "abc-123",

--- a/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
@@ -10,11 +10,10 @@ export class ActionLogsResolver {
 
     @ResolveField(() => ActionLogsUser)
     async user(@Parent() actionLog: ActionLog): Promise<ActionLogsUser> {
-        try {
-            const user = await this.userPermissionsService.findUserOrThrow(actionLog.userId);
-            return { id: user.id, name: user.name };
-        } catch {
-            return { id: actionLog.userId };
+        if (this.userPermissionsService.isSystemUser(actionLog.userId)) {
+            return { id: actionLog.userId, name: actionLog.userId };
         }
+        const user = await this.userPermissionsService.findUser(actionLog.userId);
+        return user ? { id: user.id, name: user.name } : { id: actionLog.userId };
     }
 }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts
@@ -1,0 +1,88 @@
+import type { DiscoveryService } from "@golevelup/nestjs-discovery";
+import { createMock } from "@golevelup/ts-vitest";
+import type { EntityRepository } from "@mikro-orm/postgresql";
+import { describe, expect, it, vi } from "vitest";
+
+import type { UserContentScopes } from "./entities/user-content-scopes.entity";
+import type { UserPermission } from "./entities/user-permission.entity";
+import type { User } from "./interfaces/user";
+import { UserPermissionsService } from "./user-permissions.service";
+import type { AccessControlServiceInterface, UserPermissionsOptions, UserPermissionsUserServiceInterface } from "./user-permissions.types";
+
+const createService = ({
+    options = {},
+    userService,
+}: {
+    options?: UserPermissionsOptions;
+    userService?: UserPermissionsUserServiceInterface;
+} = {}) =>
+    new UserPermissionsService(
+        options,
+        userService,
+        createMock<AccessControlServiceInterface>(),
+        createMock<EntityRepository<UserPermission>>(),
+        createMock<EntityRepository<UserContentScopes>>(),
+        createMock<DiscoveryService>(),
+    );
+
+describe("UserPermissionsService", () => {
+    describe("isSystemUser", () => {
+        it("returns true for an id listed in systemUsers", () => {
+            const service = createService({ options: { systemUsers: ["system", "cron"] } });
+
+            expect(service.isSystemUser("system")).toBe(true);
+            expect(service.isSystemUser("cron")).toBe(true);
+        });
+
+        it("returns false for an id not listed in systemUsers", () => {
+            const service = createService({ options: { systemUsers: ["system"] } });
+
+            expect(service.isSystemUser("some-user-id")).toBe(false);
+        });
+
+        it("returns false when systemUsers is undefined", () => {
+            const service = createService({ options: {} });
+
+            expect(service.isSystemUser("system")).toBe(false);
+        });
+
+        it("returns false when systemUsers is empty", () => {
+            const service = createService({ options: { systemUsers: [] } });
+
+            expect(service.isSystemUser("system")).toBe(false);
+        });
+
+        it("matches by exact id (no substring or case-insensitive match)", () => {
+            const service = createService({ options: { systemUsers: ["system"] } });
+
+            expect(service.isSystemUser("System")).toBe(false);
+            expect(service.isSystemUser("system-user")).toBe(false);
+            expect(service.isSystemUser("")).toBe(false);
+        });
+    });
+
+    describe("findUser", () => {
+        const user: User = { id: "abc", name: "Max Mustermann", email: "max@example.com" };
+
+        it("returns the user when userService resolves", async () => {
+            const userService = { getUser: vi.fn().mockResolvedValue(user), findUsers: vi.fn() };
+            const service = createService({ userService });
+
+            await expect(service.findUser("abc")).resolves.toEqual(user);
+            expect(userService.getUser).toHaveBeenCalledWith("abc");
+        });
+
+        it("returns null when userService rejects", async () => {
+            const userService = { getUser: vi.fn().mockRejectedValue(new Error("not found")), findUsers: vi.fn() };
+            const service = createService({ userService });
+
+            await expect(service.findUser("missing")).resolves.toBeNull();
+        });
+
+        it("throws when userService is not configured", async () => {
+            const service = createService({ userService: undefined });
+
+            await expect(service.findUser("abc")).rejects.toThrow(/userService/);
+        });
+    });
+});

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -125,11 +125,29 @@ export class UserPermissionsService {
         throw new Error("For this functionality you need to define `findUserOrThrow` (or the deprecated `getUser`) in the userService.");
     }
 
+    async findUser(id: string): Promise<User | null> {
+        if (this.userService?.findUser) {
+            return this.userService.findUser(id);
+        }
+        if (this.userService?.getUser) {
+            try {
+                return await this.userService.getUser(id);
+            } catch {
+                return null;
+            }
+        }
+        throw new Error("For this functionality you need to define `findUser` (or the deprecated `getUser`) in the userService.");
+    }
+
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {
         if (!this.userService) {
             throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
         }
         return this.userService.findUsers(args);
+    }
+
+    isSystemUser(id: string): boolean {
+        return this.options.systemUsers?.includes(id) ?? false;
     }
 
     async checkContentScopes(contentScopes: ContentScope[]): Promise<void> {


### PR DESCRIPTION
## Summary

Registered system users (e.g. `console.ts` invoking `storage.runWith({ user: SYSTEM_USER_NAME })`) were rendered as "Unknown user (system-user)" in the action log because the `user` ResolveField wrapped `UserPermissionsService.getUser` in a try/catch and treated every throw as "unknown".

System users are a first-class framework concept — `UserPermissionsOptions.systemUsers: string[]` is the registry — so the action log now handles them explicitly and surfaces the registered identifier as the display name.

<img width="1200" height="80" alt="image" src="https://github.com/user-attachments/assets/470f3764-d6ad-4b49-91d3-d4bca15ed1b1" />


## Key Changes

- **`UserPermissionsService`**: new helpers
  - `isSystemUser(id: string): boolean` — wraps `options.systemUsers?.includes(id)` so consumers don't need access to `USER_PERMISSIONS_OPTIONS`.
  - `findUser(id: string): Promise<User | null>` — wraps `getUser` and returns `null` instead of throwing, so callers no longer rely on try/catch for control flow.
- **`ActionLogsResolver.user`**: checks `isSystemUser` first and returns `{ id, name: <system identifier> }`; otherwise calls `findUser` and falls back to `{ id }` only when the user really can't be resolved.
- **Stories**: added system-user and unknown-user examples to `UserCell` so all three states are covered.

The admin needs no changes — system users now flow through the normal "user with a name" rendering path.

https://claude.ai/code/session_01671MVv1jRh66RWAgLdbb8S