### PR TITLE
Remove duplicated changeset guidance

### DIFF
--- a/packages/mail-react/README.md
+++ b/packages/mail-react/README.md
@@ -37,8 +37,6 @@ Every custom component has a story in `src/components/<concern>/__stories__/<Com
 
 ### Changesets
 
-A changeset describes what changes for the consumer. If the public API and end-user behavior are unchanged, no changeset is needed.
-
 When a custom component replaces a re-export, describe the change against the previous re-export — the added props, features, or behavior. Consumers don't need to know the internal component is new; they only see what's different in the API they use.
 
 ## Living document


### PR DESCRIPTION
`CONTRIBUTING.md` is the canonical reference for when to add a changeset.
The mail-react `README`'s own scope rules forbid restating parent-level guidance, but the deleted paragraph paraphrased `CONTRIBUTING.md` anyway — a second copy that drifts out of sync and tells the reader nothing new.
The kept paragraph covers the mail-react-specific case (custom components replacing re-exports) that `CONTRIBUTING.md` doesn't.
