### PR TITLE
Export `isLinkTarget` and `validateLinkTarget`

### DIFF
--- a/.changeset/export-link-target-validation.md
+++ b/.changeset/export-link-target-validation.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Export `isLinkTarget` and `validateLinkTarget`

--- a/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
+++ b/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
@@ -238,6 +238,19 @@ Reinstall dependencies after updating `package.json`:
 npm install
 ```
 
+### Replace `/lib` imports from `@comet/*` packages
+
+`@comet/eslint-config` v9 forbids importing from `@comet/*/lib` and `@comet/*/lib/**`. Only the package root (and explicit subpath exports like `@comet/site-nextjs/server`) may be imported. Reaching into `/lib` couples your project to internal file layout and breaks whenever a package is restructured.
+
+```diff
+- import { Something } from "@comet/cms-api/lib/some/internal/path";
++ import { Something } from "@comet/cms-api";
+```
+
+If the symbol you need isn't exported from the package root, **do not copy the code from `/lib` into your project**. The duplicate drifts out of sync with the library, misses bug fixes, and defeats the purpose of using the package.
+
+Instead, open a pull request in [vivid-planet/comet](https://github.com/vivid-planet/comet) that adds the missing export to the package's `src/index.ts` (plus a changeset). Once merged and released, import it from the package root.
+
 ### Verify lint passes
 
 ```sh

--- a/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
+++ b/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
@@ -76,6 +76,23 @@ npm run lint:root
 
 Repeat this step, fixing all lint errors, until the lint passes.
 
+## All packages
+
+The following changes apply to API, Admin, and Site. Run the steps in each package that consumes `@comet/*` packages.
+
+### Replace `/lib` imports from `@comet/*` packages
+
+`@comet/eslint-config` v9 forbids importing from `@comet/*/lib` and `@comet/*/lib/**`. Only the package root (and explicit subpath exports like `@comet/site-nextjs/server`) may be imported. Reaching into `/lib` couples your project to internal file layout and breaks whenever a package is restructured.
+
+```diff
+- import { Something } from "@comet/cms-api/lib/some/internal/path";
++ import { Something } from "@comet/cms-api";
+```
+
+If the symbol you need isn't exported from the package root, **do not copy the code from `/lib` into your project**. The duplicate drifts out of sync with the library, misses bug fixes, and defeats the purpose of using the package.
+
+Instead, open a pull request in [vivid-planet/comet](https://github.com/vivid-planet/comet) that adds the missing export to the package's `src/index.ts` (plus a changeset). Once merged and released, import it from the package root.
+
 ## API
 
 ### Update Comet dependencies
@@ -237,19 +254,6 @@ Reinstall dependencies after updating `package.json`:
 ```sh
 npm install
 ```
-
-### Replace `/lib` imports from `@comet/*` packages
-
-`@comet/eslint-config` v9 forbids importing from `@comet/*/lib` and `@comet/*/lib/**`. Only the package root (and explicit subpath exports like `@comet/site-nextjs/server`) may be imported. Reaching into `/lib` couples your project to internal file layout and breaks whenever a package is restructured.
-
-```diff
-- import { Something } from "@comet/cms-api/lib/some/internal/path";
-+ import { Something } from "@comet/cms-api";
-```
-
-If the symbol you need isn't exported from the package root, **do not copy the code from `/lib` into your project**. The duplicate drifts out of sync with the library, misses bug fixes, and defeats the purpose of using the package.
-
-Instead, open a pull request in [vivid-planet/comet](https://github.com/vivid-planet/comet) that adds the missing export to the package's `src/index.ts` (plus a changeset). Once merged and released, import it from the package root.
 
 ### Verify lint passes
 

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -223,6 +223,8 @@ export { UserPermissionsUserPagePermissionsPanel } from "./userPermissions/user/
 export { UserPermissionsUserPageToolbar } from "./userPermissions/user/UserPageToolbar";
 export { UserPermissionsUserGrid } from "./userPermissions/UserGrid";
 export { UserPermissionsPage } from "./userPermissions/UserPermissionsPage";
+export { isLinkTarget } from "./validation/isLinkTarget";
+export { validateLinkTarget } from "./validation/validateLinkTarget";
 export { LatestWarningsDashboardWidget } from "./warnings/LatestWarningsDashboardWidget";
 export { WarningsPage } from "./warnings/WarningsPage";
 import packageJson from "../package.json";


### PR DESCRIPTION
Also used in a client project (like https://github.com/vivid-planet/comet/pull/5767)