### PR TITLE
site-react: Fix preview-image to playback transition in video blocks

### DIFF
--- a/.changeset/fix-video-block-preview-to-playback-transition.md
+++ b/.changeset/fix-video-block-preview-to-playback-transition.md
@@ -1,0 +1,8 @@
+---
+"@comet/site-react": patch
+---
+
+Fix preview-image to playback transition in video blocks
+
+- `DamVideoBlock`: clicking the preview image's play button now starts video playback. Previously, the click dismissed the preview but the browser's autoplay policy blocked playback of videos with sound because the gesture happened on the preview image rather than the `<video>` element. Playback is now triggered explicitly inside the ref callback to stay within the user gesture window.
+- `YouTubeVideoBlock` / `VimeoVideoBlock`: when the preview image is dismissed, `isPlaying` is now set to `true` so `PlayPauseButton` shows the correct icon, and the playback is flagged as manually handled so the viewport handler does not immediately pause the video.

--- a/packages/site/site-react/src/blocks/DamVideoBlock.tsx
+++ b/packages/site/site-react/src/blocks/DamVideoBlock.tsx
@@ -45,7 +45,25 @@ export const DamVideoBlock = withPreview(
         const hasPreviewImage = Boolean(previewImage && previewImage.damFile);
 
         const [videoElement, setVideoElement] = useState<HTMLVideoElement | null>(null);
-        const videoRef = setVideoElement;
+
+        const videoRef = useCallback(
+            (element: HTMLVideoElement | null) => {
+                setVideoElement(element);
+                // The user gesture from clicking the preview image's play button does not extend to the
+                // freshly-mounted <video> element, so the browser blocks autoplay for unmuted videos.
+                // Call play() explicitly during the ref-callback to keep playback in the user gesture window.
+                if (element && hasPreviewImage && !showPreviewImage && element.paused) {
+                    element.play();
+                }
+            },
+            [hasPreviewImage, showPreviewImage],
+        );
+
+        const handlePreviewPlay = () => {
+            setShowPreviewImage(false);
+            setIsPlaying(true);
+            setIsHandledManually(true);
+        };
 
         const handleInView = useCallback(
             (inView: boolean) => {
@@ -79,7 +97,7 @@ export const DamVideoBlock = withPreview(
             <>
                 {hasPreviewImage && showPreviewImage ? (
                     renderPreviewImage({
-                        onPlay: () => setShowPreviewImage(false),
+                        onPlay: handlePreviewPlay,
                         image: previewImage,
                         aspectRatio,
                         sizes: previewImageSizes,

--- a/packages/site/site-react/src/blocks/DamVideoBlock.tsx
+++ b/packages/site/site-react/src/blocks/DamVideoBlock.tsx
@@ -108,7 +108,7 @@ export const DamVideoBlock = withPreview(
                 ) : (
                     <div className={styles.root}>
                         <video
-                            autoPlay={autoplay || (hasPreviewImage && !showPreviewImage)}
+                            autoPlay={autoplay}
                             controls={showControls}
                             loop={loop}
                             playsInline

--- a/packages/site/site-react/src/blocks/VimeoVideoBlock.tsx
+++ b/packages/site/site-react/src/blocks/VimeoVideoBlock.tsx
@@ -113,6 +113,12 @@ export const VimeoVideoBlock = withPreview(
         const vimeoUrl = new URL(`${vimeoBaseUrl}${identifier ?? ""}`);
         vimeoUrl.search = searchParams.toString();
 
+        const handlePreviewPlay = () => {
+            setShowPreviewImage(false);
+            setIsPlaying(true);
+            setIsHandledManually(true);
+        };
+
         const handlePlayPauseClick = () => {
             if (isPlaying) {
                 setIsPlaying(false);
@@ -128,7 +134,7 @@ export const VimeoVideoBlock = withPreview(
             <>
                 {hasPreviewImage && showPreviewImage ? (
                     renderPreviewImage({
-                        onPlay: () => setShowPreviewImage(false),
+                        onPlay: handlePreviewPlay,
                         image: previewImage,
                         aspectRatio,
                         sizes: previewImageSizes,

--- a/packages/site/site-react/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/site/site-react/src/blocks/YouTubeVideoBlock.tsx
@@ -114,6 +114,12 @@ export const YouTubeVideoBlock = withPreview(
         const youtubeUrl = new URL(`${youtubeBaseUrl}${identifier ?? ""}`);
         youtubeUrl.search = searchParams.toString();
 
+        const handlePreviewPlay = () => {
+            setShowPreviewImage(false);
+            setIsPlaying(true);
+            setIsHandledManually(true);
+        };
+
         const handlePlayPauseClick = () => {
             if (isPlaying) {
                 setIsPlaying(false);
@@ -130,7 +136,7 @@ export const YouTubeVideoBlock = withPreview(
             <>
                 {hasPreviewImage && showPreviewImage ? (
                     renderPreviewImage({
-                        onPlay: () => setShowPreviewImage(false),
+                        onPlay: handlePreviewPlay,
                         image: previewImage,
                         aspectRatio,
                         sizes: previewImageSizes,


### PR DESCRIPTION
## Problem

  Three related bugs around the preview-image → playback transition in the video blocks in `@comet/site-react`:

  1. **`DamVideoBlock`** — Clicking the preview image's play button dismissed the image but did not start the video. The browser's
  autoplay policy blocks autoplay of videos with sound without a direct gesture on the `<video>` element itself — the click happened on
  the preview image, which is a different element and is unmounted immediately, so playback was blocked.
  2. **`YouTubeVideoBlock`** — Playback did start (via `autoplay=1` in the iframe URL), but `isPlaying` was never updated, so
  `PlayPauseButton` kept showing the "play" icon. `isHandledManually` also stayed `false`, so the viewport handler could immediately
  pause the video.
  3. **`VimeoVideoBlock`** — Same as `YouTubeVideoBlock`.

  ## Solution

  - **`DamVideoBlock`**: Switched the `<video>` ref from a plain `setState` setter to a `useCallback` ref callback. When the video
  element mounts after the preview was dismissed, it calls `element.play()` inside the ref callback — this runs synchronously during
  commit, still within the user-gesture window from the preview-image click, so the browser allows unmuted playback.
  - **`YouTubeVideoBlock` / `VimeoVideoBlock`**: The preview's `onPlay` handler now also sets `isPlaying = true` (so the pause icon shows
   immediately) and `isHandledManually = true` (so the viewport visibility handler does not pause the freshly-started video).

  In all three blocks, the preview's `onPlay` is now a named `handlePreviewPlay` function that centralizes the state transitions.

  ## Example

  A `DamVideoBlock` configured with `autoplay: false` and a preview image:

  **Before**
  1. User clicks the preview's play button.
  2. Preview image disappears.
  3. `<video>` element mounts with `autoPlay` attribute set, but `muted` is `false` → browser blocks playback.
  4. Nothing plays. User must click again on the video controls.

  **After**
  1. User clicks the preview's play button.
  2. Preview image disappears, `<video>` element mounts.
  3. Ref callback calls `element.play()` inside the gesture window → video starts.
  4. `PlayPauseButton` already shows the pause icon.

  ## Changeset

  Patch bump for `@comet/site-react`.