### PR TITLE
mail-react: Document the image components in skill and docs

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
@@ -420,6 +420,12 @@ To set a custom link color that persists across all viewports, use `!important` 
 
 **CSS class name:** `.htmlInlineLink`.
 
+## Image
+
+`MjmlImage` and `HtmlImage` are responsive — the image scales down to fit narrow viewports.
+
+**CSS class names:** `.mjmlImage`, `.htmlImage`.
+
 ## Scoped Theming
 
 `ThemeProvider` makes a theme available to its children via React context. `MjmlMailRoot` uses it internally, so you don't need it for the top-level theme. Its main use case is **scoped theming** — applying a different theme to a subsection of the email.

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -273,7 +273,7 @@ const config: Config = { assetBaseUrl: process.env.ASSET_BASE_URL };
 | `MjmlSection`         | Full-width row, supports `indent` and `disableResponsiveBehavior` | `.mjmlSection`, `.mjmlSection--indented`                        |
 | `MjmlColumn`          | Vertical column inside a section                                  | —                                                               |
 | `MjmlText`            | Themed text block with `variant` and `bottomSpacing`              | `.mjmlText`, `.mjmlText--{variant}`, `.mjmlText--bottomSpacing` |
-| `MjmlImage`           | Image                                                             | —                                                               |
+| `MjmlImage`           | Responsive image                                                  | `.mjmlImage`                                                    |
 | `MjmlPixelImageBlock` | Renders a Comet CMS `PixelImageBlockData` via `MjmlImage`         | `.mjmlPixelImageBlock`                                          |
 | `MjmlButton`          | Button (ending tag)                                               | —                                                               |
 | `MjmlDivider`         | Horizontal divider                                                | —                                                               |
@@ -286,6 +286,7 @@ const config: Config = { assetBaseUrl: process.env.ASSET_BASE_URL };
 | --------------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
 | `HtmlText`            | Themed text as HTML element (default `<td>`)             | `.htmlText`, `.htmlText--{variant}`, `.htmlText--bottomSpacing` |
 | `HtmlInlineLink`      | `<a>` that inherits parent text styles, works in Outlook | `.htmlInlineLink`                                               |
+| `HtmlImage`           | Responsive image (`<img>`)                               | `.htmlImage`                                                    |
 | `HtmlPixelImageBlock` | Renders a Comet CMS `PixelImageBlockData` as `<img>`     | `.htmlPixelImageBlock`                                          |
 
 Text components (`MjmlText`, `HtmlText`) support `variant` and `bottomSpacing` props tied to the theme. Variants define typography presets (font size, weight, line height, color). Both support responsive values that change at different breakpoints. Set a `defaultVariant` in the theme to apply a variant automatically when none is specified.

--- a/skills/comet-mail-react/references/components-and-theme.md
+++ b/skills/comet-mail-react/references/components-and-theme.md
@@ -11,8 +11,9 @@ Detailed reference for all `@comet/mail-react` components, the theme system, mod
 5. [MjmlWrapper](#mjmlwrapper)
 6. [Text Components](#text-components)
 7. [HtmlInlineLink](#htmlinlinelink)
-8. [Scoped Theming](#scoped-theming)
-9. [MJML Component Re-exports](#mjml-component-re-exports)
+8. [Image](#image)
+9. [Scoped Theming](#scoped-theming)
+10. [MJML Component Re-exports](#mjml-component-re-exports)
 
 ---
 
@@ -334,6 +335,14 @@ Use `!important` when setting a custom link color — the responsive reset uses 
 
 ---
 
+## Image
+
+`MjmlImage` and `HtmlImage` are responsive — the image scales down to fit narrow viewports.
+
+**CSS classes:** `.mjmlImage`, `.htmlImage`.
+
+---
+
 ## Scoped Theming
 
 `ThemeProvider` applies a different theme to a subtree. Common use: dark-background sections.
@@ -390,6 +399,6 @@ Theme-aware `registerStyles` entries always resolve against the **root theme** f
 
 `@comet/mail-react` re-exports all MJML components from `@faire/mjml-react`. Consumers import everything from `@comet/mail-react` — never from `@faire/mjml-react` directly.
 
-Common re-exports: `MjmlColumn`, `MjmlImage`, `MjmlButton`, `MjmlDivider`, `MjmlSpacer`, `MjmlTable`, `MjmlRaw`, `MjmlGroup`, `MjmlAttributes`, `MjmlAll`, `MjmlClass`, `MjmlStyle`, `MjmlComment`, `MjmlConditionalComment`.
+Common re-exports: `MjmlColumn`, `MjmlButton`, `MjmlDivider`, `MjmlSpacer`, `MjmlTable`, `MjmlRaw`, `MjmlGroup`, `MjmlAttributes`, `MjmlAll`, `MjmlClass`, `MjmlStyle`, `MjmlComment`, `MjmlConditionalComment`.
 
 For the full MJML tag reference: https://documentation.mjml.io/


### PR DESCRIPTION
The skill and docs were out of date with the package's image components: `MjmlImage` was still described as a plain re-export and the new `HtmlImage` and responsive default went unmentioned.