### PR TITLE
mail-react: Document the themed divider components

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
@@ -426,6 +426,28 @@ To set a custom link color that persists across all viewports, use `!important` 
 
 **CSS class names:** `.mjmlImage`, `.htmlImage`.
 
+## Divider
+
+`MjmlDivider` and `HtmlDivider` render a themed horizontal line. Set `height`, `backgroundColor`, and `backgroundImage` directly as props, or define named `variant`s under `theme.divider` with an optional `defaultVariant`.
+
+```tsx
+const theme = createTheme({
+    divider: {
+        defaultVariant: "thin",
+        variants: {
+            thin: { height: 1, backgroundColor: "#999999" },
+            thick: { height: { default: 12, mobile: 8 }, backgroundColor: "#222222" },
+        },
+    },
+});
+
+<MjmlDivider variant="thick" />;
+```
+
+A `backgroundImage` (typically a gradient) renders on top of `backgroundColor`. Clients that ignore `background-image` fall back to the solid color, so set both when using a gradient.
+
+**CSS class names:** `.mjmlDivider`, `.htmlDivider`, and `.mjmlDivider--{variant}` / `.htmlDivider--{variant}`.
+
 ## Scoped Theming
 
 `ThemeProvider` makes a theme available to its children via React context. `MjmlMailRoot` uses it internally, so you don't need it for the top-level theme. Its main use case is **scoped theming** — applying a different theme to a subsection of the email.

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -266,28 +266,29 @@ const config: Config = { assetBaseUrl: process.env.ASSET_BASE_URL };
 
 ### MJML Components (Layout Level)
 
-| Component             | Purpose                                                           | CSS Classes                                                     |
-| --------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------- |
-| `MjmlMailRoot`        | Root element, provides theme, renders `<mjml>` skeleton           | —                                                               |
-| `MjmlWrapper`         | Groups sections sharing a background; theme-aware default bg      | —                                                               |
-| `MjmlSection`         | Full-width row, supports `indent` and `disableResponsiveBehavior` | `.mjmlSection`, `.mjmlSection--indented`                        |
-| `MjmlColumn`          | Vertical column inside a section                                  | —                                                               |
-| `MjmlText`            | Themed text block with `variant` and `bottomSpacing`              | `.mjmlText`, `.mjmlText--{variant}`, `.mjmlText--bottomSpacing` |
-| `MjmlImage`           | Responsive image                                                  | `.mjmlImage`                                                    |
-| `MjmlPixelImageBlock` | Renders a Comet CMS `PixelImageBlockData` via `MjmlImage`         | `.mjmlPixelImageBlock`                                          |
-| `MjmlButton`          | Button (ending tag)                                               | —                                                               |
-| `MjmlDivider`         | Horizontal divider                                                | —                                                               |
-| `MjmlSpacer`          | Vertical spacing                                                  | —                                                               |
-| `MjmlRaw`             | Raw HTML escape hatch (ending tag)                                | —                                                               |
+| Component             | Purpose                                                            | CSS Classes                                                     |
+| --------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------- |
+| `MjmlMailRoot`        | Root element, provides theme, renders `<mjml>` skeleton            | —                                                               |
+| `MjmlWrapper`         | Groups sections sharing a background; theme-aware default bg       | —                                                               |
+| `MjmlSection`         | Full-width row, supports `indent` and `disableResponsiveBehavior`  | `.mjmlSection`, `.mjmlSection--indented`                        |
+| `MjmlColumn`          | Vertical column inside a section                                   | —                                                               |
+| `MjmlText`            | Themed text block with `variant` and `bottomSpacing`               | `.mjmlText`, `.mjmlText--{variant}`, `.mjmlText--bottomSpacing` |
+| `MjmlImage`           | Responsive image                                                   | `.mjmlImage`                                                    |
+| `MjmlPixelImageBlock` | Renders a Comet CMS `PixelImageBlockData` via `MjmlImage`          | `.mjmlPixelImageBlock`                                          |
+| `MjmlButton`          | Button (ending tag)                                                | —                                                               |
+| `MjmlDivider`         | Themed horizontal divider, configurable through theme and variants | `.mjmlDivider`, `.mjmlDivider--{variant}`                       |
+| `MjmlSpacer`          | Vertical spacing                                                   | —                                                               |
+| `MjmlRaw`             | Raw HTML escape hatch (ending tag)                                 | —                                                               |
 
 ### HTML Components (Inside Ending Tags)
 
-| Component             | Purpose                                                  | CSS Classes                                                     |
-| --------------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
-| `HtmlText`            | Themed text as HTML element (default `<td>`)             | `.htmlText`, `.htmlText--{variant}`, `.htmlText--bottomSpacing` |
-| `HtmlInlineLink`      | `<a>` that inherits parent text styles, works in Outlook | `.htmlInlineLink`                                               |
-| `HtmlImage`           | Responsive image (`<img>`)                               | `.htmlImage`                                                    |
-| `HtmlPixelImageBlock` | Renders a Comet CMS `PixelImageBlockData` as `<img>`     | `.htmlPixelImageBlock`                                          |
+| Component             | Purpose                                                            | CSS Classes                                                     |
+| --------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------- |
+| `HtmlText`            | Themed text as HTML element (default `<td>`)                       | `.htmlText`, `.htmlText--{variant}`, `.htmlText--bottomSpacing` |
+| `HtmlInlineLink`      | `<a>` that inherits parent text styles, works in Outlook           | `.htmlInlineLink`                                               |
+| `HtmlImage`           | Responsive image (`<img>`)                                         | `.htmlImage`                                                    |
+| `HtmlPixelImageBlock` | Renders a Comet CMS `PixelImageBlockData` as `<img>`               | `.htmlPixelImageBlock`                                          |
+| `HtmlDivider`         | Themed horizontal divider, configurable through theme and variants | `.htmlDivider`, `.htmlDivider--{variant}`                       |
 
 Text components (`MjmlText`, `HtmlText`) support `variant` and `bottomSpacing` props tied to the theme. Variants define typography presets (font size, weight, line height, color). Both support responsive values that change at different breakpoints. Set a `defaultVariant` in the theme to apply a variant automatically when none is specified.
 

--- a/skills/comet-mail-react/references/components-and-theme.md
+++ b/skills/comet-mail-react/references/components-and-theme.md
@@ -12,8 +12,9 @@ Detailed reference for all `@comet/mail-react` components, the theme system, mod
 6. [Text Components](#text-components)
 7. [HtmlInlineLink](#htmlinlinelink)
 8. [Image](#image)
-9. [Scoped Theming](#scoped-theming)
-10. [MJML Component Re-exports](#mjml-component-re-exports)
+9. [Divider](#divider)
+10. [Scoped Theming](#scoped-theming)
+11. [MJML Component Re-exports](#mjml-component-re-exports)
 
 ---
 
@@ -102,6 +103,31 @@ heading: {
     fontWeight: 700,
 },
 ```
+
+### DividerVariants
+
+Controls the `variant` prop on `MjmlDivider` and `HtmlDivider`:
+
+```ts
+const theme = createTheme({
+    divider: {
+        defaultVariant: "thin",
+        variants: {
+            thin: { height: 1, backgroundColor: "#999999" },
+            thick: { height: { default: 12, mobile: 8 }, backgroundColor: "#222222" },
+        },
+    },
+});
+
+declare module "@comet/mail-react" {
+    interface DividerVariants {
+        thin: true;
+        thick: true;
+    }
+}
+```
+
+Variant properties (`height`, `backgroundColor`, `backgroundImage`) accept responsive values.
 
 ### ThemeBreakpoints
 
@@ -341,6 +367,17 @@ Use `!important` when setting a custom link color — the responsive reset uses 
 
 **CSS classes:** `.mjmlImage`, `.htmlImage`.
 
+## Divider
+
+Themed horizontal line, styled from `theme.divider` (base styles plus variants). Falls back to a built-in default when no theme is in scope; only `variant` requires a theme.
+
+- **`MjmlDivider`** — inside `MjmlColumn`. Classes `.mjmlDivider`, `.mjmlDivider--{variant}`.
+- **`HtmlDivider`** — inside ending tags (`MjmlRaw`) or raw HTML. Classes `.htmlDivider`, `.htmlDivider--{variant}`.
+
+```tsx
+<MjmlDivider variant="thick" />
+```
+
 ---
 
 ## Scoped Theming
@@ -399,6 +436,6 @@ Theme-aware `registerStyles` entries always resolve against the **root theme** f
 
 `@comet/mail-react` re-exports all MJML components from `@faire/mjml-react`. Consumers import everything from `@comet/mail-react` — never from `@faire/mjml-react` directly.
 
-Common re-exports: `MjmlColumn`, `MjmlButton`, `MjmlDivider`, `MjmlSpacer`, `MjmlTable`, `MjmlRaw`, `MjmlGroup`, `MjmlAttributes`, `MjmlAll`, `MjmlClass`, `MjmlStyle`, `MjmlComment`, `MjmlConditionalComment`.
+Common re-exports: `MjmlColumn`, `MjmlButton`, `MjmlSpacer`, `MjmlTable`, `MjmlRaw`, `MjmlGroup`, `MjmlAttributes`, `MjmlAll`, `MjmlClass`, `MjmlStyle`, `MjmlComment`, `MjmlConditionalComment`.
 
 For the full MJML tag reference: https://documentation.mjml.io/


### PR DESCRIPTION
The themed `MjmlDivider` and `HtmlDivider` shipped recently, but the skill still listed `MjmlDivider` among the `@faire/mjml-react` re-exports and described it as a plain horizontal line, and neither the skill nor the end-user docs covered `HtmlDivider` or the theme-driven variants.
A reader following them would reach for the wrong import surface and miss the theming entirely.
