### PR TITLE
Migrate DataGrid stories from global storybook to @comet/admin package

### DIFF
--- a/packages/admin/admin/src/dataGrid/__stories__/ClickableRows.stories.tsx
+++ b/packages/admin/admin/src/dataGrid/__stories__/ClickableRows.stories.tsx
@@ -1,15 +1,45 @@
-import { type GridColDef, StackLink, StackPage, StackSwitch, Toolbar, ToolbarBackButton, ToolbarTitleItem, useStackSwitchApi } from "@comet/admin";
 import { Edit } from "@comet/admin-icons";
 import { IconButton } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
 
-import { exampleColumns, exampleRows } from "../../helpers/ExampleDataGrid";
-import { stackRouteDecorator } from "../../helpers/storyDecorators";
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { ToolbarBackButton } from "../../common/toolbar/backbutton/ToolbarBackButton";
+import { ToolbarTitleItem } from "../../common/toolbar/titleitem/ToolbarTitleItem";
+import { Toolbar } from "../../common/toolbar/Toolbar";
+import { StackPage } from "../../stack/Page";
+import { StackLink } from "../../stack/StackLink";
+import { StackSwitch, useStackSwitchApi } from "../../stack/Switch";
+import type { GridColDef } from "../GridColDef";
+
+const exampleRows = [
+    { id: 1, lastName: "Snow", firstName: "Jon" },
+    { id: 2, lastName: "Lannister", firstName: "Cersei" },
+    { id: 3, lastName: "Lannister", firstName: "Jaime" },
+    { id: 4, lastName: "Stark", firstName: "Arya" },
+    { id: 5, lastName: "Targaryen", firstName: "Daenerys" },
+    { id: 6, lastName: "Melisandre", firstName: null },
+    { id: 7, lastName: "Clifford", firstName: "Ferrara" },
+    { id: 8, lastName: "Frances", firstName: "Rossini" },
+    { id: 9, lastName: "Roxie", firstName: "Harvey" },
+];
+
+const exampleColumns: GridColDef[] = [
+    {
+        field: "firstName",
+        headerName: "First name",
+        flex: 1,
+    },
+    {
+        field: "lastName",
+        headerName: "Last name",
+        flex: 1,
+    },
+];
 
 export default {
-    title: "@comet/admin/data-grid",
-    decorators: [stackRouteDecorator(), storyRouterDecorator()],
+    title: "components/dataGrid/ClickableRows",
+    parameters: {
+        stack: { topLevelTitle: "Example Page" },
+    },
 };
 
 export const ClickableRows = () => {

--- a/packages/admin/admin/src/dataGrid/__stories__/CrudMoreActionsMenu.stories.tsx
+++ b/packages/admin/admin/src/dataGrid/__stories__/CrudMoreActionsMenu.stories.tsx
@@ -1,9 +1,10 @@
-import { CrudMoreActionsMenu, CrudMoreActionsMenuItem } from "@comet/admin";
 import { Delete, Download, Excel, Favorite, Move } from "@comet/admin-icons";
 import { ListItemIcon } from "@mui/material";
 
+import { CrudMoreActionsMenu, CrudMoreActionsMenuItem } from "../CrudMoreActionsMenu";
+
 export default {
-    title: "@comet/admin/data-grid/CrudMoreActionsMenu",
+    title: "components/dataGrid/CrudMoreActionsMenu",
 };
 
 export const Basic = () => {

--- a/packages/admin/admin/src/dataGrid/__stories__/DataGrid.stories.tsx
+++ b/packages/admin/admin/src/dataGrid/__stories__/DataGrid.stories.tsx
@@ -1,12 +1,40 @@
-import { Button, DataGridToolbar, FillSpace, ToolbarTitleItem } from "@comet/admin";
 import { Add } from "@comet/admin-icons";
 import { Box } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
 
-import { exampleColumns, exampleRows } from "../../helpers/ExampleDataGrid";
+import { Button } from "../../common/buttons/Button";
+import { FillSpace } from "../../common/FillSpace";
+import { DataGridToolbar } from "../../common/toolbar/DataGridToolbar";
+import { ToolbarTitleItem } from "../../common/toolbar/titleitem/ToolbarTitleItem";
+import type { GridColDef } from "../GridColDef";
+
+const exampleRows = [
+    { id: 1, lastName: "Snow", firstName: "Jon" },
+    { id: 2, lastName: "Lannister", firstName: "Cersei" },
+    { id: 3, lastName: "Lannister", firstName: "Jaime" },
+    { id: 4, lastName: "Stark", firstName: "Arya" },
+    { id: 5, lastName: "Targaryen", firstName: "Daenerys" },
+    { id: 6, lastName: "Melisandre", firstName: null },
+    { id: 7, lastName: "Clifford", firstName: "Ferrara" },
+    { id: 8, lastName: "Frances", firstName: "Rossini" },
+    { id: 9, lastName: "Roxie", firstName: "Harvey" },
+];
+
+const exampleColumns: GridColDef[] = [
+    {
+        field: "firstName",
+        headerName: "First name",
+        flex: 1,
+    },
+    {
+        field: "lastName",
+        headerName: "Last name",
+        flex: 1,
+    },
+];
 
 export default {
-    title: "@comet/admin/mui/DataGrid",
+    title: "components/dataGrid/DataGrid",
 };
 
 type DefaultArgs = {

--- a/packages/admin/admin/src/dataGrid/__stories__/DataGridSingleSelectFilter.stories.tsx
+++ b/packages/admin/admin/src/dataGrid/__stories__/DataGridSingleSelectFilter.stories.tsx
@@ -1,10 +1,14 @@
-import { DataGridToolbar, GridCellContent, type GridColDef, GridFilterButton } from "@comet/admin";
 import { Check, Close, Education } from "@comet/admin-icons";
 import { Box } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
 
+import { DataGridToolbar } from "../../common/toolbar/DataGridToolbar";
+import { GridCellContent } from "../GridCellContent";
+import type { GridColDef } from "../GridColDef";
+import { GridFilterButton } from "../GridFilterButton";
+
 export default {
-    title: "@comet/admin/mui/DataGrid/SingleSelect Filter",
+    title: "components/dataGrid/DataGridSingleSelectFilter",
 };
 
 // Sample data


### PR DESCRIPTION
## Summary

Migrates the DataGrid-related stories from the global `/storybook` directory into the `@comet/admin` package Storybook (`packages/admin/admin/src/dataGrid/__stories__/`).

### Migrated components

- **ClickableRows** — `storybook/src/admin/data-grid/` → `packages/admin/admin/src/dataGrid/__stories__/`
- **CrudMoreActionsMenu** — `storybook/src/admin/data-grid/` → `packages/admin/admin/src/dataGrid/__stories__/`
- **DataGrid** — `storybook/src/admin/mui/` → `packages/admin/admin/src/dataGrid/__stories__/`
- **DataGridSingleSelectFilter** — `storybook/src/admin/mui/` → `packages/admin/admin/src/dataGrid/__stories__/`

### Changes per story

- All `@comet/admin` package imports replaced with relative imports (per migration guidelines)
- `storyRouterDecorator` and `stackRouteDecorator` decorators removed — the package Storybook's global `RouterDecorator` handles routing; `parameters: { stack: { topLevelTitle: "..." } }` replaces the stack wrapper for `ClickableRows`
- Story titles updated to reflect the new directory structure (e.g. `components/dataGrid/DataGrid`)
- `ExampleDataGrid` helper data inlined directly in stories that used it (no cross-package helper needed)
- `GridColDef` import updated from `@mui/x-data-grid` to relative `../GridColDef` to satisfy the `no-restricted-imports` ESLint rule

https://claude.ai/code/session_01EYXE7QBZdXa42eXcTqbs4U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYXE7QBZdXa42eXcTqbs4U)_