### PR TITLE
Use relative source imports in all Storybook stories and decorators

### DIFF
--- a/packages/admin/admin/.storybook/decorators/Apollo.decorator.tsx
+++ b/packages/admin/admin/.storybook/decorators/Apollo.decorator.tsx
@@ -1,6 +1,7 @@
 import { ApolloClient, ApolloLink, ApolloProvider, createHttpLink, InMemoryCache } from "@apollo/client";
-import { createErrorDialogApolloLink } from "@comet/admin";
 import type { Decorator } from "@storybook/react-vite";
+
+import { createErrorDialogApolloLink } from "../../src/error/errordialog/createErrorDialogApolloLink";
 
 const apolloClient = new ApolloClient({
     link: ApolloLink.from([createErrorDialogApolloLink(), createHttpLink({ uri: "/graphql" })]),

--- a/packages/admin/admin/.storybook/decorators/MasterLayout.decorator.tsx
+++ b/packages/admin/admin/.storybook/decorators/MasterLayout.decorator.tsx
@@ -1,7 +1,13 @@
-import { AppHeader, AppHeaderMenuButton, MainNavigation, MainNavigationItemRouterLink, MasterLayout, useWindowSize } from "@comet/admin";
 import { Dashboard } from "@comet/admin-icons";
 import { useTheme } from "@mui/material";
 import type { Decorator } from "@storybook/react-vite";
+
+import { AppHeader } from "../../src/appHeader/AppHeader";
+import { AppHeaderMenuButton } from "../../src/appHeader/menuButton/AppHeaderMenuButton";
+import { useWindowSize } from "../../src/helpers/useWindowSize";
+import { MainNavigationItemRouterLink } from "../../src/mui/mainNavigation/ItemRouterLink";
+import { MainNavigation } from "../../src/mui/mainNavigation/MainNavigation";
+import { MasterLayout } from "../../src/mui/MasterLayout";
 
 function MasterHeader() {
     return (

--- a/packages/admin/admin/.storybook/decorators/Router.decorator.tsx
+++ b/packages/admin/admin/.storybook/decorators/Router.decorator.tsx
@@ -1,9 +1,11 @@
-import { RouterMemoryRouter, Stack } from "@comet/admin";
 import type { Decorator } from "@storybook/react-vite";
 import type { Action, History, UnregisterCallback } from "history";
 import { type PropsWithChildren, useEffect } from "react";
 import { Route, type RouteComponentProps } from "react-router";
 import { action } from "storybook/actions";
+
+import { RouterMemoryRouter } from "../../src/router/MemoryRouter";
+import { Stack } from "../../src/stack/Stack";
 
 declare module "storybook/internal/csf" {
     interface Parameters {

--- a/packages/admin/admin/src/stack/__stories__/RouterTabsNestedStack.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/RouterTabsNestedStack.stories.tsx
@@ -1,4 +1,9 @@
-import { Button, RouterTab, RouterTabs, Stack, StackBreadcrumbs, StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
+import { Button } from "../../common/buttons/Button";
+import { RouterTab, RouterTabs } from "../../tabs/RouterTabs";
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackSwitch, StackSwitchApiContext } from "../Switch";
 
 export default {
     title: "components/stack/RouterTabsNestedStack",

--- a/packages/admin/admin/src/stack/__stories__/Stack.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/Stack.stories.tsx
@@ -1,5 +1,7 @@
-import { Stack, StackBreadcrumbs } from "@comet/admin";
 import { Typography } from "@mui/material";
+
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { Stack } from "../Stack";
 
 export default {
     title: "components/stack/Stack",

--- a/packages/admin/admin/src/stack/__stories__/StackBackButton.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackBackButton.stories.tsx
@@ -1,6 +1,11 @@
-import { Stack, StackBackButton, StackBreadcrumbs, StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
 import { useContext } from "react";
 import { Redirect, Route, Switch } from "react-router";
+
+import { StackBackButton } from "../backbutton/StackBackButton";
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackSwitch, StackSwitchApiContext } from "../Switch";
 
 function Page1() {
     const switchApi = useContext(StackSwitchApiContext);

--- a/packages/admin/admin/src/stack/__stories__/StackBreadcrumbs.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackBreadcrumbs.stories.tsx
@@ -1,4 +1,6 @@
-import { type BreadcrumbItem, Stack, StackBreadcrumbs, useStackApi } from "@comet/admin";
+import { useStackApi } from "../Api";
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { type BreadcrumbItem, Stack } from "../Stack";
 
 const singleItem: BreadcrumbItem[] = [{ id: "one", parentId: "", url: "/one", title: "Breadcrumb One" }];
 const twoItems: BreadcrumbItem[] = [...singleItem, { id: "two", parentId: "one", url: "/two", title: "BC 2" }];

--- a/packages/admin/admin/src/stack/__stories__/StackBreadcrumbsTabs.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackBreadcrumbsTabs.stories.tsx
@@ -1,5 +1,11 @@
-import { RouterTab, RouterTabs, Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch } from "@comet/admin";
 import { useLocation } from "react-router";
+
+import { RouterTab, RouterTabs } from "../../tabs/RouterTabs";
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackLink } from "../StackLink";
+import { StackSwitch } from "../Switch";
 
 export default {
     title: "components/stack/StackBreadcrumbsTabs",

--- a/packages/admin/admin/src/stack/__stories__/StackCustomSeparator.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackCustomSeparator.stories.tsx
@@ -1,7 +1,11 @@
-import { Stack, StackBreadcrumbs, StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
 import { CometColor } from "@comet/admin-icons";
 import { useContext } from "react";
 import { Redirect, Route, Switch } from "react-router";
+
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackSwitch, StackSwitchApiContext } from "../Switch";
 
 function Page1() {
     const switchApi = useContext(StackSwitchApiContext);

--- a/packages/admin/admin/src/stack/__stories__/StackLink.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackLink.stories.tsx
@@ -1,5 +1,10 @@
-import { Button, Stack, StackLink, StackPage, StackSwitch } from "@comet/admin";
 import { useLocation } from "react-router";
+
+import { Button } from "../../common/buttons/Button";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackLink } from "../StackLink";
+import { StackSwitch } from "../Switch";
 
 export default {
     title: "components/stack/StackLink",

--- a/packages/admin/admin/src/stack/__stories__/StackNested.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackNested.stories.tsx
@@ -1,6 +1,10 @@
-import { Stack, StackBreadcrumbs, StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
 import { useContext } from "react";
 import { Redirect, Route, Switch } from "react-router";
+
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackSwitch, StackSwitchApiContext } from "../Switch";
 
 function Page1() {
     const switchApi = useContext(StackSwitchApiContext);

--- a/packages/admin/admin/src/stack/__stories__/StackNestedOnInitialPage.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackNestedOnInitialPage.stories.tsx
@@ -1,6 +1,11 @@
-import { Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
+
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackLink } from "../StackLink";
+import { StackSwitch } from "../Switch";
 
 function Path() {
     const location = useLocation();

--- a/packages/admin/admin/src/stack/__stories__/StackNestedOneStack.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackNestedOneStack.stories.tsx
@@ -1,6 +1,12 @@
-import { Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch, SubRoute, useSubRoutePrefix } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
+
+import { SubRoute, useSubRoutePrefix } from "../../router/SubRoute";
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackLink } from "../StackLink";
+import { StackSwitch } from "../Switch";
 
 function Story() {
     const urlPrefix = useSubRoutePrefix();

--- a/packages/admin/admin/src/stack/__stories__/StackPageTitle.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackPageTitle.stories.tsx
@@ -1,6 +1,11 @@
-import { Stack, StackBreadcrumbs, StackPage, StackPageTitle, useStackSwitch } from "@comet/admin";
 import { useState } from "react";
 import { Redirect, Route, Switch } from "react-router";
+
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackPageTitle } from "../StackPageTitle";
+import { useStackSwitch } from "../Switch";
 
 function Page2() {
     const [counter, setCounter] = useState(0);

--- a/packages/admin/admin/src/stack/__stories__/StackReactNodeTitle.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackReactNodeTitle.stories.tsx
@@ -1,5 +1,11 @@
-import { Button, Stack, StackBreadcrumbs, StackPage, StackPageTitle, useStackSwitch } from "@comet/admin";
 import { Typography } from "@mui/material";
+
+import { Button } from "../../common/buttons/Button";
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackPageTitle } from "../StackPageTitle";
+import { useStackSwitch } from "../Switch";
 
 export default {
     title: "components/stack/StackReactNodeTitle",

--- a/packages/admin/admin/src/stack/__stories__/StackRefApi.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackRefApi.stories.tsx
@@ -1,5 +1,9 @@
-import { Stack, StackBreadcrumbs, StackPage, useStackSwitch } from "@comet/admin";
 import { Redirect, Route, Switch } from "react-router";
+
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { useStackSwitch } from "../Switch";
 
 function Story() {
     const [StackSwitch, api] = useStackSwitch();

--- a/packages/admin/admin/src/stack/__stories__/StackTableFormQueryAtStack.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackTableFormQueryAtStack.stories.tsx
@@ -1,27 +1,24 @@
 import { gql, useQuery } from "@apollo/client";
-import {
-    Field,
-    FinalForm,
-    FinalFormInput,
-    type IFilterApi,
-    Loading,
-    MainContent,
-    Stack,
-    StackPage,
-    StackSwitch,
-    StackSwitchApiContext,
-    Table,
-    TableFilterFinalForm,
-    TableQuery,
-    Toolbar,
-    ToolbarBackButton,
-    ToolbarItem,
-    useTableQuery,
-    useTableQueryFilter,
-} from "@comet/admin";
 import { Edit } from "@comet/admin-icons";
 import { Grid, IconButton, Typography } from "@mui/material";
 import { useContext } from "react";
+
+import { Loading } from "../../common/Loading";
+import { MainContent } from "../../common/MainContent";
+import { ToolbarBackButton } from "../../common/toolbar/backbutton/ToolbarBackButton";
+import { ToolbarItem } from "../../common/toolbar/item/ToolbarItem";
+import { Toolbar } from "../../common/toolbar/Toolbar";
+import { FinalForm } from "../../FinalForm";
+import { Field } from "../../form/Field";
+import { FinalFormInput } from "../../form/FinalFormInput";
+import { Table } from "../../table/Table";
+import { TableFilterFinalForm } from "../../table/TableFilterFinalForm";
+import { TableQuery } from "../../table/TableQuery";
+import { useTableQuery } from "../../table/useTableQuery";
+import { type IFilterApi, useTableQueryFilter } from "../../table/useTableQueryFilter";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackSwitch, StackSwitchApiContext } from "../Switch";
 
 const query = gql`
     query users($query: String) {

--- a/packages/admin/admin/src/stack/__stories__/StackTableFormQueryInTable.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackTableFormQueryInTable.stories.tsx
@@ -1,27 +1,25 @@
 import { gql, useQuery } from "@apollo/client";
-import {
-    Field,
-    FinalForm,
-    FinalFormInput,
-    Loading,
-    MainContent,
-    Stack,
-    StackPage,
-    StackSwitch,
-    StackSwitchApiContext,
-    Table,
-    TableFilterFinalForm,
-    TableQuery,
-    Toolbar,
-    ToolbarBackButton,
-    ToolbarItem,
-    usePersistedStateId,
-    useTableQuery,
-    useTableQueryFilter,
-} from "@comet/admin";
 import { Edit } from "@comet/admin-icons";
 import { Card, CardContent, Grid, IconButton, Typography } from "@mui/material";
 import { useContext } from "react";
+
+import { Loading } from "../../common/Loading";
+import { MainContent } from "../../common/MainContent";
+import { ToolbarBackButton } from "../../common/toolbar/backbutton/ToolbarBackButton";
+import { ToolbarItem } from "../../common/toolbar/item/ToolbarItem";
+import { Toolbar } from "../../common/toolbar/Toolbar";
+import { FinalForm } from "../../FinalForm";
+import { Field } from "../../form/Field";
+import { FinalFormInput } from "../../form/FinalFormInput";
+import { Table } from "../../table/Table";
+import { TableFilterFinalForm } from "../../table/TableFilterFinalForm";
+import { TableQuery } from "../../table/TableQuery";
+import { usePersistedStateId } from "../../table/usePersistedStateId";
+import { useTableQuery } from "../../table/useTableQuery";
+import { useTableQueryFilter } from "../../table/useTableQueryFilter";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackSwitch, StackSwitchApiContext } from "../Switch";
 
 const query = gql`
     query users($query: String) {

--- a/packages/admin/admin/src/stack/__stories__/StackUrl.stories.tsx
+++ b/packages/admin/admin/src/stack/__stories__/StackUrl.stories.tsx
@@ -1,5 +1,10 @@
-import { Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch } from "@comet/admin";
 import { useLocation } from "react-router";
+
+import { StackBreadcrumbs } from "../breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../Page";
+import { Stack } from "../Stack";
+import { StackLink } from "../StackLink";
+import { StackSwitch } from "../Switch";
 
 export default {
     title: "components/stack/StackUrl",

--- a/packages/admin/admin/src/tabs/__stories__/DynamicTabs.stories.tsx
+++ b/packages/admin/admin/src/tabs/__stories__/DynamicTabs.stories.tsx
@@ -1,6 +1,9 @@
-import { Button, RouterTab, RouterTabs, Tab, Tabs } from "@comet/admin";
 import { Typography } from "@mui/material";
 import { useState } from "react";
+
+import { Button } from "../../common/buttons/Button";
+import { RouterTab, RouterTabs } from "../RouterTabs";
+import { Tab, Tabs } from "../Tabs";
 
 export const DynamicRouterTabs = ({ showFourthTab }: { showFourthTab: boolean }) => {
     const content = ["Two", "Three"];

--- a/packages/admin/admin/src/tabs/__stories__/NestedStackSwitchWithRouterTabs.stories.tsx
+++ b/packages/admin/admin/src/tabs/__stories__/NestedStackSwitchWithRouterTabs.stories.tsx
@@ -1,5 +1,10 @@
-import { RouterTab, RouterTabs, Stack, StackBreadcrumbs, StackPage, StackSwitch } from "@comet/admin";
 import { useLocation } from "react-router";
+
+import { StackBreadcrumbs } from "../../stack/breadcrumbs/StackBreadcrumbs";
+import { StackPage } from "../../stack/Page";
+import { Stack } from "../../stack/Stack";
+import { StackSwitch } from "../../stack/Switch";
+import { RouterTab, RouterTabs } from "../RouterTabs";
 
 export default {
     title: "components/tabs/Nested StackSwitch with RouterTabs",

--- a/packages/admin/admin/src/tabs/__stories__/OverflowIssues.stories.tsx
+++ b/packages/admin/admin/src/tabs/__stories__/OverflowIssues.stories.tsx
@@ -1,9 +1,12 @@
-import { MainContent, RouterTab, RouterTabs, Toolbar, ToolbarAutomaticTitleItem } from "@comet/admin";
 import { Box, Tab, Tabs, Typography } from "@mui/material";
 import type { Decorator, Meta } from "@storybook/react-vite";
 import { useState } from "react";
 
 import { MasterLayoutDecorator } from "../../../.storybook/decorators/MasterLayout.decorator";
+import { MainContent } from "../../common/MainContent";
+import { ToolbarAutomaticTitleItem } from "../../common/toolbar/automatictitleitem/ToolbarAutomaticTitleItem";
+import { Toolbar } from "../../common/toolbar/Toolbar";
+import { RouterTab, RouterTabs } from "../RouterTabs";
 
 // Make sure the story is not too tall and can be scrolled - setting the story-height in the config only affects the min-height and does not make the content scrollable
 const MaxHeightDecorator: Decorator = (Story) => (

--- a/packages/admin/admin/src/tabs/__stories__/RouterTabs.stories.tsx
+++ b/packages/admin/admin/src/tabs/__stories__/RouterTabs.stories.tsx
@@ -1,5 +1,6 @@
-import { RouterTab, RouterTabs } from "@comet/admin";
 import { useLocation } from "react-router";
+
+import { RouterTab, RouterTabs } from "../RouterTabs";
 
 export default {
     title: "components/tabs/RouterTabs",

--- a/packages/admin/admin/src/tabs/__stories__/RouterTabsInStack.stories.tsx
+++ b/packages/admin/admin/src/tabs/__stories__/RouterTabsInStack.stories.tsx
@@ -1,5 +1,9 @@
-import { RouterTab, RouterTabs, Stack, StackPage, StackSwitch } from "@comet/admin";
 import { useEffect, useRef, useState } from "react";
+
+import { StackPage } from "../../stack/Page";
+import { Stack } from "../../stack/Stack";
+import { StackSwitch } from "../../stack/Switch";
+import { RouterTab, RouterTabs } from "../RouterTabs";
 
 const mountCount: Record<string, number> = {};
 

--- a/packages/admin/admin/src/tabs/__stories__/RouterTabsInSubroute.stories.tsx
+++ b/packages/admin/admin/src/tabs/__stories__/RouterTabsInSubroute.stories.tsx
@@ -1,6 +1,8 @@
-import { RouterTab, RouterTabs, SubRoute } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation, useRouteMatch } from "react-router";
+
+import { SubRoute } from "../../router/SubRoute";
+import { RouterTab, RouterTabs } from "../RouterTabs";
 
 function Story() {
     const match = useRouteMatch();

--- a/packages/admin/admin/src/tabs/__stories__/Tabs.stories.tsx
+++ b/packages/admin/admin/src/tabs/__stories__/Tabs.stories.tsx
@@ -1,16 +1,14 @@
-import {
-    Field,
-    FillSpace,
-    FinalForm,
-    FinalFormInput,
-    FinalFormSaveButton,
-    Tab,
-    Tabs,
-    Toolbar,
-    ToolbarActions,
-    ToolbarBackButton,
-} from "@comet/admin";
 import { Card, CardContent } from "@mui/material";
+
+import { FillSpace } from "../../common/FillSpace";
+import { ToolbarActions } from "../../common/toolbar/actions/ToolbarActions";
+import { ToolbarBackButton } from "../../common/toolbar/backbutton/ToolbarBackButton";
+import { Toolbar } from "../../common/toolbar/Toolbar";
+import { FinalForm } from "../../FinalForm";
+import { FinalFormSaveButton } from "../../FinalFormSaveButton";
+import { Field } from "../../form/Field";
+import { FinalFormInput } from "../../form/FinalFormInput";
+import { Tab, Tabs } from "../Tabs";
 
 export default {
     title: "components/tabs/Tabs",


### PR DESCRIPTION
Fixes the tests failing after merging https://github.com/vivid-planet/comet/pull/5561. This was caused by some Storybook decorators providing React contexts (e.g. the Stack's StackApiContext via Router.decorator) from the built `@comet/admin` package, while several stories imported the matching components from relative source paths, resulting in two separate context instances. Fix this by importing components from relative source paths consistently across all stories and decorators, which results in a single context instance.

https://claude.ai/code/session_01Ra33QaH1n1R2knmwtSERoC