### PR TITLE
Migrate router and navigation stories to @comet/admin package Storybook

### DIFF
--- a/packages/admin/admin/src/appHeader/__stories__/AppHeader.stories.tsx
+++ b/packages/admin/admin/src/appHeader/__stories__/AppHeader.stories.tsx
@@ -1,20 +1,17 @@
-import {
-    AppHeader,
-    AppHeaderButton,
-    AppHeaderDropdown,
-    AppHeaderMenuButton,
-    Button,
-    CometLogo,
-    FillSpace,
-    MainContent,
-    MainNavigation,
-    MainNavigationItemRouterLink,
-    MasterLayout,
-} from "@comet/admin";
 import { Account, Dashboard, Language, Logout, Preview } from "@comet/admin-icons";
 import { Avatar, Box, Divider, MenuItem, MenuList } from "@mui/material";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { Button } from "../../common/buttons/Button";
+import { CometLogo } from "../../common/CometLogo";
+import { FillSpace } from "../../common/FillSpace";
+import { MainContent } from "../../common/MainContent";
+import { MainNavigationItemRouterLink } from "../../mui/mainNavigation/ItemRouterLink";
+import { MainNavigation } from "../../mui/mainNavigation/MainNavigation";
+import { MasterLayout } from "../../mui/MasterLayout";
+import { AppHeader } from "../AppHeader";
+import { AppHeaderButton } from "../button/AppHeaderButton";
+import { AppHeaderDropdown } from "../dropdown/AppHeaderDropdown";
+import { AppHeaderMenuButton } from "../menuButton/AppHeaderMenuButton";
 
 function AccountHeaderItem() {
     return (
@@ -79,7 +76,6 @@ function MasterHeader() {
 
 export default {
     title: "@comet/admin/mui",
-    decorators: [storyRouterDecorator()],
     excludeStories: ["Story"],
 };
 

--- a/packages/admin/admin/src/appHeader/__stories__/Menu.stories.tsx
+++ b/packages/admin/admin/src/appHeader/__stories__/Menu.stories.tsx
@@ -1,22 +1,19 @@
-import {
-    AppHeader,
-    AppHeaderMenuButton,
-    CometLogo,
-    FillSpace,
-    MainContent,
-    MainNavigation,
-    MainNavigationCollapsibleItem,
-    MainNavigationItemAnchorLink,
-    MainNavigationItemGroup,
-    MainNavigationItemRouterLink,
-    MasterLayout,
-    useWindowSize,
-} from "@comet/admin";
 import { CometColor, Dashboard, Settings, Sort } from "@comet/admin-icons";
 import { Card, CardContent, Typography } from "@mui/material";
 import { Route, Switch } from "react-router";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { CometLogo } from "../../common/CometLogo";
+import { FillSpace } from "../../common/FillSpace";
+import { MainContent } from "../../common/MainContent";
+import { useWindowSize } from "../../helpers/useWindowSize";
+import { MainNavigationCollapsibleItem } from "../../mui/mainNavigation/CollapsibleItem";
+import { MainNavigationItemAnchorLink } from "../../mui/mainNavigation/ItemAnchorLink";
+import { MainNavigationItemGroup } from "../../mui/mainNavigation/ItemGroup";
+import { MainNavigationItemRouterLink } from "../../mui/mainNavigation/ItemRouterLink";
+import { MainNavigation } from "../../mui/mainNavigation/MainNavigation";
+import { MasterLayout } from "../../mui/MasterLayout";
+import { AppHeader } from "../AppHeader";
+import { AppHeaderMenuButton } from "../menuButton/AppHeaderMenuButton";
 
 const permanentMenuMinWidth = 1024;
 
@@ -77,7 +74,6 @@ const Content = ({ children }: { children: string }) => (
 
 export default {
     title: "@comet/admin/mui",
-    decorators: [storyRouterDecorator()],
     excludeStories: ["Story"],
 };
 

--- a/packages/admin/admin/src/appHeader/__stories__/MenuDynamicVariants.stories.tsx
+++ b/packages/admin/admin/src/appHeader/__stories__/MenuDynamicVariants.stories.tsx
@@ -1,24 +1,21 @@
-import {
-    AppHeader,
-    AppHeaderMenuButton,
-    CometLogo,
-    FillSpace,
-    MainContent,
-    MainNavigation,
-    MainNavigationCollapsibleItem,
-    MainNavigationItemAnchorLink,
-    MainNavigationItemRouterLink,
-    MasterLayout,
-    useMainNavigation,
-    useWindowSize,
-} from "@comet/admin";
 import { CometColor, Dashboard, LinkExternal, Settings, Sort } from "@comet/admin-icons";
 import { Card, CardContent, Divider, Typography } from "@mui/material";
 import { useEffect } from "react";
 import { matchPath, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { CometLogo } from "../../common/CometLogo";
+import { FillSpace } from "../../common/FillSpace";
+import { MainContent } from "../../common/MainContent";
+import { useWindowSize } from "../../helpers/useWindowSize";
+import { MainNavigationCollapsibleItem } from "../../mui/mainNavigation/CollapsibleItem";
+import { useMainNavigation } from "../../mui/mainNavigation/Context";
+import { MainNavigationItemAnchorLink } from "../../mui/mainNavigation/ItemAnchorLink";
+import { MainNavigationItemRouterLink } from "../../mui/mainNavigation/ItemRouterLink";
+import { MainNavigation } from "../../mui/mainNavigation/MainNavigation";
+import { MasterLayout } from "../../mui/MasterLayout";
+import { AppHeader } from "../AppHeader";
+import { AppHeaderMenuButton } from "../menuButton/AppHeaderMenuButton";
 
 const permanentMenuMinWidth = 1024;
 const pathsToAlwaysUseTemporaryMenu = ["/foo3", "/foo4"];
@@ -118,7 +115,6 @@ const Content = ({ children }: { children: string }) => (
 
 export default {
     title: "@comet/admin/mui",
-    decorators: [storyRouterDecorator()],
 };
 
 export const MenuDynamicVariants = {

--- a/packages/admin/admin/src/appHeader/__stories__/ThemableAppHeader.stories.tsx
+++ b/packages/admin/admin/src/appHeader/__stories__/ThemableAppHeader.stories.tsx
@@ -1,4 +1,7 @@
-import { AppHeader, CometLogo, createCometTheme, MuiThemeProvider } from "@comet/admin";
+import { CometLogo } from "../../common/CometLogo";
+import { MuiThemeProvider } from "../../mui/ThemeProvider";
+import { createCometTheme } from "../../theme/createCometTheme";
+import { AppHeader } from "../AppHeader";
 
 export default {
     title: "@comet/admin/theming",

--- a/packages/admin/admin/src/router/__stories__/ForcePromptRoute.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/ForcePromptRoute.stories.tsx
@@ -1,9 +1,9 @@
-import { RouterPrompt } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { ForcePromptRoute } from "../ForcePromptRoute";
+import { RouterPrompt } from "../Prompt";
 
 function Story() {
     return (
@@ -11,18 +11,27 @@ function Story() {
             <Route path="/foo">
                 <RouterPrompt
                     message={() => {
-                        return "sure?";
+                        return "rly?";
                     }}
-                    subRoutePath="/foo/s"
+                    subRoutePath="/foo"
                 >
-                    <Link to="/foo/s/sub">subLink</Link>
-                    <Link to="/foo">fooLink</Link>
-                    <Route path="/foo">
-                        <div>foo</div>
+                    <ul>
+                        <li>
+                            <Link to="/foo/sub1">/foo/sub1</Link> (no prompt)
+                        </li>
+                        <li>
+                            <Link to="/foo/sub2">/foo/sub2</Link> (force prompt)
+                        </li>
+                        <li>
+                            <Link to="/foo">/foo</Link> (back)
+                        </li>
+                    </ul>
+                    <Route path="/foo/sub1">
+                        <div>sub1</div>
                     </Route>
-                    <Route path="/foo/s/sub">
-                        <div>sub</div>
-                    </Route>
+                    <ForcePromptRoute path="/foo/sub2">
+                        <div>sub2</div>
+                    </ForcePromptRoute>
                 </RouterPrompt>
             </Route>
             <Redirect to="/foo" />
@@ -44,10 +53,9 @@ function Path() {
 
 export default {
     title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
 };
 
-export const NestedRouteWithNonSubPathRouteInPrompt = {
+export const _ForcePromptRoute = {
     render: () => {
         return (
             <>
@@ -57,5 +65,5 @@ export const NestedRouteWithNonSubPathRouteInPrompt = {
         );
     },
 
-    name: "Nested route with non-sub-path route in Prompt",
+    name: "ForcePromptRoute",
 };

--- a/packages/admin/admin/src/router/__stories__/Prompt.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/Prompt.stories.tsx
@@ -1,9 +1,8 @@
-import { ForcePromptRoute, RouterPrompt } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { RouterPrompt } from "../Prompt";
 
 function Story() {
     return (
@@ -11,27 +10,18 @@ function Story() {
             <Route path="/foo">
                 <RouterPrompt
                     message={() => {
-                        return "rly?";
+                        return "sure?";
                     }}
-                    subRoutePath="/foo"
+                    subRoutePath="/foo/s"
                 >
-                    <ul>
-                        <li>
-                            <Link to="/foo/sub1">/foo/sub1</Link> (no prompt)
-                        </li>
-                        <li>
-                            <Link to="/foo/sub2">/foo/sub2</Link> (force prompt)
-                        </li>
-                        <li>
-                            <Link to="/foo">/foo</Link> (back)
-                        </li>
-                    </ul>
-                    <Route path="/foo/sub1">
-                        <div>sub1</div>
+                    <Link to="/foo/s/sub">subLink</Link>
+                    <Link to="/foo">fooLink</Link>
+                    <Route path="/foo">
+                        <div>foo</div>
                     </Route>
-                    <ForcePromptRoute path="/foo/sub2">
-                        <div>sub2</div>
-                    </ForcePromptRoute>
+                    <Route path="/foo/s/sub">
+                        <div>sub</div>
+                    </Route>
                 </RouterPrompt>
             </Route>
             <Redirect to="/foo" />
@@ -53,10 +43,9 @@ function Path() {
 
 export default {
     title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
 };
 
-export const _ForcePromptRoute = {
+export const NestedRouteWithNonSubPathRouteInPrompt = {
     render: () => {
         return (
             <>
@@ -66,5 +55,5 @@ export const _ForcePromptRoute = {
         );
     },
 
-    name: "ForcePromptRoute",
+    name: "Nested route with non-sub-path route in Prompt",
 };

--- a/packages/admin/admin/src/router/__stories__/SubRoute.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/SubRoute.stories.tsx
@@ -1,9 +1,8 @@
-import { SubRoute, SubRouteIndexRoute, useSubRoutePrefix } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation, useRouteMatch } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { SubRoute, SubRouteIndexRoute, useSubRoutePrefix } from "../SubRoute";
 
 function Cmp1() {
     const urlPrefix = useSubRoutePrefix();
@@ -81,7 +80,6 @@ function Path() {
 
 export default {
     title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
 };
 
 export const Subroute = () => {

--- a/packages/admin/admin/src/router/__stories__/SubRouteNestedIndex.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/SubRouteNestedIndex.stories.tsx
@@ -1,9 +1,8 @@
-import { SubRouteIndexRoute, useSubRoutePrefix } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { SubRouteIndexRoute, useSubRoutePrefix } from "../SubRoute";
 
 function Cmp1() {
     const urlPrefix = useSubRoutePrefix();
@@ -49,7 +48,6 @@ function Path() {
 
 export default {
     title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
 };
 
 export const SubrouteNestedIndex = {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Migrate stories for the **router** and **AppHeader/navigation** feature domain from the global `/storybook` directory into the `@comet/admin` package Storybook.

### Migrated components

**Router** (`src/router/__stories__/`):
- `ForcePromptRoute` — demonstrates forced route prompts
- `Prompt` (RouterPrompt) — demonstrates nested route prompt behavior
- `SubRoute` — demonstrates sub-route navigation
- `SubRouteNestedIndex` — demonstrates nested index sub-routes

**AppHeader / Navigation** (`src/appHeader/__stories__/`):
- `AppHeader` — full master layout with header, navigation and dropdown menus
- `Menu` — permanent/temporary navigation with grouped items
- `MenuDynamicVariants` — navigation that switches between permanent/temporary based on route and viewport
- `ThemableAppHeader` — AppHeader theme customization via `createCometTheme`

### Changes
- Replaced `@comet/admin` package imports with relative imports (as required for in-package stories)
- Removed per-story `storyRouterDecorator` — the `@comet/admin` Storybook already applies `RouterDecorator` globally
- Deleted the original files from `storybook/src/`

### Related PRs
- #5762 (open) — alert, error-handling and snackbar stories
- #5758 (open) — edit-dialog and dialog stories
- #5785 (closed/merged) — DataGrid stories
- #5692 (closed/merged) — Tabs and RouterTabs stories
- #5691 (closed/merged) — toolbar stories
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gbhaj3ghXuHWwruCznFUVo)_