### PR TITLE
Migrate MUI components & navigation stories to @comet/admin package Storybook

### DIFF
--- a/packages/admin/admin/src/appHeader/__stories__/AppHeader.stories.tsx
+++ b/packages/admin/admin/src/appHeader/__stories__/AppHeader.stories.tsx
@@ -1,20 +1,17 @@
-import {
-    AppHeader,
-    AppHeaderButton,
-    AppHeaderDropdown,
-    AppHeaderMenuButton,
-    Button,
-    CometLogo,
-    FillSpace,
-    MainContent,
-    MainNavigation,
-    MainNavigationItemRouterLink,
-    MasterLayout,
-} from "@comet/admin";
 import { Account, Dashboard, Language, Logout, Preview } from "@comet/admin-icons";
 import { Avatar, Box, Divider, MenuItem, MenuList } from "@mui/material";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { Button } from "../../common/buttons/Button";
+import { CometLogo } from "../../common/CometLogo";
+import { FillSpace } from "../../common/FillSpace";
+import { MainContent } from "../../common/MainContent";
+import { MainNavigationItemRouterLink } from "../../mui/mainNavigation/ItemRouterLink";
+import { MainNavigation } from "../../mui/mainNavigation/MainNavigation";
+import { MasterLayout } from "../../mui/MasterLayout";
+import { AppHeader } from "../AppHeader";
+import { AppHeaderButton } from "../button/AppHeaderButton";
+import { AppHeaderDropdown } from "../dropdown/AppHeaderDropdown";
+import { AppHeaderMenuButton } from "../menuButton/AppHeaderMenuButton";
 
 function AccountHeaderItem() {
     return (
@@ -78,9 +75,7 @@ function MasterHeader() {
 }
 
 export default {
-    title: "@comet/admin/mui",
-    decorators: [storyRouterDecorator()],
-    excludeStories: ["Story"],
+    title: "components/appHeader/AppHeader",
 };
 
 export const _AppHeader = {

--- a/packages/admin/admin/src/appHeader/__stories__/ThemableAppHeader.stories.tsx
+++ b/packages/admin/admin/src/appHeader/__stories__/ThemableAppHeader.stories.tsx
@@ -1,7 +1,10 @@
-import { AppHeader, CometLogo, createCometTheme, MuiThemeProvider } from "@comet/admin";
+import { CometLogo } from "../../common/CometLogo";
+import { MuiThemeProvider } from "../../mui/ThemeProvider";
+import { createCometTheme } from "../../theme/createCometTheme";
+import { AppHeader } from "../AppHeader";
 
 export default {
-    title: "@comet/admin/theming",
+    title: "components/appHeader/ThemableAppHeader",
 };
 
 export const ThemableAppHeader = {

--- a/packages/admin/admin/src/common/__stories__/Dialog.stories.tsx
+++ b/packages/admin/admin/src/common/__stories__/Dialog.stories.tsx
@@ -1,7 +1,14 @@
-import { Button, CancelButton, CheckboxField, Dialog, OkayButton, SelectField, TextField } from "@comet/admin";
 import { Save } from "@comet/admin-icons";
 import { DialogActions, DialogContent, DialogContentText, type DialogProps } from "@mui/material";
 import { Form } from "react-final-form";
+
+import { CheckboxField } from "../../form/fields/CheckboxField";
+import { SelectField } from "../../form/fields/SelectField";
+import { TextField } from "../../form/fields/TextField";
+import { Button } from "../buttons/Button";
+import { CancelButton } from "../buttons/cancel/CancelButton";
+import { OkayButton } from "../buttons/okay/OkayButton";
+import { Dialog } from "../Dialog";
 
 type DialogSize = Exclude<DialogProps["maxWidth"], false> | "fullWidth" | "fullScreen";
 
@@ -26,7 +33,7 @@ const selectOptions = [
 ];
 
 export default {
-    title: "@comet/admin/mui",
+    title: "components/common/Dialog",
     args: {
         selectedDialogSize: "sm",
         selectedDialogTitle: "Dialog Title Example",

--- a/packages/admin/admin/src/mui/__stories__/Card.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/Card.stories.tsx
@@ -1,9 +1,10 @@
-import { Button } from "@comet/admin";
 import { ArrowRight, Reload } from "@comet/admin-icons";
 import { Card, CardContent, CardHeader, Grid, IconButton, Typography } from "@mui/material";
 
+import { Button } from "../../common/buttons/Button";
+
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/Card",
 };
 
 export const _Card = () => {

--- a/packages/admin/admin/src/mui/__stories__/Chip.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/Chip.stories.tsx
@@ -2,7 +2,7 @@ import { ChevronDown } from "@comet/admin-icons";
 import { Box, Card, CardContent, Chip, Grid, Stack, Typography } from "@mui/material";
 
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/Chip",
     args: {
         color: "default",
         variant: "filled",

--- a/packages/admin/admin/src/mui/__stories__/ChipMenu.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/ChipMenu.stories.tsx
@@ -3,7 +3,7 @@ import { Box, Card, CardContent, Chip, ListItemIcon, ListItemText, Menu, MenuIte
 import { type MouseEvent, useState } from "react";
 
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/ChipMenu",
 };
 
 export const ChipMenu = {

--- a/packages/admin/admin/src/mui/__stories__/Link.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/Link.stories.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@mui/material";
 
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/Link",
 };
 
 export const _Link = () => {

--- a/packages/admin/admin/src/mui/__stories__/ListAndMenu.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/ListAndMenu.stories.tsx
@@ -1,10 +1,11 @@
-import { Button } from "@comet/admin";
 import { Add } from "@comet/admin-icons";
 import { Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText, Menu, MenuItem, Paper } from "@mui/material";
 import { useRef, useState } from "react";
 
+import { Button } from "../../common/buttons/Button";
+
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/ListAndMenu",
 };
 
 export const ListAndMenu = {

--- a/packages/admin/admin/src/mui/mainNavigation/__stories__/MainNavigation.stories.tsx
+++ b/packages/admin/admin/src/mui/mainNavigation/__stories__/MainNavigation.stories.tsx
@@ -1,22 +1,19 @@
-import {
-    AppHeader,
-    AppHeaderMenuButton,
-    CometLogo,
-    FillSpace,
-    MainContent,
-    MainNavigation,
-    MainNavigationCollapsibleItem,
-    MainNavigationItemAnchorLink,
-    MainNavigationItemGroup,
-    MainNavigationItemRouterLink,
-    MasterLayout,
-    useWindowSize,
-} from "@comet/admin";
 import { CometColor, Dashboard, Settings, Sort } from "@comet/admin-icons";
 import { Card, CardContent, Typography } from "@mui/material";
 import { Route, Switch } from "react-router";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { AppHeader } from "../../../appHeader/AppHeader";
+import { AppHeaderMenuButton } from "../../../appHeader/menuButton/AppHeaderMenuButton";
+import { CometLogo } from "../../../common/CometLogo";
+import { FillSpace } from "../../../common/FillSpace";
+import { MainContent } from "../../../common/MainContent";
+import { useWindowSize } from "../../../helpers/useWindowSize";
+import { MasterLayout } from "../../MasterLayout";
+import { MainNavigationCollapsibleItem } from "../CollapsibleItem";
+import { MainNavigationItemAnchorLink } from "../ItemAnchorLink";
+import { MainNavigationItemGroup } from "../ItemGroup";
+import { MainNavigationItemRouterLink } from "../ItemRouterLink";
+import { MainNavigation } from "../MainNavigation";
 
 const permanentMenuMinWidth = 1024;
 
@@ -76,9 +73,7 @@ const Content = ({ children }: { children: string }) => (
 );
 
 export default {
-    title: "@comet/admin/mui",
-    decorators: [storyRouterDecorator()],
-    excludeStories: ["Story"],
+    title: "components/mainNavigation/MainNavigation",
 };
 
 export const _Menu = {

--- a/packages/admin/admin/src/mui/mainNavigation/__stories__/MainNavigationDynamicVariants.stories.tsx
+++ b/packages/admin/admin/src/mui/mainNavigation/__stories__/MainNavigationDynamicVariants.stories.tsx
@@ -1,24 +1,21 @@
-import {
-    AppHeader,
-    AppHeaderMenuButton,
-    CometLogo,
-    FillSpace,
-    MainContent,
-    MainNavigation,
-    MainNavigationCollapsibleItem,
-    MainNavigationItemAnchorLink,
-    MainNavigationItemRouterLink,
-    MasterLayout,
-    useMainNavigation,
-    useWindowSize,
-} from "@comet/admin";
 import { CometColor, Dashboard, LinkExternal, Settings, Sort } from "@comet/admin-icons";
 import { Card, CardContent, Divider, Typography } from "@mui/material";
 import { useEffect } from "react";
 import { matchPath, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { AppHeader } from "../../../appHeader/AppHeader";
+import { AppHeaderMenuButton } from "../../../appHeader/menuButton/AppHeaderMenuButton";
+import { CometLogo } from "../../../common/CometLogo";
+import { FillSpace } from "../../../common/FillSpace";
+import { MainContent } from "../../../common/MainContent";
+import { useWindowSize } from "../../../helpers/useWindowSize";
+import { MasterLayout } from "../../MasterLayout";
+import { MainNavigationCollapsibleItem } from "../CollapsibleItem";
+import { useMainNavigation } from "../Context";
+import { MainNavigationItemAnchorLink } from "../ItemAnchorLink";
+import { MainNavigationItemRouterLink } from "../ItemRouterLink";
+import { MainNavigation } from "../MainNavigation";
 
 const permanentMenuMinWidth = 1024;
 const pathsToAlwaysUseTemporaryMenu = ["/foo3", "/foo4"];
@@ -117,8 +114,7 @@ const Content = ({ children }: { children: string }) => (
 );
 
 export default {
-    title: "@comet/admin/mui",
-    decorators: [storyRouterDecorator()],
+    title: "components/mainNavigation/MainNavigationDynamicVariants",
 };
 
 export const MenuDynamicVariants = {


### PR DESCRIPTION
## Summary

Migrates all stories from `storybook/src/admin/mui/` and `storybook/src/admin/theming/` into the dedicated `@comet/admin` package Storybook.

**Feature/domain:** MUI components & navigation layout

**Migrated components:**

| Source (global storybook) | Target (package storybook) |
|---|---|
| `admin/mui/AppHeader.stories.tsx` | `src/appHeader/__stories__/AppHeader.stories.tsx` |
| `admin/theming/ThemableAppHeader.stories.tsx` | `src/appHeader/__stories__/ThemableAppHeader.stories.tsx` |
| `admin/mui/Dialog.stories.tsx` | `src/common/__stories__/Dialog.stories.tsx` |
| `admin/mui/Card.stories.tsx` | `src/mui/__stories__/Card.stories.tsx` |
| `admin/mui/Chip.stories.tsx` | `src/mui/__stories__/Chip.stories.tsx` |
| `admin/mui/ChipMenu.stories.tsx` | `src/mui/__stories__/ChipMenu.stories.tsx` |
| `admin/mui/Link.stories.tsx` | `src/mui/__stories__/Link.stories.tsx` |
| `admin/mui/ListAndMenu.stories.tsx` | `src/mui/__stories__/ListAndMenu.stories.tsx` |
| `admin/mui/Menu.stories.tsx` | `src/mui/mainNavigation/__stories__/MainNavigation.stories.tsx` |
| `admin/mui/MenuDynamicVariants.stories.tsx` | `src/mui/mainNavigation/__stories__/MainNavigationDynamicVariants.stories.tsx` |

**Changes applied per story:**
- Story titles updated to follow the `components/<domain>/<Name>` convention used in the package Storybook
- All `@comet/admin` package imports replaced with relative imports
- Removed `storyRouterDecorator()` decorator (already provided globally by `RouterDecorator` in the package Storybook's `preview.ts`)

## Test plan

- [ ] Open the `@comet/admin` package Storybook (`pnpm run storybook` in `packages/admin/admin/`) and verify all 10 migrated stories render correctly
- [ ] Verify the global storybook no longer shows the migrated stories

https://claude.ai/code/session_01Wq8TX3p6hCgZeXvGrJCmfX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wq8TX3p6hCgZeXvGrJCmfX)_