### PR TITLE
mail-react: Document prop defaults and define the agent skill's role

### DIFF
--- a/packages/mail-react/AGENTS.md
+++ b/packages/mail-react/AGENTS.md
@@ -6,6 +6,8 @@
 
 Many subdirectories also have a `README.md` describing the feature that lives there (see the convention in the root README). When you work in a directory, read its README first; if your change makes it inaccurate or adds context worth recording, update it in the same PR.
 
+When your change affects how the package is used (components, behavior, patterns, styling), update the docs and the agent skill (`skills/comet-mail-react/SKILL.md`) — see _Usage documentation_ in the README; consider a separate docs commit. The skill is the agent-facing usage guide; it doesn't restate props, types, or defaults — those live in the package's types and TSDoc.
+
 ## When creating a changeset
 
 Before adding a new changeset, check `.changeset/` at the repo root for an existing one covering the same feature (e.g. from an unmerged PR) — update it rather than creating a new file. Only add a new changeset when nothing existing fits.

--- a/packages/mail-react/README.md
+++ b/packages/mail-react/README.md
@@ -38,7 +38,10 @@ Themed components expose their styling through the theme: a flat base entry and 
 - **Location.** Custom components live in `src/components/<concern>/` (e.g. `src/components/section/MjmlSection.tsx`).
 - **File order.** Imports → types/props → component → styles. `registerStyles` calls go below the component.
 - **Module format.** ESM only (`type: module`). Use `.js` extensions in imports.
-- **TSDoc.** Short TSDoc — one line where possible — on exported components and props.
+- **TSDoc.** Short — one line where possible — on exported components and props.
+- **Prop defaults.** Add `@defaultValue` when the default isn't obvious from the type — runtime defaults, and theme-derived ones the consumer can't see in the shipped types.
+- **Phrasing a default.** Name where the value comes from, not the value itself. One theme token: name it in backticks, as in "The theme's `colors.background.content`". Computed from several: name what it depends on, as in "The theme's `divider` height for the active variant".
+- **Defaults on inherited props.** Redeclare the prop locally (`Omit` it from the base, re-add it with the same type) so the tag is on the prop itself. Never document the default in the component's TSDoc.
 
 ### Storybook
 
@@ -97,9 +100,13 @@ Other sections should be rare — only when content is durable, feature-specific
 
 Feature READMEs (this one included) should stay current. Update them in the same PR as any change that makes them inaccurate or adds context worth recording.
 
-## Consumer-facing documentation
+## Usage documentation
 
-- Docs: [docs/docs/3-features-modules/13-building-html-emails/](../../docs/docs/3-features-modules/13-building-html-emails/)
-- Agent skill: [skills/comet-mail-react/SKILL.md](../../skills/comet-mail-react/SKILL.md)
+Two artifacts document how to _use_ this package, for two readers:
 
-When a change here affects usage patterns, component APIs, or styling conventions, update these alongside the library change.
+- **Docs** — [docs/docs/3-features-modules/13-building-html-emails/](../../docs/docs/3-features-modules/13-building-html-emails/) — for people building emails with the package.
+- **Agent skill** — [skills/comet-mail-react/SKILL.md](../../skills/comet-mail-react/SKILL.md) — the same guidance for AI agents working in a project that uses this package.
+
+Both teach the same things: what the package is for, how to build emails with it, the patterns to reach for, and the email-client pitfalls — markup that's fine in a browser can render wrong in clients like Outlook. They differ in one respect — an agent already has the package's types and TSDoc in its project, so the skill doesn't restate type signatures, prop lists, or defaults; those live in the types and TSDoc, and it spends its words on everything they can't convey on their own.
+
+When a change affects how the package is used — components added/removed/renamed, changed behavior, new usage patterns, or styling conventions — update both in the same PR; consider a separate docs commit so reviewers can take them on their own.

--- a/packages/mail-react/src/components/divider/dividerProps.ts
+++ b/packages/mail-react/src/components/divider/dividerProps.ts
@@ -4,7 +4,8 @@ import type { DividerVariantName } from "../../theme/themeTypes.js";
 
 export interface DividerProps {
     /**
-     * The component's variant to apply, as defined in the theme.
+     * The component's variant to apply, as defined in the theme. Requires a
+     * theme (`ThemeProvider` or `MjmlMailRoot`) when set.
      *
      * Custom variants should be defined in the theme through module augmentation:
      *
@@ -24,15 +25,27 @@ export interface DividerProps {
      *     },
      * });
      * ```
+     *
+     * @defaultValue The theme's `divider.defaultVariant`, when set
      */
     variant?: DividerVariantName;
-    /** Height of the divider in pixels. */
+    /**
+     * Height of the divider in pixels.
+     *
+     * @defaultValue The theme's `divider` height for the active variant
+     */
     height?: number;
-    /** Background color of the divider (e.g. `"#FF0000"`). */
+    /**
+     * Background color of the divider (e.g. `"#FF0000"`).
+     *
+     * @defaultValue The theme's `divider` background color for the active variant
+     */
     backgroundColor?: string;
     /**
      * Background image for the divider — typically a gradient. Clients that
      * don't render `background-image` fall back to the solid `backgroundColor`.
+     *
+     * @defaultValue The theme's `divider` background image for the active variant
      */
     backgroundImage?: string;
     className?: string;

--- a/packages/mail-react/src/components/inlineLink/HtmlInlineLink.tsx
+++ b/packages/mail-react/src/components/inlineLink/HtmlInlineLink.tsx
@@ -5,7 +5,14 @@ import { registerStyles } from "../../styles/registerStyles.js";
 import { css } from "../../utils/css.js";
 import { useOutlookTextStyle } from "../text/OutlookTextStyleContext.js";
 
-export type HtmlInlineLinkProps = ComponentProps<"a">;
+export type HtmlInlineLinkProps = Omit<ComponentProps<"a">, "target"> & {
+    /**
+     * Where to open the linked document.
+     *
+     * @defaultValue `"_blank"`
+     */
+    target?: ComponentProps<"a">["target"];
+};
 
 /**
  * Inline link styled to match the surrounding text, for use inside `HtmlText` or `MjmlText`.

--- a/packages/mail-react/src/components/mailRoot/MjmlMailRoot.tsx
+++ b/packages/mail-react/src/components/mailRoot/MjmlMailRoot.tsx
@@ -9,8 +9,9 @@ import type { Theme } from "../../theme/themeTypes.js";
 
 type MjmlMailRootProps = PropsWithChildren<{
     /**
-     * Theme to use for the email. When omitted, the default theme
-     * (equivalent to `createTheme()`) is used.
+     * Theme to use for the email.
+     *
+     * @defaultValue `createTheme()`
      */
     theme?: Theme;
     /** Extra content appended inside the built-in `<MjmlAttributes>`, after the default `<MjmlAll>`. */

--- a/packages/mail-react/src/components/section/MjmlSection.tsx
+++ b/packages/mail-react/src/components/section/MjmlSection.tsx
@@ -9,7 +9,13 @@ import type { Theme } from "../../theme/themeTypes.js";
 import { css } from "../../utils/css.js";
 import { useIsInsideMjmlWrapper } from "../wrapper/InsideMjmlWrapperContext.js";
 
-export type MjmlSectionProps = IMjmlSectionProps & {
+export type MjmlSectionProps = Omit<IMjmlSectionProps, "backgroundColor"> & {
+    /**
+     * Background color of the section.
+     *
+     * @defaultValue The theme's `colors.background.content`, unless inside an `MjmlWrapper`
+     */
+    backgroundColor?: IMjmlSectionProps["backgroundColor"];
     /** Applies theme-based content indentation with responsive overrides. */
     indent?: boolean;
     /** When true, child columns remain side-by-side on mobile instead of stacking vertically. */

--- a/packages/mail-react/src/components/text/HtmlText.tsx
+++ b/packages/mail-react/src/components/text/HtmlText.tsx
@@ -29,6 +29,9 @@ interface HtmlTextOwnProps {
      *         },
      *     },
      * });
+     * ```
+     *
+     * @defaultValue The theme's `text.defaultVariant`, when set
      */
     variant?: VariantName;
     /** When true, applies spacing below the text. */

--- a/packages/mail-react/src/components/text/MjmlText.tsx
+++ b/packages/mail-react/src/components/text/MjmlText.tsx
@@ -30,6 +30,9 @@ export type MjmlTextProps = IMjmlTextProps & {
      *         },
      *     },
      * });
+     * ```
+     *
+     * @defaultValue The theme's `text.defaultVariant`, when set
      */
     variant?: VariantName;
     /** When true, applies spacing below the text. */

--- a/packages/mail-react/src/components/wrapper/MjmlWrapper.tsx
+++ b/packages/mail-react/src/components/wrapper/MjmlWrapper.tsx
@@ -4,10 +4,17 @@ import type { ReactNode } from "react";
 import { useOptionalTheme } from "../../theme/ThemeProvider.js";
 import { InsideMjmlWrapperContext } from "./InsideMjmlWrapperContext.js";
 
-export type MjmlWrapperProps = IMjmlWrapperProps;
+export type MjmlWrapperProps = Omit<IMjmlWrapperProps, "backgroundColor"> & {
+    /**
+     * Background color of the wrapper.
+     *
+     * @defaultValue The theme's `colors.background.content`
+     */
+    backgroundColor?: IMjmlWrapperProps["backgroundColor"];
+};
 
 /**
- * A wrapper that groups multiple sections sharing a background. Must be a direct child of MjmlBody.
+ * A wrapper that groups multiple sections sharing a background. Must be a direct child of `MjmlBody`.
  */
 export function MjmlWrapper({ children, ...restProps }: MjmlWrapperProps): ReactNode {
     const theme = useOptionalTheme();

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -171,10 +171,10 @@ function MyEmail() {
 
 ### Contributing to `<MjmlHead>` and `<MjmlAttributes>`
 
-`MjmlMailRoot` accepts two optional slot props for content that can't be expressed via `registerStyles`:
+`MjmlMailRoot` accepts `head` and `attributes` slot props for content that can't be expressed via `registerStyles`:
 
-- `head` — appended inside `<MjmlHead>` after the registered-styles block. Use for `<MjmlFont>`, `<MjmlConditionalComment>`, `<MjmlPreview>`, or `<MjmlStyle>` content that depends on React context at render time.
-- `attributes` — appended inside the built-in `<MjmlAttributes>` after the default `<MjmlAll>`. Use for `<MjmlClass>` or per-element defaults (e.g. `<MjmlText fontSize="14px" />`).
+- `head` — use for `<MjmlFont>`, `<MjmlConditionalComment>`, `<MjmlPreview>`, or `<MjmlStyle>` content that depends on React context at render time.
+- `attributes` — use for `<MjmlClass>` or per-element defaults (e.g. `<MjmlText fontSize="14px" />`).
 
 Pass the children directly — do not wrap them in another `<MjmlHead>` / `<MjmlAttributes>`:
 
@@ -227,20 +227,13 @@ declare module "@comet/mail-react" {
 
 Place `declare module` blocks in your theme file below the `createTheme()` call.
 
-→ For the full theme structure, defaults, and all component props, read [`references/components-and-theme.md`](references/components-and-theme.md).
+→ For the full theme structure, responsive values, module augmentation, and scoped theming, read [`references/components-and-theme.md`](references/components-and-theme.md).
 
 ---
 
 ## Configuration
 
-`Config` is an augmentable interface that can be used to expose, e.g., environment-specific values such as asset base URLs.
-
-- **`Config`** — augmentable interface, no built-in keys. All keys optional.
-- **`MjmlMailRoot.config`** — optional prop that exposes a `Config` value to descendants.
-- **`useConfig`** — hook returning the nearest `Config`, or `{}` if no provider is mounted.
-- **`ConfigProvider`** — standalone provider for cases that bypass `MjmlMailRoot`.
-
-Add keys via module augmentation:
+`Config` exposes environment-specific values — e.g. asset base URLs — to every component in the tree. Add keys via module augmentation:
 
 ```ts
 declare module "@comet/mail-react" {
@@ -270,9 +263,9 @@ const config: Config = { assetBaseUrl: process.env.ASSET_BASE_URL };
 | --------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------- |
 | `MjmlMailRoot`        | Root element, provides theme, renders `<mjml>` skeleton            | —                                                               |
 | `MjmlWrapper`         | Groups sections sharing a background; theme-aware default bg       | —                                                               |
-| `MjmlSection`         | Full-width row, supports `indent` and `disableResponsiveBehavior`  | `.mjmlSection`, `.mjmlSection--indented`                        |
+| `MjmlSection`         | Full-width row; theme indentation, columns stack on mobile         | `.mjmlSection`, `.mjmlSection--indented`                        |
 | `MjmlColumn`          | Vertical column inside a section                                   | —                                                               |
-| `MjmlText`            | Themed text block with `variant` and `bottomSpacing`               | `.mjmlText`, `.mjmlText--{variant}`, `.mjmlText--bottomSpacing` |
+| `MjmlText`            | Themed text block with typography variants                         | `.mjmlText`, `.mjmlText--{variant}`, `.mjmlText--bottomSpacing` |
 | `MjmlImage`           | Responsive image                                                   | `.mjmlImage`                                                    |
 | `MjmlPixelImageBlock` | Renders a Comet CMS `PixelImageBlockData` via `MjmlImage`          | `.mjmlPixelImageBlock`                                          |
 | `MjmlButton`          | Button (ending tag)                                                | —                                                               |
@@ -284,17 +277,17 @@ const config: Config = { assetBaseUrl: process.env.ASSET_BASE_URL };
 
 | Component             | Purpose                                                            | CSS Classes                                                     |
 | --------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------- |
-| `HtmlText`            | Themed text as HTML element (default `<td>`)                       | `.htmlText`, `.htmlText--{variant}`, `.htmlText--bottomSpacing` |
+| `HtmlText`            | Themed text rendered as an HTML element                            | `.htmlText`, `.htmlText--{variant}`, `.htmlText--bottomSpacing` |
 | `HtmlInlineLink`      | `<a>` that inherits parent text styles, works in Outlook           | `.htmlInlineLink`                                               |
 | `HtmlImage`           | Responsive image (`<img>`)                                         | `.htmlImage`                                                    |
 | `HtmlPixelImageBlock` | Renders a Comet CMS `PixelImageBlockData` as `<img>`               | `.htmlPixelImageBlock`                                          |
 | `HtmlDivider`         | Themed horizontal divider, configurable through theme and variants | `.htmlDivider`, `.htmlDivider--{variant}`                       |
 
-Text components (`MjmlText`, `HtmlText`) support `variant` and `bottomSpacing` props tied to the theme. Variants define typography presets (font size, weight, line height, color). Both support responsive values that change at different breakpoints. Set a `defaultVariant` in the theme to apply a variant automatically when none is specified.
+Variants are named typography presets (font size, weight, line height, color) defined in the theme; their values can change per breakpoint.
 
 All components are imported from `@comet/mail-react` — never from `@faire/mjml-react` directly.
 
-→ For complete component props, responsive values, scoped theming, and MJML re-exports, read [`references/components-and-theme.md`](references/components-and-theme.md).
+→ For theme tokens, responsive values, component behavior, scoped theming, and MJML re-exports, read [`references/components-and-theme.md`](references/components-and-theme.md).
 
 ---
 
@@ -319,7 +312,7 @@ All components are imported from `@comet/mail-react` — never from `@faire/mjml
 
 #### Configuration
 
-Both blocks read `validSizes` and `baseUrl` from `config.pixelImageBlock` and throw if it's missing. Wire it once on `MjmlMailRoot.config`. In a typical Comet project, `validSizes` is the union of `cometConfig.images.imageSizes` and `cometConfig.images.deviceSizes`; `baseUrl` is the API URL.
+Both blocks require `config.pixelImageBlock` and throw without it. Wire it once on `MjmlMailRoot.config`:
 
 ```tsx
 const config: Config = {
@@ -332,9 +325,7 @@ const config: Config = {
 
 #### Render width
 
-The required `width` prop is the desktop render width — the width at which the image displays in the default breakpoint. The block picks the actual source size from `validSizes`, accounting for retina displays.
-
-Use `largestPossibleRenderWidth` when the image stretches wider on a narrower breakpoint than its desktop width — e.g. a two-column layout that stacks on mobile. Defaults to `theme.sizes.bodyWidth`.
+The block picks the source size from the configured `validSizes`, accounting for retina displays. Use `largestPossibleRenderWidth` when the image stretches wider on a narrower breakpoint than its desktop width — e.g. a two-column layout that stacks on mobile.
 
 ```tsx
 <MjmlPixelImageBlock data={pixelImageData} width={300} largestPossibleRenderWidth={420} />
@@ -342,7 +333,7 @@ Use `largestPossibleRenderWidth` when the image stretches wider on a narrower br
 
 #### Aspect ratio
 
-By default, the rendered aspect ratio comes from the DAM crop area. Override it with the `aspectRatio` prop — accepts a number or a `"WxH"` / `"W:H"` / `"W/H"` string.
+Without `aspectRatio`, the rendered ratio comes from the DAM crop area. Pass `aspectRatio` to override it.
 
 ```tsx
 <MjmlPixelImageBlock data={pixelImageData} width={536} aspectRatio="16x9" />

--- a/skills/comet-mail-react/references/components-and-theme.md
+++ b/skills/comet-mail-react/references/components-and-theme.md
@@ -1,10 +1,10 @@
 # Components & Theme Reference
 
-Detailed reference for all `@comet/mail-react` components, the theme system, module augmentation, and scoped theming.
+Theme system, module augmentation, scoped theming, and the component behavior for `@comet/mail-react` that its types and TSDoc don't capture on their own. For prop names, types, and defaults, read the types and their TSDoc.
 
 ## Table of Contents
 
-1. [Theme Structure & Defaults](#theme-structure--defaults)
+1. [Theme tokens](#theme-tokens)
 2. [Module Augmentation Interfaces](#module-augmentation-interfaces)
 3. [MjmlMailRoot](#mjmlmailroot)
 4. [MjmlSection](#mjmlsection)
@@ -18,24 +18,9 @@ Detailed reference for all `@comet/mail-react` components, the theme system, mod
 
 ---
 
-## Theme Structure & Defaults
+## Theme tokens
 
-`createTheme(overrides?)` merges partial overrides into the default theme:
-
-| Path                        | Default                       | Description                                                 |
-| --------------------------- | ----------------------------- | ----------------------------------------------------------- |
-| `sizes.bodyWidth`           | `600`                         | Email container width in pixels                             |
-| `sizes.contentIndentation`  | `{ default: 32, mobile: 16 }` | Left/right padding when `indent` is used                    |
-| `breakpoints.default`       | `createBreakpoint(bodyWidth)` | Auto-set to body width unless explicitly overridden         |
-| `breakpoints.mobile`        | `createBreakpoint(420)`       | Mobile breakpoint (`max-width: 419px`)                      |
-| `text.fontFamily`           | System default                | Base font family                                            |
-| `text.fontSize`             | `"16px"`                      | Base font size                                              |
-| `text.lineHeight`           | `"20px"`                      | Base line height                                            |
-| `text.bottomSpacing`        | `"16px"`                      | Default spacing below text when `bottomSpacing` prop is set |
-| `text.defaultVariant`       | `undefined`                   | Variant applied when no `variant` prop is specified         |
-| `text.variants`             | `{}`                          | Named typography presets                                    |
-| `colors.background.body`    | `"#F2F2F2"`                   | Email body background                                       |
-| `colors.background.content` | `"#FFFFFF"`                   | Section content background                                  |
+`createTheme(overrides?)` merges partial overrides into the default theme; every token is optional and the `Theme` type lists them. Defaults live in `createTheme`. One behavior isn't visible from the types: **the default breakpoint derives from `sizes.bodyWidth`** unless `breakpoints.default` is overridden — they describe the same boundary, so setting them apart silently desyncs the layout.
 
 ### Breakpoints
 
@@ -181,14 +166,6 @@ declare module "@comet/mail-react" {
 
 Root element for every email template. Renders the full MJML skeleton (`<mjml>`, `<mj-head>`, `<mj-body>`) and provides the theme to all descendant components.
 
-**Props:**
-
-| Prop       | Type        | Default         | Description                                               |
-| ---------- | ----------- | --------------- | --------------------------------------------------------- |
-| `theme`    | `Theme`     | `createTheme()` | Theme for the email                                       |
-| `config`   | `Config`    | —               | Augmentable values exposed to descendants via `useConfig` |
-| `children` | `ReactNode` | —               | Email content                                             |
-
 **What it configures from the theme:**
 
 - Body width from `theme.sizes.bodyWidth`
@@ -205,15 +182,6 @@ Root element for every email template. Renders the full MJML skeleton (`<mjml>`,
 ## MjmlSection
 
 Full-width horizontal row with theme integration.
-
-**Props** (in addition to standard MJML section props):
-
-| Prop                        | Type                                  | Default                           | Description                                                                     |
-| --------------------------- | ------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------- |
-| `indent`                    | `boolean`                             | `false`                           | Applies theme-based left/right padding                                          |
-| `disableResponsiveBehavior` | `boolean`                             | `false`                           | Prevents columns from stacking on mobile                                        |
-| `slotProps`                 | `{ group?: Partial<MjmlGroupProps> }` | —                                 | Forward props to internal `MjmlGroup` (when `disableResponsiveBehavior` is set) |
-| `backgroundColor`           | `string`                              | `theme.colors.background.content` | Override section background color                                               |
 
 **CSS classes:** `.mjmlSection`, `.mjmlSection--indented` (when `indent` is set).
 
@@ -238,14 +206,7 @@ Indentation values come from `theme.sizes.contentIndentation`, which supports re
 
 Groups multiple `MjmlSection`s that share a background. Must be a direct child of `MjmlBody`; sections go inside.
 
-**Props** (standard MJML wrapper props):
-
-| Prop              | Type        | Default                           | Description                                                           |
-| ----------------- | ----------- | --------------------------------- | --------------------------------------------------------------------- |
-| `backgroundColor` | `string`    | `theme.colors.background.content` | Background applied to the whole wrapper; shows through inner sections |
-| `children`        | `ReactNode` | —                                 | Sections to group                                                     |
-
-When a theme is present, `MjmlWrapper` applies `theme.colors.background.content` as its default `backgroundColor`. Inner `MjmlSection`s suppress their own theme-default background so the wrapper's color is visible; an explicit `backgroundColor` prop on an inner section still wins.
+The wrapper takes the theme's content background by default. Inner `MjmlSection`s suppress their own theme-default background so the wrapper's color shows through; an explicit `backgroundColor` on an inner section still wins.
 
 ```tsx
 <MjmlWrapper backgroundColor="#dddddd">
@@ -272,13 +233,6 @@ Typical uses: multi-section footers with their own color, or grouping sections b
 
 MJML text component — use inside `MjmlColumn` following the standard layout model.
 
-**Props** (in addition to standard MJML text props):
-
-| Prop            | Type                 | Description                               |
-| --------------- | -------------------- | ----------------------------------------- |
-| `variant`       | `keyof TextVariants` | Named typography preset from theme        |
-| `bottomSpacing` | `boolean`            | Add spacing below (from theme or variant) |
-
 **CSS classes:** `.mjmlText`, `.mjmlText--{variant}`, `.mjmlText--bottomSpacing`.
 
 ```tsx
@@ -292,14 +246,6 @@ Variant styles merge on top of base theme text styles — properties not set by 
 ### HtmlText
 
 Themed text for use inside ending tags (`MjmlText`, `MjmlRaw`) or custom HTML structures where MJML components can't be used. Renders a plain HTML element.
-
-**Props:**
-
-| Prop            | Type                 | Default | Description            |
-| --------------- | -------------------- | ------- | ---------------------- |
-| `variant`       | `keyof TextVariants` | —       | Typography preset      |
-| `bottomSpacing` | `boolean`            | `false` | Add spacing below      |
-| `element`       | `string`             | `"td"`  | HTML element to render |
 
 **CSS classes:** `.htmlText`, `.htmlText--{variant}`, `.htmlText--bottomSpacing`.
 
@@ -334,8 +280,6 @@ The base spacing value comes from `theme.text.bottomSpacing`. Variants can overr
 ## HtmlInlineLink
 
 `<a>` element for use inside `MjmlText` or `HtmlText`. Inherits parent's font styles — even on Outlook Desktop, which normally overrides link typography with its own defaults.
-
-**Props:** Standard `<a>` props. Defaults to `target="_blank"` and `text-decoration: underline`.
 
 **CSS class:** `.htmlInlineLink`.
 


### PR DESCRIPTION
Prop defaults had no documented convention, and the agent skill's role and its boundary with the package's types and TSDoc were never written down — so it was unclear what belonged in the skill, and it had drifted from the types (still claiming the `Config` interface had no built-in keys after one was added).
A prop's default lived only in the implementation, where a consumer reading the shipped types can't see it.

This sets two conventions and brings the components and skill in line with them: non-obvious prop defaults — runtime, and especially theme-derived — are documented with `@defaultValue`; and the skill, as the agent-facing usage guide, leaves props, types, and defaults to the package's types and TSDoc.