### PR TITLE
Migrate MUI layout & navigation stories to @comet/admin package Storybook

### DIFF
--- a/packages/admin/admin/src/appHeader/__stories__/AppHeader.stories.tsx
+++ b/packages/admin/admin/src/appHeader/__stories__/AppHeader.stories.tsx
@@ -1,20 +1,17 @@
-import {
-    AppHeader,
-    AppHeaderButton,
-    AppHeaderDropdown,
-    AppHeaderMenuButton,
-    Button,
-    CometLogo,
-    FillSpace,
-    MainContent,
-    MainNavigation,
-    MainNavigationItemRouterLink,
-    MasterLayout,
-} from "@comet/admin";
 import { Account, Dashboard, Language, Logout, Preview } from "@comet/admin-icons";
 import { Avatar, Box, Divider, MenuItem, MenuList } from "@mui/material";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { Button } from "../../common/buttons/Button";
+import { CometLogo } from "../../common/CometLogo";
+import { FillSpace } from "../../common/FillSpace";
+import { MainContent } from "../../common/MainContent";
+import { MainNavigationItemRouterLink } from "../../mui/mainNavigation/ItemRouterLink";
+import { MainNavigation } from "../../mui/mainNavigation/MainNavigation";
+import { MasterLayout } from "../../mui/MasterLayout";
+import { AppHeader } from "../AppHeader";
+import { AppHeaderButton } from "../button/AppHeaderButton";
+import { AppHeaderDropdown } from "../dropdown/AppHeaderDropdown";
+import { AppHeaderMenuButton } from "../menuButton/AppHeaderMenuButton";
 
 function AccountHeaderItem() {
     return (
@@ -78,8 +75,7 @@ function MasterHeader() {
 }
 
 export default {
-    title: "@comet/admin/mui",
-    decorators: [storyRouterDecorator()],
+    title: "components/appHeader/AppHeader",
     excludeStories: ["Story"],
 };
 

--- a/packages/admin/admin/src/common/toolbar/__stories__/DataGridToolbar.stories.tsx
+++ b/packages/admin/admin/src/common/toolbar/__stories__/DataGridToolbar.stories.tsx
@@ -1,17 +1,16 @@
-import {
-    Button,
-    DataGridToolbar,
-    FillSpace,
-    GridColumnsButton,
-    GridFilterButton,
-    GridToolbarQuickFilter,
-    StackLink,
-    useDataGridRemote,
-    usePersistentColumnState,
-} from "@comet/admin";
 import { Add as AddIcon } from "@comet/admin-icons";
 import { DataGrid as DataGridCommunity } from "@mui/x-data-grid";
 import { DataGridPro } from "@mui/x-data-grid-pro";
+
+import { GridColumnsButton } from "../../../dataGrid/GridColumnsButton";
+import { GridFilterButton } from "../../../dataGrid/GridFilterButton";
+import { GridToolbarQuickFilter } from "../../../dataGrid/GridToolbarQuickFilter";
+import { useDataGridRemote } from "../../../dataGrid/useDataGridRemote";
+import { usePersistentColumnState } from "../../../dataGrid/usePersistentColumnState";
+import { StackLink } from "../../../stack/StackLink";
+import { Button } from "../../buttons/Button";
+import { FillSpace } from "../../FillSpace";
+import { DataGridToolbar } from "../DataGridToolbar";
 
 const data = [
     { id: "1f30a6a0-5b9d-4b25-8307-9e8b4a4d2b1c", firstname: "Emily", lastname: "Smith" },

--- a/packages/admin/admin/src/common/toolbar/__stories__/Toolbar.stories.tsx
+++ b/packages/admin/admin/src/common/toolbar/__stories__/Toolbar.stories.tsx
@@ -1,21 +1,20 @@
-import {
-    Button,
-    FillSpace,
-    HelpDialogButton,
-    Stack,
-    StackLink,
-    StackPage,
-    StackSwitch,
-    Toolbar,
-    ToolbarActions,
-    ToolbarAutomaticTitleItem,
-    ToolbarBackButton,
-    ToolbarItem,
-} from "@comet/admin";
 import { ArrowRight, Save } from "@comet/admin-icons";
 import { Box, Chip, Typography } from "@mui/material";
 import type { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
+
+import { StackPage } from "../../../stack/Page";
+import { Stack } from "../../../stack/Stack";
+import { StackLink } from "../../../stack/StackLink";
+import { StackSwitch } from "../../../stack/Switch";
+import { Button } from "../../buttons/Button";
+import { HelpDialogButton } from "../../buttons/helpDialogButton/HelpDialogButton";
+import { FillSpace } from "../../FillSpace";
+import { ToolbarActions } from "../actions/ToolbarActions";
+import { ToolbarAutomaticTitleItem } from "../automatictitleitem/ToolbarAutomaticTitleItem";
+import { ToolbarBackButton } from "../backbutton/ToolbarBackButton";
+import { ToolbarItem } from "../item/ToolbarItem";
+import { Toolbar } from "../Toolbar";
 
 function StackWrapper({ children }: { children: ReactNode }) {
     return (

--- a/packages/admin/admin/src/mui/__stories__/Card.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/Card.stories.tsx
@@ -1,9 +1,10 @@
-import { Button } from "@comet/admin";
 import { ArrowRight, Reload } from "@comet/admin-icons";
 import { Card, CardContent, CardHeader, Grid, IconButton, Typography } from "@mui/material";
 
+import { Button } from "../../common/buttons/Button";
+
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/Card",
 };
 
 export const _Card = () => {

--- a/packages/admin/admin/src/mui/__stories__/Chip.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/Chip.stories.tsx
@@ -2,7 +2,7 @@ import { ChevronDown } from "@comet/admin-icons";
 import { Box, Card, CardContent, Chip, Grid, Stack, Typography } from "@mui/material";
 
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/Chip",
     args: {
         color: "default",
         variant: "filled",

--- a/packages/admin/admin/src/mui/__stories__/ChipMenu.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/ChipMenu.stories.tsx
@@ -3,7 +3,7 @@ import { Box, Card, CardContent, Chip, ListItemIcon, ListItemText, Menu, MenuIte
 import { type MouseEvent, useState } from "react";
 
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/ChipMenu",
 };
 
 export const ChipMenu = {

--- a/packages/admin/admin/src/mui/__stories__/Dialog.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/Dialog.stories.tsx
@@ -1,7 +1,14 @@
-import { Button, CancelButton, CheckboxField, Dialog, OkayButton, SelectField, TextField } from "@comet/admin";
 import { Save } from "@comet/admin-icons";
 import { DialogActions, DialogContent, DialogContentText, type DialogProps } from "@mui/material";
 import { Form } from "react-final-form";
+
+import { Button } from "../../common/buttons/Button";
+import { CancelButton } from "../../common/buttons/cancel/CancelButton";
+import { OkayButton } from "../../common/buttons/okay/OkayButton";
+import { Dialog } from "../../common/Dialog";
+import { CheckboxField } from "../../form/fields/CheckboxField";
+import { SelectField } from "../../form/fields/SelectField";
+import { TextField } from "../../form/fields/TextField";
 
 type DialogSize = Exclude<DialogProps["maxWidth"], false> | "fullWidth" | "fullScreen";
 
@@ -26,7 +33,7 @@ const selectOptions = [
 ];
 
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/Dialog",
     args: {
         selectedDialogSize: "sm",
         selectedDialogTitle: "Dialog Title Example",

--- a/packages/admin/admin/src/mui/__stories__/Link.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/Link.stories.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@mui/material";
 
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/Link",
 };
 
 export const _Link = () => {

--- a/packages/admin/admin/src/mui/__stories__/ListAndMenu.stories.tsx
+++ b/packages/admin/admin/src/mui/__stories__/ListAndMenu.stories.tsx
@@ -1,10 +1,11 @@
-import { Button } from "@comet/admin";
 import { Add } from "@comet/admin-icons";
 import { Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText, Menu, MenuItem, Paper } from "@mui/material";
 import { useRef, useState } from "react";
 
+import { Button } from "../../common/buttons/Button";
+
 export default {
-    title: "@comet/admin/mui",
+    title: "components/mui/ListAndMenu",
 };
 
 export const ListAndMenu = {

--- a/packages/admin/admin/src/mui/mainNavigation/__stories__/Menu.stories.tsx
+++ b/packages/admin/admin/src/mui/mainNavigation/__stories__/Menu.stories.tsx
@@ -1,22 +1,19 @@
-import {
-    AppHeader,
-    AppHeaderMenuButton,
-    CometLogo,
-    FillSpace,
-    MainContent,
-    MainNavigation,
-    MainNavigationCollapsibleItem,
-    MainNavigationItemAnchorLink,
-    MainNavigationItemGroup,
-    MainNavigationItemRouterLink,
-    MasterLayout,
-    useWindowSize,
-} from "@comet/admin";
 import { CometColor, Dashboard, Settings, Sort } from "@comet/admin-icons";
 import { Card, CardContent, Typography } from "@mui/material";
 import { Route, Switch } from "react-router";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { AppHeader } from "../../../appHeader/AppHeader";
+import { AppHeaderMenuButton } from "../../../appHeader/menuButton/AppHeaderMenuButton";
+import { CometLogo } from "../../../common/CometLogo";
+import { FillSpace } from "../../../common/FillSpace";
+import { MainContent } from "../../../common/MainContent";
+import { useWindowSize } from "../../../helpers/useWindowSize";
+import { MasterLayout } from "../../MasterLayout";
+import { MainNavigationCollapsibleItem } from "../CollapsibleItem";
+import { MainNavigationItemAnchorLink } from "../ItemAnchorLink";
+import { MainNavigationItemGroup } from "../ItemGroup";
+import { MainNavigationItemRouterLink } from "../ItemRouterLink";
+import { MainNavigation } from "../MainNavigation";
 
 const permanentMenuMinWidth = 1024;
 
@@ -76,8 +73,7 @@ const Content = ({ children }: { children: string }) => (
 );
 
 export default {
-    title: "@comet/admin/mui",
-    decorators: [storyRouterDecorator()],
+    title: "components/mui/mainNavigation/Menu",
     excludeStories: ["Story"],
 };
 

--- a/packages/admin/admin/src/mui/mainNavigation/__stories__/MenuDynamicVariants.stories.tsx
+++ b/packages/admin/admin/src/mui/mainNavigation/__stories__/MenuDynamicVariants.stories.tsx
@@ -1,24 +1,21 @@
-import {
-    AppHeader,
-    AppHeaderMenuButton,
-    CometLogo,
-    FillSpace,
-    MainContent,
-    MainNavigation,
-    MainNavigationCollapsibleItem,
-    MainNavigationItemAnchorLink,
-    MainNavigationItemRouterLink,
-    MasterLayout,
-    useMainNavigation,
-    useWindowSize,
-} from "@comet/admin";
 import { CometColor, Dashboard, LinkExternal, Settings, Sort } from "@comet/admin-icons";
 import { Card, CardContent, Divider, Typography } from "@mui/material";
 import { useEffect } from "react";
 import { matchPath, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { AppHeader } from "../../../appHeader/AppHeader";
+import { AppHeaderMenuButton } from "../../../appHeader/menuButton/AppHeaderMenuButton";
+import { CometLogo } from "../../../common/CometLogo";
+import { FillSpace } from "../../../common/FillSpace";
+import { MainContent } from "../../../common/MainContent";
+import { useWindowSize } from "../../../helpers/useWindowSize";
+import { MasterLayout } from "../../MasterLayout";
+import { MainNavigationCollapsibleItem } from "../CollapsibleItem";
+import { useMainNavigation } from "../Context";
+import { MainNavigationItemAnchorLink } from "../ItemAnchorLink";
+import { MainNavigationItemRouterLink } from "../ItemRouterLink";
+import { MainNavigation } from "../MainNavigation";
 
 const permanentMenuMinWidth = 1024;
 const pathsToAlwaysUseTemporaryMenu = ["/foo3", "/foo4"];
@@ -117,8 +114,7 @@ const Content = ({ children }: { children: string }) => (
 );
 
 export default {
-    title: "@comet/admin/mui",
-    decorators: [storyRouterDecorator()],
+    title: "components/mui/mainNavigation/MenuDynamicVariants",
 };
 
 export const MenuDynamicVariants = {


### PR DESCRIPTION
## Summary

Migrates 9 stories from the global `/storybook` directory into the dedicated `@comet/admin` package Storybook (`packages/admin/admin`).

**Feature/domain:** MUI Layout & Navigation Components — AppHeader, Card, Chip, ChipMenu, Dialog, Link, ListAndMenu, Menu, MenuDynamicVariants

| Removed from | Moved to |
|---|---|
| `storybook/src/admin/mui/AppHeader.stories.tsx` | `packages/admin/admin/src/appHeader/__stories__/AppHeader.stories.tsx` |
| `storybook/src/admin/mui/Card.stories.tsx` | `packages/admin/admin/src/mui/__stories__/Card.stories.tsx` |
| `storybook/src/admin/mui/Chip.stories.tsx` | `packages/admin/admin/src/mui/__stories__/Chip.stories.tsx` |
| `storybook/src/admin/mui/ChipMenu.stories.tsx` | `packages/admin/admin/src/mui/__stories__/ChipMenu.stories.tsx` |
| `storybook/src/admin/mui/Dialog.stories.tsx` | `packages/admin/admin/src/mui/__stories__/Dialog.stories.tsx` |
| `storybook/src/admin/mui/Link.stories.tsx` | `packages/admin/admin/src/mui/__stories__/Link.stories.tsx` |
| `storybook/src/admin/mui/ListAndMenu.stories.tsx` | `packages/admin/admin/src/mui/__stories__/ListAndMenu.stories.tsx` |
| `storybook/src/admin/mui/Menu.stories.tsx` | `packages/admin/admin/src/mui/mainNavigation/__stories__/Menu.stories.tsx` |
| `storybook/src/admin/mui/MenuDynamicVariants.stories.tsx` | `packages/admin/admin/src/mui/mainNavigation/__stories__/MenuDynamicVariants.stories.tsx` |

### Changes per story

- **All stories:** `@comet/admin` package imports replaced with relative imports (per package Storybook convention — stories inside the package must not import from the package itself).
- **AppHeader, Menu, MenuDynamicVariants:** Removed `storyRouterDecorator()` import and decorator — `RouterDecorator` is already applied globally in the `@comet/admin` package Storybook `preview.ts`.
- **Titles:** Updated from `"@comet/admin/mui"` to `"components/appHeader/AppHeader"`, `"components/mui/…"`, `"components/mui/mainNavigation/…"`.
- No `apolloRestStoryDecorator` was used in any of these stories — no MSW migration needed.

### Additional fix

`DataGridToolbar.stories.tsx` and `Toolbar.stories.tsx` (pre-existing stories) were importing from `@comet/admin` which caused `tsc` errors in the pre-commit hook (since the package can't resolve itself by name without a path alias). Converted those two files to relative imports as well.

https://claude.ai/code/session_01NNPdkpJEjngHqyWJjEAfCj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNPdkpJEjngHqyWJjEAfCj)_