### PR TITLE
Add tests for useFocusAwarePolling

### DIFF
--- a/packages/admin/admin/src/apollo/__tests__/useFocusAwarePolling.test.ts
+++ b/packages/admin/admin/src/apollo/__tests__/useFocusAwarePolling.test.ts
@@ -1,0 +1,122 @@
+import type { ObservableQuery } from "@apollo/client";
+import { act, renderHook } from "test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useFocusAwarePolling } from "../useFocusAwarePolling";
+
+describe("useFocusAwarePolling", () => {
+    let refetch: ReturnType<typeof vi.fn<ObservableQuery["refetch"]>>;
+    let startPolling: ReturnType<typeof vi.fn<ObservableQuery["startPolling"]>>;
+    let stopPolling: ReturnType<typeof vi.fn<ObservableQuery["stopPolling"]>>;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        refetch = vi.fn<ObservableQuery["refetch"]>();
+        startPolling = vi.fn<ObservableQuery["startPolling"]>();
+        stopPolling = vi.fn<ObservableQuery["stopPolling"]>();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it("should call stopPolling immediately when pollInterval is undefined", () => {
+        renderHook(() => useFocusAwarePolling({ pollInterval: undefined, refetch, startPolling, stopPolling }));
+
+        expect(stopPolling).toHaveBeenCalledOnce();
+        expect(startPolling).not.toHaveBeenCalled();
+        expect(refetch).not.toHaveBeenCalled();
+    });
+
+    it("should call stopPolling immediately when skip is true", () => {
+        renderHook(() => useFocusAwarePolling({ pollInterval: 5000, skip: true, refetch, startPolling, stopPolling }));
+
+        expect(stopPolling).toHaveBeenCalledOnce();
+        expect(startPolling).not.toHaveBeenCalled();
+    });
+
+    it("should start polling after pollInterval delay when document has focus on mount", () => {
+        vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+        renderHook(() => useFocusAwarePolling({ pollInterval: 5000, refetch, startPolling, stopPolling }));
+
+        expect(startPolling).not.toHaveBeenCalled();
+
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+
+        expect(startPolling).toHaveBeenCalledOnce();
+        expect(startPolling).toHaveBeenCalledWith(5000);
+    });
+
+    it("should not start polling on mount when document does not have focus", () => {
+        vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+        renderHook(() => useFocusAwarePolling({ pollInterval: 5000, refetch, startPolling, stopPolling }));
+
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+
+        expect(startPolling).not.toHaveBeenCalled();
+    });
+
+    it("should refetch and restart polling when window gains focus", () => {
+        vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+        renderHook(() => useFocusAwarePolling({ pollInterval: 5000, refetch, startPolling, stopPolling }));
+
+        act(() => {
+            window.dispatchEvent(new Event("focus"));
+        });
+
+        expect(refetch).toHaveBeenCalledOnce();
+        expect(startPolling).toHaveBeenCalledOnce();
+        expect(startPolling).toHaveBeenCalledWith(5000);
+    });
+
+    it("should stop polling when window loses focus", () => {
+        vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+        renderHook(() => useFocusAwarePolling({ pollInterval: 5000, refetch, startPolling, stopPolling }));
+
+        stopPolling.mockClear();
+
+        act(() => {
+            window.dispatchEvent(new Event("blur"));
+        });
+
+        expect(stopPolling).toHaveBeenCalledOnce();
+    });
+
+    it("should remove focus and blur event listeners on unmount", () => {
+        vi.spyOn(document, "hasFocus").mockReturnValue(false);
+        const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+        const { unmount } = renderHook(() => useFocusAwarePolling({ pollInterval: 5000, refetch, startPolling, stopPolling }));
+
+        unmount();
+
+        expect(removeEventListenerSpy).toHaveBeenCalledWith("focus", expect.any(Function));
+        expect(removeEventListenerSpy).toHaveBeenCalledWith("blur", expect.any(Function));
+    });
+
+    it("should not fire focus handler after unmount", () => {
+        vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+        const { unmount } = renderHook(() => useFocusAwarePolling({ pollInterval: 5000, refetch, startPolling, stopPolling }));
+
+        unmount();
+        refetch.mockClear();
+        startPolling.mockClear();
+
+        act(() => {
+            window.dispatchEvent(new Event("focus"));
+        });
+
+        expect(refetch).not.toHaveBeenCalled();
+        expect(startPolling).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## What

Adds Vitest tests for `useFocusAwarePolling` — a hook in `@comet/admin` that manages Apollo query polling based on window focus/blur events.

The hook had no test coverage despite containing non-trivial logic: conditional polling setup, `window` event listener registration/cleanup, a delayed `startPolling` timeout when the document already has focus on mount, and early-exit paths for `skip` and undefined `pollInterval`.

## Tests added

- `packages/admin/admin/src/apollo/__tests__/useFocusAwarePolling.test.ts`

Covers:
- Calls `stopPolling` immediately when `pollInterval` is `undefined`
- Calls `stopPolling` immediately when `skip` is `true`
- Starts polling after `pollInterval` delay when document has focus on mount
- Does not start polling when document does not have focus on mount
- Calls `refetch` and `startPolling` when window gains focus
- Calls `stopPolling` when window loses focus
- Removes event listeners on unmount
- Does not fire handlers after unmount (cleanup verified behaviorally)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHvkSSyCdK2YjFx658MzYJ)_