### PR TITLE
Add `/launches` REST API mock to `@comet/admin` Storybook

### DIFF
--- a/packages/admin/admin/.storybook/mocks/handlers.ts
+++ b/packages/admin/admin/.storybook/mocks/handlers.ts
@@ -1,4 +1,4 @@
-import { graphql, HttpResponse } from "msw";
+import { graphql, http, HttpResponse } from "msw";
 
 const users = [
     { id: 1, name: "Leanne Graham", username: "Bret", email: "Sincere@april.biz" },
@@ -72,4 +72,12 @@ const productsQueryHandler = graphql.query<{ products: Product[] }, { manufactur
     });
 });
 
-export const handlers = [usersQueryHandler, userQueryHandler, manufacturersQueryHandler, productsQueryHandler];
+const launchesQueryHandler = http.get("/launches", () => {
+    return HttpResponse.json([
+        { id: "1", name: "FalconSat", date: "2006-03-24" },
+        { id: "2", name: "DemoSat", date: "2007-03-21" },
+        { id: "3", name: "Trailblazer", date: "2008-08-03" },
+    ]);
+});
+
+export const handlers = [usersQueryHandler, userQueryHandler, manufacturersQueryHandler, productsQueryHandler, launchesQueryHandler];


### PR DESCRIPTION
Add missing `/launches` REST API mock to `@comet/admin`'s Storybook that was forgotten while moving the `FetchProvider` story (see https://github.com/vivid-planet/comet/pull/5810). Should fix the flaky `FetchProvider` interaction test.

https://claude.ai/code/session_01VEenu58T3nN98pNFx7YqdF