### PR TITLE
Add findUser and findUserOrThrow to UserPermissionsUserServiceInterface

### DIFF
--- a/.changeset/add-find-user-methods-to-user-permissions-user-service-interface.md
+++ b/.changeset/add-find-user-methods-to-user-permissions-user-service-interface.md
@@ -2,14 +2,14 @@
 "@comet/cms-api": minor
 ---
 
-Add `findUser` and `findUserOrThrow` to `UserPermissionsUserServiceInterface`
+Add `findUser` / `findUserOrThrow` (and `findUserForLogin` / `findUserForLoginOrThrow`) to `UserPermissionsUserServiceInterface`
 
-The `getUser` method on `UserPermissionsUserServiceInterface` is now deprecated in favor of two new methods:
+The throwing `getUser` and `getUserForLogin` methods on `UserPermissionsUserServiceInterface` are now deprecated in favor of paired find methods:
 
-- `findUser(id): Promise<User | null>` — returns `null` when the user does not exist
-- `findUserOrThrow(id): Promise<User>` — throws when the user does not exist
+- `findUser(id): Promise<User | null>` / `findUserOrThrow(id): Promise<User>`
+- `findUserForLogin(id): Promise<User | null>` / `findUserForLoginOrThrow(id): Promise<User>`
 
-This lets consumers opt into a non-throwing path without wrapping `getUser` calls in `try`/`catch`. Existing implementations that only define `getUser` continue to work; the service falls back to it.
+This lets consumers opt into a non-throwing path without wrapping lookups in `try`/`catch`. Existing implementations that only define `getUser` / `getUserForLogin` continue to work; the service falls back to them.
 
 **Example**
 

--- a/.changeset/add-find-user-methods-to-user-permissions-user-service-interface.md
+++ b/.changeset/add-find-user-methods-to-user-permissions-user-service-interface.md
@@ -1,0 +1,32 @@
+---
+"@comet/cms-api": minor
+---
+
+Add `findUser` and `findUserOrThrow` to `UserPermissionsUserServiceInterface`
+
+The `getUser` method on `UserPermissionsUserServiceInterface` is now deprecated in favor of two new methods:
+
+- `findUser(id): Promise<User | null>` — returns `null` when the user does not exist
+- `findUserOrThrow(id): Promise<User>` — throws when the user does not exist
+
+This lets consumers opt into a non-throwing path without wrapping `getUser` calls in `try`/`catch`. Existing implementations that only define `getUser` continue to work; the service falls back to it.
+
+**Example**
+
+```ts
+export class UserService implements UserPermissionsUserServiceInterface {
+    async findUser(id: string): Promise<User | null> {
+        return this.users.find((user) => user.id === id) ?? null;
+    }
+
+    async findUserOrThrow(id: string): Promise<User> {
+        const user = await this.findUser(id);
+        if (!user) {
+            throw new Error(`User not found: ${id}`);
+        }
+        return user;
+    }
+
+    // ...
+}
+```

--- a/demo/api/src/auth/user.service.ts
+++ b/demo/api/src/auth/user.service.ts
@@ -9,18 +9,18 @@ export class UserService implements UserPermissionsUserServiceInterface, JwtToUs
         if (!jwt.sub) {
             throw new Error("JWT does not contain sub");
         }
-        const user = this.getUser(jwt.sub);
+        return this.findUserOrThrow(jwt.sub);
+    }
+    findUser(id: string): User | null {
+        const index = parseInt(id) - 1;
+        return staticUsers[index] ?? null;
+    }
+    findUserOrThrow(id: string): User {
+        const user = this.findUser(id);
         if (!user) {
-            throw new Error(`User not found: ${jwt.sub}`);
+            throw new Error(`User not found: ${id}`);
         }
         return user;
-    }
-    getUser(id: string): User {
-        const index = parseInt(id) - 1;
-        if (staticUsers[index]) {
-            return staticUsers[index];
-        }
-        throw new Error("User not found");
     }
     findUsers(args: FindUsersArgs): Users {
         const search = args.search?.toLowerCase();

--- a/packages/api/cms-api/src/auth/guards/comet.guard.ts
+++ b/packages/api/cms-api/src/auth/guards/comet.guard.ts
@@ -62,7 +62,7 @@ export class CometAuthGuard implements CanActivate {
                     if (userService.getUserForLogin) {
                         user = await userService.getUserForLogin(userId);
                     } else {
-                        user = await userService.getUser(userId);
+                        user = await this.service.findUserOrThrow(userId);
                     }
                 } catch (e) {
                     throw new UnauthorizedException(`Could not get user from UserService: ${userId} - ${(e as Error).message}`);

--- a/packages/api/cms-api/src/auth/guards/comet.guard.ts
+++ b/packages/api/cms-api/src/auth/guards/comet.guard.ts
@@ -59,7 +59,13 @@ export class CometAuthGuard implements CanActivate {
                     throw new UnauthorizedException(`User authenticated by ID but no user service given: ${userId}`);
                 }
                 try {
-                    user = await this.service.findUserForLoginOrThrow(userId);
+                    if (userService.findUserForLoginOrThrow) {
+                        user = await userService.findUserForLoginOrThrow(userId);
+                    } else if (userService.getUserForLogin) {
+                        user = await userService.getUserForLogin(userId);
+                    } else {
+                        user = await this.service.findUserOrThrow(userId);
+                    }
                 } catch (e) {
                     throw new UnauthorizedException(`Could not get user from UserService: ${userId} - ${(e as Error).message}`);
                 }

--- a/packages/api/cms-api/src/auth/guards/comet.guard.ts
+++ b/packages/api/cms-api/src/auth/guards/comet.guard.ts
@@ -63,8 +63,12 @@ export class CometAuthGuard implements CanActivate {
                         user = await userService.findUserForLoginOrThrow(userId);
                     } else if (userService.getUserForLogin) {
                         user = await userService.getUserForLogin(userId);
+                    } else if (userService.findUserOrThrow) {
+                        user = await userService.findUserOrThrow(userId);
+                    } else if (userService.getUser) {
+                        user = await userService.getUser(userId);
                     } else {
-                        user = await this.service.findUserOrThrow(userId);
+                        throw new Error("The userService must implement `findUserOrThrow` (or one of the login-specific variants).");
                     }
                 } catch (e) {
                     throw new UnauthorizedException(`Could not get user from UserService: ${userId} - ${(e as Error).message}`);

--- a/packages/api/cms-api/src/auth/guards/comet.guard.ts
+++ b/packages/api/cms-api/src/auth/guards/comet.guard.ts
@@ -59,11 +59,7 @@ export class CometAuthGuard implements CanActivate {
                     throw new UnauthorizedException(`User authenticated by ID but no user service given: ${userId}`);
                 }
                 try {
-                    if (userService.getUserForLogin) {
-                        user = await userService.getUserForLogin(userId);
-                    } else {
-                        user = await this.service.findUserOrThrow(userId);
-                    }
+                    user = await this.service.findUserForLoginOrThrow(userId);
                 } catch (e) {
                     throw new UnauthorizedException(`Could not get user from UserService: ${userId} - ${(e as Error).message}`);
                 }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -169,6 +169,13 @@ export class UserPermissionsService {
         return this.findUserOrThrow(id);
     }
 
+    /**
+     * @deprecated Use `findUserForLoginOrThrow` instead.
+     */
+    async getUserForLogin(id: string): Promise<User> {
+        return this.findUserForLoginOrThrow(id);
+    }
+
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {
         if (!this.userService) {
             throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -104,17 +104,11 @@ export class UserPermissionsService {
     }
 
     async findUser(id: string): Promise<User | null> {
-        if (!this.userService?.findUser) {
-            return null;
-        }
-        return this.userService.findUser(id);
+        return this.userService?.findUser?.(id) ?? null;
     }
 
     async findUserForLogin(id: string): Promise<User | null> {
-        if (!this.userService?.findUserForLogin) {
-            return null;
-        }
-        return this.userService.findUserForLogin(id);
+        return this.userService?.findUserForLogin?.(id) ?? null;
     }
 
     async findUserForLoginOrThrow(id: string): Promise<User> {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -103,11 +103,55 @@ export class UserPermissionsService {
         return this.userService;
     }
 
-    async getUser(id: string): Promise<User> {
+    async findUser(id: string): Promise<User | null> {
         if (!this.userService) {
             throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
         }
-        return this.userService.getUser(id);
+        if (this.userService.findUser) {
+            return this.userService.findUser(id);
+        }
+        if (this.userService.findUserOrThrow) {
+            try {
+                return await this.userService.findUserOrThrow(id);
+            } catch {
+                return null;
+            }
+        }
+        if (this.userService.getUser) {
+            try {
+                return await this.userService.getUser(id);
+            } catch {
+                return null;
+            }
+        }
+        throw new Error("The userService must implement `findUser`, `findUserOrThrow` or `getUser`.");
+    }
+
+    async findUserOrThrow(id: string): Promise<User> {
+        if (!this.userService) {
+            throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
+        }
+        if (this.userService.findUserOrThrow) {
+            return this.userService.findUserOrThrow(id);
+        }
+        if (this.userService.findUser) {
+            const user = await this.userService.findUser(id);
+            if (!user) {
+                throw new Error(`User not found: ${id}`);
+            }
+            return user;
+        }
+        if (this.userService.getUser) {
+            return this.userService.getUser(id);
+        }
+        throw new Error("The userService must implement `findUserOrThrow`, `findUser` or `getUser`.");
+    }
+
+    /**
+     * @deprecated Use `findUserOrThrow` instead.
+     */
+    async getUser(id: string): Promise<User> {
+        return this.findUserOrThrow(id);
     }
 
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -114,33 +114,6 @@ export class UserPermissionsService {
         }
     }
 
-    async findUserOrThrow(id: string): Promise<User> {
-        if (!this.userService) {
-            throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
-        }
-        if (this.userService.findUserOrThrow) {
-            return this.userService.findUserOrThrow(id);
-        }
-        if (this.userService.getUser) {
-            return this.userService.getUser(id);
-        }
-        if (this.userService.findUser) {
-            const user = await this.userService.findUser(id);
-            if (!user) {
-                throw new Error(`User not found: ${id}`);
-            }
-            return user;
-        }
-        throw new Error("The userService must implement `findUserOrThrow`, `findUser` or `getUser`.");
-    }
-
-    /**
-     * @deprecated Use `findUserOrThrow` instead.
-     */
-    async getUser(id: string): Promise<User> {
-        return this.findUserOrThrow(id);
-    }
-
     async findUserForLogin(id: string): Promise<User | null> {
         if (this.userService?.findUserForLogin) {
             return this.userService.findUserForLogin(id);
@@ -166,6 +139,33 @@ export class UserPermissionsService {
             }
             return user;
         }
+        return this.findUserOrThrow(id);
+    }
+
+    async findUserOrThrow(id: string): Promise<User> {
+        if (!this.userService) {
+            throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
+        }
+        if (this.userService.findUserOrThrow) {
+            return this.userService.findUserOrThrow(id);
+        }
+        if (this.userService.getUser) {
+            return this.userService.getUser(id);
+        }
+        if (this.userService.findUser) {
+            const user = await this.userService.findUser(id);
+            if (!user) {
+                throw new Error(`User not found: ${id}`);
+            }
+            return user;
+        }
+        throw new Error("The userService must implement `findUserOrThrow`, `findUser` or `getUser`.");
+    }
+
+    /**
+     * @deprecated Use `findUserOrThrow` instead.
+     */
+    async getUser(id: string): Promise<User> {
         return this.findUserOrThrow(id);
     }
 

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -104,39 +104,33 @@ export class UserPermissionsService {
     }
 
     async findUser(id: string): Promise<User | null> {
-        if (this.userService?.findUser) {
-            return this.userService.findUser(id);
+        if (!this.userService?.findUser) {
+            throw new Error("For this functionality you need to define `findUser` in the userService.");
         }
-        try {
-            return await this.findUserOrThrow(id);
-        } catch {
-            return null;
-        }
+        return this.userService.findUser(id);
     }
 
     async findUserForLogin(id: string): Promise<User | null> {
-        if (this.userService?.findUserForLogin) {
-            return this.userService.findUserForLogin(id);
+        if (!this.userService?.findUserForLogin) {
+            throw new Error("For this functionality you need to define `findUserForLogin` in the userService.");
         }
-        try {
-            return await this.findUserForLoginOrThrow(id);
-        } catch {
-            return null;
-        }
+        return this.userService.findUserForLogin(id);
     }
 
     async findUserForLoginOrThrow(id: string): Promise<User> {
-        if (!this.userService?.findUserForLoginOrThrow) {
-            throw new Error("For this functionality you need to define `findUserForLoginOrThrow` in the userService.");
+        const user = await this.findUserForLogin(id);
+        if (!user) {
+            throw new Error(`User not found: ${id}`);
         }
-        return this.userService.findUserForLoginOrThrow(id);
+        return user;
     }
 
     async findUserOrThrow(id: string): Promise<User> {
-        if (!this.userService?.findUserOrThrow) {
-            throw new Error("For this functionality you need to define `findUserOrThrow` in the userService.");
+        const user = await this.findUser(id);
+        if (!user) {
+            throw new Error(`User not found: ${id}`);
         }
-        return this.userService.findUserOrThrow(id);
+        return user;
     }
 
     /**

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -135,20 +135,14 @@ export class UserPermissionsService {
      * @deprecated Use `findUserOrThrow` instead.
      */
     async getUser(id: string): Promise<User> {
-        if (!this.userService?.getUser) {
-            throw new Error("For this functionality you need to define `getUser` in the userService.");
-        }
-        return this.userService.getUser(id);
+        return this.findUserOrThrow(id);
     }
 
     /**
      * @deprecated Use `findUserForLoginOrThrow` instead.
      */
     async getUserForLogin(id: string): Promise<User> {
-        if (!this.userService?.getUserForLogin) {
-            throw new Error("For this functionality you need to define `getUserForLogin` in the userService.");
-        }
-        return this.userService.getUserForLogin(id);
+        return this.findUserForLoginOrThrow(id);
     }
 
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -104,73 +104,51 @@ export class UserPermissionsService {
     }
 
     async findUser(id: string): Promise<User | null> {
-        if (this.userService?.findUser) {
-            return this.userService.findUser(id);
+        if (!this.userService?.findUser) {
+            throw new Error("For this functionality you need to define `findUser` in the userService.");
         }
-        try {
-            return await this.findUserOrThrow(id);
-        } catch {
-            return null;
-        }
+        return this.userService.findUser(id);
     }
 
     async findUserForLogin(id: string): Promise<User | null> {
-        if (this.userService?.findUserForLogin) {
-            return this.userService.findUserForLogin(id);
+        if (!this.userService?.findUserForLogin) {
+            throw new Error("For this functionality you need to define `findUserForLogin` in the userService.");
         }
-        try {
-            return await this.findUserForLoginOrThrow(id);
-        } catch {
-            return null;
-        }
+        return this.userService.findUserForLogin(id);
     }
 
     async findUserForLoginOrThrow(id: string): Promise<User> {
-        if (this.userService?.findUserForLoginOrThrow) {
-            return this.userService.findUserForLoginOrThrow(id);
+        if (!this.userService?.findUserForLoginOrThrow) {
+            throw new Error("For this functionality you need to define `findUserForLoginOrThrow` in the userService.");
         }
-        if (this.userService?.findUserForLogin) {
-            const user = await this.userService.findUserForLogin(id);
-            if (!user) {
-                throw new Error(`User not found: ${id}`);
-            }
-            return user;
-        }
-        return this.findUserOrThrow(id);
+        return this.userService.findUserForLoginOrThrow(id);
     }
 
     async findUserOrThrow(id: string): Promise<User> {
-        if (!this.userService) {
-            throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
+        if (!this.userService?.findUserOrThrow) {
+            throw new Error("For this functionality you need to define `findUserOrThrow` in the userService.");
         }
-        if (this.userService.findUserOrThrow) {
-            return this.userService.findUserOrThrow(id);
-        }
-        if (this.userService.getUser) {
-            return this.userService.getUser(id);
-        }
-        if (this.userService.findUser) {
-            const user = await this.userService.findUser(id);
-            if (!user) {
-                throw new Error(`User not found: ${id}`);
-            }
-            return user;
-        }
-        throw new Error("The userService must implement `findUserOrThrow`, `findUser` or `getUser`.");
+        return this.userService.findUserOrThrow(id);
     }
 
     /**
      * @deprecated Use `findUserOrThrow` instead.
      */
     async getUser(id: string): Promise<User> {
-        return this.findUserOrThrow(id);
+        if (!this.userService?.getUser) {
+            throw new Error("For this functionality you need to define `getUser` in the userService.");
+        }
+        return this.userService.getUser(id);
     }
 
     /**
      * @deprecated Use `findUserForLoginOrThrow` instead.
      */
     async getUserForLogin(id: string): Promise<User> {
-        return this.findUserForLoginOrThrow(id);
+        if (!this.userService?.getUserForLogin) {
+            throw new Error("For this functionality you need to define `getUserForLogin` in the userService.");
+        }
+        return this.userService.getUserForLogin(id);
     }
 
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -104,11 +104,17 @@ export class UserPermissionsService {
     }
 
     async findUser(id: string): Promise<User | null> {
-        return this.userService?.findUser?.(id) ?? null;
+        if (!this.userService?.findUser) {
+            throw new Error("For this functionality you need to define `findUser` in the userService.");
+        }
+        return this.userService.findUser(id);
     }
 
     async findUserForLogin(id: string): Promise<User | null> {
-        return this.userService?.findUserForLogin?.(id) ?? null;
+        if (!this.userService?.findUserForLogin) {
+            throw new Error("For this functionality you need to define `findUserForLogin` in the userService.");
+        }
+        return this.userService.findUserForLogin(id);
     }
 
     async findUserForLoginOrThrow(id: string): Promise<User> {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -105,14 +105,14 @@ export class UserPermissionsService {
 
     async findUser(id: string): Promise<User | null> {
         if (!this.userService?.findUser) {
-            throw new Error("For this functionality you need to define `findUser` in the userService.");
+            return null;
         }
         return this.userService.findUser(id);
     }
 
     async findUserForLogin(id: string): Promise<User | null> {
         if (!this.userService?.findUserForLogin) {
-            throw new Error("For this functionality you need to define `findUserForLogin` in the userService.");
+            return null;
         }
         return this.userService.findUserForLogin(id);
     }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -103,48 +103,24 @@ export class UserPermissionsService {
         return this.userService;
     }
 
-    async findUser(id: string): Promise<User | null> {
-        if (!this.userService?.findUser) {
-            throw new Error("For this functionality you need to define `findUser` in the userService.");
-        }
-        return this.userService.findUser(id);
-    }
-
-    async findUserForLogin(id: string): Promise<User | null> {
-        if (!this.userService?.findUserForLogin) {
-            throw new Error("For this functionality you need to define `findUserForLogin` in the userService.");
-        }
-        return this.userService.findUserForLogin(id);
-    }
-
-    async findUserForLoginOrThrow(id: string): Promise<User> {
-        const user = await this.findUserForLogin(id);
-        if (!user) {
-            throw new Error(`User not found: ${id}`);
-        }
-        return user;
-    }
-
-    async findUserOrThrow(id: string): Promise<User> {
-        const user = await this.findUser(id);
-        if (!user) {
-            throw new Error(`User not found: ${id}`);
-        }
-        return user;
-    }
-
     /**
-     * @deprecated Use `findUserOrThrow` instead.
+     * @deprecated Use `getUserService().findUserOrThrow()` instead.
      */
     async getUser(id: string): Promise<User> {
-        return this.findUserOrThrow(id);
+        if (!this.userService?.findUserOrThrow) {
+            throw new Error("For this functionality you need to define `findUserOrThrow` in the userService.");
+        }
+        return this.userService.findUserOrThrow(id);
     }
 
     /**
-     * @deprecated Use `findUserForLoginOrThrow` instead.
+     * @deprecated Use `getUserService().findUserForLoginOrThrow()` instead.
      */
     async getUserForLogin(id: string): Promise<User> {
-        return this.findUserForLoginOrThrow(id);
+        if (!this.userService?.findUserForLoginOrThrow) {
+            throw new Error("For this functionality you need to define `findUserForLoginOrThrow` in the userService.");
+        }
+        return this.userService.findUserForLoginOrThrow(id);
     }
 
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -129,9 +129,6 @@ export class UserPermissionsService {
         if (this.userService?.findUserForLoginOrThrow) {
             return this.userService.findUserForLoginOrThrow(id);
         }
-        if (this.userService?.getUserForLogin) {
-            return this.userService.getUserForLogin(id);
-        }
         if (this.userService?.findUserForLogin) {
             const user = await this.userService.findUserForLogin(id);
             if (!user) {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -104,17 +104,25 @@ export class UserPermissionsService {
     }
 
     async findUser(id: string): Promise<User | null> {
-        if (!this.userService?.findUser) {
-            throw new Error("For this functionality you need to define `findUser` in the userService.");
+        if (this.userService?.findUser) {
+            return this.userService.findUser(id);
         }
-        return this.userService.findUser(id);
+        try {
+            return await this.findUserOrThrow(id);
+        } catch {
+            return null;
+        }
     }
 
     async findUserForLogin(id: string): Promise<User | null> {
-        if (!this.userService?.findUserForLogin) {
-            throw new Error("For this functionality you need to define `findUserForLogin` in the userService.");
+        if (this.userService?.findUserForLogin) {
+            return this.userService.findUserForLogin(id);
         }
-        return this.userService.findUserForLogin(id);
+        try {
+            return await this.findUserForLoginOrThrow(id);
+        } catch {
+            return null;
+        }
     }
 
     async findUserForLoginOrThrow(id: string): Promise<User> {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -141,6 +141,34 @@ export class UserPermissionsService {
         return this.findUserOrThrow(id);
     }
 
+    async findUserForLogin(id: string): Promise<User | null> {
+        if (this.userService?.findUserForLogin) {
+            return this.userService.findUserForLogin(id);
+        }
+        try {
+            return await this.findUserForLoginOrThrow(id);
+        } catch {
+            return null;
+        }
+    }
+
+    async findUserForLoginOrThrow(id: string): Promise<User> {
+        if (this.userService?.findUserForLoginOrThrow) {
+            return this.userService.findUserForLoginOrThrow(id);
+        }
+        if (this.userService?.getUserForLogin) {
+            return this.userService.getUserForLogin(id);
+        }
+        if (this.userService?.findUserForLogin) {
+            const user = await this.userService.findUserForLogin(id);
+            if (!user) {
+                throw new Error(`User not found: ${id}`);
+            }
+            return user;
+        }
+        return this.findUserOrThrow(id);
+    }
+
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {
         if (!this.userService) {
             throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -104,27 +104,14 @@ export class UserPermissionsService {
     }
 
     async findUser(id: string): Promise<User | null> {
-        if (!this.userService) {
-            throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
-        }
-        if (this.userService.findUser) {
+        if (this.userService?.findUser) {
             return this.userService.findUser(id);
         }
-        if (this.userService.findUserOrThrow) {
-            try {
-                return await this.userService.findUserOrThrow(id);
-            } catch {
-                return null;
-            }
+        try {
+            return await this.findUserOrThrow(id);
+        } catch {
+            return null;
         }
-        if (this.userService.getUser) {
-            try {
-                return await this.userService.getUser(id);
-            } catch {
-                return null;
-            }
-        }
-        throw new Error("The userService must implement `findUser`, `findUserOrThrow` or `getUser`.");
     }
 
     async findUserOrThrow(id: string): Promise<User> {
@@ -134,15 +121,15 @@ export class UserPermissionsService {
         if (this.userService.findUserOrThrow) {
             return this.userService.findUserOrThrow(id);
         }
+        if (this.userService.getUser) {
+            return this.userService.getUser(id);
+        }
         if (this.userService.findUser) {
             const user = await this.userService.findUser(id);
             if (!user) {
                 throw new Error(`User not found: ${id}`);
             }
             return user;
-        }
-        if (this.userService.getUser) {
-            return this.userService.getUser(id);
         }
         throw new Error("The userService must implement `findUserOrThrow`, `findUser` or `getUser`.");
     }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -34,10 +34,7 @@ export interface AccessControlServiceInterface {
 }
 
 export interface UserPermissionsUserServiceInterface {
-    /**
-     * @deprecated Implement `findUserForLogin` and `findUserForLoginOrThrow` instead.
-     */
-    getUserForLogin?: (id: string) => Promise<User> | User;
+    findUser?: (id: string) => Promise<User | null> | User | null;
     /**
      * Optional method to look up the user for login if a different code path from the default `findUser` is required.
      */
@@ -46,13 +43,16 @@ export interface UserPermissionsUserServiceInterface {
      * Optional method to look up the user for login if a different code path from the default `findUserOrThrow` is required.
      */
     findUserForLoginOrThrow?: (id: string) => Promise<User> | User;
+    findUserOrThrow?: (id: string) => Promise<User> | User;
+    findUsers: (args: FindUsersArgs) => Promise<Users> | Users;
     /**
      * @deprecated Implement `findUser` and `findUserOrThrow` instead.
      */
     getUser?: (id: string) => Promise<User> | User;
-    findUser?: (id: string) => Promise<User | null> | User | null;
-    findUserOrThrow?: (id: string) => Promise<User> | User;
-    findUsers: (args: FindUsersArgs) => Promise<Users> | Users;
+    /**
+     * @deprecated Implement `findUserForLogin` and `findUserForLoginOrThrow` instead.
+     */
+    getUserForLogin?: (id: string) => Promise<User> | User;
     getAccountUrl?: (user: User) => Promise<string> | string;
 }
 

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -35,9 +35,17 @@ export interface AccessControlServiceInterface {
 
 export interface UserPermissionsUserServiceInterface {
     /**
-     * Optional method to get the user for login if a different code path from the default `findUserOrThrow` is required
+     * @deprecated Implement `findUserForLogin` and `findUserForLoginOrThrow` instead.
      */
     getUserForLogin?: (id: string) => Promise<User> | User;
+    /**
+     * Optional method to look up the user for login if a different code path from the default `findUser` is required.
+     */
+    findUserForLogin?: (id: string) => Promise<User | null> | User | null;
+    /**
+     * Optional method to look up the user for login if a different code path from the default `findUserOrThrow` is required.
+     */
+    findUserForLoginOrThrow?: (id: string) => Promise<User> | User;
     /**
      * @deprecated Implement `findUser` and `findUserOrThrow` instead.
      */

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -35,10 +35,15 @@ export interface AccessControlServiceInterface {
 
 export interface UserPermissionsUserServiceInterface {
     /**
-     * Optional method to get the user for login if a different code path from the default `getUser` is required
+     * Optional method to get the user for login if a different code path from the default `findUserOrThrow` is required
      */
     getUserForLogin?: (id: string) => Promise<User> | User;
-    getUser: (id: string) => Promise<User> | User;
+    /**
+     * @deprecated Implement `findUser` and `findUserOrThrow` instead.
+     */
+    getUser?: (id: string) => Promise<User> | User;
+    findUser?: (id: string) => Promise<User | null> | User | null;
+    findUserOrThrow?: (id: string) => Promise<User> | User;
     findUsers: (args: FindUsersArgs) => Promise<Users> | Users;
     getAccountUrl?: (user: User) => Promise<string> | string;
 }


### PR DESCRIPTION
## Summary

Follow-up to the review feedback on #5763 ([thread](https://github.com/vivid-planet/comet/pull/5763#discussion_r3371827282)): introduce a non-throwing path for looking up users so callers can opt out of wrapping `getUser` calls in `try`/`catch` to handle "user does not exist".

- Add `findUser(id): Promise<User | null>` and `findUserOrThrow(id): Promise<User>` on both `UserPermissionsUserServiceInterface` and `UserPermissionsService`.
- Deprecate `getUser`. `UserPermissionsService.getUser` now forwards to `findUserOrThrow`.
- Existing implementations that only define `getUser` continue to work — the service falls back to it when the new methods are not implemented.

## Example

```ts
export class UserService implements UserPermissionsUserServiceInterface {
    async findUser(id: string): Promise<User | null> {
        return this.users.find((user) => user.id === id) ?? null;
    }

    async findUserOrThrow(id: string): Promise<User> {
        const user = await this.findUser(id);
        if (!user) {
            throw new Error(`User not found: ${id}`);
        }
        return user;
    }

    // ...
}
```

---
_Generated by [Claude Code](https://claude.ai/code/session_012y5rkTZJaBuxPCkmdqmh7X)_