### PR TITLE
Optimize nvm setup to use existing version if available

### DIFF
--- a/.claude/scripts/session-start.sh
+++ b/.claude/scripts/session-start.sh
@@ -29,10 +29,8 @@ if [ "$CLAUDE_CODE_REMOTE" = "true" ]; then
         set +e
         . "$NVM_DIR/nvm.sh"
         set -e
-        echo ">>> nvm install (.nvmrc: $(cat .nvmrc 2>/dev/null || echo 'not found'))"
-        nvm install
-        echo ">>> nvm use"
-        nvm use
+        echo ">>> nvm use || nvm install (.nvmrc: $(cat .nvmrc 2>/dev/null || echo 'not found'))"
+        nvm use || nvm install
         node_bin=$(dirname "$(nvm which current)")
         echo ">>> node_bin=$node_bin"
         mkdir -p "$HOME/.local/bin"


### PR DESCRIPTION
## Summary
Refactored the nvm initialization logic in the session startup script to attempt using an already-installed Node version before installing a new one, reducing unnecessary installations.

## Changes
- Combined separate `nvm install` and `nvm use` commands into a single `nvm use || nvm install` operation
- Updated the echo message to reflect the new behavior and consolidate logging
- This allows the script to reuse an existing Node version that matches `.nvmrc` if already installed, only falling back to installation when necessary

## Implementation Details
The change uses bash's `||` operator to create a fallback pattern: first try to activate the version specified in `.nvmrc` with `nvm use`, and only if that fails (e.g., version not installed), proceed with `nvm install`. This is more efficient than always installing regardless of the current state.

https://claude.ai/code/session_01G32bk95RmjwrtVcooG42xK