### PR TITLE
Replace launches mock handler with users REST endpoint

### DIFF
--- a/packages/admin/admin/.storybook/mocks/handlers.ts
+++ b/packages/admin/admin/.storybook/mocks/handlers.ts
@@ -22,6 +22,10 @@ const usersQueryHandler = graphql.query<{ users: typeof users }, { query?: strin
     });
 });
 
+const usersRestHandler = http.get("/users", () => {
+    return HttpResponse.json(users);
+});
+
 const userQueryHandler = graphql.query<{ user: (typeof users)[number] | null }, { id: number }>("user", ({ variables }) => {
     return HttpResponse.json({
         data: {
@@ -72,12 +76,4 @@ const productsQueryHandler = graphql.query<{ products: Product[] }, { manufactur
     });
 });
 
-const launchesQueryHandler = http.get("/launches", () => {
-    return HttpResponse.json([
-        { id: "1", name: "FalconSat", date: "2006-03-24" },
-        { id: "2", name: "DemoSat", date: "2007-03-21" },
-        { id: "3", name: "Trailblazer", date: "2008-08-03" },
-    ]);
-});
-
-export const handlers = [usersQueryHandler, userQueryHandler, manufacturersQueryHandler, productsQueryHandler, launchesQueryHandler];
+export const handlers = [usersQueryHandler, usersRestHandler, userQueryHandler, manufacturersQueryHandler, productsQueryHandler];

--- a/packages/admin/admin/src/fetchProvider/__stories__/FetchProvider.stories.tsx
+++ b/packages/admin/admin/src/fetchProvider/__stories__/FetchProvider.stories.tsx
@@ -7,7 +7,7 @@ function ExampleFetch() {
     const [data, setData] = useState<object | null>(null);
     useEffect(() => {
         const fetchData = async () => {
-            const response = await fetch(`/launches`);
+            const response = await fetch(`/users`);
             setData(await response.json());
         };
         fetchData();


### PR DESCRIPTION
## Summary
Updated the MSW mock handlers to replace the launches endpoint with a REST handler for the users endpoint, and updated the corresponding story to fetch from the new endpoint.

## Changes
- Added `usersRestHandler` to provide a REST API endpoint for `/users` that returns the users mock data
- Removed the `launchesQueryHandler` which was providing mock data for `/launches`
- Updated the handlers export to include the new `usersRestHandler` and remove the launches handler
- Updated `FetchProvider.stories.tsx` to fetch from `/users` instead of `/launches` to match the available mock endpoints

## Details
The change consolidates mock data handling by removing an unused launches endpoint and adding a REST-based users endpoint that complements the existing GraphQL users query handler. This allows the FetchProvider story to demonstrate fetching from the available mock API.

https://claude.ai/code/session_0117NFScT2ssHU76jzS7a6BN