### PR TITLE
Add themed MjmlButton and HtmlButton components

### DIFF
--- a/.changeset/add-themed-button-components.md
+++ b/.changeset/add-themed-button-components.md
@@ -1,0 +1,58 @@
+---
+"@comet/mail-react": minor
+---
+
+Add theme support to `MjmlButton` and add a new `HtmlButton` component
+
+`MjmlButton` now supports theme-based styling through `theme.button`, an optional `variant` prop, and a `fullWidth` prop that makes the button span its container. `HtmlButton` provides the same theming for MJML ending tags and other raw-HTML contexts.
+
+- `theme.button` sets the base button styling (color, background, border, border radius, font, and inner padding); `theme.button.variants` overrides those per named variant, optionally with per-breakpoint responsive values
+- `theme.button.backgroundImage` (typically a gradient) overlays `backgroundColor`, which stays as the solid fallback for clients that don't render gradients (notably Outlook)
+- `HtmlButton` has no alignment prop; horizontal placement is handled by the containing cell or layout
+- Existing `MjmlButton` usages are unchanged when no `theme.button` is configured
+
+**Example theme**
+
+```ts
+import { createTheme } from "@comet/mail-react";
+
+const theme = createTheme({
+    button: {
+        borderRadius: "6px",
+        padding: "12px 28px",
+        defaultVariant: "primary",
+        variants: {
+            primary: { backgroundColor: "#5B4FC7", color: "#FFFFFF" },
+            gradient: {
+                backgroundColor: "#5B4FC7",
+                backgroundImage: "linear-gradient(to right, #5B4FC7, #FF6B6B)",
+                color: "#FFFFFF",
+            },
+        },
+    },
+});
+
+declare module "@comet/mail-react" {
+    interface ButtonVariants {
+        primary: true;
+        gradient: true;
+    }
+}
+```
+
+Usage:
+
+```tsx
+import { MjmlButton, MjmlMailRoot } from "@comet/mail-react";
+
+<MjmlMailRoot theme={theme}>
+    <MjmlSection>
+        <MjmlColumn>
+            <MjmlButton href="https://example.com">Default</MjmlButton>
+            <MjmlButton href="https://example.com" variant="gradient" fullWidth>
+                Gradient, full width
+            </MjmlButton>
+        </MjmlColumn>
+    </MjmlSection>
+</MjmlMailRoot>;
+```

--- a/packages/mail-react/src/components/button/HtmlButton.tsx
+++ b/packages/mail-react/src/components/button/HtmlButton.tsx
@@ -1,0 +1,102 @@
+import clsx from "clsx";
+import type { AnchorHTMLAttributes, CSSProperties, ReactNode } from "react";
+
+import { registerStyles } from "../../styles/registerStyles.js";
+import { defaultTheme } from "../../theme/defaultTheme.js";
+import { getDefaultOrUndefined } from "../../theme/responsiveValue.js";
+import { useOptionalTheme } from "../../theme/ThemeProvider.js";
+import type { ButtonVariantStyles, Theme, ThemeButton } from "../../theme/themeTypes.js";
+import type { ButtonProps } from "./buttonProps.js";
+import { defaultButtonStyles } from "./defaultButtonStyles.js";
+import { generateResponsiveButtonCss } from "./generateResponsiveButtonCss.js";
+
+export type HtmlButtonProps = ButtonProps & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof ButtonProps>;
+
+/**
+ * Themed button for use inside MJML ending tags or outside of the MJML context.
+ */
+export function HtmlButton({
+    variant: variantProp,
+    fullWidth,
+    target = "_blank",
+    href = "#",
+    className,
+    style,
+    children,
+    ...restProps
+}: HtmlButtonProps): ReactNode {
+    const theme = useOptionalTheme();
+
+    if (theme === null && variantProp !== undefined) {
+        throw new Error("The `variant` prop requires being wrapped in a ThemeProvider or MjmlMailRoot.");
+    }
+
+    const themeButton: ThemeButton = theme?.button ?? defaultButtonStyles;
+    const textStyles = theme?.text ?? defaultTheme.text;
+    const { defaultVariant, variants, ...baseStyles } = themeButton;
+    const activeVariant = variantProp ?? defaultVariant;
+    const variantStyles = activeVariant ? variants?.[activeVariant] : undefined;
+
+    const mergedStyles: ButtonVariantStyles = { ...baseStyles, ...variantStyles };
+
+    const backgroundColor = getDefaultOrUndefined(mergedStyles.backgroundColor);
+    const borderRadius = getDefaultOrUndefined(mergedStyles.borderRadius);
+    const innerPadding = getDefaultOrUndefined(mergedStyles.padding);
+
+    const cellStyle: CSSProperties = {
+        border: getDefaultOrUndefined(mergedStyles.border),
+        borderRadius,
+        backgroundColor,
+        msoPaddingAlt: innerPadding,
+    };
+
+    const anchorStyle: CSSProperties = {
+        display: fullWidth ? "block" : "inline-block",
+        boxSizing: fullWidth ? "border-box" : undefined,
+        width: fullWidth ? "100%" : undefined,
+        backgroundColor,
+        backgroundImage: getDefaultOrUndefined(mergedStyles.backgroundImage),
+        color: getDefaultOrUndefined(mergedStyles.color),
+        fontFamily: getDefaultOrUndefined(mergedStyles.fontFamily) ?? textStyles.fontFamily,
+        fontSize: getDefaultOrUndefined(mergedStyles.fontSize) ?? textStyles.fontSize,
+        fontWeight: getDefaultOrUndefined(mergedStyles.fontWeight) ?? textStyles.fontWeight,
+        lineHeight: getDefaultOrUndefined(mergedStyles.lineHeight) ?? textStyles.lineHeight,
+        margin: 0,
+        textAlign: "center",
+        textDecoration: "none",
+        padding: innerPadding,
+        borderRadius,
+        msoPaddingAlt: "0px",
+        ...style,
+    };
+
+    return (
+        <table
+            role="presentation"
+            cellPadding={0}
+            cellSpacing={0}
+            border={0}
+            width={fullWidth ? "100%" : undefined}
+            className={clsx("htmlButton", activeVariant && `htmlButton--${activeVariant}`, fullWidth && "htmlButton--fullWidth", className)}
+            style={{ borderCollapse: "separate", lineHeight: "100%", msoLineHeightRule: "exactly" }}
+        >
+            <tbody>
+                <tr>
+                    <td align="center" valign="middle" bgcolor={backgroundColor} style={cellStyle}>
+                        <a {...restProps} href={href} target={target} style={anchorStyle}>
+                            {children}
+                        </a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    );
+}
+
+export function generateHtmlButtonStyles(theme: Theme): string {
+    return generateResponsiveButtonCss(theme, {
+        styleSelector: (variantName) => `.htmlButton--${variantName} a`,
+    });
+}
+
+registerStyles(generateHtmlButtonStyles);

--- a/packages/mail-react/src/components/button/MjmlButton.tsx
+++ b/packages/mail-react/src/components/button/MjmlButton.tsx
@@ -1,0 +1,142 @@
+import { type IMjmlButtonProps, MjmlButton as BaseMjmlButton } from "@faire/mjml-react";
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+import { registerStyles } from "../../styles/registerStyles.js";
+import { getDefaultOrUndefined } from "../../theme/responsiveValue.js";
+import { useOptionalTheme } from "../../theme/ThemeProvider.js";
+import type { ButtonVariantName, ButtonVariantStyles, Theme, ThemeButton } from "../../theme/themeTypes.js";
+import { css } from "../../utils/css.js";
+import type { ButtonProps } from "./buttonProps.js";
+import { defaultButtonStyles } from "./defaultButtonStyles.js";
+import { generateResponsiveButtonCss } from "./generateResponsiveButtonCss.js";
+
+export type MjmlButtonProps = Omit<IMjmlButtonProps, "href" | "target"> & ButtonProps;
+
+/**
+ * Themed button for use inside an `MjmlColumn`.
+ */
+export function MjmlButton({
+    variant: variantProp,
+    fullWidth,
+    width,
+    href = "#",
+    target = "_blank",
+    className,
+    children,
+    ...restProps
+}: MjmlButtonProps): ReactNode {
+    const theme = useOptionalTheme();
+
+    const themedProps = getThemedProps(theme, variantProp);
+
+    return (
+        <BaseMjmlButton
+            {...themedProps.baseProps}
+            {...restProps}
+            href={href}
+            target={target}
+            width={fullWidth ? "100%" : width}
+            className={clsx(
+                "mjmlButton",
+                themedProps.activeVariant && `mjmlButton--${themedProps.activeVariant}`,
+                fullWidth && "mjmlButton--fullWidth",
+                className,
+            )}
+        >
+            {children}
+        </BaseMjmlButton>
+    );
+}
+
+function getThemedProps(
+    theme: Theme | null,
+    variantProp: ButtonVariantName | undefined,
+): { activeVariant: ButtonVariantName | undefined; baseProps: Partial<IMjmlButtonProps> } {
+    if (theme === null && variantProp !== undefined) {
+        throw new Error("The `variant` prop requires being wrapped in a ThemeProvider or MjmlMailRoot.");
+    }
+
+    const themeButton: ThemeButton = theme?.button ?? defaultButtonStyles;
+    const { defaultVariant, variants, ...baseStyles } = themeButton;
+    const activeVariant = variantProp ?? defaultVariant;
+    const variantStyles = activeVariant ? variants?.[activeVariant] : undefined;
+
+    const mergedStyles: ButtonVariantStyles = { ...baseStyles, ...variantStyles };
+
+    const fontWeightDefault = getDefaultOrUndefined(mergedStyles.fontWeight);
+
+    return {
+        activeVariant,
+        baseProps: {
+            color: getDefaultOrUndefined(mergedStyles.color),
+            backgroundColor: getDefaultOrUndefined(mergedStyles.backgroundColor),
+            border: getDefaultOrUndefined(mergedStyles.border),
+            borderRadius: getDefaultOrUndefined(mergedStyles.borderRadius),
+            fontFamily: getDefaultOrUndefined(mergedStyles.fontFamily),
+            fontSize: getDefaultOrUndefined(mergedStyles.fontSize),
+            fontWeight: fontWeightDefault !== undefined ? String(fontWeightDefault) : undefined,
+            lineHeight: getDefaultOrUndefined(mergedStyles.lineHeight),
+            innerPadding: getDefaultOrUndefined(mergedStyles.padding),
+        },
+    };
+}
+
+// The wrapped MJML button has no `background-image` prop, so a gradient goes in a `<style>`
+// rule over the solid `backgroundColor`; variant rules come after the base so they override it.
+// Only the static value lives here; responsive overrides flow through generateResponsiveButtonCss.
+function generateStaticBackgroundImageCss(theme: Theme): string {
+    const { variants, ...baseStyles } = theme.button;
+    const cssChunks: string[] = [];
+
+    const baseBackgroundImage = getDefaultOrUndefined(baseStyles.backgroundImage);
+    if (baseBackgroundImage !== undefined) {
+        cssChunks.push(css`
+            .mjmlButton a {
+                background-image: ${baseBackgroundImage} !important;
+            }
+        `);
+    }
+
+    if (variants) {
+        for (const [variantName, variantStyles] of Object.entries(variants)) {
+            const backgroundImage = getDefaultOrUndefined(variantStyles?.backgroundImage);
+            if (backgroundImage !== undefined) {
+                cssChunks.push(css`
+                    .mjmlButton--${variantName} a {
+                        background-image: ${backgroundImage} !important;
+                    }
+                `);
+            }
+        }
+    }
+
+    return cssChunks.join("\n");
+}
+
+export function generateMjmlButtonStyles(theme: Theme): string {
+    return [
+        generateStaticBackgroundImageCss(theme),
+        generateResponsiveButtonCss(theme, {
+            styleSelector: (variantName) => `.mjmlButton--${variantName} a`,
+        }),
+    ]
+        .filter(Boolean)
+        .join("\n");
+}
+
+registerStyles(generateMjmlButtonStyles);
+
+// The cell is already full-width; this widens the anchor inside it so a gradient covers the
+// whole bar and the whole bar is clickable. Inlined so it survives clients that drop `<style>`.
+registerStyles(
+    css`
+        .mjmlButton--fullWidth a {
+            display: block !important;
+            width: 100% !important;
+            box-sizing: border-box !important;
+            text-align: center !important;
+        }
+    `,
+    { inline: true },
+);

--- a/packages/mail-react/src/components/button/README.md
+++ b/packages/mail-react/src/components/button/README.md
@@ -1,0 +1,9 @@
+# Button
+
+`theme.button` gives buttons named, reusable styles plus variants — a project defines its button look once and applies it by name.
+
+## Non-goals
+
+- No style re-application for Outlook. Unlike `Text` and `InlineLink`, the button styles its anchor directly, so it has nothing to re-apply against Outlook's link overrides.
+- No alignment prop on `HtmlButton`. Do not add one for parity with `MjmlButton` — horizontal placement is the layout's job.
+- No `fontFamily` in `defaultButtonStyles`. Do not add one; the button inherits the font from `theme.text` so it blends with surrounding text, and a button default would override that.

--- a/packages/mail-react/src/components/button/__stories__/HtmlButton.stories.tsx
+++ b/packages/mail-react/src/components/button/__stories__/HtmlButton.stories.tsx
@@ -1,0 +1,359 @@
+import { MjmlColumn, MjmlRaw } from "@faire/mjml-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { registerStyles } from "../../../styles/registerStyles.js";
+import { createTheme } from "../../../theme/createTheme.js";
+import { css } from "../../../utils/css.js";
+import { MjmlSection } from "../../section/MjmlSection.js";
+import { HtmlButton } from "../HtmlButton.js";
+
+type Story = StoryObj<typeof HtmlButton>;
+
+// TODO: Replace with a dedicated `HtmlSpacer` component (future PR).
+function TemporaryHtmlSpacer({ height }: { height: string }) {
+    return <div style={{ height, lineHeight: height, msoLineHeightRule: "exactly" }}>&nbsp;</div>;
+}
+
+const config: Meta<typeof HtmlButton> = {
+    title: "Components/HtmlButton",
+    component: HtmlButton,
+    tags: ["autodocs"],
+    args: {
+        href: "https://example.com",
+        children: "Click me",
+    },
+    argTypes: {
+        variant: { control: "text" },
+        fullWidth: { control: "boolean" },
+        href: { control: "text" },
+    },
+    render: (args) => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlButton {...args} />
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export default config;
+
+export const Default: Story = {};
+
+export const WithVariants: Story = {
+    parameters: {
+        theme: createTheme({
+            button: {
+                defaultVariant: "primary",
+                variants: {
+                    primary: { backgroundColor: "#5B4FC7", color: "#FFFFFF" },
+                    secondary: { backgroundColor: "#EEEEEE", color: "#222222" },
+                    tertiary: { backgroundColor: "#FFFFFF", border: "3px solid #5B4FC7", color: "#5B4FC7" },
+                },
+            },
+        }),
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlButton href="https://example.com">Primary (default)</HtmlButton>
+                    <TemporaryHtmlSpacer height="16px" />
+                    <HtmlButton href="https://example.com" variant="secondary">
+                        Secondary
+                    </HtmlButton>
+                    <TemporaryHtmlSpacer height="16px" />
+                    <HtmlButton href="https://example.com" variant="tertiary">
+                        Tertiary
+                    </HtmlButton>
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const ResponsiveVariants: Story = {
+    parameters: {
+        theme: createTheme({
+            button: {
+                variants: {
+                    primary: {
+                        backgroundColor: "#5B4FC7",
+                        color: "#FFFFFF",
+                        fontSize: { default: "16px", mobile: "13px" },
+                        padding: { default: "14px 32px", mobile: "10px 20px" },
+                    },
+                },
+            },
+        }),
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlButton href="https://example.com" variant="primary">
+                        Shrinks on mobile
+                    </HtmlButton>
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const DefaultVariant: Story = {
+    parameters: {
+        theme: createTheme({
+            button: {
+                defaultVariant: "primary",
+                variants: {
+                    primary: { backgroundColor: "#5B4FC7", color: "#FFFFFF" },
+                },
+            },
+        }),
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlButton href="https://example.com">Uses the default &quot;primary&quot; variant</HtmlButton>
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+/**
+ * One-off gradient via the `style` prop. `backgroundColor` stays as the solid
+ * fallback for clients that don't render the gradient (notably Outlook).
+ */
+export const GradientBackground: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlButton
+                        href="https://example.com"
+                        style={{
+                            backgroundColor: "#5B4FC7",
+                            backgroundImage: "linear-gradient(to right, #5B4FC7, #FF6B6B)",
+                            color: "#FFFFFF",
+                        }}
+                    >
+                        Gradient button
+                    </HtmlButton>
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const HoverAndActiveState: Story = {
+    render: () => {
+        registerStyles(css`
+            .interactiveButton a:hover {
+                background-color: #3a2e9c !important;
+            }
+            .interactiveButton a:active {
+                background-color: #eceafb !important;
+                border-color: #5b4fc7 !important;
+                color: #5b4fc7 !important;
+            }
+        `);
+
+        return (
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlRaw>
+                        <HtmlButton
+                            href="https://example.com"
+                            className="interactiveButton"
+                            style={{ backgroundColor: "#5B4FC7", color: "#FFFFFF", border: "2px solid #5B4FC7" }}
+                        >
+                            Hover and press me
+                        </HtmlButton>
+                    </MjmlRaw>
+                </MjmlColumn>
+            </MjmlSection>
+        );
+    },
+};
+
+export const FullWidth: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlButton href="https://example.com" fullWidth>
+                        Full-width button
+                    </HtmlButton>
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const FullWidthGradient: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlButton
+                        href="https://example.com"
+                        fullWidth
+                        style={{
+                            backgroundColor: "#5B4FC7",
+                            backgroundImage: "linear-gradient(to right, #5B4FC7, #FF6B6B)",
+                            color: "#FFFFFF",
+                        }}
+                    >
+                        Full-width gradient button
+                    </HtmlButton>
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const FullWidthOnMobile: Story = {
+    render: () => {
+        registerStyles(
+            (theme) => css`
+                ${theme.breakpoints.mobile.belowMediaQuery} {
+                    .mobileFullWidth,
+                    .mobileFullWidth table {
+                        width: 100% !important;
+                    }
+                    .mobileFullWidth a {
+                        display: block !important;
+                        width: 100% !important;
+                        box-sizing: border-box !important;
+                        text-align: center !important;
+                    }
+                }
+            `,
+        );
+
+        return (
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlRaw>
+                        <HtmlButton href="https://example.com" className="mobileFullWidth">
+                            Full width on mobile only
+                        </HtmlButton>
+                    </MjmlRaw>
+                </MjmlColumn>
+            </MjmlSection>
+        );
+    },
+};
+
+/**
+ * The button does not align itself; the containing cell does. Each button sits in its own
+ * full-width row whose `align` attribute positions it left, center, or right.
+ */
+export const Alignment: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <table role="presentation" width="100%" cellPadding={0} cellSpacing={0} border={0}>
+                        <tbody>
+                            <tr>
+                                <td align="left">
+                                    <HtmlButton href="https://example.com">Left</HtmlButton>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <TemporaryHtmlSpacer height="16px" />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align="center">
+                                    <HtmlButton href="https://example.com">Center</HtmlButton>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <TemporaryHtmlSpacer height="16px" />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align="right">
+                                    <HtmlButton href="https://example.com">Right</HtmlButton>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+/**
+ * Buttons sit side by side, each in its own cell of a single-row table, with a spacer cell
+ * for the gap. The wrapper has no width, so it shrink-wraps and stays at the left.
+ */
+export const SideBySide: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <table role="presentation" cellPadding={0} cellSpacing={0} border={0}>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <HtmlButton href="https://example.com">Button A</HtmlButton>
+                                </td>
+                                <td style={{ width: "16px", fontSize: "0", lineHeight: "0" }}>&nbsp;</td>
+                                <td>
+                                    <HtmlButton href="https://example.com">Button B</HtmlButton>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const IconBeforeText: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlButton href="https://example.com">
+                        <table
+                            role="presentation"
+                            cellPadding={0}
+                            cellSpacing={0}
+                            border={0}
+                            style={{ display: "inline-block", verticalAlign: "middle" }}
+                        >
+                            <tbody>
+                                <tr>
+                                    <td valign="middle" style={{ paddingRight: "8px", fontSize: "0" }}>
+                                        <img
+                                            src="https://picsum.photos/seed/buttonicon/18/18"
+                                            alt=""
+                                            width={18}
+                                            height={18}
+                                            style={{ display: "block" }}
+                                        />
+                                    </td>
+                                    <td valign="middle" style={{ color: "#FFFFFF", textDecoration: "none" }}>
+                                        Icon before text
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </HtmlButton>
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};

--- a/packages/mail-react/src/components/button/__stories__/MjmlButton.stories.tsx
+++ b/packages/mail-react/src/components/button/__stories__/MjmlButton.stories.tsx
@@ -1,0 +1,286 @@
+import { MjmlColumn, MjmlSpacer } from "@faire/mjml-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { registerStyles } from "../../../styles/registerStyles.js";
+import { createTheme } from "../../../theme/createTheme.js";
+import { css } from "../../../utils/css.js";
+import { MjmlSection } from "../../section/MjmlSection.js";
+import { MjmlButton } from "../MjmlButton.js";
+
+type Story = StoryObj<typeof MjmlButton>;
+
+const config: Meta<typeof MjmlButton> = {
+    title: "Components/MjmlButton",
+    component: MjmlButton,
+    tags: ["autodocs"],
+    args: {
+        href: "https://example.com",
+        children: "Click me",
+    },
+    argTypes: {
+        variant: { control: "text" },
+        fullWidth: { control: "boolean" },
+        align: { control: "inline-radio", options: ["left", "center", "right"] },
+        href: { control: "text" },
+    },
+    render: (args) => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlButton {...args} />
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export default config;
+
+export const Default: Story = {};
+
+export const WithVariants: Story = {
+    parameters: {
+        theme: createTheme({
+            button: {
+                defaultVariant: "primary",
+                variants: {
+                    primary: { backgroundColor: "#5B4FC7", color: "#FFFFFF" },
+                    secondary: { backgroundColor: "#EEEEEE", color: "#222222" },
+                    tertiary: { backgroundColor: "#FFFFFF", border: "3px solid #5B4FC7", color: "#5B4FC7" },
+                },
+            },
+        }),
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlButton href="https://example.com">Primary (default)</MjmlButton>
+                <MjmlSpacer height="16px" />
+                <MjmlButton href="https://example.com" variant="secondary">
+                    Secondary
+                </MjmlButton>
+                <MjmlSpacer height="16px" />
+                <MjmlButton href="https://example.com" variant="tertiary">
+                    Tertiary
+                </MjmlButton>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const ResponsiveVariants: Story = {
+    parameters: {
+        theme: createTheme({
+            button: {
+                variants: {
+                    primary: {
+                        backgroundColor: "#5B4FC7",
+                        color: "#FFFFFF",
+                        fontSize: { default: "16px", mobile: "13px" },
+                        padding: { default: "14px 32px", mobile: "10px 20px" },
+                    },
+                },
+            },
+        }),
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlButton href="https://example.com" variant="primary">
+                    Shrinks on mobile
+                </MjmlButton>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const DefaultVariant: Story = {
+    parameters: {
+        theme: createTheme({
+            button: {
+                defaultVariant: "primary",
+                variants: {
+                    primary: { backgroundColor: "#5B4FC7", color: "#FFFFFF" },
+                },
+            },
+        }),
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlButton href="https://example.com">Uses the default &quot;primary&quot; variant</MjmlButton>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+/**
+ * `backgroundColor` is the solid fallback for clients that don't render the
+ * gradient (notably Outlook). The gradient overlay comes from the `gradientButton` class.
+ */
+export const GradientBackground: Story = {
+    render: () => {
+        registerStyles(css`
+            .gradientButton a {
+                background-image: linear-gradient(to right, #5b4fc7, #ff6b6b) !important;
+            }
+        `);
+
+        return (
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlButton href="https://example.com" backgroundColor="#5B4FC7" color="#FFFFFF" className="gradientButton">
+                        Gradient button
+                    </MjmlButton>
+                </MjmlColumn>
+            </MjmlSection>
+        );
+    },
+};
+
+export const HoverAndActiveState: Story = {
+    render: () => {
+        registerStyles(css`
+            .interactiveButton a:hover {
+                background-color: #3a2e9c !important;
+            }
+            .interactiveButton a:active {
+                background-color: #eceafb !important;
+                border-color: #5b4fc7 !important;
+                color: #5b4fc7 !important;
+            }
+        `);
+
+        return (
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlButton
+                        href="https://example.com"
+                        backgroundColor="#5B4FC7"
+                        color="#FFFFFF"
+                        border="2px solid #5B4FC7"
+                        className="interactiveButton"
+                    >
+                        Hover and press me
+                    </MjmlButton>
+                </MjmlColumn>
+            </MjmlSection>
+        );
+    },
+};
+
+export const FullWidth: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlButton href="https://example.com" fullWidth>
+                    Full-width button
+                </MjmlButton>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const FullWidthOnMobile: Story = {
+    render: () => {
+        registerStyles(
+            (theme) => css`
+                ${theme.breakpoints.mobile.belowMediaQuery} {
+                    .mobileFullWidth,
+                    .mobileFullWidth table {
+                        width: 100% !important;
+                    }
+                    .mobileFullWidth a {
+                        display: block !important;
+                        width: 100% !important;
+                        box-sizing: border-box !important;
+                        text-align: center !important;
+                    }
+                }
+            `,
+        );
+
+        return (
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlButton href="https://example.com" className="mobileFullWidth">
+                        Full width on mobile only
+                    </MjmlButton>
+                </MjmlColumn>
+            </MjmlSection>
+        );
+    },
+};
+
+export const Alignment: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlButton href="https://example.com" align="left">
+                    Left
+                </MjmlButton>
+                <MjmlSpacer height="16px" />
+                <MjmlButton href="https://example.com" align="center">
+                    Center
+                </MjmlButton>
+                <MjmlSpacer height="16px" />
+                <MjmlButton href="https://example.com" align="right">
+                    Right
+                </MjmlButton>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const FullWidthGradient: Story = {
+    render: () => {
+        registerStyles(css`
+            .gradientButton a {
+                background-image: linear-gradient(to right, #5b4fc7, #ff6b6b) !important;
+            }
+        `);
+
+        return (
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlButton href="https://example.com" backgroundColor="#5B4FC7" color="#FFFFFF" className="gradientButton" fullWidth>
+                        Full-width gradient button
+                    </MjmlButton>
+                </MjmlColumn>
+            </MjmlSection>
+        );
+    },
+};
+
+export const IconBeforeText: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlButton href="https://example.com">
+                    <table
+                        role="presentation"
+                        cellPadding={0}
+                        cellSpacing={0}
+                        border={0}
+                        style={{ display: "inline-block", verticalAlign: "middle" }}
+                    >
+                        <tbody>
+                            <tr>
+                                <td valign="middle" style={{ paddingRight: "8px", fontSize: "0" }}>
+                                    <img
+                                        src="https://picsum.photos/seed/buttonicon/18/18"
+                                        alt=""
+                                        width={18}
+                                        height={18}
+                                        style={{ display: "block" }}
+                                    />
+                                </td>
+                                <td valign="middle" style={{ color: "#FFFFFF", textDecoration: "none" }}>
+                                    Icon before text
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </MjmlButton>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};

--- a/packages/mail-react/src/components/button/__tests__/HtmlButton.test.tsx
+++ b/packages/mail-react/src/components/button/__tests__/HtmlButton.test.tsx
@@ -1,0 +1,159 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { createTheme } from "../../../theme/createTheme.js";
+import { ThemeProvider } from "../../../theme/ThemeProvider.js";
+import { generateHtmlButtonStyles, HtmlButton } from "../HtmlButton.js";
+
+describe("HtmlButton", () => {
+    it("renders an email-safe button with default props and no theme", () => {
+        const html = renderToStaticMarkup(<HtmlButton>Click me</HtmlButton>);
+
+        expect(html).toContain('href="#"');
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain("text-decoration:none");
+        // Outlook fallbacks: padding mirrored to mso-padding-alt, background repeated as a bgcolor attribute.
+        expect(html).toContain("mso-padding-alt:10px 25px");
+        expect(html).toContain('bgcolor="#414141"');
+        expect(html).toContain("Click me");
+    });
+
+    it("follows theme text font family but keeps the base button font size", () => {
+        const theme = createTheme({ text: { fontFamily: "Georgia, serif", fontSize: "18px" } });
+
+        const html = renderToStaticMarkup(
+            <ThemeProvider theme={theme}>
+                <HtmlButton href="https://example.com">Click me</HtmlButton>
+            </ThemeProvider>,
+        );
+
+        // Font family follows theme.text so the button blends with surrounding text,
+        // but its size is a button style — matching MjmlButton, which never reads theme.text.fontSize.
+        expect(html).toContain("font-family:Georgia, serif");
+        expect(html).toContain("font-size:13px");
+    });
+
+    it("applies a variant over base styles", () => {
+        const theme = createTheme({
+            button: { variants: { primary: { backgroundColor: "#5B4FC7", color: "#FFFFFF" } } },
+        });
+
+        const html = renderToStaticMarkup(
+            <ThemeProvider theme={theme}>
+                <HtmlButton variant="primary">Primary</HtmlButton>
+            </ThemeProvider>,
+        );
+
+        expect(html).toContain("background-color:#5B4FC7");
+        expect(html).toContain("htmlButton--primary");
+    });
+
+    it("inherits base button styles not overridden by a variant", () => {
+        const theme = createTheme({
+            button: {
+                backgroundColor: "#5B4FC7",
+                variants: { primary: { color: "#FFFFFF" } },
+            },
+        });
+
+        const html = renderToStaticMarkup(
+            <ThemeProvider theme={theme}>
+                <HtmlButton variant="primary">Primary</HtmlButton>
+            </ThemeProvider>,
+        );
+
+        expect(html).toContain("background-color:#5B4FC7");
+        expect(html).toContain("color:#FFFFFF");
+    });
+
+    it("applies defaultVariant when no variant prop is specified", () => {
+        const theme = createTheme({
+            button: {
+                defaultVariant: "primary",
+                variants: { primary: { backgroundColor: "#5B4FC7" } },
+            },
+        });
+
+        const html = renderToStaticMarkup(
+            <ThemeProvider theme={theme}>
+                <HtmlButton>Primary</HtmlButton>
+            </ThemeProvider>,
+        );
+
+        expect(html).toContain("background-color:#5B4FC7");
+        expect(html).toContain("htmlButton--primary");
+    });
+
+    it("renders a gradient over the solid background color", () => {
+        const theme = createTheme({
+            button: {
+                variants: {
+                    gradient: {
+                        backgroundColor: "#5B4FC7",
+                        backgroundImage: "linear-gradient(to right, red, blue)",
+                    },
+                },
+            },
+        });
+
+        const html = renderToStaticMarkup(
+            <ThemeProvider theme={theme}>
+                <HtmlButton variant="gradient">Gradient</HtmlButton>
+            </ThemeProvider>,
+        );
+
+        expect(html).toContain("background-color:#5B4FC7");
+        expect(html).toContain("background-image:linear-gradient(to right, red, blue)");
+    });
+
+    it("spans the full width when fullWidth is set", () => {
+        const html = renderToStaticMarkup(
+            <HtmlButton href="https://example.com" fullWidth>
+                Full width
+            </HtmlButton>,
+        );
+
+        // fullWidth spans the table (width attribute, honored by Outlook) and fills the
+        // anchor (display:block + width:100%) so the whole button area is clickable.
+        expect(html).toContain('width="100%"');
+        expect(html).toContain("display:block");
+        expect(html).toContain("width:100%");
+        expect(html).toContain("htmlButton--fullWidth");
+    });
+
+    it("lets the consumer style prop layer over theme styles", () => {
+        const html = renderToStaticMarkup(<HtmlButton style={{ backgroundColor: "#FF0000" }}>Click me</HtmlButton>);
+
+        expect(html).toContain("background-color:#FF0000");
+    });
+
+    it("throws when variant is set without a ThemeProvider", () => {
+        expect(() => renderToStaticMarkup(<HtmlButton variant="primary">Primary</HtmlButton>)).toThrow();
+    });
+});
+
+describe("generateHtmlButtonStyles", () => {
+    it("returns empty CSS when no variants are defined", () => {
+        const theme = createTheme();
+        expect(generateHtmlButtonStyles(theme)).toBe("");
+    });
+
+    it("emits responsive overrides targeting the variant anchor", () => {
+        const theme = createTheme({
+            button: { variants: { primary: { fontSize: { default: "13px", mobile: "16px" } } } },
+        });
+
+        const result = generateHtmlButtonStyles(theme);
+
+        expect(result).toContain(".htmlButton--primary a");
+        expect(result).toContain("font-size: 16px !important");
+    });
+
+    it("emits no media queries for a non-responsive variant", () => {
+        const theme = createTheme({
+            button: { variants: { primary: { fontSize: "16px" } } },
+        });
+
+        expect(generateHtmlButtonStyles(theme)).not.toContain("@media");
+    });
+});

--- a/packages/mail-react/src/components/button/__tests__/MjmlButton.test.tsx
+++ b/packages/mail-react/src/components/button/__tests__/MjmlButton.test.tsx
@@ -1,0 +1,190 @@
+import { MjmlColumn } from "@faire/mjml-react";
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { renderMailHtml } from "../../../server/renderMailHtml.js";
+import { createTheme } from "../../../theme/createTheme.js";
+import { MjmlMailRoot } from "../../mailRoot/MjmlMailRoot.js";
+import { MjmlSection } from "../../section/MjmlSection.js";
+import { generateMjmlButtonStyles, MjmlButton } from "../MjmlButton.js";
+
+function renderInMailRoot(button: ReactNode, theme?: ReturnType<typeof createTheme>) {
+    return renderMailHtml(
+        <MjmlMailRoot theme={theme}>
+            <MjmlSection>
+                <MjmlColumn>{button}</MjmlColumn>
+            </MjmlSection>
+        </MjmlMailRoot>,
+    );
+}
+
+describe("MjmlButton", () => {
+    it("produces no MJML warnings for default, variant, and full-width buttons", () => {
+        const theme = createTheme({
+            button: {
+                variants: {
+                    primary: { backgroundColor: "#5B4FC7", color: "#FFFFFF" },
+                    secondary: { backgroundColor: "#EEEEEE", color: "#222222" },
+                },
+            },
+        });
+
+        const { mjmlWarnings } = renderInMailRoot(
+            <>
+                <MjmlButton href="https://example.com">Default</MjmlButton>
+                <MjmlButton href="https://example.com" variant="primary">
+                    Primary
+                </MjmlButton>
+                <MjmlButton href="https://example.com" variant="secondary" fullWidth>
+                    Full width
+                </MjmlButton>
+            </>,
+            theme,
+        );
+
+        expect(mjmlWarnings).toEqual([]);
+    });
+
+    it("renders an anchor with default props when no theme is set", () => {
+        const { html } = renderInMailRoot(<MjmlButton>Click me</MjmlButton>);
+
+        expect(html).toContain("mjmlButton");
+        expect(html).toContain('href="#"');
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain("Click me");
+    });
+
+    it("applies theme base styles to the button", () => {
+        const { html } = renderInMailRoot(
+            <MjmlButton href="https://example.com">Click me</MjmlButton>,
+            createTheme({ button: { backgroundColor: "#5B4FC7" } }),
+        );
+
+        expect(html).toContain("background:#5B4FC7");
+    });
+
+    it("applies the variant modifier class", () => {
+        const { html } = renderInMailRoot(
+            <MjmlButton href="https://example.com" variant="primary">
+                Primary
+            </MjmlButton>,
+            createTheme({ button: { variants: { primary: { backgroundColor: "#5B4FC7" } } } }),
+        );
+
+        expect(html).toContain("mjmlButton--primary");
+    });
+
+    it("inherits base button styles not overridden by a variant", () => {
+        const { html } = renderInMailRoot(
+            <MjmlButton href="https://example.com" variant="primary">
+                Primary
+            </MjmlButton>,
+            createTheme({ button: { backgroundColor: "#5B4FC7", variants: { primary: { color: "#FFFFFF" } } } }),
+        );
+
+        expect(html).toContain("background:#5B4FC7");
+        expect(html).toContain("color:#FFFFFF");
+    });
+
+    it("applies defaultVariant when no variant prop is specified", () => {
+        const { html } = renderInMailRoot(
+            <MjmlButton href="https://example.com">Primary</MjmlButton>,
+            createTheme({ button: { defaultVariant: "primary", variants: { primary: { backgroundColor: "#5B4FC7" } } } }),
+        );
+
+        expect(html).toContain("mjmlButton--primary");
+        expect(html).toContain("background:#5B4FC7");
+    });
+
+    it("adds the full-width modifier class when fullWidth is set", () => {
+        const { html } = renderInMailRoot(
+            <MjmlButton href="https://example.com" fullWidth>
+                Full width
+            </MjmlButton>,
+        );
+
+        expect(html).toContain("mjmlButton--fullWidth");
+    });
+
+    it("inlines the full-width styles onto the anchor so they survive clients that drop the style block", () => {
+        const { html } = renderInMailRoot(
+            <MjmlButton href="https://example.com" fullWidth>
+                Full width
+            </MjmlButton>,
+        );
+
+        expect(html).toContain("box-sizing: border-box");
+        expect(html).not.toMatch(/\.mjmlButton--fullWidth a\s*\{/);
+    });
+
+    it("renders an icon table passed as children without warnings", () => {
+        const { html, mjmlWarnings } = renderInMailRoot(
+            <MjmlButton href="https://example.com">
+                <table role="presentation" cellPadding={0} cellSpacing={0} border={0}>
+                    <tbody>
+                        <tr>
+                            <td valign="middle" style={{ paddingRight: "8px", fontSize: "0" }}>
+                                <img src="https://example.com/icon.png" alt="" width={16} height={16} style={{ display: "block" }} />
+                            </td>
+                            <td valign="middle">Label</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </MjmlButton>,
+        );
+
+        expect(mjmlWarnings).toEqual([]);
+        expect(html).toContain("https://example.com/icon.png");
+        expect(html).toContain("Label");
+    });
+
+    it("throws when variant is set without a ThemeProvider", () => {
+        expect(() =>
+            renderToStaticMarkup(
+                <MjmlButton variant="primary" href="https://example.com">
+                    Primary
+                </MjmlButton>,
+            ),
+        ).toThrow();
+    });
+});
+
+describe("generateMjmlButtonStyles", () => {
+    it("returns empty CSS when no variants or base gradient are defined", () => {
+        const theme = createTheme();
+        expect(generateMjmlButtonStyles(theme)).toBe("");
+    });
+
+    it("emits a base gradient rule on the anchor when theme.button.backgroundImage is set", () => {
+        const theme = createTheme({ button: { backgroundImage: "linear-gradient(to right, red, blue)" } });
+
+        const result = generateMjmlButtonStyles(theme);
+
+        expect(result).toContain(".mjmlButton a");
+        expect(result).toContain("background-image: linear-gradient(to right, red, blue) !important");
+    });
+
+    it("emits a variant gradient rule targeting the variant anchor", () => {
+        const theme = createTheme({
+            button: { variants: { primary: { backgroundImage: "linear-gradient(to right, red, blue)" } } },
+        });
+
+        const result = generateMjmlButtonStyles(theme);
+
+        expect(result).toContain(".mjmlButton--primary a");
+        expect(result).toContain("background-image: linear-gradient(to right, red, blue) !important");
+    });
+
+    it("emits responsive media-query overrides for responsive variant values", () => {
+        const theme = createTheme({
+            button: { variants: { primary: { fontSize: { default: "13px", mobile: "16px" } } } },
+        });
+
+        const result = generateMjmlButtonStyles(theme);
+
+        expect(result).toContain("@media");
+        expect(result).toContain(".mjmlButton--primary a");
+        expect(result).toContain("font-size: 16px !important");
+    });
+});

--- a/packages/mail-react/src/components/button/buttonProps.ts
+++ b/packages/mail-react/src/components/button/buttonProps.ts
@@ -1,0 +1,37 @@
+import type { AnchorHTMLAttributes } from "react";
+
+import type { ButtonVariantName } from "../../theme/themeTypes.js";
+
+export interface ButtonProps {
+    /**
+     * The component's variant to apply, as defined in the theme.
+     *
+     * Custom variants should be defined in the theme through module augmentation:
+     *
+     * ```ts
+     * declare module "@comet/mail-react" {
+     *     interface ButtonVariants { primary: true; secondary: true }
+     * }
+     * ```
+     *
+     * ```ts
+     * const theme = createTheme({
+     *     button: {
+     *         variants: {
+     *             primary: { backgroundColor: "#5B4FC7", color: "#FFFFFF" },
+     *             secondary: { backgroundColor: "#EEEEEE", color: "#222222" },
+     *         },
+     *     },
+     * });
+     * ```
+     *
+     * @defaultValue The theme's `button.defaultVariant`, when set
+     */
+    variant?: ButtonVariantName;
+    /** When true, the button spans the full width of its container. */
+    fullWidth?: boolean;
+    /** @defaultValue "#" */
+    href?: string;
+    /** @defaultValue "_blank" */
+    target?: AnchorHTMLAttributes<HTMLAnchorElement>["target"];
+}

--- a/packages/mail-react/src/components/button/defaultButtonStyles.ts
+++ b/packages/mail-react/src/components/button/defaultButtonStyles.ts
@@ -1,0 +1,11 @@
+import type { ButtonStyles } from "../../theme/themeTypes.js";
+
+export const defaultButtonStyles: ButtonStyles = {
+    color: "#ffffff",
+    backgroundColor: "#414141",
+    border: "none",
+    borderRadius: "3px",
+    fontSize: "13px",
+    lineHeight: "120%",
+    padding: "10px 25px",
+};

--- a/packages/mail-react/src/components/button/generateResponsiveButtonCss.ts
+++ b/packages/mail-react/src/components/button/generateResponsiveButtonCss.ts
@@ -1,0 +1,69 @@
+import { getResponsiveOverrides } from "../../theme/responsiveValue.js";
+import type { ButtonVariantStyles, Theme, ThemeBreakpoints } from "../../theme/themeTypes.js";
+import { css } from "../../utils/css.js";
+
+const buttonCssProperties: ReadonlyArray<[keyof ButtonVariantStyles, string]> = [
+    ["color", "color"],
+    ["backgroundColor", "background-color"],
+    ["backgroundImage", "background-image"],
+    ["border", "border"],
+    ["borderRadius", "border-radius"],
+    ["fontFamily", "font-family"],
+    ["fontSize", "font-size"],
+    ["fontWeight", "font-weight"],
+    ["lineHeight", "line-height"],
+    ["padding", "padding"],
+];
+
+interface GenerateResponsiveButtonCssOptions {
+    /** Selector for variant style overrides, given a variant name. */
+    styleSelector: (variantName: string) => string;
+}
+
+/** Generates responsive CSS media queries for button variant overrides. */
+export function generateResponsiveButtonCss(theme: Theme, options: GenerateResponsiveButtonCssOptions): string {
+    const { variants } = theme.button;
+    if (!variants) {
+        return css``;
+    }
+
+    const cssChunks: string[] = [];
+
+    for (const [variantName, variantStyles] of Object.entries(variants)) {
+        if (!variantStyles) {
+            continue;
+        }
+
+        const overrides = new Map<keyof ThemeBreakpoints, string[]>();
+
+        for (const [themeKey, cssProperty] of buttonCssProperties) {
+            const value = variantStyles[themeKey];
+            if (value === undefined) {
+                continue;
+            }
+
+            for (const { breakpointKey, value: breakpointValue } of getResponsiveOverrides(value)) {
+                const declarations = overrides.get(breakpointKey) ?? [];
+                declarations.push(`${cssProperty}: ${String(breakpointValue)} !important`);
+                overrides.set(breakpointKey, declarations);
+            }
+        }
+
+        for (const [breakpointKey, declarations] of overrides) {
+            const breakpoint = theme.breakpoints[breakpointKey];
+            if (!breakpoint) {
+                continue;
+            }
+
+            cssChunks.push(css`
+                ${breakpoint.belowMediaQuery} {
+                    ${options.styleSelector(variantName)} {
+                        ${declarations.join(";\n")}
+                    }
+                }
+            `);
+        }
+    }
+
+    return cssChunks.join("\n");
+}

--- a/packages/mail-react/src/index.ts
+++ b/packages/mail-react/src/index.ts
@@ -8,6 +8,10 @@ export type { HtmlPixelImageBlockProps } from "./blocks/pixelImage/HtmlPixelImag
 export { HtmlPixelImageBlock } from "./blocks/pixelImage/HtmlPixelImageBlock.js";
 export type { MjmlPixelImageBlockProps } from "./blocks/pixelImage/MjmlPixelImageBlock.js";
 export { MjmlPixelImageBlock } from "./blocks/pixelImage/MjmlPixelImageBlock.js";
+export type { HtmlButtonProps } from "./components/button/HtmlButton.js";
+export { HtmlButton } from "./components/button/HtmlButton.js";
+export type { MjmlButtonProps } from "./components/button/MjmlButton.js";
+export { MjmlButton } from "./components/button/MjmlButton.js";
 export type { HtmlDividerProps } from "./components/divider/HtmlDivider.js";
 export { HtmlDivider } from "./components/divider/HtmlDivider.js";
 export type { MjmlDividerProps } from "./components/divider/MjmlDivider.js";
@@ -35,6 +39,9 @@ export type { ResponsiveValue } from "./theme/responsiveValue.js";
 export { getDefaultFromResponsiveValue, getResponsiveOverrides } from "./theme/responsiveValue.js";
 export { ThemeProvider, useTheme } from "./theme/ThemeProvider.js";
 export type {
+    ButtonStyles,
+    ButtonVariants,
+    ButtonVariantStyles,
     DividerStyles,
     DividerVariants,
     DividerVariantStyles,
@@ -45,6 +52,7 @@ export type {
     ThemeBackgroundColors,
     ThemeBreakpoint,
     ThemeBreakpoints,
+    ThemeButton,
     ThemeColors,
     ThemeDivider,
     ThemeSizes,
@@ -69,8 +77,6 @@ export {
     type IMjmlBodyProps as MjmlBodyProps,
     MjmlBreakpoint,
     type IMjmlBreakpointProps as MjmlBreakpointProps,
-    MjmlButton,
-    type IMjmlButtonProps as MjmlButtonProps,
     MjmlCarousel,
     MjmlCarouselImage,
     type IMjmlCarouselImageProps as MjmlCarouselImageProps,

--- a/packages/mail-react/src/reactEmailTypes.d.ts
+++ b/packages/mail-react/src/reactEmailTypes.d.ts
@@ -1,0 +1,19 @@
+// This file must be a module (hence `export {}`) so the `declare module "react"`
+// blocks augment React's types. Without it the file is a global script, and
+// `declare module "react"` would declare a standalone module that replaces
+// `@types/react` rather than merging into it — the interfaces below wouldn't apply.
+export {};
+
+declare module "react" {
+    interface CSSProperties {
+        /** Makes Outlook honor `line-height` exactly instead of auto-expanding it for tall content; pair it with every manual `line-height`. */
+        msoLineHeightRule?: "exactly" | "at-least";
+        /** Outlook applies cell padding through this instead of `padding`. */
+        msoPaddingAlt?: string;
+    }
+
+    interface TdHTMLAttributes {
+        /** Legacy background attribute Outlook honors when it ignores `background-color`. */
+        bgcolor?: string;
+    }
+}

--- a/packages/mail-react/src/theme/createTheme.ts
+++ b/packages/mail-react/src/theme/createTheme.ts
@@ -1,12 +1,13 @@
 import { createBreakpoint } from "./createBreakpoint.js";
 import { defaultTheme } from "./defaultTheme.js";
-import type { Theme, ThemeBackgroundColors, ThemeBreakpoints, ThemeColors, ThemeDivider, ThemeSizes, ThemeText } from "./themeTypes.js";
+import type { Theme, ThemeBackgroundColors, ThemeBreakpoints, ThemeButton, ThemeColors, ThemeDivider, ThemeSizes, ThemeText } from "./themeTypes.js";
 
 type CreateThemeOverrides = {
     sizes?: Partial<ThemeSizes>;
     breakpoints?: Partial<ThemeBreakpoints>;
     text?: Partial<ThemeText>;
     divider?: Partial<ThemeDivider>;
+    button?: Partial<ThemeButton>;
     colors?: { background?: Partial<ThemeBackgroundColors> } & Partial<Omit<ThemeColors, "background">>;
 };
 
@@ -33,6 +34,7 @@ export function createTheme(overrides?: CreateThemeOverrides): Theme {
         },
         text: { ...defaultTheme.text, ...overrides?.text },
         divider: { ...defaultTheme.divider, ...overrides?.divider },
+        button: { ...defaultTheme.button, ...overrides?.button },
         colors: {
             ...defaultTheme.colors,
             ...overrides?.colors,

--- a/packages/mail-react/src/theme/defaultTheme.ts
+++ b/packages/mail-react/src/theme/defaultTheme.ts
@@ -1,3 +1,4 @@
+import { defaultButtonStyles } from "../components/button/defaultButtonStyles.js";
 import { defaultDividerStyles } from "../components/divider/defaultDividerStyles.js";
 import { createBreakpoint } from "./createBreakpoint.js";
 import type { Theme } from "./themeTypes.js";
@@ -18,6 +19,7 @@ export const defaultTheme: Theme = {
         bottomSpacing: "16px",
     },
     divider: defaultDividerStyles,
+    button: defaultButtonStyles,
     colors: {
         background: {
             body: "#F2F2F2",

--- a/packages/mail-react/src/theme/themeTypes.ts
+++ b/packages/mail-react/src/theme/themeTypes.ts
@@ -92,6 +92,65 @@ export interface ThemeDivider extends DividerStyles {
 }
 
 /**
+ * Single source of truth for button style property names and their value types.
+ * Both `ButtonStyles` and `ButtonVariantStyles` are derived from this interface.
+ *
+ * `padding` is the button's inner padding (the space around the label). It is
+ * deliberately distinct from `MjmlButton`'s `padding` prop, which is the outer
+ * spacing around the button.
+ */
+interface ButtonStyleMap {
+    color: string;
+    backgroundColor: string;
+    /**
+     * A background image — typically a gradient. Rendered as progressive
+     * enhancement on top of `backgroundColor`; clients that don't render it
+     * (notably Outlook) fall back to the solid color.
+     */
+    backgroundImage: string;
+    border: string;
+    borderRadius: string;
+    fontFamily: string;
+    fontSize: string;
+    fontWeight: string | number;
+    lineHeight: string | number;
+    padding: string;
+}
+
+/** Base button styles where each property holds a plain value. */
+export type ButtonStyles = { [K in keyof ButtonStyleMap]?: ButtonStyleMap[K] };
+
+/** Variant button styles where each property supports responsive values. */
+export type ButtonVariantStyles = { [K in keyof ButtonStyleMap]?: ResponsiveValue<ButtonStyleMap[K]> };
+
+/**
+ * Defines the variants available on the `MjmlButton` and `HtmlButton` components.
+ *
+ * ```ts
+ * declare module "@comet/mail-react" {
+ *     interface ButtonVariants {
+ *         primary: true;
+ *         secondary: true;
+ *     }
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ButtonVariants {}
+
+type ButtonVariantsRecord = keyof ButtonVariants extends never
+    ? Record<string, ButtonVariantStyles>
+    : { [K in keyof ButtonVariants]?: ButtonVariantStyles };
+
+export type ButtonVariantName = keyof ButtonVariants extends never ? string : keyof ButtonVariants;
+
+/** Theme configuration for button styles, variants, and default variant. */
+export interface ThemeButton extends ButtonStyles {
+    defaultVariant?: ButtonVariantName;
+    variants?: ButtonVariantsRecord;
+}
+
+/**
  * A resolved breakpoint with its numeric value and a ready-to-use media query
  * string that targets viewports narrower than this breakpoint.
  */
@@ -152,5 +211,6 @@ export interface Theme {
     breakpoints: ThemeBreakpoints;
     text: ThemeText;
     divider: ThemeDivider;
+    button: ThemeButton;
     colors: ThemeColors;
 }


### PR DESCRIPTION
Email components are themeable through `theme.<component>`, but buttons were a plain re-export of the base MJML button: no named or reusable styles, no variants, and nothing usable in raw-HTML contexts such as MJML ending tags.

- **`MjmlButton` wraps the base button rather than replacing it.**
  The base already emits Outlook-correct markup, so wrapping keeps it and stays backwards-compatible.
  A fully custom render, as the divider uses, was rejected because nothing about buttons requires bypassing the base.
- **`defaultButtonStyles` is the single source of truth for both components' default look, including size.**
  It replicates the base button's values so the default look is unchanged and the two stay in sync.
  Font family is the one exception: it follows `theme.text` in both — `MjmlMailRoot` applies it through `<MjmlAll>` and `HtmlButton` falls back to it — so the button matches surrounding text.
  A button's size is therefore a `theme.button` concern, not a `theme.text` one.
- **Every button renders as a link, never the base button's hrefless fallback element.**
  The base renders a non-anchor element when no `href` is set, which would silently drop the styles delivered through a `<style>` rule, so both components default `href` to `#` and style only the anchor.
- **Both buttons open links in a new tab by default.**
  A mail opened in a browser tab (e.g. via a view-in-browser link) would otherwise be replaced by the clicked link.
  Each component sets this default itself so the behavior survives a change to the base button's own default.
- **A theme gradient must degrade to the solid `backgroundColor`.**
  The wrapped base button has no `background-image` prop, so `MjmlButton` applies the gradient through a `<style>` rule layered over the inline solid color; Outlook and clients that drop `<style>` keep the solid background.
  `HtmlButton` renders its own anchor and sets both the gradient and the solid color inline.
- **Full-width widens the anchor, not just its cell.**
  The cell already spans full width; left alone the anchor stays content-width, so a gradient would cover only its centre and only the text would be clickable.
  The wrapped base button's anchor can't be reached through a prop, so `MjmlButton` widens it with an inlined `<style>` rule — inlined so it holds in clients that drop `<style>`.
  `HtmlButton` sets it on its own anchor inline.
- **Email-only HTML and CSS attributes belong in one type augmentation, not a cast at each call site.**
  Outlook needs `bgcolor` and `mso-*` properties React's types omit; augmenting `react` keeps every use type-checked.
- **`textTransform` and `letterSpacing` are not themeable.**
  They render inconsistently across mail clients.
- **`HtmlButton` does not position itself; the containing cell does.**
  Positioning a button by floating its own table overlaps neighboring buttons when they stack and breaks multi-column layouts.
  `MjmlButton` instead relies on the base button's `align`, which works because MJML gives each button its own cell.
- **Stories keep raw HTML buttons and their spacing inside one `MjmlRaw`.**
  An `MjmlSpacer` placed beside `MjmlRaw` in a column lands the button tables outside its rows, which clients repair by scattering them; a temporary raw spacer covers the gap until a dedicated component exists.

---

Main Task: https://vivid-planet.atlassian.net/browse/PHSB2C-11717
Additional Task: https://vivid-planet.atlassian.net/browse/PHSB2C-11719

Due to the size of this PR, updating the agent-skill and docs will be a future PR.  
