### PR TITLE
Add tests for extractGraphqlFields

### DIFF
--- a/packages/api/cms-api/src/common/graphql/__tests__/extract-graphql-fields.test.ts
+++ b/packages/api/cms-api/src/common/graphql/__tests__/extract-graphql-fields.test.ts
@@ -1,0 +1,131 @@
+import type { GraphQLResolveInfo } from "graphql";
+import { parseResolveInfo, type ResolveTree } from "graphql-parse-resolve-info";
+import { describe, expect, it, vi } from "vitest";
+
+import { extractGraphqlFields } from "../extract-graphql-fields";
+
+vi.mock("graphql-parse-resolve-info", () => ({
+    parseResolveInfo: vi.fn(),
+}));
+
+const mockInfo = {} as GraphQLResolveInfo;
+
+function makeTree(fieldsByTypeName: ResolveTree["fieldsByTypeName"]): ResolveTree {
+    return { name: "root", alias: "root", args: {}, fieldsByTypeName };
+}
+
+function makeLeaf(name: string): ResolveTree {
+    return { name, alias: name, args: {}, fieldsByTypeName: {} };
+}
+
+describe("extractGraphqlFields", () => {
+    it("should return an empty array when there are no fields", () => {
+        vi.mocked(parseResolveInfo).mockReturnValue(makeTree({}));
+
+        expect(extractGraphqlFields(mockInfo)).toEqual([]);
+    });
+
+    it("should return flat field names", () => {
+        vi.mocked(parseResolveInfo).mockReturnValue(
+            makeTree({
+                User: {
+                    name: makeLeaf("name"),
+                    email: makeLeaf("email"),
+                },
+            }),
+        );
+
+        expect(extractGraphqlFields(mockInfo)).toEqual(["name", "email"]);
+    });
+
+    it("should return nested field paths using dot notation", () => {
+        vi.mocked(parseResolveInfo).mockReturnValue(
+            makeTree({
+                User: {
+                    address: {
+                        ...makeLeaf("address"),
+                        fieldsByTypeName: {
+                            Address: {
+                                street: makeLeaf("street"),
+                                city: makeLeaf("city"),
+                            },
+                        },
+                    },
+                },
+            }),
+        );
+
+        expect(extractGraphqlFields(mockInfo)).toEqual(["address", "address.street", "address.city"]);
+    });
+
+    it("should handle multiple levels of nesting", () => {
+        vi.mocked(parseResolveInfo).mockReturnValue(
+            makeTree({
+                Query: {
+                    user: {
+                        ...makeLeaf("user"),
+                        fieldsByTypeName: {
+                            User: {
+                                profile: {
+                                    ...makeLeaf("profile"),
+                                    fieldsByTypeName: {
+                                        Profile: {
+                                            avatar: makeLeaf("avatar"),
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            }),
+        );
+
+        expect(extractGraphqlFields(mockInfo)).toEqual(["user", "user.profile", "user.profile.avatar"]);
+    });
+
+    it("should return only sub-fields of the specified root when root option is provided", () => {
+        vi.mocked(parseResolveInfo).mockReturnValue(
+            makeTree({
+                Query: {
+                    user: {
+                        ...makeLeaf("user"),
+                        fieldsByTypeName: {
+                            User: {
+                                name: makeLeaf("name"),
+                                email: makeLeaf("email"),
+                            },
+                        },
+                    },
+                    version: makeLeaf("version"),
+                },
+            }),
+        );
+
+        expect(extractGraphqlFields(mockInfo, { root: "user" })).toEqual(["name", "email"]);
+    });
+
+    it("should return an empty array when root has no matching children", () => {
+        vi.mocked(parseResolveInfo).mockReturnValue(
+            makeTree({
+                Query: {
+                    name: makeLeaf("name"),
+                },
+            }),
+        );
+
+        expect(extractGraphqlFields(mockInfo, { root: "nonexistent" })).toEqual([]);
+    });
+
+    it("should not include the root field itself when root is a leaf node", () => {
+        vi.mocked(parseResolveInfo).mockReturnValue(
+            makeTree({
+                Query: {
+                    user: makeLeaf("user"),
+                },
+            }),
+        );
+
+        expect(extractGraphqlFields(mockInfo, { root: "user" })).toEqual([]);
+    });
+});


### PR DESCRIPTION
## What

Adds Vitest tests for `extractGraphqlFields` in `packages/api/cms-api/src/common/graphql/extract-graphql-fields.ts`.

The function is exported from `@comet/cms-api` and had no test coverage. It takes a `GraphQLResolveInfo` object, parses it via `graphql-parse-resolve-info`, then flattens the field tree into a dot-separated path list (e.g. `["user", "user.name", "user.email"]`). An optional `root` parameter filters the list to only sub-fields of the named root, stripping the prefix.

Tests cover:

- Empty field set → empty array
- Flat fields → array of names
- Nested fields → dot-separated paths (e.g. `address.street`)
- Multiple levels of nesting (e.g. `user.profile.avatar`)
- `root` option filters to sub-fields and strips the prefix
- `root` with no matching children → empty array
- `root` that is a leaf node (no children) → empty array

`parseResolveInfo` is mocked via `vi.mock` so tests are fast and isolated from GraphQL schema setup.

## Implementation feedback

**`root` never matches a leaf field named `root`:** The filter checks `i.startsWith(`${options.root}.`)` (with a dot), so a field whose path equals the root name exactly is silently dropped. If a caller passes `root: "user"` and `"user"` is a scalar leaf, the result is `[]` rather than `["user"]`. This is probably intentional (callers want sub-fields, not the root itself), but it is worth documenting.

**O(n²) spread in `reduce`:** Each reduce iteration does `[...acc, i]`, allocating a new array. For typical GraphQL queries this is fine, but `push` would be more efficient.

## Test plan

- [x] `pnpm run test` in `packages/api/cms-api` — all 387 tests pass (33 test files, including 7 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8g3dDtSgLzZeT24DR5rVU)_