### PR TITLE
Fix FullTextSearch view creation

### DIFF
--- a/.changeset/fix-full-text-search-module-global.md
+++ b/.changeset/fix-full-text-search-module-global.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix `EntityInfoFullText` view not being created when using `FullTextSearchModule`
+
+`DependenciesService` injects `FullTextSearchService` as an optional dependency to create the `EntityInfoFullText` view. Because `FullTextSearchModule` was not `@Global`, the service was not available in the (global) `DependenciesModule`'s injection scope, so the optional dependency always resolved to `undefined` and the view was silently never created.
+
+Mark `FullTextSearchModule` as `@Global` so `FullTextSearchService` is resolvable and the `EntityInfoFullText` view is created by `createBlockIndexViews`.

--- a/.changeset/fix-full-text-search-module-global.md
+++ b/.changeset/fix-full-text-search-module-global.md
@@ -1,9 +1,0 @@
----
-"@comet/cms-api": patch
----
-
-Fix `EntityInfoFullText` view not being created when using `FullTextSearchModule`
-
-`DependenciesService` injects `FullTextSearchService` as an optional dependency to create the `EntityInfoFullText` view. Because `FullTextSearchModule` was not `@Global`, the service was not available in the (global) `DependenciesModule`'s injection scope, so the optional dependency always resolved to `undefined` and the view was silently never created.
-
-Mark `FullTextSearchModule` as `@Global` so `FullTextSearchService` is resolvable and the `EntityInfoFullText` view is created by `createBlockIndexViews`.

--- a/packages/api/cms-api/src/full-text-search/full-text-search.module.ts
+++ b/packages/api/cms-api/src/full-text-search/full-text-search.module.ts
@@ -1,5 +1,5 @@
 import { MikroOrmModule } from "@mikro-orm/nestjs";
-import { Module } from "@nestjs/common";
+import { Global, Module } from "@nestjs/common";
 
 import { EntityInfoModule } from "../entity-info/entity-info.module";
 import { EntityInfoFullTextObject } from "./entities/entity-info-full-text.object";
@@ -7,6 +7,7 @@ import { FullTextSearchResolver } from "./full-text-search.resolver";
 import { FullTextSearchService } from "./full-text-search.service";
 
 /** @experimental */
+@Global()
 @Module({
     imports: [EntityInfoModule, MikroOrmModule.forFeature([EntityInfoFullTextObject])],
     providers: [FullTextSearchService, FullTextSearchResolver],


### PR DESCRIPTION
## Summary
Mark the `FullTextSearchModule` as a global module to make its providers available throughout the application without explicit imports.

Fixes the view creation which did not happen (DependenciesService imports optional FullTextSearchService to call `await this.fullTextSearchService?.createEntityInfoFullTextView();` and that never succeeded because it is not a global module)
https://github.com/vivid-planet/comet/blob/main/packages/api/cms-api/src/dependencies/dependencies.service.ts#L37

## TODO (out of scope)
- move the grown dependencies `createViews()` to a generic location 

https://claude.ai/code/session_01DqwCu1xxL3tjr6kz8hZcVh