### PR TITLE
admin: Fix FinalFormNumberInput dirtying the form on mount when initial value is null

### DIFF
--- a/.changeset/fix-final-form-number-input-dirty-on-mount.md
+++ b/.changeset/fix-final-form-number-input-dirty-on-mount.md
@@ -1,0 +1,9 @@
+---
+"@comet/admin": patch
+---
+
+Fix `FinalFormNumberInput` dirtying the form on mount when the initial value is `null`
+
+The value-sync effect inside `FinalFormNumberInput` ran on mount and called `input.onChange(undefined)` whenever `input.value` was empty. For a form whose initial value was `null`, this silently normalized the value to `undefined`, making the field `dirty` before any user interaction and breaking dirty-tracking features such as `EditDialog`, `SaveBoundary`, and the unsaved-changes router prompt.
+
+The mount-time sync now only updates the formatted display string. The empty-input normalization to `undefined` still happens on real user interaction in `handleBlur`.

--- a/packages/admin/admin/src/form/FinalFormNumberInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormNumberInput.tsx
@@ -48,13 +48,12 @@ export function FinalFormNumberInput({
     const updateFormattedNumberValue = useCallback(
         (inputValue?: number) => {
             if (!inputValue && inputValue !== 0) {
-                input.onChange(undefined);
                 setFormattedNumberValue("");
             } else {
                 setFormattedNumberValue(getFormattedValue(inputValue));
             }
         },
-        [getFormattedValue, input],
+        [getFormattedValue],
     );
 
     const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
@@ -87,7 +86,7 @@ export function FinalFormNumberInput({
 
     useEffect(() => {
         updateFormattedNumberValue(input.value);
-    }, [updateFormattedNumberValue, input]);
+    }, [updateFormattedNumberValue, input.value]);
 
     const clearable = !required && !disabled && !readOnly;
 

--- a/packages/admin/admin/src/form/__stories__/NumberField.stories.tsx
+++ b/packages/admin/admin/src/form/__stories__/NumberField.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 
 import { Alert } from "../../alert/Alert";
 import { FinalForm } from "../../FinalForm";
@@ -11,31 +12,101 @@ const config: Meta<typeof NumberField> = {
 };
 export default config;
 
-export const Default: Story = {
-    render: () => {
-        interface FormValues {
-            value: number;
-        }
-        return (
-            <FinalForm<FormValues>
-                mode="edit"
-                onSubmit={() => {
-                    // not handled
-                }}
-                subscription={{ values: true }}
-            >
-                {({ values }) => {
-                    return (
-                        <>
-                            <NumberField name="value" label="Number Field" fullWidth variant="horizontal" />
+interface FormValues {
+    value?: number | null;
+}
 
-                            <Alert title="FormState">
-                                <pre>{JSON.stringify(values, null, 2)}</pre>
-                            </Alert>
-                        </>
-                    );
-                }}
-            </FinalForm>
-        );
+export const Default: Story = {
+    render: () => (
+        <FinalForm<FormValues>
+            mode="edit"
+            onSubmit={() => {
+                // not handled
+            }}
+            subscription={{ values: true }}
+        >
+            {({ values }) => (
+                <>
+                    <NumberField name="value" label="Number Field" fullWidth variant="horizontal" />
+
+                    <Alert title="FormState">
+                        <pre>{JSON.stringify(values, null, 2)}</pre>
+                    </Alert>
+                </>
+            )}
+        </FinalForm>
+    ),
+};
+
+const renderFormWithDirtyState = (initialValues: FormValues) => (
+    <FinalForm<FormValues>
+        mode="edit"
+        initialValues={initialValues}
+        onSubmit={() => {
+            // not handled
+        }}
+        subscription={{ values: true, dirty: true, pristine: true }}
+    >
+        {({ values, dirty, pristine }) => (
+            <>
+                <NumberField name="value" label="Number Field" fullWidth variant="horizontal" />
+
+                <Alert title="FormState">
+                    <pre data-testid="form-state">{`dirty: ${dirty}\npristine: ${pristine}\nvalue: ${JSON.stringify(values.value)}`}</pre>
+                </Alert>
+            </>
+        )}
+    </FinalForm>
+);
+
+/**
+ * Regression test: an initial `null` value must not dirty the form on mount.
+ *
+ * The mount-time value-sync used to call `input.onChange(undefined)`, silently normalising
+ * `null` → `undefined` and breaking dirty tracking before the user touched anything.
+ */
+export const InitialValueNull: Story = {
+    tags: ["test"],
+    render: () => renderFormWithDirtyState({ value: null }),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const formState = await canvas.findByTestId("form-state");
+
+        await expect(formState).toHaveTextContent("dirty: false");
+        await expect(formState).toHaveTextContent("pristine: true");
+        await expect(formState).toHaveTextContent("value: null");
+    },
+};
+
+/**
+ * Regression test: an initial `undefined` value must not dirty the form on mount.
+ */
+export const InitialValueUndefined: Story = {
+    tags: ["test"],
+    render: () => renderFormWithDirtyState({ value: undefined }),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const formState = await canvas.findByTestId("form-state");
+
+        await expect(formState).toHaveTextContent("dirty: false");
+        await expect(formState).toHaveTextContent("pristine: true");
+    },
+};
+
+/**
+ * A number initial value renders as a locale-formatted display string.
+ */
+export const InitialValueNumber: Story = {
+    tags: ["test"],
+    render: () => renderFormWithDirtyState({ value: 1234 }),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const input = canvas.getByRole<HTMLInputElement>("textbox");
+
+        await expect(input).toHaveValue("1,234");
+
+        const formState = await canvas.findByTestId("form-state");
+        await expect(formState).toHaveTextContent("dirty: false");
+        await expect(formState).toHaveTextContent("pristine: true");
     },
 };


### PR DESCRIPTION
## Problem

`FinalFormNumberInput`'s value-sync effect ran on mount and called `input.onChange(undefined)` whenever `input.value` was empty. For a form initialised with `null` (a very common shape coming back from GraphQL), this silently normalised the value to `undefined`. Because final-form compares pristine by `===`, the field reported `dirty: true` before the user had touched anything.

That broke every Comet feature that depends on dirty tracking:
- `EditDialog` and `SaveBoundary` thought there were unsaved changes
- `RouterPrompt` showed an unsaved-changes dialog on navigation away from a freshly mounted page
- Disabled-when-not-dirty save buttons appeared enabled out of the box

The deliberate `inputValue !== 0` guard in the original code shows that value fidelity was the intent, but `null` still got clobbered. The deeper problem: a controlled field mounting over an existing value should be a no-op on form state.

## Fix

`FinalFormNumberInput.tsx`: the mount sync now only updates the formatted display string. The empty-input → `undefined` normalisation still happens on real user interaction in `handleBlur` (and via the clear adornment), so the public behaviour for actual edits is unchanged. The mount effect's deps are tightened from `[…, input]` (unstable identity, re-ran every render) to `[…, input.value]`.

## Tests

Three Storybook stories under `components/form/NumberField`, tagged `test`, run as Storybook interaction tests in CI and pin the regression:

- `InitialValueNull` – `null` seed → form stays pristine, `dirty: false`
- `InitialValueUndefined` – `undefined` seed → form stays pristine
- `InitialValueNumber` – number `1234` → input renders the formatted `"1,234"` display string

## Changeset

`@comet/admin` patch.

https://claude.ai/code/session_014tjBHq8i6uXpRP8d9hgGAw