### PR TITLE
TipTap: support link blocks with migrations

### DIFF
--- a/.changeset/tiptap-rich-text-block-support-link-blocks-with-migrations.md
+++ b/.changeset/tiptap-rich-text-block-support-link-blocks-with-migrations.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-api": patch
+---
+
+Support link blocks with migrations in the TipTap rich text block
+
+A link block nested inside a TipTap rich text block (configured via the `link` option of `createTipTapRichTextBlock`) can now define block migrations.
+
+Previously, once a migration had run on the nested link block, its data carried the internal `$$version` migration metadata. This metadata is stamped into the `tipTapContent` JSON on save and was rejected by the TipTap input validator. The validator now strips `$$version` from link block data before validating it.

--- a/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.test.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.test.ts
@@ -1,8 +1,13 @@
-import { validate } from "class-validator";
+import { IsBoolean, IsOptional, validate } from "class-validator";
 import { describe, expect, it } from "vitest";
 
+import { BlockData, BlockInput, blockInputToData, createBlock, transformToBlockSave } from "../block";
+import { BlockField } from "../decorators/field";
 import { ExternalLinkBlock } from "../ExternalLinkBlock";
 import { createLinkBlock } from "../factories/createLinkBlock";
+import { BlockMigration } from "../migrations/BlockMigration";
+import { typeSafeBlockMigrationPipe } from "../migrations/typeSafeBlockMigrationPipe";
+import { IsLinkTarget } from "../validator/is-link-target.validator";
 import { createTipTapRichTextBlock } from "./createTipTapRichTextBlock";
 
 describe("createTipTapRichTextBlock validation", () => {
@@ -836,6 +841,112 @@ describe("createTipTapRichTextBlock validation", () => {
             });
             const errors = await validate(input);
             expect(errors).toHaveLength(1);
+        });
+    });
+
+    describe("schema with link block that has migrations", () => {
+        // A versioned external link block whose migration adds a `noFollow` field. Once the
+        // migration runs, the block data carries `$$version`, which is stamped into the
+        // tipTapContent JSON on save. The TipTap block must still validate such link data.
+        class VersionedExternalLinkBlockData extends BlockData {
+            @BlockField({ nullable: true })
+            targetUrl?: string;
+
+            @BlockField()
+            openInNewWindow: boolean;
+
+            @BlockField()
+            noFollow: boolean;
+        }
+
+        class VersionedExternalLinkBlockInput extends BlockInput {
+            @IsOptional()
+            @IsLinkTarget()
+            @BlockField({ nullable: true })
+            targetUrl?: string;
+
+            @IsBoolean()
+            @BlockField()
+            openInNewWindow: boolean;
+
+            @IsBoolean()
+            @BlockField()
+            noFollow: boolean;
+
+            transformToBlockData(): VersionedExternalLinkBlockData {
+                return blockInputToData(VersionedExternalLinkBlockData, this);
+            }
+        }
+
+        class AddNoFollowMigration extends BlockMigration<(from: { openInNewWindow: boolean; targetUrl?: string }) => { noFollow: boolean }> {
+            public readonly toVersion = 1;
+
+            protected migrate(from: { openInNewWindow: boolean; targetUrl?: string }) {
+                return { ...from, noFollow: false };
+            }
+        }
+
+        const VersionedExternalLinkBlock = createBlock(VersionedExternalLinkBlockData, VersionedExternalLinkBlockInput, {
+            name: "VersionedExternalLink",
+            migrate: { version: 1, migrations: typeSafeBlockMigrationPipe([AddNoFollowMigration]) },
+        });
+
+        const LinkBlock = createLinkBlock({ supportedBlocks: { external: VersionedExternalLinkBlock } }, "TestVersionedLink");
+        const block = createTipTapRichTextBlock({ link: LinkBlock }, "TestWithVersionedLink");
+
+        const contentWithLink = {
+            type: "doc",
+            content: [
+                {
+                    type: "paragraph",
+                    content: [
+                        {
+                            type: "text",
+                            marks: [
+                                {
+                                    type: "link",
+                                    attrs: {
+                                        data: {
+                                            attachedBlocks: [
+                                                {
+                                                    type: "external",
+                                                    props: { targetUrl: "https://example.com", openInNewWindow: false, noFollow: false },
+                                                },
+                                            ],
+                                            activeType: "external",
+                                        },
+                                    },
+                                },
+                            ],
+                            text: "click here",
+                        },
+                    ],
+                },
+            ],
+        };
+
+        it("validates link block data after migrations have run", async () => {
+            // blockDataFactory runs the nested block's migration, stamping `$$version` onto the data.
+            const blockData = block.blockDataFactory({ tipTapContent: contentWithLink });
+            const input = block.blockInputFactory(blockData);
+            const errors = await validate(input);
+            expect(errors).toHaveLength(0);
+        });
+
+        it("validates link block data after a save round-trip stamps the nested version", async () => {
+            const blockData = block.blockDataFactory({ tipTapContent: contentWithLink });
+            const saved = transformToBlockSave(blockData);
+
+            // The saved JSON carries `$$version` inside the nested link block props.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const savedProps = (saved as any).tipTapContent.content[0].content[0].marks[0].attrs.data.attachedBlocks[0].props;
+            expect(savedProps.$$version).toBe(1);
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const reloaded = block.blockDataFactory(saved as any);
+            const input = block.blockInputFactory(reloaded);
+            const errors = await validate(input);
+            expect(errors).toHaveLength(0);
         });
     });
 

--- a/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
@@ -213,6 +213,25 @@ function mapLinkMarksData(content: TipTapContent, fn: (data: any) => any): TipTa
     return result;
 }
 
+// Block data carries the `$$version` migration metadata once migrations have run on it.
+// Link block data is validated as block input, where `$$version` is not a known field, so it
+// must be stripped recursively before validation to avoid `forbidNonWhitelisted` errors. This
+// is what allows link blocks with migrations to be nested inside a TipTap rich text block.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function stripBlockDataVersion(value: any): any {
+    if (Array.isArray(value)) {
+        return value.map(stripBlockDataVersion);
+    }
+    if (value && typeof value === "object") {
+        return Object.fromEntries(
+            Object.entries(value)
+                .filter(([key]) => key !== "$$version")
+                .map(([key, val]) => [key, stripBlockDataVersion(val)]),
+        );
+    }
+    return value;
+}
+
 function collectLinkMarks(content: TipTapContent, basePath: string[] = ["tipTapContent"]): Array<{ data: unknown; path: string[] }> {
     const results: Array<{ data: unknown; path: string[] }> = [];
 
@@ -365,8 +384,7 @@ function IsTipTapContent(
                         if (linkBlock) {
                             const linkMarks = collectLinkMarks(value as TipTapContent);
                             for (const { data } of linkMarks) {
-                                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                const validationErrors = await validate(linkBlock.blockInputFactory(data as any), {
+                                const validationErrors = await validate(linkBlock.blockInputFactory(stripBlockDataVersion(data)), {
                                     forbidNonWhitelisted: true,
                                     whitelist: true,
                                 });


### PR DESCRIPTION
## Summary
Enable link blocks with migrations to work correctly when nested inside a TipTap rich text block. Previously, the `$$version` metadata stamped onto block data by migrations would cause validation errors.

## Changes
- **Added `stripBlockDataVersion()` helper function** in `createTipTapRichTextBlock.ts` that recursively removes the `$$version` migration metadata from block data before validation. This prevents `forbidNonWhitelisted` validation errors when link blocks with migrations are used.

- **Updated link block validation** to call `stripBlockDataVersion()` on link data before passing it to the input validator, allowing versioned link blocks to validate successfully.

- **Added comprehensive test coverage** in `createTipTapRichTextBlock.test.ts` that validates:
  - A versioned external link block with a migration that adds a `noFollow` field
  - Link block data validation after migrations have run
  - Link block data validation after a save round-trip that stamps the nested version into the JSON

## Implementation Details
The `stripBlockDataVersion()` function handles nested structures (arrays and objects) to ensure `$$version` is removed at all levels of the link block data hierarchy. This allows the TipTap validator to work with migrated link blocks while maintaining strict validation of actual block fields.

https://claude.ai/code/session_019MVSSLL2NAU5hXDs9sigAA