### PR TITLE
admin: Fix Storybook IntlDecorator order so RouterPrompt dialog gets intl

### DIFF
--- a/packages/admin/admin/.storybook/preview.ts
+++ b/packages/admin/admin/.storybook/preview.ts
@@ -52,7 +52,7 @@ export const globalTypes: GlobalTypes = {
 
 const preview: Preview = {
     tags: ["autodocs"],
-    decorators: [ThemeProviderDecorator, IntlDecorator, LayoutDecorator, RouterDecorator, ApolloDecorator],
+    decorators: [ThemeProviderDecorator, LayoutDecorator, RouterDecorator, IntlDecorator, ApolloDecorator],
     loaders: [
         async () => {
             await mswReady;


### PR DESCRIPTION
## Problem

`RouterPromptHandler` renders the navigation-confirmation dialog inside `RouterMemoryRouter`, and that dialog uses `useIntl`. Storybook applies decorators last-first (outermost), so the previous order in `packages/admin/admin/.storybook/preview.ts`

```ts
decorators: [ThemeProviderDecorator, IntlDecorator, LayoutDecorator, RouterDecorator, ApolloDecorator]
```

places `RouterDecorator` outside `IntlDecorator`. As soon as a dirty form attempted to navigate away in a story, the prompt dialog crashed with:

> Error: [React Intl] Could not find required `intl` object. `<IntlProvider>` needs to exist in the component ancestry.

## Fix

Reorder so `IntlDecorator` wraps `RouterDecorator`:

```ts
decorators: [ThemeProviderDecorator, LayoutDecorator, RouterDecorator, IntlDecorator, ApolloDecorator]
```

Story content still has Intl available because `IntlProvider` is up the tree, and the navigation-prompt dialog inside the router now has Intl available too.

https://claude.ai/code/session_014tjBHq8i6uXpRP8d9hgGAw

---
_Generated by [Claude Code](https://claude.ai/code/session_014tjBHq8i6uXpRP8d9hgGAw)_