### PR TITLE
Admin: Add SearchHeaderItem component for full-text search

### DIFF
--- a/.changeset/search-header-item.md
+++ b/.changeset/search-header-item.md
@@ -1,0 +1,19 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `SearchHeaderItem` component for full-text search
+
+The `SearchHeaderItem` component renders a search input (intended for the header) that opens a dropdown with the results of the `myFullTextSearch` query. The search is restricted to the currently selected content scope. Clicking a result opens the corresponding entity using the `entityDependencyMap` from the `DependenciesConfig` (the same mechanism used by warnings and dependencies).
+
+**Example**
+
+```tsx
+import { Header, SearchHeaderItem } from "@comet/cms-admin";
+
+<Header>
+    <SearchHeaderItem />
+    <ContentScopeControls />
+    <UserHeaderItem />
+</Header>;
+```

--- a/demo/admin/src/common/MasterHeader.tsx
+++ b/demo/admin/src/common/MasterHeader.tsx
@@ -1,8 +1,9 @@
-import { BuildEntry, ContentScopeControls, Header, UserHeaderItem } from "@comet/cms-admin";
+import { BuildEntry, ContentScopeControls, Header, SearchHeaderItem, UserHeaderItem } from "@comet/cms-admin";
 
 const MasterHeader = () => {
     return (
         <Header>
+            <SearchHeaderItem />
             <ContentScopeControls />
             <BuildEntry />
             <UserHeaderItem />

--- a/packages/admin/cms-admin/src/fullTextSearch/SearchHeaderItem.tsx
+++ b/packages/admin/cms-admin/src/fullTextSearch/SearchHeaderItem.tsx
@@ -1,0 +1,115 @@
+import { gql, useApolloClient, useQuery } from "@apollo/client";
+import { Search } from "@comet/admin-icons";
+import { Box, CircularProgress, ClickAwayListener, InputBase, List, ListItemButton, ListItemText, Paper, Popper, Typography } from "@mui/material";
+import { useRef, useState } from "react";
+import { FormattedMessage } from "react-intl";
+import { useHistory } from "react-router";
+import { useDebounce } from "use-debounce";
+
+import { useContentScope } from "../contentScope/Provider";
+import { useDependenciesConfig } from "../dependencies/dependenciesConfig";
+import type { DependencyInterface } from "../dependencies/types";
+import { useUserPermissionCheck } from "../userPermissions/hooks/currentUser";
+import type { GQLSearchHeaderItemQuery, GQLSearchHeaderItemQueryVariables } from "./SearchHeaderItem.generated";
+
+const searchQuery = gql`
+    query SearchHeaderItem($search: String!, $scope: JSONObject) {
+        myFullTextSearch(search: $search, scope: $scope, limit: 10) {
+            nodes {
+                id
+                entityName
+                name
+                secondaryInformation
+            }
+            totalCount
+        }
+    }
+`;
+
+export function SearchHeaderItem() {
+    const history = useHistory();
+    const apolloClient = useApolloClient();
+    const contentScope = useContentScope();
+    const { entityDependencyMap } = useDependenciesConfig();
+    const isAllowed = useUserPermissionCheck();
+
+    const [search, setSearch] = useState("");
+    const [open, setOpen] = useState(false);
+    const anchorRef = useRef<HTMLDivElement>(null);
+
+    const [debouncedSearch] = useDebounce(search, 250);
+
+    const { data, loading } = useQuery<GQLSearchHeaderItemQuery, GQLSearchHeaderItemQueryVariables>(searchQuery, {
+        variables: { search: debouncedSearch, scope: contentScope.scope },
+        skip: debouncedSearch.length === 0 || !isAllowed("fullTextSearch"),
+    });
+
+    if (!isAllowed("fullTextSearch")) {
+        return null;
+    }
+
+    const results = data?.myFullTextSearch.nodes ?? [];
+
+    const navigateToResult = async (result: { id: string; entityName: string }) => {
+        const dependency = entityDependencyMap[result.entityName] as DependencyInterface | undefined;
+        if (!dependency) {
+            return;
+        }
+        const path = await dependency.resolvePath({ apolloClient, id: result.id });
+        setOpen(false);
+        history.push(contentScope.match.url + path);
+    };
+
+    return (
+        <ClickAwayListener onClickAway={() => setOpen(false)}>
+            <Box ref={anchorRef} sx={{ position: "relative" }}>
+                <InputBase
+                    value={search}
+                    onChange={(event) => {
+                        setSearch(event.target.value);
+                        setOpen(true);
+                    }}
+                    onFocus={() => setOpen(true)}
+                    placeholder=""
+                    startAdornment={<Search sx={{ mr: 1 }} />}
+                    sx={{
+                        backgroundColor: "rgba(255, 255, 255, 0.15)",
+                        borderRadius: 1,
+                        color: "white",
+                        px: 2,
+                        py: 0.5,
+                        width: 240,
+                    }}
+                />
+                <Popper open={open && search.length > 0} anchorEl={anchorRef.current} placement="bottom-end" sx={{ zIndex: "tooltip" }}>
+                    <Paper elevation={4} sx={{ mt: 1, width: 360, maxHeight: 400, overflowY: "auto" }}>
+                        {loading ? (
+                            <Box sx={{ display: "flex", justifyContent: "center", p: 2 }}>
+                                <CircularProgress size={20} />
+                            </Box>
+                        ) : results.length === 0 ? (
+                            <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+                                <FormattedMessage id="comet.fullTextSearch.noResults" defaultMessage="No results found" />
+                            </Typography>
+                        ) : (
+                            <List disablePadding>
+                                {results.map((result) => {
+                                    const isLinkable = entityDependencyMap[result.entityName] !== undefined;
+                                    return (
+                                        <ListItemButton
+                                            key={`${result.entityName}:${result.id}`}
+                                            disabled={!isLinkable}
+                                            onClick={() => navigateToResult(result)}
+                                        >
+                                            <ListItemText primary={result.name} secondary={result.secondaryInformation} />
+                                        </ListItemButton>
+                                    );
+                                })}
+                            </List>
+                        )}
+                    </Paper>
+                </Popper>
+            </Box>
+        </ClickAwayListener>
+    );
+}

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -174,6 +174,7 @@ export {
 export { createDocumentRootBlocksMethods } from "./documents/createDocumentRootBlocksMethods";
 export type { DocumentInterface, DocumentType, InfoTagProps, SitePreviewActionProps } from "./documents/types";
 export { ChooseDamFileDialog } from "./form/file/chooseFile/ChooseDamFileDialog";
+export { SearchHeaderItem } from "./fullTextSearch/SearchHeaderItem";
 /** @deprecated Use `ChooseDamFileDialog` instead. */
 export { ChooseDamFileDialog as ChooseFileDialog } from "./form/file/chooseFile/ChooseDamFileDialog";
 export { ChooseDamFilesDialog } from "./form/file/chooseFile/ChooseDamFilesDialog";


### PR DESCRIPTION
## Summary
Introduces a new `SearchHeaderItem` component that provides full-text search functionality in the CMS admin header. The component displays a search input that opens a dropdown with search results, allowing users to quickly navigate to entities across the system.

## Key Changes
- **New `SearchHeaderItem` component** (`packages/admin/cms-admin/src/fullTextSearch/SearchHeaderItem.tsx`):
  - Renders a search input with icon in the header
  - Executes `myFullTextSearch` GraphQL query with 250ms debounce
  - Displays results in a dropdown popper with up to 10 items
  - Respects content scope filtering
  - Navigates to results using the `entityDependencyMap` from `DependenciesConfig`
  - Includes permission check via `useUserPermissionCheck` hook
  - Handles loading and empty states with appropriate UI feedback

- **Export addition** (`packages/admin/cms-admin/src/index.ts`):
  - Exports `SearchHeaderItem` component for public API

- **Demo integration** (`demo/admin/src/common/MasterHeader.tsx`):
  - Integrated `SearchHeaderItem` into the master header between `ContentScopeControls` and `BuildEntry`

## Implementation Details
- Uses Apollo Client&#39;s `useQuery` hook with skip condition to avoid unnecessary queries
- Implements `ClickAwayListener` to close dropdown when clicking outside
- Disables result items that don&#39;t have a corresponding dependency mapping
- Integrates with existing permission and dependency systems for consistency
- Includes i18n support for &#34;no results&#34; message

## Screenshots

**Global search dropdown — results scoped to the selected content scope ("Comet Site Main / En")**

![Global search dropdown with scoped results](https://raw.githubusercontent.com/vivid-planet/comet/assets/pr-5834/global-search-dropdown.png)

**Clicking a result opens that entity within the current scope**

![Clicking a result opens the entity](https://raw.githubusercontent.com/vivid-planet/comet/assets/pr-5834/global-search-opened-entity.png)

https://claude.ai/code/session_011FVmy91vPWebnc1trnGjkk