### PR TITLE
Migrate router stories to @comet/admin package Storybook

### DIFF
--- a/packages/admin/admin/src/router/__stories__/ForcePromptRoute.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/ForcePromptRoute.stories.tsx
@@ -1,9 +1,9 @@
-import { ForcePromptRoute, RouterPrompt } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { ForcePromptRoute } from "../ForcePromptRoute";
+import { RouterPrompt } from "../Prompt";
 
 function Story() {
     return (
@@ -52,8 +52,7 @@ function Path() {
 }
 
 export default {
-    title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
+    title: "components/router/ForcePromptRoute",
 };
 
 export const _ForcePromptRoute = {

--- a/packages/admin/admin/src/router/__stories__/RouterPrompt.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/RouterPrompt.stories.tsx
@@ -1,9 +1,8 @@
-import { RouterPrompt } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { RouterPrompt } from "../Prompt";
 
 function Story() {
     return (
@@ -43,8 +42,7 @@ function Path() {
 }
 
 export default {
-    title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
+    title: "components/router/RouterPrompt",
 };
 
 export const NestedRouteWithNonSubPathRouteInPrompt = {

--- a/packages/admin/admin/src/router/__stories__/SubRoute.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/SubRoute.stories.tsx
@@ -1,9 +1,8 @@
-import { SubRoute, SubRouteIndexRoute, useSubRoutePrefix } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation, useRouteMatch } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { SubRoute, SubRouteIndexRoute, useSubRoutePrefix } from "../SubRoute";
 
 function Cmp1() {
     const urlPrefix = useSubRoutePrefix();
@@ -80,8 +79,7 @@ function Path() {
 }
 
 export default {
-    title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
+    title: "components/router/SubRoute",
 };
 
 export const Subroute = () => {

--- a/packages/admin/admin/src/router/__stories__/SubRouteNestedIndex.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/SubRouteNestedIndex.stories.tsx
@@ -1,9 +1,8 @@
-import { SubRouteIndexRoute, useSubRoutePrefix } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { SubRouteIndexRoute, useSubRoutePrefix } from "../SubRoute";
 
 function Cmp1() {
     const urlPrefix = useSubRoutePrefix();
@@ -48,8 +47,7 @@ function Path() {
 }
 
 export default {
-    title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
+    title: "components/router/SubRouteNestedIndex",
 };
 
 export const SubrouteNestedIndex = {


### PR DESCRIPTION
## Summary

Migrate router/navigation stories from the global `/storybook` directory into the `@comet/admin` package Storybook.

**Domain:** Router / Navigation
**Target package:** `@comet/admin` (`packages/admin/admin/`)

### Migrated components

| Story file | Target |
|---|---|
| `storybook/src/admin/router/ForcePromptRoute.stories.tsx` | `packages/admin/admin/src/router/__stories__/ForcePromptRoute.stories.tsx` |
| `storybook/src/admin/router/Prompt.stories.tsx` | `packages/admin/admin/src/router/__stories__/RouterPrompt.stories.tsx` |
| `storybook/src/admin/router/SubRoute.stories.tsx` | `packages/admin/admin/src/router/__stories__/SubRoute.stories.tsx` |
| `storybook/src/admin/router/SubRouteNestedIndex.stories.tsx` | `packages/admin/admin/src/router/__stories__/SubRouteNestedIndex.stories.tsx` |

### Changes per story

- `@comet/admin` package imports replaced with relative imports
- `storyRouterDecorator` removed — `RouterDecorator` is already a global decorator in the `@comet/admin` storybook preview (and `RouterMemoryRouter` already includes `RouterPromptHandler`, so prompt functionality works out of the box)
- Story titles updated to match the package convention: `components/router/*`

https://claude.ai/code/session_01Qun3gBiAXZQjyLnANMroC8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qun3gBiAXZQjyLnANMroC8)_