### PR TITLE
Loosen abbreviation guideline to allow obvious abbreviations

### DIFF
--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -8,7 +8,7 @@ Follow the coding guidelines at https://docs.comet-dxp.com/docs/coding-guideline
 
 ### General
 
-- Use descriptive naming. Avoid abbreviations (exceptions: well-known abbreviations such as HTML, CSS, API, …, or abbreviations from a 3rd party).
+- Use descriptive naming. Avoid non-obvious abbreviations (exceptions: obvious, conventional abbreviations whose meaning is unambiguous in context such as `i` for an index, well-known abbreviations such as HTML, CSS, API, …, or abbreviations from a 3rd party).
 - Name booleans with a prefix (is/has/should, e.g., `isLoading`, `hasError`).
 - Name variables in affirmative form (avoid negative naming, e.g., use `isComplete` instead of `isNotComplete`).
 - Don't use exceptions as flow control.

--- a/docs/docs/9-coding-guidelines/02-general.md
+++ b/docs/docs/9-coding-guidelines/02-general.md
@@ -79,14 +79,17 @@ const isComplete = true;
 
 :::
 
-## Don’t use Abbreviations
+## Avoid Non-Obvious Abbreviations
 
 Abbreviations make it harder read code. Even more for new Devs or Devs who are not regularly working on that project.
 
 > It’s better to save time thinking than to save time typing.
 
+Avoid non-obvious abbreviations. Obvious, conventional abbreviations whose meaning is unambiguous in context are fine. When in doubt, spell it out.
+
 ### Exceptions:
 
+- Obvious, conventional abbreviations whose meaning is unambiguous in context (e.g. `i` for a loop index, `id`, `ref`, `props`)
 - Well-known abbreviations such as protocols (HTML, CSS, TCP, IP, SSO, API, …)
 - Abbreviations coming from a 3rd party (API, Library, …)
 

--- a/rules/coding-guidelines/general.instructions.md
+++ b/rules/coding-guidelines/general.instructions.md
@@ -16,7 +16,7 @@ alwaysApply: false
 - Prefer descriptive identifiers over explanatory comments — comments drift out of sync with the code.
 - Boolean variables must read as booleans: prefix with `is` / `has` / `should` (exceptions: well-known flags like `loading`, `disabled`).
 - Name booleans in the **affirmative**: `isComplete`, not `isNotComplete`. Negate at the use site with `!`.
-- Do **not** use abbreviations. Exceptions: widely-known protocols/acronyms (HTML, CSS, TCP, API, SSO…) and names dictated by third parties.
+- Avoid non-obvious abbreviations. Exceptions: obvious, conventional abbreviations whose meaning is unambiguous in context (e.g. `i` for an index, `id`, `ref`, `props`), widely-known protocols/acronyms (HTML, CSS, TCP, API, SSO…), and names dictated by third parties. When in doubt, spell it out.
 - When an acronym appears in PascalCase / camelCase, treat it like a word: `GuiController`, `UiElement` — not `GUIController` / `UIElement`.
 
 ## Control flow


### PR DESCRIPTION
Permit obvious, conventional abbreviations whose meaning is unambiguous in context (e.g. i for a loop index) while still disallowing non-obvious ones. Update the agent rule and Copilot review instructions to match.

https://claude.ai/code/session_01GeJdnfWnKiYwefF8h91TRx