### PR TITLE
Migrate router stories to @comet/admin package Storybook

### DIFF
--- a/packages/admin/admin/src/router/__stories__/ForcePromptRoute.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/ForcePromptRoute.stories.tsx
@@ -1,9 +1,9 @@
-import { ForcePromptRoute, RouterPrompt } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { ForcePromptRoute } from "../ForcePromptRoute";
+import { RouterPrompt } from "../Prompt";
 
 function Story() {
     return (
@@ -52,8 +52,7 @@ function Path() {
 }
 
 export default {
-    title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
+    title: "components/router/ForcePromptRoute",
 };
 
 export const _ForcePromptRoute = {

--- a/packages/admin/admin/src/router/__stories__/Prompt.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/Prompt.stories.tsx
@@ -1,9 +1,8 @@
-import { RouterPrompt } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { RouterPrompt } from "../Prompt";
 
 function Story() {
     return (
@@ -43,8 +42,7 @@ function Path() {
 }
 
 export default {
-    title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
+    title: "components/router/Prompt",
 };
 
 export const NestedRouteWithNonSubPathRouteInPrompt = {

--- a/packages/admin/admin/src/router/__stories__/SubRoute.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/SubRoute.stories.tsx
@@ -1,9 +1,8 @@
-import { SubRoute, SubRouteIndexRoute, useSubRoutePrefix } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation, useRouteMatch } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { SubRoute, SubRouteIndexRoute, useSubRoutePrefix } from "../SubRoute";
 
 function Cmp1() {
     const urlPrefix = useSubRoutePrefix();
@@ -80,8 +79,7 @@ function Path() {
 }
 
 export default {
-    title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
+    title: "components/router/SubRoute",
 };
 
 export const Subroute = () => {

--- a/packages/admin/admin/src/router/__stories__/SubRouteNestedIndex.stories.tsx
+++ b/packages/admin/admin/src/router/__stories__/SubRouteNestedIndex.stories.tsx
@@ -1,9 +1,8 @@
-import { SubRouteIndexRoute, useSubRoutePrefix } from "@comet/admin";
 import { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
-import { storyRouterDecorator } from "../../story-router.decorator";
+import { SubRouteIndexRoute, useSubRoutePrefix } from "../SubRoute";
 
 function Cmp1() {
     const urlPrefix = useSubRoutePrefix();
@@ -48,8 +47,7 @@ function Path() {
 }
 
 export default {
-    title: "@comet/admin/router",
-    decorators: [storyRouterDecorator()],
+    title: "components/router/SubRouteNestedIndex",
 };
 
 export const SubrouteNestedIndex = {


### PR DESCRIPTION
## Summary

Migrates router-related stories from the global `/storybook` directory into the dedicated Storybook of `@comet/admin` (`packages/admin/admin/src/router/__stories__/`).

**Migrated components:**
- `RouterPrompt` → `components/router/Prompt`
- `ForcePromptRoute` → `components/router/ForcePromptRoute`
- `SubRoute` / `SubRouteIndexRoute` / `useSubRoutePrefix` → `components/router/SubRoute`
- `SubRouteNestedIndex` → `components/router/SubRouteNestedIndex`

**Changes per story:**
- Converted `@comet/admin` imports to relative imports
- Removed explicit `storyRouterDecorator` usage — the package Storybook already provides `RouterDecorator` globally
- Updated story titles from `@comet/admin/router` to `components/router/...` to match the package Storybook naming convention

## Open TODOs/questions

None — stories are a direct move with minimal adjustments.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrrRSYi6A2CpSAAUK5jzhC)_