### PR TITLE
Document the `MjmlButton` and `HtmlButton` components

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
@@ -448,6 +448,39 @@ A `backgroundImage` (typically a gradient) renders on top of `backgroundColor`. 
 
 **CSS class names:** `.mjmlDivider`, `.htmlDivider`, and `.mjmlDivider--{variant}` / `.htmlDivider--{variant}`.
 
+## Button
+
+`MjmlButton` and `HtmlButton` render a themed button. Use `MjmlButton` inside an `MjmlColumn`; use `HtmlButton` inside an [ending tag](./1-email-basics.md#ending-tags) or outside the MJML context. Both default `href` to `#` and `target` to `_blank`. Style them through `theme.button` — base styles plus named `variant`s with an optional `defaultVariant`.
+
+```ts title="theme.ts"
+const theme = createTheme({
+    button: {
+        defaultVariant: "primary",
+        variants: {
+            primary: { backgroundColor: "#5B4FC7", color: "#FFFFFF" },
+            gradient: {
+                backgroundColor: "#5B4FC7",
+                backgroundImage: "linear-gradient(90deg, #5B4FC7, #9C5BC7)",
+            },
+        },
+    },
+});
+```
+
+```tsx
+<MjmlButton variant="gradient" href="https://example.com">
+    Click me
+</MjmlButton>
+```
+
+The `variant` prop requires a `ThemeProvider` or `MjmlMailRoot` ancestor. Set `fullWidth` to make the button span its container.
+
+`theme.button.padding` is the inner spacing around the label. On `MjmlButton`, the separate `padding` prop is the outer spacing between the button and the surrounding content.
+
+A `backgroundImage` (typically a gradient) renders on top of `backgroundColor`. Clients that ignore `background-image`, such as Outlook, fall back to the solid color, so set both when using a gradient. Outlook ignores `border-radius` as well, so a rounded button renders with square corners there (see [Email Basics](./1-email-basics.md)).
+
+**CSS class names:** `.mjmlButton`, `.htmlButton`, `.mjmlButton--{variant}` / `.htmlButton--{variant}`, and `.mjmlButton--fullWidth` / `.htmlButton--fullWidth`.
+
 ## Scoped Theming
 
 `ThemeProvider` makes a theme available to its children via React context. `MjmlMailRoot` uses it internally, so you don't need it for the top-level theme. Its main use case is **scoped theming** — applying a different theme to a subsection of the email.

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -268,7 +268,7 @@ const config: Config = { assetBaseUrl: process.env.ASSET_BASE_URL };
 | `MjmlText`            | Themed text block with typography variants                         | `.mjmlText`, `.mjmlText--{variant}`, `.mjmlText--bottomSpacing` |
 | `MjmlImage`           | Responsive image                                                   | `.mjmlImage`                                                    |
 | `MjmlPixelImageBlock` | Renders a Comet CMS `PixelImageBlockData` via `MjmlImage`          | `.mjmlPixelImageBlock`                                          |
-| `MjmlButton`          | Button (ending tag)                                                | —                                                               |
+| `MjmlButton`          | Themed button (ending tag), theme styling and variants             | `.mjmlButton`, `.mjmlButton--{variant}`                         |
 | `MjmlDivider`         | Themed horizontal divider, configurable through theme and variants | `.mjmlDivider`, `.mjmlDivider--{variant}`                       |
 | `MjmlSpacer`          | Vertical spacing                                                   | —                                                               |
 | `MjmlRaw`             | Raw HTML escape hatch (ending tag)                                 | —                                                               |
@@ -281,6 +281,7 @@ const config: Config = { assetBaseUrl: process.env.ASSET_BASE_URL };
 | `HtmlInlineLink`      | `<a>` that inherits parent text styles, works in Outlook           | `.htmlInlineLink`                                               |
 | `HtmlImage`           | Responsive image (`<img>`)                                         | `.htmlImage`                                                    |
 | `HtmlPixelImageBlock` | Renders a Comet CMS `PixelImageBlockData` as `<img>`               | `.htmlPixelImageBlock`                                          |
+| `HtmlButton`          | Themed button for ending tags or non-MJML contexts                 | `.htmlButton`, `.htmlButton--{variant}`                         |
 | `HtmlDivider`         | Themed horizontal divider, configurable through theme and variants | `.htmlDivider`, `.htmlDivider--{variant}`                       |
 
 Variants are named typography presets (font size, weight, line height, color) defined in the theme; their values can change per breakpoint.

--- a/skills/comet-mail-react/references/components-and-theme.md
+++ b/skills/comet-mail-react/references/components-and-theme.md
@@ -13,8 +13,9 @@ Theme system, module augmentation, scoped theming, and the component behavior fo
 7. [HtmlInlineLink](#htmlinlinelink)
 8. [Image](#image)
 9. [Divider](#divider)
-10. [Scoped Theming](#scoped-theming)
-11. [MJML Component Re-exports](#mjml-component-re-exports)
+10. [Button](#button)
+11. [Scoped Theming](#scoped-theming)
+12. [MJML Component Re-exports](#mjml-component-re-exports)
 
 ---
 
@@ -113,6 +114,34 @@ declare module "@comet/mail-react" {
 ```
 
 Variant properties (`height`, `backgroundColor`, `backgroundImage`) accept responsive values.
+
+### ButtonVariants
+
+Controls the `variant` prop on `MjmlButton` and `HtmlButton`:
+
+```ts
+const theme = createTheme({
+    button: {
+        defaultVariant: "primary",
+        variants: {
+            primary: { backgroundColor: "#5B4FC7", color: "#FFFFFF" },
+            gradient: {
+                backgroundColor: "#5B4FC7",
+                backgroundImage: "linear-gradient(90deg, #5B4FC7, #9C5BC7)",
+            },
+        },
+    },
+});
+
+declare module "@comet/mail-react" {
+    interface ButtonVariants {
+        primary: true;
+        gradient: true;
+    }
+}
+```
+
+Variant properties (`color`, `backgroundColor`, `backgroundImage`, `border`, `borderRadius`, `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `padding`) accept responsive values.
 
 ### ThemeBreakpoints
 
@@ -324,6 +353,23 @@ Themed horizontal line, styled from `theme.divider` (base styles plus variants).
 
 ---
 
+## Button
+
+Themed button, styled from `theme.button` (base styles plus variants). Falls back to a built-in default when no theme is in scope; only `variant` requires a theme.
+
+- **`MjmlButton`** — inside `MjmlColumn`. Classes `.mjmlButton`, `.mjmlButton--{variant}`, `.mjmlButton--fullWidth`.
+- **`HtmlButton`** — inside ending tags (`MjmlRaw`) or any non-MJML context. Classes `.htmlButton`, `.htmlButton--{variant}`, `.htmlButton--fullWidth`.
+
+`theme.button.padding` is the inner spacing around the label; `MjmlButton`'s `padding` prop is the outer spacing. `fullWidth` makes the button span its container. A gradient `backgroundImage` overlays the solid `backgroundColor`, which stays the fallback for clients that drop `background-image` (Outlook). Outlook ignores `border-radius`, so rounded buttons render with square corners there.
+
+```tsx
+<MjmlButton variant="primary" fullWidth href="https://example.com">
+    Click me
+</MjmlButton>
+```
+
+---
+
 ## Scoped Theming
 
 `ThemeProvider` applies a different theme to a subtree. Common use: dark-background sections.
@@ -380,6 +426,6 @@ Theme-aware `registerStyles` entries always resolve against the **root theme** f
 
 `@comet/mail-react` re-exports all MJML components from `@faire/mjml-react`. Consumers import everything from `@comet/mail-react` — never from `@faire/mjml-react` directly.
 
-Common re-exports: `MjmlColumn`, `MjmlButton`, `MjmlSpacer`, `MjmlTable`, `MjmlRaw`, `MjmlGroup`, `MjmlAttributes`, `MjmlAll`, `MjmlClass`, `MjmlStyle`, `MjmlComment`, `MjmlConditionalComment`.
+Common re-exports: `MjmlColumn`, `MjmlSpacer`, `MjmlTable`, `MjmlRaw`, `MjmlGroup`, `MjmlAttributes`, `MjmlAll`, `MjmlClass`, `MjmlStyle`, `MjmlComment`, `MjmlConditionalComment`.
 
 For the full MJML tag reference: https://documentation.mjml.io/


### PR DESCRIPTION
The themed `MjmlButton` and `HtmlButton` components shipped with their documentation deferred to a follow-up. Without it, email authors have no guidance on theming buttons, choosing between the two components, or the Outlook constraints that make buttons behave differently from other content, and the agent skill still treats `MjmlButton` as a plain re-export.

- **The skill's re-export list excludes components the package replaces with its own themed wrappers.** A wrapper listed as a re-export tells skill readers to expect the upstream untyped API instead of the themed one.

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-11717