### PR TITLE
Make fullTextSearch query require explicit permissions argument

### DIFF
--- a/.changeset/add-required-permission-to-entity-info.md
+++ b/.changeset/add-required-permission-to-entity-info.md
@@ -6,7 +6,7 @@ Filter `fullTextSearch` results by the entity's required permission
 
 The `requiredPermission` of an entity (declared via the `@RequiredPermission` decorator) is now included in both the `EntityInfo` and `EntityInfoFullText` SQL views.
 
-The `fullTextSearch` query now filters results based on the current user's permissions, only returning entities where the user has the required permission. Entries without a required permission are excluded from results, as the permission cannot be determined.
+The `fullTextSearch` query now requires a `requiredPermissions` argument and only returns entities whose required permission is included in it. This makes the query idempotent: it returns the same results for all users, regardless of their individual permissions. The current user is still validated against the passed `requiredPermissions` — requesting a permission the user doesn't have results in a `ForbiddenException`. Entries without a required permission are excluded from results, as the permission cannot be determined.
 
 **Example usage:**
 

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -1976,7 +1976,7 @@ type Query {
   damMediaAlternatives(alternative: ID, for: ID, limit: Int! = 25, offset: Int! = 0, search: String, sort: [DamMediaAlternativeSort!], type: DamMediaAlternativeType): PaginatedDamMediaAlternatives!
   findCopiesOfFileInScope(id: ID!, imageCropArea: ImageCropAreaInput, scope: DamScopeInput!): [DamFile!]!
   footer(scope: FooterScopeInput!): Footer
-  fullTextSearch(limit: Int! = 25, offset: Int! = 0, search: String!): PaginatedEntityInfo!
+  fullTextSearch(limit: Int! = 25, offset: Int! = 0, requiredPermissions: [Permission!]!, search: String!): PaginatedEntityInfo!
   isBrevoConfigDefined(scope: EmailCampaignContentScopeInput!): Boolean!
   kubernetesCronJob(name: String!): KubernetesCronJob!
   kubernetesCronJobs: [KubernetesCronJob!]!

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -565,7 +565,7 @@ type Query {
   warnings(offset: Int! = 0, limit: Int! = 25, status: [WarningStatus!]! = [open], search: String, scopes: [JSONObject!]!, filter: WarningFilter, sort: [WarningSort!]): PaginatedWarnings!
   damMediaAlternative(id: ID!): DamMediaAlternative!
   damMediaAlternatives(offset: Int! = 0, limit: Int! = 25, search: String, sort: [DamMediaAlternativeSort!], for: ID, alternative: ID, type: DamMediaAlternativeType): PaginatedDamMediaAlternatives!
-  fullTextSearch(search: String!, offset: Int! = 0, limit: Int! = 25): PaginatedEntityInfo!
+  fullTextSearch(search: String!, requiredPermissions: [Permission!]!, offset: Int! = 0, limit: Int! = 25): PaginatedEntityInfo!
 }
 
 input RedirectScopeInput {

--- a/packages/api/cms-api/src/full-text-search/full-text-search.resolver.ts
+++ b/packages/api/cms-api/src/full-text-search/full-text-search.resolver.ts
@@ -1,36 +1,42 @@
 import { EntityManager } from "@mikro-orm/postgresql";
+import { ForbiddenException, Inject } from "@nestjs/common";
 import { Args, Int, Query, Resolver } from "@nestjs/graphql";
 
 import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
 import { EntityInfoObject } from "../entity-info/entity-info.object";
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { CurrentUser } from "../user-permissions/dto/current-user";
+import { ACCESS_CONTROL_SERVICE } from "../user-permissions/user-permissions.constants";
+import { AccessControlServiceInterface, CombinedPermission, Permission } from "../user-permissions/user-permissions.types";
 import { PaginatedEntityInfo } from "./dto/paginated-entity-info";
 import { EntityInfoFullTextObject } from "./entities/entity-info-full-text.object";
 
 @Resolver(() => EntityInfoObject)
 @RequiredPermission("fullTextSearch", { skipScopeCheck: true })
 export class FullTextSearchResolver {
-    constructor(private readonly entityManager: EntityManager) {}
+    constructor(
+        private readonly entityManager: EntityManager,
+        @Inject(ACCESS_CONTROL_SERVICE) private readonly accessControlService: AccessControlServiceInterface,
+    ) {}
 
     @Query(() => PaginatedEntityInfo)
     async fullTextSearch(
         @Args("search") search: string,
+        @Args("requiredPermissions", { type: () => [CombinedPermission] }) requiredPermissions: Permission[],
         @Args("offset", { type: () => Int, defaultValue: 0 }) offset: number,
         @Args("limit", { type: () => Int, defaultValue: 25 }) limit: number,
         @GetCurrentUser() user: CurrentUser,
     ): Promise<PaginatedEntityInfo> {
-        const allowedPermissions = user.permissions.map((p) => p.permission);
-
-        if (allowedPermissions.length === 0) {
-            return new PaginatedEntityInfo([], 0);
+        const missingPermission = requiredPermissions.find((permission) => !this.accessControlService.isAllowed(user, permission));
+        if (missingPermission) {
+            throw new ForbiddenException(`User does not have the required permission "${missingPermission}".`);
         }
 
         const [matches, totalCount] = await this.entityManager.findAndCount(
             EntityInfoFullTextObject,
             {
                 fullText: { $fulltext: search },
-                requiredPermission: { $overlap: allowedPermissions },
+                requiredPermission: { $overlap: requiredPermissions },
             },
             { offset, limit },
         );


### PR DESCRIPTION
alternative to #5849

## Summary
Changed the `fullTextSearch` query to require an explicit `requiredPermissions` argument instead of implicitly filtering by the current user's permissions. This makes the query idempotent and allows callers to explicitly specify which permissions to filter by, while still validating that the user has those permissions.


https://claude.ai/code/session_017BmvZmA4L3w6V8trWEBPSY