### PR TITLE
Demo: honor IDP_PORT environment variable in dev-oidc-provider config

### DIFF
--- a/dev-oidc-provider.config.mts
+++ b/dev-oidc-provider.config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from "@comet/dev-oidc-provider";
 import { staticUsers } from "./demo/api/src/auth/static-users";
 
 export default defineConfig({
+    port: process.env.IDP_PORT ? Number(process.env.IDP_PORT) : 8080,
     userProvider: () => staticUsers,
     client: {
         client_id: process.env.IDP_CLIENT_ID,


### PR DESCRIPTION
The local IDP's port can be set using the `IDP_PORT` environment variable, but the value wasn't used in the dev-oidc-provider's config.