### PR TITLE
mail-react: Consolidate responsive variant CSS generation into a shared helper

### DIFF
--- a/packages/mail-react/src/components/button/generateResponsiveButtonCss.ts
+++ b/packages/mail-react/src/components/button/generateResponsiveButtonCss.ts
@@ -1,18 +1,17 @@
-import { getResponsiveOverrides } from "../../theme/responsiveValue.js";
-import type { ButtonVariantStyles, Theme, ThemeBreakpoints } from "../../theme/themeTypes.js";
-import { css } from "../../utils/css.js";
+import { generateResponsiveVariantCss, type ResponsiveVariantProperties } from "../../styles/generateResponsiveVariantCss.js";
+import type { ButtonVariantStyles, Theme } from "../../theme/themeTypes.js";
 
-const buttonCssProperties: ReadonlyArray<[keyof ButtonVariantStyles, string]> = [
-    ["color", "color"],
-    ["backgroundColor", "background-color"],
-    ["backgroundImage", "background-image"],
-    ["border", "border"],
-    ["borderRadius", "border-radius"],
-    ["fontFamily", "font-family"],
-    ["fontSize", "font-size"],
-    ["fontWeight", "font-weight"],
-    ["lineHeight", "line-height"],
-    ["padding", "padding"],
+const buttonProperties: ResponsiveVariantProperties<ButtonVariantStyles> = [
+    "color",
+    "backgroundColor",
+    "backgroundImage",
+    "border",
+    "borderRadius",
+    "fontFamily",
+    "fontSize",
+    "fontWeight",
+    "lineHeight",
+    "padding",
 ];
 
 interface GenerateResponsiveButtonCssOptions {
@@ -22,48 +21,9 @@ interface GenerateResponsiveButtonCssOptions {
 
 /** Generates responsive CSS media queries for button variant overrides. */
 export function generateResponsiveButtonCss(theme: Theme, options: GenerateResponsiveButtonCssOptions): string {
-    const { variants } = theme.button;
-    if (!variants) {
-        return css``;
-    }
-
-    const cssChunks: string[] = [];
-
-    for (const [variantName, variantStyles] of Object.entries(variants)) {
-        if (!variantStyles) {
-            continue;
-        }
-
-        const overrides = new Map<keyof ThemeBreakpoints, string[]>();
-
-        for (const [themeKey, cssProperty] of buttonCssProperties) {
-            const value = variantStyles[themeKey];
-            if (value === undefined) {
-                continue;
-            }
-
-            for (const { breakpointKey, value: breakpointValue } of getResponsiveOverrides(value)) {
-                const declarations = overrides.get(breakpointKey) ?? [];
-                declarations.push(`${cssProperty}: ${String(breakpointValue)} !important`);
-                overrides.set(breakpointKey, declarations);
-            }
-        }
-
-        for (const [breakpointKey, declarations] of overrides) {
-            const breakpoint = theme.breakpoints[breakpointKey];
-            if (!breakpoint) {
-                continue;
-            }
-
-            cssChunks.push(css`
-                ${breakpoint.belowMediaQuery} {
-                    ${options.styleSelector(variantName)} {
-                        ${declarations.join(";\n")}
-                    }
-                }
-            `);
-        }
-    }
-
-    return cssChunks.join("\n");
+    return generateResponsiveVariantCss<ButtonVariantStyles>({
+        breakpoints: theme.breakpoints,
+        variants: theme.button.variants,
+        groups: [{ selector: options.styleSelector, properties: buttonProperties }],
+    });
 }

--- a/packages/mail-react/src/components/divider/generateResponsiveDividerCss.ts
+++ b/packages/mail-react/src/components/divider/generateResponsiveDividerCss.ts
@@ -1,12 +1,11 @@
-import { getResponsiveOverrides } from "../../theme/responsiveValue.js";
-import type { DividerVariantStyles, Theme, ThemeBreakpoints } from "../../theme/themeTypes.js";
-import { css } from "../../utils/css.js";
+import { generateResponsiveVariantCss, type ResponsiveVariantProperties } from "../../styles/generateResponsiveVariantCss.js";
+import type { DividerVariantStyles, Theme } from "../../theme/themeTypes.js";
 
-type ColorPropertyKey = Exclude<keyof DividerVariantStyles, "height">;
-
-const colorCssProperties: ReadonlyArray<[ColorPropertyKey, string]> = [
-    ["backgroundColor", "background-color"],
-    ["backgroundImage", "background-image"],
+const dividerProperties: ResponsiveVariantProperties<DividerVariantStyles> = [
+    // line-height matches height so Outlook honors the declared cell height.
+    { themeKey: "height", cssProperties: ["height", "line-height"], unit: "px" },
+    "backgroundColor",
+    "backgroundImage",
 ];
 
 interface GenerateResponsiveDividerCssOptions {
@@ -16,59 +15,9 @@ interface GenerateResponsiveDividerCssOptions {
 
 /** Generates responsive CSS media queries for divider variant overrides. */
 export function generateResponsiveDividerCss(theme: Theme, options: GenerateResponsiveDividerCssOptions): string {
-    const { variants } = theme.divider;
-    if (!variants) {
-        return css``;
-    }
-
-    const cssChunks: string[] = [];
-
-    for (const [variantName, variantStyles] of Object.entries(variants)) {
-        if (!variantStyles) {
-            continue;
-        }
-
-        const overrides = new Map<keyof ThemeBreakpoints, string[]>();
-
-        const heightValue = variantStyles.height;
-        if (heightValue !== undefined) {
-            for (const { breakpointKey, value: breakpointValue } of getResponsiveOverrides(heightValue)) {
-                const declarations = overrides.get(breakpointKey) ?? [];
-                // line-height matches height so Outlook honors the declared cell height.
-                declarations.push(`height: ${breakpointValue}px !important`);
-                declarations.push(`line-height: ${breakpointValue}px !important`);
-                overrides.set(breakpointKey, declarations);
-            }
-        }
-
-        for (const [themeKey, cssProperty] of colorCssProperties) {
-            const value = variantStyles[themeKey];
-            if (value === undefined) {
-                continue;
-            }
-
-            for (const { breakpointKey, value: breakpointValue } of getResponsiveOverrides(value)) {
-                const declarations = overrides.get(breakpointKey) ?? [];
-                declarations.push(`${cssProperty}: ${breakpointValue} !important`);
-                overrides.set(breakpointKey, declarations);
-            }
-        }
-
-        for (const [breakpointKey, declarations] of overrides) {
-            const breakpoint = theme.breakpoints[breakpointKey];
-            if (!breakpoint) {
-                continue;
-            }
-
-            cssChunks.push(css`
-                ${breakpoint.belowMediaQuery} {
-                    ${options.styleSelector(variantName)} {
-                        ${declarations.join(";\n")}
-                    }
-                }
-            `);
-        }
-    }
-
-    return cssChunks.join("\n");
+    return generateResponsiveVariantCss<DividerVariantStyles>({
+        breakpoints: theme.breakpoints,
+        variants: theme.divider.variants,
+        groups: [{ selector: options.styleSelector, properties: dividerProperties }],
+    });
 }

--- a/packages/mail-react/src/components/text/textStyles.ts
+++ b/packages/mail-react/src/components/text/textStyles.ts
@@ -1,20 +1,19 @@
-import { getResponsiveOverrides } from "../../theme/responsiveValue.js";
-import type { TextVariantStyles, Theme, ThemeBreakpoints } from "../../theme/themeTypes.js";
-import { css } from "../../utils/css.js";
+import { generateResponsiveVariantCss, type ResponsiveVariantProperties } from "../../styles/generateResponsiveVariantCss.js";
+import type { TextVariantStyles, Theme } from "../../theme/themeTypes.js";
 
-type StylePropertyKey = Exclude<keyof TextVariantStyles, "bottomSpacing">;
-
-const textStyleCssProperties: ReadonlyArray<[StylePropertyKey, string]> = [
-    ["fontFamily", "font-family"],
-    ["fontSize", "font-size"],
-    ["fontWeight", "font-weight"],
-    ["fontStyle", "font-style"],
-    ["lineHeight", "line-height"],
-    ["letterSpacing", "letter-spacing"],
-    ["textDecoration", "text-decoration"],
-    ["textTransform", "text-transform"],
-    ["color", "color"],
+const textStyleProperties: ResponsiveVariantProperties<TextVariantStyles> = [
+    "fontFamily",
+    "fontSize",
+    "fontWeight",
+    "fontStyle",
+    "lineHeight",
+    "letterSpacing",
+    "textDecoration",
+    "textTransform",
+    "color",
 ];
+
+const spacingProperties: ResponsiveVariantProperties<TextVariantStyles> = [{ themeKey: "bottomSpacing", cssProperties: "padding-bottom" }];
 
 interface GenerateResponsiveTextCssOptions {
     /** Selector for text style overrides, given a variant name. */
@@ -25,73 +24,12 @@ interface GenerateResponsiveTextCssOptions {
 
 /** Generates responsive CSS media queries for text variant overrides. */
 export function generateResponsiveTextCss(theme: Theme, options: GenerateResponsiveTextCssOptions): string {
-    const { variants } = theme.text;
-    if (!variants) {
-        return css``;
-    }
-
-    const cssChunks: string[] = [];
-
-    for (const [variantName, variantStyles] of Object.entries(variants)) {
-        if (!variantStyles) {
-            continue;
-        }
-
-        const styleOverrides = new Map<keyof ThemeBreakpoints, string[]>();
-        const spacingOverrides = new Map<keyof ThemeBreakpoints, string[]>();
-
-        for (const [themeKey, cssProperty] of textStyleCssProperties) {
-            const value = variantStyles[themeKey];
-            if (value === undefined) {
-                continue;
-            }
-
-            for (const { breakpointKey, value: breakpointValue } of getResponsiveOverrides(value)) {
-                const declarations = styleOverrides.get(breakpointKey) ?? [];
-                declarations.push(`${cssProperty}: ${String(breakpointValue)} !important`);
-                styleOverrides.set(breakpointKey, declarations);
-            }
-        }
-
-        const bottomSpacingValue = variantStyles.bottomSpacing;
-        if (bottomSpacingValue !== undefined) {
-            for (const { breakpointKey, value: breakpointValue } of getResponsiveOverrides(bottomSpacingValue)) {
-                const declarations = spacingOverrides.get(breakpointKey) ?? [];
-                declarations.push(`padding-bottom: ${String(breakpointValue)} !important`);
-                spacingOverrides.set(breakpointKey, declarations);
-            }
-        }
-
-        for (const [breakpointKey, declarations] of styleOverrides) {
-            const breakpoint = theme.breakpoints[breakpointKey];
-            if (!breakpoint) {
-                continue;
-            }
-
-            cssChunks.push(css`
-                ${breakpoint.belowMediaQuery} {
-                    ${options.styleSelector(variantName)} {
-                        ${declarations.join(";\n")}
-                    }
-                }
-            `);
-        }
-
-        for (const [breakpointKey, declarations] of spacingOverrides) {
-            const breakpoint = theme.breakpoints[breakpointKey];
-            if (!breakpoint) {
-                continue;
-            }
-
-            cssChunks.push(css`
-                ${breakpoint.belowMediaQuery} {
-                    ${options.spacingSelector(variantName)} {
-                        ${declarations.join(";\n")}
-                    }
-                }
-            `);
-        }
-    }
-
-    return cssChunks.join("\n");
+    return generateResponsiveVariantCss<TextVariantStyles>({
+        breakpoints: theme.breakpoints,
+        variants: theme.text.variants,
+        groups: [
+            { selector: options.styleSelector, properties: textStyleProperties },
+            { selector: options.spacingSelector, properties: spacingProperties },
+        ],
+    });
 }

--- a/packages/mail-react/src/styles/__tests__/generateResponsiveVariantCss.test.ts
+++ b/packages/mail-react/src/styles/__tests__/generateResponsiveVariantCss.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { createBreakpoint } from "../../theme/createBreakpoint.js";
+import type { ResponsiveValue } from "../../theme/responsiveValue.js";
+import type { ThemeBreakpoints } from "../../theme/themeTypes.js";
+import { generateResponsiveVariantCss, type ResponsiveVariantProperties } from "../generateResponsiveVariantCss.js";
+
+const breakpoints: ThemeBreakpoints = { default: createBreakpoint(600), mobile: createBreakpoint(480) };
+const mobileMediaQuery = "@media (max-width: 479px)";
+
+const countOccurrences = (haystack: string, needle: string): number => haystack.split(needle).length - 1;
+
+const declarationsFor = (css: string, selector: string): string => {
+    const start = css.indexOf(`${selector} {`);
+    return start === -1 ? "" : css.slice(start, css.indexOf("}", start));
+};
+
+interface TestStyleMap {
+    fontSize: string;
+    fontWeight: string | number;
+    color: string;
+    height: number;
+    bottomSpacing: string;
+}
+
+type TestVariantStyles = { [K in keyof TestStyleMap]?: ResponsiveValue<TestStyleMap[K]> };
+
+const styleProperties: ResponsiveVariantProperties<TestVariantStyles> = [
+    "fontSize",
+    "fontWeight",
+    "color",
+    { themeKey: "height", cssProperties: ["height", "line-height"], unit: "px" },
+];
+const spacingProperties: ResponsiveVariantProperties<TestVariantStyles> = [{ themeKey: "bottomSpacing", cssProperties: "padding-bottom" }];
+
+function generate(variants: Record<string, TestVariantStyles | undefined> | undefined): string {
+    return generateResponsiveVariantCss<TestVariantStyles>({
+        breakpoints,
+        variants,
+        groups: [
+            { selector: (variantName) => `.test--${variantName}`, properties: styleProperties },
+            { selector: (variantName) => `.test--withSpacing.test--${variantName}`, properties: spacingProperties },
+        ],
+    });
+}
+
+describe("generateResponsiveVariantCss", () => {
+    it("returns an empty string when no variants are defined", () => {
+        expect(generate(undefined)).toBe("");
+    });
+
+    it("emits no media query for a variant without responsive overrides", () => {
+        expect(generate({ heading: { fontSize: "16px" } })).toBe("");
+    });
+
+    it("merges overrides at one breakpoint into a single media query, deriving the CSS property from the key", () => {
+        const result = generate({ heading: { fontSize: { default: "24px", mobile: "20px" }, color: { default: "#000000", mobile: "#ffffff" } } });
+
+        expect(countOccurrences(result, mobileMediaQuery)).toBe(1);
+        expect(result).toContain("font-size: 20px !important");
+        expect(result).toContain("color: #ffffff !important");
+    });
+
+    it("stringifies numeric values without a unit", () => {
+        const result = generate({ heading: { fontWeight: { default: 400, mobile: 700 } } });
+
+        expect(result).toContain("font-weight: 700 !important");
+    });
+
+    it("appends the unit and fans a single value out to multiple CSS properties", () => {
+        const result = generate({ heading: { height: { default: 4, mobile: 2 } } });
+
+        expect(result).toContain("height: 2px !important");
+        expect(result).toContain("line-height: 2px !important");
+    });
+
+    it("does not emit the inline default value inside a media query", () => {
+        const result = generate({ heading: { fontSize: { default: "24px", mobile: "20px" } } });
+
+        expect(result).not.toContain("24px");
+    });
+
+    it("emits each group under its own selector", () => {
+        const result = generate({ heading: { fontSize: { default: "24px", mobile: "20px" }, bottomSpacing: { default: "16px", mobile: "8px" } } });
+
+        expect(result).toContain(".test--heading {");
+        expect(result).toContain(".test--withSpacing.test--heading {");
+        expect(result).toContain("padding-bottom: 8px !important");
+    });
+
+    it("keeps each variant's overrides within its own selector block", () => {
+        const result = generate({
+            heading: { fontSize: { default: "24px", mobile: "20px" } },
+            body: { fontSize: { default: "16px", mobile: "14px" } },
+        });
+
+        expect(declarationsFor(result, ".test--heading")).toContain("font-size: 20px !important");
+        expect(declarationsFor(result, ".test--heading")).not.toContain("14px");
+        expect(declarationsFor(result, ".test--body")).toContain("font-size: 14px !important");
+        expect(declarationsFor(result, ".test--body")).not.toContain("20px");
+    });
+});

--- a/packages/mail-react/src/styles/generateResponsiveVariantCss.ts
+++ b/packages/mail-react/src/styles/generateResponsiveVariantCss.ts
@@ -1,0 +1,123 @@
+import { getResponsiveOverrides, type ResponsiveValue } from "../theme/responsiveValue.js";
+import type { ThemeBreakpoints } from "../theme/themeTypes.js";
+import { css } from "../utils/css.js";
+
+// `string | number` covers every responsive token today; widen it if a token of another value type is added.
+type VariantStylesConstraint = Record<string, ResponsiveValue<string | number> | undefined>;
+
+export interface ResponsiveVariantProperty<TVariantStyles> {
+    themeKey: keyof TVariantStyles;
+    /** CSS property name(s); defaults to the kebab-case form of `themeKey`. */
+    cssProperties?: string | readonly string[];
+    unit?: string;
+}
+
+/** A variant property is either a bare theme key (CSS name derived) or a descriptor for the exceptions. */
+export type ResponsiveVariantProperties<TVariantStyles> = ReadonlyArray<keyof TVariantStyles | ResponsiveVariantProperty<TVariantStyles>>;
+
+interface ResponsiveVariantGroup<TVariantStyles> {
+    selector: (variantName: string) => string;
+    properties: ResponsiveVariantProperties<TVariantStyles>;
+}
+
+interface GenerateResponsiveVariantCssOptions<TVariantStyles> {
+    breakpoints: ThemeBreakpoints;
+    variants: Record<string, TVariantStyles | undefined> | undefined;
+    groups: ReadonlyArray<ResponsiveVariantGroup<TVariantStyles>>;
+}
+
+const toKebabCase = (value: string): string => value.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+
+/**
+ * Generates `max-width` media-query CSS for a themed component's variant overrides.
+ * Returns an empty string when no variant has breakpoint overrides.
+ */
+export function generateResponsiveVariantCss<TVariantStyles extends VariantStylesConstraint>({
+    breakpoints,
+    variants,
+    groups,
+}: GenerateResponsiveVariantCssOptions<TVariantStyles>): string {
+    if (!variants) {
+        return "";
+    }
+
+    const cssChunks: string[] = [];
+
+    for (const [variantName, variantStyles] of Object.entries(variants)) {
+        if (!variantStyles) {
+            continue;
+        }
+
+        for (const group of groups) {
+            const overridesByBreakpoint = collectOverridesByBreakpoint(variantStyles, group.properties);
+            cssChunks.push(renderMediaQueries({ breakpoints, selector: group.selector(variantName), overridesByBreakpoint }));
+        }
+    }
+
+    return cssChunks.filter(Boolean).join("\n");
+}
+
+function collectOverridesByBreakpoint<TVariantStyles extends VariantStylesConstraint>(
+    variantStyles: TVariantStyles,
+    properties: ResponsiveVariantProperties<TVariantStyles>,
+): Map<keyof ThemeBreakpoints, string[]> {
+    const overridesByBreakpoint = new Map<keyof ThemeBreakpoints, string[]>();
+
+    for (const entry of properties) {
+        const property: ResponsiveVariantProperty<TVariantStyles> = typeof entry === "object" ? entry : { themeKey: entry };
+        const value = variantStyles[property.themeKey];
+        if (value === undefined) {
+            continue;
+        }
+
+        const cssProperties = resolveCssProperties(property);
+
+        for (const { breakpointKey, value: breakpointValue } of getResponsiveOverrides(value)) {
+            const declarations = overridesByBreakpoint.get(breakpointKey) ?? [];
+            for (const cssProperty of cssProperties) {
+                declarations.push(formatDeclaration({ cssProperty, value: breakpointValue, unit: property.unit }));
+            }
+            overridesByBreakpoint.set(breakpointKey, declarations);
+        }
+    }
+
+    return overridesByBreakpoint;
+}
+
+function resolveCssProperties<TVariantStyles>(property: ResponsiveVariantProperty<TVariantStyles>): readonly string[] {
+    const cssProperties = property.cssProperties ?? toKebabCase(String(property.themeKey));
+    return typeof cssProperties === "string" ? [cssProperties] : cssProperties;
+}
+
+function formatDeclaration({ cssProperty, value, unit }: { cssProperty: string; value: string | number; unit?: string }): string {
+    return `${cssProperty}: ${String(value)}${unit ?? ""} !important`;
+}
+
+function renderMediaQueries({
+    breakpoints,
+    selector,
+    overridesByBreakpoint,
+}: {
+    breakpoints: ThemeBreakpoints;
+    selector: string;
+    overridesByBreakpoint: Map<keyof ThemeBreakpoints, string[]>;
+}): string {
+    const cssChunks: string[] = [];
+
+    for (const [breakpointKey, declarations] of overridesByBreakpoint) {
+        const breakpoint = breakpoints[breakpointKey];
+        if (!breakpoint) {
+            continue;
+        }
+
+        cssChunks.push(css`
+            ${breakpoint.belowMediaQuery} {
+                ${selector} {
+                    ${declarations.join(";\n")}
+                }
+            }
+        `);
+    }
+
+    return cssChunks.join("\n");
+}


### PR DESCRIPTION
The button, divider and text components each reimplemented the same loop that turns responsive variant values into max-width media queries; only the property list and selector differed. Without a shared generator, every new themed component copies the loop again.

- **Per-component differences are data, not per-property callbacks.** An earlier responsive-CSS attempt was rejected for cast-heavy per-property callbacks; describing each property declaratively keeps the generic value resolution free of casts.
- **CSS property names derive from the theme key.** The theme keys are the camelCase form of their CSS property, so a kebab-case conversion replaces a hand-written mapping for all but the few semantic exceptions, which stay explicit.