### PR TITLE
Resolve the admin language from the browser 

### DIFF
--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -22,8 +22,9 @@ import { createApolloClient } from "@src/common/apollo/createApolloClient";
 import { createConfig } from "@src/config";
 import { PageTreeNodeDependency } from "@src/pageTree/PageTreeNodeDependency";
 import type { ContentScope as BaseContentScope } from "@src/site-configs";
-import { theme } from "@src/theme";
+import { createTheme } from "@src/theme";
 import { HTML5toTouch } from "rdndmb-html5-to-touch";
+import { useMemo } from "react";
 import { DndProvider } from "react-dnd-multi-backend";
 import { FormattedMessage, IntlProvider } from "react-intl";
 import { Route, Switch } from "react-router";
@@ -67,7 +68,8 @@ declare module "@comet/cms-admin" {
 LicenseInfo.setLicenseKey(config.muiLicenseKey);
 
 export function App() {
-    const { language, messages, dateFnsLocale } = getLanguageConfig();
+    const { language, messages, dateFnsLocale, muiLocale } = getLanguageConfig();
+    const theme = useMemo(() => createTheme(muiLocale), [muiLocale]);
 
     return (
         <CometConfigProvider

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -2,6 +2,7 @@ import "@fontsource-variable/roboto-flex/full.css";
 
 import { ApolloProvider } from "@apollo/client";
 import { ErrorDialogHandler, MasterLayout, MuiThemeProvider, RouterBrowserRouter, SnackbarProvider } from "@comet/admin";
+import { DateFnsLocaleProvider } from "@comet/admin-date-time";
 import { BrevoConfigProvider } from "@comet/brevo-admin";
 import {
     AzureAiTranslatorProvider,
@@ -22,7 +23,6 @@ import { createConfig } from "@src/config";
 import { PageTreeNodeDependency } from "@src/pageTree/PageTreeNodeDependency";
 import type { ContentScope as BaseContentScope } from "@src/site-configs";
 import { theme } from "@src/theme";
-import { enUS } from "date-fns/locale";
 import { HTML5toTouch } from "rdndmb-html5-to-touch";
 import { DndProvider } from "react-dnd-multi-backend";
 import { FormattedMessage, IntlProvider } from "react-intl";
@@ -35,7 +35,7 @@ import { ImportFromPicsum } from "./dam/ImportFromPicsum";
 import { Link } from "./documents/links/Link";
 import { Page } from "./documents/pages/Page";
 import type { GQLPermission } from "./graphql.generated";
-import { getMessages } from "./lang";
+import { dateFnsLocales, getClosestSupportedLanguage, getMessages } from "./lang";
 import { NewsDetailBlock } from "./news/blocks/NewsDetailBlock";
 import { NewsLinkBlock } from "./news/blocks/NewsLinkBlock";
 import { NewsListBlock } from "./news/blocks/NewsListBlock";
@@ -67,6 +67,9 @@ declare module "@comet/cms-admin" {
 LicenseInfo.setLicenseKey(config.muiLicenseKey);
 
 export function App() {
+    const language = getClosestSupportedLanguage();
+    const dateFnsLocale = dateFnsLocales[language];
+
     return (
         <CometConfigProvider
             {...config}
@@ -158,46 +161,51 @@ export function App() {
                 }}
             >
                 <ApolloProvider client={apolloClient}>
-                    <IntlProvider locale="en" messages={getMessages("en")}>
-                        <LocalizationProvider adapterLocale={enUS} dateAdapter={AdapterDateFns}>
-                            <MuiThemeProvider theme={theme}>
-                                <DndProvider options={HTML5toTouch}>
-                                    <SnackbarProvider>
-                                        <ErrorDialogHandler />
-                                        <CurrentUserProvider>
-                                            <RouterBrowserRouter>
-                                                <GlobalStyle />
-                                                <ContentScopeProvider>
-                                                    {({ match }) => (
-                                                        <AzureAiTranslatorProvider enabled showApplyTranslationDialog>
-                                                            <Switch>
-                                                                <Route
-                                                                    path={`${match.path}/preview`}
-                                                                    render={(props) => (
-                                                                        <SitePreview
-                                                                            resolvePath={(path: string, scope) => {
-                                                                                return `/${scope.language}${path}`;
-                                                                            }}
-                                                                            {...props}
-                                                                        />
-                                                                    )}
-                                                                />
-                                                                <Route
-                                                                    render={() => (
-                                                                        <MasterLayout headerComponent={MasterHeader} menuComponent={AppMasterMenu}>
-                                                                            <AppMasterMenuRoutes />
-                                                                        </MasterLayout>
-                                                                    )}
-                                                                />
-                                                            </Switch>
-                                                        </AzureAiTranslatorProvider>
-                                                    )}
-                                                </ContentScopeProvider>
-                                            </RouterBrowserRouter>
-                                        </CurrentUserProvider>
-                                    </SnackbarProvider>
-                                </DndProvider>
-                            </MuiThemeProvider>
+                    <IntlProvider locale={language} messages={getMessages(language)}>
+                        <LocalizationProvider adapterLocale={dateFnsLocale} dateAdapter={AdapterDateFns}>
+                            <DateFnsLocaleProvider value={dateFnsLocale}>
+                                <MuiThemeProvider theme={theme}>
+                                    <DndProvider options={HTML5toTouch}>
+                                        <SnackbarProvider>
+                                            <ErrorDialogHandler />
+                                            <CurrentUserProvider>
+                                                <RouterBrowserRouter>
+                                                    <GlobalStyle />
+                                                    <ContentScopeProvider>
+                                                        {({ match }) => (
+                                                            <AzureAiTranslatorProvider enabled showApplyTranslationDialog>
+                                                                <Switch>
+                                                                    <Route
+                                                                        path={`${match.path}/preview`}
+                                                                        render={(props) => (
+                                                                            <SitePreview
+                                                                                resolvePath={(path: string, scope) => {
+                                                                                    return `/${scope.language}${path}`;
+                                                                                }}
+                                                                                {...props}
+                                                                            />
+                                                                        )}
+                                                                    />
+                                                                    <Route
+                                                                        render={() => (
+                                                                            <MasterLayout
+                                                                                headerComponent={MasterHeader}
+                                                                                menuComponent={AppMasterMenu}
+                                                                            >
+                                                                                <AppMasterMenuRoutes />
+                                                                            </MasterLayout>
+                                                                        )}
+                                                                    />
+                                                                </Switch>
+                                                            </AzureAiTranslatorProvider>
+                                                        )}
+                                                    </ContentScopeProvider>
+                                                </RouterBrowserRouter>
+                                            </CurrentUserProvider>
+                                        </SnackbarProvider>
+                                    </DndProvider>
+                                </MuiThemeProvider>
+                            </DateFnsLocaleProvider>
                         </LocalizationProvider>
                     </IntlProvider>
                 </ApolloProvider>

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -35,7 +35,7 @@ import { ImportFromPicsum } from "./dam/ImportFromPicsum";
 import { Link } from "./documents/links/Link";
 import { Page } from "./documents/pages/Page";
 import type { GQLPermission } from "./graphql.generated";
-import { dateFnsLocales, getClosestSupportedLanguage, getMessages } from "./lang";
+import { getLanguageConfig } from "./lang";
 import { NewsDetailBlock } from "./news/blocks/NewsDetailBlock";
 import { NewsLinkBlock } from "./news/blocks/NewsLinkBlock";
 import { NewsListBlock } from "./news/blocks/NewsListBlock";
@@ -67,8 +67,7 @@ declare module "@comet/cms-admin" {
 LicenseInfo.setLicenseKey(config.muiLicenseKey);
 
 export function App() {
-    const language = getClosestSupportedLanguage();
-    const dateFnsLocale = dateFnsLocales[language];
+    const { language, messages, dateFnsLocale } = getLanguageConfig();
 
     return (
         <CometConfigProvider
@@ -161,10 +160,10 @@ export function App() {
                 }}
             >
                 <ApolloProvider client={apolloClient}>
-                    <IntlProvider locale={language} messages={getMessages(language)}>
-                        <LocalizationProvider adapterLocale={dateFnsLocale} dateAdapter={AdapterDateFns}>
-                            <DateFnsLocaleProvider value={dateFnsLocale}>
-                                <MuiThemeProvider theme={theme}>
+                    <IntlProvider locale={language} messages={messages}>
+                        <MuiThemeProvider theme={theme}>
+                            <LocalizationProvider adapterLocale={dateFnsLocale} dateAdapter={AdapterDateFns}>
+                                <DateFnsLocaleProvider value={dateFnsLocale}>
                                     <DndProvider options={HTML5toTouch}>
                                         <SnackbarProvider>
                                             <ErrorDialogHandler />
@@ -204,9 +203,9 @@ export function App() {
                                             </CurrentUserProvider>
                                         </SnackbarProvider>
                                     </DndProvider>
-                                </MuiThemeProvider>
-                            </DateFnsLocaleProvider>
-                        </LocalizationProvider>
+                                </DateFnsLocaleProvider>
+                            </LocalizationProvider>
+                        </MuiThemeProvider>
                     </IntlProvider>
                 </ApolloProvider>
             </BrevoConfigProvider>

--- a/demo/admin/src/lang.ts
+++ b/demo/admin/src/lang.ts
@@ -1,3 +1,5 @@
+import type { Locale } from "date-fns";
+import { de, enUS } from "date-fns/locale";
 import type { ResolvedIntlConfig } from "react-intl";
 
 import comet_demo_messages_de from "../lang-compiled/comet-demo-lang-admin/de.json";
@@ -15,7 +17,35 @@ const cometDemoMessages = {
     de: comet_demo_messages_de,
 };
 
-export const getMessages = (language: "de" | "en"): ResolvedIntlConfig["messages"] => {
+export const supportedLanguages = ["en", "de"] as const;
+
+export type SupportedLanguage = (typeof supportedLanguages)[number];
+
+const fallbackLanguage: SupportedLanguage = "en";
+
+function isSupportedLanguage(language: string): language is SupportedLanguage {
+    return supportedLanguages.includes(language as SupportedLanguage);
+}
+
+export function getClosestSupportedLanguage(): SupportedLanguage {
+    const browserLanguages = typeof navigator !== "undefined" ? (navigator.languages ?? [navigator.language]) : [];
+
+    for (const browserLanguage of browserLanguages) {
+        const language = browserLanguage.split("-")[0].toLowerCase();
+        if (isSupportedLanguage(language)) {
+            return language;
+        }
+    }
+
+    return fallbackLanguage;
+}
+
+export const dateFnsLocales: Record<SupportedLanguage, Locale> = {
+    en: enUS,
+    de,
+};
+
+export const getMessages = (language: SupportedLanguage): ResolvedIntlConfig["messages"] => {
     if (language === "de") {
         return {
             ...cometMessages["de"],

--- a/demo/admin/src/lang.ts
+++ b/demo/admin/src/lang.ts
@@ -1,3 +1,6 @@
+import { deDE as coreDe, enUS as coreEn } from "@mui/material/locale";
+import { deDE as dataGridDe, enUS as dataGridEn } from "@mui/x-data-grid-pro/locales";
+import { deDE as datePickersDe, enUS as datePickersEn } from "@mui/x-date-pickers/locales";
 import type { Locale } from "date-fns";
 import { de, enUS } from "date-fns/locale";
 import type { ResolvedIntlConfig } from "react-intl";
@@ -17,7 +20,7 @@ const cometDemoMessages = {
     de: comet_demo_messages_de,
 };
 
-export const supportedLanguages = ["en", "de"] as const;
+const supportedLanguages = ["en", "de"] as const;
 
 export type SupportedLanguage = (typeof supportedLanguages)[number];
 
@@ -27,7 +30,7 @@ function isSupportedLanguage(language: string): language is SupportedLanguage {
     return supportedLanguages.includes(language as SupportedLanguage);
 }
 
-export function getClosestSupportedLanguage(): SupportedLanguage {
+function getClosestSupportedLanguage(): SupportedLanguage {
     const browserLanguages = typeof navigator !== "undefined" ? (navigator.languages ?? [navigator.language]) : [];
 
     for (const browserLanguage of browserLanguages) {
@@ -40,21 +43,37 @@ export function getClosestSupportedLanguage(): SupportedLanguage {
     return fallbackLanguage;
 }
 
-export const dateFnsLocales: Record<SupportedLanguage, Locale> = {
+function getMessages(language: SupportedLanguage): ResolvedIntlConfig["messages"] {
+    return {
+        ...cometMessages[language],
+        ...cometDemoMessages[language],
+    };
+}
+
+const dateFnsLocales: Record<SupportedLanguage, Locale> = {
     en: enUS,
     de,
 };
 
-export const getMessages = (language: SupportedLanguage): ResolvedIntlConfig["messages"] => {
-    if (language === "de") {
-        return {
-            ...cometMessages["de"],
-            ...cometDemoMessages["de"],
-        };
-    }
+// MUI and MUI X ship their own component translations (date picker, data grid, table pagination, …).
+// They are applied through the theme, so the bundles are spread into `createCometTheme` as additional arguments.
+const muiLocales: Record<SupportedLanguage, object[]> = {
+    en: [coreEn, dataGridEn, datePickersEn],
+    de: [coreDe, dataGridDe, datePickersDe],
+};
+
+export function getLanguageConfig(): {
+    language: SupportedLanguage;
+    messages: ResolvedIntlConfig["messages"];
+    dateFnsLocale: Locale;
+    muiLocale: object[];
+} {
+    const language = getClosestSupportedLanguage();
 
     return {
-        ...cometMessages["en"],
-        ...cometDemoMessages["en"],
+        language,
+        messages: getMessages(language),
+        dateFnsLocale: dateFnsLocales[language],
+        muiLocale: muiLocales[language],
     };
-};
+}

--- a/demo/admin/src/lang.ts
+++ b/demo/admin/src/lang.ts
@@ -10,38 +10,31 @@ import comet_demo_messages_en from "../lang-compiled/comet-demo-lang-admin/en.js
 import comet_messages_de from "../lang-compiled/comet-lang/de.json";
 import comet_messages_en from "../lang-compiled/comet-lang/en.json";
 
-const cometMessages = {
-    en: comet_messages_en,
-    de: comet_messages_de,
-};
-
-const cometDemoMessages = {
-    en: comet_demo_messages_en,
-    de: comet_demo_messages_de,
-};
-
 const supportedLanguages = ["en", "de"] as const;
 
 export type SupportedLanguage = (typeof supportedLanguages)[number];
 
 const fallbackLanguage: SupportedLanguage = "en";
 
-function isSupportedLanguage(language: string): language is SupportedLanguage {
-    return supportedLanguages.includes(language as SupportedLanguage);
-}
-
-function getClosestSupportedLanguage(): SupportedLanguage {
+function getClosestSupportedLanguageFromBrowserLanguages(): SupportedLanguage {
     const browserLanguages = typeof navigator !== "undefined" ? (navigator.languages ?? [navigator.language]) : [];
 
-    for (const browserLanguage of browserLanguages) {
-        const language = browserLanguage.split("-")[0].toLowerCase();
-        if (isSupportedLanguage(language)) {
-            return language;
-        }
-    }
+    const language = browserLanguages
+        .map((browserLanguage) => browserLanguage.split("-")[0].toLowerCase())
+        .find((language): language is SupportedLanguage => supportedLanguages.includes(language as SupportedLanguage));
 
-    return fallbackLanguage;
+    return language ?? fallbackLanguage;
 }
+
+const cometMessages = {
+    en: comet_messages_en,
+    de: comet_messages_de,
+} satisfies Record<SupportedLanguage, ResolvedIntlConfig["messages"]>;
+
+const cometDemoMessages = {
+    en: comet_demo_messages_en,
+    de: comet_demo_messages_de,
+} satisfies Record<SupportedLanguage, ResolvedIntlConfig["messages"]>;
 
 function getMessages(language: SupportedLanguage): ResolvedIntlConfig["messages"] {
     return {
@@ -55,8 +48,6 @@ const dateFnsLocales: Record<SupportedLanguage, Locale> = {
     de,
 };
 
-// MUI and MUI X ship their own component translations (date picker, data grid, table pagination, …).
-// They are applied through the theme, so the bundles are spread into `createCometTheme` as additional arguments.
 const muiLocales: Record<SupportedLanguage, object[]> = {
     en: [coreEn, dataGridEn, datePickersEn],
     de: [coreDe, dataGridDe, datePickersDe],
@@ -68,7 +59,7 @@ export function getLanguageConfig(): {
     dateFnsLocale: Locale;
     muiLocale: object[];
 } {
-    const language = getClosestSupportedLanguage();
+    const language = getClosestSupportedLanguageFromBrowserLanguages();
 
     return {
         language,

--- a/demo/admin/src/lang.ts
+++ b/demo/admin/src/lang.ts
@@ -11,8 +11,7 @@ import comet_messages_de from "../lang-compiled/comet-lang/de.json";
 import comet_messages_en from "../lang-compiled/comet-lang/en.json";
 
 const supportedLanguages = ["en", "de"] as const;
-
-export type SupportedLanguage = (typeof supportedLanguages)[number];
+type SupportedLanguage = (typeof supportedLanguages)[number];
 
 const fallbackLanguage: SupportedLanguage = "en";
 

--- a/demo/admin/src/theme.ts
+++ b/demo/admin/src/theme.ts
@@ -1,5 +1,3 @@
 import { createCometTheme } from "@comet/admin";
 
-import { getLanguageConfig } from "./lang";
-
-export const theme = createCometTheme({}, ...getLanguageConfig().muiLocale);
+export const createTheme = (muiLocale: object[]) => createCometTheme({}, ...muiLocale);

--- a/demo/admin/src/theme.ts
+++ b/demo/admin/src/theme.ts
@@ -1,3 +1,5 @@
 import { createCometTheme } from "@comet/admin";
 
-export const theme = createCometTheme();
+import { getLanguageConfig } from "./lang";
+
+export const theme = createCometTheme({}, ...getLanguageConfig().muiLocale);


### PR DESCRIPTION
## Motivation

The demo (and starter) hardcode the locale in admin to English. Support for localization based on the browser language must be added in the projects and there is no blueprint for it.

Also it's not trivial because localization has to be done for react-intl, date-fns and MUI.

## Description

This PR adds a single `getLanguageConfig` to lang.ts that provides everything necessary for localization across react-intl, date-fns and MUI / MUI X.