### PR TITLE
admin: Add class-name contract and first Future UI components

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -37,7 +37,7 @@
             "entry": ["./src/index.ts", "./src/future-ui/index.ts"],
             "project": ["./src/**/*.{ts,tsx}"],
             "ignore": [".storybook/public/mockServiceWorker.js"],
-            "ignoreDependencies": ["@mui/x-data-grid-premium"]
+            "ignoreDependencies": ["@mui/x-data-grid-premium", "sass"]
         },
         "packages/admin/admin-color-picker": {
             "project": ["./src/**/*.{ts,tsx}"]

--- a/packages/admin/admin/.storybook/main.ts
+++ b/packages/admin/admin/.storybook/main.ts
@@ -1,4 +1,33 @@
+import { createHash } from "node:crypto";
+
 import type { StorybookConfig } from "@storybook/react-vite";
+import { mergeConfig } from "vite";
+
+const futureUiModulePattern = /future-ui\/components\/[^/]+\/([A-Z][A-Za-z0-9]+)\.module\.scss$/;
+const futureUiClassnamePrefix = "comet";
+
+// Produces the stable class names defined by the Future UI class-name contract instead of Vite's default hashed names.
+function generateScopedName(name: string, filename: string): string {
+    const futureUiMatch = filename.match(futureUiModulePattern);
+
+    if (futureUiMatch) {
+        const componentName = futureUiMatch[2];
+
+        if (name === "root") {
+            return `${futureUiClassnamePrefix}${componentName}`;
+        }
+
+        const modifierPrefix = "root--";
+        if (name.startsWith(modifierPrefix)) {
+            return `${futureUiClassnamePrefix}${componentName}--${name.slice(modifierPrefix.length)}`;
+        }
+
+        return `${futureUiClassnamePrefix}${componentName}__${name}`;
+    }
+
+    // No class-name contract for modules outside future-ui — fall back to a deterministic, file-scoped name.
+    return `${name}_${createHash("sha1").update(`${filename}::${name}`).digest("hex").slice(0, 5)}`;
+}
 
 const config: StorybookConfig = {
     stories: ["../src/**/*.mdx", "../src/**/__stories__/*.stories.@(js|jsx|mjs|ts|tsx)"],
@@ -6,5 +35,15 @@ const config: StorybookConfig = {
 
     addons: ["@storybook/addon-docs", "@storybook/addon-vitest", "storybook-addon-tag-badges"],
     framework: "@storybook/react-vite",
+
+    viteFinal(viteConfig) {
+        return mergeConfig(viteConfig, {
+            css: {
+                modules: {
+                    generateScopedName,
+                },
+            },
+        });
+    },
 };
 export default config;

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -47,8 +47,10 @@
         "test:watch": "vitest --watch"
     },
     "dependencies": {
+        "@base-ui/react": "^1.5.0",
         "@comet/admin-icons": "workspace:*",
         "@mui/utils": "^7.3.11",
+        "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
         "exceljs": "^4.4.0",
         "final-form-set-field-data": "^1.0.2",
@@ -113,6 +115,7 @@
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
         "rimraf": "^6.1.2",
+        "sass": "^1.93.0",
         "storybook": "^10.3.5",
         "storybook-addon-tag-badges": "^3.1.0",
         "typescript": "^5.9.3",

--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -15,7 +15,7 @@ Any export may change or be removed at any time, without deprecation notice. Eve
 
 ## Folder and file names
 
-- **Feature folders** use kebab-case (`button/`, `text-field/`).
+- **Feature folders** use camelCase (`button/`, `textField/`).
 - **Component file**: `<ComponentName>.tsx` (PascalCase), one per component feature.
 - **Non-component code file**: `<featureName>.ts(x)` (camelCase) for utilities and hooks.
 - **Styles**: `<ComponentName>.module.scss` (CSS Modules with SCSS).

--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -67,9 +67,9 @@ Future UI's styling contract is its class names. Components built on `@base-ui/r
 
 ## Internal documentation
 
-A feature substantial enough to live in its own directory may have a `README.md` describing what it is and how it behaves — and, when a reader would assume otherwise, the boundaries it deliberately doesn't cross. These READMEs are internal: written for the people and agents maintaining the code, not for consumers.
+A feature may have a `README.md` for what its name, types, TSDoc, and commits can't carry — a non-obvious part of what it is, or a boundary it deliberately doesn't cross. These READMEs are internal: for the people and agents maintaining the code, not its consumers.
 
-Information hierarchy: code is the source of truth for what is, commits for why each step was taken, internal documentation for what a feature is and what it isn't.
+Information hierarchy: code is the source of truth for what is, TSDoc for what a feature does for its consumers, commits for why each step was taken, internal documentation for a feature's scope — what it is and isn't — that none of the others record.
 
 ### What is a feature
 
@@ -83,23 +83,23 @@ A feature that warrants a README is a directory, with the README at its root (fo
 
 **Title.** The exact identifier when the feature is a single component or function (`Button`); otherwise a sentence-case name.
 
-Two sections, in order; only the intro is required.
+Most READMEs use one or both of two sections:
 
-1. **Intro.** State, in neutral present tense, what the feature is or does. Include a non-obvious behavior or constraint when it is part of what the feature is; keep out the motivation and the prior state — the why lives in the commit. The test: describe how it behaves, not why it exists.
-2. **Non-goals** (optional). Only what a reader would reasonably assume the feature does but it doesn't; the test is whether they would look here for it and be surprised it is missing. Write each as a noun phrase, with one follow-up sentence only to point to the alternative or give the reason.
+1. **Intro.** The non-obvious part of what the feature is or does, in present tense.
+2. **Non-goals.** What a reader would reasonably assume the feature does but it doesn't. Write each as a noun phrase, with one follow-up sentence only to point to the alternative or give the reason.
 
-The two sections above are all a README normally carries. A custom section is allowed but is the exception — add one only when explicitly required, and only for durable, feature-specific content that genuinely fits neither section above. Not custom sections: Architecture (the code shows it), Design decisions (commits carry them), Usage (consumer docs), Dependencies (imports show them).
+A complex feature may add sections specific to its scope, as this sub-package's own README does. Not sections of their own: Architecture (the code shows it), Design decisions (commits carry them), Usage (consumer docs), Dependencies (imports show them).
 
-**Express the rule, not the code.** Every line says something the code doesn't. The feature's name is on its folder and export too, so the intro adds something beyond it rather than restating it: "A button component with a set of optional variants", never "The Button component".
+**Express the rule, not the code.** Every line says something the name and code don't — "A button component with a set of optional variants", never "The Button component".
 
-**Length.** Keep it as short as the feature allows. Most features need nothing beyond the one-sentence intro; a genuinely complex feature — this sub-package's own README, for one — may run longer when it warrants it, up to about a screen. Past a screen you are duplicating commit history or describing what the code shows.
+**Length.** Keep a README as short as the feature allows — often a line of intro or a few non-goals. A genuinely complex feature may run to about a screen. Past a screen you are duplicating commit history or describing what the code shows.
 
 ### Template
 
 ```md
 # <feature-name>
 
-<One sentence: what the feature is or does.>
+<Intro (optional) — the non-obvious part of what the feature is or does.>
 
 ## Non-goals <!-- only if any -->
 

--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -52,11 +52,12 @@ Future UI's styling contract is its class names. Components built on `@base-ui/r
 
 **Authoring source.** The SCSS module's local class names match the public part names; the stylesheet's file name is the single source of a component's emitted name. The mapping:
 
-| Source local     | Emitted DOM class        |
-| ---------------- | ------------------------ |
-| `root`           | `cometButton`            |
-| `root--disabled` | `cometButton--disabled`  |
-| `startIcon`      | `cometButton__startIcon` |
+| Source local           | Emitted DOM class             |
+| ---------------------- | ----------------------------- |
+| `root`                 | `cometButton`                 |
+| `root--variantPrimary` | `cometButton--variantPrimary` |
+| `root--disabled`       | `cometButton--disabled`       |
+| `startIcon`            | `cometButton__startIcon`      |
 
 - A component with no single dominant element names no class `root`.
 - Modifiers nest under `.root` with `&` (`&--disabled` → `cometButton--disabled`).

--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -6,12 +6,64 @@ Future UI builds from an unstyled foundation rather than evolving the existing M
 
 ## Experimental
 
-Any export may change or be removed at any time, without deprecation notice. Changesets are not created for changes within this sub-package.
+Any export may change or be removed at any time, without deprecation notice. Every export carries the `@experimental` TSDoc tag. Changesets are not created for changes within this sub-package.
 
 ## Non-goals
 
 - **No non-UI logic.** Forms (`final-form`, `react-hook-form`), routing (`react-router`), data fetching (Apollo), and similar concerns stay out.
 - **No dependency on `@mui/material`, `@mui/system`, Emotion, or any other part of the existing `@comet/admin` styling stack.** Future UI is a fresh foundation; cross-imports reintroduce the competing system it removes.
+
+## Folder and file names
+
+- **Feature folders** use kebab-case (`button/`, `text-field/`).
+- **Component file**: `<ComponentName>.tsx` (PascalCase), one per component feature.
+- **Non-component code file**: `<featureName>.ts(x)` (camelCase) for utilities and hooks.
+- **Styles**: `<ComponentName>.module.scss` (CSS Modules with SCSS).
+
+## Component conventions
+
+### Exports
+
+- Props are exported as an interface named `<ComponentName>Props`, never a type alias.
+- The component is exported as `<ComponentName>`.
+
+### TSDoc
+
+A component's doc comment and its prop docs say what it does, not how — they leave out implementation details (the rendered element, prop forwarding, the base-ui foundation) and never restate the component's name, the same "express the rule, not the code" principle the READMEs follow.
+
+### Root element props
+
+- A component extends the props of its root element and forwards the ones it doesn't handle itself to that element, so a consumer can set any attribute or event handler the root element accepts without a dedicated prop for each.
+- A consumer-set `className` is merged with the contract classes, never replacing them.
+
+### Class-name contract
+
+Every component emits a stable, predictable set of class names. These class names are part of the public API — renaming an emitted class is a breaking change. They are the primary path for consumer styling: a consumer writes plain CSS against them, with no React API involvement required.
+
+**The emitted shape:**
+
+- **Root** — `comet<Component>`. The outermost element of a component, camelCased. Examples: `cometButton`, `cometTextField`.
+- **Parts** — `comet<Component>__<partName>`. A part is a named sub-element; the part name is camelCased. Examples: `cometButton__startIcon`, `cometTextField__label`.
+- **Modifiers, on the root only** — `comet<Component>--<propName><Value>` for enum props (camelCase value: `cometButton--variantPrimary`), `comet<Component>--<propName>` for booleans (`cometButton--disabled`).
+
+Future UI's styling contract is its class names. Components built on `@base-ui/react` also emit base-ui's `data-*` attributes (`[data-disabled]`, …); these are base-ui's contract passed through, not one Future UI maintains — style against the class names.
+
+**Composition.** When a Future UI component is used as the root of another component, both root classes appear on the same element — a `CustomButton` rendering through `Button` produces `cometButton cometCustomButton`. Either layer is targetable.
+
+**Authoring source.** The SCSS module's local class names match the public part names; the stylesheet's file name is the single source of a component's emitted name. The mapping:
+
+| Source local     | Emitted DOM class        |
+| ---------------- | ------------------------ |
+| `root`           | `cometButton`            |
+| `root--disabled` | `cometButton--disabled`  |
+| `startIcon`      | `cometButton__startIcon` |
+
+- A component with no single dominant element names no class `root`.
+- Modifiers nest under `.root` with `&` (`&--disabled` → `cometButton--disabled`).
+
+## Known issues
+
+- Styles are not delivered by the package build yet. The Babel build compiles no CSS Modules, so the class-name mapping applies in Storybook but not in published output.
 
 ## Internal documentation
 

--- a/packages/admin/admin/src/future-ui/components/button/Button.module.scss
+++ b/packages/admin/admin/src/future-ui/components/button/Button.module.scss
@@ -1,0 +1,29 @@
+.root {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding-block: 0.5rem;
+    padding-inline: 1rem;
+    border: none;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.25;
+    cursor: pointer;
+
+    &--variantPrimary {
+        background: #1976d2;
+        color: #ffffff;
+    }
+
+    &--variantSecondary {
+        background: #2e7d32;
+        color: #ffffff;
+    }
+
+    &--disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
+}

--- a/packages/admin/admin/src/future-ui/components/button/Button.tsx
+++ b/packages/admin/admin/src/future-ui/components/button/Button.tsx
@@ -1,0 +1,34 @@
+import { Button as BaseButton } from "@base-ui/react/button";
+import { clsx } from "clsx";
+
+import styles from "./Button.module.scss";
+
+/** @experimental */
+export interface ButtonProps extends Omit<BaseButton.Props, "className"> {
+    className?: string;
+    variant?: "primary" | "secondary";
+}
+
+/**
+ * A button for triggering actions.
+ *
+ * @experimental
+ */
+export function Button({ disabled, type = "button", variant = "primary", className, children, ...restProps }: ButtonProps) {
+    return (
+        <BaseButton
+            {...restProps}
+            type={type}
+            disabled={disabled}
+            className={clsx(
+                styles.root,
+                variant === "primary" && styles["root--variantPrimary"],
+                variant === "secondary" && styles["root--variantSecondary"],
+                disabled && styles["root--disabled"],
+                className,
+            )}
+        >
+            {children}
+        </BaseButton>
+    );
+}

--- a/packages/admin/admin/src/future-ui/components/button/README.md
+++ b/packages/admin/admin/src/future-ui/components/button/README.md
@@ -1,3 +1,0 @@
-# Button
-
-A button for triggering actions.

--- a/packages/admin/admin/src/future-ui/components/button/README.md
+++ b/packages/admin/admin/src/future-ui/components/button/README.md
@@ -1,0 +1,3 @@
+# Button
+
+A button for triggering actions.

--- a/packages/admin/admin/src/future-ui/components/button/__stories__/Button.stories.tsx
+++ b/packages/admin/admin/src/future-ui/components/button/__stories__/Button.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "../Button";
+
+const meta: Meta<typeof Button> = {
+    component: Button,
+    title: "Future UI/Button",
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+    args: {
+        children: "Button",
+        variant: "primary",
+    },
+};
+
+export const Secondary: Story = {
+    args: {
+        children: "Button",
+        variant: "secondary",
+    },
+};

--- a/packages/admin/admin/src/future-ui/components/typography/README.md
+++ b/packages/admin/admin/src/future-ui/components/typography/README.md
@@ -1,8 +1,5 @@
 # Typography
 
-Renders a single block of text.
-
 ## Non-goals
 
-- **No spacing.** Default margin is zero; vertical rhythm is the caller's responsibility.
-- **No inline-text composition.** A single block of text per instance, not a wrapper for rich inline content.
+- **No spacing.** The space between blocks is the caller's responsibility.

--- a/packages/admin/admin/src/future-ui/components/typography/README.md
+++ b/packages/admin/admin/src/future-ui/components/typography/README.md
@@ -1,0 +1,8 @@
+# Typography
+
+Renders a single block of text.
+
+## Non-goals
+
+- **No spacing.** Default margin is zero; vertical rhythm is the caller's responsibility.
+- **No inline-text composition.** A single block of text per instance, not a wrapper for rich inline content.

--- a/packages/admin/admin/src/future-ui/components/typography/Typography.module.scss
+++ b/packages/admin/admin/src/future-ui/components/typography/Typography.module.scss
@@ -1,0 +1,8 @@
+.root {
+    margin: 0;
+    color: #1a1a1a;
+    font-family: inherit;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+}

--- a/packages/admin/admin/src/future-ui/components/typography/Typography.tsx
+++ b/packages/admin/admin/src/future-ui/components/typography/Typography.tsx
@@ -1,0 +1,22 @@
+import { clsx } from "clsx";
+import type { ComponentPropsWithoutRef, Ref } from "react";
+
+import styles from "./Typography.module.scss";
+
+/** @experimental */
+export interface TypographyProps extends ComponentPropsWithoutRef<"p"> {
+    ref?: Ref<HTMLParagraphElement>;
+}
+
+/**
+ * Renders a single block of text.
+ *
+ * @experimental
+ */
+export function Typography({ className, children, ref, ...restProps }: TypographyProps) {
+    return (
+        <p {...restProps} ref={ref} className={clsx(styles.root, className)}>
+            {children}
+        </p>
+    );
+}

--- a/packages/admin/admin/src/future-ui/components/typography/__stories__/Typography.stories.tsx
+++ b/packages/admin/admin/src/future-ui/components/typography/__stories__/Typography.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Typography } from "../Typography";
+
+const meta: Meta<typeof Typography> = {
+    component: Typography,
+    title: "Future UI/Typography",
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Typography>;
+
+export const Default: Story = {
+    args: {
+        children: "The quick brown fox jumps over the lazy dog",
+    },
+};

--- a/packages/admin/admin/src/future-ui/css-modules.d.ts
+++ b/packages/admin/admin/src/future-ui/css-modules.d.ts
@@ -1,0 +1,4 @@
+declare module "*.module.scss" {
+    const classes: Readonly<Record<string, string>>;
+    export default classes;
+}

--- a/packages/admin/admin/src/future-ui/index.ts
+++ b/packages/admin/admin/src/future-ui/index.ts
@@ -1,2 +1,2 @@
-// TODO: Re-export public future-ui features from here as they land.
-export {};
+export { Button, type ButtonProps } from "./components/button/Button";
+export { Typography, type TypographyProps } from "./components/typography/Typography";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,12 +760,18 @@ importers:
 
   packages/admin/admin:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.5.0
+        version: 1.5.0(@types/react@19.2.15)(date-fns@4.4.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@comet/admin-icons':
         specifier: workspace:*
         version: link:../admin-icons
       '@mui/utils':
         specifier: ^7.3.11
         version: 7.3.11(@types/react@19.2.15)(react@19.2.6)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -953,6 +959,9 @@ importers:
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
+      sass:
+        specifier: ^1.93.0
+        version: 1.93.0
       storybook:
         specifier: ^10.3.5
         version: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
Future UI styles components primarily through stable DOM class names, so a consumer can target a component's parts and state with plain CSS and no React API.

- **Enum class names include the prop name and value; boolean class names use the prop name alone.**
  Two enum props that share a value would otherwise produce the same class name.
- **Components live in a flat directory, with no primitive-versus-composed tiers.**
  Other component libraries ship flat, and tier labels force a reclassification whenever a component grows a dependency.
- **`Button` uses base-ui; `Typography` uses a native element.**
  base-ui adds nothing to a non-interactive component; adopting it in the first interactive component puts the foundation into real use.
- **`className` is restricted to a string.**
  The merge contract needs only a string, so base-ui's function form is deliberately left out of the public type.
- **`Button` defaults to `type="button"`.**
  A bare button defaults to `type="submit"` and would submit any enclosing form by accident.
- **Props are exported as interfaces, not type aliases.**
  An interface can be augmented through declaration merging, which the theme contract and consumer customization may later rely on.
- **`Button` has a `variant` prop to demonstrate the enum modifier convention.**
- **All component styling is placeholder.**
  The values are arbitrary and will be replaced when the token system lands.

---

Task: https://vivid-planet.atlassian.net/browse/COM-2973