### PR TITLE
Add Global Action Log view (base) [COM-3006]

### DIFF
--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -12,6 +12,7 @@ import {
     DamPage,
     type DocumentInterface,
     type DocumentType,
+    GlobalActionLogPage,
     MasterMenu,
     type MasterMenuData,
     MasterMenuRoutes,
@@ -284,6 +285,15 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
                         component: WarningsPage,
                     },
                     requiredPermission: "warnings",
+                },
+                {
+                    type: "route",
+                    primary: <FormattedMessage id="menu.actionLog" defaultMessage="Action Log" />,
+                    route: {
+                        path: "/system/action-log",
+                        component: GlobalActionLogPage,
+                    },
+                    requiredPermission: "actionLog",
                 },
             ],
         },

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -23,6 +23,16 @@ type ActionLog {
   version: Int!
 }
 
+input ActionLogFilter {
+  and: [ActionLogFilter!]
+  createdAt: DateTimeFilter
+  entityId: IdFilter
+  entityName: StringFilter
+  or: [ActionLogFilter!]
+  userId: StringFilter
+  version: NumberFilter
+}
+
 input ActionLogSort {
   direction: SortDirection! = ASC
   field: ActionLogSortField!
@@ -1428,6 +1438,7 @@ type PaginatedWarnings {
 }
 
 enum Permission {
+  actionLog
   blockPreview
   brevoNewsletter
   brevoNewsletterConfig
@@ -1986,6 +1997,15 @@ input ProductVariantUpdateInput {
 }
 
 type Query {
+  """
+  Returns a single action log entry by id. Requires the `actionLog` permission.
+  """
+  actionLog(id: ID!): ActionLog!
+
+  """
+  Returns action log entries across all entities. Requires the `actionLog` permission.
+  """
+  actionLogs(filter: ActionLogFilter, limit: Int! = 25, offset: Int! = 0, scopes: [JSONObject!]!, search: String, sort: [ActionLogSort!]): PaginatedActionLogs!
   autoBuildStatus: AutoBuildStatus!
   blockPreviewJwt(includeInvisible: Boolean!, scope: JSONObject!, url: String!): String!
   brevoConfig(scope: EmailCampaignContentScopeInput!): BrevoConfig

--- a/packages/admin/cms-admin/.storybook/mocks/globalActionLogHandlers.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/globalActionLogHandlers.ts
@@ -1,0 +1,120 @@
+import { graphql, HttpResponse } from "msw";
+
+const alice = { __typename: "ActionLogsUser", id: "Alice", name: "Alice" };
+const bob = { __typename: "ActionLogsUser", id: "Bob", name: "Bob" };
+
+const mockNodes = [
+    {
+        __typename: "ActionLog",
+        id: "log4",
+        user: alice,
+        entityName: "Page",
+        entityId: "550e8400-e29b-41d4-a716-446655440004",
+        version: 1,
+        type: "Deleted",
+        snapshot: null,
+        previousVersion: {
+            __typename: "ActionLog",
+            id: "log4-prev",
+            version: 1,
+            snapshot: { title: "Imprint", slug: "imprint" },
+            createdAt: "2026-05-28T08:00:00Z",
+            user: alice,
+            entityName: "Page",
+        },
+        scope: [{ domain: "main", language: "en" }],
+        createdAt: "2026-05-28T09:00:00Z",
+    },
+    {
+        __typename: "ActionLog",
+        id: "log3",
+        user: bob,
+        entityName: "News",
+        entityId: "550e8400-e29b-41d4-a716-446655440003",
+        version: 3,
+        type: "Updated",
+        snapshot: { title: "Release 9.0", slug: "release-9-0" },
+        previousVersion: {
+            __typename: "ActionLog",
+            id: "log2",
+            version: 2,
+            snapshot: { title: "Release 9.0 (draft)", slug: "release-9-0" },
+            createdAt: "2026-05-27T14:00:00Z",
+            user: bob,
+            entityName: "News",
+        },
+        scope: [{ domain: "main", language: "en" }],
+        createdAt: "2026-05-27T15:30:00Z",
+    },
+    {
+        __typename: "ActionLog",
+        id: "log2",
+        user: bob,
+        entityName: "News",
+        entityId: "550e8400-e29b-41d4-a716-446655440003",
+        version: 2,
+        type: "Updated",
+        snapshot: { title: "Release 9.0 (draft)", slug: "release-9-0" },
+        previousVersion: {
+            __typename: "ActionLog",
+            id: "log1",
+            version: 1,
+            snapshot: { title: "Release", slug: "release" },
+            createdAt: "2026-05-27T13:00:00Z",
+            user: bob,
+            entityName: "News",
+        },
+        scope: [{ domain: "main", language: "en" }],
+        createdAt: "2026-05-27T14:00:00Z",
+    },
+    {
+        __typename: "ActionLog",
+        id: "log1",
+        user: bob,
+        entityName: "News",
+        entityId: "550e8400-e29b-41d4-a716-446655440003",
+        version: 1,
+        type: "Created",
+        snapshot: { title: "Release", slug: "release" },
+        previousVersion: null,
+        scope: [{ domain: "main", language: "en" }],
+        createdAt: "2026-05-27T13:00:00Z",
+    },
+];
+
+const versionById: Record<string, (typeof mockNodes)[number]> = Object.fromEntries(mockNodes.map((node) => [node.id, node]));
+
+export const globalActionLogHandlers = [
+    graphql.query("GlobalActionLogGrid", () =>
+        HttpResponse.json({
+            data: {
+                actionLogs: { __typename: "PaginatedActionLogs", nodes: mockNodes, totalCount: mockNodes.length },
+            },
+        }),
+    ),
+    graphql.query("GlobalActionLogShowVersion", ({ variables }) =>
+        HttpResponse.json({
+            data: { actionLog: versionById[variables.id as string] ?? null },
+        }),
+    ),
+    graphql.query("GlobalActionLogDialogGrid", () =>
+        HttpResponse.json({
+            data: {
+                actionLogs: { __typename: "PaginatedActionLogs", nodes: mockNodes.slice(1), totalCount: mockNodes.length - 1 },
+            },
+        }),
+    ),
+    graphql.query("GlobalActionLogDialogShowVersion", ({ variables }) =>
+        HttpResponse.json({
+            data: { actionLog: versionById[variables.id as string] ?? null },
+        }),
+    ),
+    graphql.query("GlobalActionLogDialogCompare", ({ variables }) =>
+        HttpResponse.json({
+            data: {
+                beforeVersion: versionById[variables.beforeId as string] ?? null,
+                afterVersion: versionById[variables.afterId as string] ?? null,
+            },
+        }),
+    ),
+];

--- a/packages/admin/cms-admin/.storybook/mocks/handlers.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { actionLogDialogHandlers } from "./actionLogDialogHandler";
 import { currentUserHandler } from "./currentUserHandler";
+import { globalActionLogHandlers } from "./globalActionLogHandlers";
 
-export const handlers = [currentUserHandler, ...actionLogDialogHandlers];
+export const handlers = [currentUserHandler, ...actionLogDialogHandlers, ...globalActionLogHandlers];

--- a/packages/admin/cms-admin/src/actionLog/components/actionLogCompare/ActionLogCompare.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/actionLogCompare/ActionLogCompare.tsx
@@ -22,7 +22,7 @@ type ActionLogCompareProps = {
      * Latest name of the actual object, displayed in the title
      */
     name?: string;
-    onClickShowVersionHistory: () => void;
+    onClickShowVersionHistory?: () => void;
 };
 
 export const ActionLogCompare: FunctionComponent<ActionLogCompareProps> = ({
@@ -46,11 +46,13 @@ export const ActionLogCompare: FunctionComponent<ActionLogCompareProps> = ({
 
     return (
         <Root>
-            <Box marginBottom={4}>
-                <Button onClick={onClickShowVersionHistory} startIcon={<ArrowLeft />} variant="primary">
-                    <FormattedMessage defaultMessage="Show Version History" id="actionLog.actionLogCompare.showVersionHistory" />
-                </Button>
-            </Box>
+            {onClickShowVersionHistory && (
+                <Box marginBottom={4}>
+                    <Button onClick={onClickShowVersionHistory} startIcon={<ArrowLeft />} variant="primary">
+                        <FormattedMessage defaultMessage="Show Version History" id="actionLog.actionLogCompare.showVersionHistory" />
+                    </Button>
+                </Box>
+            )}
 
             <ActionLogHeader
                 action={

--- a/packages/admin/cms-admin/src/actionLog/components/actionLogShowVersion/ActionLogShowVersion.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/actionLogShowVersion/ActionLogShowVersion.tsx
@@ -21,7 +21,7 @@ type ActionLogShowVersionProps = {
      * Latest name of the actual object, displayed in the title
      */
     name?: string;
-    onClickShowVersionHistory: () => void;
+    onClickShowVersionHistory?: () => void;
 };
 
 export const ActionLogShowVersion: FunctionComponent<ActionLogShowVersionProps> = ({
@@ -52,11 +52,13 @@ export const ActionLogShowVersion: FunctionComponent<ActionLogShowVersionProps> 
 
     return (
         <Root>
-            <Box marginBottom={4}>
-                <Button onClick={onClickShowVersionHistory} startIcon={<ArrowLeft />} variant="primary">
-                    <FormattedMessage defaultMessage="Show Version History" id="actionLog.actionLogCompare.showVersionHistory" />
-                </Button>
-            </Box>
+            {onClickShowVersionHistory && (
+                <Box marginBottom={4}>
+                    <Button onClick={onClickShowVersionHistory} startIcon={<ArrowLeft />} variant="primary">
+                        <FormattedMessage defaultMessage="Show Version History" id="actionLog.actionLogCompare.showVersionHistory" />
+                    </Button>
+                </Box>
+            )}
 
             <ActionLogHeader dbTypes={version?.entityName ? [version.entityName] : []} id={id} title={title} />
 

--- a/packages/admin/cms-admin/src/actionLog/components/scopeCell/ScopeCell.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/scopeCell/ScopeCell.tsx
@@ -7,7 +7,7 @@ import { useIntl } from "react-intl";
 import { type ContentScope, type ContentScopeValues, useContentScope } from "../../../contentScope/Provider";
 
 type ScopeCellProps = {
-    scopes: ContentScope[];
+    scopes: ContentScope[] | null;
 };
 
 const formatScopeLabel = (scope: ContentScope, scopeValues: ContentScopeValues): string => {
@@ -22,7 +22,7 @@ export function ScopeCell({ scopes }: ScopeCellProps) {
     const intl = useIntl();
     const { values: scopeValues } = useContentScope();
 
-    if (scopes.length === 0) {
+    if (!scopes || scopes.length === 0) {
         return <Chip label={intl.formatMessage(messages.globalContentScope)} />;
     }
 

--- a/packages/admin/cms-admin/src/actionLog/components/scopeCell/ScopeCell.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/scopeCell/ScopeCell.tsx
@@ -1,0 +1,36 @@
+import { messages } from "@comet/admin";
+import { Box, Chip } from "@mui/material";
+import { capitalCase } from "change-case";
+import isEqual from "lodash.isequal";
+import { useIntl } from "react-intl";
+
+import { type ContentScope, type ContentScopeValues, useContentScope } from "../../../contentScope/Provider";
+
+type ScopeCellProps = {
+    scopes: ContentScope[];
+};
+
+const formatScopeLabel = (scope: ContentScope, scopeValues: ContentScopeValues): string => {
+    const matched = scopeValues.find((item) => isEqual(item.scope, scope));
+    const source = matched ?? { scope, label: undefined as Record<string, string> | undefined };
+    return Object.keys(source.scope)
+        .map((key) => source.label?.[key] ?? capitalCase(String(source.scope[key])))
+        .join(" / ");
+};
+
+export function ScopeCell({ scopes }: ScopeCellProps) {
+    const intl = useIntl();
+    const { values: scopeValues } = useContentScope();
+
+    if (scopes.length === 0) {
+        return <Chip label={intl.formatMessage(messages.globalContentScope)} />;
+    }
+
+    return (
+        <Box display="flex" gap={1} flexWrap="wrap">
+            {scopes.map((scope) => (
+                <Chip key={JSON.stringify(scope)} label={formatScopeLabel(scope, scopeValues)} />
+            ))}
+        </Box>
+    );
+}

--- a/packages/admin/cms-admin/src/actionLog/components/scopeCell/__stories__/ScopeCell.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/scopeCell/__stories__/ScopeCell.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ScopeCell } from "../ScopeCell";
+
+type Story = StoryObj<typeof ScopeCell>;
+const meta: Meta<typeof ScopeCell> = {
+    component: ScopeCell,
+    title: "actionLog/components/scopeCell/ScopeCell",
+};
+export default meta;
+
+export const SingleScope: Story = {
+    args: {
+        scopes: [{ domain: "main", language: "en" }],
+    },
+};
+
+export const MultipleScopes: Story = {
+    args: {
+        scopes: [
+            { domain: "main", language: "en" },
+            { domain: "main", language: "de" },
+            { domain: "secondary", language: "en" },
+        ],
+    },
+};
+
+export const GlobalScope: Story = {
+    args: {
+        scopes: null,
+    },
+};

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.gql.ts
@@ -1,0 +1,29 @@
+import { gql } from "@apollo/client";
+
+export const globalActionLogGridFragment = gql`
+    fragment GlobalActionLogGrid on ActionLog {
+        id
+        user {
+            id
+            name
+        }
+        entityName
+        entityId
+        version
+        type
+        createdAt
+        scope
+    }
+`;
+
+export const globalActionLogGridQuery = gql`
+    query GlobalActionLogGrid($offset: Int!, $limit: Int!, $sort: [ActionLogSort!], $scopes: [JSONObject!]!) {
+        actionLogs(offset: $offset, limit: $limit, sort: $sort, scopes: $scopes) {
+            nodes {
+                ...GlobalActionLogGrid
+            }
+            totalCount
+        }
+    }
+    ${globalActionLogGridFragment}
+`;

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.gql.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 
-export const globalActionLogGridFragment = gql`
+const globalActionLogGridFragment = gql`
     fragment GlobalActionLogGrid on ActionLog {
         id
         user {

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.sc.ts
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.sc.ts
@@ -1,0 +1,7 @@
+import { Chip } from "@mui/material";
+import { styled } from "@mui/material/styles";
+
+export const EntityTypeChip = styled(Chip)(({ theme }) => ({
+    backgroundColor: theme.palette.grey[100],
+    color: theme.palette.text.primary,
+}));

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
@@ -12,7 +12,7 @@ import {
 import { useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 
-import { type ContentScope, useContentScope } from "../../../contentScope/Provider";
+import { useContentScope } from "../../../contentScope/Provider";
 import { DataGrid } from "../../../dataGrid/DataGrid";
 import { ActionLogTypeChip } from "../../components/actionLogTypeChip/ActionLogTypeChip";
 import { ScopeCell } from "../../components/scopeCell/ScopeCell";
@@ -50,7 +50,7 @@ export function GlobalActionLogGrid() {
                 sortable: false,
                 filterable: false,
                 width: 150,
-                renderCell: ({ row }) => <ScopeCell scopes={(row.scope as ContentScope[] | null | undefined) ?? []} />,
+                renderCell: ({ row }) => <ScopeCell scopes={row.scope ?? []} />,
             },
             {
                 field: "type",
@@ -121,5 +121,3 @@ export function GlobalActionLogGrid() {
         </MainContent>
     );
 }
-
-export { globalActionLogGridFragment } from "./GlobalActionLogGrid.gql";

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
@@ -1,0 +1,157 @@
+import { useQuery } from "@apollo/client";
+import {
+    dataGridDateTimeColumn,
+    DataGridToolbar,
+    type GridColDef,
+    MainContent,
+    messages,
+    muiGridSortToGql,
+    useBufferedRowCount,
+    useDataGridRemote,
+    usePersistentColumnState,
+} from "@comet/admin";
+import { Box, Chip } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import { capitalCase } from "change-case";
+import isEqual from "lodash.isequal";
+import { useMemo, useState } from "react";
+import { useIntl } from "react-intl";
+
+import { type ContentScope, useContentScope } from "../../../contentScope/Provider";
+import { DataGrid } from "../../../dataGrid/DataGrid";
+import { ActionLogTypeChip } from "../../components/actionLogTypeChip/ActionLogTypeChip";
+import { UserCell } from "../../components/userCell/UserCell";
+import { GlobalActionLogShowVersionDialog } from "../globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog";
+import { globalActionLogGridQuery } from "./GlobalActionLogGrid.gql";
+import type {
+    GQLGlobalActionLogGridFragment,
+    GQLGlobalActionLogGridQuery,
+    GQLGlobalActionLogGridQueryVariables,
+} from "./GlobalActionLogGrid.gql.generated";
+
+const EntityTypeChip = styled(Chip)(({ theme }) => ({
+    backgroundColor: theme.palette.grey[100],
+    color: theme.palette.text.primary,
+}));
+
+export function GlobalActionLogGrid() {
+    const intl = useIntl();
+    const { values: scopeValues } = useContentScope();
+    const [openVersionId, setOpenVersionId] = useState<string | null>(null);
+
+    const dataGridProps = {
+        ...useDataGridRemote({ initialSort: [{ field: "createdAt", sort: "desc" }] }),
+        ...usePersistentColumnState("GlobalActionLogGrid"),
+    };
+
+    const formatScopeLabel = useMemo(
+        () =>
+            (scope: ContentScope): string => {
+                const matched = scopeValues.find((item) => isEqual(item.scope, scope));
+                const source = matched ?? { scope, label: undefined as Record<string, string> | undefined };
+                return Object.keys(source.scope)
+                    .map((key) => source.label?.[key] ?? capitalCase(String(source.scope[key])))
+                    .join(" / ");
+            },
+        [scopeValues],
+    );
+
+    const columns = useMemo<GridColDef<GQLGlobalActionLogGridFragment>[]>(
+        () => [
+            {
+                ...dataGridDateTimeColumn,
+                field: "createdAt",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.createdAt", defaultMessage: "Date / Time" }),
+                width: 200,
+            },
+            {
+                field: "scope",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.scope", defaultMessage: "Scope" }),
+                sortable: false,
+                filterable: false,
+                width: 150,
+                renderCell: ({ row }) => {
+                    const scopes = (row.scope as ContentScope[] | null | undefined) ?? [];
+                    if (scopes.length === 0) {
+                        return <Chip label={intl.formatMessage(messages.globalContentScope)} />;
+                    }
+                    return (
+                        <Box display="flex" gap={1} flexWrap="wrap">
+                            {scopes.map((scope) => (
+                                <Chip key={JSON.stringify(scope)} label={formatScopeLabel(scope)} />
+                            ))}
+                        </Box>
+                    );
+                },
+            },
+            {
+                field: "type",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.type", defaultMessage: "Type" }),
+                sortable: false,
+                filterable: false,
+                width: 150,
+                renderCell: ({ value }) => <ActionLogTypeChip actionLogType={value} label={value} />,
+            },
+            {
+                field: "entityName",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.entityName", defaultMessage: "Entity type" }),
+                width: 150,
+                renderCell: ({ value }) => <EntityTypeChip label={value} />,
+            },
+            {
+                field: "entityId",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.entity", defaultMessage: "Entity" }),
+                minWidth: 280,
+                flex: 1,
+                sortable: false,
+                filterable: false,
+            },
+            {
+                field: "user",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.user", defaultMessage: "User" }),
+                minWidth: 200,
+                flex: 1,
+                sortable: false,
+                filterable: false,
+                renderCell: ({ row }) => <UserCell id={row.user.id} name={row.user.name ?? undefined} />,
+            },
+        ],
+        [intl, formatScopeLabel],
+    );
+
+    const scopes = useMemo(() => scopeValues.map((item) => item.scope), [scopeValues]);
+
+    const { data, loading, error } = useQuery<GQLGlobalActionLogGridQuery, GQLGlobalActionLogGridQueryVariables>(globalActionLogGridQuery, {
+        variables: {
+            offset: dataGridProps.paginationModel.page * dataGridProps.paginationModel.pageSize,
+            limit: dataGridProps.paginationModel.pageSize,
+            scopes,
+            sort: muiGridSortToGql(dataGridProps.sortModel),
+        },
+    });
+
+    const rowCount = useBufferedRowCount(data?.actionLogs.totalCount);
+
+    if (error) {
+        throw error;
+    }
+
+    return (
+        <MainContent fullHeight>
+            <DataGrid
+                {...dataGridProps}
+                columns={columns}
+                rows={data?.actionLogs.nodes ?? []}
+                rowCount={rowCount}
+                loading={loading}
+                disableRowSelectionOnClick
+                onRowClick={({ row }) => setOpenVersionId(row.id)}
+                slots={{ toolbar: DataGridToolbar }}
+                showToolbar
+            />
+            <GlobalActionLogShowVersionDialog actionLogId={openVersionId} open={openVersionId !== null} onClose={() => setOpenVersionId(null)} />
+        </MainContent>
+    );
+}
+
+export { globalActionLogGridFragment } from "./GlobalActionLogGrid.gql";

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
@@ -50,7 +50,7 @@ export function GlobalActionLogGrid() {
                 sortable: false,
                 filterable: false,
                 width: 150,
-                renderCell: ({ row }) => <ScopeCell scopes={row.scope ?? []} />,
+                renderCell: ({ row }) => <ScopeCell scopes={row.scope} />,
             },
             {
                 field: "type",

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
@@ -4,22 +4,18 @@ import {
     DataGridToolbar,
     type GridColDef,
     MainContent,
-    messages,
     muiGridSortToGql,
     useBufferedRowCount,
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Box, Chip } from "@mui/material";
-import { styled } from "@mui/material/styles";
-import { capitalCase } from "change-case";
-import isEqual from "lodash.isequal";
 import { useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 
 import { type ContentScope, useContentScope } from "../../../contentScope/Provider";
 import { DataGrid } from "../../../dataGrid/DataGrid";
 import { ActionLogTypeChip } from "../../components/actionLogTypeChip/ActionLogTypeChip";
+import { ScopeCell } from "../../components/scopeCell/ScopeCell";
 import { UserCell } from "../../components/userCell/UserCell";
 import { GlobalActionLogShowVersionDialog } from "../globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog";
 import { globalActionLogGridQuery } from "./GlobalActionLogGrid.gql";
@@ -28,11 +24,7 @@ import type {
     GQLGlobalActionLogGridQuery,
     GQLGlobalActionLogGridQueryVariables,
 } from "./GlobalActionLogGrid.gql.generated";
-
-const EntityTypeChip = styled(Chip)(({ theme }) => ({
-    backgroundColor: theme.palette.grey[100],
-    color: theme.palette.text.primary,
-}));
+import { EntityTypeChip } from "./GlobalActionLogGrid.sc";
 
 export function GlobalActionLogGrid() {
     const intl = useIntl();
@@ -43,18 +35,6 @@ export function GlobalActionLogGrid() {
         ...useDataGridRemote({ initialSort: [{ field: "createdAt", sort: "desc" }] }),
         ...usePersistentColumnState("GlobalActionLogGrid"),
     };
-
-    const formatScopeLabel = useMemo(
-        () =>
-            (scope: ContentScope): string => {
-                const matched = scopeValues.find((item) => isEqual(item.scope, scope));
-                const source = matched ?? { scope, label: undefined as Record<string, string> | undefined };
-                return Object.keys(source.scope)
-                    .map((key) => source.label?.[key] ?? capitalCase(String(source.scope[key])))
-                    .join(" / ");
-            },
-        [scopeValues],
-    );
 
     const columns = useMemo<GridColDef<GQLGlobalActionLogGridFragment>[]>(
         () => [
@@ -70,19 +50,7 @@ export function GlobalActionLogGrid() {
                 sortable: false,
                 filterable: false,
                 width: 150,
-                renderCell: ({ row }) => {
-                    const scopes = (row.scope as ContentScope[] | null | undefined) ?? [];
-                    if (scopes.length === 0) {
-                        return <Chip label={intl.formatMessage(messages.globalContentScope)} />;
-                    }
-                    return (
-                        <Box display="flex" gap={1} flexWrap="wrap">
-                            {scopes.map((scope) => (
-                                <Chip key={JSON.stringify(scope)} label={formatScopeLabel(scope)} />
-                            ))}
-                        </Box>
-                    );
-                },
+                renderCell: ({ row }) => <ScopeCell scopes={(row.scope as ContentScope[] | null | undefined) ?? []} />,
             },
             {
                 field: "type",
@@ -116,7 +84,7 @@ export function GlobalActionLogGrid() {
                 renderCell: ({ row }) => <UserCell id={row.user.id} name={row.user.name ?? undefined} />,
             },
         ],
-        [intl, formatScopeLabel],
+        [intl],
     );
 
     const scopes = useMemo(() => scopeValues.map((item) => item.scope), [scopeValues]);

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/__stories__/GlobalActionLogGrid.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/__stories__/GlobalActionLogGrid.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { GlobalActionLogGrid } from "../GlobalActionLogGrid";
+
+type Story = StoryObj<typeof GlobalActionLogGrid>;
+const meta: Meta<typeof GlobalActionLogGrid> = {
+    component: GlobalActionLogGrid,
+    tags: ["!autodocs"],
+    title: "actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid",
+};
+export default meta;
+
+export const Standard: Story = {};

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogPage/GlobalActionLogPage.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogPage/GlobalActionLogPage.tsx
@@ -1,0 +1,15 @@
+import { Stack, StackToolbar } from "@comet/admin";
+import { useIntl } from "react-intl";
+
+import { ContentScopeIndicator } from "../../../contentScope/ContentScopeIndicator";
+import { GlobalActionLogGrid } from "../globalActionLogGrid/GlobalActionLogGrid";
+
+export function GlobalActionLogPage() {
+    const intl = useIntl();
+    return (
+        <Stack topLevelTitle={intl.formatMessage({ id: "comet.globalActionLog.title", defaultMessage: "Action Log" })}>
+            <StackToolbar scopeIndicator={<ContentScopeIndicator global />} />
+            <GlobalActionLogGrid />
+        </Stack>
+    );
+}

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogPage/__stories__/GlobalActionLogPage.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogPage/__stories__/GlobalActionLogPage.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { GlobalActionLogPage } from "../GlobalActionLogPage";
+
+type Story = StoryObj<typeof GlobalActionLogPage>;
+const meta: Meta<typeof GlobalActionLogPage> = {
+    component: GlobalActionLogPage,
+    tags: ["!autodocs"],
+    title: "actionLog/globalActionLog/globalActionLogPage/GlobalActionLogPage",
+};
+export default meta;
+
+export const Standard: Story = {};

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog.gql.ts
@@ -1,0 +1,15 @@
+import { gql } from "@apollo/client";
+
+import { actionLogCompareFragment } from "../../components/actionLogCompare/ActionLogCompare";
+
+export const globalActionLogShowVersionQuery = gql`
+    query GlobalActionLogShowVersion($id: ID!) {
+        actionLog(id: $id) {
+            ...ActionLogCompare
+            previousVersion {
+                ...ActionLogCompare
+            }
+        }
+    }
+    ${actionLogCompareFragment}
+`;

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog.tsx
@@ -1,0 +1,56 @@
+import { useQuery } from "@apollo/client";
+import { Dialog, InlineAlert } from "@comet/admin";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { ActionLogCompare } from "../../components/actionLogCompare/ActionLogCompare";
+import { ActionLogShowVersion } from "../../components/actionLogShowVersion/ActionLogShowVersion";
+import { globalActionLogShowVersionQuery } from "./GlobalActionLogShowVersionDialog.gql";
+import type {
+    GQLGlobalActionLogShowVersionQuery,
+    GQLGlobalActionLogShowVersionQueryVariables,
+} from "./GlobalActionLogShowVersionDialog.gql.generated";
+
+type GlobalActionLogShowVersionDialogProps = {
+    actionLogId: string | null;
+    open: boolean;
+    onClose: () => void;
+};
+
+export function GlobalActionLogShowVersionDialog({ actionLogId, open, onClose }: GlobalActionLogShowVersionDialogProps) {
+    const intl = useIntl();
+
+    const { data, loading, error } = useQuery<GQLGlobalActionLogShowVersionQuery, GQLGlobalActionLogShowVersionQueryVariables>(
+        globalActionLogShowVersionQuery,
+        {
+            variables: { id: actionLogId ?? "" },
+            skip: !open || actionLogId === null,
+        },
+    );
+
+    const current = data?.actionLog;
+    const previous = current?.previousVersion ?? undefined;
+    const hasDiff = current != null && previous != null;
+
+    return (
+        <Dialog
+            fullWidth
+            maxWidth={hasDiff ? "xl" : "md"}
+            onClose={onClose}
+            open={open}
+            title={intl.formatMessage({
+                id: "comet.globalActionLog.versionDialog.title",
+                defaultMessage: "Action Log",
+            })}
+        >
+            {error && (
+                <InlineAlert title={<FormattedMessage id="comet.globalActionLog.versionDialog.error" defaultMessage="Error loading version" />} />
+            )}
+            {!error && actionLogId !== null && hasDiff && (
+                <ActionLogCompare afterVersion={current} beforeVersion={previous} error={Boolean(error)} id={actionLogId} loading={loading} />
+            )}
+            {!error && actionLogId !== null && !hasDiff && (
+                <ActionLogShowVersion actionLog={current ?? undefined} error={Boolean(error)} id={actionLogId} loading={loading} />
+            )}
+        </Dialog>
+    );
+}

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/__stories__/GlobalActionLogShowVersionDialog.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/__stories__/GlobalActionLogShowVersionDialog.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { GlobalActionLogShowVersionDialog } from "../GlobalActionLogShowVersionDialog";
+
+type StoryArgs = {
+    actionLogId: string | null;
+    open: boolean;
+    onClose: () => void;
+};
+
+type Story = StoryObj<StoryArgs>;
+
+const meta: Meta<StoryArgs> = {
+    component: GlobalActionLogShowVersionDialog,
+    tags: ["!autodocs"],
+    title: "actionLog/globalActionLog/globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog",
+    args: {
+        open: true,
+        onClose: () => undefined,
+    },
+};
+export default meta;
+
+export const WithDiff: Story = {
+    args: { actionLogId: "log3" },
+};
+
+export const Created: Story = {
+    args: { actionLogId: "log1" },
+};
+
+export const Deleted: Story = {
+    args: { actionLogId: "log4" },
+};

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -7,7 +7,6 @@ export { ActionLogShowVersion, actionLogShowVersionFragment } from "./actionLog/
 export { ActionLogTypeChip } from "./actionLog/components/actionLogTypeChip/ActionLogTypeChip";
 export { DiffHeader, type DiffHeaderProps } from "./actionLog/components/diffHeader/DiffHeader";
 export { DiffViewer, type DiffViewerProps } from "./actionLog/components/diffViewer/DiffViewer";
-export { GlobalActionLogGrid, globalActionLogGridFragment } from "./actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid";
 export { GlobalActionLogPage } from "./actionLog/globalActionLog/globalActionLogPage/GlobalActionLogPage";
 export { AnchorBlock } from "./blocks/AnchorBlock";
 export { BlockAdminComponentButton } from "./blocks/common/BlockAdminComponentButton";

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -7,6 +7,8 @@ export { ActionLogShowVersion, actionLogShowVersionFragment } from "./actionLog/
 export { ActionLogTypeChip } from "./actionLog/components/actionLogTypeChip/ActionLogTypeChip";
 export { DiffHeader, type DiffHeaderProps } from "./actionLog/components/diffHeader/DiffHeader";
 export { DiffViewer, type DiffViewerProps } from "./actionLog/components/diffViewer/DiffViewer";
+export { GlobalActionLogGrid, globalActionLogGridFragment } from "./actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid";
+export { GlobalActionLogPage } from "./actionLog/globalActionLog/globalActionLogPage/GlobalActionLogPage";
 export { AnchorBlock } from "./blocks/AnchorBlock";
 export { BlockAdminComponentButton } from "./blocks/common/BlockAdminComponentButton";
 export { BlockAdminComponentNestedButton } from "./blocks/common/BlockAdminComponentNestedButton";

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -1,3 +1,52 @@
+type UserPermissionsUser {
+  id: String!
+  name: String!
+  email: String!
+  permissionsCount: Int!
+  contentScopesCount: Int!
+  impersonationAllowed: Boolean!
+}
+
+type CurrentUserPermission {
+  permission: Permission!
+  contentScopes: [JSONObject!]!
+}
+
+enum Permission {
+  builds
+  dam
+  pageTree
+  cronJobs
+  translation
+  userPermissions
+  prelogin
+  impersonation
+  fileUploads
+  dependencies
+  warnings
+  sitePreview
+  blockPreview
+  fullTextSearch
+  actionLog
+}
+
+"""
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+type CurrentUser {
+  id: String!
+  name: String!
+  email: String!
+  permissions: [CurrentUserPermission!]!
+  impersonated: Boolean
+  authenticatedUser: UserPermissionsUser
+  accountUrl: String
+  permissionsForScope(scope: JSONObject!): [String!]!
+  allowedContentScopes: [ContentScopeWithLabel!]!
+}
+
 type UserPermission {
   id: ID!
   source: UserPermissionSource!
@@ -16,32 +65,10 @@ enum UserPermissionSource {
   BY_RULE
 }
 
-enum Permission {
-  builds
-  dam
-  pageTree
-  cronJobs
-  translation
-  userPermissions
-  prelogin
-  impersonation
-  fileUploads
-  dependencies
-  warnings
-  sitePreview
-  blockPreview
-  fullTextSearch
-}
-
 """
 A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
 """
 scalar DateTime
-
-"""
-The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 type ActionLogsUser {
   id: ID!
@@ -75,35 +102,14 @@ enum ActionLogType {
   Deleted
 }
 
+type PaginatedActionLogs {
+  nodes: [ActionLog!]!
+  totalCount: Int!
+}
+
 type ContentScopeWithLabel {
   scope: JSONObject!
   label: JSONObject!
-}
-
-type UserPermissionsUser {
-  id: String!
-  name: String!
-  email: String!
-  permissionsCount: Int!
-  contentScopesCount: Int!
-  impersonationAllowed: Boolean!
-}
-
-type CurrentUserPermission {
-  permission: Permission!
-  contentScopes: [JSONObject!]!
-}
-
-type CurrentUser {
-  id: String!
-  name: String!
-  email: String!
-  permissions: [CurrentUserPermission!]!
-  impersonated: Boolean
-  authenticatedUser: UserPermissionsUser
-  accountUrl: String
-  permissionsForScope(scope: JSONObject!): [String!]!
-  allowedContentScopes: [ContentScopeWithLabel!]!
 }
 
 type EntityInfo {
@@ -538,6 +544,15 @@ input WarningSourceInfoInput {
 }
 
 type Query {
+  """
+  Returns action log entries across all entities. Requires the `actionLog` permission.
+  """
+  actionLogs(search: String, filter: ActionLogFilter, sort: [ActionLogSort!], offset: Int! = 0, limit: Int! = 25, scopes: [JSONObject!]!): PaginatedActionLogs!
+
+  """
+  Returns a single action log entry by id. Requires the `actionLog` permission.
+  """
+  actionLog(id: ID!): ActionLog!
   builds(limit: Float): [Build!]!
   autoBuildStatus: AutoBuildStatus!
   buildTemplates: [BuildTemplate!]!
@@ -600,6 +615,55 @@ type Query {
   myFullTextSearch(search: String!, offset: Int! = 0, limit: Int! = 25, scope: JSONObject): PaginatedEntityInfo!
 }
 
+input ActionLogFilter {
+  userId: StringFilter
+  entityId: IdFilter
+  entityName: StringFilter
+  version: NumberFilter
+  createdAt: DateTimeFilter
+  and: [ActionLogFilter!]
+  or: [ActionLogFilter!]
+}
+
+input IdFilter {
+  isAnyOf: [ID!]
+  equal: ID
+  notEqual: ID
+}
+
+input NumberFilter {
+  equal: Float
+  lowerThan: Float
+  greaterThan: Float
+  lowerThanEqual: Float
+  greaterThanEqual: Float
+  notEqual: Float
+  isAnyOf: [Float!]
+  isEmpty: Boolean
+  isNotEmpty: Boolean
+}
+
+input DateTimeFilter {
+  equal: DateTime
+  lowerThan: DateTime
+  greaterThan: DateTime
+  lowerThanEqual: DateTime
+  greaterThanEqual: DateTime
+  notEqual: DateTime
+  isEmpty: Boolean
+  isNotEmpty: Boolean
+}
+
+input ActionLogSort {
+  field: ActionLogSortField!
+  direction: SortDirection! = ASC
+}
+
+enum ActionLogSortField {
+  version
+  createdAt
+}
+
 input RedirectScopeInput {
   thisScopeHasNoFields____: String
 }
@@ -621,17 +685,6 @@ input RedirectSourceTypeEnumFilter {
   isAnyOf: [RedirectSourceType!]
   equal: RedirectSourceType
   notEqual: RedirectSourceType
-}
-
-input DateTimeFilter {
-  equal: DateTime
-  lowerThan: DateTime
-  greaterThan: DateTime
-  lowerThanEqual: DateTime
-  greaterThanEqual: DateTime
-  notEqual: DateTime
-  isEmpty: Boolean
-  isNotEmpty: Boolean
 }
 
 input RedirectSort {

--- a/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
@@ -1,17 +1,76 @@
-import { Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { EntityManager, type FilterQuery, type ObjectQuery, PostgreSqlDriver } from "@mikro-orm/postgresql";
+import { UnauthorizedException } from "@nestjs/common";
+import { Args, ID, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import isEqual from "lodash.isequal";
 
+import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
+import { filtersToMikroOrmQuery, gqlSortToMikroOrmOrderBy, searchToMikroOrmQuery } from "../common/filter/mikro-orm";
+import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
+import { CurrentUser } from "../user-permissions/dto/current-user";
 import { UserPermissionsService } from "../user-permissions/user-permissions.service";
 import { ActionLogType } from "./dto/action-log-type.enum";
 import { ActionLogsUser } from "./dto/action-logs-user";
+import { GlobalActionLogsArgs } from "./dto/global-action-logs.args";
+import { PaginatedActionLogs } from "./dto/paginated-action-logs";
 import { ActionLog } from "./entities/action-log.entity";
 import { PreviousActionLogLoaderService } from "./previous-action-log-loader.service";
 
 @Resolver(() => ActionLog)
+@RequiredPermission(["actionLog"], { skipScopeCheck: true })
 export class ActionLogsResolver {
     constructor(
+        private readonly entityManager: EntityManager<PostgreSqlDriver>,
         private readonly userPermissionsService: UserPermissionsService,
         private readonly previousActionLogLoader: PreviousActionLogLoaderService,
     ) {}
+
+    @Query(() => PaginatedActionLogs, {
+        description: "Returns action log entries across all entities. Requires the `actionLog` permission.",
+    })
+    async actionLogs(
+        @Args() { search, filter, scopes, offset, limit, sort }: GlobalActionLogsArgs,
+        @GetCurrentUser() user: CurrentUser,
+    ): Promise<PaginatedActionLogs> {
+        const allowedScopesForUser = user.permissions.find(({ permission }) => permission === "actionLog")?.contentScopes;
+        for (const scope of scopes) {
+            if (!allowedScopesForUser?.find((allowedScope) => isEqual(allowedScope, scope))) {
+                throw new UnauthorizedException("Scopes were passed that the user does not have permission to");
+            }
+        }
+
+        const andFilters: ObjectQuery<ActionLog>[] = [];
+
+        if (search) {
+            andFilters.push(searchToMikroOrmQuery(search, ["entityName", "userId"]));
+        }
+
+        if (filter) {
+            andFilters.push(filtersToMikroOrmQuery(filter));
+        }
+
+        // Use $contained (<@) so a row's scope must be a subset of one of the user's allowed scopes.
+        // This naturally handles partially-scoped entities (e.g. scope only by domain) without sub-scope expansion.
+        andFilters.push({
+            $or: [...scopes.map((scope) => ({ scope: { $contained: [scope] } })), { scope: null }],
+        });
+
+        const where: FilterQuery<ActionLog> = { $and: andFilters };
+
+        const [entities, totalCount] = await this.entityManager.findAndCount(ActionLog, where, {
+            offset,
+            limit,
+            orderBy: sort ? gqlSortToMikroOrmOrderBy(sort) : { createdAt: "DESC" },
+        });
+
+        return new PaginatedActionLogs(entities, totalCount);
+    }
+
+    @Query(() => ActionLog, {
+        description: "Returns a single action log entry by id. Requires the `actionLog` permission.",
+    })
+    async actionLog(@Args("id", { type: () => ID }) id: string): Promise<ActionLog> {
+        return this.entityManager.findOneOrFail(ActionLog, { id });
+    }
 
     @ResolveField(() => ActionLog, {
         nullable: true,

--- a/packages/api/cms-api/src/action-logs/dto/action-log.filter.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-log.filter.ts
@@ -1,0 +1,54 @@
+import { Field, InputType } from "@nestjs/graphql";
+import { Type } from "class-transformer";
+import { ValidateNested } from "class-validator";
+
+import { DateTimeFilter } from "../../common/filter/date-time.filter";
+import { IdFilter } from "../../common/filter/id.filter";
+import { NumberFilter } from "../../common/filter/number.filter";
+import { StringFilter } from "../../common/filter/string.filter";
+import { IsUndefinable } from "../../common/validators/is-undefinable";
+
+@InputType()
+export class ActionLogFilter {
+    @Field(() => StringFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => StringFilter)
+    @IsUndefinable()
+    userId?: StringFilter;
+
+    @Field(() => IdFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => IdFilter)
+    @IsUndefinable()
+    entityId?: IdFilter;
+
+    @Field(() => StringFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => StringFilter)
+    @IsUndefinable()
+    entityName?: StringFilter;
+
+    @Field(() => NumberFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => NumberFilter)
+    @IsUndefinable()
+    version?: NumberFilter;
+
+    @Field(() => DateTimeFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => DateTimeFilter)
+    @IsUndefinable()
+    createdAt?: DateTimeFilter;
+
+    @Field(() => [ActionLogFilter], { nullable: true })
+    @ValidateNested({ each: true })
+    @Type(() => ActionLogFilter)
+    @IsUndefinable()
+    and?: ActionLogFilter[];
+
+    @Field(() => [ActionLogFilter], { nullable: true })
+    @ValidateNested({ each: true })
+    @Type(() => ActionLogFilter)
+    @IsUndefinable()
+    or?: ActionLogFilter[];
+}

--- a/packages/api/cms-api/src/action-logs/dto/action-logs.args.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-logs.args.ts
@@ -1,0 +1,28 @@
+import { ArgsType, Field } from "@nestjs/graphql";
+import { Type } from "class-transformer";
+import { IsString, ValidateNested } from "class-validator";
+
+import { OffsetBasedPaginationArgs } from "../../common/pagination/offset-based.args";
+import { IsUndefinable } from "../../common/validators/is-undefinable";
+import { ActionLogFilter } from "./action-log.filter";
+import { ActionLogSort } from "./action-log.sort";
+
+@ArgsType()
+export class ActionLogsArgs extends OffsetBasedPaginationArgs {
+    @Field({ nullable: true })
+    @IsString()
+    @IsUndefinable()
+    search?: string;
+
+    @Field(() => ActionLogFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => ActionLogFilter)
+    @IsUndefinable()
+    filter?: ActionLogFilter;
+
+    @Field(() => [ActionLogSort], { nullable: true })
+    @ValidateNested({ each: true })
+    @Type(() => ActionLogSort)
+    @IsUndefinable()
+    sort?: ActionLogSort[];
+}

--- a/packages/api/cms-api/src/action-logs/dto/global-action-logs.args.ts
+++ b/packages/api/cms-api/src/action-logs/dto/global-action-logs.args.ts
@@ -1,0 +1,13 @@
+import { ArgsType, Field } from "@nestjs/graphql";
+import { IsArray } from "class-validator";
+import { GraphQLJSONObject } from "graphql-scalars";
+
+import { ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
+import { ActionLogsArgs } from "./action-logs.args";
+
+@ArgsType()
+export class GlobalActionLogsArgs extends ActionLogsArgs {
+    @Field(() => [GraphQLJSONObject])
+    @IsArray()
+    scopes: ContentScope[];
+}

--- a/packages/api/cms-api/src/common/enum/core-permission.enum.ts
+++ b/packages/api/cms-api/src/common/enum/core-permission.enum.ts
@@ -13,4 +13,5 @@ export enum CorePermission {
     sitePreview = "sitePreview",
     blockPreview = "blockPreview",
     fullTextSearch = "fullTextSearch",
+    actionLog = "actionLog",
 }


### PR DESCRIPTION
Jira: [COM-3006](https://vivid-planet.atlassian.net/browse/COM-3006)

## Summary

The base of the Global Action Log feature: a top-level cross-entity `actionLogs` query plus an admin grid + page that uses it. An admin with the new `globalActionLog` permission can read every change across every scope they have access to — including for already-deleted entities.

<img width="960" height="577" alt="Screen Recording 2026-05-28 at 11 28 15" src="https://github.com/user-attachments/assets/50591cb7-da83-4c01-a9b6-c11e3178b2d2"/>


[COM-3006]: ``https://vivid-planet.atlassian.net/browse/COM-3006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ``