### PR TITLE
Add per-entity drill-in dialog to Global Action Log [COM-3006]

### DIFF
--- a/.changeset/global-action-log-drill-in.md
+++ b/.changeset/global-action-log-drill-in.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add per-entity drill-in dialog to Global Action Log view
+
+Adds a row action on `GlobalActionLogGrid` (clock icon) that opens a new `GlobalActionLogDialog` showing the complete version history of the clicked entity. Inside that dialog, users get the familiar version grid → show single version → compare two versions workflow, reusing `ActionLogVersionGrid`, `ActionLogShowVersion`, and `ActionLogCompare`.
+
+The dialog reads from the top-level `actionLogs(filter)` query — same gating (`globalActionLog` permission) as the grid — so it also works for entities that have been deleted.

--- a/.changeset/global-action-log-scope-filter.md
+++ b/.changeset/global-action-log-scope-filter.md
@@ -1,0 +1,18 @@
+---
+"@comet/cms-api": minor
+"@comet/cms-admin": minor
+---
+
+Add scope filter and sort to Global Action Log view
+
+Extends the Global Action Log view introduced in the previous PR with the ability to filter and sort by content scope. The scope column gets an autocomplete-style filter that lists every scope the user has access to plus a "Global" entry for unscoped rows.
+
+**API**
+
+- New `ActionLogScopeFilter` input on `ActionLogFilter` with operators `equal` / `notEqual` / `isAnyOf` / `isGlobal`. The resolver translates these into PostgreSQL `jsonb` containment predicates so the filter is applied at the database layer.
+- `scope` is added to `ActionLogSortField`.
+
+**Admin**
+
+- The Scope column on `GlobalActionLogGrid` gets a typeahead filter using MUI Autocomplete (`is` / `not` for single-value, `isAnyOf` for multi-select). Built on top of the data-grid's `baseTextField` slot so it inherits the panel theme.
+- The Scope column becomes sortable.

--- a/.changeset/global-action-log-view.md
+++ b/.changeset/global-action-log-view.md
@@ -1,0 +1,35 @@
+---
+"@comet/cms-api": minor
+"@comet/cms-admin": minor
+---
+
+Add Global Action Log view
+
+Adds a top-level `actionLogs` cross-entity Query plus an admin grid + page that uses it. Admins with the new `globalActionLog` permission can now inspect activity across all entities — including for deletions, where the entity's detail page no longer exists.
+
+**API**
+
+- New top-level Query `actionLogs(scopes, filter, sort, offset, limit, search): PaginatedActionLogs!` — read directly from the `action_log` table, scope-restricted server-side so users can only see action logs in scopes they have the `globalActionLog` permission for.
+- Single-row Query `actionLog(id): ActionLog!` — used by the admin's show-version dialog.
+- New `globalActionLog` core permission.
+- New DTO `GlobalActionLogsArgs` (extends `ActionLogsArgs` with `scopes: ContentScope[]`).
+
+**Admin**
+
+- `GlobalActionLogGrid` — paginated grid with columns Date / Time, Scope, Action (chip), Entity type, Entity (display name + id), User.
+- `GlobalActionLogPage` — top-level page using `GlobalActionLogGrid`.
+- `GlobalActionLogShowVersionDialog` — opened on row click; renders `ActionLogCompare` for diffable rows (or `ActionLogShowVersion` for the first version of an entity).
+
+**Example menu entry**
+
+```tsx
+{
+    type: "route",
+    primary: <FormattedMessage id="menu.actionLog" defaultMessage="Action Log" />,
+    route: {
+        path: "/system/action-log",
+        component: GlobalActionLogPage,
+    },
+    requiredPermission: "globalActionLog",
+}
+```

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -12,6 +12,7 @@ import {
     DamPage,
     type DocumentInterface,
     type DocumentType,
+    GlobalActionLogPage,
     MasterMenu,
     type MasterMenuData,
     MasterMenuRoutes,
@@ -284,6 +285,15 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
                         component: WarningsPage,
                     },
                     requiredPermission: "warnings",
+                },
+                {
+                    type: "route",
+                    primary: <FormattedMessage id="menu.actionLog" defaultMessage="Action Log" />,
+                    route: {
+                        path: "/system/action-log",
+                        component: GlobalActionLogPage,
+                    },
+                    requiredPermission: "actionLog",
                 },
             ],
         },

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -1421,6 +1421,7 @@ enum Permission {
   dependencies
   fileUploads
   fullTextSearch
+  globalActionLog
   impersonation
   manufacturers
   news
@@ -1970,6 +1971,15 @@ input ProductVariantUpdateInput {
 }
 
 type Query {
+  """
+  Returns a single action log entry by id. Requires the `globalActionLog` permission.
+  """
+  actionLog(id: ID!): ActionLog!
+
+  """
+  Returns action log entries across all entities. Requires the `globalActionLog` permission.
+  """
+  actionLogs(filter: ActionLogFilter, limit: Int! = 25, offset: Int! = 0, scopes: [JSONObject!]!, search: String, sort: [ActionLogSort!]): PaginatedActionLogs!
   autoBuildStatus: AutoBuildStatus!
   blockPreviewJwt(includeInvisible: Boolean!, scope: JSONObject!, url: String!): String!
   brevoConfig(scope: EmailCampaignContentScopeInput!): BrevoConfig

--- a/packages/admin/cms-admin/.storybook/mocks/globalActionLogHandlers.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/globalActionLogHandlers.ts
@@ -1,0 +1,98 @@
+import { graphql, HttpResponse } from "msw";
+
+const mockNodes = [
+    {
+        __typename: "ActionLog",
+        id: "log4",
+        userId: "Alice",
+        entityName: "Page",
+        entityId: "550e8400-e29b-41d4-a716-446655440004",
+        version: 1,
+        snapshot: null,
+        previousVersion: {
+            __typename: "ActionLog",
+            snapshot: { title: "Imprint", slug: "imprint" },
+        },
+        scope: [{ domain: "main", language: "en" }],
+        createdAt: "2026-05-28T09:00:00Z",
+    },
+    {
+        __typename: "ActionLog",
+        id: "log3",
+        userId: "Bob",
+        entityName: "News",
+        entityId: "550e8400-e29b-41d4-a716-446655440003",
+        version: 3,
+        snapshot: { title: "Release 9.0", slug: "release-9-0" },
+        previousVersion: {
+            __typename: "ActionLog",
+            snapshot: { title: "Release 9.0 (draft)", slug: "release-9-0" },
+        },
+        scope: [{ domain: "main", language: "en" }],
+        createdAt: "2026-05-27T15:30:00Z",
+    },
+    {
+        __typename: "ActionLog",
+        id: "log2",
+        userId: "Bob",
+        entityName: "News",
+        entityId: "550e8400-e29b-41d4-a716-446655440003",
+        version: 2,
+        snapshot: { title: "Release 9.0 (draft)", slug: "release-9-0" },
+        previousVersion: {
+            __typename: "ActionLog",
+            snapshot: { title: "Release", slug: "release" },
+        },
+        scope: [{ domain: "main", language: "en" }],
+        createdAt: "2026-05-27T14:00:00Z",
+    },
+    {
+        __typename: "ActionLog",
+        id: "log1",
+        userId: "Bob",
+        entityName: "News",
+        entityId: "550e8400-e29b-41d4-a716-446655440003",
+        version: 1,
+        snapshot: { title: "Release", slug: "release" },
+        previousVersion: null,
+        scope: [{ domain: "main", language: "en" }],
+        createdAt: "2026-05-27T13:00:00Z",
+    },
+];
+
+const versionById: Record<string, (typeof mockNodes)[number]> = Object.fromEntries(mockNodes.map((node) => [node.id, node]));
+
+export const globalActionLogHandlers = [
+    graphql.query("GlobalActionLogGrid", () =>
+        HttpResponse.json({
+            data: {
+                actionLogs: { __typename: "PaginatedActionLogs", nodes: mockNodes, totalCount: mockNodes.length },
+            },
+        }),
+    ),
+    graphql.query("GlobalActionLogShowVersion", ({ variables }) =>
+        HttpResponse.json({
+            data: { actionLog: versionById[variables.id as string] ?? null },
+        }),
+    ),
+    graphql.query("GlobalActionLogDialogGrid", () =>
+        HttpResponse.json({
+            data: {
+                actionLogs: { __typename: "PaginatedActionLogs", nodes: mockNodes.slice(1), totalCount: mockNodes.length - 1 },
+            },
+        }),
+    ),
+    graphql.query("GlobalActionLogDialogShowVersion", ({ variables }) =>
+        HttpResponse.json({
+            data: { actionLog: versionById[variables.id as string] ?? null },
+        }),
+    ),
+    graphql.query("GlobalActionLogDialogCompare", ({ variables }) =>
+        HttpResponse.json({
+            data: {
+                beforeVersion: versionById[variables.beforeId as string] ?? null,
+                afterVersion: versionById[variables.afterId as string] ?? null,
+            },
+        }),
+    ),
+];

--- a/packages/admin/cms-admin/.storybook/mocks/handlers.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { actionLogDialogHandlers } from "./actionLogDialogHandler";
 import { currentUserHandler } from "./currentUserHandler";
+import { globalActionLogHandlers } from "./globalActionLogHandlers";
 
-export const handlers = [currentUserHandler, ...actionLogDialogHandlers];
+export const handlers = [currentUserHandler, ...actionLogDialogHandlers, ...globalActionLogHandlers];

--- a/packages/admin/cms-admin/src/actionLog/components/actionLogCompare/ActionLogCompare.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/actionLogCompare/ActionLogCompare.tsx
@@ -22,7 +22,7 @@ type ActionLogCompareProps = {
      * Latest name of the actual object, displayed in the title
      */
     name?: string;
-    onClickShowVersionHistory: () => void;
+    onClickShowVersionHistory?: () => void;
 };
 
 export const ActionLogCompare: FunctionComponent<ActionLogCompareProps> = ({
@@ -46,11 +46,13 @@ export const ActionLogCompare: FunctionComponent<ActionLogCompareProps> = ({
 
     return (
         <Root>
-            <Box marginBottom={4}>
-                <Button onClick={onClickShowVersionHistory} startIcon={<ArrowLeft />} variant="primary">
-                    <FormattedMessage defaultMessage="Show Version History" id="actionLog.actionLogCompare.showVersionHistory" />
-                </Button>
-            </Box>
+            {onClickShowVersionHistory && (
+                <Box marginBottom={4}>
+                    <Button onClick={onClickShowVersionHistory} startIcon={<ArrowLeft />} variant="primary">
+                        <FormattedMessage defaultMessage="Show Version History" id="actionLog.actionLogCompare.showVersionHistory" />
+                    </Button>
+                </Box>
+            )}
 
             <ActionLogHeader
                 action={

--- a/packages/admin/cms-admin/src/actionLog/components/actionLogShowVersion/ActionLogShowVersion.tsx
+++ b/packages/admin/cms-admin/src/actionLog/components/actionLogShowVersion/ActionLogShowVersion.tsx
@@ -21,7 +21,7 @@ type ActionLogShowVersionProps = {
      * Latest name of the actual object, displayed in the title
      */
     name?: string;
-    onClickShowVersionHistory: () => void;
+    onClickShowVersionHistory?: () => void;
 };
 
 export const ActionLogShowVersion: FunctionComponent<ActionLogShowVersionProps> = ({
@@ -52,11 +52,13 @@ export const ActionLogShowVersion: FunctionComponent<ActionLogShowVersionProps> 
 
     return (
         <Root>
-            <Box marginBottom={4}>
-                <Button onClick={onClickShowVersionHistory} startIcon={<ArrowLeft />} variant="primary">
-                    <FormattedMessage defaultMessage="Show Version History" id="actionLog.actionLogCompare.showVersionHistory" />
-                </Button>
-            </Box>
+            {onClickShowVersionHistory && (
+                <Box marginBottom={4}>
+                    <Button onClick={onClickShowVersionHistory} startIcon={<ArrowLeft />} variant="primary">
+                        <FormattedMessage defaultMessage="Show Version History" id="actionLog.actionLogCompare.showVersionHistory" />
+                    </Button>
+                </Box>
+            )}
 
             <ActionLogHeader dbTypes={version?.entityName ? [version.entityName] : []} id={id} title={title} />
 

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogDialog/GlobalActionLogDialog.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogDialog/GlobalActionLogDialog.gql.ts
@@ -1,0 +1,40 @@
+import { gql } from "@apollo/client";
+
+import { actionLogVersionGridFragment } from "../../actionLog/actionLogVersionGrid/ActionLogVersionGrid";
+import { actionLogCompareFragment } from "../../components/actionLogCompare/ActionLogCompare";
+
+export const globalActionLogDialogGridQuery = gql`
+    query GlobalActionLogDialogGrid($filter: ActionLogFilter!, $offset: Int!, $limit: Int!, $sort: [ActionLogSort!], $scopes: [JSONObject!]!) {
+        actionLogs(filter: $filter, offset: $offset, limit: $limit, sort: $sort, scopes: $scopes) {
+            nodes {
+                ...ActionLogVersionGrid
+            }
+            totalCount
+        }
+    }
+    ${actionLogVersionGridFragment}
+`;
+
+export const globalActionLogDialogShowVersionQuery = gql`
+    query GlobalActionLogDialogShowVersion($id: ID!) {
+        actionLog(id: $id) {
+            ...ActionLogCompare
+            previousVersion {
+                ...ActionLogCompare
+            }
+        }
+    }
+    ${actionLogCompareFragment}
+`;
+
+export const globalActionLogDialogCompareQuery = gql`
+    query GlobalActionLogDialogCompare($beforeId: ID!, $afterId: ID!) {
+        beforeVersion: actionLog(id: $beforeId) {
+            ...ActionLogCompare
+        }
+        afterVersion: actionLog(id: $afterId) {
+            ...ActionLogCompare
+        }
+    }
+    ${actionLogCompareFragment}
+`;

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogDialog/GlobalActionLogDialog.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogDialog/GlobalActionLogDialog.tsx
@@ -1,0 +1,157 @@
+import { useQuery } from "@apollo/client";
+import { Dialog, InlineAlert, useDataGridRemote, usePersistentColumnState } from "@comet/admin";
+import { useEffect, useMemo, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { useContentScope } from "../../../contentScope/Provider";
+import type { GQLActionLogSortField } from "../../../graphql.generated";
+import { ActionLogVersionGrid } from "../../actionLog/actionLogVersionGrid/ActionLogVersionGrid";
+import { ActionLogCompare } from "../../components/actionLogCompare/ActionLogCompare";
+import { ActionLogShowVersion } from "../../components/actionLogShowVersion/ActionLogShowVersion";
+import {
+    globalActionLogDialogCompareQuery,
+    globalActionLogDialogGridQuery,
+    globalActionLogDialogShowVersionQuery,
+} from "./GlobalActionLogDialog.gql";
+import type {
+    GQLGlobalActionLogDialogCompareQuery,
+    GQLGlobalActionLogDialogCompareQueryVariables,
+    GQLGlobalActionLogDialogGridQuery,
+    GQLGlobalActionLogDialogGridQueryVariables,
+    GQLGlobalActionLogDialogShowVersionQuery,
+    GQLGlobalActionLogDialogShowVersionQueryVariables,
+} from "./GlobalActionLogDialog.gql.generated";
+
+type GlobalActionLogDialogView =
+    | { type: "grid" }
+    | { type: "showVersion"; versionId: string }
+    | { type: "compareVersions"; beforeVersionId: string; afterVersionId: string };
+
+type GlobalActionLogDialogProps = {
+    entityName: string;
+    entityId: string;
+    open: boolean;
+    onClose: () => void;
+};
+
+export function GlobalActionLogDialog({ entityName, entityId, open, onClose }: GlobalActionLogDialogProps) {
+    const intl = useIntl();
+    const { values: scopeValues } = useContentScope();
+    const scopes = useMemo(() => scopeValues.map((item) => item.scope), [scopeValues]);
+    const [view, setView] = useState<GlobalActionLogDialogView>({ type: "grid" });
+
+    useEffect(() => {
+        if (!open) {
+            setView({ type: "grid" });
+        }
+    }, [open]);
+
+    const dataGridRemote = useDataGridRemote({ initialSort: [{ field: "version", sort: "desc" }] });
+    const persistentColumnState = usePersistentColumnState(`GlobalActionLogDialog-${entityName}`);
+
+    const filter = useMemo(
+        () => ({
+            entityName: { equal: entityName },
+            entityId: { equal: entityId },
+        }),
+        [entityName, entityId],
+    );
+
+    const gridResult = useQuery<GQLGlobalActionLogDialogGridQuery, GQLGlobalActionLogDialogGridQueryVariables>(globalActionLogDialogGridQuery, {
+        variables: {
+            filter,
+            scopes,
+            offset: dataGridRemote.paginationModel.page * dataGridRemote.paginationModel.pageSize,
+            limit: dataGridRemote.paginationModel.pageSize,
+            sort: dataGridRemote.sortModel.map((entry) => ({
+                field: entry.field as GQLActionLogSortField,
+                direction: entry.sort === "desc" ? "DESC" : "ASC",
+            })),
+        },
+        skip: !open || view.type !== "grid",
+    });
+
+    const showVersionResult = useQuery<GQLGlobalActionLogDialogShowVersionQuery, GQLGlobalActionLogDialogShowVersionQueryVariables>(
+        globalActionLogDialogShowVersionQuery,
+        {
+            variables: { id: view.type === "showVersion" ? view.versionId : "" },
+            skip: !open || view.type !== "showVersion",
+        },
+    );
+
+    const compareResult = useQuery<GQLGlobalActionLogDialogCompareQuery, GQLGlobalActionLogDialogCompareQueryVariables>(
+        globalActionLogDialogCompareQuery,
+        {
+            variables:
+                view.type === "compareVersions" ? { beforeId: view.beforeVersionId, afterId: view.afterVersionId } : { beforeId: "", afterId: "" },
+            skip: !open || view.type !== "compareVersions",
+        },
+    );
+
+    const showVersionCurrent = showVersionResult.data?.actionLog;
+    const showVersionPrevious = showVersionCurrent?.previousVersion ?? undefined;
+    const showVersionHasDiff = showVersionCurrent != null && showVersionPrevious != null;
+
+    return (
+        <Dialog
+            fullWidth
+            maxWidth={view.type === "compareVersions" || showVersionHasDiff ? "xl" : "md"}
+            onClose={onClose}
+            open={open}
+            title={intl.formatMessage({
+                id: "comet.globalActionLogDialog.title",
+                defaultMessage: "Action Log",
+            })}
+        >
+            {view.type === "grid" && gridResult.error && (
+                <InlineAlert title={<FormattedMessage id="comet.globalActionLogDialog.gridError" defaultMessage="Error loading action logs" />} />
+            )}
+
+            {view.type === "grid" && !gridResult.error && (
+                <ActionLogVersionGrid
+                    {...dataGridRemote}
+                    {...persistentColumnState}
+                    actionLogs={gridResult.data?.actionLogs ?? undefined}
+                    id={entityId}
+                    loading={gridResult.loading}
+                    onShowVersionClick={(versionId) => setView({ type: "showVersion", versionId })}
+                    onCompareVersionsClick={(beforeVersionId, afterVersionId) =>
+                        setView({ type: "compareVersions", beforeVersionId, afterVersionId })
+                    }
+                />
+            )}
+
+            {view.type === "showVersion" && showVersionHasDiff && (
+                <ActionLogCompare
+                    afterVersion={showVersionCurrent}
+                    beforeVersion={showVersionPrevious}
+                    error={Boolean(showVersionResult.error)}
+                    id={entityId}
+                    loading={showVersionResult.loading}
+                    onClickShowVersionHistory={() => setView({ type: "grid" })}
+                />
+            )}
+
+            {view.type === "showVersion" && !showVersionHasDiff && (
+                <ActionLogShowVersion
+                    actionLog={showVersionCurrent ?? undefined}
+                    error={Boolean(showVersionResult.error)}
+                    id={entityId}
+                    loading={showVersionResult.loading}
+                    onClickShowVersionHistory={() => setView({ type: "grid" })}
+                />
+            )}
+
+            {view.type === "compareVersions" && (
+                <ActionLogCompare
+                    afterVersion={compareResult.data?.afterVersion ?? undefined}
+                    beforeVersion={compareResult.data?.beforeVersion ?? undefined}
+                    error={Boolean(compareResult.error)}
+                    id={entityId}
+                    loading={compareResult.loading}
+                    onClickShowVersionHistory={() => setView({ type: "grid" })}
+                />
+            )}
+        </Dialog>
+    );
+}

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogDialog/__stories__/GlobalActionLogDialog.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogDialog/__stories__/GlobalActionLogDialog.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { GlobalActionLogDialog } from "../GlobalActionLogDialog";
+
+type StoryArgs = {
+    entityName: string;
+    entityId: string;
+    open: boolean;
+    onClose: () => void;
+};
+
+type Story = StoryObj<StoryArgs>;
+
+const meta: Meta<StoryArgs> = {
+    component: GlobalActionLogDialog,
+    tags: ["!autodocs"],
+    title: "actionLog/globalActionLog/globalActionLogDialog/GlobalActionLogDialog",
+    args: {
+        entityName: "News",
+        entityId: "550e8400-e29b-41d4-a716-446655440003",
+        open: true,
+        onClose: () => undefined,
+    },
+};
+export default meta;
+
+export const Default: Story = {};

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.gql.ts
@@ -21,8 +21,8 @@ export const globalActionLogGridFragment = gql`
 `;
 
 export const globalActionLogGridQuery = gql`
-    query GlobalActionLogGrid($offset: Int!, $limit: Int!, $sort: [ActionLogSort!], $scopes: [JSONObject!]!) {
-        actionLogs(offset: $offset, limit: $limit, sort: $sort, scopes: $scopes) {
+    query GlobalActionLogGrid($offset: Int!, $limit: Int!, $sort: [ActionLogSort!], $filter: ActionLogFilter, $scopes: [JSONObject!]!) {
+        actionLogs(offset: $offset, limit: $limit, sort: $sort, filter: $filter, scopes: $scopes) {
             nodes {
                 ...GlobalActionLogGrid
             }

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.gql.ts
@@ -1,0 +1,33 @@
+import { gql } from "@apollo/client";
+
+export const globalActionLogGridFragment = gql`
+    fragment GlobalActionLogGrid on ActionLog {
+        id
+        user {
+            id
+            name
+        }
+        entityName
+        entityId
+        version
+        action
+        createdAt
+        scope
+        snapshot
+        previousVersion {
+            snapshot
+        }
+    }
+`;
+
+export const globalActionLogGridQuery = gql`
+    query GlobalActionLogGrid($offset: Int!, $limit: Int!, $sort: [ActionLogSort!], $scopes: [JSONObject!]!) {
+        actionLogs(offset: $offset, limit: $limit, sort: $sort, scopes: $scopes) {
+            nodes {
+                ...GlobalActionLogGrid
+            }
+            totalCount
+        }
+    }
+    ${globalActionLogGridFragment}
+`;

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
@@ -4,24 +4,30 @@ import {
     DataGridToolbar,
     GridCellContent,
     type GridColDef,
+    GridFilterButton,
     MainContent,
     messages,
+    muiGridFilterToGql,
     muiGridSortToGql,
+    ToolbarItem,
+    Tooltip,
     useBufferedRowCount,
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Box, Chip } from "@mui/material";
+import { Time } from "@comet/admin-icons";
+import { Autocomplete, Box, Chip, IconButton } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { DataGrid } from "@mui/x-data-grid";
+import { DataGrid, type GridFilterInputValueProps, type GridFilterItem, type GridFilterOperator, useGridRootProps } from "@mui/x-data-grid";
 import { capitalCase } from "change-case";
 import isEqual from "lodash.isequal";
-import { useMemo, useState } from "react";
-import { useIntl } from "react-intl";
+import { createContext, useContext, useMemo, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { type ContentScope, useContentScope } from "../../../contentScope/Provider";
 import { ActionChip } from "../../components/actionChip/ActionChip";
 import { UserCell } from "../../components/userCell/UserCell";
+import { GlobalActionLogDialog } from "../globalActionLogDialog/GlobalActionLogDialog";
 import { GlobalActionLogShowVersionDialog } from "../globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog";
 import { globalActionLogGridQuery } from "./GlobalActionLogGrid.gql";
 import type {
@@ -50,10 +56,112 @@ const EntityTypeChip = styled(Chip)(({ theme }) => ({
     color: theme.palette.text.primary,
 }));
 
+const GLOBAL_SCOPE_VALUE = "__global__";
+
+function scopeColumnToGqlFilter(filterItem: GridFilterItem) {
+    if (filterItem.operator === "isAnyOf") {
+        const values = (filterItem.value as string[] | undefined) ?? [];
+        const hasGlobal = values.includes(GLOBAL_SCOPE_VALUE);
+        const scopes = values.filter((value) => value !== GLOBAL_SCOPE_VALUE).map((value) => JSON.parse(value));
+        if (hasGlobal && scopes.length > 0) {
+            return { or: [{ scope: { isGlobal: true } }, { scope: { isAnyOf: scopes } }] };
+        }
+        if (hasGlobal) {
+            return { scope: { isGlobal: true } };
+        }
+        return { scope: { isAnyOf: scopes } };
+    }
+    if (filterItem.value === GLOBAL_SCOPE_VALUE) {
+        return { scope: { isGlobal: filterItem.operator !== "not" } };
+    }
+    const gqlOperator = filterItem.operator === "not" ? "notEqual" : "equal";
+    const value = typeof filterItem.value === "string" ? JSON.parse(filterItem.value) : filterItem.value;
+    return { scope: { [gqlOperator]: value } };
+}
+
+type ScopeOption = { value: string; label: string };
+
+const ScopeFilterOptionsContext = createContext<ScopeOption[]>([]);
+
+function ScopeFilterSingleInput({ item, applyValue, focusElementRef, apiRef }: GridFilterInputValueProps) {
+    const options = useContext(ScopeFilterOptionsContext);
+    const rootProps = useGridRootProps();
+    const selectedValue = typeof item.value === "string" ? (options.find((option) => option.value === item.value) ?? null) : null;
+    return (
+        <Autocomplete<ScopeOption, false, false, false>
+            options={options}
+            value={selectedValue}
+            getOptionLabel={(option) => option.label}
+            isOptionEqualToValue={(option, candidate) => option.value === candidate.value}
+            onChange={(_, newValue) => applyValue({ ...item, value: newValue?.value ?? null })}
+            renderInput={(params) => (
+                <rootProps.slots.baseTextField
+                    {...params}
+                    label={apiRef.current.getLocaleText("filterPanelInputLabel")}
+                    inputRef={focusElementRef}
+                    slotProps={{
+                        inputLabel: { shrink: true },
+                        input: params.InputProps,
+                    }}
+                />
+            )}
+        />
+    );
+}
+
+function ScopeFilterMultiInput({ item, applyValue, focusElementRef, apiRef }: GridFilterInputValueProps) {
+    const options = useContext(ScopeFilterOptionsContext);
+    const rootProps = useGridRootProps();
+    const selectedValues = Array.isArray(item.value) ? (item.value as string[]) : [];
+    const selectedOptions = options.filter((option) => selectedValues.includes(option.value));
+    return (
+        <Autocomplete<ScopeOption, true, false, false>
+            multiple
+            options={options}
+            value={selectedOptions}
+            getOptionLabel={(option) => option.label}
+            isOptionEqualToValue={(option, candidate) => option.value === candidate.value}
+            onChange={(_, newValue) => applyValue({ ...item, value: newValue.map((option) => option.value) })}
+            renderInput={(params) => (
+                <rootProps.slots.baseTextField
+                    {...params}
+                    label={apiRef.current.getLocaleText("filterPanelInputLabel")}
+                    inputRef={focusElementRef}
+                    slotProps={{
+                        inputLabel: { shrink: true },
+                        input: params.InputProps,
+                    }}
+                />
+            )}
+        />
+    );
+}
+
+const throwOnLocalScopeFilter = () => {
+    throw new Error("Server-side filter; not applied on the client.");
+};
+
+const scopeFilterOperators: GridFilterOperator[] = [
+    { value: "is", getApplyFilterFn: throwOnLocalScopeFilter, InputComponent: ScopeFilterSingleInput },
+    { value: "not", getApplyFilterFn: throwOnLocalScopeFilter, InputComponent: ScopeFilterSingleInput },
+    { value: "isAnyOf", getApplyFilterFn: throwOnLocalScopeFilter, InputComponent: ScopeFilterMultiInput },
+];
+
+function GlobalActionLogGridToolbar() {
+    return (
+        <DataGridToolbar>
+            <ToolbarItem>
+                <GridFilterButton />
+            </ToolbarItem>
+        </DataGridToolbar>
+    );
+}
+
 export function GlobalActionLogGrid() {
     const intl = useIntl();
     const { values: scopeValues } = useContentScope();
     const [openVersionId, setOpenVersionId] = useState<string | null>(null);
+    const [openDialog, setOpenDialog] = useState<{ entityName: string; entityId: string } | null>(null);
 
     const dataGridProps = {
         ...useDataGridRemote({ initialSort: [{ field: "createdAt", sort: "desc" }] }),
@@ -72,6 +180,17 @@ export function GlobalActionLogGrid() {
         [scopeValues],
     );
 
+    const scopeValueOptions = useMemo(
+        () => [
+            { value: GLOBAL_SCOPE_VALUE, label: intl.formatMessage(messages.globalContentScope) },
+            ...scopeValues.map((item) => ({
+                value: JSON.stringify(item.scope),
+                label: formatScopeLabel(item.scope),
+            })),
+        ],
+        [intl, scopeValues, formatScopeLabel],
+    );
+
     const columns = useMemo<GridColDef<GQLGlobalActionLogGridFragment>[]>(
         () => [
             {
@@ -83,8 +202,8 @@ export function GlobalActionLogGrid() {
             {
                 field: "scope",
                 headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.scope", defaultMessage: "Scope" }),
-                sortable: false,
-                filterable: false,
+                filterOperators: scopeFilterOperators,
+                toGqlFilter: scopeColumnToGqlFilter,
                 width: 150,
                 renderCell: ({ row }) => {
                     const scopes = (row.scope as ContentScope[] | null | undefined) ?? [];
@@ -103,9 +222,14 @@ export function GlobalActionLogGrid() {
             {
                 field: "action",
                 headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.action", defaultMessage: "Action" }),
+                type: "singleSelect",
                 sortable: false,
-                filterable: false,
                 width: 150,
+                valueOptions: [
+                    { value: "Created", label: intl.formatMessage({ id: "comet.globalActionLog.action.created", defaultMessage: "Created" }) },
+                    { value: "Updated", label: intl.formatMessage({ id: "comet.globalActionLog.action.updated", defaultMessage: "Updated" }) },
+                    { value: "Deleted", label: intl.formatMessage({ id: "comet.globalActionLog.action.deleted", defaultMessage: "Deleted" }) },
+                ],
                 renderCell: ({ value }) => <ActionChip actionValue={value} label={value} />,
             },
             {
@@ -137,9 +261,33 @@ export function GlobalActionLogGrid() {
                 filterable: false,
                 renderCell: ({ row }) => <UserCell id={row.user.id} name={row.user.name ?? undefined} />,
             },
+            {
+                field: "actions",
+                type: "actions",
+                headerName: "",
+                width: 100,
+                sortable: false,
+                filterable: false,
+                renderCell: ({ row }) => (
+                    <Tooltip
+                        title={
+                            <FormattedMessage
+                                id="comet.globalActionLog.actions.showEntityActionLog"
+                                defaultMessage="Show action log for this entity"
+                            />
+                        }
+                    >
+                        <IconButton onClick={() => setOpenDialog({ entityName: row.entityName, entityId: row.entityId })}>
+                            <Time />
+                        </IconButton>
+                    </Tooltip>
+                ),
+            },
         ],
         [intl, formatScopeLabel],
     );
+
+    const { filter: gqlFilter } = muiGridFilterToGql(columns, dataGridProps.filterModel);
 
     const scopes = useMemo(() => scopeValues.map((item) => item.scope), [scopeValues]);
 
@@ -147,6 +295,7 @@ export function GlobalActionLogGrid() {
         variables: {
             offset: dataGridProps.paginationModel.page * dataGridProps.paginationModel.pageSize,
             limit: dataGridProps.paginationModel.pageSize,
+            filter: gqlFilter,
             scopes,
             sort: muiGridSortToGql(dataGridProps.sortModel),
         },
@@ -159,20 +308,30 @@ export function GlobalActionLogGrid() {
     }
 
     return (
-        <MainContent fullHeight>
-            <DataGrid
-                {...dataGridProps}
-                columns={columns}
-                rows={data?.actionLogs.nodes ?? []}
-                rowCount={rowCount}
-                loading={loading}
-                disableRowSelectionOnClick
-                onRowClick={({ row }) => setOpenVersionId(row.id)}
-                slots={{ toolbar: DataGridToolbar }}
-                showToolbar
-            />
-            <GlobalActionLogShowVersionDialog actionLogId={openVersionId} open={openVersionId !== null} onClose={() => setOpenVersionId(null)} />
-        </MainContent>
+        <ScopeFilterOptionsContext.Provider value={scopeValueOptions}>
+            <MainContent fullHeight>
+                <DataGrid
+                    {...dataGridProps}
+                    columns={columns}
+                    rows={data?.actionLogs.nodes ?? []}
+                    rowCount={rowCount}
+                    loading={loading}
+                    disableRowSelectionOnClick
+                    onRowClick={({ row }) => setOpenVersionId(row.id)}
+                    slots={{ toolbar: GlobalActionLogGridToolbar }}
+                    showToolbar
+                />
+                <GlobalActionLogShowVersionDialog actionLogId={openVersionId} open={openVersionId !== null} onClose={() => setOpenVersionId(null)} />
+                {openDialog && (
+                    <GlobalActionLogDialog
+                        entityName={openDialog.entityName}
+                        entityId={openDialog.entityId}
+                        open
+                        onClose={() => setOpenDialog(null)}
+                    />
+                )}
+            </MainContent>
+        </ScopeFilterOptionsContext.Provider>
     );
 }
 

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
@@ -1,0 +1,179 @@
+import { useQuery } from "@apollo/client";
+import {
+    dataGridDateTimeColumn,
+    DataGridToolbar,
+    GridCellContent,
+    type GridColDef,
+    MainContent,
+    messages,
+    muiGridSortToGql,
+    useBufferedRowCount,
+    useDataGridRemote,
+    usePersistentColumnState,
+} from "@comet/admin";
+import { Box, Chip } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import { DataGrid } from "@mui/x-data-grid";
+import { capitalCase } from "change-case";
+import isEqual from "lodash.isequal";
+import { useMemo, useState } from "react";
+import { useIntl } from "react-intl";
+
+import { type ContentScope, useContentScope } from "../../../contentScope/Provider";
+import { ActionChip } from "../../components/actionChip/ActionChip";
+import { UserCell } from "../../components/userCell/UserCell";
+import { GlobalActionLogShowVersionDialog } from "../globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog";
+import { globalActionLogGridQuery } from "./GlobalActionLogGrid.gql";
+import type {
+    GQLGlobalActionLogGridFragment,
+    GQLGlobalActionLogGridQuery,
+    GQLGlobalActionLogGridQueryVariables,
+} from "./GlobalActionLogGrid.gql.generated";
+
+const displayNameFields = ["name", "title", "label", "slug", "description"] as const;
+
+function extractDisplayName(snapshot: Record<string, unknown> | null | undefined): string | undefined {
+    if (!snapshot) {
+        return undefined;
+    }
+    for (const field of displayNameFields) {
+        const value = snapshot[field];
+        if (typeof value === "string" && value.length > 0) {
+            return value;
+        }
+    }
+    return undefined;
+}
+
+const EntityTypeChip = styled(Chip)(({ theme }) => ({
+    backgroundColor: theme.palette.grey[100],
+    color: theme.palette.text.primary,
+}));
+
+export function GlobalActionLogGrid() {
+    const intl = useIntl();
+    const { values: scopeValues } = useContentScope();
+    const [openVersionId, setOpenVersionId] = useState<string | null>(null);
+
+    const dataGridProps = {
+        ...useDataGridRemote({ initialSort: [{ field: "createdAt", sort: "desc" }] }),
+        ...usePersistentColumnState("GlobalActionLogGrid"),
+    };
+
+    const formatScopeLabel = useMemo(
+        () =>
+            (scope: ContentScope): string => {
+                const matched = scopeValues.find((item) => isEqual(item.scope, scope));
+                const source = matched ?? { scope, label: undefined as Record<string, string> | undefined };
+                return Object.keys(source.scope)
+                    .map((key) => source.label?.[key] ?? capitalCase(String(source.scope[key])))
+                    .join(" / ");
+            },
+        [scopeValues],
+    );
+
+    const columns = useMemo<GridColDef<GQLGlobalActionLogGridFragment>[]>(
+        () => [
+            {
+                ...dataGridDateTimeColumn,
+                field: "createdAt",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.createdAt", defaultMessage: "Date / Time" }),
+                width: 200,
+            },
+            {
+                field: "scope",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.scope", defaultMessage: "Scope" }),
+                sortable: false,
+                filterable: false,
+                width: 150,
+                renderCell: ({ row }) => {
+                    const scopes = (row.scope as ContentScope[] | null | undefined) ?? [];
+                    if (scopes.length === 0) {
+                        return <Chip label={intl.formatMessage(messages.globalContentScope)} />;
+                    }
+                    return (
+                        <Box display="flex" gap={1} flexWrap="wrap">
+                            {scopes.map((scope) => (
+                                <Chip key={JSON.stringify(scope)} label={formatScopeLabel(scope)} />
+                            ))}
+                        </Box>
+                    );
+                },
+            },
+            {
+                field: "action",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.action", defaultMessage: "Action" }),
+                sortable: false,
+                filterable: false,
+                width: 150,
+                renderCell: ({ value }) => <ActionChip actionValue={value} label={value} />,
+            },
+            {
+                field: "entityName",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.entityName", defaultMessage: "Entity type" }),
+                width: 150,
+                renderCell: ({ value }) => <EntityTypeChip label={value} />,
+            },
+            {
+                field: "entityId",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.entity", defaultMessage: "Entity" }),
+                minWidth: 280,
+                flex: 1,
+                sortable: false,
+                filterable: false,
+                renderCell: ({ row }) => {
+                    const displayName =
+                        extractDisplayName(row.snapshot as Record<string, unknown> | null | undefined) ??
+                        extractDisplayName(row.previousVersion?.snapshot as Record<string, unknown> | null | undefined);
+                    return <GridCellContent primaryText={displayName ?? row.entityId} secondaryText={displayName ? row.entityId : undefined} />;
+                },
+            },
+            {
+                field: "user",
+                headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.user", defaultMessage: "User" }),
+                minWidth: 200,
+                flex: 1,
+                sortable: false,
+                filterable: false,
+                renderCell: ({ row }) => <UserCell id={row.user.id} name={row.user.name ?? undefined} />,
+            },
+        ],
+        [intl, formatScopeLabel],
+    );
+
+    const scopes = useMemo(() => scopeValues.map((item) => item.scope), [scopeValues]);
+
+    const { data, loading, error } = useQuery<GQLGlobalActionLogGridQuery, GQLGlobalActionLogGridQueryVariables>(globalActionLogGridQuery, {
+        variables: {
+            offset: dataGridProps.paginationModel.page * dataGridProps.paginationModel.pageSize,
+            limit: dataGridProps.paginationModel.pageSize,
+            scopes,
+            sort: muiGridSortToGql(dataGridProps.sortModel),
+        },
+    });
+
+    const rowCount = useBufferedRowCount(data?.actionLogs.totalCount);
+
+    if (error) {
+        throw error;
+    }
+
+    return (
+        <MainContent fullHeight>
+            <DataGrid
+                {...dataGridProps}
+                columns={columns}
+                rows={data?.actionLogs.nodes ?? []}
+                rowCount={rowCount}
+                loading={loading}
+                disableRowSelectionOnClick
+                onRowClick={({ row }) => setOpenVersionId(row.id)}
+                slots={{ toolbar: DataGridToolbar }}
+                showToolbar
+            />
+            <GlobalActionLogShowVersionDialog actionLogId={openVersionId} open={openVersionId !== null} onClose={() => setOpenVersionId(null)} />
+        </MainContent>
+    );
+}
+
+export { globalActionLogGridFragment } from "./GlobalActionLogGrid.gql";

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
@@ -10,21 +10,24 @@ import {
     muiGridFilterToGql,
     muiGridSortToGql,
     ToolbarItem,
+    Tooltip,
     useBufferedRowCount,
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Autocomplete, Box, Chip } from "@mui/material";
+import { Time } from "@comet/admin-icons";
+import { Autocomplete, Box, Chip, IconButton } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { DataGrid, type GridFilterInputValueProps, type GridFilterItem, type GridFilterOperator, useGridRootProps } from "@mui/x-data-grid";
 import { capitalCase } from "change-case";
 import isEqual from "lodash.isequal";
 import { createContext, useContext, useMemo, useState } from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { type ContentScope, useContentScope } from "../../../contentScope/Provider";
 import { ActionChip } from "../../components/actionChip/ActionChip";
 import { UserCell } from "../../components/userCell/UserCell";
+import { GlobalActionLogDialog } from "../globalActionLogDialog/GlobalActionLogDialog";
 import { GlobalActionLogShowVersionDialog } from "../globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog";
 import { globalActionLogGridQuery } from "./GlobalActionLogGrid.gql";
 import type {
@@ -158,6 +161,7 @@ export function GlobalActionLogGrid() {
     const intl = useIntl();
     const { values: scopeValues } = useContentScope();
     const [openVersionId, setOpenVersionId] = useState<string | null>(null);
+    const [openDialog, setOpenDialog] = useState<{ entityName: string; entityId: string } | null>(null);
 
     const dataGridProps = {
         ...useDataGridRemote({ initialSort: [{ field: "createdAt", sort: "desc" }] }),
@@ -252,6 +256,28 @@ export function GlobalActionLogGrid() {
                 filterable: false,
                 renderCell: ({ row }) => <UserCell id={row.user.id} name={row.user.name ?? undefined} />,
             },
+            {
+                field: "actions",
+                type: "actions",
+                headerName: "",
+                width: 100,
+                sortable: false,
+                filterable: false,
+                renderCell: ({ row }) => (
+                    <Tooltip
+                        title={
+                            <FormattedMessage
+                                id="comet.globalActionLog.actions.showEntityActionLog"
+                                defaultMessage="Show action log for this entity"
+                            />
+                        }
+                    >
+                        <IconButton onClick={() => setOpenDialog({ entityName: row.entityName, entityId: row.entityId })}>
+                            <Time />
+                        </IconButton>
+                    </Tooltip>
+                ),
+            },
         ],
         [intl, formatScopeLabel],
     );
@@ -291,6 +317,9 @@ export function GlobalActionLogGrid() {
                     showToolbar
                 />
                 <GlobalActionLogShowVersionDialog actionLogId={openVersionId} open={openVersionId !== null} onClose={() => setOpenVersionId(null)} />
+                {openDialog && (
+                    <GlobalActionLogDialog entityName={openDialog.entityName} entityId={openDialog.entityId} open onClose={() => setOpenDialog(null)} />
+                )}
             </MainContent>
         </ScopeFilterOptionsContext.Provider>
     );

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
@@ -10,24 +10,21 @@ import {
     muiGridFilterToGql,
     muiGridSortToGql,
     ToolbarItem,
-    Tooltip,
     useBufferedRowCount,
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Time } from "@comet/admin-icons";
-import { Autocomplete, Box, Chip, IconButton } from "@mui/material";
+import { Autocomplete, Box, Chip } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { DataGrid, type GridFilterInputValueProps, type GridFilterItem, type GridFilterOperator, useGridRootProps } from "@mui/x-data-grid";
 import { capitalCase } from "change-case";
 import isEqual from "lodash.isequal";
 import { createContext, useContext, useMemo, useState } from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import { type ContentScope, useContentScope } from "../../../contentScope/Provider";
 import { ActionChip } from "../../components/actionChip/ActionChip";
 import { UserCell } from "../../components/userCell/UserCell";
-import { GlobalActionLogDialog } from "../globalActionLogDialog/GlobalActionLogDialog";
 import { GlobalActionLogShowVersionDialog } from "../globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog";
 import { globalActionLogGridQuery } from "./GlobalActionLogGrid.gql";
 import type {
@@ -161,7 +158,6 @@ export function GlobalActionLogGrid() {
     const intl = useIntl();
     const { values: scopeValues } = useContentScope();
     const [openVersionId, setOpenVersionId] = useState<string | null>(null);
-    const [openDialog, setOpenDialog] = useState<{ entityName: string; entityId: string } | null>(null);
 
     const dataGridProps = {
         ...useDataGridRemote({ initialSort: [{ field: "createdAt", sort: "desc" }] }),
@@ -222,14 +218,9 @@ export function GlobalActionLogGrid() {
             {
                 field: "action",
                 headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.action", defaultMessage: "Action" }),
-                type: "singleSelect",
                 sortable: false,
+                filterable: false,
                 width: 150,
-                valueOptions: [
-                    { value: "Created", label: intl.formatMessage({ id: "comet.globalActionLog.action.created", defaultMessage: "Created" }) },
-                    { value: "Updated", label: intl.formatMessage({ id: "comet.globalActionLog.action.updated", defaultMessage: "Updated" }) },
-                    { value: "Deleted", label: intl.formatMessage({ id: "comet.globalActionLog.action.deleted", defaultMessage: "Deleted" }) },
-                ],
                 renderCell: ({ value }) => <ActionChip actionValue={value} label={value} />,
             },
             {
@@ -260,28 +251,6 @@ export function GlobalActionLogGrid() {
                 sortable: false,
                 filterable: false,
                 renderCell: ({ row }) => <UserCell id={row.user.id} name={row.user.name ?? undefined} />,
-            },
-            {
-                field: "actions",
-                type: "actions",
-                headerName: "",
-                width: 100,
-                sortable: false,
-                filterable: false,
-                renderCell: ({ row }) => (
-                    <Tooltip
-                        title={
-                            <FormattedMessage
-                                id="comet.globalActionLog.actions.showEntityActionLog"
-                                defaultMessage="Show action log for this entity"
-                            />
-                        }
-                    >
-                        <IconButton onClick={() => setOpenDialog({ entityName: row.entityName, entityId: row.entityId })}>
-                            <Time />
-                        </IconButton>
-                    </Tooltip>
-                ),
             },
         ],
         [intl, formatScopeLabel],
@@ -322,14 +291,6 @@ export function GlobalActionLogGrid() {
                     showToolbar
                 />
                 <GlobalActionLogShowVersionDialog actionLogId={openVersionId} open={openVersionId !== null} onClose={() => setOpenVersionId(null)} />
-                {openDialog && (
-                    <GlobalActionLogDialog
-                        entityName={openDialog.entityName}
-                        entityId={openDialog.entityId}
-                        open
-                        onClose={() => setOpenDialog(null)}
-                    />
-                )}
             </MainContent>
         </ScopeFilterOptionsContext.Provider>
     );

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogPage/GlobalActionLogPage.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogPage/GlobalActionLogPage.tsx
@@ -1,0 +1,15 @@
+import { Stack, StackToolbar } from "@comet/admin";
+import { useIntl } from "react-intl";
+
+import { ContentScopeIndicator } from "../../../contentScope/ContentScopeIndicator";
+import { GlobalActionLogGrid } from "../globalActionLogGrid/GlobalActionLogGrid";
+
+export function GlobalActionLogPage() {
+    const intl = useIntl();
+    return (
+        <Stack topLevelTitle={intl.formatMessage({ id: "comet.globalActionLog.title", defaultMessage: "Action Log" })}>
+            <StackToolbar scopeIndicator={<ContentScopeIndicator global />} />
+            <GlobalActionLogGrid />
+        </Stack>
+    );
+}

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog.gql.ts
@@ -1,0 +1,15 @@
+import { gql } from "@apollo/client";
+
+import { actionLogCompareFragment } from "../../components/actionLogCompare/ActionLogCompare";
+
+export const globalActionLogShowVersionQuery = gql`
+    query GlobalActionLogShowVersion($id: ID!) {
+        actionLog(id: $id) {
+            ...ActionLogCompare
+            previousVersion {
+                ...ActionLogCompare
+            }
+        }
+    }
+    ${actionLogCompareFragment}
+`;

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog.tsx
@@ -1,0 +1,56 @@
+import { useQuery } from "@apollo/client";
+import { Dialog, InlineAlert } from "@comet/admin";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { ActionLogCompare } from "../../components/actionLogCompare/ActionLogCompare";
+import { ActionLogShowVersion } from "../../components/actionLogShowVersion/ActionLogShowVersion";
+import { globalActionLogShowVersionQuery } from "./GlobalActionLogShowVersionDialog.gql";
+import type {
+    GQLGlobalActionLogShowVersionQuery,
+    GQLGlobalActionLogShowVersionQueryVariables,
+} from "./GlobalActionLogShowVersionDialog.gql.generated";
+
+type GlobalActionLogShowVersionDialogProps = {
+    actionLogId: string | null;
+    open: boolean;
+    onClose: () => void;
+};
+
+export function GlobalActionLogShowVersionDialog({ actionLogId, open, onClose }: GlobalActionLogShowVersionDialogProps) {
+    const intl = useIntl();
+
+    const { data, loading, error } = useQuery<GQLGlobalActionLogShowVersionQuery, GQLGlobalActionLogShowVersionQueryVariables>(
+        globalActionLogShowVersionQuery,
+        {
+            variables: { id: actionLogId ?? "" },
+            skip: !open || actionLogId === null,
+        },
+    );
+
+    const current = data?.actionLog;
+    const previous = current?.previousVersion ?? undefined;
+    const hasDiff = current != null && previous != null;
+
+    return (
+        <Dialog
+            fullWidth
+            maxWidth={hasDiff ? "xl" : "md"}
+            onClose={onClose}
+            open={open}
+            title={intl.formatMessage({
+                id: "comet.globalActionLog.versionDialog.title",
+                defaultMessage: "Action Log",
+            })}
+        >
+            {error && (
+                <InlineAlert title={<FormattedMessage id="comet.globalActionLog.versionDialog.error" defaultMessage="Error loading version" />} />
+            )}
+            {!error && actionLogId !== null && hasDiff && (
+                <ActionLogCompare afterVersion={current} beforeVersion={previous} error={Boolean(error)} id={actionLogId} loading={loading} />
+            )}
+            {!error && actionLogId !== null && !hasDiff && (
+                <ActionLogShowVersion actionLog={current ?? undefined} error={Boolean(error)} id={actionLogId} loading={loading} />
+            )}
+        </Dialog>
+    );
+}

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/__stories__/GlobalActionLogShowVersionDialog.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogShowVersionDialog/__stories__/GlobalActionLogShowVersionDialog.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { GlobalActionLogShowVersionDialog } from "../GlobalActionLogShowVersionDialog";
+
+type StoryArgs = {
+    actionLogId: string | null;
+    open: boolean;
+    onClose: () => void;
+};
+
+type Story = StoryObj<StoryArgs>;
+
+const meta: Meta<StoryArgs> = {
+    component: GlobalActionLogShowVersionDialog,
+    tags: ["!autodocs"],
+    title: "actionLog/globalActionLog/globalActionLogShowVersionDialog/GlobalActionLogShowVersionDialog",
+    args: {
+        open: true,
+        onClose: () => undefined,
+    },
+};
+export default meta;
+
+export const WithDiff: Story = {
+    args: { actionLogId: "log3" },
+};
+
+export const Created: Story = {
+    args: { actionLogId: "log1" },
+};
+
+export const Deleted: Story = {
+    args: { actionLogId: "log4" },
+};

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -6,6 +6,8 @@ export { ActionLogHeader, type ActionLogHeaderProps } from "./actionLog/componen
 export { ActionLogShowVersion, actionLogShowVersionFragment } from "./actionLog/components/actionLogShowVersion/ActionLogShowVersion";
 export { DiffHeader, type DiffHeaderProps } from "./actionLog/components/diffHeader/DiffHeader";
 export { DiffViewer, type DiffViewerProps } from "./actionLog/components/diffViewer/DiffViewer";
+export { GlobalActionLogGrid, globalActionLogGridFragment } from "./actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid";
+export { GlobalActionLogPage } from "./actionLog/globalActionLog/globalActionLogPage/GlobalActionLogPage";
 export { AnchorBlock } from "./blocks/AnchorBlock";
 export { BlockAdminComponentButton } from "./blocks/common/BlockAdminComponentButton";
 export { BlockAdminComponentNestedButton } from "./blocks/common/BlockAdminComponentNestedButton";

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -605,6 +605,7 @@ input ActionLogFilter {
   entityName: StringFilter
   version: NumberFilter
   createdAt: DateTimeFilter
+  scope: ActionLogScopeFilter
   and: [ActionLogFilter!]
   or: [ActionLogFilter!]
 }
@@ -638,6 +639,13 @@ input DateTimeFilter {
   isNotEmpty: Boolean
 }
 
+input ActionLogScopeFilter {
+  isAnyOf: [JSONObject!]
+  equal: JSONObject
+  notEqual: JSONObject
+  isGlobal: Boolean
+}
+
 input ActionLogSort {
   field: ActionLogSortField!
   direction: SortDirection! = ASC
@@ -646,6 +654,8 @@ input ActionLogSort {
 enum ActionLogSortField {
   version
   createdAt
+  entityName
+  scope
 }
 
 input RedirectScopeInput {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -1,3 +1,52 @@
+type UserPermissionsUser {
+  id: String!
+  name: String!
+  email: String!
+  permissionsCount: Int!
+  contentScopesCount: Int!
+  impersonationAllowed: Boolean!
+}
+
+type CurrentUserPermission {
+  permission: Permission!
+  contentScopes: [JSONObject!]!
+}
+
+enum Permission {
+  builds
+  dam
+  pageTree
+  cronJobs
+  translation
+  userPermissions
+  prelogin
+  impersonation
+  fileUploads
+  dependencies
+  warnings
+  sitePreview
+  blockPreview
+  fullTextSearch
+  globalActionLog
+}
+
+"""
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+type CurrentUser {
+  id: String!
+  name: String!
+  email: String!
+  permissions: [CurrentUserPermission!]!
+  impersonated: Boolean
+  authenticatedUser: UserPermissionsUser
+  accountUrl: String
+  permissionsForScope(scope: JSONObject!): [String!]!
+  allowedContentScopes: [ContentScopeWithLabel!]!
+}
+
 type UserPermission {
   id: ID!
   source: UserPermissionSource!
@@ -16,32 +65,10 @@ enum UserPermissionSource {
   BY_RULE
 }
 
-enum Permission {
-  builds
-  dam
-  pageTree
-  cronJobs
-  translation
-  userPermissions
-  prelogin
-  impersonation
-  fileUploads
-  dependencies
-  warnings
-  sitePreview
-  blockPreview
-  fullTextSearch
-}
-
 """
 A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
 """
 scalar DateTime
-
-"""
-The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 type ActionLogsUser {
   id: ID!
@@ -59,35 +86,14 @@ type ActionLog {
   user: ActionLogsUser!
 }
 
+type PaginatedActionLogs {
+  nodes: [ActionLog!]!
+  totalCount: Int!
+}
+
 type ContentScopeWithLabel {
   scope: JSONObject!
   label: JSONObject!
-}
-
-type UserPermissionsUser {
-  id: String!
-  name: String!
-  email: String!
-  permissionsCount: Int!
-  contentScopesCount: Int!
-  impersonationAllowed: Boolean!
-}
-
-type CurrentUserPermission {
-  permission: Permission!
-  contentScopes: [JSONObject!]!
-}
-
-type CurrentUser {
-  id: String!
-  name: String!
-  email: String!
-  permissions: [CurrentUserPermission!]!
-  impersonated: Boolean
-  authenticatedUser: UserPermissionsUser
-  accountUrl: String
-  permissionsForScope(scope: JSONObject!): [String!]!
-  allowedContentScopes: [ContentScopeWithLabel!]!
 }
 
 type EntityInfo {
@@ -522,6 +528,15 @@ input WarningSourceInfoInput {
 }
 
 type Query {
+  """
+  Returns action log entries across all entities. Requires the `globalActionLog` permission.
+  """
+  actionLogs(search: String, filter: ActionLogFilter, sort: [ActionLogSort!], offset: Int! = 0, limit: Int! = 25, scopes: [JSONObject!]!): PaginatedActionLogs!
+
+  """
+  Returns a single action log entry by id. Requires the `globalActionLog` permission.
+  """
+  actionLog(id: ID!): ActionLog!
   builds(limit: Float): [Build!]!
   autoBuildStatus: AutoBuildStatus!
   buildTemplates: [BuildTemplate!]!
@@ -584,6 +599,55 @@ type Query {
   myFullTextSearch(search: String!, offset: Int! = 0, limit: Int! = 25, scope: JSONObject): PaginatedEntityInfo!
 }
 
+input ActionLogFilter {
+  userId: StringFilter
+  entityId: IdFilter
+  entityName: StringFilter
+  version: NumberFilter
+  createdAt: DateTimeFilter
+  and: [ActionLogFilter!]
+  or: [ActionLogFilter!]
+}
+
+input IdFilter {
+  isAnyOf: [ID!]
+  equal: ID
+  notEqual: ID
+}
+
+input NumberFilter {
+  equal: Float
+  lowerThan: Float
+  greaterThan: Float
+  lowerThanEqual: Float
+  greaterThanEqual: Float
+  notEqual: Float
+  isAnyOf: [Float!]
+  isEmpty: Boolean
+  isNotEmpty: Boolean
+}
+
+input DateTimeFilter {
+  equal: DateTime
+  lowerThan: DateTime
+  greaterThan: DateTime
+  lowerThanEqual: DateTime
+  greaterThanEqual: DateTime
+  notEqual: DateTime
+  isEmpty: Boolean
+  isNotEmpty: Boolean
+}
+
+input ActionLogSort {
+  field: ActionLogSortField!
+  direction: SortDirection! = ASC
+}
+
+enum ActionLogSortField {
+  version
+  createdAt
+}
+
 input RedirectScopeInput {
   thisScopeHasNoFields____: String
 }
@@ -605,17 +669,6 @@ input RedirectSourceTypeEnumFilter {
   isAnyOf: [RedirectSourceType!]
   equal: RedirectSourceType
   notEqual: RedirectSourceType
-}
-
-input DateTimeFilter {
-  equal: DateTime
-  lowerThan: DateTime
-  greaterThan: DateTime
-  lowerThanEqual: DateTime
-  greaterThanEqual: DateTime
-  notEqual: DateTime
-  isEmpty: Boolean
-  isNotEmpty: Boolean
 }
 
 input RedirectSort {

--- a/packages/api/cms-api/src/action-logs/action-logs-filter.utils.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs-filter.utils.ts
@@ -7,7 +7,22 @@ import type { ActionLog } from "./entities/action-log.entity";
 export function actionLogFilterToWhere(filter: ActionLogFilter): ObjectQuery<ActionLog> {
     const andConditions: ObjectQuery<ActionLog>[] = [];
 
-    const { and, or, ...rest } = filter;
+    if (filter.scope) {
+        if (filter.scope.isGlobal === true) {
+            andConditions.push({ scope: null });
+        }
+        if (filter.scope.equal !== undefined) {
+            andConditions.push({ scope: { $contains: [filter.scope.equal] } });
+        }
+        if (filter.scope.isAnyOf !== undefined && filter.scope.isAnyOf.length > 0) {
+            andConditions.push({ $or: filter.scope.isAnyOf.map((scope) => ({ scope: { $contains: [scope] } })) });
+        }
+        if (filter.scope.notEqual !== undefined) {
+            andConditions.push({ $not: { scope: { $contains: [filter.scope.notEqual] } } });
+        }
+    }
+
+    const { scope: _scope, and, or, ...rest } = filter;
     if (Object.keys(rest).length > 0) {
         andConditions.push(filtersToMikroOrmQuery(rest));
     }

--- a/packages/api/cms-api/src/action-logs/action-logs-filter.utils.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs-filter.utils.ts
@@ -1,0 +1,29 @@
+import type { ObjectQuery } from "@mikro-orm/postgresql";
+
+import { filtersToMikroOrmQuery } from "../common/filter/mikro-orm";
+import type { ActionLogFilter } from "./dto/action-log.filter";
+import type { ActionLog } from "./entities/action-log.entity";
+
+export function actionLogFilterToWhere(filter: ActionLogFilter): ObjectQuery<ActionLog> {
+    const andConditions: ObjectQuery<ActionLog>[] = [];
+
+    const { and, or, ...rest } = filter;
+    if (Object.keys(rest).length > 0) {
+        andConditions.push(filtersToMikroOrmQuery(rest));
+    }
+
+    if (and && and.length > 0) {
+        andConditions.push({ $and: and.map(actionLogFilterToWhere) });
+    }
+    if (or && or.length > 0) {
+        andConditions.push({ $or: or.map(actionLogFilterToWhere) });
+    }
+
+    if (andConditions.length === 0) {
+        return {};
+    }
+    if (andConditions.length === 1) {
+        return andConditions[0];
+    }
+    return { $and: andConditions };
+}

--- a/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
@@ -1,12 +1,74 @@
-import { Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { EntityManager, type FilterQuery, type ObjectQuery, PostgreSqlDriver } from "@mikro-orm/postgresql";
+import { UnauthorizedException } from "@nestjs/common";
+import { Args, ID, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import isEqual from "lodash.isequal";
 
+import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
+import { gqlSortToMikroOrmOrderBy, searchToMikroOrmQuery } from "../common/filter/mikro-orm";
+import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
+import { CurrentUser } from "../user-permissions/dto/current-user";
 import { UserPermissionsService } from "../user-permissions/user-permissions.service";
+import { actionLogFilterToWhere } from "./action-logs-filter.utils";
 import { ActionLogsUser } from "./dto/action-logs-user";
+import { GlobalActionLogsArgs } from "./dto/global-action-logs.args";
+import { PaginatedActionLogs } from "./dto/paginated-action-logs";
 import { ActionLog } from "./entities/action-log.entity";
 
 @Resolver(() => ActionLog)
+@RequiredPermission(["globalActionLog"], { skipScopeCheck: true })
 export class ActionLogsResolver {
-    constructor(private readonly userPermissionsService: UserPermissionsService) {}
+    constructor(
+        private readonly entityManager: EntityManager<PostgreSqlDriver>,
+        private readonly userPermissionsService: UserPermissionsService,
+    ) {}
+
+    @Query(() => PaginatedActionLogs, {
+        description: "Returns action log entries across all entities. Requires the `globalActionLog` permission.",
+    })
+    async actionLogs(
+        @Args() { search, filter, scopes, offset, limit, sort }: GlobalActionLogsArgs,
+        @GetCurrentUser() user: CurrentUser,
+    ): Promise<PaginatedActionLogs> {
+        const allowedScopesForUser = user.permissions.find(({ permission }) => permission === "globalActionLog")?.contentScopes;
+        for (const scope of scopes) {
+            if (!allowedScopesForUser?.find((allowedScope) => isEqual(allowedScope, scope))) {
+                throw new UnauthorizedException("Scopes were passed that the user does not have permission to");
+            }
+        }
+
+        const andFilters: ObjectQuery<ActionLog>[] = [];
+
+        if (search) {
+            andFilters.push(searchToMikroOrmQuery(search, ["entityName", "userId"]));
+        }
+
+        if (filter) {
+            andFilters.push(actionLogFilterToWhere(filter));
+        }
+
+        // Use $contained (<@) so a row's scope must be a subset of one of the user's allowed scopes.
+        // This naturally handles partially-scoped entities (e.g. scope only by domain) without sub-scope expansion.
+        andFilters.push({
+            $or: [...scopes.map((scope) => ({ scope: { $contained: [scope] } })), { scope: null }],
+        });
+
+        const where: FilterQuery<ActionLog> = { $and: andFilters };
+
+        const [entities, totalCount] = await this.entityManager.findAndCount(ActionLog, where, {
+            offset,
+            limit,
+            orderBy: sort ? gqlSortToMikroOrmOrderBy(sort) : { createdAt: "DESC" },
+        });
+
+        return new PaginatedActionLogs(entities, totalCount);
+    }
+
+    @Query(() => ActionLog, {
+        description: "Returns a single action log entry by id. Requires the `globalActionLog` permission.",
+    })
+    async actionLog(@Args("id", { type: () => ID }) id: string): Promise<ActionLog> {
+        return this.entityManager.findOneOrFail(ActionLog, { id });
+    }
 
     @ResolveField(() => ActionLogsUser)
     async user(@Parent() actionLog: ActionLog): Promise<ActionLogsUser> {

--- a/packages/api/cms-api/src/action-logs/dto/action-log.filter.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-log.filter.ts
@@ -1,0 +1,54 @@
+import { Field, InputType } from "@nestjs/graphql";
+import { Type } from "class-transformer";
+import { ValidateNested } from "class-validator";
+
+import { DateTimeFilter } from "../../common/filter/date-time.filter";
+import { IdFilter } from "../../common/filter/id.filter";
+import { NumberFilter } from "../../common/filter/number.filter";
+import { StringFilter } from "../../common/filter/string.filter";
+import { IsUndefinable } from "../../common/validators/is-undefinable";
+
+@InputType()
+export class ActionLogFilter {
+    @Field(() => StringFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => StringFilter)
+    @IsUndefinable()
+    userId?: StringFilter;
+
+    @Field(() => IdFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => IdFilter)
+    @IsUndefinable()
+    entityId?: IdFilter;
+
+    @Field(() => StringFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => StringFilter)
+    @IsUndefinable()
+    entityName?: StringFilter;
+
+    @Field(() => NumberFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => NumberFilter)
+    @IsUndefinable()
+    version?: NumberFilter;
+
+    @Field(() => DateTimeFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => DateTimeFilter)
+    @IsUndefinable()
+    createdAt?: DateTimeFilter;
+
+    @Field(() => [ActionLogFilter], { nullable: true })
+    @ValidateNested({ each: true })
+    @Type(() => ActionLogFilter)
+    @IsUndefinable()
+    and?: ActionLogFilter[];
+
+    @Field(() => [ActionLogFilter], { nullable: true })
+    @ValidateNested({ each: true })
+    @Type(() => ActionLogFilter)
+    @IsUndefinable()
+    or?: ActionLogFilter[];
+}

--- a/packages/api/cms-api/src/action-logs/dto/action-log.filter.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-log.filter.ts
@@ -1,12 +1,33 @@
 import { Field, InputType } from "@nestjs/graphql";
 import { Type } from "class-transformer";
-import { ValidateNested } from "class-validator";
+import { IsOptional, ValidateNested } from "class-validator";
+import { GraphQLJSONObject } from "graphql-scalars";
 
 import { DateTimeFilter } from "../../common/filter/date-time.filter";
 import { IdFilter } from "../../common/filter/id.filter";
 import { NumberFilter } from "../../common/filter/number.filter";
 import { StringFilter } from "../../common/filter/string.filter";
 import { IsUndefinable } from "../../common/validators/is-undefinable";
+import { ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
+
+@InputType({ isAbstract: true })
+class ActionLogScopeFilter {
+    @Field(() => [GraphQLJSONObject], { nullable: true })
+    @IsOptional()
+    isAnyOf?: ContentScope[];
+
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @IsOptional()
+    equal?: ContentScope;
+
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @IsOptional()
+    notEqual?: ContentScope;
+
+    @Field(() => Boolean, { nullable: true })
+    @IsOptional()
+    isGlobal?: boolean;
+}
 
 @InputType()
 export class ActionLogFilter {
@@ -39,6 +60,10 @@ export class ActionLogFilter {
     @Type(() => DateTimeFilter)
     @IsUndefinable()
     createdAt?: DateTimeFilter;
+
+    @Field(() => ActionLogScopeFilter, { nullable: true })
+    @IsOptional()
+    scope?: ActionLogScopeFilter;
 
     @Field(() => [ActionLogFilter], { nullable: true })
     @ValidateNested({ each: true })

--- a/packages/api/cms-api/src/action-logs/dto/action-log.sort.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-log.sort.ts
@@ -6,6 +6,8 @@ import { SortDirection } from "../../common/sorting/sort-direction.enum";
 enum ActionLogSortField {
     version = "version",
     createdAt = "createdAt",
+    entityName = "entityName",
+    scope = "scope",
 }
 registerEnumType(ActionLogSortField, {
     name: "ActionLogSortField",

--- a/packages/api/cms-api/src/action-logs/dto/action-logs.args.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-logs.args.ts
@@ -1,0 +1,28 @@
+import { ArgsType, Field } from "@nestjs/graphql";
+import { Type } from "class-transformer";
+import { IsString, ValidateNested } from "class-validator";
+
+import { OffsetBasedPaginationArgs } from "../../common/pagination/offset-based.args";
+import { IsUndefinable } from "../../common/validators/is-undefinable";
+import { ActionLogFilter } from "./action-log.filter";
+import { ActionLogSort } from "./action-log.sort";
+
+@ArgsType()
+export class ActionLogsArgs extends OffsetBasedPaginationArgs {
+    @Field({ nullable: true })
+    @IsString()
+    @IsUndefinable()
+    search?: string;
+
+    @Field(() => ActionLogFilter, { nullable: true })
+    @ValidateNested()
+    @Type(() => ActionLogFilter)
+    @IsUndefinable()
+    filter?: ActionLogFilter;
+
+    @Field(() => [ActionLogSort], { nullable: true })
+    @ValidateNested({ each: true })
+    @Type(() => ActionLogSort)
+    @IsUndefinable()
+    sort?: ActionLogSort[];
+}

--- a/packages/api/cms-api/src/action-logs/dto/global-action-logs.args.ts
+++ b/packages/api/cms-api/src/action-logs/dto/global-action-logs.args.ts
@@ -1,0 +1,13 @@
+import { ArgsType, Field } from "@nestjs/graphql";
+import { IsArray } from "class-validator";
+import { GraphQLJSONObject } from "graphql-scalars";
+
+import { ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
+import { ActionLogsArgs } from "./action-logs.args";
+
+@ArgsType()
+export class GlobalActionLogsArgs extends ActionLogsArgs {
+    @Field(() => [GraphQLJSONObject])
+    @IsArray()
+    scopes: ContentScope[];
+}

--- a/packages/api/cms-api/src/common/enum/core-permission.enum.ts
+++ b/packages/api/cms-api/src/common/enum/core-permission.enum.ts
@@ -13,4 +13,5 @@ export enum CorePermission {
     sitePreview = "sitePreview",
     blockPreview = "blockPreview",
     fullTextSearch = "fullTextSearch",
+    globalActionLog = "globalActionLog",
 }


### PR DESCRIPTION
Jira: [COM-3006](https://vivid-planet.atlassian.net/browse/COM-3006)

## Summary

Adds a clock-icon row action to `GlobalActionLogGrid` that lets an admin jump from "I see a change to Page X in the global feed" to "show me Page X's complete version history". Inside the dialog, the user gets the familiar version-history workflow (grid → show one version → compare two versions).

## Changes

### `cms-admin`

- New `GlobalActionLogDialog` — uses the same top-level `actionLogs(filter, scopes)` query filtered by `{ entityName, entityId }`. Renders `ActionLogVersionGrid` inside, with row click → `ActionLogShowVersion`, and compare-2-versions → `ActionLogCompare`. Works for deleted entities (the query is rooted at the top level, not at the entity).
- `GlobalActionLogGrid` gains a clock-icon row action that opens the dialog with the row's `{ entityName, entityId }`.

No API changes — the resolver, fragments, and DTOs from the previous PRs cover everything.

## Why a separate dialog?

The existing per-record `ActionLogDialog` (from `ActionLogButton` on detail pages) queries the entity via `${rootField}(id: $id)`, which returns null for deleted entities. The new dialog queries the top-level `actionLogs` resolver instead, so it also works after the entity is gone — which is exactly when the global log matters most.

## Depends on

- #5861 — the base Global Action Log view (the grid this PR attaches to).

## Test plan

- [ ] On `/system/action-log`, click the clock icon on any row. The drill-in dialog opens.
- [ ] Inside the dialog, click a version row → the show-version view renders (with diff if there's a previous version).
- [ ] Inside the dialog, select 2 versions via the checkboxes → click "Compare selected versions" → the compare view renders.
- [ ] Repeat on a row whose entity has been deleted — confirm the dialog still loads and shows the version history.


---
_Generated by [Claude Code](https://claude.ai/code/session_012YKxucGjjtFStey4ZggbDi)_

[COM-3006]: https://vivid-planet.atlassian.net/browse/COM-3006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ