### PR TITLE
Fix Cookiebot consent initialization

### DIFF
--- a/.changeset/itchy-cameras-chew.md
+++ b/.changeset/itchy-cameras-chew.md
@@ -1,0 +1,7 @@
+---
+"@comet/site-react": patch
+---
+
+Fix Cookiebot consent initialization
+
+Fix a race condition where the `CookiebotOnConsentReady` event fires before the `useCookieBotCookieApi` hook is mounted.

--- a/packages/site/site-react/src/cookies/useCookieBotCookieApi.tsx
+++ b/packages/site/site-react/src/cookies/useCookieBotCookieApi.tsx
@@ -31,6 +31,9 @@ export const useCookieBotCookieApi: CookieApiHook = () => {
 
         window.addEventListener("CookiebotOnConsentReady", handleCookieUpdated);
 
+        // Initial consent
+        handleCookieUpdated();
+
         return () => {
             window.removeEventListener("CookiebotOnConsentReady", handleCookieUpdated);
         };


### PR DESCRIPTION
Fixes the following race condition: the `CookiebotOnConsentReady` event may fire before the `useCookieBotCookieApi` hook mounts and the effect runs, leaving the consent in an uninitialized state. Fix by manually calling `handleCookieUpdated()` in the effect to always initialize the consent.