### PR TITLE
cms-admin: Show Page not found for unknown top-level routes

### DIFF
--- a/.changeset/evil-streets-boil.md
+++ b/.changeset/evil-streets-boil.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `NotFound` component and render it for unmatched routes in `MasterMenuRoutes`.

--- a/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
@@ -4,6 +4,7 @@ import { Redirect, type RouteProps, Switch, useRouteMatch } from "react-router-d
 
 import { type Permission, useUserPermissionCheck } from "../userPermissions/hooks/currentUser";
 import type { MasterMenuData, MasterMenuItem } from "./MasterMenu";
+import { NotFound } from "./notFound/NotFound";
 
 export function useRoutePropsFromMasterMenuData(items: MasterMenuData): RouteProps[] {
     const isAllowed = useUserPermissionCheck();
@@ -56,18 +57,24 @@ export function useRoutePropsFromMasterMenuData(items: MasterMenuData): RoutePro
 
 export interface MasterMenuRoutesProps {
     menu: MasterMenuData;
+    fallback?: ReactNode;
 }
 
-export const MasterMenuRoutes = ({ menu }: MasterMenuRoutesProps) => {
+export const MasterMenuRoutes = ({ menu, fallback = <NotFound /> }: MasterMenuRoutesProps) => {
     const routes = useRoutePropsFromMasterMenuData(menu);
     const match = useRouteMatch();
-
     return (
         <Switch>
             <Redirect to={`${match.url}${routes[0].path}`} exact={true} from={match.path} />
             {routes.map((route, index) => (
                 <RouteWithErrorBoundary key={index} {...route} path={`${match.path}${route.path}`} />
             ))}
+            <RouteWithErrorBoundary
+                component={() => {
+                    return fallback;
+                }}
+                path="*"
+            />
         </Switch>
     );
 };

--- a/packages/admin/cms-admin/src/common/notFound/NotFound.tsx
+++ b/packages/admin/cms-admin/src/common/notFound/NotFound.tsx
@@ -1,0 +1,15 @@
+import { FullPageAlert, type FullPageAlertProps } from "@comet/admin";
+import type { FunctionComponent } from "react";
+import { FormattedMessage } from "react-intl";
+
+export type NotFoundProps = FullPageAlertProps;
+
+export const NotFound: FunctionComponent<NotFoundProps> = (props) => {
+    return (
+        <FullPageAlert
+            title={<FormattedMessage id="comet.notFound.title" defaultMessage="Page not found (404)" />}
+            description={<FormattedMessage id="comet.notFound.description" defaultMessage="The requested page does not exist or has been moved." />}
+            {...props}
+        />
+    );
+};

--- a/packages/admin/cms-admin/src/common/notFound/__stories__/NotFound.stories.tsx
+++ b/packages/admin/cms-admin/src/common/notFound/__stories__/NotFound.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { NotFound } from "../NotFound";
+
+type Story = StoryObj<typeof NotFound>;
+
+const config: Meta<typeof NotFound> = {
+    component: NotFound,
+    title: "common/notFound/NotFound",
+};
+
+export default config;
+
+/**
+ * The `NotFound` component is used to display a not found page.
+ */
+export const Default: Story = {};

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -125,6 +125,8 @@ export type { MasterMenuData, MasterMenuProps } from "./common/MasterMenu";
 export { MasterMenu, useMenuFromMasterMenuData } from "./common/MasterMenu";
 export type { MasterMenuRoutesProps } from "./common/MasterMenuRoutes";
 export { MasterMenuRoutes, useRoutePropsFromMasterMenuData } from "./common/MasterMenuRoutes";
+export type { NotFoundProps } from "./common/notFound/NotFound";
+export { NotFound } from "./common/notFound/NotFound";
 export type { PageListItem } from "./common/PageList";
 export { PageList } from "./common/PageList";
 export { PageName } from "./common/PageName";


### PR DESCRIPTION
## Problem

Opening an unknown top-level admin URL (e.g. `/main/en/<does-not-exist>`) previously rendered a blank screen, giving the user no indication that the page does not exist.

## Solution

Add a `NotFound` component and render it as the fallback for unmatched routes in `MasterMenuRoutes`. The fallback is configurable via a new optional `fallback` prop on `MasterMenuRoutes` and defaults to `<NotFound />`.

`NotFound` is a thin wrapper around `@comet/admin`'s `FullPageAlert`, providing the 404-specific title and description while reusing the shared full-page-alert layout, logo and "Return to home page" action.

<img width="2784" height="3044" alt="Screen Recording 2026-06-16 at 08 48 08" src="https://github.com/user-attachments/assets/83d3c1b3-beae-4fbb-902f-ccd8f1832746" />


## Acceptance

Visit `/main/en/foo` (any unknown top-level admin URL) — a "Page not found (404)" page renders instead of a blank screen.

## Ticket

https://vivid-planet.atlassian.net/browse/COM-1880

https://claude.ai/code/session_01JWDNyqGJVaT567vsP7NkiJ