### PR TITLE
Rename UserPermissionsService proxies to findUserOrThrow / findUserForLoginOrThrow

### DIFF
--- a/.changeset/migrate-internal-user-lookups-off-deprecated-getuser.md
+++ b/.changeset/migrate-internal-user-lookups-off-deprecated-getuser.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Migrate internal user lookups off the deprecated `getUser`
+
+The user-permissions resolvers and `UserPermissionsService.getImpersonatedUser` now use `getUserService().findUserOrThrow()` / `findUser()` instead of the deprecated `getUser` method. The deprecated `getUser` and `getUserForLogin` methods are removed from `UserPermissionsService` (the internal service is not re-exported, so this does not affect public consumers). The corresponding deprecated methods on `UserPermissionsUserServiceInterface` remain for back-compat and will be removed in v10.

--- a/.changeset/migrate-internal-user-lookups-off-deprecated-getuser.md
+++ b/.changeset/migrate-internal-user-lookups-off-deprecated-getuser.md
@@ -2,6 +2,8 @@
 "@comet/cms-api": minor
 ---
 
-Migrate internal user lookups off the deprecated `getUser`
+Rename `UserPermissionsService.getUser` / `getUserForLogin` to `findUserOrThrow` / `findUserForLoginOrThrow`
 
-The user-permissions resolvers and `UserPermissionsService.getImpersonatedUser` now use `getUserService().findUserOrThrow()` / `findUser()` instead of the deprecated `getUser` method. The deprecated `getUser` and `getUserForLogin` methods are removed from `UserPermissionsService` (the internal service is not re-exported, so this does not affect public consumers). The corresponding deprecated methods on `UserPermissionsUserServiceInterface` remain for back-compat and will be removed in v10.
+The proxy methods on `UserPermissionsService` are renamed to align with the new `findUser`/`findUserOrThrow` API on `UserPermissionsUserServiceInterface`. Both proxies fall back to the deprecated `userService.getUser` / `getUserForLogin` to preserve back-compat for consumers that haven't migrated their user service yet.
+
+Internal callers (`user.resolver`, `user-permission.resolver`, `user-content-scopes.resolver`, `getImpersonatedUser`) are updated to use the new method names.

--- a/.changeset/migrate-internal-user-lookups-off-deprecated-getuser.md
+++ b/.changeset/migrate-internal-user-lookups-off-deprecated-getuser.md
@@ -1,9 +1,0 @@
----
-"@comet/cms-api": minor
----
-
-Rename `UserPermissionsService.getUser` / `getUserForLogin` to `findUserOrThrow` / `findUserForLoginOrThrow`
-
-The proxy methods on `UserPermissionsService` are renamed to align with the new `findUser`/`findUserOrThrow` API on `UserPermissionsUserServiceInterface`. Both proxies fall back to the deprecated `userService.getUser` / `getUserForLogin` to preserve back-compat for consumers that haven't migrated their user service yet.
-
-Internal callers (`user.resolver`, `user-permission.resolver`, `user-content-scopes.resolver`, `getImpersonatedUser`) are updated to use the new method names.

--- a/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
@@ -43,11 +43,7 @@ export class UserContentScopesResolver {
         @Args("userId", { type: () => String }) userId: string,
         @Args("skipManual", { type: () => Boolean, nullable: true }) skipManual = false,
     ): Promise<ContentScope[]> {
-        const userService = this.userService.getUserService();
-        if (!userService?.findUserOrThrow) {
-            throw new Error("UserService is not configured.");
-        }
-        const contentScopes = await this.userService.getContentScopes(await userService.findUserOrThrow(userId), !skipManual);
+        const contentScopes = await this.userService.getContentScopes(await this.userService.findUserOrThrow(userId), !skipManual);
         return (await this.userService.getAvailableContentScopes())
             .filter((availableContentScope) => contentScopes.some((contentScope) => isEqual(contentScope, availableContentScope.scope)))
             .map((availableContentScope) => availableContentScope.scope);

--- a/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
@@ -43,7 +43,11 @@ export class UserContentScopesResolver {
         @Args("userId", { type: () => String }) userId: string,
         @Args("skipManual", { type: () => Boolean, nullable: true }) skipManual = false,
     ): Promise<ContentScope[]> {
-        const contentScopes = await this.userService.getContentScopes(await this.userService.getUser(userId), !skipManual);
+        const userService = this.userService.getUserService();
+        if (!userService?.findUserOrThrow) {
+            throw new Error("UserService is not configured.");
+        }
+        const contentScopes = await this.userService.getContentScopes(await userService.findUserOrThrow(userId), !skipManual);
         return (await this.userService.getAvailableContentScopes())
             .filter((availableContentScope) => contentScopes.some((contentScope) => isEqual(contentScope, availableContentScope.scope)))
             .map((availableContentScope) => availableContentScope.scope);

--- a/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
@@ -7,6 +7,7 @@ import { SkipBuild } from "../builds/skip-build.decorator";
 import { RequiredPermission } from "./decorators/required-permission.decorator";
 import { UserPermissionInput, UserPermissionOverrideContentScopesInput } from "./dto/user-permission.input";
 import { UserPermission, UserPermissionSource } from "./entities/user-permission.entity";
+import { User } from "./interfaces/user";
 import { UserPermissionsService } from "./user-permissions.service";
 
 @ArgsType()
@@ -27,7 +28,7 @@ export class UserPermissionResolver {
 
     @Query(() => [UserPermission])
     async userPermissionsPermissionList(@Args() args: UserPermissionListArgs): Promise<UserPermission[]> {
-        return this.service.getPermissions(await this.service.getUser(args.userId));
+        return this.service.getPermissions(await this.findUserOrThrow(args.userId));
     }
 
     @Query(() => UserPermission)
@@ -45,7 +46,7 @@ export class UserPermissionResolver {
         @Args("input", { type: () => UserPermissionInput }) input: UserPermissionInput,
     ): Promise<UserPermission> {
         const permission = new UserPermission();
-        this.service.getUser(userId); //validate user exists
+        await this.findUserOrThrow(userId); //validate user exists
         permission.userId = userId;
         permission.assign(input);
         await this.entityManager.persistAndFlush(permission);
@@ -97,11 +98,19 @@ export class UserPermissionResolver {
         if (!userId) {
             throw new Error(`Permission not found: ${id}`);
         }
-        for (const p of await this.service.getPermissions(await this.service.getUser(userId))) {
+        for (const p of await this.service.getPermissions(await this.findUserOrThrow(userId))) {
             if (p.id === id) {
                 return p;
             }
         }
         throw new Error("Permission not found");
+    }
+
+    private async findUserOrThrow(id: string): Promise<User> {
+        const userService = this.service.getUserService();
+        if (!userService?.findUserOrThrow) {
+            throw new Error("UserService is not configured.");
+        }
+        return userService.findUserOrThrow(id);
     }
 }

--- a/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
@@ -7,7 +7,6 @@ import { SkipBuild } from "../builds/skip-build.decorator";
 import { RequiredPermission } from "./decorators/required-permission.decorator";
 import { UserPermissionInput, UserPermissionOverrideContentScopesInput } from "./dto/user-permission.input";
 import { UserPermission, UserPermissionSource } from "./entities/user-permission.entity";
-import { User } from "./interfaces/user";
 import { UserPermissionsService } from "./user-permissions.service";
 
 @ArgsType()
@@ -28,7 +27,7 @@ export class UserPermissionResolver {
 
     @Query(() => [UserPermission])
     async userPermissionsPermissionList(@Args() args: UserPermissionListArgs): Promise<UserPermission[]> {
-        return this.service.getPermissions(await this.findUserOrThrow(args.userId));
+        return this.service.getPermissions(await this.service.findUserOrThrow(args.userId));
     }
 
     @Query(() => UserPermission)
@@ -46,7 +45,7 @@ export class UserPermissionResolver {
         @Args("input", { type: () => UserPermissionInput }) input: UserPermissionInput,
     ): Promise<UserPermission> {
         const permission = new UserPermission();
-        await this.findUserOrThrow(userId); //validate user exists
+        await this.service.findUserOrThrow(userId); //validate user exists
         permission.userId = userId;
         permission.assign(input);
         await this.entityManager.persistAndFlush(permission);
@@ -98,19 +97,11 @@ export class UserPermissionResolver {
         if (!userId) {
             throw new Error(`Permission not found: ${id}`);
         }
-        for (const p of await this.service.getPermissions(await this.findUserOrThrow(userId))) {
+        for (const p of await this.service.getPermissions(await this.service.findUserOrThrow(userId))) {
             if (p.id === id) {
                 return p;
             }
         }
         throw new Error("Permission not found");
-    }
-
-    private async findUserOrThrow(id: string): Promise<User> {
-        const userService = this.service.getUserService();
-        if (!userService?.findUserOrThrow) {
-            throw new Error("UserService is not configured.");
-        }
-        return userService.findUserOrThrow(id);
     }
 }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -103,26 +103,6 @@ export class UserPermissionsService {
         return this.userService;
     }
 
-    /**
-     * @deprecated Use `getUserService().findUserOrThrow()` instead.
-     */
-    async getUser(id: string): Promise<User> {
-        if (!this.userService?.findUserOrThrow) {
-            throw new Error("For this functionality you need to define `findUserOrThrow` in the userService.");
-        }
-        return this.userService.findUserOrThrow(id);
-    }
-
-    /**
-     * @deprecated Use `getUserService().findUserForLoginOrThrow()` instead.
-     */
-    async getUserForLogin(id: string): Promise<User> {
-        if (!this.userService?.findUserForLoginOrThrow) {
-            throw new Error("For this functionality you need to define `findUserForLoginOrThrow` in the userService.");
-        }
-        return this.userService.findUserForLoginOrThrow(id);
-    }
-
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {
         if (!this.userService) {
             throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
@@ -230,18 +210,15 @@ export class UserPermissionsService {
         if (request?.cookies["comet-impersonate-user-id"]) {
             const permissions = await this.getPermissions(authenticatedUser);
             if (permissions.find((permission) => permission.permission === "impersonation")) {
-                try {
-                    const user = await this.getUser(request?.cookies["comet-impersonate-user-id"]);
-                    if (
-                        await AbstractAccessControlService.isEqualOrMorePermissions(
-                            await this.getPermissionsAndContentScopes(authenticatedUser),
-                            await this.getPermissionsAndContentScopes(user),
-                        )
-                    ) {
-                        return user;
-                    }
-                } catch {
-                    return undefined;
+                const user = await this.userService?.findUser?.(request.cookies["comet-impersonate-user-id"]);
+                if (
+                    user &&
+                    (await AbstractAccessControlService.isEqualOrMorePermissions(
+                        await this.getPermissionsAndContentScopes(authenticatedUser),
+                        await this.getPermissionsAndContentScopes(user),
+                    ))
+                ) {
+                    return user;
                 }
             }
         }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -103,6 +103,28 @@ export class UserPermissionsService {
         return this.userService;
     }
 
+    async findUserForLoginOrThrow(id: string): Promise<User> {
+        if (this.userService?.findUserForLoginOrThrow) {
+            return this.userService.findUserForLoginOrThrow(id);
+        }
+        if (this.userService?.getUserForLogin) {
+            return this.userService.getUserForLogin(id);
+        }
+        throw new Error(
+            "For this functionality you need to define `findUserForLoginOrThrow` (or the deprecated `getUserForLogin`) in the userService.",
+        );
+    }
+
+    async findUserOrThrow(id: string): Promise<User> {
+        if (this.userService?.findUserOrThrow) {
+            return this.userService.findUserOrThrow(id);
+        }
+        if (this.userService?.getUser) {
+            return this.userService.getUser(id);
+        }
+        throw new Error("For this functionality you need to define `findUserOrThrow` (or the deprecated `getUser`) in the userService.");
+    }
+
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {
         if (!this.userService) {
             throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
@@ -210,15 +232,18 @@ export class UserPermissionsService {
         if (request?.cookies["comet-impersonate-user-id"]) {
             const permissions = await this.getPermissions(authenticatedUser);
             if (permissions.find((permission) => permission.permission === "impersonation")) {
-                const user = await this.userService?.findUser?.(request.cookies["comet-impersonate-user-id"]);
-                if (
-                    user &&
-                    (await AbstractAccessControlService.isEqualOrMorePermissions(
-                        await this.getPermissionsAndContentScopes(authenticatedUser),
-                        await this.getPermissionsAndContentScopes(user),
-                    ))
-                ) {
-                    return user;
+                try {
+                    const user = await this.findUserOrThrow(request.cookies["comet-impersonate-user-id"]);
+                    if (
+                        await AbstractAccessControlService.isEqualOrMorePermissions(
+                            await this.getPermissionsAndContentScopes(authenticatedUser),
+                            await this.getPermissionsAndContentScopes(user),
+                        )
+                    ) {
+                        return user;
+                    }
+                } catch {
+                    return undefined;
                 }
             }
         }

--- a/packages/api/cms-api/src/user-permissions/user.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user.resolver.ts
@@ -23,7 +23,11 @@ export class UserResolver {
 
     @Query(() => UserPermissionsUser)
     async userPermissionsUserById(@Args("id", { type: () => String }) id: string): Promise<UserPermissionsUser> {
-        return this.userService.getUser(id);
+        const userService = this.userService.getUserService();
+        if (!userService?.findUserOrThrow) {
+            throw new Error("UserService is not configured.");
+        }
+        return userService.findUserOrThrow(id);
     }
 
     @Query(() => UserPermissionPaginatedUserList)

--- a/packages/api/cms-api/src/user-permissions/user.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user.resolver.ts
@@ -23,11 +23,7 @@ export class UserResolver {
 
     @Query(() => UserPermissionsUser)
     async userPermissionsUserById(@Args("id", { type: () => String }) id: string): Promise<UserPermissionsUser> {
-        const userService = this.userService.getUserService();
-        if (!userService?.findUserOrThrow) {
-            throw new Error("UserService is not configured.");
-        }
-        return userService.findUserOrThrow(id);
+        return this.userService.findUserOrThrow(id);
     }
 
     @Query(() => UserPermissionPaginatedUserList)


### PR DESCRIPTION
## Summary

Follow-up to #5814 — renames the proxy methods on `UserPermissionsService` to align with the new `find*` naming on `UserPermissionsUserServiceInterface`, and migrates the internal callers to the new names.

- `UserPermissionsService.getUser` → **`findUserOrThrow`**
- `UserPermissionsService.getUserForLogin` → **`findUserForLoginOrThrow`**

Each proxy prefers the new userService method and falls back to its deprecated counterpart, so user services that haven't migrated yet keep working:

```ts
async findUserOrThrow(id: string): Promise<User> {
    if (this.userService?.findUserOrThrow) return this.userService.findUserOrThrow(id);
    if (this.userService?.getUser) return this.userService.getUser(id);
    throw new Error("...");
}
```

Internal callers updated:
- `user.resolver.ts`, `user-permission.resolver.ts`, `user-content-scopes.resolver.ts` → call `service.findUserOrThrow(id)`
- `UserPermissionsService.getImpersonatedUser` → calls `this.findUserOrThrow(id)` (still wrapped in `try`/`catch` because the deprecated path only has a throwing variant; the impersonation flow needs to fall through to "no impersonation" on not-found)

The deprecated `getUser` / `getUserForLogin` methods on `UserPermissionsUserServiceInterface` remain and got deprecated.
