### PR TITLE
admin: render NotFound in stacks for unknown sub-pages

### DIFF
--- a/.changeset/render-not-found-in-stacks.md
+++ b/.changeset/render-not-found-in-stacks.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": minor
+"@comet/cms-admin": minor
+---
+
+Render NotFound for unknown sub-pages in `StackSwitch`. Adds `NotFoundProvider`
+and `useNotFound` to `@comet/admin`; `MasterMenuRoutes` wires the provider so
+cms-admin projects pick this up automatically.

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -207,6 +207,7 @@ export type { MainNavigationClassKey } from "./mui/mainNavigation/MainNavigation
 export { MasterLayout, type MasterLayoutClassKey, type MasterLayoutProps } from "./mui/MasterLayout";
 export { MasterLayoutContext } from "./mui/MasterLayoutContext";
 export { MuiThemeProvider } from "./mui/ThemeProvider";
+export { NotFoundProvider, useNotFound } from "./notFound/NotFoundContext";
 export { renderFinalFormChildren } from "./renderFinalFormChildren";
 export { RouterBrowserRouter } from "./router/BrowserRouter";
 export { RouterConfirmationDialog, type RouterConfirmationDialogClassKey, type RouterConfirmationDialogProps } from "./router/ConfirmationDialog";

--- a/packages/admin/admin/src/notFound/NotFoundContext.tsx
+++ b/packages/admin/admin/src/notFound/NotFoundContext.tsx
@@ -1,0 +1,11 @@
+import { createContext, type ReactNode, useContext } from "react";
+
+const NotFoundContext = createContext<ReactNode>(null);
+
+export function NotFoundProvider({ notFound, children }: { notFound: ReactNode; children: ReactNode }) {
+    return <NotFoundContext.Provider value={notFound}>{children}</NotFoundContext.Provider>;
+}
+
+export function useNotFound(): ReactNode {
+    return useContext(NotFoundContext);
+}

--- a/packages/admin/admin/src/stack/Switch.tsx
+++ b/packages/admin/admin/src/stack/Switch.tsx
@@ -16,6 +16,7 @@ import {
 import { matchPath, Route, type RouteChildrenProps, useHistory, useLocation, useRouteMatch } from "react-router";
 import { v4 as uuid } from "uuid";
 
+import { useNotFound } from "../notFound/NotFoundContext";
 import { ForcePromptRoute } from "../router/ForcePromptRoute";
 import { SubRouteIndexRoute, useSubRoutePrefix } from "../router/SubRoute";
 import { StackBreadcrumb } from "./Breadcrumb";
@@ -105,6 +106,7 @@ const StackSwitchInner: ForwardRefRenderFunction<IStackSwitchApi, IProps & IHook
     const match = useRouteMatch<IRouteParams>();
     const subRoutePrefix = useSubRoutePrefix();
     const location = useLocation();
+    const notFound = useNotFound();
 
     let activePage: string | undefined;
 
@@ -224,7 +226,13 @@ const StackSwitchInner: ForwardRefRenderFunction<IStackSwitchApi, IProps & IHook
                         if (!routeProps.match) {
                             return null;
                         }
-                        // now render initial page (as last route so it's a fallback)
+                        const matchedUrl = removeTrailingSlash(routeProps.match.url);
+                        const currentPath = removeTrailingSlash(location.pathname);
+                        const remainder = currentPath.slice(matchedUrl.length);
+                        const isInitialPageInternalRoute = remainder === "/index" || remainder.startsWith("/index/");
+                        if (notFound && remainder.length > 0 && !isInitialPageInternalRoute) {
+                            return notFound;
+                        }
                         let initialPage: ReactElement<IStackPageProps> | null = null;
                         Children.forEach(props.children, (page: ReactElement<IStackPageProps>) => {
                             if (isInitialPage(page.props.name)) {

--- a/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
+++ b/packages/admin/cms-admin/src/common/MasterMenuRoutes.tsx
@@ -1,4 +1,4 @@
-import { RouteWithErrorBoundary } from "@comet/admin";
+import { NotFoundProvider, RouteWithErrorBoundary } from "@comet/admin";
 import type { ReactNode } from "react";
 import { Redirect, type RouteProps, Switch, useRouteMatch } from "react-router-dom";
 
@@ -64,17 +64,19 @@ export const MasterMenuRoutes = ({ menu, fallback = <NotFound /> }: MasterMenuRo
     const routes = useRoutePropsFromMasterMenuData(menu);
     const match = useRouteMatch();
     return (
-        <Switch>
-            <Redirect to={`${match.url}${routes[0].path}`} exact={true} from={match.path} />
-            {routes.map((route, index) => (
-                <RouteWithErrorBoundary key={index} {...route} path={`${match.path}${route.path}`} />
-            ))}
-            <RouteWithErrorBoundary
-                component={() => {
-                    return fallback;
-                }}
-                path="*"
-            />
-        </Switch>
+        <NotFoundProvider notFound={fallback}>
+            <Switch>
+                <Redirect to={`${match.url}${routes[0].path}`} exact={true} from={match.path} />
+                {routes.map((route, index) => (
+                    <RouteWithErrorBoundary key={index} {...route} path={`${match.path}${route.path}`} />
+                ))}
+                <RouteWithErrorBoundary
+                    component={() => {
+                        return fallback;
+                    }}
+                    path="*"
+                />
+            </Switch>
+        </NotFoundProvider>
     );
 };


### PR DESCRIPTION
> **Stacked on top of #5865.** After #5865 is merged, change this PR's
> base to `main` and rebase, then force-push.

## Problem

When a stack-based page (Pages, News, Assets, …) is navigated to an unknown sub-page name (e.g. `/main/en/news/123/foo`), `StackSwitch` silently falls back to the initial list view instead of indicating that the sub-page does not exist.

## Solution

Propagate the `NotFound` fallback into nested navigation:

- Add a `NotFoundProvider` context and a `useNotFound` hook to `@comet/admin`.
- `StackSwitch` consumes the context and renders the configured `NotFound` for unknown sub-routes instead of falling back to the initial page.
- An `/index/` guard ensures the initial page's own routing space (used by `EditDialog` and `SelectionRoute`, e.g. `${prefix}/index/add`) keeps working — add/edit dialogs and selection flows are unaffected.
- `MasterMenuRoutes` wires the provider automatically, so cms-admin projects pick this up without any change.

## Acceptance

- `/main/en/news/<valid-id>/foo` → renders the NotFound page
- `/main/en/assets/index/add` → "Add folder" dialog still opens (regression check)
- `/main/en/news` → still works

## Ticket

https://vivid-planet.atlassian.net/browse/COM-1880


---
_Generated by [Claude Code](https://claude.ai/code/session_0183XxkgRVzC1io7eSrU6CFX)_