### PR TITLE
Allow `role` attribute and same-document `<use>` references in uploaded SVGs

### DIFF
--- a/.changeset/svg-validation-dompurify.md
+++ b/.changeset/svg-validation-dompurify.md
@@ -6,3 +6,5 @@ Validate uploaded SVGs with `DOMPurify` (backed by `jsdom`) instead of the custo
 
 The previous implementation parsed SVGs with `fast-xml-parser` and applied a hand-written allow/deny list to reject scripts, event handlers and unsafe links.
 SVGs are now sanitized with the vetted `DOMPurify` library and rejected when it has to strip any tags or attributes, providing more robust protection against XSS vectors in uploaded SVGs.
+
+The `role` attribute and the `<use>` element are allowed, since they're commonly used in valid SVGs. `<use>` is restricted to same-document fragment references (e.g. `href="#id"`); references to external resources are rejected to prevent XSS/SSRF.

--- a/packages/api/cms-api/src/file-utils/files.utils.spec.ts
+++ b/packages/api/cms-api/src/file-utils/files.utils.spec.ts
@@ -58,5 +58,30 @@ describe("Files Utils", () => {
 
             expect(isValidSvg(svgWithUppercaseHref)).toBe(false);
         });
+
+        it("should return true if the svg contains a role attribute", async () => {
+            const svgWithRole = `<svg xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16" viewBox="0 0 16 16">
+                <path role="presentation" fill="#242424" fill-rule="evenodd" d=""/>
+            </svg>`;
+
+            expect(isValidSvg(svgWithRole)).toBe(true);
+        });
+
+        it("should return true if the svg contains a use element with a same-document fragment reference", async () => {
+            const svgWithFragmentUse = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16">
+                <defs><path id="icon" d=""/></defs>
+                <use xlink:href="#icon" mask="url(#mask0)" transform="matrix(1,0,0,1,0,0)"/>
+            </svg>`;
+
+            expect(isValidSvg(svgWithFragmentUse)).toBe(true);
+        });
+
+        it("should return false if the svg contains a use element referencing an external resource", async () => {
+            const svgWithExternalUse = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                <use href="https://evil.example.com/payload.svg#icon"/>
+            </svg>`;
+
+            expect(isValidSvg(svgWithExternalUse)).toBe(false);
+        });
     });
 });

--- a/packages/api/cms-api/src/file-utils/files.utils.ts
+++ b/packages/api/cms-api/src/file-utils/files.utils.ts
@@ -45,8 +45,27 @@ export const calculatePartialRanges = (size: number, range: string): { start: nu
 const { window } = new JSDOM("");
 const DOMPurify = createDOMPurify(window);
 
+// `<use>` is forbidden by DOMPurify's svg profile because it can pull in external or
+// attacker-controlled content (XSS/SSRF). Allow it only for same-document fragment references
+// (e.g. href="#id"); any other reference is dropped, which makes the SVG fail validation below.
+DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
+    if ((node as unknown as { nodeName: string }).nodeName.toLowerCase() !== "use") {
+        return;
+    }
+    if ((data.attrName === "href" || data.attrName === "xlink:href") && !data.attrValue.startsWith("#")) {
+        data.keepAttr = false;
+    }
+});
+
 export const isValidSvg = (svg: string): boolean => {
-    DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true }, WHOLE_DOCUMENT: true });
+    // `role` and `<use>` aren't part of DOMPurify's svg profile, so they're allowed explicitly.
+    // `<use>` is additionally constrained to same-document references by the hook above.
+    DOMPurify.sanitize(svg, {
+        USE_PROFILES: { svg: true, svgFilters: true },
+        WHOLE_DOCUMENT: true,
+        ADD_TAGS: ["use"],
+        ADD_ATTR: ["role", "href", "xlink:href"],
+    });
 
     // DOMPurify strips forbidden tags (e.g. <script>) and attributes (e.g. event handlers, javascript: URLs).
     // If it had to remove anything, the SVG contained content we don't consider safe.


### PR DESCRIPTION
depends on https://github.com/vivid-planet/comet/pull/5837

## Problem

The SVG upload validation (DOMPurify with the `svg`/`svgFilters` profiles) rejected legitimate SVGs because two common, safe constructs aren't part of DOMPurify's SVG profile:

- The `role` attribute (it belongs to DOMPurify's `html` profile, not `svg`), used for accessibility.
- The `<use>` element, which is forbidden by default because it can reference external/attacker-controlled content. Many icon SVGs (e.g. Inkscape/cairo output) use it to reference internal `defs` via `<use href="#id">`.

Since validation rejects an upload whenever DOMPurify strips anything, these SVGs failed even though they're safe.

## Solution

- Allow `role` via `ADD_ATTR`.
- Allow `<use>` via `ADD_TAGS`, but constrain its `href`/`xlink:href` to same-document fragment references (`#id`) with a `uponSanitizeAttribute` hook. Any other reference is dropped — which makes the SVG fail validation rather than being stored as-is.

## Security

- `<use>` is allowed **only** for same-document fragment refs. External references (`https://…`), `javascript:`, and `data:` URIs are rejected, so the external-content (XSS/SSRF) and tracking-beacon vectors are closed at upload time rather than relying on browser same-origin enforcement.
- The whole document is still sanitized (`WHOLE_DOCUMENT`), so the targets a `<use>` references are themselves cleaned.
- Note: same-origin _relative_ refs (e.g. `href="/sprite.svg#x"`) are also rejected. This is intended; cross-file sprite references would reopen the external-reference surface.

## Tests

Added cases: `role` passes, internal-fragment `<use>` passes, external-ref `<use>` is rejected.