### PR TITLE
admin: Set up the experimental future-ui sub-package

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -34,6 +34,7 @@
             "project": ["./src/**/*.{ts,tsx}"]
         },
         "packages/admin/admin": {
+            "entry": ["./src/index.ts", "./src/future-ui/index.ts"],
             "project": ["./src/**/*.{ts,tsx}"],
             "ignore": [".storybook/public/mockServiceWorker.js"],
             "ignoreDependencies": ["@mui/x-data-grid-premium"]

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -14,6 +14,10 @@
         ".": {
             "import": "./lib/index.js",
             "types": "./lib/index.d.ts"
+        },
+        "./future-ui": {
+            "import": "./lib/future-ui/index.js",
+            "types": "./lib/future-ui/index.d.ts"
         }
     },
     "files": [

--- a/packages/admin/admin/src/future-ui/AGENTS.md
+++ b/packages/admin/admin/src/future-ui/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions — Future UI
+
+Read [README.md](README.md) in full before working in this folder. It defines the sub-package and its conventions — which differ from the rest of `@comet/admin`, so neighboring code is not a reliable guide — and it takes precedence over instructions from parent directories.
+
+A feature may have its own `README.md` (see the convention in the README); read it before working on that feature or anything that touches it. When a change shifts a convention, reverses a decision, or makes a README inaccurate, update that README in the same change.

--- a/packages/admin/admin/src/future-ui/CLAUDE.md
+++ b/packages/admin/admin/src/future-ui/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -1,0 +1,59 @@
+# Future UI
+
+This sub-package is an **experimental**, UI-only React component library inside `@comet/admin`, consumed as `@comet/admin/future-ui`. It is self-contained: it keeps its own directory and contains no routing, forms, data fetching, or other non-UI logic. Whether it stays a separate sub-package or later becomes part of `@comet/admin`'s own UI layer is still open; the UI-only separation holds either way.
+
+Future UI builds from an unstyled foundation rather than evolving the existing MUI-based components; `@base-ui/react` is the chosen foundation.
+
+## Experimental
+
+Any export may change or be removed at any time, without deprecation notice. Changesets are not created for changes within this sub-package.
+
+## Non-goals
+
+- **No non-UI logic.** Forms (`final-form`, `react-hook-form`), routing (`react-router`), data fetching (Apollo), and similar concerns stay out.
+- **No dependency on `@mui/material`, `@mui/system`, Emotion, or any other part of the existing `@comet/admin` styling stack.** Future UI is a fresh foundation; cross-imports reintroduce the competing system it removes.
+
+## Internal documentation
+
+A feature substantial enough to live in its own directory may have a `README.md` describing what it is and how it behaves — and, when a reader would assume otherwise, the boundaries it deliberately doesn't cross. These READMEs are internal: written for the people and agents maintaining the code, not for consumers.
+
+Information hierarchy: code is the source of truth for what is, commits for why each step was taken, internal documentation for what a feature is and what it isn't.
+
+### What is a feature
+
+A feature is any self-contained part of the codebase worth describing on its own — a component, a utility, or the sub-package itself. Features nest: this README documents Future UI as a feature, and the components and utilities inside it are features in their own right. A feature README describes only its own feature, never the parent that contains it nor the sub-features it contains — each of those has its own README.
+
+### Where they live
+
+A feature that warrants a README is a directory, with the README at its root (for example, a component folder's `README.md`). A feature small enough to live as a single file inside a parent doesn't get its own README — it is part of the parent. Turn a file into a directory at the moment you give it a README.
+
+### What goes in a feature README
+
+**Title.** The exact identifier when the feature is a single component or function (`Button`); otherwise a sentence-case name.
+
+Two sections, in order; only the intro is required.
+
+1. **Intro.** State, in neutral present tense, what the feature is or does. Include a non-obvious behavior or constraint when it is part of what the feature is; keep out the motivation and the prior state — the why lives in the commit. The test: describe how it behaves, not why it exists.
+2. **Non-goals** (optional). Only what a reader would reasonably assume the feature does but it doesn't; the test is whether they would look here for it and be surprised it is missing. Write each as a noun phrase, with one follow-up sentence only to point to the alternative or give the reason.
+
+The two sections above are all a README normally carries. A custom section is allowed but is the exception — add one only when explicitly required, and only for durable, feature-specific content that genuinely fits neither section above. Not custom sections: Architecture (the code shows it), Design decisions (commits carry them), Usage (consumer docs), Dependencies (imports show them).
+
+**Express the rule, not the code.** Every line says something the code doesn't. The feature's name is on its folder and export too, so the intro adds something beyond it rather than restating it: "A button component with a set of optional variants", never "The Button component".
+
+**Length.** Keep it as short as the feature allows. Most features need nothing beyond the one-sentence intro; a genuinely complex feature — this sub-package's own README, for one — may run longer when it warrants it, up to about a screen. Past a screen you are duplicating commit history or describing what the code shows.
+
+### Template
+
+```md
+# <feature-name>
+
+<One sentence: what the feature is or does.>
+
+## Non-goals <!-- only if any -->
+
+- <Noun phrase naming what the feature deliberately doesn't do.> <Optional follow-up pointing to the alternative or stating why.>
+```
+
+### Living documents
+
+These READMEs stay current. A change that makes one inaccurate, shifts a convention, or reverses a decision updates the affected README in the same change.

--- a/packages/admin/admin/src/future-ui/index.ts
+++ b/packages/admin/admin/src/future-ui/index.ts
@@ -1,0 +1,2 @@
+// TODO: Re-export public future-ui features from here as they land.
+export {};


### PR DESCRIPTION
The existing `@comet/admin` components build Comet's design system on top of MUI Material's, and the two conflict often enough that the overrides are brittle and break on MUI version upgrades.
Future UI re-creates them from an unstyled foundation, removing the competing system.

The sub-package is named `future-ui` rather than `future` to keep its UI-only boundary explicit in the name: routing, forms, data, and other non-UI logic stay out, and the code keeps its own directory whether it stays a sub-package or is later moved into `@comet/admin`.

- **`@base-ui/react` is the chosen foundation, but no dependency is added yet.**
  The first component that needs it will add it.
- **The entry point resolves before any component exists.**
  Consumers and the package's own tooling can import `@comet/admin/future-ui` from day one, and later changes only add exports.
- **Changes within the sub-package get no changeset while experimental.**
  This overrides the repo-wide rule that would otherwise require one.
- **No dependency on the existing `@comet/admin` styling stack.**
  Importing `@mui/material`, `@mui/system`, or Emotion would reintroduce the competing system the fresh start removes.
- **Internal documentation follows the per-feature README convention from `@comet/mail-react`.**
  An agent works from a feature's README, not from neighboring `@comet/admin` code, whose conventions Future UI departs from.
- **`AGENTS.md` and `CLAUDE.md` point to the README rather than restate it.**
  The same guidance serves humans and agents, so keeping it in one place is what stops the artifacts from drifting apart.

--- 

### What will follow this PR?

This sub-package setup PR is the foundation for the following topics that are already in the works. They extend the conventions and definitions created here, and apply those:

- The first components (Button, Typography)
- Common conventions for components (variants, slots, class-names, etc.)
- The theme and styling system
- Conventions for user documentation (Storybook docs, design panels, and agent skill)
- Conventions for dev-stories and testing

---

Task: https://vivid-planet.atlassian.net/browse/COM-2973  
This reverts the [revert](https://github.com/vivid-planet/comet/pull/5871) to the [change](https://github.com/vivid-planet/comet/pull/5855) lands in the feature-branch instead of `main`. 