### PR TITLE
mail-react: Add createRichTextBlock for rendering RichText block data

### DIFF
--- a/.changeset/add-mail-react-rich-text-block.md
+++ b/.changeset/add-mail-react-rich-text-block.md
@@ -1,0 +1,37 @@
+---
+"@comet/mail-react": minor
+---
+
+Add `createRichTextBlock` for rendering Comet CMS RichText block data in emails
+
+The factory returns an `MjmlRichTextBlock` for the MJML context and an `HtmlRichTextBlock` for raw-HTML contexts (e.g. inside `MjmlRaw`), both driven by the same configuration. The `blockTypes` option maps the application's draft block types to theme text variants or plain style values; without it, every block renders with the base theme text styles. The `linkTypes` option adds href resolvers for the application's link block types on top of the built-in `external` support.
+
+Call the factory once — at the top level of a file, not inside a component — and export the returned components:
+
+```tsx
+export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
+    blockTypes: {
+        "header-one": { variant: "heading1" },
+        "paragraph-standard": { variant: "body" },
+    },
+});
+```
+
+Usage sites pass only the block data:
+
+```tsx
+<MjmlRichTextBlock data={richTextData} />
+```
+
+Call the factory again for differently-configured blocks, renaming the destructured components — e.g. a headline-only block:
+
+```tsx
+export const { MjmlRichTextBlock: MjmlHeadlineRichTextBlock, HtmlRichTextBlock: HtmlHeadlineRichTextBlock } = createRichTextBlock({
+    blockTypes: {
+        "header-one": { variant: "heading1" },
+        "header-two": { variant: "heading2" },
+    },
+});
+```
+
+External links render as `HtmlInlineLink`. Lists render flat as `<ul>` / `<ol>`.

--- a/.changeset/add-mail-react-rich-text-block.md
+++ b/.changeset/add-mail-react-rich-text-block.md
@@ -4,7 +4,7 @@
 
 Add `createRichTextBlock` for rendering Comet CMS RichText block data in emails
 
-The factory returns an `MjmlRichTextBlock` for the MJML context and an `HtmlRichTextBlock` for raw-HTML contexts (e.g. inside `MjmlRaw`), both driven by the same configuration. The `blockTypes` option maps the application's draft block types to theme text variants or plain style values; without it, every block renders with the base theme text styles. The `linkTypes` option adds href resolvers for the application's link block types on top of the built-in `external` support.
+The factory returns an `MjmlRichTextBlock` for the MJML context and an `HtmlRichTextBlock` for raw-HTML contexts (e.g. inside `MjmlRaw`), both driven by the same configuration. The `blockTypes` option maps the application's draft block types to theme text variants or plain style values; without it, every block renders with the base theme text styles. The `linkTypes` option adds href resolvers for the application's link block types on top of the built-in `external` support. The `inline` option overrides the built-in inline styles (`BOLD`, `ITALIC`, …) or renders custom inline styles the application defines in its RTE (e.g. `HIGHLIGHT`).
 
 Call the factory once — at the top level of a file, not inside a component — and export the returned components:
 

--- a/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
@@ -71,3 +71,88 @@ By default, the rendered aspect ratio comes from the DAM crop area. The `aspectR
 ### Responsive scaling
 
 On viewports narrower than the default body width, both blocks automatically scale the rendered image to fit its container.
+
+## Rich-text blocks
+
+The `createRichTextBlock` factory creates components that render `RichTextBlockData` (draft-js raw content) from the CMS. It returns one component for the MJML context and one for raw HTML, both driven by the same configuration.
+
+| Component           | Renders each draft block as | Use within                                                                        |
+| ------------------- | --------------------------- | --------------------------------------------------------------------------------- |
+| `MjmlRichTextBlock` | `MjmlText`                  | an `MjmlColumn` (standard MJML layout model)                                      |
+| `HtmlRichTextBlock` | `HtmlText` (`<div>`)        | raw HTML or [MJML ending tags](./1-email-basics.md#ending-tags) such as `MjmlRaw` |
+
+Call the factory once — at the top level of a file, not inside a component — and export the returned components:
+
+```tsx title="src/emails/blocks/richText.ts"
+import { createRichTextBlock } from "@comet/mail-react";
+
+export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
+    blockTypes: {
+        "header-one": { variant: "heading1" },
+        "header-two": { variant: "heading2" },
+        "paragraph-standard": { variant: "body" },
+    },
+});
+```
+
+Usage sites then pass only the block data:
+
+```tsx
+<MjmlSection indent>
+    <MjmlColumn>
+        <MjmlRichTextBlock data={richTextData} />
+    </MjmlColumn>
+</MjmlSection>
+```
+
+### Block type configuration
+
+The `blockTypes` option maps the application's draft block types to the styling of the text component that renders them. Each entry accepts a theme [text variant](./2-components-and-theme.md), plain style values (`color`, `fontSize`, `fontWeight`, …), and a `className`.
+
+The factory works without any configuration: `createRichTextBlock()` renders every draft block with the base `theme.text` styles, as do block types missing from `blockTypes`. This makes the block usable before any text variants exist in the theme.
+
+Style values in `blockTypes` don't support responsive values — define a theme variant for responsive styling, or set a `className` and register responsive CSS via `registerStyles`.
+
+### Link types
+
+`LINK` entities reference a link block (`{ type, props }`). The `external` link type is built in and renders as `HtmlInlineLink`. Add the application's other link types via the `linkTypes` option — a resolver per link block type that receives the link block's props and returns the href, or `undefined` to render the text without a link:
+
+```tsx
+export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
+    linkTypes: {
+        phone: (props) =>
+            typeof props === "object" &&
+            props !== null &&
+            "phoneNumber" in props &&
+            typeof props.phoneNumber === "string"
+                ? `tel:${props.phoneNumber}`
+                : undefined,
+    },
+});
+```
+
+Link types without a resolver render their text as plain text.
+
+### Multiple configurations
+
+Each factory call is independent, so an application can create differently-configured pairs and name them by use case:
+
+```tsx
+export const {
+    MjmlRichTextBlock: MjmlHeadlineRichTextBlock,
+    HtmlRichTextBlock: HtmlHeadlineRichTextBlock,
+} = createRichTextBlock({
+    blockTypes: {
+        "header-one": { variant: "heading1" },
+        "header-two": { variant: "heading2" },
+    },
+});
+```
+
+### Rendering behavior
+
+- Each draft block renders as its own text component; spacing between blocks comes from the theme's `bottomSpacing`, and the last block gets none.
+- List items render flat as `<ul>` / `<ol>` inside one text component per list; nesting by draft depth isn't supported.
+- Headings are styled text, not semantic `<h1>` elements, matching the text components' design.
+- Empty draft blocks are skipped; when the data contains no text at all, the block renders nothing.
+- Rendered elements carry `richTextBlock__text`, `richTextBlock__list`, `richTextBlock__listItem`, and `richTextBlock__link` class names for targeting with [registerStyles](./2-components-and-theme.md).

--- a/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
@@ -115,18 +115,12 @@ Style values in `blockTypes` don't support responsive values — define a theme 
 
 ### Link types
 
-`LINK` entities reference a link block (`{ type, props }`). The `external` link type is built in and renders as `HtmlInlineLink`. Add the application's other link types via the `linkTypes` option — a resolver per link block type that receives the link block's props and returns the href, or `undefined` to render the text without a link:
+`LINK` entities reference a link block (`{ type, props }`). The `external` link type is built in and renders as `HtmlInlineLink`. Add the application's other link types via the `linkTypes` option — a resolver per link block type that receives the link block's props and returns the href, or `undefined` to render the text without a link. Declare the props' shape by annotating the resolver parameter to work with them typed rather than as `unknown`:
 
 ```tsx
 export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
     linkTypes: {
-        phone: (props) =>
-            typeof props === "object" &&
-            props !== null &&
-            "phoneNumber" in props &&
-            typeof props.phoneNumber === "string"
-                ? `tel:${props.phoneNumber}`
-                : undefined,
+        phone: (props: { phoneNumber: string }) => `tel:${props.phoneNumber}`,
     },
 });
 ```

--- a/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
@@ -133,6 +133,40 @@ export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
 
 Link types without a resolver render their text as plain text.
 
+### Inline styles
+
+Inline style ranges (`BOLD`, `ITALIC`, `SUB`, `SUP`, `STRIKETHROUGH`) render with built-in renderers. The `inline` option maps a draft-js inline style name to a renderer and merges over those built-ins, so you can override one while the others keep their defaults:
+
+```tsx
+export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
+    inline: {
+        BOLD: (children, { key }) => (
+            <strong key={key} style={{ fontWeight: "bold", color: "#cc0000" }}>
+                {children}
+            </strong>
+        ),
+    },
+});
+```
+
+The same option renders **custom** inline styles an application adds to its RTE via `customInlineStyles` on `IRteOptions` (see `@comet/admin-rte`). The style name you configure there — for example `HIGHLIGHT` — is stored verbatim in the content's inline style ranges but carries no styling of its own, so the email defines how it looks:
+
+```tsx
+export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
+    inline: {
+        HIGHLIGHT: (children, { key }) => (
+            <span key={key} style={{ backgroundColor: "#ff0000", color: "#ffffff" }}>
+                {children}
+            </span>
+        ),
+    },
+});
+```
+
+:::note
+Register the renderer under the exact style name used in the RTE. Prefer inline HTML elements known to render across email clients — `<span>`, `<strong>`, `<em>` — and set explicit styles rather than relying on a tag's defaults, which email clients apply inconsistently.
+:::
+
 ### Multiple configurations
 
 Each factory call is independent, so an application can create differently-configured pairs and name them by use case:

--- a/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
@@ -115,12 +115,14 @@ Style values in `blockTypes` don't support responsive values — define a theme 
 
 ### Link types
 
-`LINK` entities reference a link block (`{ type, props }`). The `external` link type is built in and renders as `HtmlInlineLink`. Add the application's other link types via the `linkTypes` option — a resolver per link block type that receives the link block's props and returns the href, or `undefined` to render the text without a link. Declare the props' shape by annotating the resolver parameter to work with them typed rather than as `unknown`:
+`LINK` entities reference a link block (`{ type, props }`). The `external` link type is built in and renders as `HtmlInlineLink`. Add the application's other link types via the `linkTypes` option — a resolver per link block type that receives the link block's props and returns the `href`, or `undefined` to render the text without a link. Annotate each resolver's parameter with the application's generated block-data type so the props are typed without redeclaring their shape:
 
 ```tsx
+import type { PhoneLinkBlockData } from "@src/blocks.generated";
+
 export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
     linkTypes: {
-        phone: (props: { phoneNumber: string }) => `tel:${props.phoneNumber}`,
+        phone: (props: PhoneLinkBlockData) => (props.phone ? `tel:${props.phone}` : undefined),
     },
 });
 ```

--- a/packages/mail-react/package.json
+++ b/packages/mail-react/package.json
@@ -44,7 +44,8 @@
         "@faire/mjml-react": "^3.5.4",
         "clsx": "^2.1.1",
         "mjml": "^4.18.0",
-        "mjml-browser": "^4.18.0"
+        "mjml-browser": "^4.18.0",
+        "redraft": "^0.10.2"
     },
     "devDependencies": {
         "@comet/cli": "workspace:*",

--- a/packages/mail-react/src/blocks/richText/README.md
+++ b/packages/mail-react/src/blocks/richText/README.md
@@ -1,0 +1,7 @@
+# RichText block
+
+Renders CMS RichText block data (draft-js raw content) in emails. Email templates need to style each draft block type — a `header-one` as a heading, a `paragraph-standard` as body text — and that mapping differs per application, so it is configured per `createRichTextBlock` call rather than shipped with the package.
+
+## Non-goals
+
+- No custom block or entity renderers. The factory configures how block types are styled and how link types resolve to URLs — not the markup itself, which the package controls.

--- a/packages/mail-react/src/blocks/richText/README.md
+++ b/packages/mail-react/src/blocks/richText/README.md
@@ -4,4 +4,4 @@ Renders CMS RichText block data (draft-js raw content) in emails. Email template
 
 ## Non-goals
 
-- No custom block or entity renderers. The factory configures how block types are styled and how link types resolve to URLs — not the markup itself, which the package controls.
+- No custom block or entity renderers. Block and link markup is controlled by the package; the factory configures only how block types are styled, how link types resolve to URLs, and how inline styles render.

--- a/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
@@ -1,0 +1,135 @@
+import { MjmlColumn, MjmlRaw } from "@faire/mjml-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MjmlSection } from "../../../components/section/MjmlSection.js";
+import { createTheme } from "../../../theme/createTheme.js";
+import { createRichTextBlock } from "../createRichTextBlock.js";
+import { exampleBlockData, headlinesOnlyBlockData } from "./exampleBlockData.js";
+
+const { HtmlRichTextBlock } = createRichTextBlock();
+
+type Story = StoryObj<typeof HtmlRichTextBlock>;
+
+const config: Meta<typeof HtmlRichTextBlock> = {
+    title: "Components/Blocks/HtmlRichTextBlock",
+    component: HtmlRichTextBlock,
+    tags: ["autodocs"],
+    parameters: {
+        docs: {
+            description: {
+                // Duplicates the TSDoc on HtmlRichTextBlock in createRichTextBlock.tsx — Storybook cannot read it from factory return type properties. Update both when the description changes.
+                component:
+                    "Renders CMS RichText block data (draft-js raw content) as one `HtmlText` div per draft block, for raw-HTML contexts such as `MjmlRaw`.",
+            },
+        },
+    },
+};
+
+export default config;
+
+/** A block from `createRichTextBlock()` without options: every draft block renders with the base theme text styles. */
+export const Default: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlRichTextBlock data={exampleBlockData} />
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+function resolveInternalLinkHref(props: unknown): string | undefined {
+    if (typeof props !== "object" || props === null || !("targetPage" in props)) {
+        return undefined;
+    }
+
+    const { targetPage } = props;
+
+    if (typeof targetPage !== "object" || targetPage === null || !("path" in targetPage)) {
+        return undefined;
+    }
+
+    const { path } = targetPage;
+
+    return typeof path === "string" ? `https://example.com${path}` : undefined;
+}
+
+const { HtmlRichTextBlock: HtmlCustomLinkTypeRichTextBlock } = createRichTextBlock({
+    linkTypes: {
+        internal: resolveInternalLinkHref,
+    },
+});
+
+/** Configuring a custom link type via the `linkTypes` option. The built-in `external` resolver is included by default; add entries for any other link types your CMS uses (e.g. `internal`) to render them as anchors. Email links must be absolute URLs, so the resolver prepends the site's base URL. */
+export const WithCustomLinkType: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlCustomLinkTypeRichTextBlock data={exampleBlockData} />
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+const { HtmlRichTextBlock: HtmlVariantsRichTextBlock } = createRichTextBlock({
+    blockTypes: {
+        "header-one": { variant: "heading1" },
+        "header-two": { variant: "heading2" },
+        "paragraph-standard": { variant: "body" },
+        "unordered-list-item": { variant: "body" },
+        "ordered-list-item": { variant: "body" },
+    },
+});
+
+const themeWithVariants = createTheme({
+    text: {
+        variants: {
+            heading1: { fontSize: "32px", fontWeight: 700, lineHeight: "40px", bottomSpacing: "24px" },
+            heading2: { fontSize: "24px", fontWeight: 700, lineHeight: "32px", bottomSpacing: "20px" },
+            body: { fontSize: "16px", lineHeight: "24px" },
+        },
+    },
+});
+
+/** Draft block types mapped to theme text variants via the factory's `blockTypes` option. */
+export const WithVariants: Story = {
+    parameters: {
+        theme: themeWithVariants,
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlVariantsRichTextBlock data={exampleBlockData} />
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+const { HtmlRichTextBlock: HtmlHeadlineRichTextBlock } = createRichTextBlock({
+    blockTypes: {
+        "header-one": { variant: "heading1" },
+        "header-two": { variant: "heading2" },
+    },
+});
+
+/** A second factory call configured for headline-only content, renamed at the consumer (`HtmlHeadlineRichTextBlock`). */
+export const RestrictedHeadlineBlock: Story = {
+    parameters: {
+        theme: themeWithVariants,
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlHeadlineRichTextBlock data={headlinesOnlyBlockData} />
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};

--- a/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
@@ -40,20 +40,8 @@ export const Default: Story = {
     ),
 };
 
-function resolveInternalLinkHref(props: unknown): string | undefined {
-    if (typeof props !== "object" || props === null || !("targetPage" in props)) {
-        return undefined;
-    }
-
-    const { targetPage } = props;
-
-    if (typeof targetPage !== "object" || targetPage === null || !("path" in targetPage)) {
-        return undefined;
-    }
-
-    const { path } = targetPage;
-
-    return typeof path === "string" ? `https://example.com${path}` : undefined;
+function resolveInternalLinkHref(props: { targetPage: { path: string } }): string {
+    return `https://example.com${props.targetPage.path}`;
 }
 
 const { HtmlRichTextBlock: HtmlCustomLinkTypeRichTextBlock } = createRichTextBlock({

--- a/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { MjmlSection } from "../../../components/section/MjmlSection.js";
 import { createTheme } from "../../../theme/createTheme.js";
 import { createRichTextBlock } from "../createRichTextBlock.js";
-import { exampleBlockData, headlinesOnlyBlockData } from "./exampleBlockData.js";
+import { exampleBlockData, headlinesOnlyBlockData, highlightBlockData } from "./exampleBlockData.js";
 
 const { HtmlRichTextBlock } = createRichTextBlock();
 
@@ -105,6 +105,29 @@ export const WithVariants: Story = {
             <MjmlColumn>
                 <MjmlRaw>
                     <HtmlVariantsRichTextBlock data={exampleBlockData} />
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+const { HtmlRichTextBlock: HtmlCustomInlineStyleRichTextBlock } = createRichTextBlock({
+    inline: {
+        HIGHLIGHT: (children, { key }) => (
+            <span key={key} style={{ backgroundColor: "#ff0000", color: "#ffffff" }}>
+                {children}
+            </span>
+        ),
+    },
+});
+
+/** Rendering a custom inline style via the `inline` option. `HIGHLIGHT` is not a built-in style — the application defines it in its RTE (`customInlineStyles`), and the email decides how it looks. The `inline` option merges over the built-in styles, so any the caller does not override keep their defaults. */
+export const WithCustomInlineStyle: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlCustomInlineStyleRichTextBlock data={highlightBlockData} />
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>

--- a/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
@@ -72,20 +72,8 @@ export const WithVariants: Story = {
     ),
 };
 
-function resolveInternalLinkHref(props: unknown): string | undefined {
-    if (typeof props !== "object" || props === null || !("targetPage" in props)) {
-        return undefined;
-    }
-
-    const { targetPage } = props;
-
-    if (typeof targetPage !== "object" || targetPage === null || !("path" in targetPage)) {
-        return undefined;
-    }
-
-    const { path } = targetPage;
-
-    return typeof path === "string" ? `https://example.com${path}` : undefined;
+function resolveInternalLinkHref(props: { targetPage: { path: string } }): string {
+    return `https://example.com${props.targetPage.path}`;
 }
 
 const { MjmlRichTextBlock: MjmlCustomLinkTypeRichTextBlock } = createRichTextBlock({

--- a/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { MjmlSection } from "../../../components/section/MjmlSection.js";
 import { createTheme } from "../../../theme/createTheme.js";
 import { createRichTextBlock } from "../createRichTextBlock.js";
-import { exampleBlockData, headlinesOnlyBlockData } from "./exampleBlockData.js";
+import { exampleBlockData, headlinesOnlyBlockData, highlightBlockData } from "./exampleBlockData.js";
 
 const { MjmlRichTextBlock } = createRichTextBlock();
 
@@ -100,6 +100,27 @@ export const WithCustomLinkType: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlCustomLinkTypeRichTextBlock data={exampleBlockData} />
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+const { MjmlRichTextBlock: MjmlCustomInlineStyleRichTextBlock } = createRichTextBlock({
+    inline: {
+        HIGHLIGHT: (children, { key }) => (
+            <span key={key} style={{ backgroundColor: "#ff0000", color: "#ffffff" }}>
+                {children}
+            </span>
+        ),
+    },
+});
+
+/** Rendering a custom inline style via the `inline` option. `HIGHLIGHT` is not a built-in style — the application defines it in its RTE (`customInlineStyles`), and the email decides how it looks. The `inline` option merges over the built-in styles, so any the caller does not override keep their defaults. */
+export const WithCustomInlineStyle: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlCustomInlineStyleRichTextBlock data={highlightBlockData} />
             </MjmlColumn>
         </MjmlSection>
     ),

--- a/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
@@ -1,0 +1,127 @@
+import { MjmlColumn } from "@faire/mjml-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MjmlSection } from "../../../components/section/MjmlSection.js";
+import { createTheme } from "../../../theme/createTheme.js";
+import { createRichTextBlock } from "../createRichTextBlock.js";
+import { exampleBlockData, headlinesOnlyBlockData } from "./exampleBlockData.js";
+
+const { MjmlRichTextBlock } = createRichTextBlock();
+
+type Story = StoryObj<typeof MjmlRichTextBlock>;
+
+const config: Meta<typeof MjmlRichTextBlock> = {
+    title: "Components/Blocks/MjmlRichTextBlock",
+    component: MjmlRichTextBlock,
+    tags: ["autodocs"],
+    parameters: {
+        docs: {
+            description: {
+                // Duplicates the TSDoc on MjmlRichTextBlock in createRichTextBlock.tsx — Storybook cannot read it from factory return type properties. Update both when the description changes.
+                component:
+                    "Renders CMS RichText block data (draft-js raw content) as one `MjmlText` per draft block. Must be placed within an `MjmlColumn`.",
+            },
+        },
+    },
+};
+
+export default config;
+
+/** A block from `createRichTextBlock()` without options: every draft block renders with the base theme text styles. */
+export const Default: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRichTextBlock data={exampleBlockData} />
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+const { MjmlRichTextBlock: MjmlVariantsRichTextBlock } = createRichTextBlock({
+    blockTypes: {
+        "header-one": { variant: "heading1" },
+        "header-two": { variant: "heading2" },
+        "paragraph-standard": { variant: "body" },
+        "unordered-list-item": { variant: "body" },
+        "ordered-list-item": { variant: "body" },
+    },
+});
+
+const themeWithVariants = createTheme({
+    text: {
+        variants: {
+            heading1: { fontSize: "32px", fontWeight: 700, lineHeight: "40px", bottomSpacing: "24px" },
+            heading2: { fontSize: "24px", fontWeight: 700, lineHeight: "32px", bottomSpacing: "20px" },
+            body: { fontSize: "16px", lineHeight: "24px" },
+        },
+    },
+});
+
+/** Draft block types mapped to theme text variants via the factory's `blockTypes` option. */
+export const WithVariants: Story = {
+    parameters: {
+        theme: themeWithVariants,
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlVariantsRichTextBlock data={exampleBlockData} />
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+function resolveInternalLinkHref(props: unknown): string | undefined {
+    if (typeof props !== "object" || props === null || !("targetPage" in props)) {
+        return undefined;
+    }
+
+    const { targetPage } = props;
+
+    if (typeof targetPage !== "object" || targetPage === null || !("path" in targetPage)) {
+        return undefined;
+    }
+
+    const { path } = targetPage;
+
+    return typeof path === "string" ? `https://example.com${path}` : undefined;
+}
+
+const { MjmlRichTextBlock: MjmlCustomLinkTypeRichTextBlock } = createRichTextBlock({
+    linkTypes: {
+        internal: resolveInternalLinkHref,
+    },
+});
+
+/** Configuring a custom link type via the `linkTypes` option. The built-in `external` resolver is included by default; add entries for any other link types your CMS uses (e.g. `internal`) to render them as anchors. Email links must be absolute URLs, so the resolver prepends the site's base URL. */
+export const WithCustomLinkType: Story = {
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlCustomLinkTypeRichTextBlock data={exampleBlockData} />
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+const { MjmlRichTextBlock: MjmlHeadlineRichTextBlock } = createRichTextBlock({
+    blockTypes: {
+        "header-one": { variant: "heading1" },
+        "header-two": { variant: "heading2" },
+    },
+});
+
+/** A second factory call configured for headline-only content, renamed at the consumer (`MjmlHeadlineRichTextBlock`). */
+export const RestrictedHeadlineBlock: Story = {
+    parameters: {
+        theme: themeWithVariants,
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlHeadlineRichTextBlock data={headlinesOnlyBlockData} />
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};

--- a/packages/mail-react/src/blocks/richText/__stories__/exampleBlockData.ts
+++ b/packages/mail-react/src/blocks/richText/__stories__/exampleBlockData.ts
@@ -142,6 +142,23 @@ export const exampleBlockData: RichTextBlockData = {
     },
 };
 
+export const highlightBlockData: RichTextBlockData = {
+    draftContent: {
+        blocks: [
+            {
+                key: "hlt1",
+                text: "This paragraph contains highlighted text a reader should not miss.",
+                type: "paragraph-standard",
+                depth: 0,
+                inlineStyleRanges: [{ offset: 24, length: 16, style: "HIGHLIGHT" }],
+                entityRanges: [],
+                data: {},
+            },
+        ],
+        entityMap: {},
+    },
+};
+
 export const headlinesOnlyBlockData: RichTextBlockData = {
     draftContent: {
         blocks: [

--- a/packages/mail-react/src/blocks/richText/__stories__/exampleBlockData.ts
+++ b/packages/mail-react/src/blocks/richText/__stories__/exampleBlockData.ts
@@ -1,0 +1,169 @@
+import type { RichTextBlockData } from "../common.js";
+
+export const exampleBlockData: RichTextBlockData = {
+    draftContent: {
+        blocks: [
+            {
+                key: "dkq9u",
+                text: "Heading One",
+                type: "header-one",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "ajl7h",
+                text: "Default paragraph: Inventore eum velit fuga qui quae voluptatibus similique odio. Libero molestias non et dignissimos numquam est. Sint amet voluptate non.",
+                type: "paragraph-standard",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "4hl5r",
+                text: "Default paragraph with an external link and an internal link within it.",
+                type: "paragraph-standard",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [
+                    { offset: 26, length: 13, key: 0 },
+                    { offset: 47, length: 13, key: 1 },
+                ],
+                data: {},
+            },
+            {
+                key: "a968k",
+                text: "This paragraph has bold text, italic text and both at once. \nAnd this has strike through, after a line break.",
+                type: "paragraph-standard",
+                depth: 0,
+                inlineStyleRanges: [
+                    { offset: 19, length: 9, style: "BOLD" },
+                    { offset: 46, length: 12, style: "BOLD" },
+                    { offset: 30, length: 11, style: "ITALIC" },
+                    { offset: 46, length: 12, style: "ITALIC" },
+                    { offset: 75, length: 14, style: "STRIKETHROUGH" },
+                ],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "h2lst",
+                text: "Heading Two above a list",
+                type: "header-two",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "ul1",
+                text: "Unordered list item one",
+                type: "unordered-list-item",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "ul2",
+                text: "Unordered list item two",
+                type: "unordered-list-item",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "ol1",
+                text: "Ordered list item one",
+                type: "ordered-list-item",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "ol2",
+                text: "Ordered list item two",
+                type: "ordered-list-item",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "fu9f1",
+                text: "",
+                type: "paragraph-standard",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+        ],
+        entityMap: {
+            "0": {
+                type: "LINK",
+                mutability: "MUTABLE",
+                data: {
+                    attachedBlocks: [],
+                    block: {
+                        type: "external",
+                        props: {
+                            targetUrl: "https://example.com",
+                            openInNewWindow: false,
+                        },
+                    },
+                    activeType: "external",
+                },
+            },
+            "1": {
+                type: "LINK",
+                mutability: "MUTABLE",
+                data: {
+                    attachedBlocks: [],
+                    block: {
+                        type: "internal",
+                        props: {
+                            targetPage: {
+                                id: "home",
+                                name: "Home",
+                                path: "/",
+                                documentType: "Page",
+                            },
+                        },
+                    },
+                    activeType: "internal",
+                },
+            },
+        },
+    },
+};
+
+export const headlinesOnlyBlockData: RichTextBlockData = {
+    draftContent: {
+        blocks: [
+            {
+                key: "hl1",
+                text: "Main headline",
+                type: "header-one",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "hl2",
+                text: "Secondary headline",
+                type: "header-two",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+        ],
+        entityMap: {},
+    },
+};

--- a/packages/mail-react/src/blocks/richText/__tests__/createRichTextBlock.test.tsx
+++ b/packages/mail-react/src/blocks/richText/__tests__/createRichTextBlock.test.tsx
@@ -179,6 +179,50 @@ describe("createRichTextBlock — inline styles and line breaks", () => {
 
         expect(markup).toContain("line one<br/>line two");
     });
+
+    it("merges the inline option over the built-in marks: overrides one, keeps the rest", () => {
+        const { HtmlRichTextBlock: HtmlCustomBoldRichTextBlock } = createRichTextBlock({
+            inline: {
+                BOLD: (children, { key }) => (
+                    <span key={key} className="customBold">
+                        {children}
+                    </span>
+                ),
+            },
+        });
+        const data = createBlockData([
+            createDraftBlock({
+                key: "a",
+                text: "bold italic",
+                inlineStyleRanges: [
+                    { offset: 0, length: 4, style: "BOLD" },
+                    { offset: 5, length: 6, style: "ITALIC" },
+                ],
+            }),
+        ]);
+        const markup = renderWithTheme(<HtmlCustomBoldRichTextBlock data={data} />);
+
+        expect(markup).toContain('<span class="customBold">bold</span>');
+        expect(markup).toContain('<em style="font-style:italic">italic</em>');
+    });
+
+    it("renders a custom inline style that has no built-in renderer", () => {
+        const { HtmlRichTextBlock: HtmlHighlightRichTextBlock } = createRichTextBlock({
+            inline: {
+                HIGHLIGHT: (children, { key }) => (
+                    <span key={key} style={{ backgroundColor: "#ff0000" }}>
+                        {children}
+                    </span>
+                ),
+            },
+        });
+        const data = createBlockData([
+            createDraftBlock({ key: "a", text: "highlighted", inlineStyleRanges: [{ offset: 0, length: 11, style: "HIGHLIGHT" }] }),
+        ]);
+        const markup = renderWithTheme(<HtmlHighlightRichTextBlock data={data} />);
+
+        expect(markup).toContain('<span style="background-color:#ff0000">highlighted</span>');
+    });
 });
 
 describe("createRichTextBlock — links", () => {

--- a/packages/mail-react/src/blocks/richText/__tests__/createRichTextBlock.test.tsx
+++ b/packages/mail-react/src/blocks/richText/__tests__/createRichTextBlock.test.tsx
@@ -1,0 +1,262 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { createTheme } from "../../../theme/createTheme.js";
+import { ThemeProvider } from "../../../theme/ThemeProvider.js";
+import type { RichTextBlockData } from "../common.js";
+import { createRichTextBlock } from "../createRichTextBlock.js";
+
+function renderWithTheme(node: ReactNode, theme = createTheme()): string {
+    return renderToStaticMarkup(<ThemeProvider theme={theme}>{node}</ThemeProvider>);
+}
+
+function createDraftBlock(overrides: { key: string; text: string; type?: string; [key: string]: unknown }) {
+    return { type: "unstyled", depth: 0, inlineStyleRanges: [], entityRanges: [], data: {}, ...overrides };
+}
+
+function createBlockData(blocks: Array<Record<string, unknown>>, entityMap: Record<string, unknown> = {}): RichTextBlockData {
+    return { draftContent: { blocks, entityMap } };
+}
+
+const themeWithVariants = createTheme({
+    text: {
+        variants: {
+            heading1: { fontSize: "32px", fontWeight: 700 },
+            body: { fontSize: "16px" },
+        },
+    },
+});
+
+describe("createRichTextBlock — base rendering", () => {
+    const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock();
+
+    it("renders each draft block as its own MjmlText with base theme styles", () => {
+        const data = createBlockData([createDraftBlock({ key: "a", text: "First" }), createDraftBlock({ key: "b", text: "Second" })]);
+        const markup = renderWithTheme(<MjmlRichTextBlock data={data} />);
+
+        expect(markup.match(/<mj-text/g)).toHaveLength(2);
+        expect(markup).toContain("First");
+        expect(markup).toContain("Second");
+    });
+
+    it("renders each draft block as its own HtmlText div with a richTextBlock__text class", () => {
+        const data = createBlockData([createDraftBlock({ key: "a", text: "First" }), createDraftBlock({ key: "b", text: "Second" })]);
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
+
+        expect(markup.match(/<div/g)).toHaveLength(2);
+        expect(markup.match(/richTextBlock__text/g)).toHaveLength(2);
+    });
+
+    it("renders unmapped block types with base styles instead of failing", () => {
+        const data = createBlockData([createDraftBlock({ key: "a", text: "Custom", type: "paragraph-standard" })]);
+        const markup = renderWithTheme(<MjmlRichTextBlock data={data} />);
+
+        expect(markup).toContain("Custom");
+        expect(markup).not.toContain("mjmlText--");
+    });
+
+    it("renders nothing when draftContent has no blocks with text", () => {
+        const data = createBlockData([createDraftBlock({ key: "a", text: "" })]);
+
+        expect(renderWithTheme(<MjmlRichTextBlock data={data} />)).toBe("");
+    });
+
+    it("renders nothing when draftContent is not draft-js raw content", () => {
+        const data: RichTextBlockData = { draftContent: "not draft content" };
+
+        expect(renderWithTheme(<MjmlRichTextBlock data={data} />)).toBe("");
+    });
+
+    it("filters empty draft blocks", () => {
+        const data = createBlockData([
+            createDraftBlock({ key: "a", text: "Content" }),
+            createDraftBlock({ key: "b", text: "" }),
+            createDraftBlock({ key: "c", text: "More" }),
+        ]);
+        const markup = renderWithTheme(<MjmlRichTextBlock data={data} />);
+
+        expect(markup.match(/<mj-text/g)).toHaveLength(2);
+    });
+});
+
+describe("createRichTextBlock — block type configuration", () => {
+    const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
+        blockTypes: {
+            "header-one": { variant: "heading1" },
+            "paragraph-standard": { variant: "body", className: "customParagraph" },
+            unstyled: { color: "#ff0000", fontWeight: 700 },
+        },
+    });
+
+    it("applies the mapped variant to the text component", () => {
+        const data = createBlockData([createDraftBlock({ key: "a", text: "Heading", type: "header-one" })]);
+
+        expect(renderWithTheme(<MjmlRichTextBlock data={data} />, themeWithVariants)).toContain("mjmlText--heading1");
+        expect(renderWithTheme(<HtmlRichTextBlock data={data} />, themeWithVariants)).toContain("htmlText--heading1");
+    });
+
+    it("keeps the variant's resolved styles when the block type config sets no style props", () => {
+        const data = createBlockData([createDraftBlock({ key: "a", text: "Heading", type: "header-one" })]);
+        const markup = renderWithTheme(<MjmlRichTextBlock data={data} />, themeWithVariants);
+
+        expect(markup).toContain('font-weight="700"');
+        expect(markup).toContain('font-size="32px"');
+    });
+
+    it("passes className through to the text component", () => {
+        const data = createBlockData([createDraftBlock({ key: "a", text: "Paragraph", type: "paragraph-standard" })]);
+
+        expect(renderWithTheme(<MjmlRichTextBlock data={data} />, themeWithVariants)).toContain("customParagraph");
+    });
+
+    it("applies plain style props in the Mjml variant as MjmlText attributes", () => {
+        const data = createBlockData([createDraftBlock({ key: "a", text: "Styled" })]);
+        const markup = renderWithTheme(<MjmlRichTextBlock data={data} />);
+
+        expect(markup).toContain('color="#ff0000"');
+        expect(markup).toContain('font-weight="700"');
+    });
+
+    it("applies plain style props in the Html variant as inline styles", () => {
+        const data = createBlockData([createDraftBlock({ key: "a", text: "Styled" })]);
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
+
+        expect(markup).toContain("color:#ff0000");
+        expect(markup).toContain("font-weight:700");
+    });
+});
+
+describe("createRichTextBlock — bottom spacing", () => {
+    const { HtmlRichTextBlock } = createRichTextBlock();
+
+    it("applies bottomSpacing to every block except the last one with text", () => {
+        const data = createBlockData([
+            createDraftBlock({ key: "a", text: "First" }),
+            createDraftBlock({ key: "b", text: "Last" }),
+            createDraftBlock({ key: "c", text: "" }),
+        ]);
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
+        const blocks = markup.split("</div>").filter((block) => block !== "");
+
+        expect(blocks[0]).toContain("htmlText--bottomSpacing");
+        expect(blocks[1]).not.toContain("htmlText--bottomSpacing");
+    });
+});
+
+describe("createRichTextBlock — inline styles and line breaks", () => {
+    const { HtmlRichTextBlock } = createRichTextBlock();
+
+    it("renders BOLD and ITALIC ranges as semantic tags with an explicit style fallback", () => {
+        const data = createBlockData([
+            createDraftBlock({
+                key: "a",
+                text: "bold italic",
+                inlineStyleRanges: [
+                    { offset: 0, length: 4, style: "BOLD" },
+                    { offset: 5, length: 6, style: "ITALIC" },
+                ],
+            }),
+        ]);
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
+
+        expect(markup).toContain('<strong style="font-weight:bold">bold</strong>');
+        expect(markup).toContain('<em style="font-style:italic">italic</em>');
+    });
+
+    it("renders a STRIKETHROUGH range", () => {
+        const data = createBlockData([
+            createDraftBlock({ key: "a", text: "struck", inlineStyleRanges: [{ offset: 0, length: 6, style: "STRIKETHROUGH" }] }),
+        ]);
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
+
+        expect(markup).toContain("<s>struck</s>");
+    });
+
+    it("renders a line break within a block as <br/>", () => {
+        const data = createBlockData([createDraftBlock({ key: "a", text: "line one\nline two" })]);
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
+
+        expect(markup).toContain("line one<br/>line two");
+    });
+});
+
+describe("createRichTextBlock — links", () => {
+    const { HtmlRichTextBlock } = createRichTextBlock();
+
+    function createLinkBlockData(linkBlock: Record<string, unknown>): RichTextBlockData {
+        return createBlockData([createDraftBlock({ key: "a", text: "Visit our website now", entityRanges: [{ offset: 6, length: 11, key: 0 }] })], {
+            "0": { type: "LINK", mutability: "MUTABLE", data: { block: linkBlock } },
+        });
+    }
+
+    it("renders an external LINK entity as an inline link with the target URL", () => {
+        const data = createLinkBlockData({ type: "external", props: { targetUrl: "https://example.com", openInNewWindow: false } });
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
+
+        expect(markup).toContain('href="https://example.com"');
+        expect(markup).toContain("richTextBlock__link");
+        expect(markup).toContain("our website");
+    });
+
+    it("renders the text of an unconfigured link type without a link", () => {
+        const data = createLinkBlockData({ type: "internal", props: { targetPage: { id: "1", path: "/" } } });
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
+
+        expect(markup).not.toContain("<a");
+        expect(markup).toContain("our website");
+    });
+
+    it("resolves application-defined link types through the linkTypes option", () => {
+        const { HtmlRichTextBlock: HtmlPhoneLinkRichTextBlock } = createRichTextBlock({
+            linkTypes: {
+                phone: (props) => {
+                    if (typeof props !== "object" || props === null || !("phoneNumber" in props)) {
+                        return undefined;
+                    }
+
+                    return typeof props.phoneNumber === "string" ? `tel:${props.phoneNumber}` : undefined;
+                },
+            },
+        });
+        const data = createLinkBlockData({ type: "phone", props: { phoneNumber: "+431234567" } });
+        const markup = renderWithTheme(<HtmlPhoneLinkRichTextBlock data={data} />);
+
+        expect(markup).toContain('href="tel:+431234567"');
+    });
+
+    it("keeps the built-in external link type when linkTypes adds more", () => {
+        const { HtmlRichTextBlock: HtmlPhoneLinkRichTextBlock } = createRichTextBlock({ linkTypes: { phone: () => undefined } });
+        const data = createLinkBlockData({ type: "external", props: { targetUrl: "https://example.com", openInNewWindow: false } });
+        const markup = renderWithTheme(<HtmlPhoneLinkRichTextBlock data={data} />);
+
+        expect(markup).toContain('href="https://example.com"');
+    });
+});
+
+describe("createRichTextBlock — lists", () => {
+    const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock();
+
+    it("groups consecutive unordered list items into one list within one text component", () => {
+        const data = createBlockData([
+            createDraftBlock({ key: "a", text: "Item one", type: "unordered-list-item" }),
+            createDraftBlock({ key: "b", text: "Item two", type: "unordered-list-item" }),
+        ]);
+        const markup = renderWithTheme(<MjmlRichTextBlock data={data} />);
+
+        expect(markup.match(/<mj-text/g)).toHaveLength(1);
+        expect(markup.match(/<ul/g)).toHaveLength(1);
+        expect(markup.match(/<li/g)).toHaveLength(2);
+    });
+
+    it("renders ordered list items as an ol with element class names", () => {
+        const data = createBlockData([
+            createDraftBlock({ key: "a", text: "Item one", type: "ordered-list-item" }),
+            createDraftBlock({ key: "b", text: "Item two", type: "ordered-list-item" }),
+        ]);
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
+
+        expect(markup.match(/<ol class="richTextBlock__list"/g)).toHaveLength(1);
+        expect(markup.match(/<li class="richTextBlock__listItem"/g)).toHaveLength(2);
+    });
+});

--- a/packages/mail-react/src/blocks/richText/__tests__/createRichTextBlock.test.tsx
+++ b/packages/mail-react/src/blocks/richText/__tests__/createRichTextBlock.test.tsx
@@ -254,19 +254,41 @@ describe("createRichTextBlock — links", () => {
     it("resolves application-defined link types through the linkTypes option", () => {
         const { HtmlRichTextBlock: HtmlPhoneLinkRichTextBlock } = createRichTextBlock({
             linkTypes: {
-                phone: (props) => {
-                    if (typeof props !== "object" || props === null || !("phoneNumber" in props)) {
-                        return undefined;
-                    }
-
-                    return typeof props.phoneNumber === "string" ? `tel:${props.phoneNumber}` : undefined;
-                },
+                phone: (props: { phoneNumber: string }) => `tel:${props.phoneNumber}`,
             },
         });
         const data = createLinkBlockData({ type: "phone", props: { phoneNumber: "+431234567" } });
         const markup = renderWithTheme(<HtmlPhoneLinkRichTextBlock data={data} />);
 
         expect(markup).toContain('href="tel:+431234567"');
+    });
+
+    it("types resolver props from the factory's type argument", () => {
+        createRichTextBlock<{ phone: { phoneNumber: string } }>({
+            linkTypes: {
+                phone: (props) => {
+                    // Accessing `phoneNumber` compiles only because `props` is typed from the type argument, not `unknown`.
+                    const phoneNumber: string = props.phoneNumber;
+                    // @ts-expect-error `props.phoneNumber` is a string, not a number
+                    const wrongType: number = props.phoneNumber;
+
+                    return `tel:${phoneNumber}${String(wrongType)}`;
+                },
+            },
+        });
+    });
+
+    it("types resolver props from an annotated parameter", () => {
+        createRichTextBlock({
+            linkTypes: {
+                phone: (props: { phoneNumber: string }) => {
+                    // @ts-expect-error `props.phoneNumber` is a string, not a number
+                    const phoneNumber: number = props.phoneNumber;
+
+                    return `tel:${String(phoneNumber)}`;
+                },
+            },
+        });
     });
 
     it("keeps the built-in external link type when linkTypes adds more", () => {

--- a/packages/mail-react/src/blocks/richText/common.ts
+++ b/packages/mail-react/src/blocks/richText/common.ts
@@ -31,7 +31,7 @@ export type RichTextBlockTypeProps = Omit<TextStyles, "bottomSpacing"> & {
  *
  * Return `undefined` to render the linked text without a link.
  */
-export type RichTextLinkHrefResolver = (props: unknown) => string | undefined;
+export type RichTextLinkHrefResolver<TProps = unknown> = (props: TProps) => string | undefined;
 
 /**
  * Renders the text spanned by one draft-js inline style (e.g. `BOLD`).
@@ -40,7 +40,7 @@ export type RichTextLinkHrefResolver = (props: unknown) => string | undefined;
  */
 export type RichTextInlineRenderer = (children: ReactNode, options: { key: string }) => ReactNode;
 
-export interface CreateRichTextBlockOptions {
+export interface CreateRichTextBlockOptions<TLinkTypes extends Record<string, unknown> = Record<string, unknown>> {
     /**
      * Maps draft block types (e.g. `"header-one"`, `"paragraph-standard"`) to the
      * styling of the text component that renders them.
@@ -55,7 +55,7 @@ export interface CreateRichTextBlockOptions {
      * Merged on top of the built-in `external` link type. Link types without
      * a resolver render their text without a link.
      */
-    linkTypes?: Record<string, RichTextLinkHrefResolver>;
+    linkTypes?: { [TLinkType in keyof TLinkTypes]: RichTextLinkHrefResolver<TLinkTypes[TLinkType]> };
     /**
      * Maps draft-js inline style names to renderers, keyed by the style name as
      * it appears in the content's `inlineStyleRanges`.

--- a/packages/mail-react/src/blocks/richText/common.ts
+++ b/packages/mail-react/src/blocks/richText/common.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import type { TextStyles, VariantName } from "../../theme/themeTypes.js";
 import type { PropsWithData } from "../helpers/PropsWithData.js";
 
@@ -31,6 +33,13 @@ export type RichTextBlockTypeProps = Omit<TextStyles, "bottomSpacing"> & {
  */
 export type RichTextLinkHrefResolver = (props: unknown) => string | undefined;
 
+/**
+ * Renders the text spanned by one draft-js inline style (e.g. `BOLD`).
+ *
+ * `key` must be set on the returned element's root.
+ */
+export type RichTextInlineRenderer = (children: ReactNode, options: { key: string }) => ReactNode;
+
 export interface CreateRichTextBlockOptions {
     /**
      * Maps draft block types (e.g. `"header-one"`, `"paragraph-standard"`) to the
@@ -47,4 +56,14 @@ export interface CreateRichTextBlockOptions {
      * a resolver render their text without a link.
      */
     linkTypes?: Record<string, RichTextLinkHrefResolver>;
+    /**
+     * Maps draft-js inline style names to renderers, keyed by the style name as
+     * it appears in the content's `inlineStyleRanges`.
+     *
+     * Merged on top of the built-in styles (`BOLD`, `ITALIC`, `SUB`, `SUP`,
+     * `STRIKETHROUGH`): use it to override a built-in style, or to render a
+     * custom inline style the application defines in its RTE (e.g. `HIGHLIGHT`),
+     * which has no built-in renderer.
+     */
+    inline?: Record<string, RichTextInlineRenderer>;
 }

--- a/packages/mail-react/src/blocks/richText/common.ts
+++ b/packages/mail-react/src/blocks/richText/common.ts
@@ -1,0 +1,50 @@
+import type { TextStyles, VariantName } from "../../theme/themeTypes.js";
+import type { PropsWithData } from "../helpers/PropsWithData.js";
+
+export interface RichTextBlockData {
+    /** Draft.js raw content state (`{ blocks, entityMap }`), as produced by the CMS RichText block. */
+    draftContent: unknown;
+}
+
+export type RichTextBlockProps = PropsWithData<RichTextBlockData>;
+
+/**
+ * Styling for all draft blocks of one type, applied on top of the base theme text styles.
+ *
+ * Style props accept plain values only. For responsive styling, use a theme
+ * variant, or set a `className` and register responsive CSS via `registerStyles`.
+ */
+export type RichTextBlockTypeProps = Omit<TextStyles, "bottomSpacing"> & {
+    /**
+     * The text component's variant to apply, as defined in the theme.
+     *
+     * @defaultValue The theme's `text.defaultVariant`, when set
+     */
+    variant?: VariantName;
+    className?: string;
+};
+
+/**
+ * Resolves the href of one link block type from the link block's props.
+ *
+ * Return `undefined` to render the linked text without a link.
+ */
+export type RichTextLinkHrefResolver = (props: unknown) => string | undefined;
+
+export interface CreateRichTextBlockOptions {
+    /**
+     * Maps draft block types (e.g. `"header-one"`, `"paragraph-standard"`) to the
+     * styling of the text component that renders them.
+     *
+     * Unmapped block types render with the base theme text styles.
+     */
+    blockTypes?: Record<string, RichTextBlockTypeProps>;
+    /**
+     * Maps the application's link block types within `LINK` entities to a
+     * resolver returning the link's href.
+     *
+     * Merged on top of the built-in `external` link type. Link types without
+     * a resolver render their text without a link.
+     */
+    linkTypes?: Record<string, RichTextLinkHrefResolver>;
+}

--- a/packages/mail-react/src/blocks/richText/createRichTextBlock.tsx
+++ b/packages/mail-react/src/blocks/richText/createRichTextBlock.tsx
@@ -4,7 +4,13 @@ import redraftImport from "redraft";
 
 import { HtmlText } from "../../components/text/HtmlText.js";
 import { MjmlText } from "../../components/text/MjmlText.js";
-import type { CreateRichTextBlockOptions, RichTextBlockProps, RichTextBlockTypeProps, RichTextLinkHrefResolver } from "./common.js";
+import type {
+    CreateRichTextBlockOptions,
+    RichTextBlockProps,
+    RichTextBlockTypeProps,
+    RichTextInlineRenderer,
+    RichTextLinkHrefResolver,
+} from "./common.js";
 import { type BlockTextProps, builtInLinkTypes, createRichTextRenderers } from "./createRichTextRenderers.js";
 
 // redraft is CommonJS-only: under native ESM the default import is the whole
@@ -64,10 +70,11 @@ interface RenderRichTextContentOptions {
     draftContent: unknown;
     blockTypes: Record<string, RichTextBlockTypeProps>;
     linkTypes: Record<string, RichTextLinkHrefResolver>;
+    inline: Record<string, RichTextInlineRenderer>;
     blockTextComponent: ComponentType<BlockTextProps>;
 }
 
-function renderRichTextContent({ draftContent, blockTypes, linkTypes, blockTextComponent }: RenderRichTextContentOptions): ReactNode {
+function renderRichTextContent({ draftContent, blockTypes, linkTypes, inline, blockTextComponent }: RenderRichTextContentOptions): ReactNode {
     if (!isDraftContent(draftContent)) {
         return null;
     }
@@ -79,7 +86,7 @@ function renderRichTextContent({ draftContent, blockTypes, linkTypes, blockTextC
         return null;
     }
 
-    const renderers = createRichTextRenderers({ blockTypes, linkTypes, blockTextComponent, lastBlockKey });
+    const renderers = createRichTextRenderers({ blockTypes, linkTypes, inline, blockTextComponent, lastBlockKey });
 
     return redraft({ ...draftContent, blocks: blocksWithText }, renderers);
 }
@@ -116,13 +123,14 @@ export function createRichTextBlock(options: CreateRichTextBlockOptions = {}): {
 } {
     const blockTypes = options.blockTypes ?? {};
     const linkTypes = { ...builtInLinkTypes, ...options.linkTypes };
+    const inline = options.inline ?? {};
 
     function MjmlRichTextBlock({ data }: RichTextBlockProps): ReactNode {
-        return renderRichTextContent({ draftContent: data.draftContent, blockTypes, linkTypes, blockTextComponent: MjmlBlockText });
+        return renderRichTextContent({ draftContent: data.draftContent, blockTypes, linkTypes, inline, blockTextComponent: MjmlBlockText });
     }
 
     function HtmlRichTextBlock({ data }: RichTextBlockProps): ReactNode {
-        return renderRichTextContent({ draftContent: data.draftContent, blockTypes, linkTypes, blockTextComponent: HtmlBlockText });
+        return renderRichTextContent({ draftContent: data.draftContent, blockTypes, linkTypes, inline, blockTextComponent: HtmlBlockText });
     }
 
     return { MjmlRichTextBlock, HtmlRichTextBlock };

--- a/packages/mail-react/src/blocks/richText/createRichTextBlock.tsx
+++ b/packages/mail-react/src/blocks/richText/createRichTextBlock.tsx
@@ -113,7 +113,9 @@ function renderRichTextContent({ draftContent, blockTypes, linkTypes, inline, bl
  * });
  * ```
  */
-export function createRichTextBlock(options: CreateRichTextBlockOptions = {}): {
+export function createRichTextBlock<TLinkTypes extends Record<string, unknown> = Record<string, unknown>>(
+    options: CreateRichTextBlockOptions<TLinkTypes> = {},
+): {
     // The description below is duplicated in MjmlRichTextBlock.stories.tsx because Storybook cannot read TSDoc from factory return type properties. Update both when the description changes.
     /** Renders CMS RichText block data (draft-js raw content) as one `MjmlText` per draft block. Must be placed within an `MjmlColumn`. */
     MjmlRichTextBlock: (props: RichTextBlockProps) => ReactNode;
@@ -122,7 +124,13 @@ export function createRichTextBlock(options: CreateRichTextBlockOptions = {}): {
     HtmlRichTextBlock: (props: RichTextBlockProps) => ReactNode;
 } {
     const blockTypes = options.blockTypes ?? {};
-    const linkTypes = { ...builtInLinkTypes, ...options.linkTypes };
+    const linkTypes: Record<string, RichTextLinkHrefResolver> = {
+        ...builtInLinkTypes,
+        // Consumers declare each resolver's props via the typed map, but at
+        // runtime they are unknown draft-js data. This one contained cast lets
+        // consumers work typed without casting in their own resolvers.
+        ...(options.linkTypes as Record<string, RichTextLinkHrefResolver>),
+    };
     const inline = options.inline ?? {};
 
     function MjmlRichTextBlock({ data }: RichTextBlockProps): ReactNode {

--- a/packages/mail-react/src/blocks/richText/createRichTextBlock.tsx
+++ b/packages/mail-react/src/blocks/richText/createRichTextBlock.tsx
@@ -1,0 +1,129 @@
+import clsx from "clsx";
+import type { ComponentType, ReactNode } from "react";
+import redraftImport from "redraft";
+
+import { HtmlText } from "../../components/text/HtmlText.js";
+import { MjmlText } from "../../components/text/MjmlText.js";
+import type { CreateRichTextBlockOptions, RichTextBlockProps, RichTextBlockTypeProps, RichTextLinkHrefResolver } from "./common.js";
+import { type BlockTextProps, builtInLinkTypes, createRichTextRenderers } from "./createRichTextRenderers.js";
+
+// redraft is CommonJS-only: under native ESM the default import is the whole
+// `module.exports` object, under bundlers it is the render function itself.
+const redraft = typeof redraftImport === "function" ? redraftImport : redraftImport.default;
+
+function MjmlBlockText({ bottomSpacing, variant, className, fontWeight, children, ...styleProps }: BlockTextProps): ReactNode {
+    return (
+        <MjmlText
+            variant={variant}
+            bottomSpacing={bottomSpacing}
+            className={clsx("richTextBlock__text", className)}
+            // Spread conditionally: MjmlText spreads explicit props after the theme-resolved variant
+            // props, so an explicit `fontWeight={undefined}` would erase the variant's value.
+            {...(fontWeight !== undefined && { fontWeight: String(fontWeight) })}
+            {...styleProps}
+        >
+            {children}
+        </MjmlText>
+    );
+}
+
+function HtmlBlockText({ bottomSpacing, variant, className, children, ...styleProps }: BlockTextProps): ReactNode {
+    return (
+        <HtmlText element="div" variant={variant} bottomSpacing={bottomSpacing} className={clsx("richTextBlock__text", className)} style={styleProps}>
+            {children}
+        </HtmlText>
+    );
+}
+
+interface DraftBlock {
+    key: string;
+    text: string;
+}
+
+function isDraftBlock(block: unknown): block is DraftBlock {
+    if (typeof block !== "object" || block === null || !("key" in block) || !("text" in block)) {
+        return false;
+    }
+
+    const { key, text } = block;
+
+    return typeof key === "string" && typeof text === "string";
+}
+
+function isDraftContent(draftContent: unknown): draftContent is { blocks: DraftBlock[] } {
+    if (typeof draftContent !== "object" || draftContent === null || !("blocks" in draftContent)) {
+        return false;
+    }
+
+    const { blocks } = draftContent;
+
+    return Array.isArray(blocks) && blocks.every(isDraftBlock);
+}
+
+interface RenderRichTextContentOptions {
+    draftContent: unknown;
+    blockTypes: Record<string, RichTextBlockTypeProps>;
+    linkTypes: Record<string, RichTextLinkHrefResolver>;
+    blockTextComponent: ComponentType<BlockTextProps>;
+}
+
+function renderRichTextContent({ draftContent, blockTypes, linkTypes, blockTextComponent }: RenderRichTextContentOptions): ReactNode {
+    if (!isDraftContent(draftContent)) {
+        return null;
+    }
+
+    const blocksWithText = draftContent.blocks.filter((block) => block.text !== "");
+    const lastBlockKey = blocksWithText[blocksWithText.length - 1]?.key;
+
+    if (lastBlockKey === undefined) {
+        return null;
+    }
+
+    const renderers = createRichTextRenderers({ blockTypes, linkTypes, blockTextComponent, lastBlockKey });
+
+    return redraft({ ...draftContent, blocks: blocksWithText }, renderers);
+}
+
+/**
+ * Creates a pair of rich-text block components that render CMS RichText block
+ * data (draft-js raw content) as themed text.
+ *
+ * Call the factory once per configuration — at the top level of a file, not
+ * inside a component — and reuse the returned components. Call it again for
+ * differently-configured rich-text blocks (e.g. a generic and a headline-only
+ * one).
+ *
+ * `MjmlRichTextBlock` renders each draft block as `MjmlText` and must be
+ * placed within an `MjmlColumn`. `HtmlRichTextBlock` renders each draft block
+ * as `HtmlText` for raw-HTML contexts (e.g. inside `MjmlRaw`).
+ *
+ * ```ts
+ * export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
+ *     blockTypes: {
+ *         "header-one": { variant: "heading1" },
+ *         "paragraph-standard": { variant: "body" },
+ *     },
+ * });
+ * ```
+ */
+export function createRichTextBlock(options: CreateRichTextBlockOptions = {}): {
+    // The description below is duplicated in MjmlRichTextBlock.stories.tsx because Storybook cannot read TSDoc from factory return type properties. Update both when the description changes.
+    /** Renders CMS RichText block data (draft-js raw content) as one `MjmlText` per draft block. Must be placed within an `MjmlColumn`. */
+    MjmlRichTextBlock: (props: RichTextBlockProps) => ReactNode;
+    // The description below is duplicated in HtmlRichTextBlock.stories.tsx because Storybook cannot read TSDoc from factory return type properties. Update both when the description changes.
+    /** Renders CMS RichText block data (draft-js raw content) as one `HtmlText` div per draft block, for raw-HTML contexts such as `MjmlRaw`. */
+    HtmlRichTextBlock: (props: RichTextBlockProps) => ReactNode;
+} {
+    const blockTypes = options.blockTypes ?? {};
+    const linkTypes = { ...builtInLinkTypes, ...options.linkTypes };
+
+    function MjmlRichTextBlock({ data }: RichTextBlockProps): ReactNode {
+        return renderRichTextContent({ draftContent: data.draftContent, blockTypes, linkTypes, blockTextComponent: MjmlBlockText });
+    }
+
+    function HtmlRichTextBlock({ data }: RichTextBlockProps): ReactNode {
+        return renderRichTextContent({ draftContent: data.draftContent, blockTypes, linkTypes, blockTextComponent: HtmlBlockText });
+    }
+
+    return { MjmlRichTextBlock, HtmlRichTextBlock };
+}

--- a/packages/mail-react/src/blocks/richText/createRichTextRenderers.tsx
+++ b/packages/mail-react/src/blocks/richText/createRichTextRenderers.tsx
@@ -1,0 +1,165 @@
+import type { ComponentType, PropsWithChildren, ReactNode } from "react";
+import type { Renderers, TextBlockRenderFn } from "redraft";
+
+import { HtmlInlineLink } from "../../components/inlineLink/HtmlInlineLink.js";
+import type { RichTextBlockTypeProps, RichTextLinkHrefResolver } from "./common.js";
+
+export type BlockTextProps = PropsWithChildren<
+    RichTextBlockTypeProps & {
+        /** Whether the theme's spacing below the text applies — set for every draft block except the last. */
+        bottomSpacing: boolean;
+    }
+>;
+
+const inlineStyleRenderers: Renderers["inline"] = {
+    // The explicit styles back up the semantic tags in rendering engines that don't apply their default styling.
+    BOLD: (children, { key }) => (
+        <strong key={key} style={{ fontWeight: "bold" }}>
+            {children}
+        </strong>
+    ),
+    ITALIC: (children, { key }) => (
+        <em key={key} style={{ fontStyle: "italic" }}>
+            {children}
+        </em>
+    ),
+    SUB: (children, { key }) => <sub key={key}>{children}</sub>,
+    SUP: (children, { key }) => <sup key={key}>{children}</sup>,
+    STRIKETHROUGH: (children, { key }) => <s key={key}>{children}</s>,
+};
+
+function resolveExternalLinkHref(props: unknown): string | undefined {
+    if (typeof props !== "object" || props === null || !("targetUrl" in props)) {
+        return undefined;
+    }
+
+    const { targetUrl } = props;
+
+    return typeof targetUrl === "string" ? targetUrl : undefined;
+}
+
+export const builtInLinkTypes: Record<string, RichTextLinkHrefResolver> = {
+    external: resolveExternalLinkHref,
+};
+
+function getLinkBlock(entityData: unknown): { type: string; props: unknown } | undefined {
+    if (typeof entityData !== "object" || entityData === null || !("block" in entityData)) {
+        return undefined;
+    }
+
+    const { block } = entityData;
+
+    if (typeof block !== "object" || block === null || !("type" in block) || !("props" in block)) {
+        return undefined;
+    }
+
+    const { type, props } = block;
+
+    return typeof type === "string" ? { type, props } : undefined;
+}
+
+function renderWithLineBreaks(node: ReactNode): ReactNode {
+    if (typeof node === "string" && node.includes("\n")) {
+        const lines = node.split("\n");
+
+        return lines.flatMap((line, index) => (index === 0 ? [line] : [<br key={index} />, line]));
+    }
+
+    if (Array.isArray(node)) {
+        return node.map((child) => renderWithLineBreaks(child));
+    }
+
+    return node;
+}
+
+interface CreateBlockRenderFnOptions {
+    blockTextComponent: ComponentType<BlockTextProps>;
+    blockTypeProps: RichTextBlockTypeProps;
+    lastBlockKey: string;
+}
+
+function createTextBlockRenderFn({ blockTextComponent: BlockText, blockTypeProps, lastBlockKey }: CreateBlockRenderFnOptions): TextBlockRenderFn {
+    return (children, { keys }) =>
+        children.map((child, index) => (
+            <BlockText key={keys[index]} bottomSpacing={keys[index] !== lastBlockKey} {...blockTypeProps}>
+                {renderWithLineBreaks(child)}
+            </BlockText>
+        ));
+}
+
+function createListBlockRenderFn({
+    listElement: ListElement,
+    blockTextComponent: BlockText,
+    blockTypeProps,
+    lastBlockKey,
+}: CreateBlockRenderFnOptions & { listElement: "ul" | "ol" }): TextBlockRenderFn {
+    return (children, { keys }) => (
+        <BlockText key={keys.join("-")} bottomSpacing={!keys.includes(lastBlockKey)} {...blockTypeProps}>
+            {/* Vertical margins are removed so the spacing between blocks comes from the theme's bottomSpacing alone. */}
+            <ListElement className="richTextBlock__list" style={{ marginTop: 0, marginBottom: 0 }}>
+                {children.map((child, index) => (
+                    <li key={keys[index]} className="richTextBlock__listItem">
+                        {renderWithLineBreaks(child)}
+                    </li>
+                ))}
+            </ListElement>
+        </BlockText>
+    );
+}
+
+const listBlockTypes = ["unordered-list-item", "ordered-list-item"];
+
+interface CreateRichTextRenderersOptions {
+    blockTypes: Record<string, RichTextBlockTypeProps>;
+    linkTypes: Record<string, RichTextLinkHrefResolver>;
+    blockTextComponent: ComponentType<BlockTextProps>;
+    lastBlockKey: string;
+}
+
+export function createRichTextRenderers({ blockTypes, linkTypes, blockTextComponent, lastBlockKey }: CreateRichTextRenderersOptions): Renderers {
+    const blocks: Renderers["blocks"] = {};
+
+    // "unstyled" is redraft's blockFallback: registering it makes every block type the caller did not configure render with base theme styles.
+    for (const blockType of new Set(["unstyled", ...Object.keys(blockTypes)])) {
+        if (listBlockTypes.includes(blockType)) {
+            continue;
+        }
+
+        blocks[blockType] = createTextBlockRenderFn({ blockTextComponent, blockTypeProps: blockTypes[blockType] ?? {}, lastBlockKey });
+    }
+
+    for (const listBlockType of listBlockTypes) {
+        blocks[listBlockType] = createListBlockRenderFn({
+            listElement: listBlockType === "unordered-list-item" ? "ul" : "ol",
+            blockTextComponent,
+            blockTypeProps: blockTypes[listBlockType] ?? {},
+            lastBlockKey,
+        });
+    }
+
+    return {
+        inline: inlineStyleRenderers,
+        blocks,
+        entities: {
+            LINK: (children, data, { key }) => {
+                const linkBlock = getLinkBlock(data);
+
+                if (linkBlock === undefined) {
+                    return children;
+                }
+
+                const href = linkTypes[linkBlock.type]?.(linkBlock.props);
+
+                if (href === undefined) {
+                    return children;
+                }
+
+                return (
+                    <HtmlInlineLink key={key} className="richTextBlock__link" href={href}>
+                        {children}
+                    </HtmlInlineLink>
+                );
+            },
+        },
+    };
+}

--- a/packages/mail-react/src/blocks/richText/createRichTextRenderers.tsx
+++ b/packages/mail-react/src/blocks/richText/createRichTextRenderers.tsx
@@ -2,7 +2,7 @@ import type { ComponentType, PropsWithChildren, ReactNode } from "react";
 import type { Renderers, TextBlockRenderFn } from "redraft";
 
 import { HtmlInlineLink } from "../../components/inlineLink/HtmlInlineLink.js";
-import type { RichTextBlockTypeProps, RichTextLinkHrefResolver } from "./common.js";
+import type { RichTextBlockTypeProps, RichTextInlineRenderer, RichTextLinkHrefResolver } from "./common.js";
 
 export type BlockTextProps = PropsWithChildren<
     RichTextBlockTypeProps & {
@@ -112,11 +112,18 @@ const listBlockTypes = ["unordered-list-item", "ordered-list-item"];
 interface CreateRichTextRenderersOptions {
     blockTypes: Record<string, RichTextBlockTypeProps>;
     linkTypes: Record<string, RichTextLinkHrefResolver>;
+    inline: Record<string, RichTextInlineRenderer>;
     blockTextComponent: ComponentType<BlockTextProps>;
     lastBlockKey: string;
 }
 
-export function createRichTextRenderers({ blockTypes, linkTypes, blockTextComponent, lastBlockKey }: CreateRichTextRenderersOptions): Renderers {
+export function createRichTextRenderers({
+    blockTypes,
+    linkTypes,
+    inline,
+    blockTextComponent,
+    lastBlockKey,
+}: CreateRichTextRenderersOptions): Renderers {
     const blocks: Renderers["blocks"] = {};
 
     // "unstyled" is redraft's blockFallback: registering it makes every block type the caller did not configure render with base theme styles.
@@ -138,7 +145,7 @@ export function createRichTextRenderers({ blockTypes, linkTypes, blockTextCompon
     }
 
     return {
-        inline: inlineStyleRenderers,
+        inline: { ...inlineStyleRenderers, ...inline },
         blocks,
         entities: {
             LINK: (children, data, { key }) => {

--- a/packages/mail-react/src/index.ts
+++ b/packages/mail-react/src/index.ts
@@ -13,6 +13,7 @@ export type {
     RichTextBlockData,
     RichTextBlockProps,
     RichTextBlockTypeProps,
+    RichTextInlineRenderer,
     RichTextLinkHrefResolver,
 } from "./blocks/richText/common.js";
 export { createRichTextBlock } from "./blocks/richText/createRichTextBlock.js";

--- a/packages/mail-react/src/index.ts
+++ b/packages/mail-react/src/index.ts
@@ -8,14 +8,7 @@ export type { HtmlPixelImageBlockProps } from "./blocks/pixelImage/HtmlPixelImag
 export { HtmlPixelImageBlock } from "./blocks/pixelImage/HtmlPixelImageBlock.js";
 export type { MjmlPixelImageBlockProps } from "./blocks/pixelImage/MjmlPixelImageBlock.js";
 export { MjmlPixelImageBlock } from "./blocks/pixelImage/MjmlPixelImageBlock.js";
-export type {
-    CreateRichTextBlockOptions,
-    RichTextBlockData,
-    RichTextBlockProps,
-    RichTextBlockTypeProps,
-    RichTextInlineRenderer,
-    RichTextLinkHrefResolver,
-} from "./blocks/richText/common.js";
+export type { CreateRichTextBlockOptions, RichTextBlockProps } from "./blocks/richText/common.js";
 export { createRichTextBlock } from "./blocks/richText/createRichTextBlock.js";
 export type { HtmlButtonProps } from "./components/button/HtmlButton.js";
 export { HtmlButton } from "./components/button/HtmlButton.js";

--- a/packages/mail-react/src/index.ts
+++ b/packages/mail-react/src/index.ts
@@ -8,6 +8,14 @@ export type { HtmlPixelImageBlockProps } from "./blocks/pixelImage/HtmlPixelImag
 export { HtmlPixelImageBlock } from "./blocks/pixelImage/HtmlPixelImageBlock.js";
 export type { MjmlPixelImageBlockProps } from "./blocks/pixelImage/MjmlPixelImageBlock.js";
 export { MjmlPixelImageBlock } from "./blocks/pixelImage/MjmlPixelImageBlock.js";
+export type {
+    CreateRichTextBlockOptions,
+    RichTextBlockData,
+    RichTextBlockProps,
+    RichTextBlockTypeProps,
+    RichTextLinkHrefResolver,
+} from "./blocks/richText/common.js";
+export { createRichTextBlock } from "./blocks/richText/createRichTextBlock.js";
 export type { HtmlButtonProps } from "./components/button/HtmlButton.js";
 export { HtmlButton } from "./components/button/HtmlButton.js";
 export type { MjmlButtonProps } from "./components/button/MjmlButton.js";

--- a/packages/mail-react/src/redraft.d.ts
+++ b/packages/mail-react/src/redraft.d.ts
@@ -1,0 +1,27 @@
+// redraft ships no type declarations (and no `@types/redraft` exists), so the
+// parts of its API used by this package are declared here.
+declare module "redraft" {
+    import type { ReactNode } from "react";
+
+    export type InlineRenderFn = (children: ReactNode, options: { key: string }) => ReactNode;
+    export type TextBlockRenderFn = (children: ReactNode[], options: { key: string; depth: number; keys: string[] }) => ReactNode;
+    export type EntityRenderFn = (children: ReactNode, data: unknown, options: { key: string }) => ReactNode;
+
+    export interface Renderers {
+        inline?: Record<string, InlineRenderFn>;
+        blocks?: Record<string, TextBlockRenderFn>;
+        entities?: Record<string, EntityRenderFn>;
+    }
+
+    export interface RedraftOptions {
+        /** Renderer to fall back to for unknown draft block types. @defaultValue `"unstyled"` */
+        blockFallback?: string;
+    }
+
+    type RenderRichText = (raw: unknown, renderers: Renderers, options?: RedraftOptions) => ReactNode;
+
+    // redraft is CommonJS-only: under native ESM the default import is the whole
+    // `module.exports` object, under bundlers it is the render function itself.
+    const redraft: RenderRichText | { default: RenderRichText };
+    export default redraft;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,10 +505,10 @@ importers:
         version: 5.9.3
       vite-tsconfig-paths:
         specifier: ^6.0.4
-        version: 6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
+        version: 6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   demo/site:
     dependencies:
@@ -967,10 +967,10 @@ importers:
         version: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: ^6.0.4
-        version: 6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
+        version: 6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/admin/admin-babel-preset:
     dependencies:
@@ -1234,7 +1234,7 @@ importers:
         version: 0.20.0-beta.4(oxc-resolver@11.19.1)(synckit@0.11.13)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/admin/admin-icons:
     dependencies:
@@ -1392,7 +1392,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/admin/brevo-admin:
     dependencies:
@@ -1823,10 +1823,10 @@ importers:
         version: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: ^6.0.3
-        version: 6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
+        version: 6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/agent-features: {}
 
@@ -1901,7 +1901,7 @@ importers:
         version: 11.1.1
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/api/brevo-api:
     dependencies:
@@ -2022,7 +2022,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/api/cms-api:
     dependencies:
@@ -2293,7 +2293,7 @@ importers:
         version: 1.5.9(@swc/core@1.15.41)(rollup@4.59.0)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/cli:
     dependencies:
@@ -2333,7 +2333,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/eslint-config:
     dependencies:
@@ -2451,7 +2451,7 @@ importers:
         version: 8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/mail-react:
     dependencies:
@@ -2467,6 +2467,9 @@ importers:
       mjml-browser:
         specifier: ^4.18.0
         version: 4.18.0
+      redraft:
+        specifier: ^0.10.2
+        version: 0.10.2
     devDependencies:
       '@comet/cli':
         specifier: workspace:*
@@ -2536,7 +2539,7 @@ importers:
         version: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/site/site-nextjs:
     dependencies:
@@ -2612,7 +2615,7 @@ importers:
         version: 4.5.4(@types/node@24.12.4)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/site/site-react:
     dependencies:
@@ -2700,7 +2703,7 @@ importers:
         version: 4.5.4(@types/node@24.12.4)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       webpack:
         specifier: ^5.106.2
         version: 5.106.2
@@ -2914,7 +2917,7 @@ importers:
         version: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
 
 packages:
 
@@ -17383,6 +17386,11 @@ packages:
 
   vite-tsconfig-paths@6.0.4:
     resolution: {integrity: sha512-iIsEJ+ek5KqRTK17pmxtgIxXtqr3qDdE6OxrP9mVeGhVDNXRJTKN/l9oMbujTQNzMLe6XZ8qmpztfbkPu2TiFQ==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -17440,6 +17448,7 @@ packages:
       '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -24710,7 +24719,7 @@ snapshots:
       '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.8)
       '@vitest/browser-playwright': 4.1.8(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.8)
       '@vitest/runner': 4.1.8
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -26007,7 +26016,7 @@ snapshots:
       '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -26023,7 +26032,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -36028,26 +36037,16 @@ snapshots:
       pathe: 0.2.0
       vite: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
 
-  vite-tsconfig-paths@6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3):
+  vite-tsconfig-paths@6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
+    optionalDependencies:
       vite: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
     transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
       - supports-color
-      - terser
-      - tsx
       - typescript
-      - yaml
 
   vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
@@ -36065,7 +36064,7 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.3
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
@@ -36093,17 +36092,7 @@ snapshots:
       '@vitest/browser-playwright': 4.1.8(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.8)
       jsdom: 28.1.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   vscode-jsonrpc@8.2.0: {}
 

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -413,6 +413,20 @@ Key behaviors:
     });
     ```
 
+- **Inline styles**: built-in styles (`BOLD`, `ITALIC`, `SUB`, `SUP`, `STRIKETHROUGH`) render out of the box. The `inline` option maps a draft-js inline style name to a renderer and merges over the built-ins — override one, or render a custom style the app adds to its RTE (`customInlineStyles` on `IRteOptions`). The RTE stores only the style name, so the email defines the appearance. Register under the exact style name, use an inline element known to render across email clients (`<span>`, `<strong>`, `<em>` — not `<mark>`), and set explicit styles (email clients apply little of their own):
+
+    ```tsx
+    const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
+        inline: {
+            HIGHLIGHT: (children, { key }) => (
+                <span key={key} style={{ backgroundColor: "#ff0000", color: "#ffffff" }}>
+                    {children}
+                </span>
+            ),
+        },
+    });
+    ```
+
 - **Lists** render flat (`<ul>` / `<ol>` inside one text component per list); nesting by draft depth isn't supported.
 - Spacing between blocks comes from the theme's `bottomSpacing` (the last block gets none); headings are styled text, not semantic `<h1>` elements.
 - Rendered elements carry `richTextBlock__text`, `richTextBlock__list`, `richTextBlock__listItem`, and `richTextBlock__link` class names for targeting with `registerStyles`.

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -400,12 +400,14 @@ Key behaviors:
     });
     ```
 
-- **Links**: the `external` link type is built in — `LINK` entities with an `external` link block render as `HtmlInlineLink`. Add the application's other link types via `linkTypes`, a resolver per link block type that receives the link block's props and returns the href (or `undefined` for no link). Annotate the resolver parameter to receive the props typed as the app declares them, rather than narrowing `unknown` by hand. Unconfigured link types render as plain text:
+- **Links**: the `external` link type is built in — `LINK` entities with an `external` link block render as `HtmlInlineLink`. Add the application's other link types via `linkTypes`, a resolver per link block type that receives the link block's props and returns the `href` (or `undefined` for no link). Annotate the resolver parameter with the app's generated block-data type so the props are typed without redeclaring their shape. Unconfigured link types render as plain text:
 
     ```tsx
+    import type { PhoneLinkBlockData } from "@src/blocks.generated";
+
     const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
         linkTypes: {
-            phone: (props: { phoneNumber: string }) => `tel:${props.phoneNumber}`,
+            phone: (props: PhoneLinkBlockData) => (props.phone ? `tel:${props.phone}` : undefined),
         },
     });
     ```

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -294,7 +294,7 @@ All components are imported from `@comet/mail-react` — never from `@faire/mjml
 
 ## Blocks
 
-`@comet/mail-react` ships components that render Comet CMS block data — currently `PixelImageBlockData`. Reach for these instead of raw `MjmlImage` / `<img>` whenever the source is a CMS block-data record.
+`@comet/mail-react` ships components that render Comet CMS block data — currently pixel-image and rich-text blocks. Reach for these instead of hand-rolled markup whenever the source is a CMS block-data record.
 
 ### Pixel-image blocks
 
@@ -341,6 +341,81 @@ Without `aspectRatio`, the rendered ratio comes from the DAM crop area. Pass `as
 ```
 
 When `data.damFile?.image` is absent, both blocks render nothing — no element, no error. Render a placeholder at the call site if you need one.
+
+### Rich-text blocks
+
+`createRichTextBlock` renders CMS RichText block data (draft-js raw content). **Call the factory once per configuration — at the top level of a file, never inside a component** — and export the returned pair; one configuration drives both rendering contexts.
+
+```tsx title="src/emails/blocks/richText.ts"
+export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
+    blockTypes: {
+        "header-one": { variant: "heading1" },
+        "header-two": { variant: "heading2" },
+        "paragraph-standard": { variant: "body" },
+    },
+});
+```
+
+| Component           | Renders each draft block as | Use within                                     |
+| ------------------- | --------------------------- | ---------------------------------------------- |
+| `MjmlRichTextBlock` | `MjmlText`                  | an `MjmlColumn` (standard MJML layout)         |
+| `HtmlRichTextBlock` | `HtmlText` (`<div>`)        | raw HTML or MJML ending tags such as `MjmlRaw` |
+
+Usage sites pass only `data`:
+
+```tsx
+<MjmlSection indent>
+    <MjmlColumn>
+        <MjmlRichTextBlock data={richTextData} />
+    </MjmlColumn>
+</MjmlSection>
+```
+
+Key behaviors:
+
+- **Works without variants.** `createRichTextBlock()` with no options renders every draft block with the base `theme.text` styles — map block types to variants later as the theme grows. Unmapped block types also fall back to base styles.
+- **`blockTypes` values are text-component props**: a theme `variant`, plain (non-responsive) style values (`color`, `fontSize`, `fontWeight`, …), and a `className`. For responsive styling without a variant, set a `className` and register CSS via `registerStyles`:
+
+    ```tsx
+    const { MjmlRichTextBlock } = createRichTextBlock({
+        blockTypes: { "header-one": { className: "richTextHeadlineOne" } },
+    });
+
+    registerStyles(
+        (theme) => css`
+            ${theme.breakpoints.default.belowMediaQuery} {
+                .richTextHeadlineOne > div {
+                    font-size: 24px !important;
+                }
+            }
+        `,
+    );
+    ```
+
+- **Multiple configurations per app.** Each factory call is independent — rename the destructured components per use case:
+
+    ```tsx
+    export const { MjmlRichTextBlock: MjmlHeadlineRichTextBlock, HtmlRichTextBlock: HtmlHeadlineRichTextBlock } = createRichTextBlock({
+        blockTypes: { "header-one": { variant: "heading1" }, "header-two": { variant: "heading2" } },
+    });
+    ```
+
+- **Links**: the `external` link type is built in — `LINK` entities with an `external` link block render as `HtmlInlineLink`. Add the application's other link types via `linkTypes`, a resolver per link block type that receives the link block's props and returns the href (or `undefined` for no link). Unconfigured link types render as plain text:
+
+    ```tsx
+    const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
+        linkTypes: {
+            phone: (props) =>
+                typeof props === "object" && props !== null && "phoneNumber" in props && typeof props.phoneNumber === "string"
+                    ? `tel:${props.phoneNumber}`
+                    : undefined,
+        },
+    });
+    ```
+
+- **Lists** render flat (`<ul>` / `<ol>` inside one text component per list); nesting by draft depth isn't supported.
+- Spacing between blocks comes from the theme's `bottomSpacing` (the last block gets none); headings are styled text, not semantic `<h1>` elements.
+- Rendered elements carry `richTextBlock__text`, `richTextBlock__list`, `richTextBlock__listItem`, and `richTextBlock__link` class names for targeting with `registerStyles`.
 
 ---
 

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -400,15 +400,12 @@ Key behaviors:
     });
     ```
 
-- **Links**: the `external` link type is built in — `LINK` entities with an `external` link block render as `HtmlInlineLink`. Add the application's other link types via `linkTypes`, a resolver per link block type that receives the link block's props and returns the href (or `undefined` for no link). Unconfigured link types render as plain text:
+- **Links**: the `external` link type is built in — `LINK` entities with an `external` link block render as `HtmlInlineLink`. Add the application's other link types via `linkTypes`, a resolver per link block type that receives the link block's props and returns the href (or `undefined` for no link). Annotate the resolver parameter to receive the props typed as the app declares them, rather than narrowing `unknown` by hand. Unconfigured link types render as plain text:
 
     ```tsx
     const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
         linkTypes: {
-            phone: (props) =>
-                typeof props === "object" && props !== null && "phoneNumber" in props && typeof props.phoneNumber === "string"
-                    ? `tel:${props.phoneNumber}`
-                    : undefined,
+            phone: (props: { phoneNumber: string }) => `tel:${props.phoneNumber}`,
         },
     });
     ```


### PR DESCRIPTION
Emails need to render the CMS RichText block, but the mapping this requires is defined per application on both ends: draft block types in the admin's RTE configuration, text variants in the mail theme. The package can therefore not ship a working mapping — it ships a factory that binds one per call and returns the matching `MjmlText`- and `HtmlText`-based block pair.

- **A factory call binds the configuration, not a context.**
  A mail can contain differently-configured rich-text blocks side by side (e.g. a generic and a headline-only one); a context can carry only one configuration per subtree. This also mirrors how the admin package configures its rich-text editor.
- **Link href resolution is configured per application, with `external` built in.**
  A `LINK` entity wraps an application-defined link block; only the resolver knows how to turn its props into an href, so the factory takes a resolver per link type. Only the consuming application knows a link block's shape, so resolver props are typed from the caller's own declaration (parameter annotation or type argument), defaulting to `unknown`; one contained cast in the package trusts that declaration so no consumer casts in its own resolver, safe because the API validates link props on write. Unresolved links render as plain text.
- **Inline styles are configurable; block and entity rendering is not.**
  The `inline` option merges over the built-in styles (`BOLD`, `ITALIC`, …) to restyle one or render a custom style the application defines in its RTE. `LINK` is the only entity the CMS RichText block produces — the API rejects any other — so there are no further entity renderers to expose; block and link rendering stays fixed, configured through `blockTypes` styling and `linkTypes` href resolution.
- **The block's data type is hand-written.**
  The draft-js content shape is not in the package's block schema, so there is nothing to generate from.
- **`redraft` renders the content despite being CommonJS-only and dormant.**
  It is the renderer the demo site's RichText block already uses, and the draft-js format it targets is frozen, so its dormancy carries no drift risk. A runtime interop guard and a local module declaration cover the ESM and typing gaps.
- **Bold and italic include an explicit inline style.**
  Some rendering engines apply no default styling to `strong`/`em`, so the inline `font-weight`/`font-style` keeps the emphasis visible there.
- **Lists render flat, not nested.**
  Nested-list indentation relies on `padding-left`/`margin-left`, which classic Outlook ignores or breaks (`<li>` becomes `<p>`); reliable nesting would need table-based markup over semantic `<ul>`/`<ol>`, so the draft `depth` is ignored until a template needs it.

---

**Task:** https://vivid-planet.atlassian.net/browse/PHSB2C-11757