### PR TITLE
demo: update fulltext not only onUpdate but also onCreate

### DIFF
--- a/demo/api/src/documents/pages/entities/page.entity.ts
+++ b/demo/api/src/documents/pages/entities/page.entity.ts
@@ -36,7 +36,12 @@ export class Page extends BaseEntity implements DocumentInterface {
     content: BlockDataInterface;
 
     @Index({ type: "fulltext" })
-    @Property<Page>({ nullable: true, type: new FullTextType(), onUpdate: (page) => blockToMikroOrmFullText(page.content) })
+    @Property<Page>({
+        nullable: true,
+        type: new FullTextType(),
+        onCreate: (page) => blockToMikroOrmFullText(page.content),
+        onUpdate: (page) => blockToMikroOrmFullText(page.content),
+    })
     fullTextContent?: string;
 
     @RootBlock(SeoBlock)
@@ -45,7 +50,12 @@ export class Page extends BaseEntity implements DocumentInterface {
     seo: BlockDataInterface;
 
     @Index({ type: "fulltext" })
-    @Property<Page>({ nullable: true, type: new FullTextType(), onUpdate: (page) => blockToMikroOrmFullText(page.seo) })
+    @Property<Page>({
+        nullable: true,
+        type: new FullTextType(),
+        onCreate: (page) => blockToMikroOrmFullText(page.seo),
+        onUpdate: (page) => blockToMikroOrmFullText(page.seo),
+    })
     fullTextSeo?: string;
 
     @RootBlock(StageBlock)
@@ -54,7 +64,12 @@ export class Page extends BaseEntity implements DocumentInterface {
     stage: BlockDataInterface;
 
     @Index({ type: "fulltext" })
-    @Property<Page>({ nullable: true, type: new FullTextType(), onUpdate: (page) => blockToMikroOrmFullText(page.stage) })
+    @Property<Page>({
+        nullable: true,
+        type: new FullTextType(),
+        onCreate: (page) => blockToMikroOrmFullText(page.stage),
+        onUpdate: (page) => blockToMikroOrmFullText(page.stage),
+    })
     fullTextStage?: string;
 
     @Property({

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -134,6 +134,7 @@ export class News extends BaseEntity {
     @Property<News>({
         nullable: true,
         type: new FullTextType(),
+        onCreate: (news) => entityToMikroOrmFullText({ A: news.title, D: news.slug }, news.content),
         onUpdate: (news) => entityToMikroOrmFullText({ A: news.title, D: news.slug }, news.content),
     })
     fullText?: string;

--- a/demo/api/src/products/entities/manufacturer.entity.ts
+++ b/demo/api/src/products/entities/manufacturer.entity.ts
@@ -134,9 +134,14 @@ export class Manufacturer extends BaseEntity {
     @Property<Manufacturer>({
         nullable: true,
         type: new FullTextType(),
-        onUpdate: (page) => {
+        onCreate: (manufacturer) => {
             return {
-                A: page.name,
+                A: manufacturer.name,
+            };
+        },
+        onUpdate: (manufacturer) => {
+            return {
+                A: manufacturer.name,
             };
         },
     })

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -256,10 +256,16 @@ export class Product extends BaseEntity implements ImportTargetInterface {
     @Property<Product>({
         nullable: true,
         type: new FullTextType(),
-        onUpdate: (page) => {
+        onCreate: (product) => {
             return {
-                A: page.title,
-                D: page.description,
+                A: product.title,
+                D: product.description,
+            };
+        },
+        onUpdate: (product) => {
+            return {
+                A: product.title,
+                D: product.description,
             };
         },
     })


### PR DESCRIPTION
## Summary
This PR adds the `onCreate` lifecycle hook to fulltext indexed properties across multiple entities, ensuring that fulltext search content is properly generated when entities are first created, not just when updated.

## Key Changes
- **Page entity**: Added `onCreate` hook to `fullTextContent`, `fullTextSeo`, and `fullTextStage` properties alongside existing `onUpdate` hooks
- **Product entity**: Added `onCreate` hook to fulltext property and fixed parameter naming from `page` to `product` for consistency
- **Manufacturer entity**: Added `onCreate` hook to fulltext property and fixed parameter naming from `page` to `manufacturer` for consistency
- **News entity**: Added `onCreate` hook to fulltext property

## Implementation Details
- All changes follow the same pattern: the `onCreate` hook executes the same fulltext generation logic as `onUpdate`
- Parameter names were corrected to match their respective entity types (e.g., `page` → `product`, `page` → `manufacturer`) for code clarity
- This ensures fulltext search indexes are populated immediately upon entity creation, improving search functionality for newly created records

https://claude.ai/code/session_01RTdjuCPmdBtMAVJ2PYJGRL