### PR TITLE
Fix page tree full-text search permission handling

### DIFF
--- a/packages/api/cms-api/src/full-text-search/full-text-search.service.ts
+++ b/packages/api/cms-api/src/full-text-search/full-text-search.service.ts
@@ -31,10 +31,9 @@ export class FullTextSearchService {
 
             if (typeof entityInfo === "string" || isEntityInfoSql(entityInfo)) {
                 if (pageTreeFullText && targetEntity.metadata.tableName === "PageTreeNode") {
-                    const permissionMetadata = Reflect.getMetadata(REQUIRED_PERMISSION_METADATA_KEY, targetEntity.entity) as
-                        | RequiredPermissionMetadata
-                        | undefined;
-                    const requiredPermissionSql = requiredPermissionToSql(permissionMetadata?.requiredPermission);
+                    // Page tree nodes don't carry a @RequiredPermission decorator; access is governed by the "pageTree"
+                    // permission, matching the hardcoded value used for page tree documents in the EntityInfo view.
+                    const requiredPermissionSql = requiredPermissionToSql("pageTree");
                     const scopesSql = resolveScopesToSql({ metadata: targetEntity.metadata, scopedEntity: undefined });
 
                     indexSelects.push(`SELECT "PageTreeNodeEntityInfo"."id", 'PageTreeNode' AS "entityName", "PageTreeNodeFullText"."fullText",


### PR DESCRIPTION
## Summary
Fixed the full-text search service to correctly handle permissions for page tree nodes by using the hardcoded "pageTree" permission instead of attempting to read a non-existent @RequiredPermission decorator.

## Key Changes
- Replaced dynamic permission metadata reflection with hardcoded "pageTree" permission for PageTreeNode entities
- Added clarifying comments explaining that page tree nodes don't use the @RequiredPermission decorator and instead rely on the "pageTree" permission that matches the EntityInfo view configuration

## Implementation Details
Page tree nodes are a special case in the full-text search indexing. Unlike other entities that may have a @RequiredPermission decorator, page tree nodes govern access through a hardcoded "pageTree" permission. This change aligns the full-text search service with the existing permission model used in the EntityInfo view, ensuring consistent access control across the system.

https://claude.ai/code/session_01RKLMdj7WPuvv2F1S3p7YVu