### PR TITLE
Load TipTap rich text child blocks via BlockLoader

### DIFF
--- a/.changeset/block-loader-rich-text-child-blocks.md
+++ b/.changeset/block-loader-rich-text-child-blocks.md
@@ -1,0 +1,13 @@
+---
+"@comet/site-nextjs": minor
+"@comet/site-react": minor
+"@comet/cms-api": minor
+---
+
+Support loading data for child blocks embedded in rich text content in `recursivelyLoadBlockData`
+
+Child blocks embedded in a `createTipTapRichTextBlock` rich text block (stored as `cmsBlock`/`cmsInlineBlock` nodes) are now traversed by `recursivelyLoadBlockData`, so their registered block loaders run just like for any other nested block. This allows rich text child blocks to load additional data (e.g. via a GraphQL query) without relying on a `BlockTransformerService` on the API side.
+
+To support this, the `tipTapContent` field of a `createTipTapRichTextBlock` block is now declared with a dedicated `TipTapRichTextBlock` block meta kind (instead of `Json`) that carries the configured child blocks. The block loader uses this kind to detect rich text content instead of inspecting arbitrary `Json` fields.
+
+Also re-exported from `@comet/site-nextjs`.

--- a/demo/admin/src/common/blocks/TipTapRichTextBlock.tsx
+++ b/demo/admin/src/common/blocks/TipTapRichTextBlock.tsx
@@ -1,5 +1,6 @@
 import { createTipTapRichTextBlock } from "@comet/cms-admin";
 import { ProductPriceBlock } from "@src/products/blocks/ProductPriceBlock";
+import { ProductTeaserBlock } from "@src/products/blocks/ProductTeaserBlock";
 import type { HTMLAttributes } from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -7,7 +8,10 @@ import { LinkBlock } from "./LinkBlock";
 
 export const TipTapRichTextBlock = createTipTapRichTextBlock({
     link: LinkBlock,
-    childBlocks: { productPrice: { block: ProductPriceBlock, display: "inline" } },
+    childBlocks: {
+        productPrice: { block: ProductPriceBlock, display: "inline" },
+        productTeaser: { block: ProductTeaserBlock, display: "block" },
+    },
     textBlockStyles: [
         {
             name: "paragraph300",

--- a/demo/admin/src/products/blocks/ProductTeaserBlock.tsx
+++ b/demo/admin/src/products/blocks/ProductTeaserBlock.tsx
@@ -1,0 +1,95 @@
+import { gql, useApolloClient } from "@apollo/client";
+import { AsyncSelectField } from "@comet/admin";
+import { Image } from "@comet/admin-icons";
+import { type BlockInterface, BlocksFinalForm, createBlockSkeleton } from "@comet/cms-admin";
+import type { ProductTeaserBlockData, ProductTeaserBlockInput } from "@src/blocks.generated";
+import { FormattedMessage } from "react-intl";
+
+import type {
+    GQLProductTeaserBlockProductQuery,
+    GQLProductTeaserBlockProductQueryVariables,
+    GQLProductTeaserSelectQuery,
+    GQLProductTeaserSelectQueryVariables,
+} from "./ProductTeaserBlock.generated";
+
+type ProductOption = { id: string; title: string };
+
+type State = {
+    product?: ProductOption;
+};
+
+const productTeaserSelectQuery = gql`
+    query ProductTeaserSelect {
+        products {
+            nodes {
+                id
+                title
+            }
+        }
+    }
+`;
+
+const productTeaserProductQuery = gql`
+    query ProductTeaserBlockProduct($id: ID!) {
+        product(id: $id) {
+            id
+            title
+        }
+    }
+`;
+
+const ProductTeaserBlock: BlockInterface<ProductTeaserBlockData, State, ProductTeaserBlockInput> = {
+    ...createBlockSkeleton(),
+
+    name: "ProductTeaser",
+
+    displayName: <FormattedMessage id="blocks.productTeaser.displayName" defaultMessage="Product Teaser" />,
+
+    defaultValues: () => ({}),
+
+    state2Output: (state) => ({
+        productId: state.product?.id,
+    }),
+
+    output2State: async (output, { apolloClient }) => {
+        if (output.productId === undefined) {
+            return {};
+        }
+
+        const { data } = await apolloClient.query<GQLProductTeaserBlockProductQuery, GQLProductTeaserBlockProductQueryVariables>({
+            query: productTeaserProductQuery,
+            variables: { id: output.productId },
+        });
+
+        return {
+            product: { id: data.product.id, title: data.product.title },
+        };
+    },
+
+    AdminComponent: ({ state, updateState }) => {
+        const client = useApolloClient();
+
+        return (
+            <BlocksFinalForm onSubmit={updateState} initialValues={state}>
+                <AsyncSelectField
+                    name="product"
+                    fullWidth
+                    label={<FormattedMessage id="blocks.productTeaser.product" defaultMessage="Product" />}
+                    loadOptions={async () => {
+                        const { data } = await client.query<GQLProductTeaserSelectQuery, GQLProductTeaserSelectQueryVariables>({
+                            query: productTeaserSelectQuery,
+                        });
+                        return data.products.nodes.map((node) => ({ id: node.id, title: node.title }));
+                    }}
+                    getOptionLabel={(option: ProductOption) => option.title}
+                />
+            </BlocksFinalForm>
+        );
+    },
+
+    previewContent: (state) => (state.product ? [{ type: "text", content: state.product.title }] : []),
+
+    icon: () => <Image color="primary" />,
+};
+
+export { ProductTeaserBlock };

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -2663,6 +2663,23 @@
         ]
     },
     {
+        "name": "ProductTeaser",
+        "fields": [
+            {
+                "name": "productId",
+                "kind": "String",
+                "nullable": true
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "productId",
+                "kind": "String",
+                "nullable": true
+            }
+        ]
+    },
+    {
         "name": "RedirectsLink",
         "fields": [
             {
@@ -3793,15 +3810,23 @@
         "fields": [
             {
                 "name": "tipTapContent",
-                "kind": "Json",
-                "nullable": false
+                "kind": "TipTapRichTextBlock",
+                "nullable": false,
+                "childBlocks": {
+                    "productPrice": "ProductPrice",
+                    "productTeaser": "ProductTeaser"
+                }
             }
         ],
         "inputFields": [
             {
                 "name": "tipTapContent",
-                "kind": "Json",
-                "nullable": false
+                "kind": "TipTapRichTextBlock",
+                "nullable": false,
+                "childBlocks": {
+                    "productPrice": "ProductPrice",
+                    "productTeaser": "ProductTeaser"
+                }
             }
         ]
     },

--- a/demo/api/src/common/blocks/tip-tap-rich-text.block.ts
+++ b/demo/api/src/common/blocks/tip-tap-rich-text.block.ts
@@ -1,5 +1,6 @@
 import { createTipTapRichTextBlock, typeSafeBlockMigrationPipe } from "@comet/cms-api";
 import { ProductPriceBlock } from "@src/products/blocks/product-price.block";
+import { ProductTeaserBlock } from "@src/products/blocks/product-teaser.block";
 
 import { LinkBlock } from "./link.block";
 import { Heading1ToHeading2Migration } from "./tip-tap-rich-text/migrations/2-heading-1-to-heading-2.migration";
@@ -7,7 +8,10 @@ import { Heading1ToHeading2Migration } from "./tip-tap-rich-text/migrations/2-he
 export const TipTapRichTextBlock = createTipTapRichTextBlock(
     {
         link: LinkBlock,
-        childBlocks: { productPrice: { block: ProductPriceBlock, display: "inline" } },
+        childBlocks: {
+            productPrice: { block: ProductPriceBlock, display: "inline" },
+            productTeaser: { block: ProductTeaserBlock, display: "block" },
+        },
         textBlockStyles: [
             { name: "paragraph300", appliesTo: ["paragraph"] },
             { name: "paragraph200", appliesTo: ["paragraph"] },

--- a/demo/api/src/products/blocks/product-teaser.block.ts
+++ b/demo/api/src/products/blocks/product-teaser.block.ts
@@ -1,0 +1,37 @@
+import { BlockData, BlockField, BlockIndexData, BlockInput, blockInputToData, createBlock } from "@comet/cms-api";
+import { IsOptional, IsUUID } from "class-validator";
+
+class ProductTeaserBlockData extends BlockData {
+    @BlockField({ nullable: true })
+    productId?: string;
+
+    indexData(): BlockIndexData {
+        if (this.productId === undefined) {
+            return {};
+        }
+
+        return {
+            dependencies: [
+                {
+                    targetEntityName: "Product",
+                    id: this.productId,
+                },
+            ],
+        };
+    }
+}
+
+class ProductTeaserBlockInput extends BlockInput {
+    @BlockField({ nullable: true })
+    @IsUUID()
+    @IsOptional()
+    productId?: string;
+
+    transformToBlockData(): ProductTeaserBlockData {
+        return blockInputToData(ProductTeaserBlockData, this);
+    }
+}
+
+const ProductTeaserBlock = createBlock(ProductTeaserBlockData, ProductTeaserBlockInput, "ProductTeaser");
+
+export { ProductTeaserBlock };

--- a/demo/site/src/common/blocks/TipTapRichTextBlock.tsx
+++ b/demo/site/src/common/blocks/TipTapRichTextBlock.tsx
@@ -9,9 +9,11 @@ import {
     type TipTapNodeHandler,
     withPreview,
 } from "@comet/site-nextjs";
-import type { LinkBlockData, ProductPriceBlockData, TipTapRichTextBlockData } from "@src/blocks.generated";
+import type { LinkBlockData, ProductPriceBlockData, ProductTeaserBlockData, TipTapRichTextBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
 import { ProductPriceBlock } from "@src/products/blocks/ProductPriceBlock";
+import { ProductTeaserBlock } from "@src/products/blocks/ProductTeaserBlock";
+import type { LoadedData as ProductTeaserLoadedData } from "@src/products/blocks/ProductTeaserBlock.loader";
 
 import { Typography, type TypographyProps } from "../components/Typography";
 import { isValidLink } from "../helpers/HiddenIfInvalidLink";
@@ -32,6 +34,9 @@ const headingLevelToVariant: Record<1 | 2 | 3 | 4 | 5 | 6, TypographyVariant> = 
 const renderCmsBlock: TipTapNodeHandler = ({ node }) => {
     if (node.attrs?.blockType === "productPrice") {
         return <ProductPriceBlock data={node.attrs?.data as ProductPriceBlockData} />;
+    }
+    if (node.attrs?.blockType === "productTeaser") {
+        return <ProductTeaserBlock data={node.attrs?.data as ProductTeaserBlockData & { loaded: ProductTeaserLoadedData }} />;
     }
     return null;
 };

--- a/demo/site/src/products/blocks/ProductTeaserBlock.loader.ts
+++ b/demo/site/src/products/blocks/ProductTeaserBlock.loader.ts
@@ -1,0 +1,28 @@
+import { type BlockLoaderOptions, gql } from "@comet/site-nextjs";
+import type { ProductTeaserBlockData } from "@src/blocks.generated";
+
+import type { GQLProductTeaserBlockQuery, GQLProductTeaserBlockQueryVariables } from "./ProductTeaserBlock.loader.generated";
+
+export type LoadedData = Awaited<ReturnType<typeof loader>>;
+
+export const loader = async ({ blockData, graphQLFetch }: BlockLoaderOptions<ProductTeaserBlockData>) => {
+    if (!blockData.productId) {
+        return null;
+    }
+
+    const data = await graphQLFetch<GQLProductTeaserBlockQuery, GQLProductTeaserBlockQueryVariables>(
+        gql`
+            query ProductTeaserBlock($id: ID!) {
+                product(id: $id) {
+                    id
+                    title
+                    description
+                    price
+                }
+            }
+        `,
+        { id: blockData.productId },
+    );
+
+    return data.product;
+};

--- a/demo/site/src/products/blocks/ProductTeaserBlock.tsx
+++ b/demo/site/src/products/blocks/ProductTeaserBlock.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { type PropsWithData, withPreview } from "@comet/site-nextjs";
+import type { ProductTeaserBlockData } from "@src/blocks.generated";
+
+import type { LoadedData } from "./ProductTeaserBlock.loader";
+
+export const ProductTeaserBlock = withPreview(
+    ({ data: { loaded } }: PropsWithData<ProductTeaserBlockData & { loaded: LoadedData }>) => {
+        if (!loaded) {
+            return null;
+        }
+
+        return (
+            <div>
+                <h3>{loaded.title}</h3>
+                {loaded.description && <p>{loaded.description}</p>}
+                {loaded.price != null && <strong>{loaded.price} €</strong>}
+            </div>
+        );
+    },
+    { label: "Product Teaser" },
+);

--- a/demo/site/src/util/recursivelyLoadBlockData.ts
+++ b/demo/site/src/util/recursivelyLoadBlockData.ts
@@ -3,6 +3,7 @@ import type { AllBlockNames } from "@src/blocks.generated";
 import { loader as pageTreeIndexLoader } from "@src/common/blocks/PageTreeIndexBlock.loader";
 import { loader as newsDetailLoader } from "@src/news/blocks/NewsDetailBlock.loader";
 import { loader as newsListLoader } from "@src/news/blocks/NewsListBlock.loader";
+import { loader as productTeaserLoader } from "@src/products/blocks/ProductTeaserBlock.loader";
 import type { ContentScope } from "@src/site-configs";
 
 declare module "@comet/site-nextjs" {
@@ -16,6 +17,7 @@ const blockLoaders: Partial<Record<AllBlockNames, BlockLoader>> = {
     NewsDetail: newsDetailLoader,
     NewsList: newsListLoader,
     PageTreeIndex: pageTreeIndexLoader,
+    ProductTeaser: productTeaserLoader,
 };
 
 //small wrapper for @comet/site-nextjs recursivelyLoadBlockData that injects blockMeta from block-meta.json

--- a/packages/api/cms-api/src/blocks/block.ts
+++ b/packages/api/cms-api/src/blocks/block.ts
@@ -221,6 +221,7 @@ export enum BlockMetaFieldKind {
     OneOfBlocks = "OneOfBlocks",
     NestedObject = "NestedObject",
     NestedObjectList = "NestedObjectList",
+    TipTapRichTextBlock = "TipTapRichTextBlock",
 }
 
 export type BlockMetaLiteralFieldKind = BlockMetaFieldKind.String | BlockMetaFieldKind.Number | BlockMetaFieldKind.Boolean | BlockMetaFieldKind.Json;
@@ -236,7 +237,17 @@ export type BlockMetaField =
     | { name: string; kind: BlockMetaFieldKind.Block; block: Block; nullable: boolean }
     | { name: string; kind: BlockMetaFieldKind.NestedObject; object: BlockMetaInterface; nullable: boolean }
     | { name: string; kind: BlockMetaFieldKind.NestedObjectList; object: BlockMetaInterface; nullable: boolean }
-    | { name: string; kind: BlockMetaFieldKind.OneOfBlocks; blocks: Record<string, Block>; nullable: boolean };
+    | { name: string; kind: BlockMetaFieldKind.OneOfBlocks; blocks: Record<string, Block>; nullable: boolean }
+    | {
+          name: string;
+          kind: BlockMetaFieldKind.TipTapRichTextBlock;
+          /**
+           * The child blocks the rich text content may contain, keyed by their stable config key.
+           * Lets consumers like the block loader process blocks embedded in the content.
+           */
+          childBlocks: Record<string, Block>;
+          nullable: boolean;
+      };
 
 export interface BlockMetaInterface {
     fields: BlockMetaField[];

--- a/packages/api/cms-api/src/blocks/blocks-meta.ts
+++ b/packages/api/cms-api/src/blocks/blocks-meta.ts
@@ -5,6 +5,13 @@ type BlockMetaField =
           name: string;
           kind: "String" | "Number" | "Boolean" | "Json";
           nullable: boolean;
+          array?: boolean;
+      }
+    | {
+          name: string;
+          kind: "TipTapRichTextBlock";
+          nullable: boolean;
+          childBlocks: Record<string, string>;
       }
     | {
           name: string;
@@ -56,6 +63,13 @@ function extractFromBlockMeta(blockMeta: BlockMetaInterface): BlockMetaField[] {
                 kind: field.kind,
                 nullable: field.nullable,
                 array: field.array,
+            };
+        } else if (field.kind === BlockMetaFieldKind.TipTapRichTextBlock) {
+            return {
+                name: field.name,
+                kind: field.kind,
+                nullable: field.nullable,
+                childBlocks: Object.fromEntries(Object.entries(field.childBlocks).map(([blockType, block]) => [blockType, block.name])),
             };
         } else if (field.kind === BlockMetaFieldKind.Enum) {
             return {

--- a/packages/api/cms-api/src/blocks/decorators/field.ts
+++ b/packages/api/cms-api/src/blocks/decorators/field.ts
@@ -25,6 +25,11 @@ type BlockFieldOptions =
           array?: boolean;
       }
     | {
+          type: "tipTapRichTextBlock";
+          nullable?: boolean;
+          childBlocks: Record<string, Block>;
+      }
+    | {
           nullable?: boolean;
       }
     | {
@@ -63,6 +68,7 @@ type BlockFieldData =
           array?: boolean;
       }
     | { kind: BlockMetaFieldKind.Enum; enum: string[]; nullable: boolean; array?: boolean }
+    | { kind: BlockMetaFieldKind.TipTapRichTextBlock; childBlocks: Record<string, Block>; nullable: boolean }
     | { kind: BlockMetaFieldKind.Block; block: Block; nullable: boolean }
     | { kind: BlockMetaFieldKind.NestedObject; object: ClassConstructor<BlockDataInterface | BlockInputInterface>; nullable: boolean }
     | { kind: BlockMetaFieldKind.NestedObjectList; object: ClassConstructor<BlockDataInterface | BlockInputInterface>; nullable: boolean }
@@ -87,6 +93,8 @@ export function getBlockFieldData(ctor: { prototype: any }, propertyKey: string)
             ret = { kind: BlockMetaFieldKind.Boolean, nullable, array };
         } else if (fieldType.type === "json") {
             ret = { kind: BlockMetaFieldKind.Json, nullable, array };
+        } else if (fieldType.type === "tipTapRichTextBlock") {
+            ret = { kind: BlockMetaFieldKind.TipTapRichTextBlock, childBlocks: fieldType.childBlocks, nullable };
         } else if (fieldType.type === "enum") {
             const enumValues = Array.isArray(fieldType.enum) ? fieldType.enum : Object.values(fieldType.enum);
             ret = { kind: BlockMetaFieldKind.Enum, enum: enumValues, nullable, array };
@@ -168,6 +176,13 @@ export class AnnotationBlockMeta implements BlockMetaInterface {
                     enum: field.enum,
                     nullable: field.nullable,
                     array: field.array,
+                });
+            } else if (field.kind === BlockMetaFieldKind.TipTapRichTextBlock) {
+                ret.push({
+                    name,
+                    kind: field.kind,
+                    childBlocks: field.childBlocks,
+                    nullable: field.nullable,
                 });
             } else if (field.kind === BlockMetaFieldKind.Block) {
                 ret.push({

--- a/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
@@ -581,7 +581,7 @@ export function createTipTapRichTextBlock(
 
     @BlockDataMigrationVersion(migrate.version)
     class TipTapRichTextBlockData extends BlockData implements TipTapRichTextBlockDataInterface {
-        @BlockField({ type: "json" })
+        @BlockField({ type: "tipTapRichTextBlock", childBlocks })
         tipTapContent: JSONContent;
 
         searchText(): SearchText[] {
@@ -641,7 +641,7 @@ export function createTipTapRichTextBlock(
             allowedPlaceholderNames,
             listLevelMax,
         })
-        @BlockField({ type: "json" })
+        @BlockField({ type: "tipTapRichTextBlock", childBlocks })
         tipTapContent: JSONContent;
 
         transformToBlockData(): TipTapRichTextBlockData {

--- a/packages/cli/src/BlockMeta.ts
+++ b/packages/cli/src/BlockMeta.ts
@@ -13,6 +13,12 @@ export type BlockMetaField =
       }
     | {
           name: string;
+          kind: "TipTapRichTextBlock";
+          nullable: boolean;
+          childBlocks: Record<string, string>;
+      }
+    | {
+          name: string;
           kind: "Enum";
           nullable: boolean;
           enum: string[];

--- a/packages/cli/src/commands/generate-block-types.ts
+++ b/packages/cli/src/commands/generate-block-types.ts
@@ -31,6 +31,8 @@ function writeFieldType(field: BlockMetaField, blockNamePostfix: string) {
         if (field.array) {
             content += "[]";
         }
+    } else if (field.kind === "TipTapRichTextBlock") {
+        content += "unknown";
     } else if (field.kind === "Enum") {
         const enumType = `"${field.enum.join('" | "')}"`;
         content += field.array ? `(${enumType})[]` : enumType;

--- a/packages/site/site-react/src/blockLoader/blockLoader.test.ts
+++ b/packages/site/site-react/src/blockLoader/blockLoader.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { type BlockLoader, recursivelyLoadBlockData } from "./blockLoader";
+
+const dependencies = {
+    graphQLFetch: vi.fn(),
+    fetch: vi.fn(),
+};
+
+describe("recursivelyLoadBlockData: rich text child blocks", () => {
+    const blocksMeta = [
+        {
+            name: "TipTapRichText",
+            fields: [{ name: "tipTapContent", kind: "TipTapRichTextBlock", nullable: false, childBlocks: { productTeaser: "ProductTeaser" } }],
+            inputFields: [{ name: "tipTapContent", kind: "TipTapRichTextBlock", nullable: false, childBlocks: { productTeaser: "ProductTeaser" } }],
+        },
+        {
+            name: "ProductTeaser",
+            fields: [{ name: "productId", kind: "String", nullable: true }],
+            inputFields: [{ name: "productId", kind: "String", nullable: true }],
+        },
+    ];
+
+    it("runs the loader for child blocks embedded as cmsBlock/cmsInlineBlock nodes", async () => {
+        const productTeaserLoader: BlockLoader = vi.fn(async ({ blockData }) => ({ title: `Product ${blockData.productId}` }));
+
+        const blockData = {
+            tipTapContent: {
+                type: "doc",
+                content: [
+                    { type: "paragraph", content: [{ type: "text", text: "Intro" }] },
+                    { type: "cmsBlock", attrs: { blockType: "productTeaser", data: { productId: "block-1" } } },
+                    {
+                        type: "paragraph",
+                        content: [{ type: "cmsInlineBlock", attrs: { blockType: "productTeaser", data: { productId: "inline-1" } } }],
+                    },
+                ],
+            },
+        };
+
+        const result = await recursivelyLoadBlockData({
+            blockType: "TipTapRichText",
+            blockData,
+            blocksMeta,
+            loaders: { ProductTeaser: productTeaserLoader },
+            ...dependencies,
+        });
+
+        expect(productTeaserLoader).toHaveBeenCalledTimes(2);
+        expect(result.tipTapContent.content[1].attrs.data.loaded).toEqual({ title: "Product block-1" });
+        expect(result.tipTapContent.content[2].content[0].attrs.data.loaded).toEqual({ title: "Product inline-1" });
+    });
+
+    it("leaves rich text content untouched when no loader matches", async () => {
+        const blockData = {
+            tipTapContent: {
+                type: "doc",
+                content: [{ type: "cmsBlock", attrs: { blockType: "productTeaser", data: { productId: "block-1" } } }],
+            },
+        };
+
+        const result = await recursivelyLoadBlockData({
+            blockType: "TipTapRichText",
+            blockData,
+            blocksMeta,
+            loaders: {},
+            ...dependencies,
+        });
+
+        expect(result.tipTapContent.content[0].attrs.data).toEqual({ productId: "block-1" });
+        expect(result.tipTapContent.content[0].attrs.data.loaded).toBeUndefined();
+    });
+
+    it("does not process embedded blocks in a plain Json field", async () => {
+        const productTeaserLoader: BlockLoader = vi.fn(async () => ({ title: "loaded" }));
+
+        const blocksMetaWithJsonField = [
+            {
+                name: "TipTapRichText",
+                fields: [{ name: "tipTapContent", kind: "Json", nullable: false }],
+                inputFields: [{ name: "tipTapContent", kind: "Json", nullable: false }],
+            },
+            ...blocksMeta.slice(1),
+        ];
+
+        const blockData = {
+            tipTapContent: {
+                type: "doc",
+                content: [{ type: "cmsBlock", attrs: { blockType: "productTeaser", data: { productId: "block-1" } } }],
+            },
+        };
+
+        const result = await recursivelyLoadBlockData({
+            blockType: "TipTapRichText",
+            blockData,
+            blocksMeta: blocksMetaWithJsonField,
+            loaders: { ProductTeaser: productTeaserLoader },
+            ...dependencies,
+        });
+
+        expect(productTeaserLoader).not.toHaveBeenCalled();
+        expect(result.tipTapContent.content[0].attrs.data).toEqual({ productId: "block-1" });
+    });
+});

--- a/packages/site/site-react/src/blockLoader/blockLoader.ts
+++ b/packages/site/site-react/src/blockLoader/blockLoader.ts
@@ -7,6 +7,7 @@ type BlockMetaField = {
     enum?: string[];
     block?: string;
     blocks?: Record<string, string>;
+    childBlocks?: Record<string, string>;
     object?: { fields: BlockMetaField[] };
 };
 
@@ -24,6 +25,13 @@ type BetterBlockMetaField =
           name: string;
           kind: "String" | "Number" | "Boolean" | "Json";
           nullable: boolean;
+      }
+    | {
+          name: string;
+          kind: "TipTapRichTextBlock";
+          nullable: boolean;
+          // The child blocks the rich text content may contain, keyed by their stable config key.
+          childBlocks: Record<string, string>;
       }
     | {
           name: string;
@@ -83,6 +91,36 @@ export async function recursivelyLoadBlockData({
     blocksMeta: BlockMeta[];
     loaders: Record<string, BlockLoader>;
 } & BlockLoaderDependencies) {
+    // Rich text fields (e.g. TipTapRichText's `tipTapContent`) are marked in the block meta with the child
+    // blocks they may contain. Child blocks are embedded as `cmsBlock`/`cmsInlineBlock` nodes carrying their
+    // block type and data. Walk the content tree and run each embedded child block through the regular block
+    // loading so their loaders run too.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function loadRichTextChildBlocks(node: any, childBlocks: Record<string, string>): any {
+        if (!node || typeof node !== "object") {
+            return node;
+        }
+
+        let result = node;
+        const blockType = node.type === "cmsBlock" || node.type === "cmsInlineBlock" ? node.attrs?.blockType : undefined;
+        if (blockType && childBlocks[blockType]) {
+            result = {
+                ...result,
+                attrs: {
+                    ...result.attrs,
+                    data: iterateBlock({ blockType: childBlocks[blockType], blockData: result.attrs.data }),
+                },
+            };
+        }
+
+        if (Array.isArray(result.content)) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            result = { ...result, content: result.content.map((child: any) => loadRichTextChildBlocks(child, childBlocks)) };
+        }
+
+        return result;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function iterateField(block: BetterBlockMeta | BetterBlockMetaNestedObject, passedBlockData: any) {
         const blockData = { ...passedBlockData };
@@ -111,6 +149,8 @@ export async function recursivelyLoadBlockData({
                     blockType: field.block,
                     blockData: blockData[field.name],
                 });
+            } else if (field.kind == "TipTapRichTextBlock") {
+                blockData[field.name] = loadRichTextChildBlocks(blockData[field.name], field.childBlocks);
             }
         }
         return blockData;


### PR DESCRIPTION
## Problem

A TipTap rich text child block can resolve additional data on the API side via a `BlockTransformerService` (as the demo `ProductPriceBlock` does). That approach also requires admin-side effort and isn't always desirable. The site already has a `BlockLoader` mechanism (used e.g. by `NewsDetailBlock`) that loads data for nested blocks, but it skipped the rich text content, so child blocks embedded in a `createTipTapRichTextBlock` never reached their loaders.

## Solution

Make `recursivelyLoadBlockData` (`@comet/site-react`, re-exported from `@comet/site-nextjs`) load child blocks embedded in rich text content. Embedded child blocks — stored as `cmsBlock` / `cmsInlineBlock` nodes with a `blockType` (the stable config key) + `data` — are routed through the same block-loading path as any other nested block, so their registered loaders run.

To detect rich text content reliably (instead of inspecting arbitrary `Json` fields), the `tipTapContent` field is now declared with a dedicated **`TipTapRichTextBlock`** block meta kind instead of `Json`. The kind carries the configured child blocks (`childBlocks`, keyed by config key), which the loader uses to resolve embedded nodes to their registered blocks.

This lets a rich text child block load its data from the site instead of via a `BlockTransformerService`.

## Example

A new demo child block, `ProductTeaser`, showcases the approach. Unlike `ProductPriceBlock`, it stores only a `productId` (no transformer service); a site-side loader fetches the product:

```ts
// demo/site/src/products/blocks/ProductTeaserBlock.loader.ts
export const loader = async ({ blockData, graphQLFetch }: BlockLoaderOptions<ProductTeaserBlockData>) => {
    if (!blockData.productId) return null;
    const data = await graphQLFetch(/* query product(id) { title, description, price } */, { id: blockData.productId });
    return data.product;
};
```

The loader is registered in the demo's `recursivelyLoadBlockData` wrapper, and `ProductTeaser` is added to the `TipTapRichTextBlock` `childBlocks` (API + admin, `display: "block"`).

## Changes

- **`@comet/cms-api`**: new `BlockMetaFieldKind.TipTapRichTextBlock` (with a `@BlockField({ type: "tipTapRichTextBlock", childBlocks })` declaration); `createTipTapRichTextBlock` declares its `tipTapContent` field with this kind, carrying the configured child blocks.
- **`@comet/cli`**: `generate-block-types` handles the new kind (emits `unknown` for the content type, identical to the previous `Json` output).
- **`@comet/site-react`**: `recursivelyLoadBlockData` processes child blocks for `TipTapRichTextBlock` fields; added a unit test covering block-level and inline child blocks plus a plain-`Json` field that is left untouched. Re-exported from `@comet/site-nextjs`.
- **Demo**: new `ProductTeaser` block (API / admin / site) loaded via the `BlockLoader` feature; added to the demo `TipTapRichTextBlock`.
- Added a changeset (`@comet/cms-api`, `@comet/site-react`, `@comet/site-nextjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qrC8WFjTAvPFQ3tj9k5fo