### PR TITLE
Update `@getbrevo/brevo` to v5

### DIFF
--- a/.changeset/major-worms-create.md
+++ b/.changeset/major-worms-create.md
@@ -1,7 +1,0 @@
----
-"@comet/brevo-api": patch
----
-
-Fix fetching Brevo statistics
-
-Fetching a Brevo campaign (and therefore its statistics) is broken in `@getbrevo/brevo` v3. Fix by temporarily downgrading to v2.

--- a/.changeset/update-brevo-sdk-to-v5.md
+++ b/.changeset/update-brevo-sdk-to-v5.md
@@ -4,6 +4,4 @@
 
 Update `@getbrevo/brevo` to v5
 
-The Brevo Node.js SDK v5 is a ground-up rewrite based on a unified client architecture. Instead of instantiating one API class per resource and authenticating each with `setApiKey`, a single `BrevoClient` is now created per scope and exposes all resources (e.g. `client.contacts`, `client.transactionalEmails`).
-
 The transactional mail service's `send` method now accepts a `SendTransacEmailRequest` (without `sender`) instead of a `SendSmtpEmail`. The commonly used fields (`to`, `subject`, `htmlContent`, `textContent`) are unchanged, so existing calls continue to work.

--- a/.changeset/update-brevo-sdk-to-v5.md
+++ b/.changeset/update-brevo-sdk-to-v5.md
@@ -1,5 +1,5 @@
 ---
-"@comet/brevo-api": minor
+"@comet/brevo-api": major
 ---
 
 Update `@getbrevo/brevo` to v5

--- a/.changeset/update-brevo-sdk-to-v5.md
+++ b/.changeset/update-brevo-sdk-to-v5.md
@@ -1,0 +1,9 @@
+---
+"@comet/brevo-api": minor
+---
+
+Update `@getbrevo/brevo` to v5
+
+The Brevo Node.js SDK v5 is a ground-up rewrite based on a unified client architecture. Instead of instantiating one API class per resource and authenticating each with `setApiKey`, a single `BrevoClient` is now created per scope and exposes all resources (e.g. `client.contacts`, `client.transactionalEmails`).
+
+The transactional mail service's `send` method now accepts a `SendTransacEmailRequest` (without `sender`) instead of a `SendSmtpEmail`. The commonly used fields (`to`, `subject`, `htmlContent`, `textContent`) are unchanged, so existing calls continue to work.

--- a/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
+++ b/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
@@ -281,6 +281,18 @@ Repeat this step, fixing all lint errors, until the lint passes.
 
 Use `RedirectSourceType` instead of `RedirectSourceTypeValues` from `@comet/cms-api`
 
+### Brevo: `@getbrevo/brevo` upgraded to v5
+
+`@comet/brevo-api` now uses `@getbrevo/brevo` v5, which is a ground-up rewrite of the Brevo SDK. If your project imports `@getbrevo/brevo` directly, upgrade it to `^5` and follow the [Brevo SDK migration guide](https://github.com/getbrevo/brevo-node).
+
+`BrevoTransactionalMailsService.send()` now resolves to the Brevo response body directly instead of the previous `{ response, body }` wrapper, and its options are typed as `SendTransacEmailRequest` instead of `SendSmtpEmail`. The supported fields (`to`, `subject`, `htmlContent`, `textContent`, …) are unchanged, so only adjust code that reads the return value:
+
+```diff title="api/src/.../some.service.ts"
+- const { body } = await this.brevoTransactionalMailsService.send({ to: [{ email }], subject, htmlContent }, scope);
+- const messageId = body.messageId;
++ const { messageId } = await this.brevoTransactionalMailsService.send({ to: [{ email }], subject, htmlContent }, scope);
+```
+
 ## Admin
 
 ### Update Comet and peer dependencies

--- a/packages/api/brevo-api/package.json
+++ b/packages/api/brevo-api/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@comet/cms-api": "workspace:*",
         "@fast-csv/parse": "^5.0.7",
-        "@getbrevo/brevo": "^3.0.4",
+        "@getbrevo/brevo": "^5.0.4",
         "@nestjs/axios": "^4.0.1",
         "@nestjs/cache-manager": "^3.1.2",
         "@nestjs/jwt": "^11.0.2",

--- a/packages/api/brevo-api/package.json
+++ b/packages/api/brevo-api/package.json
@@ -63,6 +63,8 @@
         "@nestjs/core": "^11.1.21",
         "@nestjs/graphql": "^13.4.0",
         "@nestjs/platform-express": "^11.1.21",
+        "@nestjs/testing": "^11.1.21",
+        "@swc/core": "^1.15.40",
         "@types/inquirer": "^8.2.12",
         "@types/lodash.isequal": "^4.5.8",
         "chokidar-cli": "^2.1.0",
@@ -75,6 +77,7 @@
         "rxjs": "^7.8.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
+        "unplugin-swc": "^1.5.9",
         "vitest": "^4.1.8"
     },
     "peerDependencies": {

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-campaigns.service.spec.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-campaigns.service.spec.ts
@@ -1,15 +1,12 @@
 import { Brevo } from "@getbrevo/brevo";
 import { CACHE_MANAGER } from "@nestjs/cache-manager";
 import { Test, type TestingModule } from "@nestjs/testing";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
-import type { EmailCampaignInterface } from "../email-campaign/entities/email-campaign-entity.factory";
 import { SendingState } from "../email-campaign/sending-state.enum";
 import { BrevoApiCampaignsService } from "./brevo-api-campaigns.service";
 import { BrevoApiClientFactory } from "./brevo-api-client.factory";
 import type { BrevoApiCampaign } from "./dto/brevo-api-campaign";
-
-const scope = { domain: "main" };
 
 function campaignWithStatus(status: Brevo.GetEmailCampaignResponse.Status): BrevoApiCampaign {
     return { status } as unknown as BrevoApiCampaign;
@@ -17,16 +14,12 @@ function campaignWithStatus(status: Brevo.GetEmailCampaignResponse.Status): Brev
 
 describe("BrevoApiCampaignsService", () => {
     let service: BrevoApiCampaignsService;
-    const emailCampaigns = {
-        createEmailCampaign: vi.fn(),
-    };
 
     beforeEach(async () => {
-        vi.clearAllMocks();
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 BrevoApiCampaignsService,
-                { provide: BrevoApiClientFactory, useValue: { getClient: () => ({ emailCampaigns }) } },
+                { provide: BrevoApiClientFactory, useValue: { getClient: () => ({}) } },
                 { provide: CACHE_MANAGER, useValue: {} },
             ],
         }).compile();
@@ -48,31 +41,6 @@ describe("BrevoApiCampaignsService", () => {
             expect(service.getSendingInformationFromBrevoCampaign(campaignWithStatus(Brevo.GetEmailCampaignResponse.Status.Draft))).toBe(
                 SendingState.DRAFT,
             );
-        });
-    });
-
-    describe("createBrevoCampaign", () => {
-        it("creates the campaign with the mapped fields and returns its id", async () => {
-            emailCampaigns.createEmailCampaign.mockResolvedValue({ id: 42 });
-            const campaign = {
-                title: "Newsletter",
-                subject: "Hello",
-                scope,
-                targetGroups: { loadItems: vi.fn().mockResolvedValue([{ brevoId: 10 }, { brevoId: 11 }]) },
-            } as unknown as EmailCampaignInterface;
-
-            const id = await service.createBrevoCampaign({ campaign, htmlContent: "<p>Hi</p>", sender: { name: "Sender", mail: "s@example.com" } });
-
-            expect(id).toBe(42);
-            expect(emailCampaigns.createEmailCampaign).toHaveBeenCalledWith({
-                name: "Newsletter",
-                subject: "Hello",
-                sender: { name: "Sender", email: "s@example.com" },
-                recipients: { listIds: [10, 11] },
-                htmlContent: "<p>Hi</p>",
-                scheduledAt: undefined,
-                unsubscriptionPageId: undefined,
-            });
         });
     });
 });

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-campaigns.service.spec.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-campaigns.service.spec.ts
@@ -1,0 +1,78 @@
+import { Brevo } from "@getbrevo/brevo";
+import { CACHE_MANAGER } from "@nestjs/cache-manager";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EmailCampaignInterface } from "../email-campaign/entities/email-campaign-entity.factory";
+import { SendingState } from "../email-campaign/sending-state.enum";
+import { BrevoApiCampaignsService } from "./brevo-api-campaigns.service";
+import { BrevoApiClientFactory } from "./brevo-api-client.factory";
+import type { BrevoApiCampaign } from "./dto/brevo-api-campaign";
+
+const scope = { domain: "main" };
+
+function campaignWithStatus(status: Brevo.GetEmailCampaignResponse.Status): BrevoApiCampaign {
+    return { status } as unknown as BrevoApiCampaign;
+}
+
+describe("BrevoApiCampaignsService", () => {
+    let service: BrevoApiCampaignsService;
+    const emailCampaigns = {
+        createEmailCampaign: vi.fn(),
+    };
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                BrevoApiCampaignsService,
+                { provide: BrevoApiClientFactory, useValue: { getClient: () => ({ emailCampaigns }) } },
+                { provide: CACHE_MANAGER, useValue: {} },
+            ],
+        }).compile();
+
+        service = module.get(BrevoApiCampaignsService);
+    });
+
+    describe("getSendingInformationFromBrevoCampaign", () => {
+        it("maps the Brevo campaign status to the sending state", () => {
+            expect(service.getSendingInformationFromBrevoCampaign(campaignWithStatus(Brevo.GetEmailCampaignResponse.Status.Sent))).toBe(
+                SendingState.SENT,
+            );
+            expect(service.getSendingInformationFromBrevoCampaign(campaignWithStatus(Brevo.GetEmailCampaignResponse.Status.Queued))).toBe(
+                SendingState.SCHEDULED,
+            );
+            expect(service.getSendingInformationFromBrevoCampaign(campaignWithStatus(Brevo.GetEmailCampaignResponse.Status.InProcess))).toBe(
+                SendingState.SCHEDULED,
+            );
+            expect(service.getSendingInformationFromBrevoCampaign(campaignWithStatus(Brevo.GetEmailCampaignResponse.Status.Draft))).toBe(
+                SendingState.DRAFT,
+            );
+        });
+    });
+
+    describe("createBrevoCampaign", () => {
+        it("creates the campaign with the mapped fields and returns its id", async () => {
+            emailCampaigns.createEmailCampaign.mockResolvedValue({ id: 42 });
+            const campaign = {
+                title: "Newsletter",
+                subject: "Hello",
+                scope,
+                targetGroups: { loadItems: vi.fn().mockResolvedValue([{ brevoId: 10 }, { brevoId: 11 }]) },
+            } as unknown as EmailCampaignInterface;
+
+            const id = await service.createBrevoCampaign({ campaign, htmlContent: "<p>Hi</p>", sender: { name: "Sender", mail: "s@example.com" } });
+
+            expect(id).toBe(42);
+            expect(emailCampaigns.createEmailCampaign).toHaveBeenCalledWith({
+                name: "Newsletter",
+                subject: "Hello",
+                sender: { name: "Sender", email: "s@example.com" },
+                recipients: { listIds: [10, 11] },
+                htmlContent: "<p>Hi</p>",
+                scheduledAt: undefined,
+                unsubscriptionPageId: undefined,
+            });
+        });
+    });
+});

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-campaigns.service.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-campaigns.service.ts
@@ -1,60 +1,33 @@
-import * as Brevo from "@getbrevo/brevo";
+import { Brevo } from "@getbrevo/brevo";
 import { Cache, CACHE_MANAGER } from "@nestjs/cache-manager";
 import { Inject, Injectable } from "@nestjs/common";
 import { EmailCampaignScopeInterface } from "src/types";
 
-import { BrevoModuleConfig } from "../config/brevo-module.config";
-import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
 import { EmailCampaignInterface } from "../email-campaign/entities/email-campaign-entity.factory";
 import { SendingState } from "../email-campaign/sending-state.enum";
 import { handleBrevoError } from "./brevo-api.utils";
+import { BrevoApiClientFactory } from "./brevo-api-client.factory";
 import { BrevoApiCampaign } from "./dto/brevo-api-campaign";
 import { BrevoApiCampaignStatistics } from "./dto/brevo-api-campaign-statistics";
 
 @Injectable()
 export class BrevoApiCampaignsService {
-    private readonly campaignsApis = new Map<string, Brevo.EmailCampaignsApi>();
-
     constructor(
-        @Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig,
+        private readonly clientFactory: BrevoApiClientFactory,
         @Inject(CACHE_MANAGER) private cacheManager: Cache,
     ) {}
 
-    private getCampaignsApi(scope: EmailCampaignScopeInterface): Brevo.EmailCampaignsApi {
-        try {
-            const existingCampaignsApiForScope = this.campaignsApis.get(JSON.stringify(scope));
-
-            if (existingCampaignsApiForScope) {
-                return existingCampaignsApiForScope;
-            }
-
-            const { apiKey } = this.config.brevo.resolveConfig(scope);
-            const campaignsApi = new Brevo.EmailCampaignsApi();
-            campaignsApi.setApiKey(Brevo.EmailCampaignsApiApiKeys.apiKey, apiKey);
-
-            this.campaignsApis.set(JSON.stringify(scope), campaignsApi);
-
-            return campaignsApi;
-        } catch (error) {
-            handleBrevoError(error);
-        }
-    }
-
     public getSendingInformationFromBrevoCampaign(campaign: BrevoApiCampaign): SendingState {
-        try {
-            if (campaign.status === Brevo.GetEmailCampaignsCampaignsInner.StatusEnum.Sent) {
-                return SendingState.SENT;
-            } else if (
-                campaign.status === Brevo.GetEmailCampaignsCampaignsInner.StatusEnum.Queued ||
-                campaign.status === Brevo.GetEmailCampaignsCampaignsInner.StatusEnum.InProcess
-            ) {
-                return SendingState.SCHEDULED;
-            }
-
-            return SendingState.DRAFT;
-        } catch (error) {
-            handleBrevoError(error);
+        if (campaign.status === Brevo.GetEmailCampaignResponse.Status.Sent) {
+            return SendingState.SENT;
+        } else if (
+            campaign.status === Brevo.GetEmailCampaignResponse.Status.Queued ||
+            campaign.status === Brevo.GetEmailCampaignResponse.Status.InProcess
+        ) {
+            return SendingState.SCHEDULED;
         }
+
+        return SendingState.DRAFT;
     }
 
     public async createBrevoCampaign({
@@ -73,7 +46,7 @@ export class BrevoApiCampaignsService {
         try {
             const targetGroups = await campaign.targetGroups.loadItems();
 
-            const emailCampaign = {
+            const data = await this.clientFactory.getClient(campaign.scope).emailCampaigns.createEmailCampaign({
                 name: campaign.title,
                 subject: campaign.subject,
                 sender: { name: sender.name, email: sender.mail },
@@ -81,10 +54,8 @@ export class BrevoApiCampaignsService {
                 htmlContent,
                 scheduledAt: scheduledAt?.toISOString(),
                 unsubscriptionPageId,
-            };
-
-            const data = await this.getCampaignsApi(campaign.scope).createEmailCampaign(emailCampaign);
-            return data.body.id;
+            });
+            return data.id;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -106,17 +77,16 @@ export class BrevoApiCampaignsService {
         try {
             const targetGroups = await campaign.targetGroups.loadItems();
 
-            const emailCampaign = {
+            await this.clientFactory.getClient(campaign.scope).emailCampaigns.updateEmailCampaign({
+                campaignId: id,
                 name: campaign.title,
                 subject: campaign.subject,
                 sender: { name: sender.name, email: sender.mail },
                 recipients: { listIds: targetGroups.map((targetGroup) => targetGroup.brevoId) },
                 htmlContent,
                 scheduledAt: scheduledAt?.toISOString(),
-            };
-
-            const result = await this.getCampaignsApi(campaign.scope).updateEmailCampaign(id, emailCampaign);
-            return result.response.statusCode === 204;
+            });
+            return true;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -128,23 +98,23 @@ export class BrevoApiCampaignsService {
                 throw new Error("Campaign has no brevoId");
             }
 
-            const result = await this.getCampaignsApi(campaign.scope).sendEmailCampaignNow(campaign.brevoId);
-            return result.response.statusCode === 204;
+            await this.clientFactory.getClient(campaign.scope).emailCampaigns.sendEmailCampaignNow({ campaignId: campaign.brevoId });
+            return true;
         } catch (error) {
             handleBrevoError(error);
         }
     }
 
-    public async updateBrevoCampaignStatus(campaign: EmailCampaignInterface, updatedStatus: Brevo.UpdateCampaignStatus.StatusEnum): Promise<boolean> {
+    public async updateBrevoCampaignStatus(campaign: EmailCampaignInterface, updatedStatus: Brevo.UpdateCampaignStatus.Status): Promise<boolean> {
         try {
             if (!campaign.brevoId) {
                 throw new Error("Campaign has no brevoId");
             }
 
-            const status = new Brevo.UpdateCampaignStatus();
-            status.status = updatedStatus;
-            const result = await this.getCampaignsApi(campaign.scope).updateCampaignStatus(campaign.brevoId, status);
-            return result.response.statusCode === 204;
+            await this.clientFactory
+                .getClient(campaign.scope)
+                .emailCampaigns.updateCampaignStatus({ campaignId: campaign.brevoId, body: { status: updatedStatus } });
+            return true;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -156,8 +126,10 @@ export class BrevoApiCampaignsService {
                 throw new Error("Campaign has no brevoId");
             }
 
-            const result = await this.getCampaignsApi(campaign.scope).sendTestEmail(campaign.brevoId, { emailTo: emails });
-            return result.response.statusCode === 204;
+            await this.clientFactory
+                .getClient(campaign.scope)
+                .emailCampaigns.sendTestEmail({ campaignId: campaign.brevoId, body: { emailTo: emails } });
+            return true;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -196,9 +168,7 @@ export class BrevoApiCampaignsService {
             }
 
             return this.cacheManager.wrap<BrevoApiCampaign>(`brevo-campaign-${campaign.id}`, async () => {
-                const response = await this.getCampaignsApi(campaign.scope).getEmailCampaign(brevoId);
-
-                return response.body;
+                return this.clientFactory.getClient(campaign.scope).emailCampaigns.getEmailCampaign({ campaignId: brevoId });
             });
         } catch (error) {
             handleBrevoError(error);
@@ -232,16 +202,8 @@ export class BrevoApiCampaignsService {
 
         while (true) {
             try {
-                const campaignsResponse = await this.getCampaignsApi(scope).getEmailCampaigns(
-                    undefined,
-                    status,
-                    undefined,
-                    undefined,
-                    undefined,
-                    limit,
-                    offset,
-                );
-                const campaignArray = (campaignsResponse.body.campaigns ?? []).filter((item) => ids.includes(item.id));
+                const campaignsResponse = await this.clientFactory.getClient(scope).emailCampaigns.getEmailCampaigns({ status, limit, offset });
+                const campaignArray = (campaignsResponse.campaigns ?? []).filter((item) => ids.includes(item.id));
 
                 if (campaignArray.length === 0) {
                     break;

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-client.factory.spec.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-client.factory.spec.ts
@@ -1,0 +1,45 @@
+import { BrevoClient } from "@getbrevo/brevo";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
+import { BrevoApiClientFactory } from "./brevo-api-client.factory";
+
+describe("BrevoApiClientFactory", () => {
+    let factory: BrevoApiClientFactory;
+    const resolveConfig = vi.fn((scope: { domain: string }) => ({ apiKey: `key-${scope.domain}`, redirectUrlForImport: "" }));
+
+    beforeEach(async () => {
+        resolveConfig.mockClear();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [BrevoApiClientFactory, { provide: BREVO_MODULE_CONFIG, useValue: { brevo: { resolveConfig } } }],
+        }).compile();
+
+        factory = module.get(BrevoApiClientFactory);
+    });
+
+    it("creates a BrevoClient with the api key resolved for the scope", () => {
+        const scope = { domain: "main" };
+
+        const client = factory.getClient(scope);
+
+        expect(client).toBeInstanceOf(BrevoClient);
+        expect(resolveConfig).toHaveBeenCalledWith(scope);
+    });
+
+    it("caches one client per scope", () => {
+        const first = factory.getClient({ domain: "main" });
+        const second = factory.getClient({ domain: "main" });
+
+        expect(second).toBe(first);
+        expect(resolveConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates separate clients for different scopes", () => {
+        const main = factory.getClient({ domain: "main" });
+        const secondary = factory.getClient({ domain: "secondary" });
+
+        expect(secondary).not.toBe(main);
+        expect(resolveConfig).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-client.factory.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-client.factory.ts
@@ -1,0 +1,34 @@
+import { BrevoClient } from "@getbrevo/brevo";
+import { Inject, Injectable } from "@nestjs/common";
+import { EmailCampaignScopeInterface } from "src/types";
+
+import { BrevoModuleConfig } from "../config/brevo-module.config";
+import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
+import { handleBrevoError } from "./brevo-api.utils";
+
+@Injectable()
+export class BrevoApiClientFactory {
+    private readonly clients = new Map<string, BrevoClient>();
+
+    constructor(@Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig) {}
+
+    getClient(scope: EmailCampaignScopeInterface): BrevoClient {
+        try {
+            const key = JSON.stringify(scope);
+            const existingClient = this.clients.get(key);
+
+            if (existingClient) {
+                return existingClient;
+            }
+
+            const { apiKey } = this.config.brevo.resolveConfig(scope);
+            const client = new BrevoClient({ apiKey });
+
+            this.clients.set(key, client);
+
+            return client;
+        } catch (error) {
+            handleBrevoError(error);
+        }
+    }
+}

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-contact.service.spec.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-contact.service.spec.ts
@@ -13,8 +13,6 @@ describe("BrevoApiContactsService", () => {
     let service: BrevoApiContactsService;
     const contactsApi = {
         getContactInfo: vi.fn(),
-        getContactsFromList: vi.fn(),
-        updateContact: vi.fn(),
     };
 
     beforeEach(async () => {
@@ -65,35 +63,6 @@ describe("BrevoApiContactsService", () => {
 
             await expect(service.getContactInfoByEmail("ghost@example.com", scope)).resolves.toBeNull();
             expect(contactsApi.getContactInfo).toHaveBeenCalledWith({ identifier: "ghost@example.com" });
-        });
-    });
-
-    describe("findContactsByListId", () => {
-        it("returns the contacts and count as a tuple", async () => {
-            const contacts = [{ id: 1 }, { id: 2 }];
-            contactsApi.getContactsFromList.mockResolvedValue({ contacts, count: 2 });
-
-            await expect(service.findContactsByListId(7, 25, 50, scope)).resolves.toEqual([contacts, 2]);
-            expect(contactsApi.getContactsFromList).toHaveBeenCalledWith({ listId: 7, limit: 25, offset: 50 });
-        });
-    });
-
-    describe("updateContact", () => {
-        it("sends the update request and returns the refetched contact", async () => {
-            const updatedContact = { id: 9, email: "jane@example.com" };
-            contactsApi.updateContact.mockResolvedValue(undefined);
-            contactsApi.getContactInfo.mockResolvedValue(updatedContact);
-
-            const result = await service.updateContact(9, { blocked: true, listIds: [3] }, scope);
-
-            expect(contactsApi.updateContact).toHaveBeenCalledWith({
-                identifier: 9,
-                emailBlacklisted: true,
-                attributes: undefined,
-                listIds: [3],
-                unlinkListIds: undefined,
-            });
-            expect(result).toBe(updatedContact);
         });
     });
 });

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-contact.service.spec.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-contact.service.spec.ts
@@ -1,0 +1,99 @@
+import { Brevo, BrevoError } from "@getbrevo/brevo";
+import { getRepositoryToken } from "@mikro-orm/nestjs";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
+import { BrevoApiClientFactory } from "./brevo-api-client.factory";
+import { BrevoApiContactsService } from "./brevo-api-contact.service";
+
+const scope = { domain: "main" };
+
+describe("BrevoApiContactsService", () => {
+    let service: BrevoApiContactsService;
+    const contactsApi = {
+        getContactInfo: vi.fn(),
+        getContactsFromList: vi.fn(),
+        updateContact: vi.fn(),
+    };
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                BrevoApiContactsService,
+                { provide: BREVO_MODULE_CONFIG, useValue: { brevo: {} } },
+                { provide: getRepositoryToken("BrevoConfig"), useValue: {} },
+                { provide: BrevoApiClientFactory, useValue: { getClient: () => ({ contacts: contactsApi }) } },
+            ],
+        }).compile();
+
+        service = module.get(BrevoApiContactsService);
+    });
+
+    describe("findContact", () => {
+        it("returns the contact when found", async () => {
+            const contact = { id: 5, email: "jane@example.com" };
+            contactsApi.getContactInfo.mockResolvedValue(contact);
+
+            await expect(service.findContact(5, scope)).resolves.toBe(contact);
+            expect(contactsApi.getContactInfo).toHaveBeenCalledWith({ identifier: 5 });
+        });
+
+        it("returns null when the contact does not exist (404)", async () => {
+            contactsApi.getContactInfo.mockRejectedValue(new Brevo.NotFoundError({ code: "not_found", message: "not found" }));
+
+            await expect(service.findContact(5, scope)).resolves.toBeNull();
+        });
+
+        it("returns null when the identifier is invalid (400)", async () => {
+            contactsApi.getContactInfo.mockRejectedValue(new Brevo.BadRequestError({ code: "invalid_parameter", message: "bad" }));
+
+            await expect(service.findContact("not-an-email", scope)).resolves.toBeNull();
+        });
+
+        it("rethrows other Brevo errors", async () => {
+            contactsApi.getContactInfo.mockRejectedValue(new BrevoError({ message: "x", statusCode: 500, body: { message: "Server error" } }));
+
+            await expect(service.findContact(5, scope)).rejects.toThrowError("Server error");
+        });
+    });
+
+    describe("getContactInfoByEmail", () => {
+        it("looks the contact up by email and returns null on 404", async () => {
+            contactsApi.getContactInfo.mockRejectedValue(new Brevo.NotFoundError({ code: "not_found", message: "not found" }));
+
+            await expect(service.getContactInfoByEmail("ghost@example.com", scope)).resolves.toBeNull();
+            expect(contactsApi.getContactInfo).toHaveBeenCalledWith({ identifier: "ghost@example.com" });
+        });
+    });
+
+    describe("findContactsByListId", () => {
+        it("returns the contacts and count as a tuple", async () => {
+            const contacts = [{ id: 1 }, { id: 2 }];
+            contactsApi.getContactsFromList.mockResolvedValue({ contacts, count: 2 });
+
+            await expect(service.findContactsByListId(7, 25, 50, scope)).resolves.toEqual([contacts, 2]);
+            expect(contactsApi.getContactsFromList).toHaveBeenCalledWith({ listId: 7, limit: 25, offset: 50 });
+        });
+    });
+
+    describe("updateContact", () => {
+        it("sends the update request and returns the refetched contact", async () => {
+            const updatedContact = { id: 9, email: "jane@example.com" };
+            contactsApi.updateContact.mockResolvedValue(undefined);
+            contactsApi.getContactInfo.mockResolvedValue(updatedContact);
+
+            const result = await service.updateContact(9, { blocked: true, listIds: [3] }, scope);
+
+            expect(contactsApi.updateContact).toHaveBeenCalledWith({
+                identifier: 9,
+                emailBlacklisted: true,
+                attributes: undefined,
+                listIds: [3],
+                unlinkListIds: undefined,
+            });
+            expect(result).toBe(updatedContact);
+        });
+    });
+});

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-contact.service.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-contact.service.ts
@@ -1,4 +1,4 @@
-import * as Brevo from "@getbrevo/brevo";
+import { Brevo } from "@getbrevo/brevo";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
 import { Inject, Injectable, Optional } from "@nestjs/common";
@@ -12,6 +12,7 @@ import { ContactSource } from "../brevo-email-import-log/entity/brevo-email-impo
 import { BrevoModuleConfig } from "../config/brevo-module.config";
 import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
 import { handleBrevoError, isErrorFromBrevo } from "./brevo-api.utils";
+import { BrevoApiClientFactory } from "./brevo-api-client.factory";
 import { BrevoApiContactList } from "./dto/brevo-api-contact-list";
 
 export interface CreateDoubleOptInContactData {
@@ -22,34 +23,13 @@ export interface CreateDoubleOptInContactData {
 
 @Injectable()
 export class BrevoApiContactsService {
-    private readonly contactsApis = new Map<string, Brevo.ContactsApi>();
-
     constructor(
         @Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig,
         @InjectRepository("BrevoConfig") private readonly brevoConfigRepository: EntityRepository<BrevoConfigInterface>,
+        private readonly clientFactory: BrevoApiClientFactory,
         @Optional() private readonly blacklistedContactsService: BlacklistedContactsService,
         @Optional() private readonly brevoContactLogService: BrevoEmailImportLogService,
     ) {}
-
-    private getContactsApi(scope: EmailCampaignScopeInterface): Brevo.ContactsApi {
-        try {
-            const existingContactsApiForScope = this.contactsApis.get(JSON.stringify(scope));
-
-            if (existingContactsApiForScope) {
-                return existingContactsApiForScope;
-            }
-
-            const { apiKey } = this.config.brevo.resolveConfig(scope);
-            const contactsApi = new Brevo.ContactsApi();
-            contactsApi.setApiKey(Brevo.ContactsApiApiKeys.apiKey, apiKey);
-
-            this.contactsApis.set(JSON.stringify(scope), contactsApi);
-
-            return contactsApi;
-        } catch (error) {
-            handleBrevoError(error);
-        }
-    }
 
     public async createDoubleOptInBrevoContact(
         { email, redirectionUrl, attributes }: CreateDoubleOptInContactData,
@@ -59,16 +39,15 @@ export class BrevoApiContactsService {
     ): Promise<boolean> {
         try {
             if (redirectionUrl) {
-                const contact = {
+                await this.clientFactory.getClient(scope).contacts.createDoiContact({
                     email,
                     includeListIds: brevoIds,
                     templateId,
                     redirectionUrl,
                     attributes,
-                };
-                const { response } = await this.getContactsApi(scope).createDoiContact(contact);
+                });
 
-                return response.statusCode === 204 || response.statusCode === 201;
+                return true;
             }
             return false;
         } catch (error) {
@@ -77,35 +56,31 @@ export class BrevoApiContactsService {
     }
 
     public async createBrevoContactWithoutDoubleOptIn(
-        { email, attributes }: Brevo.CreateContact,
+        { email, attributes }: Brevo.CreateContactRequest,
         brevoIds: number[],
-        templateId: number,
         scope: EmailCampaignScopeInterface,
     ): Promise<boolean> {
-        const contact = {
+        await this.clientFactory.getClient(scope).contacts.createContact({
             email,
             listIds: brevoIds,
-            templateId,
             attributes,
-        };
-        const { response } = await this.getContactsApi(scope).createContact(contact);
+        });
 
-        return response.statusCode === 204 || response.statusCode === 201;
+        return true;
     }
 
     public async createTestContact(
-        { email, attributes }: Brevo.CreateContact,
+        { email, attributes }: Brevo.CreateContactRequest,
         brevoIds: number[],
         scope: EmailCampaignScopeInterface,
     ): Promise<boolean> {
-        const contact = {
+        await this.clientFactory.getClient(scope).contacts.createContact({
             email,
             listIds: brevoIds,
             attributes,
-        };
-        const { response } = await this.getContactsApi(scope).createContact(contact);
+        });
 
-        return response.statusCode === 204 || response.statusCode === 201;
+        return true;
     }
 
     public async updateContact(
@@ -123,8 +98,9 @@ export class BrevoApiContactsService {
         importId?: string,
     ): Promise<BrevoContactInterface> {
         try {
-            const idAsString = id.toString(); // brevo expects a string, because it can be an email or the id, so we have to transform the id to string
-            await this.getContactsApi(scope).updateContact(idAsString, { emailBlacklisted: blocked, attributes, listIds, unlinkListIds });
+            await this.clientFactory
+                .getClient(scope)
+                .contacts.updateContact({ identifier: id, emailBlacklisted: blocked, attributes, listIds, unlinkListIds });
 
             const brevoContact = await this.findContact(id, scope);
 
@@ -142,10 +118,13 @@ export class BrevoApiContactsService {
         }
     }
 
-    public async updateMultipleContacts(contacts: Brevo.UpdateBatchContactsContactsInner[], scope: EmailCampaignScopeInterface): Promise<boolean> {
+    public async updateMultipleContacts(
+        contacts: Brevo.UpdateBatchContactsRequest.Contacts.Item[],
+        scope: EmailCampaignScopeInterface,
+    ): Promise<boolean> {
         try {
-            const { response } = await this.getContactsApi(scope).updateBatchContacts({ contacts });
-            return response.statusCode === 204;
+            await this.clientFactory.getClient(scope).contacts.updateBatchContacts({ contacts });
+            return true;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -153,16 +132,16 @@ export class BrevoApiContactsService {
 
     public async deleteContact(id: number, scope: EmailCampaignScopeInterface): Promise<boolean> {
         try {
-            const idAsString = id.toString(); // brevo expects a string, because it can be an email or the id, so we have to transform the id to string
-            const { body } = await this.getContactsApi(scope).getContactInfo(idAsString);
+            const contactsApi = this.clientFactory.getClient(scope).contacts;
+            const contact = await contactsApi.getContactInfo({ identifier: id });
 
-            if (body.email && this.config.contactsWithoutDoi?.allowAddingContactsWithoutDoi) {
-                await this.blacklistedContactsService.addBlacklistedContacts([body.email], scope);
+            if (contact.email && this.config.contactsWithoutDoi?.allowAddingContactsWithoutDoi) {
+                await this.blacklistedContactsService.addBlacklistedContacts([contact.email], scope);
             }
 
-            const { response } = await this.getContactsApi(scope).deleteContact(idAsString);
+            await contactsApi.deleteContact({ identifier: id });
 
-            return response.statusCode === 204;
+            return true;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -170,13 +149,12 @@ export class BrevoApiContactsService {
 
     public async findContact(idOrEmail: string | number, scope: EmailCampaignScopeInterface): Promise<BrevoContactInterface | null> {
         try {
-            const idAsString = String(idOrEmail); // brevo expects a string, because it can be an email or the id
-            const { body } = await this.getContactsApi(scope).getContactInfo(idAsString);
+            const contact = await this.clientFactory.getClient(scope).contacts.getContactInfo({ identifier: idOrEmail });
 
-            return body;
+            return contact;
         } catch (error) {
             // Brevo returns a 404 error if no contact is found and a 400 error if an invalid email is provided.
-            if (isErrorFromBrevo(error) && (error.status === 404 || error.status === 400)) {
+            if (isErrorFromBrevo(error) && (error.statusCode === 404 || error.statusCode === 400)) {
                 return null;
             }
 
@@ -186,15 +164,14 @@ export class BrevoApiContactsService {
 
     public async getContactInfoByEmail(email: string, scope: EmailCampaignScopeInterface): Promise<BrevoContactInterface | null> {
         try {
-            const data = await this.getContactsApi(scope).getContactInfo(email);
-            const contact = data.body;
+            const contact = await this.clientFactory.getClient(scope).contacts.getContactInfo({ identifier: email });
             if (!contact) {
                 return null;
             }
             return contact;
         } catch (error) {
             // Brevo returns a 404 error if no contact is found and a 400 error if an invalid email is provided.
-            if (isErrorFromBrevo(error) && (error.status === 404 || error.status === 400)) {
+            if (isErrorFromBrevo(error) && (error.statusCode === 404 || error.statusCode === 400)) {
                 return null;
             }
             handleBrevoError(error);
@@ -208,9 +185,9 @@ export class BrevoApiContactsService {
         scope: EmailCampaignScopeInterface,
     ): Promise<[BrevoContactInterface[], number]> {
         try {
-            const data = await this.getContactsApi(scope).getContactsFromList(id, undefined, limit, offset);
+            const data = await this.clientFactory.getClient(scope).contacts.getContactsFromList({ listId: id, limit, offset });
 
-            return [data.body.contacts, data.body.count];
+            return [data.contacts, data.count];
         } catch (error) {
             handleBrevoError(error);
         }
@@ -218,8 +195,8 @@ export class BrevoApiContactsService {
 
     public async getContactCountByListId(id: number, scope: EmailCampaignScopeInterface): Promise<number> {
         try {
-            const data = await this.getContactsApi(scope).getContactsFromList(id);
-            return data.body.count;
+            const data = await this.clientFactory.getClient(scope).contacts.getContactsFromList({ listId: id });
+            return data.count;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -227,9 +204,9 @@ export class BrevoApiContactsService {
 
     public async findContacts(limit: number, offset: number, scope: EmailCampaignScopeInterface): Promise<BrevoContactInterface[]> {
         try {
-            const data = await this.getContactsApi(scope).getContacts(limit, offset);
+            const data = await this.clientFactory.getClient(scope).contacts.getContacts({ limit, offset });
 
-            return data.body.contacts;
+            return data.contacts;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -237,15 +214,12 @@ export class BrevoApiContactsService {
 
     public async deleteContacts(contacts: BrevoContactInterface[], scope: EmailCampaignScopeInterface): Promise<boolean> {
         try {
+            const contactsApi = this.clientFactory.getClient(scope).contacts;
             for (const contact of contacts) {
-                const idAsString = contact.id.toString();
                 if (contact.email && this.config.contactsWithoutDoi?.allowAddingContactsWithoutDoi) {
                     await this.blacklistedContactsService.addBlacklistedContacts([contact.email], scope);
                 }
-                const response = await this.getContactsApi(scope).deleteContact(idAsString);
-                if (response.response.statusCode !== 204) {
-                    return false;
-                }
+                await contactsApi.deleteContact({ identifier: contact.id });
             }
             return true;
         } catch (error) {
@@ -256,20 +230,18 @@ export class BrevoApiContactsService {
     public async blacklistMultipleContacts(emails: string[], scope: EmailCampaignScopeInterface): Promise<void> {
         const blacklistedContacts = emails.map((email) => ({ email, emailBlacklisted: true }));
 
-        await this.getContactsApi(scope).updateBatchContacts({ contacts: blacklistedContacts });
+        await this.clientFactory.getClient(scope).contacts.updateBatchContacts({ contacts: blacklistedContacts });
     }
 
     public async createBrevoContactList(title: string, scope: EmailCampaignScopeInterface): Promise<number | undefined> {
         const brevoConfig = await this.brevoConfigRepository.findOne({ scope });
 
         try {
-            const contactList = {
+            const data = await this.clientFactory.getClient(scope).contacts.createList({
                 name: title,
                 folderId: brevoConfig?.folderId ?? 1,
-            };
-
-            const data = await this.getContactsApi(scope).createList(contactList);
-            return data.body.id;
+            });
+            return data.id;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -277,8 +249,8 @@ export class BrevoApiContactsService {
 
     public async updateBrevoContactList(id: number, title: string, scope: EmailCampaignScopeInterface): Promise<boolean> {
         try {
-            const data = await this.getContactsApi(scope).updateList(id, { name: title });
-            return data.response.statusCode === 204;
+            await this.clientFactory.getClient(scope).contacts.updateList({ listId: id, name: title });
+            return true;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -286,8 +258,8 @@ export class BrevoApiContactsService {
 
     public async deleteBrevoContactList(id: number, scope: EmailCampaignScopeInterface): Promise<boolean> {
         try {
-            const data = await this.getContactsApi(scope).deleteList(id);
-            return data.response.statusCode === 204;
+            await this.clientFactory.getClient(scope).contacts.deleteList({ listId: id });
+            return true;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -295,8 +267,8 @@ export class BrevoApiContactsService {
 
     public async findBrevoContactListById(id: number, scope: EmailCampaignScopeInterface): Promise<BrevoApiContactList> {
         try {
-            const data = await this.getContactsApi(scope).getList(id);
-            return data.body;
+            const data = await this.clientFactory.getClient(scope).contacts.getList({ listId: id });
+            return data;
         } catch (error) {
             handleBrevoError(error);
         }
@@ -305,7 +277,7 @@ export class BrevoApiContactsService {
     public async findBrevoContactListsByIds(ids: number[], scope: EmailCampaignScopeInterface): Promise<BrevoApiContactList[]> {
         try {
             const lists: BrevoApiContactList[] = [];
-            for await (const list of await this.getBrevoContactListResponses(scope)) {
+            for await (const list of this.getBrevoContactListResponses(scope)) {
                 if (ids.includes(list.id)) {
                     lists.push(list);
                 }
@@ -322,8 +294,8 @@ export class BrevoApiContactsService {
 
         while (true) {
             try {
-                const listsResponse = await this.getContactsApi(scope).getLists(limit, offset);
-                const lists = listsResponse.body.lists ?? [];
+                const listsResponse = await this.clientFactory.getClient(scope).contacts.getLists({ limit, offset });
+                const lists = listsResponse.lists ?? [];
 
                 if (lists.length === 0) {
                     break;

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-folders.service.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-folders.service.ts
@@ -1,38 +1,24 @@
-import * as Brevo from "@getbrevo/brevo";
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { EmailCampaignScopeInterface } from "src/types";
 
-import { BrevoModuleConfig } from "../config/brevo-module.config";
-import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
 import { handleBrevoError } from "./brevo-api.utils";
+import { BrevoApiClientFactory } from "./brevo-api-client.factory";
 import { BrevoApiFolder } from "./dto/brevo-api-folder";
 
 @Injectable()
 export class BrevoApiFoldersService {
-    private readonly contactsApi: Brevo.ContactsApi;
-
-    constructor(@Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig) {
-        this.contactsApi = new Brevo.ContactsApi();
-    }
+    constructor(private readonly clientFactory: BrevoApiClientFactory) {}
 
     async *getAllBrevoFolders(scope: EmailCampaignScopeInterface): AsyncGenerator<BrevoApiFolder, void, undefined> {
-        const apiKey = this.config.brevo.resolveConfig(scope).apiKey;
-        this.contactsApi.setApiKey(Brevo.ContactsApiApiKeys.apiKey, apiKey);
-
         // Limit set by Brevo
         const limit = 50;
         let offset = 0;
 
         while (true) {
             try {
-                const { response, body } = await this.contactsApi.getFolders(limit, offset);
+                const { folders } = await this.clientFactory.getClient(scope).contacts.getFolders({ limit, offset });
 
-                if (response.statusCode !== 200) {
-                    throw new Error("Failed to get folders");
-                }
-
-                const folders = body.folders ?? [];
-                if (folders.length === 0) {
+                if (!folders || folders.length === 0) {
                     break;
                 }
 

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-sender.service.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-sender.service.ts
@@ -1,29 +1,21 @@
-import * as Brevo from "@getbrevo/brevo";
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { EmailCampaignScopeInterface } from "src/types";
 
-import { BrevoModuleConfig } from "../config/brevo-module.config";
-import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
+import { handleBrevoError } from "./brevo-api.utils";
+import { BrevoApiClientFactory } from "./brevo-api-client.factory";
 import { BrevoApiSender } from "./dto/brevo-api-sender";
 
 @Injectable()
 export class BrevoApiSenderService {
-    private readonly senderApi: Brevo.SendersApi;
+    constructor(private readonly clientFactory: BrevoApiClientFactory) {}
 
-    constructor(@Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig) {
-        this.senderApi = new Brevo.SendersApi();
-    }
+    public async getSenders(scope: EmailCampaignScopeInterface): Promise<BrevoApiSender[] | undefined> {
+        try {
+            const { senders } = await this.clientFactory.getClient(scope).senders.getSenders();
 
-    public async getSenders(scope: EmailCampaignScopeInterface): Promise<Array<Brevo.GetSendersListSendersInner> | undefined> {
-        const apiKey = this.config.brevo.resolveConfig(scope).apiKey;
-        this.senderApi.setApiKey(Brevo.SendersApiApiKeys.apiKey, apiKey);
-
-        const { response, body } = await this.senderApi.getSenders();
-
-        if (response.statusCode !== 200) {
-            throw new Error("Failed to get senders");
+            return senders as BrevoApiSender[] | undefined;
+        } catch (error) {
+            handleBrevoError(error);
         }
-
-        return body.senders as BrevoApiSender[];
     }
 }

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-transactional-mails.service.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-transactional-mails.service.ts
@@ -1,51 +1,26 @@
-import * as Brevo from "@getbrevo/brevo";
+import { Brevo } from "@getbrevo/brevo";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { BrevoConfigInterface } from "src/brevo-config/entities/brevo-config-entity.factory";
 import { EmailCampaignScopeInterface } from "src/types";
 
-import { BrevoModuleConfig } from "../config/brevo-module.config";
-import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
 import { handleBrevoError } from "./brevo-api.utils";
+import { BrevoApiClientFactory } from "./brevo-api-client.factory";
 import { BrevoApiEmailTemplateList } from "./dto/brevo-api-email-templates-list";
-
-type SendTransacEmailResponse = ReturnType<Brevo.TransactionalEmailsApi["sendTransacEmail"]>;
 
 @Injectable()
 export class BrevoTransactionalMailsService {
-    private readonly transactionalEmailsApi = new Map<string, Brevo.TransactionalEmailsApi>();
-
     constructor(
-        @Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig,
         @InjectRepository("BrevoConfig") private readonly brevoConfigRepository: EntityRepository<BrevoConfigInterface>,
+        private readonly clientFactory: BrevoApiClientFactory,
     ) {}
 
-    private getTransactionalEmailsApi(scope: EmailCampaignScopeInterface): Brevo.TransactionalEmailsApi {
-        try {
-            const existingTransactionalEmailsApiForScope = this.transactionalEmailsApi.get(JSON.stringify(scope));
-
-            if (existingTransactionalEmailsApiForScope) {
-                return existingTransactionalEmailsApiForScope;
-            }
-
-            const { apiKey } = this.config.brevo.resolveConfig(scope);
-            const transactionalEmailApi = new Brevo.TransactionalEmailsApi();
-            transactionalEmailApi.setApiKey(Brevo.TransactionalEmailsApiApiKeys.apiKey, apiKey);
-
-            this.transactionalEmailsApi.set(JSON.stringify(scope), transactionalEmailApi);
-
-            return transactionalEmailApi;
-        } catch (error) {
-            handleBrevoError(error);
-        }
-    }
-
-    async send(options: Omit<Brevo.SendSmtpEmail, "sender">, scope: EmailCampaignScopeInterface): SendTransacEmailResponse {
+    async send(options: Omit<Brevo.SendTransacEmailRequest, "sender">, scope: EmailCampaignScopeInterface): Promise<Brevo.SendTransacEmailResponse> {
         try {
             const brevoConfig = await this.brevoConfigRepository.findOneOrFail({ scope });
 
-            return this.getTransactionalEmailsApi(scope).sendTransacEmail({
+            return this.clientFactory.getClient(scope).transactionalEmails.sendTransacEmail({
                 ...options,
                 sender: { name: brevoConfig.senderName, email: brevoConfig.senderMail },
             });
@@ -56,14 +31,9 @@ export class BrevoTransactionalMailsService {
 
     public async getEmailTemplates(scope: EmailCampaignScopeInterface): Promise<BrevoApiEmailTemplateList> {
         try {
-            const transactionalEmailsApi = this.getTransactionalEmailsApi(scope);
-            const { response, body } = await transactionalEmailsApi.getSmtpTemplates(true);
+            const templates = await this.clientFactory.getClient(scope).transactionalEmails.getSmtpTemplates({ templateStatus: true });
 
-            if (response.statusCode !== 200) {
-                throw new Error("Failed to get templates");
-            }
-
-            return body as BrevoApiEmailTemplateList;
+            return templates as BrevoApiEmailTemplateList;
         } catch (error) {
             handleBrevoError(error);
         }

--- a/packages/api/brevo-api/src/brevo-api/brevo-api.module.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api.module.ts
@@ -4,6 +4,7 @@ import { Module } from "@nestjs/common";
 
 import { ConfigModule } from "../config/config.module";
 import { BrevoApiCampaignsService } from "./brevo-api-campaigns.service";
+import { BrevoApiClientFactory } from "./brevo-api-client.factory";
 import { BrevoApiContactsService } from "./brevo-api-contact.service";
 import { BrevoApiFoldersService } from "./brevo-api-folders.service";
 import { BrevoApiSenderService } from "./brevo-api-sender.service";
@@ -11,7 +12,14 @@ import { BrevoTransactionalMailsService } from "./brevo-api-transactional-mails.
 
 @Module({
     imports: [ConfigModule, CacheModule.register({ ttl: 1000 * 60 }), MikroOrmModule.forFeature(["BrevoConfig"])],
-    providers: [BrevoApiContactsService, BrevoApiCampaignsService, BrevoTransactionalMailsService, BrevoApiSenderService, BrevoApiFoldersService],
+    providers: [
+        BrevoApiClientFactory,
+        BrevoApiContactsService,
+        BrevoApiCampaignsService,
+        BrevoTransactionalMailsService,
+        BrevoApiSenderService,
+        BrevoApiFoldersService,
+    ],
     exports: [BrevoApiContactsService, BrevoApiCampaignsService, BrevoTransactionalMailsService, BrevoApiSenderService, BrevoApiFoldersService],
 })
 export class BrevoApiModule {}

--- a/packages/api/brevo-api/src/brevo-api/brevo-api.utils.spec.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api.utils.spec.ts
@@ -1,0 +1,45 @@
+import { Brevo, BrevoError } from "@getbrevo/brevo";
+import { describe, expect, it } from "vitest";
+
+import { handleBrevoError, isErrorFromBrevo } from "./brevo-api.utils";
+
+describe("brevo-api.utils", () => {
+    describe("isErrorFromBrevo", () => {
+        it("returns true for a BrevoError", () => {
+            expect(isErrorFromBrevo(new Brevo.NotFoundError({ code: "not_found", message: "Contact does not exist" }))).toBe(true);
+        });
+
+        it("returns false for a plain error or arbitrary value", () => {
+            expect(isErrorFromBrevo(new Error("boom"))).toBe(false);
+            expect(isErrorFromBrevo({ statusCode: 404 })).toBe(false);
+            expect(isErrorFromBrevo(undefined)).toBe(false);
+        });
+    });
+
+    describe("handleBrevoError", () => {
+        it("throws an Error with the message from the Brevo response body", () => {
+            const error = new Brevo.BadRequestError({ code: "invalid_parameter", message: "Invalid email address" });
+
+            expect(() => handleBrevoError(error)).toThrowError("Invalid email address");
+        });
+
+        it("falls back to the error message when the body has no message", () => {
+            const error = new BrevoError({ message: "Something went wrong", statusCode: 500 });
+
+            expect(() => handleBrevoError(error)).toThrowError(error.message);
+        });
+
+        it("rethrows a non-Brevo error unchanged", () => {
+            const error = new Error("network down");
+
+            let caught: unknown;
+            try {
+                handleBrevoError(error);
+            } catch (e) {
+                caught = e;
+            }
+
+            expect(caught).toBe(error);
+        });
+    });
+});

--- a/packages/api/brevo-api/src/brevo-api/brevo-api.utils.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api.utils.ts
@@ -1,15 +1,13 @@
-import type { ErrorModel } from "@getbrevo/brevo";
-import axios, { type AxiosError } from "axios";
+import { BrevoError } from "@getbrevo/brevo";
 
-type AxiosErrorWithResponse<T = unknown> = AxiosError<T> & { response: NonNullable<AxiosError<T>["response"]> };
-
-export function isErrorFromBrevo(error: unknown): error is AxiosErrorWithResponse<ErrorModel> {
-    return axios.isAxiosError(error) && error.response !== undefined && "code" in error.response.data && "message" in error.response.data;
+export function isErrorFromBrevo(error: unknown): error is BrevoError {
+    return error instanceof BrevoError;
 }
 
 export function handleBrevoError(error: unknown): never {
     if (isErrorFromBrevo(error)) {
-        throw new Error(error.response.data.message);
+        const message = (error.body as { message?: string } | undefined)?.message ?? error.message;
+        throw new Error(message);
     } else {
         throw error;
     }

--- a/packages/api/brevo-api/src/brevo-api/dto/brevo-api-campaign.ts
+++ b/packages/api/brevo-api/src/brevo-api/dto/brevo-api-campaign.ts
@@ -1,4 +1,4 @@
-import type { GetEmailCampaignsCampaignsInner } from "@getbrevo/brevo";
+import type { Brevo } from "@getbrevo/brevo";
 
 interface BrevoStatistics {
     uniqueClicks: number;
@@ -19,8 +19,8 @@ export interface BrevoApiCampaign {
     id: number;
     name: string;
     subject?: string;
-    type: GetEmailCampaignsCampaignsInner.TypeEnum;
-    status: GetEmailCampaignsCampaignsInner.StatusEnum;
+    type: Brevo.GetEmailCampaignResponse.Type;
+    status: Brevo.GetEmailCampaignResponse.Status;
     statistics: {
         globalStats: BrevoStatistics; // Overall statistics of the campaign
         campaignStats: BrevoStatistics[]; // List-wise statistics of the campaign.

--- a/packages/api/brevo-api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/brevo-api/src/brevo-contact/brevo-contacts.service.ts
@@ -82,12 +82,7 @@ export class BrevoContactsService {
             }
 
             if (contactSource) {
-                const created = await this.brevoContactsApiService.createBrevoContactWithoutDoubleOptIn(
-                    { email, attributes },
-                    brevoIds,
-                    templateId,
-                    scope,
-                );
+                const created = await this.brevoContactsApiService.createBrevoContactWithoutDoubleOptIn({ email, attributes }, brevoIds, scope);
                 if (created) {
                     await this.brevoEmailImportLogService.addContactToLogs(email, responsibleUserId, scope, contactSource);
                     return SubscribeResponse.SUCCESSFUL;

--- a/packages/api/brevo-api/src/email-campaign/email-campaigns.service.ts
+++ b/packages/api/brevo-api/src/email-campaign/email-campaigns.service.ts
@@ -1,5 +1,5 @@
 import { BlocksTransformerService, filtersToMikroOrmQuery, searchToMikroOrmQuery } from "@comet/cms-api";
-import { UpdateCampaignStatus } from "@getbrevo/brevo";
+import { Brevo } from "@getbrevo/brevo";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository, ObjectQuery, wrap } from "@mikro-orm/postgresql";
 import { HttpService } from "@nestjs/axios";
@@ -98,7 +98,7 @@ export class EmailCampaignsService {
     }
 
     async suspendEmailCampaign(campaign: EmailCampaignInterface): Promise<boolean> {
-        return this.brevoApiCampaignService.updateBrevoCampaignStatus(campaign, UpdateCampaignStatus.StatusEnum.Suspended);
+        return this.brevoApiCampaignService.updateBrevoCampaignStatus(campaign, Brevo.UpdateCampaignStatus.Status.Suspended);
     }
 
     public async loadEmailCampaignSendingStatesForEmailCampaigns(

--- a/packages/api/brevo-api/vitest.config.ts
+++ b/packages/api/brevo-api/vitest.config.ts
@@ -1,8 +1,15 @@
+import swc from "unplugin-swc";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+    plugins: [
+        // The SWC plugin is required to emit decorator metadata.
+        // See https://github.com/vitest-dev/vitest/discussions/3320.
+        swc.vite(),
+    ],
     test: {
         environment: "node",
+        setupFiles: ["./vitest.setup.ts"],
         reporters: ["default", "junit"],
         outputFile: { junit: "./junit.xml" },
     },

--- a/packages/api/brevo-api/vitest.setup.ts
+++ b/packages/api/brevo-api/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "reflect-metadata";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,7 +505,7 @@ importers:
         version: 5.9.3
       vite-tsconfig-paths:
         specifier: ^6.0.4
-        version: 6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
+        version: 6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
@@ -967,7 +967,7 @@ importers:
         version: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: ^6.0.4
-        version: 6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
+        version: 6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
@@ -1823,7 +1823,7 @@ importers:
         version: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: ^6.0.3
-        version: 6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
+        version: 6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
@@ -1912,8 +1912,8 @@ importers:
         specifier: ^5.0.7
         version: 5.0.7
       '@getbrevo/brevo':
-        specifier: ^3.0.4
-        version: 3.0.4
+        specifier: ^5.0.4
+        version: 5.0.4
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.1)(rxjs@7.8.2)
@@ -5062,17 +5062,9 @@ packages:
     resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@2.1.4':
-    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/js@8.57.1':
-    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@eslint/js@9.39.4':
     resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
@@ -5215,8 +5207,9 @@ packages:
       ts-jest:
         optional: true
 
-  '@getbrevo/brevo@3.0.4':
-    resolution: {integrity: sha512-MtsqqsB9MjMEDYKP3QBHGRJmYbUBHCYH2RxA4DHeB8sbm0TEraoaiOfng0kBebPplR9WSvf6jXw+ri10bGP/aA==}
+  '@getbrevo/brevo@5.0.4':
+    resolution: {integrity: sha512-wN4mHE6O0Pb/d/Dh3E4MAm2zCHbLLUcFF8/wgwTeMPy9KzHBYLu7S/nsJbzd0AWL09MHn8vwue8ULL9YOzluOQ==}
+    engines: {node: '>=18.0.0'}
 
   '@golevelup/nestjs-discovery@5.0.0':
     resolution: {integrity: sha512-NaIWLCLI+XvneUK05LH2idHLmLNITYT88YnpOuUQmllKtiJNIS3woSt7QXrMZ5k3qUWuZpehEVz1JtlX4I1KyA==}
@@ -5637,18 +5630,9 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanwhocodes/config-array@0.13.0':
-    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
-    engines: {node: '>=10.10.0'}
-    deprecated: Use @eslint/config-array instead
-
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
-
-  '@humanwhocodes/object-schema@2.0.3':
-    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
-    deprecated: Use @eslint/object-schema instead
 
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
@@ -9745,9 +9729,6 @@ packages:
   bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
-  bluebird@3.7.2:
-    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
-
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -11428,10 +11409,6 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
-  eslint-scope@7.2.2:
-    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -11447,12 +11424,6 @@ packages:
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  eslint@8.57.1:
-    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
 
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
@@ -11719,10 +11690,6 @@ packages:
   file-entry-cache@10.1.4:
     resolution: {integrity: sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==}
 
-  file-entry-cache@6.0.1:
-    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -11809,10 +11776,6 @@ packages:
   find-up@6.3.0:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  flat-cache@3.2.0:
-    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -12072,10 +12035,6 @@ packages:
   global-prefix@3.0.0:
     resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
     engines: {node: '>=6'}
-
-  globals@13.24.0:
-    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
-    engines: {node: '>=8'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -15862,9 +15821,6 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rewire@7.0.0:
-    resolution: {integrity: sha512-DyyNyzwMtGYgu0Zl/ya0PR/oaunM+VuCuBxCuhYJHHaV0V+YvYa3bBGxb5OZ71vndgmp1pYY8F4YOwQo1siRGw==}
-
   rfc4648@1.5.2:
     resolution: {integrity: sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg==}
 
@@ -16752,9 +16708,6 @@ packages:
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
-  text-table@0.2.0:
-    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-
   thingies@2.5.0:
     resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
     engines: {node: '>=10.18'}
@@ -16986,10 +16939,6 @@ packages:
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
-
-  type-fest@0.20.2:
-    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
-    engines: {node: '>=10'}
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -17386,6 +17335,11 @@ packages:
 
   vite-tsconfig-paths@6.0.4:
     resolution: {integrity: sha512-iIsEJ+ek5KqRTK17pmxtgIxXtqr3qDdE6OxrP9mVeGhVDNXRJTKN/l9oMbujTQNzMLe6XZ8qmpztfbkPu2TiFQ==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -21134,11 +21088,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
-    dependencies:
-      eslint: 8.57.1
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
@@ -21162,20 +21111,6 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@2.1.4':
-    dependencies:
-      ajv: 6.14.0
-      debug: 4.4.3
-      espree: 9.6.1
-      globals: 13.24.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.5
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
@@ -21189,8 +21124,6 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@eslint/js@8.57.1': {}
 
   '@eslint/js@9.39.4': {}
 
@@ -21338,14 +21271,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
 
-  '@getbrevo/brevo@3.0.4':
-    dependencies:
-      axios: 1.16.1
-      bluebird: 3.7.2
-      rewire: 7.0.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
+  '@getbrevo/brevo@5.0.4': {}
 
   '@golevelup/nestjs-discovery@5.0.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)':
     dependencies:
@@ -22036,17 +21962,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanwhocodes/config-array@0.13.0':
-    dependencies:
-      '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3
-      minimatch: 3.1.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@humanwhocodes/module-importer@1.0.1': {}
-
-  '@humanwhocodes/object-schema@2.0.3': {}
 
   '@humanwhocodes/retry@0.4.3': {}
 
@@ -26805,8 +26721,6 @@ snapshots:
 
   bluebird@3.4.7: {}
 
-  bluebird@3.7.2: {}
-
   body-parser@1.20.4:
     dependencies:
       bytes: 3.1.2
@@ -28701,11 +28615,6 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
-  eslint-scope@7.2.2:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -28716,49 +28625,6 @@ snapshots:
   eslint-visitor-keys@4.2.1: {}
 
   eslint-visitor-keys@5.0.1: {}
-
-  eslint@8.57.1:
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      '@ungap/structured-clone': 1.2.0
-      ajv: 6.14.0
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.24.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.5
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
 
   eslint@9.39.4(jiti@2.7.0):
     dependencies:
@@ -29149,10 +29015,6 @@ snapshots:
     dependencies:
       flat-cache: 6.1.14
 
-  file-entry-cache@6.0.1:
-    dependencies:
-      flat-cache: 3.2.0
-
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -29258,12 +29120,6 @@ snapshots:
     dependencies:
       locate-path: 7.2.0
       path-exists: 5.0.0
-
-  flat-cache@3.2.0:
-    dependencies:
-      flatted: 3.3.3
-      keyv: 4.5.4
-      rimraf: 3.0.2
 
   flat-cache@4.0.1:
     dependencies:
@@ -29566,10 +29422,6 @@ snapshots:
       ini: 1.3.8
       kind-of: 6.0.3
       which: 1.3.1
-
-  globals@13.24.0:
-    dependencies:
-      type-fest: 0.20.2
 
   globals@14.0.0: {}
 
@@ -34226,12 +34078,6 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rewire@7.0.0:
-    dependencies:
-      eslint: 8.57.1
-    transitivePeerDependencies:
-      - supports-color
-
   rfc4648@1.5.2: {}
 
   rfdc@1.4.1: {}
@@ -35387,8 +35233,6 @@ snapshots:
     dependencies:
       b4a: 1.6.7
 
-  text-table@0.2.0: {}
-
   thingies@2.5.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
@@ -35590,8 +35434,6 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-detect@4.1.0: {}
-
-  type-fest@0.20.2: {}
 
   type-fest@0.21.3: {}
 
@@ -36031,26 +35873,16 @@ snapshots:
       pathe: 0.2.0
       vite: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
 
-  vite-tsconfig-paths@6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3):
+  vite-tsconfig-paths@6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
+    optionalDependencies:
       vite: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
     transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
       - supports-color
-      - terser
-      - tsx
       - typescript
-      - yaml
 
   vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1984,6 +1984,12 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)
+      '@nestjs/testing':
+        specifier: ^11.1.21
+        version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(@nestjs/platform-express@11.1.21)
+      '@swc/core':
+        specifier: ^1.15.40
+        version: 1.15.41
       '@types/inquirer':
         specifier: ^8.2.12
         version: 8.2.12
@@ -2020,6 +2026,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      unplugin-swc:
+        specifier: ^1.5.9
+        version: 1.5.9(@swc/core@1.15.41)(rollup@4.59.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)


### PR DESCRIPTION
Upgrade the `@getbrevo/brevo` SDK from v2 to v5. 

The key change is how the Brevo APIs are accessed:

Previously:

```ts
const campaignsApi = new Brevo.EmailCampaignsApi();
campaignsApi.setApiKey(Brevo.EmailCampaignsApiApiKeys.apiKey, apiKey);

campaignsApi.createEmailCampaign({ ... });
```

Now:

```ts
const client = new BrevoClient({ apiKey });

await client.emailCampaigns.createEmailCampaign({ ... });
```

-> The API key is set per client, not per service. Add a new `BrevoApiClientFactory` factory that creates and caches `BrevoClient` instances per scope to address this change.

Other noteworthy changes:
- Remove the `templateId` parameter from `createBrevoContactWithoutDoubleOptIn()` as it's not used by the API
- Change `BrevoTransactionalMailsService.send()` to accept `SendTransacEmailRequest` instead of `SendSmtpEmail`

## Further Information

- Task: https://vivid-planet.atlassian.net/browse/COM-3022
- Session: https://claude.ai/code/session_01HQqFdURZ1BZ8ZsQuig88hh