### PR TITLE
Draft: Brevo API Scope Check Fix

### DIFF
--- a/.changeset/fix-brevo-contact-resolver-scope-check.md
+++ b/.changeset/fix-brevo-contact-resolver-scope-check.md
@@ -1,0 +1,9 @@
+---
+"@comet/brevo-api": patch
+---
+
+Enforce the content scope on the Brevo contact and contact-import resolvers
+
+`BrevoContactResolver` and `BrevoContactImportResolver` were declared with `@RequiredPermission(["brevoNewsletter"], { skipScopeCheck: true })`. With `skipScopeCheck`, the guard only verified that the caller held the `brevoNewsletter` permission in _some_ scope, not in the scope passed in the request. In a multi-scope setup, a newsletter editor permissioned for one scope could therefore read, modify, delete, import, and trigger sends against the contacts of any other scope by passing that scope in the GraphQL arguments.
+
+The resolvers now enforce the scope like their `BrevoTargetGroupResolver` and `EmailCampaignsResolver` siblings: the scope argument is checked against the caller's permissions. `manuallyAssignedBrevoContacts`, which has no scope argument, resolves its scope from the referenced target group.

--- a/.changeset/fix-brevo-contact-resolver-scope-check.md
+++ b/.changeset/fix-brevo-contact-resolver-scope-check.md
@@ -2,8 +2,11 @@
 "@comet/brevo-api": patch
 ---
 
-Enforce the content scope on the Brevo contact and contact-import resolvers
+Enforce the content scope on the Brevo contact, contact-import, and config resolvers
 
-`BrevoContactResolver` and `BrevoContactImportResolver` were declared with `@RequiredPermission(["brevoNewsletter"], { skipScopeCheck: true })`. With `skipScopeCheck`, the guard only verified that the caller held the `brevoNewsletter` permission in _some_ scope, not in the scope passed in the request. In a multi-scope setup, a newsletter editor permissioned for one scope could therefore read, modify, delete, import, and trigger sends against the contacts of any other scope by passing that scope in the GraphQL arguments.
+Several Brevo resolver operations were declared with `{ skipScopeCheck: true }`. With `skipScopeCheck`, the guard only verified that the caller held the permission in _some_ scope, not in the scope passed in the request. In a multi-scope setup, an editor permissioned for one scope could therefore operate on another scope's data by passing that scope in the GraphQL arguments:
 
-The resolvers now enforce the scope like their `BrevoTargetGroupResolver` and `EmailCampaignsResolver` siblings: the scope argument is checked against the caller's permissions. `manuallyAssignedBrevoContacts`, which has no scope argument, resolves its scope from the referenced target group.
+- `BrevoContactResolver` and `BrevoContactImportResolver` (`brevoNewsletter`) — read, modify, delete, import, and trigger sends against the contacts of any other scope.
+- `brevoSenders` and `brevoDoubleOptInTemplates` on `BrevoConfigResolver` (`brevoNewsletterConfig`) — read the configured senders and double-opt-in templates of any other scope.
+
+These operations now enforce the scope like their `BrevoTargetGroupResolver` and `EmailCampaignsResolver` siblings: the scope argument is checked against the caller's permissions. `manuallyAssignedBrevoContacts`, which has no scope argument, resolves its scope from the referenced target group.

--- a/packages/api/brevo-api/package.json
+++ b/packages/api/brevo-api/package.json
@@ -63,6 +63,7 @@
         "@nestjs/core": "^11.1.21",
         "@nestjs/graphql": "^13.4.0",
         "@nestjs/platform-express": "^11.1.21",
+        "@swc/core": "^1.15.40",
         "@types/inquirer": "^8.2.12",
         "@types/lodash.isequal": "^4.5.8",
         "chokidar-cli": "^2.1.0",
@@ -75,6 +76,7 @@
         "rxjs": "^7.8.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
+        "unplugin-swc": "^1.5.9",
         "vitest": "^4.1.8"
     },
     "peerDependencies": {

--- a/packages/api/brevo-api/src/brevo-config/brevo-config.resolver.spec.ts
+++ b/packages/api/brevo-api/src/brevo-config/brevo-config.resolver.spec.ts
@@ -9,6 +9,9 @@ import type { BrevoConfigInterface } from "./entities/brevo-config-entity.factor
 // Metadata key read by cms-api's UserPermissionsGuard to determine the required permission.
 // It is not exported from @comet/cms-api, so it is referenced here by its stable string value.
 const REQUIRED_PERMISSION_METADATA_KEY = "requiredPermission";
+// Set by @nestjs/graphql's @Query/@Mutation on the method, holding the resolver type ("Query" | "Mutation").
+// Used to discover a resolver's GraphQL operations so newly added ones are checked automatically.
+const RESOLVER_TYPE_METADATA_KEY = "graphql:resolver_type";
 
 type RequiredPermissionMetadata = { requiredPermission: string[]; options?: { skipScopeCheck?: boolean } };
 
@@ -25,25 +28,41 @@ const getRequiredPermission = (target: object): RequiredPermissionMetadata | und
 
 const getPrototypeMember = (resolver: object, member: string): object => (resolver as { prototype: Record<string, object> }).prototype[member];
 
+// Discovers the resolver's GraphQL operations (queries and mutations) so newly added operations are
+// covered by the scope-check assertions automatically, instead of relying on a hand-maintained list.
+const getGraphQLOperations = (resolver: object): string[] => {
+    const prototype = (resolver as { prototype: object }).prototype;
+    return Object.getOwnPropertyNames(prototype).filter((member) => {
+        if (member === "constructor") {
+            return false;
+        }
+        const resolverType = Reflect.getMetadata(RESOLVER_TYPE_METADATA_KEY, getPrototypeMember(resolver, member));
+        return resolverType === "Query" || resolverType === "Mutation";
+    });
+};
+
 // Mirrors Reflector.getAllAndOverride([handler, class]) used by the guard: a method-level
 // decorator overrides the class-level one.
 const getEffectiveRequiredPermission = (resolver: object, operation: string): RequiredPermissionMetadata | undefined =>
     getRequiredPermission(getPrototypeMember(resolver, operation)) ?? getRequiredPermission(resolver);
 
-const configOperations = [
-    "brevoSenders",
-    "brevoDoubleOptInTemplates",
-    "isBrevoConfigDefined",
-    "brevoConfig",
-    "createBrevoConfig",
-    "updateBrevoConfig",
-];
+// Operations that are intentionally exposed without a content-scope check. Adding an entry here is a
+// deliberate security decision: the operation must be safe to call across all scopes.
+const operationsExemptFromScopeCheck: string[] = [];
+
+const configOperations = getGraphQLOperations(BrevoConfigResolver).filter((operation) => !operationsExemptFromScopeCheck.includes(operation));
 
 describe("BrevoConfigResolver authorization", () => {
     it("requires the scope-checked brevoNewsletterConfig permission on the resolver", () => {
         const permission = getRequiredPermission(BrevoConfigResolver);
         expect(permission?.requiredPermission).toEqual(["brevoNewsletterConfig"]);
         expect(permission?.options?.skipScopeCheck ?? false).toBe(false);
+    });
+
+    it("discovers the resolver's GraphQL operations", () => {
+        // Guards against the metadata key drifting and silently turning the per-operation checks
+        // below into a no-op (it.each([]) passes vacuously).
+        expect(configOperations.length).toBeGreaterThan(0);
     });
 
     it.each(configOperations)("enforces the content scope on %s", (operation) => {

--- a/packages/api/brevo-api/src/brevo-config/brevo-config.resolver.spec.ts
+++ b/packages/api/brevo-api/src/brevo-config/brevo-config.resolver.spec.ts
@@ -1,0 +1,52 @@
+import "reflect-metadata";
+
+import type { Type } from "@nestjs/common";
+import { describe, expect, it } from "vitest";
+
+import { createBrevoConfigResolver } from "./brevo-config.resolver";
+import type { BrevoConfigInterface } from "./entities/brevo-config-entity.factory";
+
+// Metadata key read by cms-api's UserPermissionsGuard to determine the required permission.
+// It is not exported from @comet/cms-api, so it is referenced here by its stable string value.
+const REQUIRED_PERMISSION_METADATA_KEY = "requiredPermission";
+
+type RequiredPermissionMetadata = { requiredPermission: string[]; options?: { skipScopeCheck?: boolean } };
+
+class Scope {
+    domain: string;
+    language: string;
+}
+const BrevoConfig = class BrevoConfig {} as unknown as Type<BrevoConfigInterface>;
+
+const BrevoConfigResolver = createBrevoConfigResolver({ Scope, BrevoConfig });
+
+const getRequiredPermission = (target: object): RequiredPermissionMetadata | undefined =>
+    Reflect.getMetadata(REQUIRED_PERMISSION_METADATA_KEY, target);
+
+const getPrototypeMember = (resolver: object, member: string): object => (resolver as { prototype: Record<string, object> }).prototype[member];
+
+// Mirrors Reflector.getAllAndOverride([handler, class]) used by the guard: a method-level
+// decorator overrides the class-level one.
+const getEffectiveRequiredPermission = (resolver: object, operation: string): RequiredPermissionMetadata | undefined =>
+    getRequiredPermission(getPrototypeMember(resolver, operation)) ?? getRequiredPermission(resolver);
+
+const configOperations = [
+    "brevoSenders",
+    "brevoDoubleOptInTemplates",
+    "isBrevoConfigDefined",
+    "brevoConfig",
+    "createBrevoConfig",
+    "updateBrevoConfig",
+];
+
+describe("BrevoConfigResolver authorization", () => {
+    it("requires the scope-checked brevoNewsletterConfig permission on the resolver", () => {
+        const permission = getRequiredPermission(BrevoConfigResolver);
+        expect(permission?.requiredPermission).toEqual(["brevoNewsletterConfig"]);
+        expect(permission?.options?.skipScopeCheck ?? false).toBe(false);
+    });
+
+    it.each(configOperations)("enforces the content scope on %s", (operation) => {
+        expect(getEffectiveRequiredPermission(BrevoConfigResolver, operation)?.options?.skipScopeCheck ?? false).toBe(false);
+    });
+});

--- a/packages/api/brevo-api/src/brevo-config/brevo-config.resolver.ts
+++ b/packages/api/brevo-api/src/brevo-config/brevo-config.resolver.ts
@@ -69,7 +69,6 @@ export function createBrevoConfigResolver({
             return false;
         }
 
-        @RequiredPermission("brevoNewsletterConfig", { skipScopeCheck: true })
         @Query(() => [BrevoApiSender], { nullable: true })
         async brevoSenders(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
@@ -79,7 +78,6 @@ export function createBrevoConfigResolver({
             return senders;
         }
 
-        @RequiredPermission("brevoNewsletterConfig", { skipScopeCheck: true })
         @Query(() => [BrevoApiEmailTemplate], { nullable: true })
         async brevoDoubleOptInTemplates(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))

--- a/packages/api/brevo-api/src/brevo-contact/brevo-contact-import.resolver.ts
+++ b/packages/api/brevo-api/src/brevo-contact/brevo-contact-import.resolver.ts
@@ -24,7 +24,7 @@ export function createBrevoContactImportResolver({
     class BrevoContactImportArgs extends BrevoContactImportArgsFactory.create({ Scope }) {}
 
     @Resolver(() => BrevoContact)
-    @RequiredPermission(["brevoNewsletter"], { skipScopeCheck: true })
+    @RequiredPermission(["brevoNewsletter"])
     class BrevoContactImportResolver {
         constructor(
             @Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig,

--- a/packages/api/brevo-api/src/brevo-contact/brevo-contact.module.ts
+++ b/packages/api/brevo-api/src/brevo-contact/brevo-contact.module.ts
@@ -51,6 +51,7 @@ export class BrevoContactModule {
             BrevoContactInput,
             BrevoContactUpdateInput,
             BrevoTestContactInput,
+            BrevoTargetGroup,
         });
 
         const BrevoContactImportResolver = createBrevoContactImportResolver({ Scope, BrevoContact });

--- a/packages/api/brevo-api/src/brevo-contact/brevo-contact.resolver.spec.ts
+++ b/packages/api/brevo-api/src/brevo-contact/brevo-contact.resolver.spec.ts
@@ -1,0 +1,99 @@
+import "reflect-metadata";
+
+import type { Type } from "@nestjs/common";
+import { describe, expect, it } from "vitest";
+
+import type { TargetGroupInterface } from "../target-group/entity/target-group-entity.factory";
+import { createBrevoContactResolver } from "./brevo-contact.resolver";
+import { createBrevoContactImportResolver } from "./brevo-contact-import.resolver";
+import { BrevoContactFactory } from "./dto/brevo-contact.factory";
+import { BrevoContactInputFactory } from "./dto/brevo-contact-input.factory";
+import { BrevoTestContactInputFactory } from "./dto/brevo-test-contact-input.factory";
+import { SubscribeInputFactory } from "./dto/subscribe-input.factory";
+
+// Metadata keys read by cms-api's UserPermissionsGuard / ContentScopeService to determine the
+// required permission and the affected content scope. They are not exported from @comet/cms-api,
+// so they are referenced here by their stable string values.
+const REQUIRED_PERMISSION_METADATA_KEY = "requiredPermission";
+const AFFECTED_ENTITY_METADATA_KEY = "affectedEntities";
+
+class Scope {
+    domain: string;
+    language: string;
+}
+const BrevoTargetGroup = class BrevoTargetGroup {} as unknown as Type<TargetGroupInterface>;
+
+const BrevoContact = BrevoContactFactory.create({});
+const BrevoContactSubscribeInput = SubscribeInputFactory.create({ Scope });
+const [BrevoContactInput, BrevoContactUpdateInput] = BrevoContactInputFactory.create({ Scope });
+const [BrevoTestContactInput] = BrevoTestContactInputFactory.create({ Scope });
+
+const BrevoContactResolver = createBrevoContactResolver({
+    BrevoContact,
+    BrevoContactSubscribeInput,
+    Scope,
+    BrevoContactInput,
+    BrevoContactUpdateInput,
+    BrevoTestContactInput,
+    BrevoTargetGroup,
+});
+
+const BrevoContactImportResolver = createBrevoContactImportResolver({ Scope, BrevoContact });
+
+type RequiredPermissionMetadata = { requiredPermission: string[]; options?: { skipScopeCheck?: boolean } };
+
+const getRequiredPermission = (target: object): RequiredPermissionMetadata | undefined =>
+    Reflect.getMetadata(REQUIRED_PERMISSION_METADATA_KEY, target);
+
+const getPrototypeMember = (resolver: object, member: string): object => (resolver as { prototype: Record<string, object> }).prototype[member];
+
+// Mirrors Reflector.getAllAndOverride([handler, class]) used by the guard: a method-level
+// decorator overrides the class-level one.
+const getEffectiveRequiredPermission = (resolver: object, operation: string): RequiredPermissionMetadata | undefined =>
+    getRequiredPermission(getPrototypeMember(resolver, operation)) ?? getRequiredPermission(resolver);
+
+const expectScopeCheckEnforced = (permission: RequiredPermissionMetadata | undefined) => {
+    expect(permission?.requiredPermission).toEqual(["brevoNewsletter"]);
+    expect(permission?.options?.skipScopeCheck ?? false).toBe(false);
+};
+
+const contactOperations = [
+    "brevoContact",
+    "brevoContacts",
+    "brevoTestContacts",
+    "manuallyAssignedBrevoContacts",
+    "updateBrevoContact",
+    "createBrevoContact",
+    "createBrevoTestContact",
+    "deleteBrevoContact",
+    "deleteBrevoTestContact",
+    "subscribeBrevoContact",
+];
+
+describe("BrevoContactResolver authorization", () => {
+    it("requires the scope-checked brevoNewsletter permission on the resolver", () => {
+        expectScopeCheckEnforced(getRequiredPermission(BrevoContactResolver));
+    });
+
+    it.each(contactOperations)("enforces the content scope on %s", (operation) => {
+        expectScopeCheckEnforced(getEffectiveRequiredPermission(BrevoContactResolver, operation));
+    });
+
+    it("resolves the content scope of manuallyAssignedBrevoContacts from its target group", () => {
+        // manuallyAssignedBrevoContacts has no scope argument, so the scope must be resolved from the
+        // referenced target group for the guard to be able to enforce it.
+        const affectedEntities = Reflect.getMetadata(
+            AFFECTED_ENTITY_METADATA_KEY,
+            getPrototypeMember(BrevoContactResolver, "manuallyAssignedBrevoContacts"),
+        );
+        expect(affectedEntities).toHaveLength(1);
+        expect(affectedEntities[0].entity).toBe(BrevoTargetGroup);
+        expect(affectedEntities[0].options.idArg).toBe("targetGroupId");
+    });
+});
+
+describe("BrevoContactImportResolver authorization", () => {
+    it("enforces the content scope on startBrevoContactImport", () => {
+        expectScopeCheckEnforced(getEffectiveRequiredPermission(BrevoContactImportResolver, "startBrevoContactImport"));
+    });
+});

--- a/packages/api/brevo-api/src/brevo-contact/brevo-contact.resolver.spec.ts
+++ b/packages/api/brevo-api/src/brevo-contact/brevo-contact.resolver.spec.ts
@@ -16,6 +16,9 @@ import { SubscribeInputFactory } from "./dto/subscribe-input.factory";
 // so they are referenced here by their stable string values.
 const REQUIRED_PERMISSION_METADATA_KEY = "requiredPermission";
 const AFFECTED_ENTITY_METADATA_KEY = "affectedEntities";
+// Set by @nestjs/graphql's @Query/@Mutation on the method, holding the resolver type ("Query" | "Mutation").
+// Used to discover a resolver's GraphQL operations so newly added ones are checked automatically.
+const RESOLVER_TYPE_METADATA_KEY = "graphql:resolver_type";
 
 class Scope {
     domain: string;
@@ -47,6 +50,19 @@ const getRequiredPermission = (target: object): RequiredPermissionMetadata | und
 
 const getPrototypeMember = (resolver: object, member: string): object => (resolver as { prototype: Record<string, object> }).prototype[member];
 
+// Discovers the resolver's GraphQL operations (queries and mutations) so newly added operations are
+// covered by the scope-check assertions automatically, instead of relying on a hand-maintained list.
+const getGraphQLOperations = (resolver: object): string[] => {
+    const prototype = (resolver as { prototype: object }).prototype;
+    return Object.getOwnPropertyNames(prototype).filter((member) => {
+        if (member === "constructor") {
+            return false;
+        }
+        const resolverType = Reflect.getMetadata(RESOLVER_TYPE_METADATA_KEY, getPrototypeMember(resolver, member));
+        return resolverType === "Query" || resolverType === "Mutation";
+    });
+};
+
 // Mirrors Reflector.getAllAndOverride([handler, class]) used by the guard: a method-level
 // decorator overrides the class-level one.
 const getEffectiveRequiredPermission = (resolver: object, operation: string): RequiredPermissionMetadata | undefined =>
@@ -57,22 +73,21 @@ const expectScopeCheckEnforced = (permission: RequiredPermissionMetadata | undef
     expect(permission?.options?.skipScopeCheck ?? false).toBe(false);
 };
 
-const contactOperations = [
-    "brevoContact",
-    "brevoContacts",
-    "brevoTestContacts",
-    "manuallyAssignedBrevoContacts",
-    "updateBrevoContact",
-    "createBrevoContact",
-    "createBrevoTestContact",
-    "deleteBrevoContact",
-    "deleteBrevoTestContact",
-    "subscribeBrevoContact",
-];
+// Operations that are intentionally exposed without a content-scope check. Adding an entry here is a
+// deliberate security decision: the operation must be safe to call across all scopes.
+const operationsExemptFromScopeCheck: string[] = [];
+
+const contactOperations = getGraphQLOperations(BrevoContactResolver).filter((operation) => !operationsExemptFromScopeCheck.includes(operation));
 
 describe("BrevoContactResolver authorization", () => {
     it("requires the scope-checked brevoNewsletter permission on the resolver", () => {
         expectScopeCheckEnforced(getRequiredPermission(BrevoContactResolver));
+    });
+
+    it("discovers the resolver's GraphQL operations", () => {
+        // Guards against the metadata key drifting and silently turning the per-operation checks
+        // below into a no-op (it.each([]) passes vacuously).
+        expect(contactOperations.length).toBeGreaterThan(0);
     });
 
     it.each(contactOperations)("enforces the content scope on %s", (operation) => {
@@ -93,7 +108,13 @@ describe("BrevoContactResolver authorization", () => {
 });
 
 describe("BrevoContactImportResolver authorization", () => {
-    it("enforces the content scope on startBrevoContactImport", () => {
-        expectScopeCheckEnforced(getEffectiveRequiredPermission(BrevoContactImportResolver, "startBrevoContactImport"));
+    const importOperations = getGraphQLOperations(BrevoContactImportResolver);
+
+    it("discovers the resolver's GraphQL operations", () => {
+        expect(importOperations.length).toBeGreaterThan(0);
+    });
+
+    it.each(importOperations)("enforces the content scope on %s", (operation) => {
+        expectScopeCheckEnforced(getEffectiveRequiredPermission(BrevoContactImportResolver, operation));
     });
 });

--- a/packages/api/brevo-api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/brevo-api/src/brevo-contact/brevo-contact.resolver.ts
@@ -30,6 +30,7 @@ export function createBrevoContactResolver({
     BrevoContactInput,
     BrevoContactUpdateInput,
     BrevoTestContactInput,
+    BrevoTargetGroup,
 }: {
     BrevoContact: Type<BrevoContactInterface>;
     BrevoContactSubscribeInput: Type<SubscribeInputInterface>;
@@ -37,6 +38,7 @@ export function createBrevoContactResolver({
     BrevoContactUpdateInput: Type<Partial<BrevoContactInputInterface>>;
     BrevoTestContactInput: Type<BrevoTestContactInputInterface>;
     Scope: Type<EmailCampaignScopeInterface>;
+    BrevoTargetGroup: Type<TargetGroupInterface>;
 }): Type<unknown> {
     @ObjectType()
     class PaginatedBrevoContacts extends PaginatedResponseFactory.create(BrevoContact) {}
@@ -45,7 +47,7 @@ export function createBrevoContactResolver({
     class BrevoContactsArgs extends BrevoContactsArgsFactory.create({ Scope }) {}
 
     @Resolver(() => BrevoContact)
-    @RequiredPermission(["brevoNewsletter"], { skipScopeCheck: true })
+    @RequiredPermission(["brevoNewsletter"])
     class BrevoContactResolver {
         constructor(
             @Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig,
@@ -58,7 +60,6 @@ export function createBrevoContactResolver({
         ) {}
 
         @Query(() => BrevoContact)
-        @AffectedEntity(BrevoContact)
         async brevoContact(
             @Args("id", { type: () => Int }) id: number,
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
@@ -128,6 +129,7 @@ export function createBrevoContactResolver({
         }
 
         @Query(() => PaginatedBrevoContacts)
+        @AffectedEntity(BrevoTargetGroup, { idArg: "targetGroupId" })
         async manuallyAssignedBrevoContacts(
             @Args() { offset, limit, email, targetGroupId }: ManuallyAssignedBrevoContactsArgs,
         ): Promise<PaginatedBrevoContacts> {
@@ -155,7 +157,6 @@ export function createBrevoContactResolver({
         }
 
         @Mutation(() => BrevoContact)
-        @AffectedEntity(BrevoContact)
         async updateBrevoContact(
             @Args("id", { type: () => Int }) id: number,
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
@@ -204,7 +205,6 @@ export function createBrevoContactResolver({
         }
 
         @Mutation(() => SubscribeResponse)
-        @RequiredPermission(["brevoNewsletter"], { skipScopeCheck: true })
         async createBrevoContact(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
             @Args("input", { type: () => BrevoContactInput })
@@ -230,7 +230,6 @@ export function createBrevoContactResolver({
         }
 
         @Mutation(() => SubscribeResponse)
-        @RequiredPermission(["brevoNewsletter"], { skipScopeCheck: true })
         async createBrevoTestContact(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
             @Args("input", { type: () => BrevoTestContactInput })
@@ -275,7 +274,6 @@ export function createBrevoContactResolver({
         }
 
         @Mutation(() => Boolean)
-        @AffectedEntity(BrevoContact)
         async deleteBrevoContact(
             @Args("id", { type: () => Int }) id: number,
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
@@ -309,7 +307,6 @@ export function createBrevoContactResolver({
         }
 
         @Mutation(() => Boolean)
-        @AffectedEntity(BrevoContact)
         async deleteBrevoTestContact(
             @Args("id", { type: () => Int }) id: number,
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,

--- a/packages/api/brevo-api/vitest.config.ts
+++ b/packages/api/brevo-api/vitest.config.ts
@@ -1,8 +1,23 @@
+import swc from "unplugin-swc";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+    resolve: {
+        // NestJS internally `require`s the CJS build of `graphql`. Force Vite to
+        // resolve it the same way so `instanceof` checks across module boundaries
+        // (e.g. for `GraphQLScalarType`) work as expected.
+        alias: {
+            graphql: "graphql/index.js",
+        },
+    },
+    plugins: [
+        // The SWC plugin is required to emit decorator metadata.
+        // See https://github.com/vitest-dev/vitest/discussions/3320.
+        swc.vite(),
+    ],
     test: {
         environment: "node",
+        setupFiles: ["./vitest.setup.ts"],
         reporters: ["default", "junit"],
         outputFile: { junit: "./junit.xml" },
     },

--- a/packages/api/brevo-api/vitest.setup.ts
+++ b/packages/api/brevo-api/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "reflect-metadata";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1984,6 +1984,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)
+      '@swc/core':
+        specifier: ^1.15.40
+        version: 1.15.41
       '@types/inquirer':
         specifier: ^8.2.12
         version: 8.2.12
@@ -2020,6 +2023,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      unplugin-swc:
+        specifier: ^1.5.9
+        version: 1.5.9(@swc/core@1.15.41)(rollup@4.59.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)


### PR DESCRIPTION
# Enforce content scope on Brevo resolvers (cross-scope authorization bypass)

## Problem

Several `@comet/brevo-api` operations were declared with `@RequiredPermission(..., { skipScopeCheck: true })` while accepting a client-supplied `scope` argument. With `skipScopeCheck`, the guard only verifies the caller holds the permission in _some_ scope — not the scope passed in the request. In a multi-scope deployment, an editor permissioned for one scope could act on another scope's data simply by passing it in the GraphQL arguments (cross-tenant authorization bypass).

Affected operations:

- **`BrevoContactResolver`** and **`BrevoContactImportResolver`** (`brevoNewsletter`) — read, modify, delete, import contacts and trigger sends in another scope (contact PII).
- **`brevoSenders`** and **`brevoDoubleOptInTemplates`** on **`BrevoConfigResolver`** (`brevoNewsletterConfig`) — read another scope's configured senders and double-opt-in templates.

## Solution

Remove `skipScopeCheck` so the `scope` argument is enforced, matching the `BrevoTargetGroupResolver` / `EmailCampaignsResolver` siblings. `manuallyAssignedBrevoContacts` has no `scope` argument, so it resolves its scope from the referenced target group via `@AffectedEntity(BrevoTargetGroup, { idArg: "targetGroupId" })`.

The `@AffectedEntity(BrevoContact)` decorators are removed: `BrevoContact` is a remote GraphQL type, not a scoped DB entity, so they were dead code under `skipScopeCheck` and would crash scope resolution.

## Verification

Added regression tests asserting no operation skips the scope check (reintroducing `skipScopeCheck` fails the suite). `@comet/brevo-api` had no test harness, so `vitest.config.ts` was aligned with `@comet/cms-api`'s (SWC plugin + setup; deps already used there).

Reproduced against the Demo for two scopes (`main/en`, `main/de`) via raw GraphQL. As a **Non-Admin** scoped to `main/en` only:

| Query                         | `main/en` (authorized) | `main/de` (not authorized) |
| ----------------------------- | ---------------------- | -------------------------- |
| `brevoContacts`               | 200, data              | **`FORBIDDEN`**            |
| `brevoSenders`                | 200, data              | **`FORBIDDEN`**            |
| `brevoDoubleOptInTemplates`   | 200, data              | **`FORBIDDEN`**            |
| `brevoTargetGroups` (control) | 200, data              | `FORBIDDEN`                |

An all-scopes Admin still reaches `main/de`, so the fix is not over-broad. The GraphQL schema is unchanged (guard-level metadata only), and all callers already supply `BrevoTargetGroup` to the module.

## Out of scope (follow-ups)

- `updateBrevoEmailCampaign` assigns `targetGroups` from input IDs without checking they belong to the campaign's scope — separate relation-integrity concern.
- `generateAltText` / `generateImageTitle` in `@comet/cms-api` share the same `skipScopeCheck` pattern — separate package.