### PR TITLE
brevo-api: verify that schema.gql is up-to-date

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,4 +59,5 @@ jobs:
                   # check if schema files are up to date
                   pnpm --filter '@comet/cms-api' run generate-block-meta
                   pnpm --filter '@comet/cms-api' run generate-schema
+                  pnpm --filter '@comet/brevo-api' run generate-schema
                   git diff --exit-code HEAD --

--- a/packages/api/brevo-api/schema.gql
+++ b/packages/api/brevo-api/schema.gql
@@ -23,6 +23,7 @@ enum Permission {
   warnings
   sitePreview
   blockPreview
+  fullTextSearch
   brevoNewsletterConfig
   brevoNewsletter
 }
@@ -31,6 +32,13 @@ enum Permission {
 The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
 scalar JSONObject @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+type EntityInfo {
+  id: String!
+  entityName: String!
+  name: String!
+  secondaryInformation: String
+}
 
 type Dependency {
   rootId: String!


### PR DESCRIPTION
Add the same check we have for `@comet/cms-api` to verify that the generated schema.gql is up-to-date.

https://claude.ai/code/session_01QDkEAzjx522prBZZ13GuQn