### PR TITLE
admin: Add a consumer override API to Future UI

### DIFF
--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -25,13 +25,14 @@ Any export may change or be removed at any time, without deprecation notice. Eve
 ### Exports
 
 - Props are exported as an interface named `<ComponentName>Props`, never a type alias.
+- The resolved configuration is exported as a type named `<ComponentName>OwnerState`.
 - The component is exported as `<ComponentName>`.
 
 ### TSDoc
 
 Components and utilities are documented in TSDoc on the export itself, so the docs ship with the package, get picked up by Storybook, and stay next to the code.
 
-Keep each comment as close as possible to what it describes: the component comment says what the component is for, while a prop's description and its `@defaultValue` go on the prop. Say what a feature does, not how (leave out the rendered element, prop forwarding, the base-ui foundation) and not why (the commit carries that); don't merely restate the name. Keep it as short as the feature allows.
+Keep each comment as close as possible to what it describes: the component comment says what the component is for, while a prop's description and its `@defaultValue` go on the prop. Say what a feature does, not how (leave out the rendered element, prop forwarding, the base-ui foundation) and not why (the commit carries that); don't merely restate the name. Keep it as short as the feature allows. The shared override-API members — `className`, `slots`, `slotProps`, and the `OwnerState` type — share the wording shown below, extended only where a component needs more detail.
 
 ```tsx
 /**
@@ -41,6 +42,14 @@ export function Button(props: ButtonProps) {
     // ...
 }
 
+/**
+ * The resolved configuration that influences the component's appearance or behavior.
+ */
+export type ButtonOwnerState = {
+    variant: "primary" | "secondary";
+    disabled: boolean;
+};
+
 export interface ButtonProps {
     /**
      * Use `primary` only for the single main action on a page, dialog, etc.
@@ -48,6 +57,12 @@ export interface ButtonProps {
      * @defaultValue `"primary"`
      */
     variant?: "primary" | "secondary";
+    /** Added alongside the component's own classes. */
+    className?: string;
+    /** Sets which element a named inner part renders as. */
+    slots?: ButtonSlots;
+    /** Props for each slot, merged with the slot's own props rather than replacing them. */
+    slotProps?: ButtonSlotProps;
 }
 ```
 
@@ -55,8 +70,16 @@ A change that makes a comment inaccurate updates it in the same change.
 
 ### Root element props
 
-- A component extends the props of its root element and forwards the ones it doesn't handle itself to that element, so a consumer can set any attribute or event handler the root element accepts without a dedicated prop for each.
-- A consumer-set `className` is merged with the contract classes, never replacing them.
+A component extends the props of its root element and passes the ones it doesn't handle itself to that element, so a consumer can set any attribute or event handler the root element accepts without us maintaining a dedicated prop for each. By default it doesn't re-declare or document them; they stay as the root element defines them. It may still re-declare one to support it as a documented feature.
+
+### Override props
+
+Future UI's exported components share one set of override props; each offers the ones that apply to it. The [class-name contract](#class-name-contract) is the primary way to style a component; these props do what it can't — place and swap inner parts, and set or vary their props.
+
+- **`className`** — a string, merged with the contract classes, never replacing them. It is not a function: every value in `ownerState` already emits a modifier class, so an `ownerState`-dependent class would add nothing.
+- **`slots`** — sets which element a named inner part renders as. The root is not a slot — it is the component's own outermost element, configured through the component's top-level props directly (`className`, event handlers, ARIA, …).
+- **`slotProps`** — props for those same inner parts, as an object **or** a function of `ownerState`. They are merged with the component's own props, so a contract class or handler is never dropped.
+- **`ownerState`** — one object per component: the resolved configuration (`variant`, `disabled`, …) that influences the component's appearance or behavior; the root modifier classes are derived from it. It holds no transient interaction state (hover/press/focus).
 
 ### Class-name contract
 

--- a/packages/admin/admin/src/future-ui/components/button/Button.module.scss
+++ b/packages/admin/admin/src/future-ui/components/button/Button.module.scss
@@ -2,6 +2,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 0.5rem;
     padding-block: 0.5rem;
     padding-inline: 1rem;
     border: none;
@@ -26,4 +27,11 @@
         cursor: not-allowed;
         opacity: 0.5;
     }
+}
+
+.startIcon,
+.endIcon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }

--- a/packages/admin/admin/src/future-ui/components/button/Button.tsx
+++ b/packages/admin/admin/src/future-ui/components/button/Button.tsx
@@ -53,9 +53,9 @@ export interface ButtonProps extends Omit<BaseButton.Props, "className"> {
     slots?: ButtonSlots;
     /** Props for each slot, merged with the slot's own props rather than replacing them. */
     slotProps?: ButtonSlotProps;
-    /** Content rendered before `children`. */
+    /** The icon to render before the button's text. */
     startIcon?: ReactNode;
-    /** Content rendered after `children`. */
+    /** The icon to render after the button's text. */
     endIcon?: ReactNode;
 }
 

--- a/packages/admin/admin/src/future-ui/components/button/Button.tsx
+++ b/packages/admin/admin/src/future-ui/components/button/Button.tsx
@@ -1,12 +1,62 @@
 import { Button as BaseButton } from "@base-ui/react/button";
 import { clsx } from "clsx";
+import type { ElementType, ReactNode } from "react";
 
+import { resolveSlotProps, type SlotPropsValue } from "../../utils/slotProps";
 import styles from "./Button.module.scss";
+
+type ButtonVariant = "primary" | "secondary";
+
+/**
+ * The resolved configuration that influences the component's appearance or behavior.
+ *
+ * @experimental
+ */
+export type ButtonOwnerState = {
+    variant: ButtonVariant;
+    disabled: boolean;
+};
+
+interface ButtonSlots {
+    /**
+     * Element for the `startIcon` slot.
+     *
+     * @defaultValue `span`
+     */
+    startIcon?: ElementType;
+    /**
+     * Element for the `endIcon` slot.
+     *
+     * @defaultValue `span`
+     */
+    endIcon?: ElementType;
+}
+
+interface ButtonSlotProps {
+    /** Props for the `startIcon` slot. */
+    startIcon?: SlotPropsValue<ButtonOwnerState, "span">;
+    /** Props for the `endIcon` slot. */
+    endIcon?: SlotPropsValue<ButtonOwnerState, "span">;
+}
 
 /** @experimental */
 export interface ButtonProps extends Omit<BaseButton.Props, "className"> {
+    /**
+     * Visual style.
+     *
+     * @defaultValue `"primary"`
+     */
+    variant?: ButtonVariant;
+    /** Added alongside the component's own classes. */
     className?: string;
-    variant?: "primary" | "secondary";
+    /** Sets which element a named inner part renders as. */
+    slots?: ButtonSlots;
+    /** Props for each slot, merged with the slot's own props rather than replacing them. */
+    slotProps?: ButtonSlotProps;
+    /** Content rendered before `children`. */
+    startIcon?: ReactNode;
+    /** Content rendered after `children`. */
+    endIcon?: ReactNode;
 }
 
 /**
@@ -14,21 +64,42 @@ export interface ButtonProps extends Omit<BaseButton.Props, "className"> {
  *
  * @experimental
  */
-export function Button({ disabled, type = "button", variant = "primary", className, children, ...restProps }: ButtonProps) {
+export function Button({
+    disabled = false,
+    type = "button",
+    variant = "primary",
+    className,
+    slots,
+    slotProps,
+    startIcon,
+    endIcon,
+    children,
+    ...restProps
+}: ButtonProps) {
+    const ownerState: ButtonOwnerState = { variant, disabled };
+
+    const StartIconSlot = slots?.startIcon ?? "span";
+    const EndIconSlot = slots?.endIcon ?? "span";
+
+    const startIconProps = resolveSlotProps<ButtonOwnerState, "span">({ className: styles.startIcon }, slotProps?.startIcon, ownerState);
+    const endIconProps = resolveSlotProps<ButtonOwnerState, "span">({ className: styles.endIcon }, slotProps?.endIcon, ownerState);
+
     return (
         <BaseButton
             {...restProps}
             type={type}
-            disabled={disabled}
+            disabled={ownerState.disabled}
             className={clsx(
                 styles.root,
-                variant === "primary" && styles["root--variantPrimary"],
-                variant === "secondary" && styles["root--variantSecondary"],
-                disabled && styles["root--disabled"],
+                ownerState.variant === "primary" && styles["root--variantPrimary"],
+                ownerState.variant === "secondary" && styles["root--variantSecondary"],
+                ownerState.disabled && styles["root--disabled"],
                 className,
             )}
         >
+            {startIcon != null && <StartIconSlot {...startIconProps}>{startIcon}</StartIconSlot>}
             {children}
+            {endIcon != null && <EndIconSlot {...endIconProps}>{endIcon}</EndIconSlot>}
         </BaseButton>
     );
 }

--- a/packages/admin/admin/src/future-ui/components/button/__stories__/Button.stories.tsx
+++ b/packages/admin/admin/src/future-ui/components/button/__stories__/Button.stories.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight, Favorite } from "@comet/admin-icons";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Button } from "../Button";
@@ -22,5 +23,33 @@ export const Secondary: Story = {
     args: {
         children: "Button",
         variant: "secondary",
+    },
+};
+
+/**
+ * `startIcon` and `endIcon` accept any `ReactNode`.
+ */
+export const WithIcons: Story = {
+    render: () => (
+        <div style={{ display: "flex", gap: "1rem" }}>
+            <Button startIcon={<Favorite />}>Start only</Button>
+            <Button endIcon={<ArrowRight />}>End only</Button>
+            <Button startIcon={<Favorite />} endIcon={<ArrowRight />}>
+                Both
+            </Button>
+        </div>
+    ),
+};
+
+/**
+ * Native button props (`onClick`, ARIA attributes, `type`, …) are part of
+ * the top-level surface.
+ */
+export const WithClickHandler: Story = {
+    args: {
+        children: "Click me",
+        onClick: () => {
+            window.alert("Clicked");
+        },
     },
 };

--- a/packages/admin/admin/src/future-ui/index.ts
+++ b/packages/admin/admin/src/future-ui/index.ts
@@ -1,2 +1,2 @@
-export { Button, type ButtonProps } from "./components/button/Button";
+export { Button, type ButtonOwnerState, type ButtonProps } from "./components/button/Button";
 export { Typography, type TypographyProps } from "./components/typography/Typography";

--- a/packages/admin/admin/src/future-ui/utils/slotProps.ts
+++ b/packages/admin/admin/src/future-ui/utils/slotProps.ts
@@ -1,0 +1,24 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import type { ComponentPropsWithRef, ElementType } from "react";
+
+export type SlotPropsValue<OwnerState, T extends ElementType> = ComponentPropsWithRef<T> | ((ownerState: OwnerState) => ComponentPropsWithRef<T>);
+
+function isOwnerStateFunction<OwnerState, T extends ElementType>(
+    value: SlotPropsValue<OwnerState, T> | undefined,
+): value is (ownerState: OwnerState) => ComponentPropsWithRef<T> {
+    return typeof value === "function";
+}
+
+/**
+ * Resolves a slot's `slotProps` value — calling it with `ownerState` when it's a
+ * function — then merges it with the slot's own props via `mergeProps`.
+ */
+export function resolveSlotProps<OwnerState, T extends ElementType>(
+    ownProps: ComponentPropsWithRef<T>,
+    value: SlotPropsValue<OwnerState, T> | undefined,
+    ownerState: OwnerState,
+) {
+    const consumerProps = isOwnerStateFunction(value) ? value(ownerState) : value;
+
+    return mergeProps<T>(ownProps, consumerProps);
+}


### PR DESCRIPTION
Future UI components style themselves through a class-name contract, but consumers had no React-level way to swap an inner element or set attributes that depend on component state. This adds `slots`, `slotProps`, and `ownerState` alongside the existing `className`, used first on `Button`'s icons.

- **Inner parts are exposed as props and slots, not as compound components** (`<Button.StartIcon>`) — compound parts are `base-ui`'s idiom for multi-part components, but they're verbose, can be misordered or duplicated, and TypeScript can't restrict `children` to them.
- **`slotProps` can be a function of `ownerState`; `className` can't** — only a function sets the `aria-*`/`data-*` attributes the class contract can't express, and a state-dependent class string is redundant since the contract already emits a class per state.
- **The logic that resolves and merges slot props is a shared helper, not Button-local** — later slotted components reuse it, and centralizing the merge stops a reordered spread from dropping a contract class.
- **Modifier classes and `slotProps` callbacks read one `ownerState` object** — a consumer's callback always sees the same resolved values the component used to style itself.
- **The resolved-config object is named `ownerState`, MUI's term, not `base-ui`'s `state`** — `state` looks like React state.

---

Tasks: https://vivid-planet.atlassian.net/browse/COM-2973 https://vivid-planet.atlassian.net/browse/COM-3014