### PR TITLE
cms-admin: Add global ContentScopeProvider storybook decorator

### DIFF
--- a/packages/admin/cms-admin/.storybook/decorators/ContentScopeProvider.decorator.tsx
+++ b/packages/admin/cms-admin/.storybook/decorators/ContentScopeProvider.decorator.tsx
@@ -1,0 +1,17 @@
+import type { Decorator } from "@storybook/react-vite";
+
+import { ContentScopeProvider } from "../../src/contentScope/Provider";
+
+export const ContentScopeProviderDecorator: Decorator = (Story, context) => {
+    if (context.parameters.skipContentScopeProvider) {
+        return <Story />;
+    }
+    return (
+        <ContentScopeProvider
+            values={[{ scope: { domain: "main", language: "en" }, label: { domain: "Main", language: "English" } }]}
+            defaultValue={{ domain: "main", language: "en" }}
+        >
+            {() => <Story />}
+        </ContentScopeProvider>
+    );
+};

--- a/packages/admin/cms-admin/.storybook/decorators/ContentScopeProvider.decorator.tsx
+++ b/packages/admin/cms-admin/.storybook/decorators/ContentScopeProvider.decorator.tsx
@@ -1,16 +1,17 @@
 import type { Decorator } from "@storybook/react-vite";
 
 import { ContentScopeProvider } from "../../src/contentScope/Provider";
+import type { ContentScopeParameters } from "../../src/storybook";
+
+const defaultContentScope: Required<ContentScopeParameters> = {
+    values: [{ scope: { domain: "main", language: "en" }, label: { domain: "Main", language: "English" } }],
+    defaultValue: { domain: "main", language: "en" },
+};
 
 export const ContentScopeProviderDecorator: Decorator = (Story, context) => {
-    if (context.parameters.skipContentScopeProvider) {
-        return <Story />;
-    }
+    const { values, defaultValue } = (context.parameters.contentScope ?? {}) as ContentScopeParameters;
     return (
-        <ContentScopeProvider
-            values={[{ scope: { domain: "main", language: "en" }, label: { domain: "Main", language: "English" } }]}
-            defaultValue={{ domain: "main", language: "en" }}
-        >
+        <ContentScopeProvider values={values ?? defaultContentScope.values} defaultValue={defaultValue ?? defaultContentScope.defaultValue}>
             {() => <Story />}
         </ContentScopeProvider>
     );

--- a/packages/admin/cms-admin/.storybook/preview.ts
+++ b/packages/admin/cms-admin/.storybook/preview.ts
@@ -3,6 +3,7 @@ import { type GlobalTypes } from "storybook/internal/csf";
 
 import { ApolloDecorator } from "./decorators/Apollo.decorator";
 import { CometConfigProviderDecorator } from "./decorators/CometConfigProvider.decorator";
+import { ContentScopeProviderDecorator } from "./decorators/ContentScopeProvider.decorator";
 import { CurrentUserProviderDecorator } from "./decorators/CurrentUserProvider.decorator";
 import { DndProviderDecorator } from "./decorators/DndProvider.decorator";
 import { IntlDecorator, LocaleOption } from "./decorators/IntlProvider.decorator";
@@ -56,7 +57,18 @@ export const globalTypes: GlobalTypes = {
 
 const preview: Preview = {
     tags: ["autodocs"],
-    decorators: [ThemeProviderDecorator, IntlDecorator, LayoutDecorator, RouterDecorator, CometConfigProviderDecorator, SnackbarDecorator, DndProviderDecorator, CurrentUserProviderDecorator, ApolloDecorator],
+    decorators: [
+        ThemeProviderDecorator,
+        IntlDecorator,
+        LayoutDecorator,
+        ContentScopeProviderDecorator,
+        RouterDecorator,
+        CometConfigProviderDecorator,
+        SnackbarDecorator,
+        DndProviderDecorator,
+        CurrentUserProviderDecorator,
+        ApolloDecorator,
+    ],
     loaders: [
         async () => {
             await mswReady;

--- a/packages/admin/cms-admin/src/contentScope/__stories__/ContentScopeProvider.stories.tsx
+++ b/packages/admin/cms-admin/src/contentScope/__stories__/ContentScopeProvider.stories.tsx
@@ -1,69 +1,71 @@
 import { AppHeader, AppHeaderMenuButton, CometLogo, FillSpace, MainContent } from "@comet/admin";
 import { Typography } from "@mui/material";
-import type { Meta } from "@storybook/react-vite";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import type { ContentScopeParameters } from "../../storybook";
 import { ContentScopeIndicator } from "../ContentScopeIndicator";
 import { ContentScopeControls } from "../Controls";
-import { ContentScopeProvider, type ContentScopeValues, useContentScope } from "../Provider";
+import { ContentScopeProvider, useContentScope } from "../Provider";
 
+const optionalDimensions: ContentScopeParameters = {
+    values: [
+        { scope: { organizationId: "organization-1" }, label: { organizationId: "Organization 1" } },
+        { scope: { organizationId: "organization-2" }, label: { organizationId: "Organization 2" } },
+        { scope: { channelId: "channel-1" }, label: { channelId: "Channel 1" } },
+        { scope: { channelId: "channel-2" }, label: { channelId: "Channel 2" } },
+    ],
+    defaultValue: { organizationId: "organization-1" },
+};
+
+type Story = StoryObj<typeof ContentScopeProvider>;
 const config: Meta<typeof ContentScopeProvider> = {
     component: ContentScopeProvider,
     title: "contentScope/ContentScopeProvider",
-    parameters: { skipContentScopeProvider: true },
+    parameters: {
+        contentScope: optionalDimensions,
+    },
 };
 
 export default config;
 
-export const OptionalDimensions = {
+function PrintContentScope() {
+    const { scope } = useContentScope();
+
+    return <>{JSON.stringify(scope)}</>;
+}
+
+export const OptionalDimensions: Story = {
     render: () => {
-        const values: ContentScopeValues = [
-            { scope: { organizationId: "organization-1" }, label: { organizationId: "Organization 1" } },
-            { scope: { organizationId: "organization-2" }, label: { organizationId: "Organization 2" } },
-            { scope: { channelId: "channel-1" }, label: { channelId: "Channel 1" } },
-            { scope: { channelId: "channel-2" }, label: { channelId: "Channel 2" } },
-        ];
-
-        function PrintContentScope() {
-            const { scope } = useContentScope();
-
-            return <>{JSON.stringify(scope)}</>;
-        }
+        const { match } = useContentScope();
 
         return (
-            <ContentScopeProvider values={values} defaultValue={{ organizationId: "organization-1" }}>
-                {({ match }) => {
-                    return (
-                        <>
-                            <AppHeader position="relative" headerHeight={60}>
-                                <AppHeaderMenuButton />
-                                <CometLogo />
-                                <FillSpace />
-                                <ContentScopeControls />
-                            </AppHeader>
-                            <MainContent>
-                                <ContentScopeIndicator />
-                                <Typography gutterBottom>
-                                    This is a development story to test optional scope dimensions in the content scope provider. Try changing the
-                                    scope in the content scope select.
-                                </Typography>
-                                <Typography>
-                                    Path: <strong>{match.path}</strong>
-                                </Typography>
-                                <Typography>
-                                    URL: <strong>{match.url}</strong>
-                                </Typography>
-                                <Typography>
-                                    Scope:{" "}
-                                    <strong>
-                                        <PrintContentScope />
-                                    </strong>
-                                </Typography>
-                            </MainContent>
-                        </>
-                    );
-                }}
-            </ContentScopeProvider>
+            <>
+                <AppHeader position="relative" headerHeight={60}>
+                    <AppHeaderMenuButton />
+                    <CometLogo />
+                    <FillSpace />
+                    <ContentScopeControls />
+                </AppHeader>
+                <MainContent>
+                    <ContentScopeIndicator />
+                    <Typography gutterBottom>
+                        This is a development story to test optional scope dimensions in the content scope provider. Try changing the scope in the
+                        content scope select.
+                    </Typography>
+                    <Typography>
+                        Path: <strong>{match.path}</strong>
+                    </Typography>
+                    <Typography>
+                        URL: <strong>{match.url}</strong>
+                    </Typography>
+                    <Typography>
+                        Scope:{" "}
+                        <strong>
+                            <PrintContentScope />
+                        </strong>
+                    </Typography>
+                </MainContent>
+            </>
         );
     },
-    name: "Optional dimensions",
 };

--- a/packages/admin/cms-admin/src/contentScope/__stories__/ContentScopeProvider.stories.tsx
+++ b/packages/admin/cms-admin/src/contentScope/__stories__/ContentScopeProvider.stories.tsx
@@ -9,6 +9,7 @@ import { ContentScopeProvider, type ContentScopeValues, useContentScope } from "
 const config: Meta<typeof ContentScopeProvider> = {
     component: ContentScopeProvider,
     title: "contentScope/ContentScopeProvider",
+    parameters: { skipContentScopeProvider: true },
 };
 
 export default config;

--- a/packages/admin/cms-admin/src/storybook.d.ts
+++ b/packages/admin/cms-admin/src/storybook.d.ts
@@ -1,0 +1,10 @@
+import type { ContentScopeProviderProps } from "./contentScope/Provider";
+
+export type ContentScopeParameters = Pick<ContentScopeProviderProps, "values" | "defaultValue">;
+
+declare module "storybook/internal/types" {
+    interface Parameters {
+        // Configures the scope provided by the global ContentScopeProviderDecorator.
+        contentScope?: ContentScopeParameters;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a global Storybook decorator for `ContentScopeProvider`. Stories no longer need to wrap themselves in a `ContentScopeProvider` — every story gets a default content scope automatically.

Stories that need a custom content scope (e.g. `ContentScopeProvider.stories.tsx`, which tests custom dimensions) can set it via the `contentScope` parameter.

## Why

Reduces boilerplate in stories that consume scope-aware components. Most existing and upcoming cms-admin stories need `useContentScope()` to work; previously each set up its own provider.

---
_Generated by [Claude Code](https://claude.ai/code/session_012YKxucGjjtFStey4ZggbDi)_