### PR TITLE
Add ActionLog.previousVersion and use it for ActionLogVersionGrid row click

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -7,6 +7,11 @@ type ActionLog {
   entityId: ID!
   entityName: String!
   id: ID!
+
+  """
+  The most recent earlier action log entry for the same entity. Null when this is the first version.
+  """
+  previousVersion: ActionLog
   scope: [JSONObject!]
   snapshot: JSONObject
 

--- a/packages/admin/cms-admin/.storybook/mocks/actionLogDialogHandler.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/actionLogDialogHandler.ts
@@ -9,6 +9,7 @@ const mockGridNodes = [
         version: 3,
         type: "Updated",
         createdAt: "2023-10-03T12:00:00Z",
+        previousVersion: { __typename: "ActionLog", id: "log2" },
     },
     {
         __typename: "ActionLog",
@@ -18,6 +19,7 @@ const mockGridNodes = [
         version: 2,
         type: "Updated",
         createdAt: "2023-10-02T12:00:00Z",
+        previousVersion: { __typename: "ActionLog", id: "log1" },
     },
     {
         __typename: "ActionLog",
@@ -27,6 +29,7 @@ const mockGridNodes = [
         version: 1,
         type: "Created",
         createdAt: "2023-10-01T12:00:00Z",
+        previousVersion: null,
     },
 ];
 

--- a/packages/admin/cms-admin/src/actionLog/actionLog/actionLogVersionGrid/ActionLogVersionGrid.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/actionLog/actionLogVersionGrid/ActionLogVersionGrid.gql.ts
@@ -11,5 +11,8 @@ export const actionLogVersionGridFragment = gql`
         version
         type
         createdAt
+        previousVersion {
+            id
+        }
     }
 `;

--- a/packages/admin/cms-admin/src/actionLog/actionLog/actionLogVersionGrid/ActionLogVersionGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLog/actionLogVersionGrid/ActionLogVersionGrid.tsx
@@ -160,7 +160,13 @@ export const ActionLogVersionGrid: FunctionComponent<ActionLogVersionGridProps> 
                     return selectionModel.ids.size < 2;
                 }}
                 loading={loading}
-                onRowClick={({ row }) => onShowVersionClick(row.id)}
+                onRowClick={({ row }) => {
+                    if (row.previousVersion) {
+                        onCompareVersionsClick(row.previousVersion.id, row.id);
+                    } else {
+                        onShowVersionClick(row.id);
+                    }
+                }}
                 onRowSelectionModelChange={(newSelectionModel) => {
                     setSelectionModel(newSelectionModel);
                 }}

--- a/packages/admin/cms-admin/src/actionLog/actionLog/actionLogVersionGrid/__stories__/ActionLogVersionGrid.stories.tsx
+++ b/packages/admin/cms-admin/src/actionLog/actionLog/actionLogVersionGrid/__stories__/ActionLogVersionGrid.stories.tsx
@@ -15,6 +15,7 @@ const mockActionLogs: { totalCount: number; nodes: GQLActionLogVersionGridFragme
             version: 4,
             type: "Updated",
             createdAt: "2023-10-04T12:00:00Z",
+            previousVersion: { id: "log3" },
         },
         {
             id: "log3",
@@ -23,6 +24,7 @@ const mockActionLogs: { totalCount: number; nodes: GQLActionLogVersionGridFragme
             version: 3,
             type: "Updated",
             createdAt: "2023-10-03T12:00:00Z",
+            previousVersion: { id: "log2" },
         },
         {
             id: "log2",
@@ -31,6 +33,7 @@ const mockActionLogs: { totalCount: number; nodes: GQLActionLogVersionGridFragme
             version: 2,
             type: "Updated",
             createdAt: "2023-10-02T12:00:00Z",
+            previousVersion: { id: "log1" },
         },
         {
             id: "log1",
@@ -39,6 +42,7 @@ const mockActionLogs: { totalCount: number; nodes: GQLActionLogVersionGridFragme
             version: 1,
             type: "Created",
             createdAt: "2023-10-01T12:00:00Z",
+            previousVersion: null,
         },
     ],
 };

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -58,6 +58,11 @@ type ActionLog {
   createdAt: DateTime!
 
   """
+  The most recent earlier action log entry for the same entity. Null when this is the first version.
+  """
+  previousVersion: ActionLog
+
+  """
   Derived from snapshot and version: snapshot null → Deleted, version 1 → Created, otherwise → Updated.
   """
   type: ActionLogType!

--- a/packages/api/cms-api/src/action-logs/action-logs.module.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.module.ts
@@ -8,13 +8,14 @@ import { ActionLogsService } from "./action-logs.service";
 import { ActionLogsSubscriber } from "./action-logs.subscriber";
 import { ActionLogsFeatureModule } from "./action-logs-feature.module";
 import { ActionLog } from "./entities/action-log.entity";
+import { PreviousActionLogLoaderService } from "./previous-action-log-loader.service";
 
 export class ActionLogsModule {
     static forRoot(): DynamicModule {
         return {
             module: ActionLogsModule,
             imports: [MikroOrmModule.forFeature([ActionLog])],
-            providers: [ActionLogsSubscriber, ActionLogsService, ActionLogsResolver],
+            providers: [ActionLogsSubscriber, ActionLogsService, ActionLogsResolver, PreviousActionLogLoaderService],
         };
     }
 

--- a/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
@@ -4,10 +4,25 @@ import { UserPermissionsService } from "../user-permissions/user-permissions.ser
 import { ActionLogType } from "./dto/action-log-type.enum";
 import { ActionLogsUser } from "./dto/action-logs-user";
 import { ActionLog } from "./entities/action-log.entity";
+import { PreviousActionLogLoaderService } from "./previous-action-log-loader.service";
 
 @Resolver(() => ActionLog)
 export class ActionLogsResolver {
-    constructor(private readonly userPermissionsService: UserPermissionsService) {}
+    constructor(
+        private readonly userPermissionsService: UserPermissionsService,
+        private readonly previousActionLogLoader: PreviousActionLogLoaderService,
+    ) {}
+
+    @ResolveField(() => ActionLog, {
+        nullable: true,
+        description: "The most recent earlier action log entry for the same entity. Null when this is the first version.",
+    })
+    async previousVersion(@Parent() actionLog: ActionLog): Promise<ActionLog | null> {
+        if (actionLog.version <= 1) {
+            return null;
+        }
+        return this.previousActionLogLoader.load(actionLog);
+    }
 
     @ResolveField(() => ActionLogType, {
         description: "Derived from snapshot and version: snapshot null → Deleted, version 1 → Created, otherwise → Updated.",

--- a/packages/api/cms-api/src/action-logs/previous-action-log-loader.service.ts
+++ b/packages/api/cms-api/src/action-logs/previous-action-log-loader.service.ts
@@ -1,0 +1,42 @@
+import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
+import { Injectable, Scope } from "@nestjs/common";
+import DataLoader from "dataloader";
+
+import { ActionLog } from "./entities/action-log.entity";
+
+type Key = Pick<ActionLog, "entityName" | "entityId" | "version">;
+
+@Injectable({ scope: Scope.REQUEST })
+export class PreviousActionLogLoaderService {
+    private dataLoader: DataLoader<Key, ActionLog | null, string>;
+
+    constructor(private readonly entityManager: EntityManager<PostgreSqlDriver>) {
+        this.dataLoader = new DataLoader<Key, ActionLog | null, string>(
+            async (keys) => {
+                const candidates = await this.entityManager.find(
+                    ActionLog,
+                    {
+                        $or: keys.map((key) => ({
+                            entityName: key.entityName,
+                            entityId: key.entityId,
+                            version: { $lt: key.version },
+                        })),
+                    },
+                    { orderBy: { version: "DESC" } },
+                );
+                return keys.map(
+                    (key) =>
+                        candidates.find(
+                            (candidate) =>
+                                candidate.entityName === key.entityName && candidate.entityId === key.entityId && candidate.version < key.version,
+                        ) ?? null,
+                );
+            },
+            { cacheKeyFn: (key) => `${key.entityName}/${key.entityId}/${key.version}` },
+        );
+    }
+
+    load(actionLog: Key): Promise<ActionLog | null> {
+        return this.dataLoader.load(actionLog);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ActionLog.previousVersion` — the most recent earlier action log entry for the same entity, or `null` when this is the first version — and wires it into `ActionLogVersionGrid` so that **clicking a row opens the diff against the previous version** instead of the single-version view.

## Screencast

<img width="2784" height="3044" alt="Screen Recording 2026-06-18 at 12 11 33" src="https://github.com/user-attachments/assets/7dd30916-8fed-4a94-a62f-94eed6a66654" />

## Why

Reviewing a change is almost always done relative to "what was it before?". The previous flow required selecting two rows and clicking *Compare*; with `previousVersion` the diff is one click. Rows with no previous version (e.g. the first `Created` row) keep the single-version view.

