### PR TITLE
Fix BrevoContactForm sending sendDoubleOptIn in update mutation

### DIFF
--- a/.changeset/fix-brevo-contact-update-send-double-opt-in.md
+++ b/.changeset/fix-brevo-contact-update-send-double-opt-in.md
@@ -1,0 +1,7 @@
+---
+"@comet/brevo-admin": patch
+---
+
+Fix `BrevoContactForm` sending `sendDoubleOptIn` in update mutation
+
+`sendDoubleOptIn` is not a valid field of `BrevoContactUpdateInput` and only applies when creating a contact. The field was being included in the update payload because it was initialized in form state but not stripped out before the update mutation was called.

--- a/packages/admin/brevo-admin/src/brevoContacts/form/BrevoContactForm.tsx
+++ b/packages/admin/brevo-admin/src/brevoContacts/form/BrevoContactForm.tsx
@@ -51,6 +51,7 @@ export type EditBrevoContactFormValues = {
 type EditBrevoContactFormValuesWithAttributes = EditBrevoContactFormValues & {
     email: string;
     redirectionUrl: string;
+    sendDoubleOptIn?: boolean;
 };
 
 interface FormProps {
@@ -139,7 +140,7 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
                 if (!id) {
                     throw new Error("Missing id in edit mode");
                 }
-                const { email, redirectionUrl, ...rest } = output;
+                const { email, redirectionUrl, sendDoubleOptIn, ...rest } = output;
                 await client.mutate<GQLUpdateBrevoContactMutation, GQLUpdateBrevoContactMutationVariables>({
                     mutation: updateBrevoContactMutation(brevoContactFormFragment),
                     variables: { id, input: rest, scope },

--- a/packages/admin/brevo-admin/src/brevoContacts/form/BrevoContactForm.tsx
+++ b/packages/admin/brevo-admin/src/brevoContacts/form/BrevoContactForm.tsx
@@ -140,10 +140,13 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
                 if (!id) {
                     throw new Error("Missing id in edit mode");
                 }
-                const { email, redirectionUrl, sendDoubleOptIn, ...rest } = output;
                 await client.mutate<GQLUpdateBrevoContactMutation, GQLUpdateBrevoContactMutationVariables>({
                     mutation: updateBrevoContactMutation(brevoContactFormFragment),
-                    variables: { id, input: rest, scope },
+                    variables: {
+                        id,
+                        input: { blocked: false, attributes: state.attributes } as GQLUpdateBrevoContactMutationVariables["input"],
+                        scope,
+                    },
                 });
             } else {
                 const { data: mutationResponse } = await client.mutate<GQLCreateBrevoContactMutation, GQLCreateBrevoContactMutationVariables>({

--- a/packages/admin/brevo-admin/src/brevoContacts/form/BrevoContactForm.tsx
+++ b/packages/admin/brevo-admin/src/brevoContacts/form/BrevoContactForm.tsx
@@ -140,13 +140,10 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
                 if (!id) {
                     throw new Error("Missing id in edit mode");
                 }
+                const { email, redirectionUrl, sendDoubleOptIn, ...rest } = output;
                 await client.mutate<GQLUpdateBrevoContactMutation, GQLUpdateBrevoContactMutationVariables>({
                     mutation: updateBrevoContactMutation(brevoContactFormFragment),
-                    variables: {
-                        id,
-                        input: { blocked: false, attributes: state.attributes } as GQLUpdateBrevoContactMutationVariables["input"],
-                        scope,
-                    },
+                    variables: { id, input: rest, scope },
                 });
             } else {
                 const { data: mutationResponse } = await client.mutate<GQLCreateBrevoContactMutation, GQLCreateBrevoContactMutationVariables>({


### PR DESCRIPTION
## Summary
Fixed a bug where `BrevoContactForm` was incorrectly including the `sendDoubleOptIn` field when updating an existing contact. This field is only valid during contact creation, not updates.

## Changes
- Added `sendDoubleOptIn` to the `EditBrevoContactFormValuesWithAttributes` type to properly track the field
- Modified the form submission handler to explicitly destructure and exclude `sendDoubleOptIn` from the update mutation payload

## Details
The `sendDoubleOptIn` field was being initialized in the form state but was not being stripped out before calling the update mutation. Since `sendDoubleOptIn` is not a valid field in `BrevoContactUpdateInput`, this was causing the mutation to fail or behave unexpectedly. The fix ensures this field is only used during contact creation and is excluded from update operations.

https://claude.ai/code/session_01LnZx49MDQGTz2JdYK6bUPb