### PR TITLE
Fix copying the home page creating a second page with the slug "home"

### DIFF
--- a/.changeset/fix-copy-home-page-duplicate-slug.md
+++ b/.changeset/fix-copy-home-page-duplicate-slug.md
@@ -2,8 +2,6 @@
 "@comet/cms-api": patch
 ---
 
-Prevent creating a second page with the slug `home` in the same scope
+Fix copying the home page creating a second page with the slug `home`
 
-The home page is stored with the slug `home` but lives at the canonical path `/`. Because looking up `/home` always resolved to `null`, the duplicate-path check failed to detect an existing home page. As a result, copying the home page produced a second page with the slug `home`, and afterwards none of the home pages could be deleted (deleting a page with the slug `home` is forbidden).
-
-The home page is now correctly recognized as a duplicate. When copying the home page into a scope that already has a home page, the copy receives a different slug (e.g. `home-2`); when the target scope has no home page yet, the copy keeps the slug `home`.
+The copy now receives a different slug if the target scope already has a home page, and keeps `home` only when there is none yet.

--- a/.changeset/fix-copy-home-page-duplicate-slug.md
+++ b/.changeset/fix-copy-home-page-duplicate-slug.md
@@ -4,4 +4,4 @@
 
 Fix copying the home page creating a second page with the slug `home`
 
-The copy now receives a different slug if the target scope already has a home page, and keeps `home` only when there is none yet.
+Previously, copying the home page produced a second page with the slug `home`, after which none of the home pages could be deleted (deleting a page with the slug `home` is forbidden). The copy now receives a different slug if the target scope already has a home page, and keeps `home` only when there is none yet.

--- a/.changeset/fix-copy-home-page-duplicate-slug.md
+++ b/.changeset/fix-copy-home-page-duplicate-slug.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-api": patch
+---
+
+Prevent creating a second page with the slug `home` in the same scope
+
+The home page is stored with the slug `home` but lives at the canonical path `/`. Because looking up `/home` always resolved to `null`, the duplicate-path check failed to detect an existing home page. As a result, copying the home page produced a second page with the slug `home`, and afterwards none of the home pages could be deleted (deleting a page with the slug `home` is forbidden).
+
+The home page is now correctly recognized as a duplicate. When copying the home page into a scope that already has a home page, the copy receives a different slug (e.g. `home-2`); when the target scope has no home page yet, the copy keeps the slug `home`.

--- a/packages/api/cms-api/src/page-tree/page-tree.service.test.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { PageTreeService } from "./page-tree.service";
+import { type PageTreeNodeInterface, PageTreeNodeVisibility } from "./types";
+
+function createServiceWithNodes(nodes: PageTreeNodeInterface[]): { service: PageTreeService; andWhereArgs: Array<Record<string, unknown>> } {
+    const andWhereArgs: Array<Record<string, unknown>> = [];
+
+    const queryBuilder = {
+        where: () => queryBuilder,
+        andWhere: (arg: Record<string, unknown>) => {
+            andWhereArgs.push(arg);
+            return queryBuilder;
+        },
+        orderBy: () => queryBuilder,
+        limit: () => queryBuilder,
+        getResultList: async () => {
+            const slug = andWhereArgs.find((arg) => "slug" in arg)?.slug;
+            return slug !== undefined ? nodes.filter((node) => node.slug === slug) : nodes;
+        },
+    };
+
+    const pageTreeRepository = { createQueryBuilder: () => queryBuilder };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const service = new PageTreeService(pageTreeRepository as any, {} as any, {} as any, {} as any, {} as any);
+
+    return { service, andWhereArgs };
+}
+
+const homeNode = {
+    id: "home-id",
+    slug: "home",
+    parentId: null,
+    visibility: PageTreeNodeVisibility.Published,
+} as unknown as PageTreeNodeInterface;
+
+describe("PageTreeService", () => {
+    describe("nodeWithSamePath", () => {
+        it("detects an existing home page when checking the path '/home'", async () => {
+            // The home page has the slug "home" but lives at the canonical path "/", so a duplicate
+            // check for the path "/home" must still find it (e.g. when copying the home page).
+            const { service, andWhereArgs } = createServiceWithNodes([homeNode]);
+
+            await expect(service.nodeWithSamePath("/home")).resolves.toBe(homeNode);
+            expect(andWhereArgs).toContainEqual({ slug: "home" });
+        });
+
+        it("returns null when no home page exists yet", async () => {
+            const { service } = createServiceWithNodes([]);
+
+            await expect(service.nodeWithSamePath("/home")).resolves.toBeNull();
+        });
+    });
+});

--- a/packages/api/cms-api/src/page-tree/page-tree.service.test.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.test.ts
@@ -3,53 +3,103 @@ import { describe, expect, it } from "vitest";
 import { PageTreeService } from "./page-tree.service";
 import { type PageTreeNodeInterface, PageTreeNodeVisibility } from "./types";
 
-function createServiceWithNodes(nodes: PageTreeNodeInterface[]): { service: PageTreeService; andWhereArgs: Array<Record<string, unknown>> } {
-    const andWhereArgs: Array<Record<string, unknown>> = [];
+function createServiceWithNodes(nodes: PageTreeNodeInterface[]): { service: PageTreeService; queriedFilters: Array<Record<string, unknown>> } {
+    const queriedFilters: Array<Record<string, unknown>> = [];
 
-    const queryBuilder = {
-        where: () => queryBuilder,
-        andWhere: (arg: Record<string, unknown>) => {
-            andWhereArgs.push(arg);
+    const pageTreeRepository = {
+        createQueryBuilder: () => {
+            const filters: Record<string, unknown> = {};
+            const queryBuilder = {
+                where: () => queryBuilder,
+                andWhere: (arg: Record<string, unknown>) => {
+                    Object.assign(filters, arg);
+                    return queryBuilder;
+                },
+                orderBy: () => queryBuilder,
+                limit: () => queryBuilder,
+                getResultList: async () => {
+                    queriedFilters.push({ ...filters });
+                    return nodes.filter((node) => {
+                        if ("slug" in filters && node.slug !== filters.slug) {
+                            return false;
+                        }
+                        if ("parentId" in filters && node.parentId !== filters.parentId) {
+                            return false;
+                        }
+                        return true;
+                    });
+                },
+            };
             return queryBuilder;
         },
-        orderBy: () => queryBuilder,
-        limit: () => queryBuilder,
-        getResultList: async () => {
-            const slug = andWhereArgs.find((arg) => "slug" in arg)?.slug;
-            return slug !== undefined ? nodes.filter((node) => node.slug === slug) : nodes;
-        },
     };
-
-    const pageTreeRepository = { createQueryBuilder: () => queryBuilder };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const service = new PageTreeService(pageTreeRepository as any, {} as any, {} as any, {} as any, {} as any);
 
-    return { service, andWhereArgs };
+    return { service, queriedFilters };
 }
 
-const homeNode = {
-    id: "home-id",
-    slug: "home",
-    parentId: null,
-    visibility: PageTreeNodeVisibility.Published,
-} as unknown as PageTreeNodeInterface;
+function createPageTreeNode(node: Partial<PageTreeNodeInterface>): PageTreeNodeInterface {
+    return {
+        parentId: null,
+        visibility: PageTreeNodeVisibility.Published,
+        ...node,
+    } as PageTreeNodeInterface;
+}
+
+const homeNode = createPageTreeNode({ id: "home-id", slug: "home" });
 
 describe("PageTreeService", () => {
     describe("nodeWithSamePath", () => {
         it("detects an existing home page when checking the path '/home'", async () => {
             // The home page has the slug "home" but lives at the canonical path "/", so a duplicate
             // check for the path "/home" must still find it (e.g. when copying the home page).
-            const { service, andWhereArgs } = createServiceWithNodes([homeNode]);
+            const { service, queriedFilters } = createServiceWithNodes([homeNode]);
 
             await expect(service.nodeWithSamePath("/home")).resolves.toBe(homeNode);
-            expect(andWhereArgs).toContainEqual({ slug: "home" });
+            expect(queriedFilters).toContainEqual({ slug: "home" });
         });
 
         it("returns null when no home page exists yet", async () => {
             const { service } = createServiceWithNodes([]);
 
             await expect(service.nodeWithSamePath("/home")).resolves.toBeNull();
+        });
+
+        it("finds the home page via its canonical path '/'", async () => {
+            const { service } = createServiceWithNodes([homeNode]);
+
+            await expect(service.nodeWithSamePath("/")).resolves.toBe(homeNode);
+        });
+
+        it("resolves a non-home path normally", async () => {
+            const aboutNode = createPageTreeNode({ id: "about-id", slug: "about" });
+            const { service } = createServiceWithNodes([homeNode, aboutNode]);
+
+            await expect(service.nodeWithSamePath("/about")).resolves.toBe(aboutNode);
+        });
+
+        it("resolves a nested non-home path normally", async () => {
+            const parentNode = createPageTreeNode({ id: "parent-id", slug: "products" });
+            const childNode = createPageTreeNode({ id: "child-id", slug: "shoes", parentId: "parent-id" });
+            const { service } = createServiceWithNodes([parentNode, childNode]);
+
+            await expect(service.nodeWithSamePath("/products/shoes")).resolves.toBe(childNode);
+        });
+
+        it("returns null for a non-home path without a matching node", async () => {
+            const { service } = createServiceWithNodes([homeNode]);
+
+            await expect(service.nodeWithSamePath("/about")).resolves.toBeNull();
+        });
+    });
+
+    describe("delete", () => {
+        it("refuses to delete the home page", async () => {
+            const { service } = createServiceWithNodes([homeNode]);
+
+            await expect(service.delete(homeNode)).rejects.toThrow(`Page "home" cannot be deleted`);
         });
     });
 });

--- a/packages/api/cms-api/src/page-tree/page-tree.service.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.ts
@@ -399,7 +399,10 @@ export class PageTreeService {
     }
 
     public async nodeWithSamePath(path: string, scope?: ScopeInterface): Promise<PageTreeNodeInterface | null> {
-        return this.createReadApi({ visibility: [Visibility.Published, Visibility.Unpublished] }).getNodeByPath(path, {
+        // The home page has the slug "home" but lives at the canonical path "/". getNodeByPath("/home") returns null by
+        // design, so the home page must be looked up via "/" to detect it as a duplicate (e.g. when copying it).
+        const lookupPath = path === "/home" ? "/" : path;
+        return this.createReadApi({ visibility: [Visibility.Published, Visibility.Unpublished] }).getNodeByPath(lookupPath, {
             scope,
         }); // Slugs of archived pages can be reused
     }


### PR DESCRIPTION
## Problem

Copying the home page produced a second page with the slug `home`. None of the home pages could then be deleted (deleting a `home` page is forbidden), so the only fix was editing the database.

The home page has the slug `home` but lives at the path `/`. The duplicate check resolved `/home` via `getNodeByPath`, which returns `null` for `/home` by design, so an existing home page was never found.

## Solution

Map `/home` to `/` in `nodeWithSamePath`. The copy now gets a different slug (e.g. `home-2`) when the target scope already has a home page, and keeps `home` only when there is none yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)