### PR TITLE
admin: Add root-element control to Future UI Typography

### DIFF
--- a/packages/admin/admin/src/future-ui/components/typography/Typography.module.scss
+++ b/packages/admin/admin/src/future-ui/components/typography/Typography.module.scss
@@ -2,7 +2,16 @@
     margin: 0;
     color: #1a1a1a;
     font-family: inherit;
-    font-size: 1rem;
-    font-weight: 400;
-    line-height: 1.5;
+
+    &--variantHeadline {
+        font-size: 1.5rem;
+        font-weight: 600;
+        line-height: 1.25;
+    }
+
+    &--variantBody {
+        font-size: 1rem;
+        font-weight: 400;
+        line-height: 1.5;
+    }
 }

--- a/packages/admin/admin/src/future-ui/components/typography/Typography.tsx
+++ b/packages/admin/admin/src/future-ui/components/typography/Typography.tsx
@@ -58,11 +58,11 @@ export interface TypographyProps extends Omit<HTMLAttributes<HTMLElement>, "clas
  */
 export function Typography({ variant = "body", element, className, children, ref, render, ...restProps }: TypographyProps) {
     const ownerState: TypographyOwnerState = { variant };
-    const tagName = element ?? variantElement[variant];
+    const tagName = element ?? variantElement[ownerState.variant];
     const rootClassName = clsx(
         styles.root,
-        variant === "headline" && styles["root--variantHeadline"],
-        variant === "body" && styles["root--variantBody"],
+        ownerState.variant === "headline" && styles["root--variantHeadline"],
+        ownerState.variant === "body" && styles["root--variantBody"],
         className,
     );
 

--- a/packages/admin/admin/src/future-ui/components/typography/Typography.tsx
+++ b/packages/admin/admin/src/future-ui/components/typography/Typography.tsx
@@ -1,24 +1,78 @@
+import { useRender } from "@base-ui/react/use-render";
 import { clsx } from "clsx";
-import type { ComponentPropsWithoutRef, Ref } from "react";
+import type { HTMLAttributes, Ref } from "react";
 
 import styles from "./Typography.module.scss";
 
-/** @experimental */
-export interface TypographyProps extends ComponentPropsWithoutRef<"p"> {
-    ref?: Ref<HTMLParagraphElement>;
-}
+type TypographyVariant = "headline" | "body";
+type TypographyElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
 
 /**
- * Renders a single block of text.
- *
- * Carries no margin of its own; spacing around it is the caller's responsibility.
+ * The resolved configuration that influences the component's appearance or behavior.
  *
  * @experimental
  */
-export function Typography({ className, children, ref, ...restProps }: TypographyProps) {
-    return (
-        <p {...restProps} ref={ref} className={clsx(styles.root, className)}>
-            {children}
-        </p>
+export type TypographyOwnerState = {
+    variant: TypographyVariant;
+};
+
+const variantElement: Record<TypographyVariant, TypographyElement> = {
+    headline: "h2",
+    body: "p",
+};
+
+/** @experimental */
+export interface TypographyProps extends Omit<HTMLAttributes<HTMLElement>, "className"> {
+    /**
+     * Visual style. Each variant has a default semantic element.
+     *
+     * @defaultValue `"body"`
+     */
+    variant?: TypographyVariant;
+    /**
+     * The semantic element to render, overriding the variant's default.
+     *
+     * @defaultValue The variant's default element
+     */
+    element?: TypographyElement;
+    /** Added alongside the component's own classes. */
+    className?: string;
+    /** Ref forwarded to the root element. */
+    ref?: Ref<HTMLElement>;
+    /**
+     * Render a custom root element instead of the variant's default.
+     *
+     * @example
+     * ```tsx
+     * <Typography render={<label htmlFor="email" />}>Email</Typography>
+     * ```
+     */
+    render?: useRender.RenderProp<TypographyOwnerState>;
+}
+
+/**
+ * Renders a single block of text in one of several visual variants, each
+ * mapping to a default semantic element.
+ *
+ * @experimental
+ */
+export function Typography({ variant = "body", element, className, children, ref, render, ...restProps }: TypographyProps) {
+    const ownerState: TypographyOwnerState = { variant };
+    const tagName = element ?? variantElement[variant];
+    const rootClassName = clsx(
+        styles.root,
+        variant === "headline" && styles["root--variantHeadline"],
+        variant === "body" && styles["root--variantBody"],
+        className,
     );
+
+    return useRender({
+        render,
+        ref,
+        state: ownerState,
+        // Typography styles through the class-name contract, not data-* attributes.
+        stateAttributesMapping: { variant: () => null },
+        defaultTagName: tagName,
+        props: { ...restProps, className: rootClassName, children },
+    });
 }

--- a/packages/admin/admin/src/future-ui/components/typography/Typography.tsx
+++ b/packages/admin/admin/src/future-ui/components/typography/Typography.tsx
@@ -70,8 +70,6 @@ export function Typography({ variant = "body", element, className, children, ref
         render,
         ref,
         state: ownerState,
-        // Typography styles through the class-name contract, not data-* attributes.
-        stateAttributesMapping: { variant: () => null },
         defaultTagName: tagName,
         props: { ...restProps, className: rootClassName, children },
     });

--- a/packages/admin/admin/src/future-ui/components/typography/__stories__/Typography.stories.tsx
+++ b/packages/admin/admin/src/future-ui/components/typography/__stories__/Typography.stories.tsx
@@ -5,6 +5,16 @@ import { Typography } from "../Typography";
 const meta: Meta<typeof Typography> = {
     component: Typography,
     title: "Future UI/Typography",
+    argTypes: {
+        variant: {
+            control: "select",
+            options: ["headline", "body"],
+        },
+        element: {
+            control: "select",
+            options: ["h1", "h2", "h3", "h4", "h5", "h6", "p", "span"],
+        },
+    },
 };
 
 export default meta;
@@ -14,5 +24,39 @@ type Story = StoryObj<typeof Typography>;
 export const Default: Story = {
     args: {
         children: "The quick brown fox jumps over the lazy dog",
+    },
+};
+
+export const Variants: Story = {
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+            <Typography variant="headline">Headline</Typography>
+            <Typography variant="body">Body — the quick brown fox jumps over the lazy dog.</Typography>
+        </div>
+    ),
+};
+
+/**
+ * Each variant maps to a default semantic element (`h2` for `headline`, `p`
+ * for `body`). `element` overrides it when visual level and document outline
+ * disagree — for example, a `headline` rendered as an `h1`.
+ */
+export const WithCustomElement: Story = {
+    args: {
+        variant: "headline",
+        element: "h1",
+        children: "Visually headline, semantically h1",
+    },
+};
+
+/**
+ * `render` replaces the root element while keeping Typography's styling. Here a
+ * `headline` renders as a `<label>`, with `htmlFor` typed natively.
+ */
+export const WithRender: Story = {
+    args: {
+        variant: "headline",
+        render: <label htmlFor="email" />,
+        children: "Email",
     },
 };

--- a/packages/admin/admin/src/future-ui/index.ts
+++ b/packages/admin/admin/src/future-ui/index.ts
@@ -1,2 +1,2 @@
 export { Button, type ButtonOwnerState, type ButtonProps } from "./components/button/Button";
-export { Typography, type TypographyProps } from "./components/typography/Typography";
+export { Typography, type TypographyOwnerState, type TypographyProps } from "./components/typography/Typography";


### PR DESCRIPTION
A consumer needs to render a component's semantically correct root element without losing its styling or behavior.
`Typography` gains two complementary, cast-free mechanisms: a closed `element` prop and a `render` prop.

- **`render` replaces the root with a consumer-authored element**
  Because the consumer writes it, element-specific attributes (`htmlFor`, `href`) are typed without a cast.
- **A closed `element` prop is added where semantic tags are interchangeable, alongside `render`**
  It is shorter to write and autocompletable, and `render` takes precedence when both are set.
- **An open `as`/`ElementType` prop is rejected**
  Spreading props onto a dynamically chosen element can't be typed without an internal cast, which `render` avoids by letting the consumer author the element.
- **The `variant` names (`headline`, `body`) are provisional**
  The full set of variants comes later, so this change settles the mechanism (the variant-to-element mapping, the modifier classes, and the `TypographyOwnerState` passed to a `render` callback), not the names.
- **`Typography` calls base-ui's `useRender` directly rather than reimplementing prop-merging**
  `useRender` is base-ui's public API for giving a non-base-ui component a `render` prop, and it is the same engine `Button` reaches by wrapping base-ui's `Button`. `Typography` has no primitive to wrap, so it calls the hook directly.
- **`Typography` does not override base-ui's `variant` state reflection**
  `variant` is emitted as a `data-*` attribute, a base-ui pass-through rather than part of Future UI's class-name styling contract.

---

Tasks: https://vivid-planet.atlassian.net/browse/COM-2973 https://vivid-planet.atlassian.net/browse/COM-3014