### PR TITLE
admin: Fix Future UI class names including undefined in Storybook

### DIFF
--- a/packages/admin/admin/.storybook/main.ts
+++ b/packages/admin/admin/.storybook/main.ts
@@ -11,7 +11,7 @@ function generateScopedName(name: string, filename: string): string {
     const futureUiMatch = filename.match(futureUiModulePattern);
 
     if (futureUiMatch) {
-        const componentName = futureUiMatch[2];
+        const componentName = futureUiMatch[1];
 
         if (name === "root") {
             return `${futureUiClassnamePrefix}${componentName}`;


### PR DESCRIPTION
The Storybook scoped-name generator read a capture group the class-name pattern doesn't define, so every Future UI class resolved to `cometundefined` instead of its contract name (`cometButton`, `cometButton--variantPrimary`). Both the component styles and consumer CSS target the contract names, so neither matched the rendered element.

---

Task: https://vivid-planet.atlassian.net/browse/COM-2973