### PR TITLE
Remove CORS configuration from demo api

### DIFF
--- a/.env
+++ b/.env
@@ -52,7 +52,6 @@ ADMIN_URL_INTERNAL=http://localhost:$ADMIN_PORT
 API_PORT=4000
 API_URL=$ADMIN_URL/api
 API_URL_INTERNAL=http://localhost:$API_PORT/api
-CORS_ALLOWED_ORIGIN="^http:\/\/(localhost|.*\.dev\.vivid-planet\.cloud|192\.168\.\d{1,3}\.\d{1,3}):\d{2,4}"
 BASIC_AUTH_SYSTEM_USER_PASSWORD=aPasswordWith16Characters
 POST_LOGOUT_REDIRECT_URI=${AUTHPROXY_URL}/oauth2/sign_out?rd=%2F
 

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -101,12 +101,6 @@ export class AppModule {
                             return error;
                         },
                         context: ({ req }: { req: Request }) => ({ ...req }),
-                        cors: {
-                            origin: config.corsAllowedOrigin,
-                            methods: ["GET", "POST"],
-                            credentials: false,
-                            maxAge: 600,
-                        },
                         useGlobalPrefix: true,
                         buildSchemaOptions: {
                             fieldMiddleware: [BlocksTransformerMiddlewareFactory.create(moduleRef)],

--- a/demo/api/src/config/config.ts
+++ b/demo/api/src/config/config.ts
@@ -32,7 +32,6 @@ export function createConfig(processEnv: NodeJS.ProcessEnv) {
         apiUrl: envVars.API_URL,
         apiPort: envVars.API_PORT,
         adminUrl: envVars.ADMIN_URL,
-        corsAllowedOrigin: new RegExp(envVars.CORS_ALLOWED_ORIGIN),
         defaultLocale: "en", // fallback locale
         auth: {
             systemUserPassword: envVars.BASIC_AUTH_SYSTEM_USER_PASSWORD,

--- a/demo/api/src/config/environment-variables.ts
+++ b/demo/api/src/config/environment-variables.ts
@@ -63,9 +63,6 @@ export class EnvironmentVariables {
     API_PORT: number;
 
     @IsString()
-    CORS_ALLOWED_ORIGIN: string;
-
-    @IsString()
     IMGPROXY_SALT: string;
 
     @IsString()

--- a/demo/api/src/main.ts
+++ b/demo/api/src/main.ts
@@ -33,12 +33,6 @@ async function bootstrap(): Promise<void> {
     useContainer(app.select(appModule), { fallbackOnErrors: true });
 
     app.setGlobalPrefix("api");
-    app.enableCors({
-        origin: config.corsAllowedOrigin,
-        methods: ["GET", "POST"],
-        credentials: false,
-        maxAge: 600,
-    });
 
     app.useGlobalFilters(new ExceptionFilter(config.debug));
     app.useGlobalPipes(


### PR DESCRIPTION
The authproxy routes the api and admin to the same domain, so cross-origin
requests no longer occur and CORS handling is unnecessary. Remove the
`enableCors` call, the GraphQL `cors` option, and the now-unused
`CORS_ALLOWED_ORIGIN` environment variable.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MQpLJX61zCfPvFsyejwaeT