### PR TITLE
brevo-api: fix error handling for non-existing contacts

### DIFF
--- a/.changeset/nice-kiwis-appear.md
+++ b/.changeset/nice-kiwis-appear.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-api": patch
+---
+
+Fix error handling for non-existing contacts

--- a/packages/api/brevo-api/src/brevo-api/brevo-api-contact.service.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api-contact.service.ts
@@ -176,7 +176,7 @@ export class BrevoApiContactsService {
             return body;
         } catch (error) {
             // Brevo returns a 404 error if no contact is found and a 400 error if an invalid email is provided.
-            if (isErrorFromBrevo(error) && (error.status === 404 || error.status === 400)) {
+            if (isErrorFromBrevo(error) && (error.response.statusCode === 404 || error.response.statusCode === 400)) {
                 return null;
             }
 
@@ -194,7 +194,7 @@ export class BrevoApiContactsService {
             return contact;
         } catch (error) {
             // Brevo returns a 404 error if no contact is found and a 400 error if an invalid email is provided.
-            if (isErrorFromBrevo(error) && (error.status === 404 || error.status === 400)) {
+            if (isErrorFromBrevo(error) && (error.response.statusCode === 404 || error.response.statusCode === 400)) {
                 return null;
             }
             handleBrevoError(error);

--- a/packages/api/brevo-api/src/brevo-api/brevo-api.utils.ts
+++ b/packages/api/brevo-api/src/brevo-api/brevo-api.utils.ts
@@ -1,15 +1,25 @@
 import type { ErrorModel } from "@getbrevo/brevo";
-import axios, { type AxiosError } from "axios";
+import { IncomingMessage } from "http";
 
-type AxiosErrorWithResponse<T = unknown> = AxiosError<T> & { response: NonNullable<AxiosError<T>["response"]> };
-
-export function isErrorFromBrevo(error: unknown): error is AxiosErrorWithResponse<ErrorModel> {
-    return axios.isAxiosError(error) && error.response !== undefined && "code" in error.response.data && "message" in error.response.data;
+export function isErrorFromBrevo(error: unknown): error is { response: IncomingMessage; body: ErrorModel } {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        "response" in error &&
+        error.response instanceof IncomingMessage &&
+        "body" in error &&
+        typeof error.body === "object" &&
+        error.body !== null &&
+        "code" in error.body &&
+        typeof error.body.code === "string" &&
+        "message" in error.body &&
+        typeof error.body.message === "string"
+    );
 }
 
 export function handleBrevoError(error: unknown): never {
     if (isErrorFromBrevo(error)) {
-        throw new Error(error.response.data.message);
+        throw new Error(error.body.message);
     } else {
         throw error;
     }


### PR DESCRIPTION
The downgraded `@getbrevo/brevo` package (see https://github.com/vivid-planet/comet/pull/5886) uses [request](https://www.npmjs.com/package/request) instead of [axios](https://www.npmjs.com/package/axios) for making requests but the error handling still checked if the error was an axios error. This resulted in throwing an internal server error when checking if a contact already exists, thereby breaking subscribing to newsletters in one of our customer projects. Fix by restoring [the old error handling](https://github.com/vivid-planet/comet-brevo-module/blob/main/packages/api/src/brevo-api/brevo-api.utils.ts#L4-L18).