### PR TITLE
Strengthen v9 migration guide for async params and webcomponents

### DIFF
--- a/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
+++ b/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
@@ -967,8 +967,20 @@ Multiple Next.js APIs are now asynchronous and must be `await`ed. This applies t
 - `params` and `searchParams` on pages, layouts, and route handlers
 
 Update your usages to support the asynchronous APIs.
-Use the new props helper types.
+Use the new generated props helper types (`PageProps<"…">`, `LayoutProps<"…">`, and the route handler context type) instead of hand-written param types.
 Review the [migration guide](https://nextjs.org/docs/app/guides/upgrading/version-16#async-request-apis-breaking-change) for more information.
+
+:::danger Replace every hand-written `params`/`searchParams` type — do not rely on `tsc` to find them
+
+A hand-written type such as `{ params: { domain: string } }` describes `params` as a plain object, so reading it synchronously (`params.domain`) type-checks even though `params` is actually a `Promise` at runtime. The missing `await` is invisible to the type checker, the build passes, and `params.domain` is `undefined` at runtime. Fed into a scope, that `undefined` serializes to `{}` and fails only when the page is requested:
+
+```
+Variable "$scope" got invalid value {}; Field "domain" of required type "String!" was not provided.
+```
+
+Switching to the generated `PageProps`/`LayoutProps` types makes `params` a `Promise`, so `tsc` then enforces the `await`. Because `tsc` cannot flag the old hand-written types, you must find and convert **every** routing file yourself — see [Scan the whole site](#scan-the-whole-site-for-synchronous-paramssearchparams-usage) below.
+
+:::
 
 #### Examples
 
@@ -1024,6 +1036,31 @@ Review the [migration guide](https://nextjs.org/docs/app/guides/upgrading/versio
         language = "en";
     }
 ```
+
+#### Scan the whole site for synchronous `params`/`searchParams` usage
+
+Do not stop at the files that fail `tsc` — hand-written param types hide the missing `await`, so a project can build cleanly while several pages are silently broken at runtime. Check **every** `page.tsx`, `layout.tsx`, `route.ts`/`route.tsx`, and every file exporting `generateMetadata` or `generateStaticParams` under `src/app`. Repeat this for **every** site app in the project (some projects contain more than one site).
+
+List the routing files that reference `params`/`searchParams`:
+
+```sh
+cd site
+grep -rlE "params|searchParams" src/app --include="*.ts" --include="*.tsx"
+```
+
+Find the hand-written param/searchParams object types that mask a missing `await`:
+
+```sh
+grep -rnE "(params|searchParams)\s*:\s*\{" src/app --include="*.ts" --include="*.tsx"
+```
+
+For each file:
+
+1. Replace the hand-written type with the generated `PageProps<"/route/pattern">`, `LayoutProps<"/route/pattern">`, or route handler context type.
+2. Make the function `async` if it is not already — a synchronous page such as `export default function Page({ params }: { params: { domain: string } })` must become `export default async function Page({ params }: PageProps<"…">)`.
+3. `await params` / `await searchParams` before reading any field, and use the awaited values everywhere (including in nested helpers, `generateMetadata`, and JSX).
+
+When done, run the grep again to confirm no hand-written `params: {` / `searchParams: {` types remain under `src/app`, then run `npm run lint` (which runs `next typegen` + `tsc`).
 
 #### Rename `middleware.ts` to `proxy.ts`
 
@@ -1343,3 +1380,48 @@ npm run lint
 ```
 
 Repeat this step, fixing all lint errors, until the lint passes.
+
+### Verify embedded webcomponents still work
+
+If your site embeds third-party **webcomponents** / micro-frontends — typically a block that loads an external `<script>` which mounts a widget provided by another team (forms, product sliders, search or booking widgets, etc.) — the React 19 and `react-intl` v7 upgrades can break them **at runtime even though lint, `tsc`, and the production build all pass**.
+
+#### Why this breaks
+
+Such webcomponents often bundle their own React 18 + `react-intl` and, by default, reuse the host page's global `react-intl` context via `window.__REACT_INTL_CONTEXT__`. Once the host runs React 19 + `react-intl` v7, that context's shape is incompatible with the webcomponent's React 18 reconciler, so the webcomponent crashes as soon as it renders — usually with a cryptic minified error such as `TypeError: <minified> is not a function` originating deep inside React.
+
+#### Detect webcomponents
+
+Look for script-based embeds, custom elements, and the global react-intl context flag:
+
+```sh
+cd site
+grep -rnE "customElements|__REACT_INTL|next/script|<script" src
+```
+
+Also review any block whose purpose is to embed an externally hosted widget.
+
+#### Workaround until the webcomponents are fixed
+
+Set `window.__REACT_INTL_BYPASS_GLOBAL_CONTEXT__ = true` **before** the affected webcomponent's script loads, so its bundled `react-intl` creates its own isolated context instead of reusing the host's. Extract it into a shared side-effect module and import it from each affected block:
+
+```ts title="site/src/util/bypassReactIntlGlobalContext.ts"
+declare global {
+    interface Window {
+        __REACT_INTL_BYPASS_GLOBAL_CONTEXT__?: boolean;
+    }
+}
+
+if (typeof window !== "undefined") {
+    window.__REACT_INTL_BYPASS_GLOBAL_CONTEXT__ = true;
+}
+
+export {};
+```
+
+Apply it only to the webcomponents that actually break — not every embed reuses the global context. This is a temporary workaround: the proper fix belongs in the webcomponent itself, and you can remove the module and its imports once the upstream webcomponents isolate their own context.
+
+:::danger Smoke-test every webcomponent before deploying to production
+
+This is a runtime failure that CI cannot catch — lint, `tsc`, and the build all succeed. Before any production deployment, run the site and manually open **every** page that renders a webcomponent, confirming each one mounts and works. Treat pages containing webcomponents as the highest-risk part of this upgrade, and verify them on a staging/preview environment first.
+
+:::


### PR DESCRIPTION
Two classes of runtime failures slipped through real v9 migrations because they pass lint, tsc, and the build but break at runtime:

- Hand-written params/searchParams types (e.g. `{ params: { domain: string } }`) mask the missing `await` from the type checker, so `params` is undefined at runtime and the scope serializes to `{}`. Add a danger callout explaining the trap and a mandatory "scan the whole site" step that converts every routing file in every site to the generated PageProps/LayoutProps types.

- Embedded third-party webcomponents that bundle their own React/react-intl and reuse the host's global react-intl context crash under React 19. Add a section on detecting them, the bypass workaround, and a danger callout to smoke-test every webcomponent before deploying to production.