### PR TITLE
admin: Type slot props from the element chosen in slots

### DIFF
--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -78,8 +78,10 @@ Future UI's exported components share one set of override props; each offers the
 
 - **`className`** — a string, merged with the contract classes, never replacing them. It is not a function: every value in `ownerState` already emits a modifier class, so an `ownerState`-dependent class would add nothing.
 - **`slots`** — sets which element a named inner part renders as. The root is not a slot — it is the component's own outermost element, configured through the component's top-level props directly (`className`, event handlers, ARIA, …).
-- **`slotProps`** — props for those same inner parts, as an object **or** a function of `ownerState`. They are merged with the component's own props, so a contract class or handler is never dropped.
+- **`slotProps`** — props for those same inner parts, as an object **or** a function of `ownerState`. Their type follows the element chosen for the slot in `slots`, and falls back to the slot's default element when `slots` is omitted. They are merged with the component's own props, so a contract class or handler is never dropped.
 - **`ownerState`** — one object per component: the resolved configuration (`variant`, `disabled`, …) that influences the component's appearance or behavior; the root modifier classes are derived from it. It holds no transient interaction state (hover/press/focus).
+
+A slot accepts any element only while the component injects nothing element-specific into it — a universal prop like `className` is fine, `href` is not. When the component injects an element-specific prop, the slot narrows to the elements that accept it — a minimum prop contract any intrinsic element or custom component can satisfy. A part limited for semantic reasons instead — a heading restricted to `h1`–`h6` — takes a fixed set of allowed elements.
 
 ### Class-name contract
 

--- a/packages/admin/admin/src/future-ui/components/button/Button.test.tsx
+++ b/packages/admin/admin/src/future-ui/components/button/Button.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "test-utils";
+import { describe, expect, it } from "vitest";
+
+import { Button } from "./Button";
+
+/**
+ * Compile-time contract for slot-prop typing. Never rendered — it exists so
+ * `tsc` fails if the typing regresses.
+ */
+export function ButtonSlotPropsTypeContract() {
+    const icon = <span />;
+    return (
+        <>
+            {/* The chosen element flows into slotProps: an anchor slot accepts `href`, no cast. */}
+            <Button slots={{ startIcon: "a" }} slotProps={{ startIcon: { href: "/x" } }} startIcon={icon} />
+            {/* Two slots infer their elements independently from one `slots` literal. */}
+            <Button
+                slots={{ startIcon: "a", endIcon: "button" }}
+                slotProps={{ startIcon: { href: "/x" }, endIcon: { type: "submit" } }}
+                startIcon={icon}
+                endIcon={icon}
+            />
+            <Button
+                slots={{ startIcon: "a" }}
+                slotProps={{
+                    // @ts-expect-error an anchor slot's href must be a string
+                    startIcon: { href: 123 },
+                }}
+                startIcon={icon}
+            />
+            <Button
+                slotProps={{
+                    // @ts-expect-error the default span slot has no href
+                    startIcon: { href: "/x" },
+                }}
+                startIcon={icon}
+            />
+        </>
+    );
+}
+
+describe("Button slots", () => {
+    it("renders a slot as the element chosen in `slots`, merging the contract class with consumer props", () => {
+        render(
+            <Button slots={{ startIcon: "a" }} slotProps={{ startIcon: { href: "/downloads", className: "consumer-class" } }} startIcon={<span />}>
+                Download
+            </Button>,
+        );
+
+        const startIcon = screen.getByRole("link");
+        expect(startIcon.getAttribute("href")).toBe("/downloads");
+        expect(startIcon.className).toContain("consumer-class");
+        expect(startIcon.className).toContain("startIcon");
+    });
+});

--- a/packages/admin/admin/src/future-ui/components/button/Button.tsx
+++ b/packages/admin/admin/src/future-ui/components/button/Button.tsx
@@ -17,30 +17,31 @@ export type ButtonOwnerState = {
     disabled: boolean;
 };
 
-interface ButtonSlots {
+interface ButtonSlots<StartIcon extends ElementType, EndIcon extends ElementType> {
     /**
      * Element for the `startIcon` slot.
      *
      * @defaultValue `span`
      */
-    startIcon?: ElementType;
+    startIcon?: StartIcon;
     /**
      * Element for the `endIcon` slot.
      *
      * @defaultValue `span`
      */
-    endIcon?: ElementType;
+    endIcon?: EndIcon;
 }
 
-interface ButtonSlotProps {
+interface ButtonSlotProps<StartIcon extends ElementType, EndIcon extends ElementType> {
     /** Props for the `startIcon` slot. */
-    startIcon?: SlotPropsValue<ButtonOwnerState, "span">;
+    startIcon?: SlotPropsValue<ButtonOwnerState, StartIcon>;
     /** Props for the `endIcon` slot. */
-    endIcon?: SlotPropsValue<ButtonOwnerState, "span">;
+    endIcon?: SlotPropsValue<ButtonOwnerState, EndIcon>;
 }
 
 /** @experimental */
-export interface ButtonProps extends Omit<BaseButton.Props, "className"> {
+export interface ButtonProps<StartIcon extends ElementType = "span", EndIcon extends ElementType = "span">
+    extends Omit<BaseButton.Props, "className"> {
     /**
      * Visual style.
      *
@@ -50,9 +51,9 @@ export interface ButtonProps extends Omit<BaseButton.Props, "className"> {
     /** Added alongside the component's own classes. */
     className?: string;
     /** Sets which element a named inner part renders as. */
-    slots?: ButtonSlots;
+    slots?: ButtonSlots<StartIcon, EndIcon>;
     /** Props for each slot, merged with the slot's own props rather than replacing them. */
-    slotProps?: ButtonSlotProps;
+    slotProps?: ButtonSlotProps<StartIcon, EndIcon>;
     /** The icon to render before the button's text. */
     startIcon?: ReactNode;
     /** The icon to render after the button's text. */
@@ -64,7 +65,7 @@ export interface ButtonProps extends Omit<BaseButton.Props, "className"> {
  *
  * @experimental
  */
-export function Button({
+export function Button<StartIcon extends ElementType = "span", EndIcon extends ElementType = "span">({
     disabled = false,
     type = "button",
     variant = "primary",
@@ -75,14 +76,14 @@ export function Button({
     endIcon,
     children,
     ...restProps
-}: ButtonProps) {
+}: ButtonProps<StartIcon, EndIcon>) {
     const ownerState: ButtonOwnerState = { variant, disabled };
 
-    const StartIconSlot = slots?.startIcon ?? "span";
-    const EndIconSlot = slots?.endIcon ?? "span";
+    const StartIconSlot: ElementType = slots?.startIcon ?? "span";
+    const EndIconSlot: ElementType = slots?.endIcon ?? "span";
 
-    const startIconProps = resolveSlotProps<ButtonOwnerState, "span">({ className: styles.startIcon }, slotProps?.startIcon, ownerState);
-    const endIconProps = resolveSlotProps<ButtonOwnerState, "span">({ className: styles.endIcon }, slotProps?.endIcon, ownerState);
+    const startIconProps = resolveSlotProps<ButtonOwnerState, StartIcon, "span">({ className: styles.startIcon }, slotProps?.startIcon, ownerState);
+    const endIconProps = resolveSlotProps<ButtonOwnerState, EndIcon, "span">({ className: styles.endIcon }, slotProps?.endIcon, ownerState);
 
     return (
         <BaseButton

--- a/packages/admin/admin/src/future-ui/utils/slotProps.ts
+++ b/packages/admin/admin/src/future-ui/utils/slotProps.ts
@@ -10,15 +10,18 @@ function isOwnerStateFunction<OwnerState, T extends ElementType>(
 }
 
 /**
- * Resolves a slot's `slotProps` value — calling it with `ownerState` when it's a
- * function — then merges it with the slot's own props via `mergeProps`.
+ * Merges a slot's consumer props with the component's own props, resolving the
+ * consumer value with `ownerState` when it is a function.
+ *
+ * `ownProps` are typed for the slot's default element and the consumer value
+ * for the chosen element, so the result fits whichever element renders.
  */
-export function resolveSlotProps<OwnerState, T extends ElementType>(
-    ownProps: ComponentPropsWithRef<T>,
-    value: SlotPropsValue<OwnerState, T> | undefined,
+export function resolveSlotProps<OwnerState, Slot extends ElementType, Default extends ElementType>(
+    ownProps: ComponentPropsWithRef<Default>,
+    value: SlotPropsValue<OwnerState, Slot> | undefined,
     ownerState: OwnerState,
 ) {
     const consumerProps = isOwnerStateFunction(value) ? value(ownerState) : value;
 
-    return mergeProps<T>(ownProps, consumerProps);
+    return mergeProps<Slot>(ownProps, consumerProps);
 }


### PR DESCRIPTION
A consumer could change a slot's element through `slots` but not pass that element's props without a cast: `slotProps` were typed against the slot's fixed default element, so overriding a slot to an anchor and setting `href` was a type error.
Avoiding consumer casts is a goal of this override surface, so a slot's prop type now follows the element the consumer chooses for it.

- **Each slot's element is its own defaulted type parameter.**
  TypeScript infers each element from the `slots` object the consumer writes; one type parameter covering the whole object does not infer the individual elements reliably.
- **The merge helper takes the chosen element and the default element separately.**
  A component's own injected props belong to the default element while consumer props follow the chosen one, so the merge is typed against both.
- **Inside the component, the element each slot renders through is typed as `ElementType`, not its per-slot generic.**
  Spreading the slot's resolved props onto that element does not type-check while its type is still the generic parameter, so the precise per-slot types stay on the public props, where the consumer needs them.

---

Tasks: https://vivid-planet.atlassian.net/browse/COM-2973 https://vivid-planet.atlassian.net/browse/COM-3014