### PR TITLE
demo-site: Increase Node.js heap size for dev server

### DIFF
--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -10,7 +10,7 @@
         "check-node-version": "check-node-version --node $(cat ../../.nvmrc)",
         "css:types": "typed-scss-modules src --nameFormat none --exportType default --aliasPrefixes.@src src",
         "css:types:watch": "pnpm run css:types --watch",
-        "dev": "pnpm check-node-version && run-s intl:compile && run-p gql:types generate-block-types css:types build-server && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node --inspect=localhost:9230 --max-old-space-size=1024 dist/server.js",
+        "dev": "pnpm check-node-version && run-s intl:compile && run-p gql:types generate-block-types css:types build-server && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node --inspect=localhost:9230 --max-old-space-size=768 dist/server.js",
         "export": "next export",
         "generate-block-types": "comet generate-block-types",
         "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"pnpm generate-block-types\"",

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -10,7 +10,7 @@
         "check-node-version": "check-node-version --node $(cat ../../.nvmrc)",
         "css:types": "typed-scss-modules src --nameFormat none --exportType default --aliasPrefixes.@src src",
         "css:types:watch": "pnpm run css:types --watch",
-        "dev": "pnpm check-node-version && run-s intl:compile && run-p gql:types generate-block-types css:types build-server && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node --inspect=localhost:9230 --max-old-space-size=512 dist/server.js",
+        "dev": "pnpm check-node-version && run-s intl:compile && run-p gql:types generate-block-types css:types build-server && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node --inspect=localhost:9230 --max-old-space-size=2048 dist/server.js",
         "export": "next export",
         "generate-block-types": "comet generate-block-types",
         "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"pnpm generate-block-types\"",

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -10,7 +10,7 @@
         "check-node-version": "check-node-version --node $(cat ../../.nvmrc)",
         "css:types": "typed-scss-modules src --nameFormat none --exportType default --aliasPrefixes.@src src",
         "css:types:watch": "pnpm run css:types --watch",
-        "dev": "pnpm check-node-version && run-s intl:compile && run-p gql:types generate-block-types css:types build-server && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node --inspect=localhost:9230 --max-old-space-size=2048 dist/server.js",
+        "dev": "pnpm check-node-version && run-s intl:compile && run-p gql:types generate-block-types css:types build-server && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node --inspect=localhost:9230 --max-old-space-size=1024 dist/server.js",
         "export": "next export",
         "generate-block-types": "comet generate-block-types",
         "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"pnpm generate-block-types\"",


### PR DESCRIPTION
Increases the maximum old space size allocation for the site development server from 512MB to 768MB.

With the current limit you get regular crash loops for demo-site. This is caused by the webpack dev server, so increasing the limit is fine. See https://claude.ai/code/session_01M7E27CGiaGn2YKgj4Km16A.