### PR TITLE
Fix fallback cache storing wrong value shape in site cache handler

### DIFF
--- a/demo/site/cache-handler.ts
+++ b/demo/site/cache-handler.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { Redis } from "ioredis";
 import { LRUCache } from "lru-cache";
-import { CacheHandler as NextCacheHandler } from "next/dist/server/lib/incremental-cache";
+import { CacheHandler as NextCacheHandler, CacheHandlerValue } from "next/dist/server/lib/incremental-cache";
 
 import { getOrCreateCounter, getOrCreateHistogram } from "./opentelemetry-metrics";
 
@@ -32,8 +32,10 @@ const redis = new Redis({
     enableAutoPipelining: true,
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const fallbackCache = new LRUCache<string, any>({
+// Typed with Next's `CacheHandlerValue` so the in-memory fallback stores the exact same
+// wrapped `{ lastModified, value }` shape as the Redis path (and as `get` returns). This
+// prevents the two cache paths from drifting apart
+const fallbackCache = new LRUCache<string, CacheHandlerValue>({
     maxSize: 50 * 1024 * 1024, // 50MB
     ttl: CACHE_TTL_IN_S * 1000,
     ttlAutopurge: true,
@@ -79,7 +81,7 @@ function isCacheKeyFullRoute(key: string) {
 }
 
 export default class CacheHandler {
-    async get(key: string): ReturnType<NextCacheHandler["get"]> {
+    async get(key: string): Promise<ReturnType<NextCacheHandler["get"]>> {
         if (isCacheKeyFullRoute(key)) {
             return null;
         }
@@ -99,7 +101,7 @@ export default class CacheHandler {
                     return null;
                 }
                 cacheHitCount.add(1);
-                const response = JSON.parse(redisResponse);
+                const response = JSON.parse(redisResponse) as CacheHandlerValue;
                 if (response.lastModified) {
                     cacheGetAge.record((new Date().getTime() - response.lastModified) / 1000);
                 }
@@ -143,10 +145,11 @@ export default class CacheHandler {
         }
         cacheSetCount.add(1);
 
-        const stringData = JSON.stringify({
+        const data: CacheHandlerValue = {
             lastModified: Date.now(),
             value,
-        });
+        };
+        const stringData = JSON.stringify(data);
 
         if (redis.status === "ready") {
             try {
@@ -162,7 +165,7 @@ export default class CacheHandler {
         if (CACHE_HANDLER_DEBUG) {
             console.log("CacheHandler.set fallbackCache", key);
         }
-        fallbackCache.set(key, value, { size: stringData.length });
+        fallbackCache.set(key, data, { size: stringData.length });
     }
 
     async revalidateTag(tags: string | string[]): Promise<void> {


### PR DESCRIPTION
## Problem

If valkey goes down, the in memory cache handler takes over. However, we had a critical bug in the fallback cache handler: 

The in-memory fallback cache stores the bare value, while the Redis path and get use the wrapped { lastModified, value } shape. When Valkey is down, reads from the fallback return a different shape than Next.js exprects, triggering an "Expected cached value to be a FETCH kind, got undefined" invariant (vercel/next.js#76838).

<img width="1631" height="262" alt="Bildschirmfoto 2026-06-23 um 11 08 37" src="https://github.com/user-attachments/assets/845a01ed-b0af-49d3-8db0-2ebbc375dc89" />

This was a preexisting issue. However, in Next 14 it was apparently swallowed silently. In Next 16 it causes an error and the site stops responding -> downtime.

## Solution

Store the wrapped shape in the fallback cache too, and type both paths with Next's CacheHandlerValue so the two caches can no longer drift apart.