### PR TITLE
Backport v8: Fix home page duplication when copying in page tree

### DIFF
--- a/.changeset/fix-copy-home-page-duplicate-slug.md
+++ b/.changeset/fix-copy-home-page-duplicate-slug.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Fix copying the home page creating a second page with the slug `home`
+
+Previously, copying the home page produced a second page with the slug `home`, after which none of the home pages could be deleted (deleting a page with the slug `home` is forbidden). The copy now receives a different slug if the target scope already has a home page, and keeps `home` only when there is none yet.

--- a/packages/api/cms-api/src/page-tree/page-tree.service.test.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.test.ts
@@ -1,0 +1,103 @@
+import { PageTreeService } from "./page-tree.service";
+import { type PageTreeNodeInterface, PageTreeNodeVisibility } from "./types";
+
+function createServiceWithNodes(nodes: PageTreeNodeInterface[]): { service: PageTreeService; queriedFilters: Array<Record<string, unknown>> } {
+    const queriedFilters: Array<Record<string, unknown>> = [];
+
+    const pageTreeRepository = {
+        createQueryBuilder: () => {
+            const filters: Record<string, unknown> = {};
+            const queryBuilder = {
+                where: () => queryBuilder,
+                andWhere: (arg: Record<string, unknown>) => {
+                    Object.assign(filters, arg);
+                    return queryBuilder;
+                },
+                orderBy: () => queryBuilder,
+                limit: () => queryBuilder,
+                getResultList: async () => {
+                    queriedFilters.push({ ...filters });
+                    return nodes.filter((node) => {
+                        if ("slug" in filters && node.slug !== filters.slug) {
+                            return false;
+                        }
+                        if ("parentId" in filters && node.parentId !== filters.parentId) {
+                            return false;
+                        }
+                        return true;
+                    });
+                },
+            };
+            return queryBuilder;
+        },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const service = new PageTreeService(pageTreeRepository as any, {} as any, {} as any, {} as any, {} as any);
+
+    return { service, queriedFilters };
+}
+
+function createPageTreeNode(node: Partial<PageTreeNodeInterface>): PageTreeNodeInterface {
+    return {
+        parentId: null,
+        visibility: PageTreeNodeVisibility.Published,
+        ...node,
+    } as PageTreeNodeInterface;
+}
+
+const homeNode = createPageTreeNode({ id: "home-id", slug: "home" });
+
+describe("PageTreeService", () => {
+    describe("nodeWithSamePath", () => {
+        it("detects an existing home page when checking the path '/home'", async () => {
+            // The home page has the slug "home" but lives at the canonical path "/", so a duplicate
+            // check for the path "/home" must still find it (e.g. when copying the home page).
+            const { service, queriedFilters } = createServiceWithNodes([homeNode]);
+
+            await expect(service.nodeWithSamePath("/home")).resolves.toBe(homeNode);
+            expect(queriedFilters).toContainEqual({ slug: "home" });
+        });
+
+        it("returns null when no home page exists yet", async () => {
+            const { service } = createServiceWithNodes([]);
+
+            await expect(service.nodeWithSamePath("/home")).resolves.toBeNull();
+        });
+
+        it("finds the home page via its canonical path '/'", async () => {
+            const { service } = createServiceWithNodes([homeNode]);
+
+            await expect(service.nodeWithSamePath("/")).resolves.toBe(homeNode);
+        });
+
+        it("resolves a non-home path normally", async () => {
+            const aboutNode = createPageTreeNode({ id: "about-id", slug: "about" });
+            const { service } = createServiceWithNodes([homeNode, aboutNode]);
+
+            await expect(service.nodeWithSamePath("/about")).resolves.toBe(aboutNode);
+        });
+
+        it("resolves a nested non-home path normally", async () => {
+            const parentNode = createPageTreeNode({ id: "parent-id", slug: "products" });
+            const childNode = createPageTreeNode({ id: "child-id", slug: "shoes", parentId: "parent-id" });
+            const { service } = createServiceWithNodes([parentNode, childNode]);
+
+            await expect(service.nodeWithSamePath("/products/shoes")).resolves.toBe(childNode);
+        });
+
+        it("returns null for a non-home path without a matching node", async () => {
+            const { service } = createServiceWithNodes([homeNode]);
+
+            await expect(service.nodeWithSamePath("/about")).resolves.toBeNull();
+        });
+    });
+
+    describe("delete", () => {
+        it("refuses to delete the home page", async () => {
+            const { service } = createServiceWithNodes([homeNode]);
+
+            await expect(service.delete(homeNode)).rejects.toThrow(`Page "home" cannot be deleted`);
+        });
+    });
+});

--- a/packages/api/cms-api/src/page-tree/page-tree.service.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.service.ts
@@ -393,7 +393,10 @@ export class PageTreeService {
     }
 
     public async nodeWithSamePath(path: string, scope?: ScopeInterface): Promise<PageTreeNodeInterface | null> {
-        return this.createReadApi({ visibility: [Visibility.Published, Visibility.Unpublished] }).getNodeByPath(path, {
+        // The home page has the slug "home" but lives at the canonical path "/". getNodeByPath("/home") returns null by
+        // design, so the home page must be looked up via "/" to detect it as a duplicate (e.g. when copying it).
+        const lookupPath = path === "/home" ? "/" : path;
+        return this.createReadApi({ visibility: [Visibility.Published, Visibility.Unpublished] }).getNodeByPath(lookupPath, {
             scope,
         }); // Slugs of archived pages can be reused
     }


### PR DESCRIPTION
> [!NOTE]
> This is a backport of #5901 to `v8.x.x`.

## Summary
Fixes an issue where copying the home page would create a duplicate page with the slug `home`, preventing deletion of either home page since pages with that slug cannot be deleted.

## Changes
- **page-tree.service.ts**: Updated `nodeWithSamePath()` to correctly detect the home page when checking for duplicates. Since the home page has the slug "home" but lives at the canonical path "/", the method now converts path "/home" to "/" for lookup to properly identify existing home pages during copy operations.

- **page-tree.service.test.ts**: Added comprehensive test coverage for the `nodeWithSamePath()` method, including:
  - Detection of existing home page when checking path "/home"
  - Handling of canonical home path "/"
  - Resolution of non-home paths (both simple and nested)
  - Proper null returns when nodes don't exist
  - Validation that home page deletion is prevented

## Implementation Details
The fix recognizes that the home page's slug ("home") doesn't match its URL path ("/"), which caused the duplicate detection logic to fail during copy operations. By normalizing the lookup path from "/home" to "/" when checking for duplicates, the service can now correctly identify an existing home page and prevent slug conflicts.

The test was adapted from the original PR to use jest (with global test functions) instead of vitest, matching the test setup on the `v8.x.x` branch.

https://claude.ai/code/session_019mbJD6fKgC8bmrytTXBDLz