### PR TITLE
Fix pagination in StartBuildsDialog

### DIFF
--- a/.changeset/fix-start-builds-dialog-paging.md
+++ b/.changeset/fix-start-builds-dialog-paging.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix pagination in `StartBuildsDialog` not advancing past the first page

--- a/packages/admin/cms-admin/.storybook/mocks/buildTemplatesHandler.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/buildTemplatesHandler.ts
@@ -1,0 +1,14 @@
+import { graphql, HttpResponse } from "msw";
+
+export const buildTemplatesHandler = graphql.query("BuildTemplates", () => {
+    return HttpResponse.json({
+        data: {
+            buildTemplates: Array.from({ length: 8 }, (_, i) => ({
+                __typename: "BuildTemplate",
+                id: `template-${i + 1}`,
+                name: `scope-${i + 1}`,
+                label: `Scope ${i + 1}`,
+            })),
+        },
+    });
+});

--- a/packages/admin/cms-admin/.storybook/mocks/handlers.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { buildTemplatesHandler } from "./buildTemplatesHandler";
 import { currentUserHandler } from "./currentUserHandler";
 
-export const handlers = [currentUserHandler];
+export const handlers = [currentUserHandler, buildTemplatesHandler];

--- a/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
+++ b/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
@@ -52,6 +52,7 @@ export function StartBuildsDialog(props: StartBuildsDialogProps) {
         type: "include",
         ids: new Set([]),
     });
+    const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 5 });
 
     const rows = data?.buildTemplates ?? [];
 
@@ -90,7 +91,8 @@ export function StartBuildsDialog(props: StartBuildsDialogProps) {
                     }}
                     disableRowSelectionExcludeModel
                     rowSelectionModel={selectionModel}
-                    paginationModel={{ page: 0, pageSize: 5 }}
+                    paginationModel={paginationModel}
+                    onPaginationModelChange={setPaginationModel}
                     hideFooterPagination={rows.length <= 5}
                 />
             </DialogContent>

--- a/packages/admin/cms-admin/src/builds/__stories__/StartBuildsDialog.stories.tsx
+++ b/packages/admin/cms-admin/src/builds/__stories__/StartBuildsDialog.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { StartBuildsDialog } from "../StartBuildsDialog";
+
+const config: Meta<typeof StartBuildsDialog> = {
+    component: StartBuildsDialog,
+    title: "builds/StartBuildsDialog",
+};
+
+export default config;
+
+type Story = StoryObj<typeof StartBuildsDialog>;
+
+export const WithPagination: Story = {
+    args: {
+        open: true,
+        onClose: () => undefined,
+    },
+};


### PR DESCRIPTION
## Summary
Fixed pagination in `StartBuildsDialog` that was preventing users from advancing past the first page of build templates.

## Changes
- Added state management for pagination model (`paginationModel` and `setPaginationModel`) to track the current page and page size
- Connected the pagination state to the DataGrid component by:
  - Replacing the hardcoded `paginationModel={{ page: 0, pageSize: 5 }}` with the state variable
  - Adding `onPaginationModelChange` handler to update pagination state when users navigate pages
- Added Storybook story for `StartBuildsDialog` with pagination support
- Added MSW mock handler for `BuildTemplates` GraphQL query to support Storybook testing with realistic data (8 templates)

## Implementation Details
The issue was that the pagination model was hardcoded to always show page 0, preventing the DataGrid from responding to pagination changes. By converting it to a managed state variable and connecting the `onPaginationModelChange` callback, the component now properly maintains pagination state across user interactions.

https://claude.ai/code/session_01Bu6vnu1dpQNAtEAp9ecDyy