### PR TITLE
Remove pagination from StartBuildsDialog

### DIFF
--- a/.changeset/remove-start-builds-dialog-paging.md
+++ b/.changeset/remove-start-builds-dialog-paging.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Remove pagination from `StartBuildsDialog` data grid
+
+The `buildTemplates` query always returns all templates, so the page-based pagination in the dialog grid was misleading. All templates are now displayed at once.

--- a/packages/admin/cms-admin/.storybook/mocks/buildTemplatesHandler.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/buildTemplatesHandler.ts
@@ -1,0 +1,14 @@
+import { graphql, HttpResponse } from "msw";
+
+export const buildTemplatesHandler = graphql.query("BuildTemplates", () => {
+    return HttpResponse.json({
+        data: {
+            buildTemplates: Array.from({ length: 10 }, (_, i) => ({
+                __typename: "BuildTemplate",
+                id: `template-${i + 1}`,
+                name: `template-${i + 1}`,
+                label: `Build Template ${i + 1}`,
+            })),
+        },
+    });
+});

--- a/packages/admin/cms-admin/.storybook/mocks/handlers.ts
+++ b/packages/admin/cms-admin/.storybook/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { buildTemplatesHandler } from "./buildTemplatesHandler";
 import { currentUserHandler } from "./currentUserHandler";
 
-export const handlers = [currentUserHandler];
+export const handlers = [currentUserHandler, buildTemplatesHandler];

--- a/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
+++ b/packages/admin/cms-admin/src/builds/StartBuildsDialog.tsx
@@ -90,8 +90,7 @@ export function StartBuildsDialog(props: StartBuildsDialogProps) {
                     }}
                     disableRowSelectionExcludeModel
                     rowSelectionModel={selectionModel}
-                    paginationModel={{ page: 0, pageSize: 5 }}
-                    hideFooterPagination={rows.length <= 5}
+                    hideFooter
                 />
             </DialogContent>
             <DialogActions>

--- a/packages/admin/cms-admin/src/builds/__stories__/StartBuildsDialog.stories.tsx
+++ b/packages/admin/cms-admin/src/builds/__stories__/StartBuildsDialog.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { StartBuildsDialog } from "../StartBuildsDialog";
+
+const config: Meta<typeof StartBuildsDialog> = {
+    component: StartBuildsDialog,
+    title: "builds/StartBuildsDialog",
+};
+
+export default config;
+
+type Story = StoryObj<typeof config>;
+
+export const TenTemplates: Story = {
+    args: {
+        open: true,
+        onClose: () => undefined,
+    },
+    name: "Ten templates (no pagination)",
+};


### PR DESCRIPTION
The `StartBuildsDialog` data grid hardcodes a page size of five while the `buildTemplates` query doesn't support paging at all. This leads to inaccessible rows if a project has more than five build templates. Fix by removing the pagination.

https://claude.ai/code/session_01AFthtKTHEv93CwpVgwwQse