### PR TITLE
Export full-text search types for custom resolvers

### DIFF
--- a/.changeset/site-full-text-search-exports.md
+++ b/.changeset/site-full-text-search-exports.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Export `EntityInfoObject`, `EntityInfoFullTextObject` and `PaginatedEntityInfo`
+
+This allows building custom full-text search resolvers (for example a public, permission-independent site search) that reuse the existing full-text search views and re-use the `entityInfo` relation to return name and secondary information.

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -210,6 +210,7 @@ export { DocumentInterface } from "./document/dto/document-interface";
 export { SaveDocument } from "./document/dto/save-document";
 export { validateNotModified } from "./document/validateNotModified";
 export { EntityInfo, EntityInfoSql } from "./entity-info/entity-info.decorator";
+export { EntityInfoObject } from "./entity-info/entity-info.object";
 export { FileUpload } from "./file-uploads/entities/file-upload.entity";
 export { FileUploadsModule } from "./file-uploads/file-uploads.module";
 export { FileUploadsService } from "./file-uploads/file-uploads.service";
@@ -217,6 +218,8 @@ export { FileUploadInput, FileUploadInterface } from "./file-utils/file-upload.i
 export { createFileUploadInputFromUrl, slugifyFilename } from "./file-utils/files.utils";
 export { FocalPoint } from "./file-utils/focal-point.enum";
 export { getCenteredPosition, getMaxDimensionsFromArea, ImageDimensionsAndCoordinates } from "./file-utils/images.util";
+export { PaginatedEntityInfo } from "./full-text-search/dto/paginated-entity-info";
+export { EntityInfoFullTextObject } from "./full-text-search/entities/entity-info-full-text.object";
 export { FullTextSearchModule } from "./full-text-search/full-text-search.module";
 export { IMGPROXY_CONFIG } from "./imgproxy/imgproxy.constants";
 export { Extension, Gravity, ResizingType } from "./imgproxy/imgproxy.enum";


### PR DESCRIPTION
## Summary
Export three types from the full-text search module to enable building custom full-text search resolvers that can reuse existing full-text search views and entity information.

ported from [#5887](https://github.com/vivid-planet/comet/issues/5887)

https://claude.ai/code/session_01NQtHHdFHGyQ57BpLUmiL8v