### PR TITLE
Add .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ junit-storybook.xml
 .claude/skills/
 .claude/rules/
 .claude/worktrees/
+.claude/settings.local.json
 .github/instructions/


### PR DESCRIPTION
## Summary
Added `.claude/settings.local.json` to the `.gitignore` file to prevent local Claude settings from being committed to the repository. Also excludes `.claude/settings.local.json` from prettier.

## Changes
- Added `.claude/settings.local.json` entry to `.gitignore` to exclude local configuration files from version control

## Rationale
This prevents local Claude IDE settings and configurations from being accidentally committed, allowing developers to maintain personal settings without affecting the shared repository state. This follows the existing pattern of excluding other `.claude/` subdirectories like `skills/`, `rules/`, and `worktrees/`.

https://claude.ai/code/session_01BDuuHayiQuNVoUYdaCdmFm