### PR TITLE
Run Storybook and docs CI for pull requests targeting any branch

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -5,9 +5,6 @@ on:
         paths:
             - docs/**
             - storybook/**
-        branches:
-            - main
-            - next
     push:
         paths:
             - docs/**

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,9 +2,6 @@ name: Chromatic
 
 on:
     pull_request:
-        branches:
-            - main
-            - next
     push:
         branches:
             - main


### PR DESCRIPTION
The Chromatic deployment and docs build only ran for pull requests whose base was `main` or `next`. We frequently open stacking pull requests that target each other, so those branches never got a Storybook or docs build for review.

- **Both workflows must run for pull requests into any branch, not a named subset.** A `feature/*` glob can't capture stacking pull requests, which target each other and aren't reliably named by prefix.