### PR TITLE
Exclude Storybook and test files from published package builds

### DIFF
--- a/.changeset/keep-build-artifacts-out-of-bundle.md
+++ b/.changeset/keep-build-artifacts-out-of-bundle.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": patch
+"@comet/cms-admin": patch
+"@comet/mail-react": patch
+"@comet/cli": patch
+---
+
+Reduce published package size by keeping non-runtime build artifacts out of the bundle

--- a/packages/admin/admin/.babelrc.build.json
+++ b/packages/admin/admin/.babelrc.build.json
@@ -1,0 +1,3 @@
+{
+    "ignore": ["**/__stories__/**", "**/*.stories.ts", "**/*.stories.tsx"]
+}

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -22,7 +22,7 @@
     "scripts": {
         "build": "pnpm run clean && run-p build:babel build:types",
         "build-storybook": "storybook build --disable-telemetry",
-        "build:babel": "pnpm exec babel ./src -x \".ts,.tsx\" -d lib",
+        "build:babel": "pnpm exec babel ./src -x \".ts,.tsx\" -d lib --config-file ./.babelrc.build.json",
         "build:types": "tsc --project ./tsconfig.build.json --emitDeclarationOnly",
         "clean": "rimraf lib",
         "lint": "run-p lint:prettier lint:eslint lint:tsc",
@@ -34,7 +34,7 @@
         "lint:prettier": "pnpm exec prettier --check '*.{ts,js,json,md,yml,yaml}'",
         "lint:tsc": "tsc --noEmit",
         "start": "run-p start:babel start:types",
-        "start:babel": "pnpm exec babel ./src -x \".ts,.tsx\" -d lib -w",
+        "start:babel": "pnpm exec babel ./src -x \".ts,.tsx\" -d lib -w --config-file ./.babelrc.build.json",
         "start:types": "tsc --project ./tsconfig.json --emitDeclarationOnly --watch --preserveWatchOutput",
         "storybook": "storybook dev -p 26646 --no-open --disable-telemetry",
         "test": "pnpm run test:unit && pnpm run test:storybook",

--- a/packages/admin/cms-admin/.babelrc.build.json
+++ b/packages/admin/cms-admin/.babelrc.build.json
@@ -1,0 +1,3 @@
+{
+    "ignore": ["**/__stories__/**", "**/*.stories.ts", "**/*.stories.tsx"]
+}

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -22,7 +22,7 @@
     "scripts": {
         "build": "pnpm run clean && run-p gql:types generate-block-types && run-p build:babel build:types",
         "build-storybook": "storybook build --disable-telemetry",
-        "build:babel": "pnpm exec babel ./src -x \".ts,.tsx\" -d lib",
+        "build:babel": "pnpm exec babel ./src -x \".ts,.tsx\" -d lib --config-file ./.babelrc.build.json",
         "build:types": "tsc --project ./tsconfig.build.json --emitDeclarationOnly",
         "clean": "rimraf lib 'src/**/*.generated.ts'",
         "generate-block-types": "comet generate-block-types --inputs",
@@ -38,7 +38,7 @@
         "lint:prettier": "pnpm exec prettier --check '*.{ts,js,json,md,yml,yaml}'",
         "lint:tsc": "tsc --noEmit",
         "start": "run-p gql:types generate-block-types && run-p start:babel start:types",
-        "start:babel": "pnpm exec babel ./src -x \".ts,.tsx\" -d lib -w",
+        "start:babel": "pnpm exec babel ./src -x \".ts,.tsx\" -d lib -w --config-file ./.babelrc.build.json",
         "start:types": "tsc --project ./tsconfig.json --emitDeclarationOnly --watch --preserveWatchOutput",
         "storybook": "storybook dev -p 26647 --no-open --disable-telemetry",
         "test": "pnpm run test:unit && pnpm run test:storybook",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
         "lib/*"
     ],
     "scripts": {
-        "build": "pnpm run clean && tsc",
+        "build": "pnpm run clean && tsc -p tsconfig.build.json",
         "clean": "rimraf lib",
         "dev": "tsc --watch",
         "lint": "run-p lint:prettier lint:eslint lint:tsc",

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "exclude": ["node_modules", "lib", "**/*.test.tsx", "**/*.test.ts", "**/*.spec.tsx", "**/*.spec.ts", "**/__tests__"],
+    "extends": "./tsconfig.json"
+}

--- a/packages/mail-react/package.json
+++ b/packages/mail-react/package.json
@@ -20,7 +20,7 @@
         "lib/*"
     ],
     "scripts": {
-        "build": "pnpm run clean && pnpm run generate-block-types && tsc",
+        "build": "pnpm run clean && pnpm run generate-block-types && tsc -p tsconfig.build.json",
         "build-storybook": "storybook build",
         "clean": "rimraf lib 'src/**/*.generated.ts'",
         "dev": "pnpm run clean && pnpm generate-block-types && tsc --watch",

--- a/packages/mail-react/tsconfig.build.json
+++ b/packages/mail-react/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+    "exclude": [
+        "node_modules",
+        "lib",
+        "**/*.test.tsx",
+        "**/*.test.ts",
+        "**/*.spec.tsx",
+        "**/*.spec.ts",
+        "**/__tests__",
+        "**/__stories__/**",
+        "**/*.stories.ts",
+        "**/*.stories.tsx"
+    ],
+    "extends": "./tsconfig.json"
+}


### PR DESCRIPTION
Four packages compiled development-only files into their published bundle: `@comet/admin` and `@comet/cms-admin` shipped compiled stories, `@comet/mail-react` shipped stories and tests with their declarations, and `@comet/cli` shipped compiled tests.
None are part of any public API or needed at runtime, so they only inflated install size.

- **Build-only excludes belong in a build-only config, not the shared one the dev tooling reads.**
  The babel packages add a `.babelrc.build.json` (loaded via `--config-file`); the tsc packages add a `tsconfig.build.json`.
  The shared `.babelrc.json` and `tsconfig.json` stay untouched, so Storybook and the type-checker keep seeing stories and tests.
- **`@comet/mail-react` excludes by story and test filename, not by directory.**
  Its `./storybook` export is public API living beside the demo stories, so a directory-level exclude would drop it.

**Bundle size impact** — measured with `npm pack --dry-run --json` (before = `main`, after = this branch):

| Package | tarball (gzip) | unpacked | files |
| --- | --- | --- | --- |
| `@comet/admin` | 475,012 → 356,114 B (−25.0%) | 3,042,069 → 2,318,616 B (−23.8%) | 1,146 → 1,029 (−117) |
| `@comet/cms-admin` | 1,002,194 → 985,766 B (−1.6%) | 5,533,589 → 5,404,337 B (−2.3%) | 1,450 → 1,438 (−12) |
| `@comet/mail-react` | 56,957 → 31,303 B (−45.0%) | 270,088 → 117,474 B (−56.5%) | 192 → 116 (−76) |
| `@comet/cli` | 15,687 → 11,626 B (−25.9%) | 87,945 → 63,919 B (−27.3%) | 24 → 20 (−4) |
| **Total** | **1,549,850 → 1,384,809 B (−10.6%)** | **8,933,691 → 7,904,346 B (−11.5%)** | **2,812 → 2,603 (−209)** |