### PR TITLE
admin: Add story and design-panel conventions to Future UI

### DIFF
--- a/packages/admin/admin/.storybook/main.ts
+++ b/packages/admin/admin/.storybook/main.ts
@@ -33,7 +33,7 @@ const config: StorybookConfig = {
     stories: ["../src/**/*.mdx", "../src/**/__stories__/*.stories.@(js|jsx|mjs|ts|tsx)"],
     staticDirs: ["./public"],
 
-    addons: ["@storybook/addon-docs", "@storybook/addon-vitest", "storybook-addon-tag-badges"],
+    addons: ["@storybook/addon-designs", "@storybook/addon-docs", "@storybook/addon-vitest", "storybook-addon-tag-badges"],
     framework: "@storybook/react-vite",
 
     viteFinal(viteConfig) {

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -80,6 +80,7 @@
         "@mui/x-data-grid-pro": "^8.28.7",
         "@mui/x-date-pickers": "^8.28.7",
         "@mui/x-date-pickers-pro": "^8.28.7",
+        "@storybook/addon-designs": "^11.1.3",
         "@storybook/addon-docs": "^10.3.5",
         "@storybook/addon-vitest": "10.3.5",
         "@storybook/react-vite": "^10.3.5",

--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -109,6 +109,56 @@ Future UI's styling contract is its class names. Components built on `@base-ui/r
 - A component with no single dominant element names no class `root`.
 - Modifiers nest under `.root` with `&` (`&--disabled` → `cometButton--disabled`).
 
+### Stories
+
+Stories live under the "Future UI" section. Each consumer-facing component has its own story file in an `__stories__/` directory next to its source; story-only helpers (decorators, the Figma-link builder) live in [`storybook/`](storybook). The component's TSDoc and prop table (see [TSDoc](#tsdoc)) drive its autodocs page, so stories don't restate it.
+
+#### Main story
+
+`__stories__/<ComponentName>.stories.tsx`, included in autodocs, is the component's consumer-facing documentation: a new variant, feature, or state gets a story in the same change, keeping the docs page current.
+
+Stories use [Component Story Format 3](https://storybook.js.org/docs/api/csf), typed with `satisfies` so `meta` is checked against the component's props and each story inherits its args:
+
+```tsx
+const meta = {
+    component: Button,
+    args: { children: "Button", onClick: fn() },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+```
+
+`meta.args` holds only what a practical example needs: required content such as `children`, and the event handlers that make it interactive. It omits any prop that has a component default — a defaulted prop is set in the story that demonstrates it instead.
+
+The first story is `Default`, the autodocs example: it sets no args of its own, showing that smallest practical example. Each prop that changes the component visibly then gets one story per option; a prop that changes only semantics, such as `Typography`'s `element`, stays a control, since a story per value would look the same.
+
+Each declared prop is exposed as a control through `argTypes`, by kind:
+
+- **Boolean** — a toggle.
+- **Enum** — `radio` for three options or fewer, `select` for more.
+- **`ReactNode`** — a `select` whose `options` are labels and whose `mapping` resolves each to the node. The built-in empty choice covers the unset case.
+- **Override-API props** (`className`, `slots`, `slotProps`, `ref`, `render`) — `control: false`, keeping the prop-table row without an unusable control.
+- **Event handlers** — `fn()` from `storybook/test`, so calls show in the Actions panel and an interaction test can verify the handler ran.
+
+#### Dev story
+
+`__stories__/<name>.dev.stories.tsx`, optional, nests its title under a `Dev` segment (`Future UI/<Component>/Dev/<Name>`) and sets `tags: ["!autodocs"]` in its meta, keeping these out of the consumer docs. A dev story serves any development, testing, or debugging need, so add them freely — e.g. reproduce a bug in a dev story and use it to confirm the fix, rather than reaching for the Comet demo or a consuming project.
+
+#### Figma
+
+Linking the Figma design is strongly recommended: the main story's `meta` links it through [`@storybook/addon-designs`](https://storybook.js.org/addons/@storybook/addon-designs), so the design panel shows the frame across the component's stories. Every component lives in the same DDS Figma file and differs only by frame, so a story passes only its node id — the `node-id` from the frame's Figma link — to a shared helper:
+
+```tsx
+const meta = {
+    // …
+    parameters: {
+        design: figmaDesign({ nodeId: "25-2" }),
+    },
+} satisfies Meta<typeof Button>;
+```
+
 ## Theme
 
 Components read their colors and metrics from CSS custom properties (`var(--comet-button-…)`, `var(--comet-color-…)`, `var(--comet-typography-…)`) with **no fallback** — an unthemed component renders visibly unstyled rather than silently drifting to a default. There is no runtime JS theme object.

--- a/packages/admin/admin/src/future-ui/components/button/Button.tsx
+++ b/packages/admin/admin/src/future-ui/components/button/Button.tsx
@@ -48,6 +48,12 @@ export interface ButtonProps<StartIcon extends ElementType = "span", EndIcon ext
      * @defaultValue `"primary"`
      */
     variant?: ButtonVariant;
+    /**
+     * Prevents interaction with the button.
+     *
+     * @defaultValue `false`
+     */
+    disabled?: boolean;
     /** Added alongside the component's own classes. */
     className?: string;
     /** Sets which element a named inner part renders as. */

--- a/packages/admin/admin/src/future-ui/components/button/__stories__/Button.stories.tsx
+++ b/packages/admin/admin/src/future-ui/components/button/__stories__/Button.stories.tsx
@@ -1,30 +1,63 @@
 import { ArrowRight, Favorite } from "@comet/admin-icons";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 
+import { figmaDesign } from "../../../storybook/figmaDesign";
 import { themeDecorator } from "../../../storybook/themeDecorator";
 import { Button } from "../Button";
 
-const meta: Meta<typeof Button> = {
+const iconOptions = {
+    Favorite: <Favorite />,
+    ArrowRight: <ArrowRight />,
+};
+
+const meta = {
     component: Button,
     title: "Future UI/Button",
     decorators: [themeDecorator],
-};
+    parameters: {
+        design: figmaDesign({ nodeId: "25-2" }),
+    },
+    args: {
+        children: "Button",
+        onClick: fn(),
+    },
+    argTypes: {
+        variant: {
+            control: "radio",
+            options: ["primary", "secondary"],
+        },
+        startIcon: {
+            control: "select",
+            options: Object.keys(iconOptions),
+            mapping: iconOptions,
+        },
+        endIcon: {
+            control: "select",
+            options: Object.keys(iconOptions),
+            mapping: iconOptions,
+        },
+        className: { control: false },
+        slots: { control: false },
+        slotProps: { control: false },
+    },
+} satisfies Meta<typeof Button>;
 
 export default meta;
 
-type Story = StoryObj<typeof Button>;
+type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {
-    args: {
-        children: "Button",
-        variant: "primary",
-    },
-};
+export const Default: Story = {};
 
 export const Secondary: Story = {
     args: {
-        children: "Button",
         variant: "secondary",
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        disabled: true,
     },
 };
 
@@ -41,17 +74,4 @@ export const WithIcons: Story = {
             </Button>
         </div>
     ),
-};
-
-/**
- * Native button props (`onClick`, ARIA attributes, `type`, …) are part of
- * the top-level surface.
- */
-export const WithClickHandler: Story = {
-    args: {
-        children: "Click me",
-        onClick: () => {
-            window.alert("Clicked");
-        },
-    },
 };

--- a/packages/admin/admin/src/future-ui/components/button/__stories__/customization.dev.module.scss
+++ b/packages/admin/admin/src/future-ui/components/button/__stories__/customization.dev.module.scss
@@ -1,0 +1,35 @@
+.customRoot {
+    background: linear-gradient(135deg, #ff6b6b, #ffa94d);
+    border-radius: 999px;
+    color: #ffffff;
+    box-shadow: 0 4px 12px rgba(255, 107, 107, 0.4);
+}
+
+.customStartIcon {
+    color: #ffe066;
+    font-size: 1.1em;
+}
+
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1.5rem;
+    background: #f4f0fa;
+    border-radius: 12px;
+
+    :global(.cometButton) {
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+    }
+
+    :global(.cometButton--variantPrimary) {
+        background: #6750a4;
+    }
+
+    :global(.cometButton__startIcon),
+    :global(.cometButton__endIcon) {
+        color: #f4af3e;
+    }
+}

--- a/packages/admin/admin/src/future-ui/components/button/__stories__/customization.dev.stories.tsx
+++ b/packages/admin/admin/src/future-ui/components/button/__stories__/customization.dev.stories.tsx
@@ -1,0 +1,40 @@
+import { ArrowRight, Favorite } from "@comet/admin-icons";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { themeDecorator } from "../../../storybook/themeDecorator";
+import { Button } from "../Button";
+import styles from "./customization.dev.module.scss";
+
+const meta = {
+    component: Button,
+    title: "Future UI/Button/Dev/Customization",
+    tags: ["!autodocs"],
+    decorators: [themeDecorator],
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ViaSlotPropsClassName: Story = {
+    args: {
+        children: "Slot-level override",
+        startIcon: <Favorite />,
+        endIcon: <ArrowRight />,
+        className: styles.customRoot,
+        slotProps: {
+            startIcon: { className: styles.customStartIcon },
+        },
+    },
+};
+
+export const ViaWrapperGlobalSelectors: Story = {
+    render: () => (
+        <div className={styles.wrapper}>
+            <Button startIcon={<Favorite />}>Themed via wrapper</Button>
+            <Button variant="secondary" endIcon={<ArrowRight />}>
+                Secondary in the same wrapper
+            </Button>
+        </div>
+    ),
+};

--- a/packages/admin/admin/src/future-ui/components/typography/__stories__/Typography.stories.tsx
+++ b/packages/admin/admin/src/future-ui/components/typography/__stories__/Typography.stories.tsx
@@ -3,39 +3,39 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { themeDecorator } from "../../../storybook/themeDecorator";
 import { Typography } from "../Typography";
 
-const meta: Meta<typeof Typography> = {
+const meta = {
     component: Typography,
     title: "Future UI/Typography",
     decorators: [themeDecorator],
+    args: {
+        children: "The quick brown fox jumps over the lazy dog",
+    },
     argTypes: {
         variant: {
-            control: "select",
+            control: "radio",
             options: ["headline", "body"],
         },
         element: {
             control: "select",
             options: ["h1", "h2", "h3", "h4", "h5", "h6", "p", "span"],
         },
+        className: { control: false },
+        ref: { control: false },
+        render: { control: false },
     },
-};
+} satisfies Meta<typeof Typography>;
 
 export default meta;
 
-type Story = StoryObj<typeof Typography>;
+type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Default: Story = {};
+
+export const Headline: Story = {
     args: {
-        children: "The quick brown fox jumps over the lazy dog",
+        variant: "headline",
+        children: "Headline",
     },
-};
-
-export const Variants: Story = {
-    render: () => (
-        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-            <Typography variant="headline">Headline</Typography>
-            <Typography variant="body">Body — the quick brown fox jumps over the lazy dog.</Typography>
-        </div>
-    ),
 };
 
 /**

--- a/packages/admin/admin/src/future-ui/storybook/figmaDesign.ts
+++ b/packages/admin/admin/src/future-ui/storybook/figmaDesign.ts
@@ -1,0 +1,12 @@
+const ddsFigmaFileUrl = "https://www.figma.com/design/xAe7acdpccDSRCrfeOdAg3/DDS---Dextinity-Admin-UI---V-0.1";
+
+/**
+ * Builds the `@storybook/addon-designs` `design` parameter for a frame in the
+ * shared DDS Figma file, from the frame's `node-id` (for example `25-2`).
+ */
+export function figmaDesign({ nodeId }: { nodeId: string }): { type: "figma"; url: string } {
+    return {
+        type: "figma",
+        url: `${ddsFigmaFileUrl}?node-id=${nodeId}`,
+    };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,6 +851,9 @@ importers:
       '@mui/x-date-pickers-pro':
         specifier: ^8.28.7
         version: 8.28.7(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/addon-designs':
+        specifier: ^11.1.3
+        version: 11.1.3(@storybook/addon-docs@10.3.5(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.106.2(@swc/core@1.15.41)(esbuild@0.27.4)))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/addon-docs':
         specifier: ^10.3.5
         version: 10.3.5(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.106.2(@swc/core@1.15.41)(esbuild@0.27.4))
@@ -2831,6 +2834,9 @@ importers:
       '@graphql-mocks/network-msw':
         specifier: ^0.4.4
         version: 0.4.4(graphql-mocks@0.12.0(graphql@16.14.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))
+      '@storybook/addon-designs':
+        specifier: ^11.1.3
+        version: 11.1.3(@storybook/addon-docs@10.3.5(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.4)))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/addon-docs':
         specifier: ^10.3.5
         version: 10.3.5(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.4))
@@ -5132,6 +5138,14 @@ packages:
     peerDependencies:
       commander: ^11.1.0
 
+  '@figspec/components@2.1.0':
+    resolution: {integrity: sha512-PFKBX2oFz+vhThKTNsu7Mh4ZT3X7YCiM694UkAMT36j/p0tdmXs9Je0Sf88stTEcMgwYvNv9TZtvniYmgaE+bw==}
+
+  '@figspec/react@2.0.1':
+    resolution: {integrity: sha512-xflqJ3XQZVzm8+7dsm8OFxVAmBNNA3Mg65sqwNHiq7VRSMSD7qwH4BPsBy07ZaX+9nHeaacBpFZd3Q0aIsISqw==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@fingerprintjs/fingerprintjs@3.4.2':
     resolution: {integrity: sha512-3Ncze6JsJpB7BpYhqIgvBpfvEX1jsEKrad5hQBpyRQxtoAp6hx3+R46zqfsuQG4D9egQZ+xftQ0u4LPFMB7Wmg==}
 
@@ -6130,6 +6144,14 @@ packages:
 
   '@leichtgewicht/ip-codec@2.0.4':
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
+
+  '@lit-labs/react@2.1.3':
+    resolution: {integrity: sha512-OD9h2JynerBQUMNzb563jiVpxfvPF0HjQkKY2mx0lpVYvD7F+rtJpOGz6ek+6ufMidV3i+MPT9SX62OKWHFrQg==}
+
+  '@lit/react@1.0.8':
+    resolution: {integrity: sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==}
+    peerDependencies:
+      '@types/react': 17 || 18 || 19
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -8034,6 +8056,21 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@storybook/addon-designs@11.1.3':
+    resolution: {integrity: sha512-AK+ij478Y6S16TCNPwm7H90OipVe2wZApOlHjC6qDvMW61zyd4yP1icrRtjehSadw5SCoz8HcAmIYfQCOY6E4A==}
+    peerDependencies:
+      '@storybook/addon-docs': ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0
+    peerDependenciesMeta:
+      '@storybook/addon-docs':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@storybook/addon-docs@10.3.5':
     resolution: {integrity: sha512-WuHbxia/o5TX4Rg/IFD0641K5qId/Nk0dxhmAUNoFs5L0+yfZUwh65XOBbzXqrkYmYmcVID4v7cgDRmzstQNkA==}
@@ -21370,6 +21407,16 @@ snapshots:
       commander: 11.1.0
       prettier: 3.6.2
 
+  '@figspec/components@2.1.0': {}
+
+  '@figspec/react@2.0.1(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@figspec/components': 2.1.0
+      '@lit-labs/react': 2.1.3(@types/react@19.2.15)
+      react: 19.2.6
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@fingerprintjs/fingerprintjs@3.4.2':
     dependencies:
       tslib: 2.8.1
@@ -22621,6 +22668,16 @@ snapshots:
       - utf-8-validate
 
   '@leichtgewicht/ip-codec@2.0.4': {}
+
+  '@lit-labs/react@2.1.3(@types/react@19.2.15)':
+    dependencies:
+      '@lit/react': 1.0.8(@types/react@19.2.15)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@lit/react@1.0.8(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
 
   '@lukeed/csprng@1.1.0': {}
 
@@ -24794,6 +24851,28 @@ snapshots:
       tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@storybook/addon-designs@11.1.3(@storybook/addon-docs@10.3.5(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.106.2(@swc/core@1.15.41)(esbuild@0.27.4)))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+    dependencies:
+      '@figspec/react': 2.0.1(@types/react@19.2.15)(react@19.2.6)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    optionalDependencies:
+      '@storybook/addon-docs': 10.3.5(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.106.2(@swc/core@1.15.41)(esbuild@0.27.4))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@storybook/addon-designs@11.1.3(@storybook/addon-docs@10.3.5(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.4)))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+    dependencies:
+      '@figspec/react': 2.0.1(@types/react@19.2.15)(react@19.2.6)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    optionalDependencies:
+      '@storybook/addon-docs': 10.3.5(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.4))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@storybook/addon-docs@10.3.5(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.106.2(@swc/core@1.15.41)(esbuild@0.27.4))':
     dependencies:

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -5,6 +5,7 @@ const config: StorybookConfig = {
     framework: "@storybook/react-vite",
     stories: ["../src/**/*.@(mdx|stories.tsx)"],
     addons: [
+        "@storybook/addon-designs",
         {
             name: "@storybook/addon-docs",
             options: {

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -61,6 +61,7 @@
         "@comet/eslint-config": "workspace:*",
         "@faker-js/faker": "^10.4.0",
         "@graphql-mocks/network-msw": "^0.4.4",
+        "@storybook/addon-designs": "^11.1.3",
         "@storybook/addon-docs": "^10.3.5",
         "@storybook/addon-vitest": "10.3.5",
         "@storybook/react-vite": "^10.3.5",


### PR DESCRIPTION
Future UI has carried stories since its first components, but the rules for how a component is storied were never written down, so each new component invents its own structure and leaves its design unlinked in Figma.
This writes the conventions into the sub-package README and applies them to Button and Typography.

- **The design addon is registered in the aggregating Storybook as well as the package one.**
  The root Storybook composes the package instance by reference, and an addon present only in the composed instance does not show in the aggregated view.

---

Tasks: https://vivid-planet.atlassian.net/browse/COM-3013, https://vivid-planet.atlassian.net/browse/COM-2973