### PR TITLE
Renovate: remove React Router group

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -51,10 +51,6 @@
             "enabled": false
         },
         {
-            "groupName": "React Router",
-            "matchPackageNames": ["/^react-router/"]
-        },
-        {
             "matchPackageNames": ["@graphql-codegen/*"],
             "groupName": "GraphQL Codegen"
         },


### PR DESCRIPTION
Remove the React Router group from Renovate to prevent immortal PRs, for instance, https://github.com/vivid-planet/comet-starter/pull/1560.

https://claude.ai/code/session_01Gn2Tcccad8dm6zVFdNJ1Gn