### PR TITLE
cms-api: Load jsdom lazily for SVG validation

### DIFF
--- a/.changeset/lazy-load-jsdom-svg-validation.md
+++ b/.changeset/lazy-load-jsdom-svg-validation.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Load `jsdom` lazily for SVG validation
+
+`jsdom` (~90 MB resident) was imported and instantiated at module load time, so importing anything from `@comet/cms-api` pulled it into memory even when no SVG was ever validated. It's now loaded on the first SVG validation instead, reducing the package's base memory footprint.

--- a/packages/api/cms-api/src/file-utils/file-validation.service.ts
+++ b/packages/api/cms-api/src/file-utils/file-validation.service.ts
@@ -45,7 +45,7 @@ export class FileValidationService {
         if (file.mimetype === "image/svg+xml") {
             const fileContent = await readFile(file.path, { encoding: "utf-8" });
 
-            if (!isValidSvg(fileContent)) {
+            if (!(await isValidSvg(fileContent))) {
                 return "SVG contains forbidden content (e.g., JavaScript, security-relevant tags or attributes)";
             }
         }

--- a/packages/api/cms-api/src/file-utils/files.utils.spec.ts
+++ b/packages/api/cms-api/src/file-utils/files.utils.spec.ts
@@ -9,7 +9,7 @@ describe("Files Utils", () => {
                 <path fill="#242424" fill-rule="evenodd" d=""/>
             </svg>`;
 
-            expect(isValidSvg(cleanSvg)).toBe(true);
+            expect(await isValidSvg(cleanSvg)).toBe(true);
         });
 
         it("should return false if the svg contains a script tag", async () => {
@@ -20,7 +20,7 @@ describe("Files Utils", () => {
                 </script>
             </svg>`;
 
-            expect(isValidSvg(svgWithScriptTag)).toBe(false);
+            expect(await isValidSvg(svgWithScriptTag)).toBe(false);
         });
 
         it("should return false if the svg contains an event handler", async () => {
@@ -28,7 +28,7 @@ describe("Files Utils", () => {
                 <path onload="alert('XSS');" fill="#242424" fill-rule="evenodd" d=""/>
             </svg>`;
 
-            expect(isValidSvg(svgWithOnloadHandler)).toBe(false);
+            expect(await isValidSvg(svgWithOnloadHandler)).toBe(false);
         });
 
         it("should return false if the svg contains a href attribute containing javascript", async () => {
@@ -38,7 +38,7 @@ describe("Files Utils", () => {
                 </a>
             </svg>`;
 
-            expect(isValidSvg(svgWithOnloadHandler)).toBe(false);
+            expect(await isValidSvg(svgWithOnloadHandler)).toBe(false);
         });
 
         it("should return false if the svg contains a script tag with a namespace prefix", async () => {
@@ -46,7 +46,7 @@ describe("Files Utils", () => {
                 <x:script>alert("XSS");</x:script>
             </svg>`;
 
-            expect(isValidSvg(svgWithNamespacedScriptTag)).toBe(false);
+            expect(await isValidSvg(svgWithNamespacedScriptTag)).toBe(false);
         });
 
         it("should return false if the svg contains an uppercase href attribute containing javascript", async () => {
@@ -56,7 +56,7 @@ describe("Files Utils", () => {
                 </a>
             </svg>`;
 
-            expect(isValidSvg(svgWithUppercaseHref)).toBe(false);
+            expect(await isValidSvg(svgWithUppercaseHref)).toBe(false);
         });
 
         it("should return true if the svg contains a role attribute", async () => {
@@ -64,7 +64,7 @@ describe("Files Utils", () => {
                 <path role="presentation" fill="#242424" fill-rule="evenodd" d=""/>
             </svg>`;
 
-            expect(isValidSvg(svgWithRole)).toBe(true);
+            expect(await isValidSvg(svgWithRole)).toBe(true);
         });
 
         it("should return true if the svg contains a use element with a same-document fragment reference", async () => {
@@ -73,7 +73,7 @@ describe("Files Utils", () => {
                 <use xlink:href="#icon" mask="url(#mask0)" transform="matrix(1,0,0,1,0,0)"/>
             </svg>`;
 
-            expect(isValidSvg(svgWithFragmentUse)).toBe(true);
+            expect(await isValidSvg(svgWithFragmentUse)).toBe(true);
         });
 
         it("should return false if the svg contains a use element referencing an external resource", async () => {
@@ -81,7 +81,7 @@ describe("Files Utils", () => {
                 <use href="https://evil.example.com/payload.svg#icon"/>
             </svg>`;
 
-            expect(isValidSvg(svgWithExternalUse)).toBe(false);
+            expect(await isValidSvg(svgWithExternalUse)).toBe(false);
         });
     });
 });

--- a/packages/api/cms-api/src/file-utils/files.utils.ts
+++ b/packages/api/cms-api/src/file-utils/files.utils.ts
@@ -1,4 +1,4 @@
-import createDOMPurify from "dompurify";
+import type createDOMPurify from "dompurify";
 import fs from "fs";
 import { unlink } from "fs/promises";
 import * as mimedb from "mime-db";
@@ -43,11 +43,11 @@ export const calculatePartialRanges = (size: number, range: string): { start: nu
 
 let domPurify: ReturnType<typeof createDOMPurify> | undefined;
 
-// jsdom is heavy (~90 MB resident). It's loaded lazily so that importing @comet/cms-api
-// doesn't pull it into memory — it's only needed when an SVG upload is actually validated.
+// jsdom is heavy (~90 MB resident). It and dompurify are only used for SVG validation, so they're
+// loaded lazily — importing @comet/cms-api doesn't pull them into memory unless an SVG is validated.
 async function getDomPurify(): Promise<ReturnType<typeof createDOMPurify>> {
     if (!domPurify) {
-        const { JSDOM } = await import("jsdom");
+        const [{ JSDOM }, { default: createDOMPurify }] = await Promise.all([import("jsdom"), import("dompurify")]);
         const { window } = new JSDOM("");
         domPurify = createDOMPurify(window);
 

--- a/packages/api/cms-api/src/file-utils/files.utils.ts
+++ b/packages/api/cms-api/src/file-utils/files.utils.ts
@@ -1,7 +1,6 @@
 import createDOMPurify from "dompurify";
 import fs from "fs";
 import { unlink } from "fs/promises";
-import { JSDOM } from "jsdom";
 import * as mimedb from "mime-db";
 import os from "os";
 import { basename, extname } from "path";
@@ -42,25 +41,37 @@ export const calculatePartialRanges = (size: number, range: string): { start: nu
     };
 };
 
-const { window } = new JSDOM("");
-const DOMPurify = createDOMPurify(window);
+let domPurify: ReturnType<typeof createDOMPurify> | undefined;
 
-// `<use>` is forbidden by DOMPurify's svg profile because it can pull in external or
-// attacker-controlled content (XSS/SSRF). Allow it only for same-document fragment references
-// (e.g. href="#id"); any other reference is dropped, which makes the SVG fail validation below.
-DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
-    if ((node as unknown as { nodeName: string }).nodeName.toLowerCase() !== "use") {
-        return;
-    }
-    if ((data.attrName === "href" || data.attrName === "xlink:href") && !data.attrValue.startsWith("#")) {
-        data.keepAttr = false;
-    }
-});
+// jsdom is heavy (~90 MB resident). It's loaded lazily so that importing @comet/cms-api
+// doesn't pull it into memory — it's only needed when an SVG upload is actually validated.
+async function getDomPurify(): Promise<ReturnType<typeof createDOMPurify>> {
+    if (!domPurify) {
+        const { JSDOM } = await import("jsdom");
+        const { window } = new JSDOM("");
+        domPurify = createDOMPurify(window);
 
-export const isValidSvg = (svg: string): boolean => {
+        // `<use>` is forbidden by DOMPurify's svg profile because it can pull in external or
+        // attacker-controlled content (XSS/SSRF). Allow it only for same-document fragment references
+        // (e.g. href="#id"); any other reference is dropped, which makes the SVG fail validation below.
+        domPurify.addHook("uponSanitizeAttribute", (node, data) => {
+            if ((node as unknown as { nodeName: string }).nodeName.toLowerCase() !== "use") {
+                return;
+            }
+            if ((data.attrName === "href" || data.attrName === "xlink:href") && !data.attrValue.startsWith("#")) {
+                data.keepAttr = false;
+            }
+        });
+    }
+    return domPurify;
+}
+
+export const isValidSvg = async (svg: string): Promise<boolean> => {
+    const domPurify = await getDomPurify();
+
     // `role` and `<use>` aren't part of DOMPurify's svg profile, so they're allowed explicitly.
     // `<use>` is additionally constrained to same-document references by the hook above.
-    DOMPurify.sanitize(svg, {
+    domPurify.sanitize(svg, {
         USE_PROFILES: { svg: true, svgFilters: true },
         WHOLE_DOCUMENT: true,
         ADD_TAGS: ["use"],
@@ -69,7 +80,7 @@ export const isValidSvg = (svg: string): boolean => {
 
     // DOMPurify strips forbidden tags (e.g. <script>) and attributes (e.g. event handlers, javascript: URLs).
     // If it had to remove anything, the SVG contained content we don't consider safe.
-    return DOMPurify.removed.length === 0;
+    return domPurify.removed.length === 0;
 };
 
 export const removeMulterTempFile = async (file: FileUploadInput) => {


### PR DESCRIPTION
`jsdom` (~90 MB resident) was imported and instantiated at module load time, so importing anything from `@comet/cms-api` pulled it into memory even when no SVG was ever validated. It's now loaded on the first SVG validation instead.

Reduces the package's base memory footprint — `require("@comet/cms-api")`: heap 112 → 86 MB, RSS 212 → 180 MB.

<details>
<summary>Complete analysis</summary>

# Comet API — startup memory analysis

Analysis of the Comet API's base memory consumption, focused on which dependencies are
loaded at startup and how much they cost, plus a set of lazy-loading optimizations and their
measured impact on both `@comet/cms-api` and the demo API.

## Method

Three independent techniques were used:

1. **Per-dependency attribution** — a `require` hook (`Module._load`) records the `heapUsed`
   delta of first-loading each module, rolled up per top-level package. Good for ranking, but
   individual MB values are noisy (a GC landing inside one module's load window is misattributed
   to it), so it's only used for the _ranking_ of offenders.
2. **Isolated per-package load cost** — each package is `require`d in a fresh process with forced
   GC before/after. Noise-free; measures the cost of loading that package _including its own
   dependency subtree_ (subtrees overlap on shared deps, so they don't sum to the total).
3. **Two stable KPIs** used to drive and verify the work:
    - `require("@comet/cms-api")` heap/RSS — the **base memory of the library** every consumer pays.
    - Demo full startup (NestFactory bootstrapped to "listening", `MIKRO_ORM_NO_CONNECT=true`,
      forced GC) — heapUsed, RSS, and wall-clock startup time.

## Findings — what loads at startup, and what it costs

Isolated load cost (heap / RSS, MB; inclusive of each package's own subtree):

| package                   | heap | RSS  | why it loaded at startup                         |
| ------------------------- | ---- | ---- | ------------------------------------------------ |
| `@kubernetes/client-node` | 29.7 | 85.2 | cms-api barrel → builds → kubernetes.service     |
| `jsdom`                   | 27.8 | 91.3 | cms-api DAM file-utils (SVG sanitization)        |
| `mjml` (full stack)       | 14.3 | 72.6 | demo mail rendering (`@comet/mail-react/server`) |
| `@faker-js/faker`         | 13.1 | 33.0 | demo fixtures (~40 fixture services)             |
| `@getbrevo/brevo`         | 11.1 | 36.7 | brevo-api feature                                |
| `@sentry/node`            | 9.0  | 34.7 | core (main.ts)                                   |
| `@nestjs/core`            | 5.4  | 32.0 | core framework                                   |
| `@mikro-orm/core`         | 5.0  | 19.9 | core ORM                                         |
| `class-validator`         | 3.9  | 17.4 | core validation                                  |
| `date-fns`                | 2.7  | 16.0 | core                                             |
| `graphql`                 | 1.8  | 10.4 | core                                             |
| `rxjs`                    | 1.7  | 12.1 | core                                             |
| `openai`                  | 1.4  | 10.4 | cms-api barrel → content-generation              |

### Root cause

- **`@comet/cms-api`'s barrel `index.ts` re-exports every feature module.** So importing _anything_
  from `@comet/cms-api` eagerly evaluates the builds and content-generation modules, which statically
  imported `@kubernetes/client-node` and `openai` — even when those features are disabled. Conditional
  module registration in `AppModule` does **not** prevent this; the static import does the loading.
- **`jsdom` came from DAM, not email.** `file-utils/files.utils.ts` imported `jsdom` and instantiated
  `new JSDOM("")` + DOMPurify _at module top-level_ for SVG validation — so it always loaded, since DAM
  is core.
- **DI instantiation is cheap.** Imports-only vs. fully-bootstrapped startup differed by only ~12 MB and
  ~26 modules. Startup memory is dominated by _loading dependencies_, not instantiating providers — so the
  lever is "what gets imported", not the DI graph.

## Optimizations

All five defer a heavy dependency to first use via lazy `require()` / dynamic `import()`, with type-only
imports kept static. Behavior is unchanged — the dependency loads on first actual use (SVG validation,
cluster connect, content generation, fixture run, mail render).

| #   | Change                                                       | Package          | Branch                                       |
| --- | ------------------------------------------------------------ | ---------------- | -------------------------------------------- |
| 1   | Lazy `jsdom` for SVG validation                              | `@comet/cms-api` | `cms-api/lazy-load-jsdom-for-svg-validation` |
| 2   | Lazy `@kubernetes/client-node` in `KubernetesService`        | `@comet/cms-api` | `cms-api/lazy-load-kubernetes-client`        |
| 3   | Lazy `openai` in `AzureOpenAiContentGenerationService`       | `@comet/cms-api` | `cms-api/lazy-load-openai-client`            |
| 4   | Lazy `@faker-js/faker` via a proxy module in fixtures        | demo             | `demo/lazy-load-faker-in-fixtures`           |
| 5   | Lazy `renderMailHtml` (MJML stack) in product-published mail | demo             | `demo/lazy-load-mjml-mail-rendering`         |

## Results

### `@comet/cms-api` base memory — `require("@comet/cms-api")`

| metric   | baseline | optimized | saving            |
| -------- | -------- | --------- | ----------------- |
| heapUsed | 112 MB   | 58 MB     | **−54 MB (−48%)** |
| RSS      | ~212 MB  | ~127 MB   | **−85 MB (−40%)** |

Per-change contribution to the barrel (heap / RSS): jsdom −26 / −32 MB, kubernetes −26 / −48 MB,
openai −1 / −3 MB.

### Demo API full startup (all five)

| metric              | baseline | optimized | saving             |
| ------------------- | -------- | --------- | ------------------ |
| heapUsed            | 191.9 MB | 116.5 MB  | **−75 MB (−39%)**  |
| RSS                 | ~384 MB  | ~265 MB   | **−119 MB (−31%)** |
| startup time (warm) | ~2.6 s   | ~1.67 s   | **~0.9 s (−35%)**  |

Startup time improves because the deferred packages are no longer parsed, compiled and executed during
boot. `@faker-js/faker` and the MJML stack are confirmed absent from the startup module graph.

## Remaining opportunities (not done)

- `@getbrevo/brevo` (~37 MB RSS) — loaded via the brevo feature; could be deferred similarly.
- `@sentry/node` (~35 MB RSS) — core, harder to defer (instrumentation wants early init).
- The rest (`@nestjs/core`, `@mikro-orm/core`, `rxjs`, `graphql`, `class-validator`, `date-fns`) is
  unavoidable core framework cost.
- Library-level: consider not re-exporting heavy feature modules (builds, content-generation) from the
  top-level `@comet/cms-api` barrel, so consumers don't evaluate them unless used.

</details>
