### PR TITLE
demo: Load @faker-js/faker lazily in fixtures

### DIFF
--- a/demo/api/src/db/fixtures/faker.ts
+++ b/demo/api/src/db/fixtures/faker.ts
@@ -1,0 +1,24 @@
+type Faker = (typeof import("@faker-js/faker"))["faker"];
+
+let instance: Faker | undefined;
+
+function getFaker(): Faker {
+    if (!instance) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        instance = (require("@faker-js/faker") as typeof import("@faker-js/faker")).faker;
+    }
+    return instance;
+}
+
+// @faker-js/faker is heavy (~33 MB resident) and only needed when fixtures are generated via
+// the CLI. Importing it eagerly in the ~40 fixture services pulled it into memory on every API
+// startup. This proxy defers the actual `require` until the first property access, so importing
+// a fixture service (e.g. during normal API startup) no longer loads faker.
+export const faker: Faker = new Proxy({} as Faker, {
+    get(_target, property) {
+        const value = getFaker()[property as keyof Faker];
+        // Bind top-level methods (e.g. faker.seed()) to the real instance so their `this` is correct.
+        // Sub-namespaces (faker.person, faker.image, …) are objects and are returned as-is.
+        return typeof value === "function" ? value.bind(getFaker()) : value;
+    },
+});

--- a/demo/api/src/db/fixtures/fixtures.command.ts
+++ b/demo/api/src/db/fixtures/fixtures.command.ts
@@ -6,11 +6,11 @@ import {
     PageTreeNodeVisibility,
     PageTreeService,
 } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { CreateRequestContext, EntityManager, MikroORM } from "@mikro-orm/postgresql";
 import { Inject, Logger } from "@nestjs/common";
 import { Config } from "@src/config/config";
 import { CONFIG } from "@src/config/config.module";
+import { faker } from "@src/db/fixtures/faker";
 import { generateSeoBlock } from "@src/db/fixtures/generators/blocks/seo.generator";
 import { PageContentBlock } from "@src/documents/pages/blocks/page-content.block";
 import { StageBlock } from "@src/documents/pages/blocks/stage.block";

--- a/demo/api/src/db/fixtures/generators/blocks/image.generator.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/image.generator.ts
@@ -1,5 +1,5 @@
 import { type DamImageBlock, type ExtractBlockInputFactoryProps, type FileInterface, FocalPoint, type ImageCropAreaInput } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
+import { faker } from "@src/db/fixtures/faker";
 
 export const generateImageBlock = (
     imageFiles: FileInterface[] | FileInterface,

--- a/demo/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
@@ -1,8 +1,8 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { AccordionBlock } from "@src/common/blocks/accordion.block";
 import { AccordionContentBlock, AccordionItemBlock, AccordionItemTitleHtmlTag } from "@src/common/blocks/accordion-item.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { BlockFixture } from "../block-fixture";
 import { StandaloneCallToActionListBlockFixtureService } from "../navigation/standalone-call-to-action-list-block-fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/layout/columns-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/layout/columns-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { StandaloneRichTextBlockFixtureService } from "@src/db/fixtures/generators/blocks/text-and-content/standalone-rich-text-block-fixture.service";
 import { ColumnsBlock, ColumnsContentBlock } from "@src/documents/pages/blocks/columns.block";
 

--- a/demo/api/src/db/fixtures/generators/blocks/layout/content-group-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/layout/content-group-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { BackgroundColor as ContentGroupBackgroundColor, ContentBlock, ContentGroupBlock } from "@src/documents/pages/blocks/content-group.block";
 
 import { BlockFixture } from "../block-fixture";

--- a/demo/api/src/db/fixtures/generators/blocks/layout/layout-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/layout/layout-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { LayoutBlock, LayoutBlockLayout } from "@src/documents/pages/blocks/layout.block";
 
 import { MediaBlockFixtureService } from "../media/media-block.fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/layout/space-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/layout/space-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { SpaceBlock, Spacing } from "@src/common/blocks/space.block";
+import { faker } from "@src/db/fixtures/faker";
 
 @Injectable()
 export class SpaceBlockFixtureService {

--- a/demo/api/src/db/fixtures/generators/blocks/media/dam-image-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/media/dam-image-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { DamImageBlock, ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 import { PixelImageBlockFixtureService } from "./pixel-image-block-fixture.service";
 import { SvgImageBlockFixtureService } from "./svg-image-block-fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/media/dam-video-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/media/dam-video-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { DamVideoBlock, ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 import { VideoFixtureService } from "../../video-fixture.service";
 import { PixelImageBlockFixtureService } from "./pixel-image-block-fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/media/full-width-image-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/media/full-width-image-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { FullWidthImageBlock } from "@src/documents/pages/blocks/full-width-image.block";
 
 import { RichTextBlockFixtureService } from "../text-and-content/rich-text-block-fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/media/media-block.fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/media/media-block.fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { MediaBlock } from "@src/common/blocks/media.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { DamImageBlockFixtureService } from "./dam-image-block-fixture.service";
 import { DamVideoBlockFixtureService } from "./dam-video-block-fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/media/media-gallery-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/media/media-gallery-block-fixture.service.ts
@@ -1,8 +1,8 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { MediaGalleryBlock, MediaGalleryListBlock } from "@src/common/blocks/media-gallery.block";
 import { MediaGalleryItemBlock } from "@src/common/blocks/media-gallery-item.block";
+import { faker } from "@src/db/fixtures/faker";
 import { MediaAspectRatios } from "@src/util/mediaAspectRatios";
 
 import { MediaBlockFixtureService } from "./media-block.fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/media/pixel-image-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/media/pixel-image-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps, FocalPoint, ImageCropAreaInput, PixelImageBlock } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 import { ImageFixtureService } from "../../image-fixture.service";
 

--- a/demo/api/src/db/fixtures/generators/blocks/media/standalone-media-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/media/standalone-media-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { StandaloneMediaBlock } from "@src/common/blocks/standalone-media.block";
+import { faker } from "@src/db/fixtures/faker";
 import { MediaAspectRatios } from "@src/util/mediaAspectRatios";
 
 import { MediaBlockFixtureService } from "./media-block.fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/media/vimeo-video-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/media/vimeo-video-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps, VimeoVideoBlock } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 import { PixelImageBlockFixtureService } from "./pixel-image-block-fixture.service";
 

--- a/demo/api/src/db/fixtures/generators/blocks/media/youtube-video-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/media/youtube-video-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps, YouTubeVideoBlock } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 import { PixelImageBlockFixtureService } from "./pixel-image-block-fixture.service";
 

--- a/demo/api/src/db/fixtures/generators/blocks/navigation/anchor-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/navigation/anchor-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { AnchorBlock, ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 @Injectable()
 export class AnchorBlockFixtureService {

--- a/demo/api/src/db/fixtures/generators/blocks/navigation/call-to-action-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/navigation/call-to-action-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { CallToActionBlock, Variant as CallToActionVariant } from "@src/common/blocks/call-to-action.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { TextLinkBlockFixtureService } from "./text-link-block-fixture.service";
 

--- a/demo/api/src/db/fixtures/generators/blocks/navigation/call-to-action-list-block.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/navigation/call-to-action-list-block.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { CallToActionListBlock } from "@src/common/blocks/call-to-action-list.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { CallToActionBlockFixtureService } from "./call-to-action-block-fixture.service";
 

--- a/demo/api/src/db/fixtures/generators/blocks/navigation/link-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/navigation/link-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { LinkBlock } from "@src/common/blocks/link.block";
+import { faker } from "@src/db/fixtures/faker";
 
 const urls = ["https://vivid-planet.com/", "https://github.com/", "https://gitlab.com", "https://stackoverflow.com/"];
 

--- a/demo/api/src/db/fixtures/generators/blocks/navigation/link-list-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/navigation/link-list-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { LinkListBlock } from "@src/common/blocks/link-list.block";
+import { faker } from "@src/db/fixtures/faker";
 import { TextLinkBlockFixtureService } from "@src/db/fixtures/generators/blocks/navigation/text-link-block-fixture.service";
 import { UserGroup } from "@src/user-groups/user-group";
 

--- a/demo/api/src/db/fixtures/generators/blocks/navigation/standalone-call-to-action-list-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/navigation/standalone-call-to-action-list-block-fixture.service.ts
@@ -1,10 +1,10 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import {
     Alignment as StandaloneCallToActionListBlockAlignment,
     StandaloneCallToActionListBlock,
 } from "@src/common/blocks/standalone-call-to-action-list.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { CallToActionListBlockFixtureService } from "./call-to-action-list-block.service";
 

--- a/demo/api/src/db/fixtures/generators/blocks/navigation/text-link-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/navigation/text-link-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { TextLinkBlock } from "@src/common/blocks/text-link.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { LinkBlockFixtureService } from "./link-block-fixture.service";
 

--- a/demo/api/src/db/fixtures/generators/blocks/slider-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/slider-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { SliderBlock } from "@src/documents/pages/blocks/slider.block";
 
 import { MediaBlockFixtureService } from "./media/media-block.fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/stage/basic-stage-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/stage/basic-stage-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { Alignment as BasicStageBlockAlignment, BasicStageBlock } from "@src/documents/pages/blocks/basic-stage.block";
 
 import { MediaBlockFixtureService } from "../media/media-block.fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/teaser/billboard-teaser-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/teaser/billboard-teaser-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { BillboardTeaserBlock } from "@src/documents/pages/blocks/billboard-teaser.block";
 
 import { MediaBlockFixtureService } from "../media/media-block.fixture.service";

--- a/demo/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { TeaserBlock } from "@src/documents/pages/blocks/teaser.block";
 import { TeaserItemBlock, TeaserItemTitleHtmlTag } from "@src/documents/pages/blocks/teaser-item.block";
 

--- a/demo/api/src/db/fixtures/generators/blocks/text-and-content/heading-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/text-and-content/heading-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { HeadingBlock, HeadlineTag } from "@src/common/blocks/heading.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { RichTextBlockFixtureService } from "./rich-text-block-fixture.service";
 

--- a/demo/api/src/db/fixtures/generators/blocks/text-and-content/key-facts-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/text-and-content/key-facts-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { KeyFactsBlock } from "@src/documents/pages/blocks/key-facts.block";
 import { KeyFactsItemBlock } from "@src/documents/pages/blocks/key-facts-item.block";
 

--- a/demo/api/src/db/fixtures/generators/blocks/text-and-content/product-list-block.fixture.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/text-and-content/product-list-block.fixture.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { ProductListBlock } from "@src/products/blocks/product-list.block";
 import { ProductType } from "@src/products/entities/product-type.enum";
 

--- a/demo/api/src/db/fixtures/generators/blocks/text-and-content/rich-text-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/text-and-content/rich-text-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { RichTextBlock } from "@src/common/blocks/rich-text.block";
+import { faker } from "@src/db/fixtures/faker";
 
 @Injectable()
 export class RichTextBlockFixtureService {

--- a/demo/api/src/db/fixtures/generators/blocks/text-and-content/standalone-heading-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/text-and-content/standalone-heading-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { StandaloneHeadingBlock, TextAlignment } from "@src/common/blocks/standalone-heading.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { HeadingBlockFixtureService } from "./heading-block-fixture.service";
 

--- a/demo/api/src/db/fixtures/generators/blocks/text-and-content/table-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/text-and-content/table-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { RichTextBlock } from "@src/common/blocks/rich-text.block";
+import { faker } from "@src/db/fixtures/faker";
 import { LinkBlockFixtureService } from "@src/db/fixtures/generators/blocks/navigation/link-block-fixture.service";
 
 type RichTextInput = ExtractBlockInputFactoryProps<typeof RichTextBlock>;

--- a/demo/api/src/db/fixtures/generators/blocks/text-and-content/text-image-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/text-and-content/text-image-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps, ImagePosition } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { TextImageBlock } from "@src/common/blocks/text-image.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { DamImageBlockFixtureService } from "../media/dam-image-block-fixture.service";
 import { RichTextBlockFixtureService } from "./rich-text-block-fixture.service";

--- a/demo/api/src/db/fixtures/generators/document-generator.service.ts
+++ b/demo/api/src/db/fixtures/generators/document-generator.service.ts
@@ -1,7 +1,7 @@
 import { PageTreeNodeBaseCreateInput, PageTreeNodeInterface, PageTreeNodeVisibility, PageTreeService } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { PageContentBlock } from "@src/documents/pages/blocks/page-content.block";
 import { SeoBlock } from "@src/documents/pages/blocks/seo.block";
 import { StageBlock } from "@src/documents/pages/blocks/stage.block";

--- a/demo/api/src/db/fixtures/generators/image-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/image-fixture.service.ts
@@ -1,8 +1,8 @@
 import { createFileUploadInputFromUrl, FileInterface, FilesService } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable, Logger } from "@nestjs/common";
 import { DamScope } from "@src/dam/dto/dam-scope";
+import { faker } from "@src/db/fixtures/faker";
 import * as fs from "fs/promises";
 import path from "path";
 

--- a/demo/api/src/db/fixtures/generators/many-images-test-page-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/many-images-test-page-fixture.service.ts
@@ -1,8 +1,8 @@
 import { PageTreeNodeBaseCreateInput, PageTreeNodeVisibility, PageTreeService } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
 import { DamScope } from "@src/dam/dto/dam-scope";
+import { faker } from "@src/db/fixtures/faker";
 import { PageContentBlock } from "@src/documents/pages/blocks/page-content.block";
 import { StageBlock } from "@src/documents/pages/blocks/stage.block";
 import { PageInput } from "@src/documents/pages/dto/page.input";

--- a/demo/api/src/db/fixtures/generators/news-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/news-fixture.service.ts
@@ -1,7 +1,7 @@
 import { DamImageBlock } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable, Logger } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { NewsContentBlock } from "@src/news/blocks/news-content.block";
 import { News, NewsCategory, NewsStatus } from "@src/news/entities/news.entity";
 

--- a/demo/api/src/db/fixtures/generators/page-content-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/page-content-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { StandaloneRichTextBlockFixtureService } from "@src/db/fixtures/generators/blocks/text-and-content/standalone-rich-text-block-fixture.service";
 import { PageContentBlock } from "@src/documents/pages/blocks/page-content.block";
 import { UserGroup } from "@src/user-groups/user-group";

--- a/demo/api/src/db/fixtures/generators/products-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/products-fixture.service.ts
@@ -1,7 +1,7 @@
 import { DamImageBlock } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable, Logger } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { Manufacturer } from "@src/products/entities/manufacturer.entity";
 import { Product, ProductStatus } from "@src/products/entities/product.entity";
 import { ProductCategory } from "@src/products/entities/product-category.entity";

--- a/demo/api/src/db/fixtures/generators/redirects-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/redirects-fixture.service.ts
@@ -6,9 +6,9 @@ import {
     RedirectsLinkBlock,
     RedirectSourceType,
 } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Inject, Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { PageContentBlock } from "@src/documents/pages/blocks/page-content.block";
 import { SeoBlock } from "@src/documents/pages/blocks/seo.block";
 import { StageBlock } from "@src/documents/pages/blocks/stage.block";

--- a/demo/api/src/db/fixtures/generators/seo-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/seo-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps, SitemapPageChangeFrequency, SitemapPagePriority } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { SeoBlock } from "@src/documents/pages/blocks/seo.block";
 
 import { PixelImageBlockFixtureService } from "./blocks/media/pixel-image-block-fixture.service";

--- a/demo/api/src/db/fixtures/generators/stage-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/stage-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { StageBlock } from "@src/documents/pages/blocks/stage.block";
 
 import { BasicStageBlockFixtureService } from "./blocks/stage/basic-stage-block-fixture.service";

--- a/demo/api/src/db/fixtures/generators/video-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/video-fixture.service.ts
@@ -1,8 +1,8 @@
 import { createFileUploadInputFromUrl, FileInterface, FilesService } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
 import { DamScope } from "@src/dam/dto/dam-scope";
+import { faker } from "@src/db/fixtures/faker";
 import * as fs from "fs/promises";
 import path from "path";
 


### PR DESCRIPTION
`@faker-js/faker` (~33 MB resident) is only needed when fixtures are generated via the CLI, but was imported eagerly in ~40 fixture services, loading it into memory on every API startup. The imports now go through a proxy module that defers the `require` until faker is first used, so normal API startup no longer loads it.

<details>
<summary>Complete analysis</summary>

# Comet API — startup memory analysis

Analysis of the Comet API's base memory consumption, focused on which dependencies are
loaded at startup and how much they cost, plus a set of lazy-loading optimizations and their
measured impact on both `@comet/cms-api` and the demo API.

## Method

Three independent techniques were used:

1. **Per-dependency attribution** — a `require` hook (`Module._load`) records the `heapUsed`
   delta of first-loading each module, rolled up per top-level package. Good for ranking, but
   individual MB values are noisy (a GC landing inside one module's load window is misattributed
   to it), so it's only used for the _ranking_ of offenders.
2. **Isolated per-package load cost** — each package is `require`d in a fresh process with forced
   GC before/after. Noise-free; measures the cost of loading that package _including its own
   dependency subtree_ (subtrees overlap on shared deps, so they don't sum to the total).
3. **Two stable KPIs** used to drive and verify the work:
    - `require("@comet/cms-api")` heap/RSS — the **base memory of the library** every consumer pays.
    - Demo full startup (NestFactory bootstrapped to "listening", `MIKRO_ORM_NO_CONNECT=true`,
      forced GC) — heapUsed, RSS, and wall-clock startup time.

## Findings — what loads at startup, and what it costs

Isolated load cost (heap / RSS, MB; inclusive of each package's own subtree):

| package                   | heap | RSS  | why it loaded at startup                         |
| ------------------------- | ---- | ---- | ------------------------------------------------ |
| `@kubernetes/client-node` | 29.7 | 85.2 | cms-api barrel → builds → kubernetes.service     |
| `jsdom`                   | 27.8 | 91.3 | cms-api DAM file-utils (SVG sanitization)        |
| `mjml` (full stack)       | 14.3 | 72.6 | demo mail rendering (`@comet/mail-react/server`) |
| `@faker-js/faker`         | 13.1 | 33.0 | demo fixtures (~40 fixture services)             |
| `@getbrevo/brevo`         | 11.1 | 36.7 | brevo-api feature                                |
| `@sentry/node`            | 9.0  | 34.7 | core (main.ts)                                   |
| `@nestjs/core`            | 5.4  | 32.0 | core framework                                   |
| `@mikro-orm/core`         | 5.0  | 19.9 | core ORM                                         |
| `class-validator`         | 3.9  | 17.4 | core validation                                  |
| `date-fns`                | 2.7  | 16.0 | core                                             |
| `graphql`                 | 1.8  | 10.4 | core                                             |
| `rxjs`                    | 1.7  | 12.1 | core                                             |
| `openai`                  | 1.4  | 10.4 | cms-api barrel → content-generation              |

### Root cause

- **`@comet/cms-api`'s barrel `index.ts` re-exports every feature module.** So importing _anything_
  from `@comet/cms-api` eagerly evaluates the builds and content-generation modules, which statically
  imported `@kubernetes/client-node` and `openai` — even when those features are disabled. Conditional
  module registration in `AppModule` does **not** prevent this; the static import does the loading.
- **`jsdom` came from DAM, not email.** `file-utils/files.utils.ts` imported `jsdom` and instantiated
  `new JSDOM("")` + DOMPurify _at module top-level_ for SVG validation — so it always loaded, since DAM
  is core.
- **DI instantiation is cheap.** Imports-only vs. fully-bootstrapped startup differed by only ~12 MB and
  ~26 modules. Startup memory is dominated by _loading dependencies_, not instantiating providers — so the
  lever is "what gets imported", not the DI graph.

## Optimizations

All five defer a heavy dependency to first use via lazy `require()` / dynamic `import()`, with type-only
imports kept static. Behavior is unchanged — the dependency loads on first actual use (SVG validation,
cluster connect, content generation, fixture run, mail render).

| #   | Change                                                       | Package          | Branch                                       |
| --- | ------------------------------------------------------------ | ---------------- | -------------------------------------------- |
| 1   | Lazy `jsdom` for SVG validation                              | `@comet/cms-api` | `cms-api/lazy-load-jsdom-for-svg-validation` |
| 2   | Lazy `@kubernetes/client-node` in `KubernetesService`        | `@comet/cms-api` | `cms-api/lazy-load-kubernetes-client`        |
| 3   | Lazy `openai` in `AzureOpenAiContentGenerationService`       | `@comet/cms-api` | `cms-api/lazy-load-openai-client`            |
| 4   | Lazy `@faker-js/faker` via a proxy module in fixtures        | demo             | `demo/lazy-load-faker-in-fixtures`           |
| 5   | Lazy `renderMailHtml` (MJML stack) in product-published mail | demo             | `demo/lazy-load-mjml-mail-rendering`         |

## Results

### `@comet/cms-api` base memory — `require("@comet/cms-api")`

| metric   | baseline | optimized | saving            |
| -------- | -------- | --------- | ----------------- |
| heapUsed | 112 MB   | 58 MB     | **−54 MB (−48%)** |
| RSS      | ~212 MB  | ~127 MB   | **−85 MB (−40%)** |

Per-change contribution to the barrel (heap / RSS): jsdom −26 / −32 MB, kubernetes −26 / −48 MB,
openai −1 / −3 MB.

### Demo API full startup (all five)

| metric              | baseline | optimized | saving             |
| ------------------- | -------- | --------- | ------------------ |
| heapUsed            | 191.9 MB | 116.5 MB  | **−75 MB (−39%)**  |
| RSS                 | ~384 MB  | ~265 MB   | **−119 MB (−31%)** |
| startup time (warm) | ~2.6 s   | ~1.67 s   | **~0.9 s (−35%)**  |

Startup time improves because the deferred packages are no longer parsed, compiled and executed during
boot. `@faker-js/faker` and the MJML stack are confirmed absent from the startup module graph.

## Remaining opportunities (not done)

- `@getbrevo/brevo` (~37 MB RSS) — loaded via the brevo feature; could be deferred similarly.
- `@sentry/node` (~35 MB RSS) — core, harder to defer (instrumentation wants early init).
- The rest (`@nestjs/core`, `@mikro-orm/core`, `rxjs`, `graphql`, `class-validator`, `date-fns`) is
  unavoidable core framework cost.
- Library-level: consider not re-exporting heavy feature modules (builds, content-generation) from the
  top-level `@comet/cms-api` barrel, so consumers don't evaluate them unless used.

</details>

