### PR TITLE
demo: Render product-published mail lazily to avoid loading MJML at startup

### DIFF
--- a/demo/api/src/products/published-mail/product-published.mail.tsx
+++ b/demo/api/src/products/published-mail/product-published.mail.tsx
@@ -1,5 +1,4 @@
 import { MailTemplate, MailTemplateInterface } from "@comet/cms-api";
-import { renderMailHtml } from "@comet/mail-react/server";
 import { TranslationService } from "@src/translation/translation.service";
 import { IntlProvider } from "react-intl";
 
@@ -10,6 +9,10 @@ export class ProductPublishedMail implements MailTemplateInterface<MailProps> {
     constructor(private readonly translationService: TranslationService) {}
 
     async generateMail(props: MailProps) {
+        // Imported lazily so the heavy MJML/jsdom rendering stack isn't pulled into memory on
+        // API startup — it's only needed when a mail is actually rendered.
+        const { renderMailHtml } = await import("@comet/mail-react/server");
+
         const intl = await this.translationService.getIntl(props.recipient.language);
         const { html, mjmlWarnings } = renderMailHtml(
             <IntlProvider {...intl}>


### PR DESCRIPTION
`renderMailHtml` from `@comet/mail-react/server` statically pulled the MJML/jsdom rendering stack (~70 MB resident) into memory on every API startup, although mail is only rendered on demand. It's now imported dynamically inside `generateMail`, so the rendering stack loads only when a mail is actually generated.

<details>
<summary>Complete analysis</summary>

# Comet API — startup memory analysis

Analysis of the Comet API's base memory consumption, focused on which dependencies are
loaded at startup and how much they cost, plus a set of lazy-loading optimizations and their
measured impact on both `@comet/cms-api` and the demo API.

## Method

Three independent techniques were used:

1. **Per-dependency attribution** — a `require` hook (`Module._load`) records the `heapUsed`
   delta of first-loading each module, rolled up per top-level package. Good for ranking, but
   individual MB values are noisy (a GC landing inside one module's load window is misattributed
   to it), so it's only used for the _ranking_ of offenders.
2. **Isolated per-package load cost** — each package is `require`d in a fresh process with forced
   GC before/after. Noise-free; measures the cost of loading that package _including its own
   dependency subtree_ (subtrees overlap on shared deps, so they don't sum to the total).
3. **Two stable KPIs** used to drive and verify the work:
    - `require("@comet/cms-api")` heap/RSS — the **base memory of the library** every consumer pays.
    - Demo full startup (NestFactory bootstrapped to "listening", `MIKRO_ORM_NO_CONNECT=true`,
      forced GC) — heapUsed, RSS, and wall-clock startup time.

## Findings — what loads at startup, and what it costs

Isolated load cost (heap / RSS, MB; inclusive of each package's own subtree):

| package                   | heap | RSS  | why it loaded at startup                         |
| ------------------------- | ---- | ---- | ------------------------------------------------ |
| `@kubernetes/client-node` | 29.7 | 85.2 | cms-api barrel → builds → kubernetes.service     |
| `jsdom`                   | 27.8 | 91.3 | cms-api DAM file-utils (SVG sanitization)        |
| `mjml` (full stack)       | 14.3 | 72.6 | demo mail rendering (`@comet/mail-react/server`) |
| `@faker-js/faker`         | 13.1 | 33.0 | demo fixtures (~40 fixture services)             |
| `@getbrevo/brevo`         | 11.1 | 36.7 | brevo-api feature                                |
| `@sentry/node`            | 9.0  | 34.7 | core (main.ts)                                   |
| `@nestjs/core`            | 5.4  | 32.0 | core framework                                   |
| `@mikro-orm/core`         | 5.0  | 19.9 | core ORM                                         |
| `class-validator`         | 3.9  | 17.4 | core validation                                  |
| `date-fns`                | 2.7  | 16.0 | core                                             |
| `graphql`                 | 1.8  | 10.4 | core                                             |
| `rxjs`                    | 1.7  | 12.1 | core                                             |
| `openai`                  | 1.4  | 10.4 | cms-api barrel → content-generation              |

### Root cause

- **`@comet/cms-api`'s barrel `index.ts` re-exports every feature module.** So importing _anything_
  from `@comet/cms-api` eagerly evaluates the builds and content-generation modules, which statically
  imported `@kubernetes/client-node` and `openai` — even when those features are disabled. Conditional
  module registration in `AppModule` does **not** prevent this; the static import does the loading.
- **`jsdom` came from DAM, not email.** `file-utils/files.utils.ts` imported `jsdom` and instantiated
  `new JSDOM("")` + DOMPurify _at module top-level_ for SVG validation — so it always loaded, since DAM
  is core.
- **DI instantiation is cheap.** Imports-only vs. fully-bootstrapped startup differed by only ~12 MB and
  ~26 modules. Startup memory is dominated by _loading dependencies_, not instantiating providers — so the
  lever is "what gets imported", not the DI graph.

## Optimizations

All five defer a heavy dependency to first use via lazy `require()` / dynamic `import()`, with type-only
imports kept static. Behavior is unchanged — the dependency loads on first actual use (SVG validation,
cluster connect, content generation, fixture run, mail render).

| #   | Change                                                       | Package          | Branch                                       |
| --- | ------------------------------------------------------------ | ---------------- | -------------------------------------------- |
| 1   | Lazy `jsdom` for SVG validation                              | `@comet/cms-api` | `cms-api/lazy-load-jsdom-for-svg-validation` |
| 2   | Lazy `@kubernetes/client-node` in `KubernetesService`        | `@comet/cms-api` | `cms-api/lazy-load-kubernetes-client`        |
| 3   | Lazy `openai` in `AzureOpenAiContentGenerationService`       | `@comet/cms-api` | `cms-api/lazy-load-openai-client`            |
| 4   | Lazy `@faker-js/faker` via a proxy module in fixtures        | demo             | `demo/lazy-load-faker-in-fixtures`           |
| 5   | Lazy `renderMailHtml` (MJML stack) in product-published mail | demo             | `demo/lazy-load-mjml-mail-rendering`         |

## Results

### `@comet/cms-api` base memory — `require("@comet/cms-api")`

| metric   | baseline | optimized | saving            |
| -------- | -------- | --------- | ----------------- |
| heapUsed | 112 MB   | 58 MB     | **−54 MB (−48%)** |
| RSS      | ~212 MB  | ~127 MB   | **−85 MB (−40%)** |

Per-change contribution to the barrel (heap / RSS): jsdom −26 / −32 MB, kubernetes −26 / −48 MB,
openai −1 / −3 MB.

### Demo API full startup (all five)

| metric              | baseline | optimized | saving             |
| ------------------- | -------- | --------- | ------------------ |
| heapUsed            | 191.9 MB | 116.5 MB  | **−75 MB (−39%)**  |
| RSS                 | ~384 MB  | ~265 MB   | **−119 MB (−31%)** |
| startup time (warm) | ~2.6 s   | ~1.67 s   | **~0.9 s (−35%)**  |

Startup time improves because the deferred packages are no longer parsed, compiled and executed during
boot. `@faker-js/faker` and the MJML stack are confirmed absent from the startup module graph.

## Remaining opportunities (not done)

- `@getbrevo/brevo` (~37 MB RSS) — loaded via the brevo feature; could be deferred similarly.
- `@sentry/node` (~35 MB RSS) — core, harder to defer (instrumentation wants early init).
- The rest (`@nestjs/core`, `@mikro-orm/core`, `rxjs`, `graphql`, `class-validator`, `date-fns`) is
  unavoidable core framework cost.
- Library-level: consider not re-exporting heavy feature modules (builds, content-generation) from the
  top-level `@comet/cms-api` barrel, so consumers don't evaluate them unless used.

</details>

