### PR TITLE
Add styled-component placement conventions to comet-admin-ui skill

### DIFF
--- a/skills/comet-admin-ui/SKILL.md
+++ b/skills/comet-admin-ui/SKILL.md
@@ -75,8 +75,6 @@ const Panel = styled("div")`
 <Panel>{children}</Panel>;
 ```
 
-Move the styles to a private `*.sc.ts` sibling once a component grows several styled parts.
-
 ### Spacing and color: theme tokens, not hard-coded values
 
 Read spacing and color from the theme instead of typing pixels and hex codes. The theme is the
@@ -136,3 +134,26 @@ const Title = styled("h2")`
 // Prefer — a Typography variant from the type scale
 <Typography variant="h4">{title}</Typography>;
 ```
+
+## Organizing styled components
+
+By default, define a component's styled parts at the bottom of its own file, below the component
+that uses them:
+
+```
+imports → types → component → styled components
+```
+
+When a file grows hard to read, refactor the component itself first — split it into smaller
+components and compose them, each keeping its own styled parts at the bottom. Move styles to a
+separate `*.sc.ts` sibling only when you are asked to, or when the styles grow but the component
+cannot be split logically. A `*.sc.ts` file is private to its equally-named component
+(`FooButton.sc.ts` belongs to `FooButton.tsx`). Don't import one component's `*.sc.ts` from another:
+that couples them through styling neither owns. When styling is shared, give it a single owner — a
+reusable component (below).
+
+When the same styled component is used by several components, it is no longer a styled part of any
+one of them. Promote it to its own reusable component: one export per file, named exactly as that
+export so it is easy to find, e.g. `SpecialButton.ts` exporting
+`export const SpecialButton = styled(Button)`. Group several small related ones into a single
+generically-named file only when explicitly instructed.


### PR DESCRIPTION
Agents building admin UIs have no consistent rule for where a styled component should live, so they scatter styling across files or pull it into separate files too early. This adds a default — styled parts at the bottom of their own file — and rules for what to do as a file grows or a styled component is reused, so placement stays predictable and reviewable.

- **Growth is handled by splitting the component, not by extracting its styles.** 
A file with many styled parts usually means the component is doing too much; splitting it addresses that, where moving the styles to a separate file only hides it.
- **Reusable styled components get one file each by default.** 
A shared generically-named file is allowed only when explicitly requested, so one file does not collect unrelated styled components.