### PR TITLE
Block form submission while FileUploadField is uploading

### DIFF
--- a/.changeset/file-upload-loading-state.md
+++ b/.changeset/file-upload-loading-state.md
@@ -1,0 +1,26 @@
+---
+"@comet/cms-admin": minor
+---
+
+Block form submission while `FileUploadField` is uploading
+
+`FileUploadField` now puts its React Final Form field into a validating state (by returning a pending Promise from its `validate` function) for the duration of any file upload. This means:
+
+- `formState.validating` is `true` while a file is being uploaded
+- Final Form blocks `form.submit()` until all uploads have completed
+- The save button can be disabled by subscribing to `formState.validating`
+
+**Example** — disable the save button while uploading:
+
+```tsx
+<FinalForm subscription={{ submitting: true, validating: true }}>
+    {({ handleSubmit, submitting, validating }) => (
+        <form onSubmit={handleSubmit}>
+            <FileUploadField name="file" label="File" />
+            <Button type="submit" disabled={submitting || validating}>
+                Save
+            </Button>
+        </form>
+    )}
+</FinalForm>
+```

--- a/packages/admin/cms-admin/src/form/file/FileUploadField.tsx
+++ b/packages/admin/cms-admin/src/form/file/FileUploadField.tsx
@@ -1,4 +1,5 @@
 import { Field, type FieldProps } from "@comet/admin";
+import { useCallback, useRef } from "react";
 
 import { FinalFormFileUpload, type FinalFormFileUploadProps } from "./FinalFormFileUpload";
 import type { GQLFinalFormFileUploadDownloadableFragment, GQLFinalFormFileUploadFragment } from "./FinalFormFileUpload.generated";
@@ -11,7 +12,55 @@ type MultipleFileUploadProps = FieldProps<Array<GQLFinalFormFileUploadFragment |
 
 export type FileUploadFieldProps<Multiple extends boolean | undefined> = Multiple extends true ? MultipleFileUploadProps : SingleFileUploadProps;
 
-export const FileUploadField = <Multiple extends boolean | undefined>({ name, ...restProps }: FileUploadFieldProps<Multiple>) => {
+export const FileUploadField = <Multiple extends boolean | undefined>({
+    name,
+    validate: externalValidate,
+    ...restProps
+}: FileUploadFieldProps<Multiple>) => {
+    const uploadingDeferredRef = useRef<{
+        promise: Promise<undefined>;
+        resolve: () => void;
+    } | null>(null);
+    const uploadingCountRef = useRef(0);
+
+    const uploadingValidate = useCallback((_value: unknown): Promise<undefined> | undefined => {
+        if (uploadingCountRef.current > 0) {
+            return uploadingDeferredRef.current?.promise;
+        }
+        return undefined;
+    }, []);
+
+    const handleUploadingChange = useCallback((isUploading: boolean) => {
+        if (isUploading) {
+            uploadingCountRef.current++;
+            if (!uploadingDeferredRef.current) {
+                let resolve!: () => void;
+                const promise = new Promise<undefined>((res) => {
+                    resolve = () => res(undefined);
+                });
+                uploadingDeferredRef.current = { promise, resolve };
+            }
+        } else {
+            uploadingCountRef.current = Math.max(0, uploadingCountRef.current - 1);
+            if (uploadingCountRef.current === 0 && uploadingDeferredRef.current) {
+                uploadingDeferredRef.current.resolve();
+                uploadingDeferredRef.current = null;
+            }
+        }
+    }, []);
+
+    const validate = useCallback(
+        (value: unknown, allValues: object, meta?: unknown) => {
+            const uploadingError = uploadingValidate(value);
+            if (uploadingError !== undefined) {
+                return uploadingError;
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return externalValidate?.(value as any, allValues, meta as any);
+        },
+        [externalValidate, uploadingValidate],
+    );
+
     return (
         <Field<
             Multiple extends true
@@ -20,6 +69,8 @@ export const FileUploadField = <Multiple extends boolean | undefined>({ name, ..
         >
             component={FinalFormFileUpload}
             name={name}
+            validate={validate}
+            onUploadingChange={handleUploadingChange}
             {...restProps}
         />
     );

--- a/packages/admin/cms-admin/src/form/file/FinalFormFileUpload.tsx
+++ b/packages/admin/cms-admin/src/form/file/FinalFormFileUpload.tsx
@@ -8,7 +8,7 @@ import {
     type ValidFileSelectItem,
 } from "@comet/admin";
 import { useMemo, useState } from "react";
-import type { FieldRenderProps } from "react-final-form";
+import { type FieldRenderProps, useForm } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
 import { useCometConfig } from "../../config/CometConfigContext";
@@ -84,19 +84,23 @@ export type FinalFormFileUploadProps<Multiple extends boolean | undefined> = (Mu
          * If both the default configuration and expiresIn are undefined, the file will never be deleted.
          */
         expiresIn?: number;
+        /** Called with `true` when an upload starts and `false` when all uploads are done. Used internally by `FileUploadField` to block form submission. */
+        onUploadingChange?: (isUploading: boolean) => void;
     };
 
 export const FinalFormFileUpload = <Multiple extends boolean | undefined>({
-    input: { onChange, value: fieldValue, multiple },
+    input: { onChange, value: fieldValue, multiple, name: fieldName },
     expiresIn,
     maxFiles,
     uploadEndpoint,
+    onUploadingChange,
     ...restProps
 }: FinalFormFileUploadProps<Multiple> & FinalFormFileUploadInternalProps<Multiple>) => {
     const [tooManyFilesSelected, setTooManyFilesSelected] = useState(false);
     const [uploadingFiles, setUploadingFiles] = useState<LoadingFileSelectItem[]>([]);
     const [failedUploads, setFailedUploads] = useState<ErrorFileSelectItem[]>([]);
     const { apiUrl } = useCometConfig();
+    const form = useForm();
 
     const singleFile = (!multiple && typeof maxFiles === "undefined") || maxFiles === 1;
     const inputValue = useMemo<ValidFileSelectItem<GQLFinalFormFileUploadFragment | GQLFinalFormFileUploadDownloadableFragment>[]>(() => {
@@ -152,8 +156,12 @@ export const FinalFormFileUpload = <Multiple extends boolean | undefined>({
                     setFailedUploads((existing) => [...existing, failedFile]);
                 });
 
+                onUploadingChange?.(true);
+
                 if (singleFile) {
                     onChange(undefined);
+                } else {
+                    form.change(fieldName, fieldValue);
                 }
 
                 setUploadingFiles(acceptedFiles.map((file) => ({ name: file.name, loading: true })));
@@ -208,6 +216,8 @@ export const FinalFormFileUpload = <Multiple extends boolean | undefined>({
                         ]);
                     }
                 }
+
+                onUploadingChange?.(false);
             }}
             onRemove={(fileToRemove) => {
                 setTooManyFilesSelected(false);


### PR DESCRIPTION
## Summary
`FileUploadField` now prevents form submission while file uploads are in progress by leveraging React Final Form's validation state mechanism.

## Key Changes
- **FileUploadField**: Added validation logic that returns a pending Promise while uploads are active, causing `formState.validating` to be `true` and blocking form submission
  - Tracks upload state using refs (`uploadingCountRef` and `uploadingDeferredRef`)
  - Wraps external validation to chain with upload validation
  - Passes `onUploadingChange` callback to `FinalFormFileUpload`

- **FinalFormFileUpload**: 
  - Added `onUploadingChange` prop to notify parent component of upload state changes
  - Calls `onUploadingChange(true)` when uploads start
  - Calls `onUploadingChange(false)` when all uploads complete
  - Triggers form field change for multiple file uploads to ensure proper state updates

## Implementation Details
- Uses `useRef` to maintain upload counter and deferred Promise across renders
- Deferred Promise is created once and reused until all uploads complete
- Supports multiple concurrent uploads by tracking count rather than boolean state
- Integrates seamlessly with existing external validation functions
- Allows consumers to disable save buttons by subscribing to `formState.validating`

https://claude.ai/code/session_018R6kq2tZvvY1Wq8T8VPYuL