### PR TITLE
[Backport v8] cms-api: Load jsdom lazily for SVG validation

### DIFF
--- a/.changeset/lazy-load-jsdom-svg-validation.md
+++ b/.changeset/lazy-load-jsdom-svg-validation.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Load `jsdom` lazily for SVG validation
+
+`jsdom` (~90 MB resident) was imported and instantiated at module load time, so importing anything from `@comet/cms-api` pulled it into memory even when no SVG was ever validated. It's now loaded on the first SVG validation instead, reducing the package's base memory footprint.

--- a/packages/api/cms-api/src/file-utils/file-validation.service.ts
+++ b/packages/api/cms-api/src/file-utils/file-validation.service.ts
@@ -45,7 +45,7 @@ export class FileValidationService {
         if (file.mimetype === "image/svg+xml") {
             const fileContent = await readFile(file.path, { encoding: "utf-8" });
 
-            if (!isValidSvg(fileContent)) {
+            if (!(await isValidSvg(fileContent))) {
                 return "SVG contains forbidden content (e.g., JavaScript, security-relevant tags or attributes)";
             }
         }

--- a/packages/api/cms-api/src/file-utils/files.utils.spec.ts
+++ b/packages/api/cms-api/src/file-utils/files.utils.spec.ts
@@ -7,7 +7,7 @@ describe("Files Utils", () => {
                 <path fill="#242424" fill-rule="evenodd" d=""/>
             </svg>`;
 
-            expect(isValidSvg(cleanSvg)).toBe(true);
+            expect(await isValidSvg(cleanSvg)).toBe(true);
         });
 
         it("should return false if the svg contains a script tag", async () => {
@@ -18,7 +18,7 @@ describe("Files Utils", () => {
                 </script>
             </svg>`;
 
-            expect(isValidSvg(svgWithScriptTag)).toBe(false);
+            expect(await isValidSvg(svgWithScriptTag)).toBe(false);
         });
 
         it("should return false if the svg contains an event handler", async () => {
@@ -26,7 +26,7 @@ describe("Files Utils", () => {
                 <path onload="alert('XSS');" fill="#242424" fill-rule="evenodd" d=""/>
             </svg>`;
 
-            expect(isValidSvg(svgWithOnloadHandler)).toBe(false);
+            expect(await isValidSvg(svgWithOnloadHandler)).toBe(false);
         });
 
         it("should return false if the svg contains a href attribute containing javascript", async () => {
@@ -36,7 +36,7 @@ describe("Files Utils", () => {
                 </a>
             </svg>`;
 
-            expect(isValidSvg(svgWithOnloadHandler)).toBe(false);
+            expect(await isValidSvg(svgWithOnloadHandler)).toBe(false);
         });
 
         it("should return false if the svg contains a script tag with a namespace prefix", async () => {
@@ -44,7 +44,7 @@ describe("Files Utils", () => {
                 <x:script>alert("XSS");</x:script>
             </svg>`;
 
-            expect(isValidSvg(svgWithNamespacedScriptTag)).toBe(false);
+            expect(await isValidSvg(svgWithNamespacedScriptTag)).toBe(false);
         });
 
         it("should return false if the svg contains an uppercase href attribute containing javascript", async () => {
@@ -54,7 +54,7 @@ describe("Files Utils", () => {
                 </a>
             </svg>`;
 
-            expect(isValidSvg(svgWithUppercaseHref)).toBe(false);
+            expect(await isValidSvg(svgWithUppercaseHref)).toBe(false);
         });
 
         it("should return true if the svg contains a role attribute", async () => {
@@ -62,7 +62,7 @@ describe("Files Utils", () => {
                 <path role="presentation" fill="#242424" fill-rule="evenodd" d=""/>
             </svg>`;
 
-            expect(isValidSvg(svgWithRole)).toBe(true);
+            expect(await isValidSvg(svgWithRole)).toBe(true);
         });
 
         it("should return true if the svg contains a use element with a same-document fragment reference", async () => {
@@ -71,7 +71,7 @@ describe("Files Utils", () => {
                 <use xlink:href="#icon" mask="url(#mask0)" transform="matrix(1,0,0,1,0,0)"/>
             </svg>`;
 
-            expect(isValidSvg(svgWithFragmentUse)).toBe(true);
+            expect(await isValidSvg(svgWithFragmentUse)).toBe(true);
         });
 
         it("should return false if the svg contains a use element referencing an external resource", async () => {
@@ -79,7 +79,7 @@ describe("Files Utils", () => {
                 <use href="https://evil.example.com/payload.svg#icon"/>
             </svg>`;
 
-            expect(isValidSvg(svgWithExternalUse)).toBe(false);
+            expect(await isValidSvg(svgWithExternalUse)).toBe(false);
         });
     });
 });

--- a/packages/api/cms-api/src/file-utils/files.utils.ts
+++ b/packages/api/cms-api/src/file-utils/files.utils.ts
@@ -1,8 +1,7 @@
-import createDOMPurify from "dompurify";
+import type createDOMPurify from "dompurify";
 import FileType from "file-type";
 import fs from "fs";
 import { unlink } from "fs/promises";
-import { JSDOM } from "jsdom";
 import * as mimedb from "mime-db";
 import os from "os";
 import { basename, extname } from "path";
@@ -43,25 +42,37 @@ export const calculatePartialRanges = (size: number, range: string): { start: nu
     };
 };
 
-const { window } = new JSDOM("");
-const DOMPurify = createDOMPurify(window);
+let domPurify: ReturnType<typeof createDOMPurify> | undefined;
 
-// `<use>` is forbidden by DOMPurify's svg profile because it can pull in external or
-// attacker-controlled content (XSS/SSRF). Allow it only for same-document fragment references
-// (e.g. href="#id"); any other reference is dropped, which makes the SVG fail validation below.
-DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
-    if ((node as unknown as { nodeName: string }).nodeName.toLowerCase() !== "use") {
-        return;
-    }
-    if ((data.attrName === "href" || data.attrName === "xlink:href") && !data.attrValue.startsWith("#")) {
-        data.keepAttr = false;
-    }
-});
+// jsdom is heavy (~90 MB resident). It and dompurify are only used for SVG validation, so they're
+// loaded lazily — importing @comet/cms-api doesn't pull them into memory unless an SVG is validated.
+async function getDomPurify(): Promise<ReturnType<typeof createDOMPurify>> {
+    if (!domPurify) {
+        const [{ JSDOM }, { default: createDOMPurify }] = await Promise.all([import("jsdom"), import("dompurify")]);
+        const { window } = new JSDOM("");
+        domPurify = createDOMPurify(window);
 
-export const isValidSvg = (svg: string): boolean => {
+        // `<use>` is forbidden by DOMPurify's svg profile because it can pull in external or
+        // attacker-controlled content (XSS/SSRF). Allow it only for same-document fragment references
+        // (e.g. href="#id"); any other reference is dropped, which makes the SVG fail validation below.
+        domPurify.addHook("uponSanitizeAttribute", (node, data) => {
+            if ((node as unknown as { nodeName: string }).nodeName.toLowerCase() !== "use") {
+                return;
+            }
+            if ((data.attrName === "href" || data.attrName === "xlink:href") && !data.attrValue.startsWith("#")) {
+                data.keepAttr = false;
+            }
+        });
+    }
+    return domPurify;
+}
+
+export const isValidSvg = async (svg: string): Promise<boolean> => {
+    const domPurify = await getDomPurify();
+
     // `role` and `<use>` aren't part of DOMPurify's svg profile, so they're allowed explicitly.
     // `<use>` is additionally constrained to same-document references by the hook above.
-    DOMPurify.sanitize(svg, {
+    domPurify.sanitize(svg, {
         USE_PROFILES: { svg: true, svgFilters: true },
         WHOLE_DOCUMENT: true,
         ADD_TAGS: ["use"],
@@ -70,7 +81,7 @@ export const isValidSvg = (svg: string): boolean => {
 
     // DOMPurify strips forbidden tags (e.g. <script>) and attributes (e.g. event handlers, javascript: URLs).
     // If it had to remove anything, the SVG contained content we don't consider safe.
-    return DOMPurify.removed.length === 0;
+    return domPurify.removed.length === 0;
 };
 
 export const removeMulterTempFile = async (file: FileUploadInput) => {


### PR DESCRIPTION
Backport of #5937 to `v8.x.x`.

`jsdom` (~90 MB resident) was imported and instantiated at module load time, so importing anything from `@comet/cms-api` pulled it into memory even when no SVG was ever validated. It's now loaded on the first SVG validation instead.

Reduces the package's base memory footprint — `require("@comet/cms-api")`: heap 112 → 86 MB, RSS 212 → 180 MB.

**Note:** Cherry-pick required manual conflict resolution in `files.utils.ts` — `v8.x.x` still has the `FileType` import from `file-type` in this file (removed later on `main`), which was preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKrKaNFfH3ZTqoEkoARbfG)_