### PR TITLE
Fix page search tree expansion after collapse all

### DIFF
--- a/.changeset/fix-page-search-expand-after-collapse-all.md
+++ b/.changeset/fix-page-search-expand-after-collapse-all.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix page search not expanding the tree when navigating between matches after "Collapse all"
+
+Previously, jumping to the next or previous search match only scrolled to the match without expanding its collapsed ancestors. After collapsing the tree via "Collapse all" during an active search, continuing the search revealed nothing. Navigating between matches now re-expands the current match's ancestors before scrolling to it.

--- a/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
+++ b/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 import escapeRegExp from "lodash.escaperegexp";
-import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useState } from "react";
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { TextMatch } from "../../common/MarkedMatches";
 import type { PageTreePage } from "../pageTree/usePageTree";
@@ -38,6 +38,10 @@ const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pa
     const [matches, setMatches] = useState<PageSearchMatch[] | null>(null);
     const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
     const [query, setQuery] = useState("");
+
+    // Page id of a match that should be scrolled to once its tree row is rendered. Scrolling has to be deferred
+    // because navigating to a match may first need to re-expand collapsed ancestors (e.g. after "Collapse all").
+    const pageIdToScrollTo = useRef<string | null>(null);
 
     let domainHost: string | undefined;
 
@@ -157,6 +161,18 @@ const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pa
         [matches, pagesToRender],
     );
 
+    useEffect(() => {
+        const pageId = pageIdToScrollTo.current;
+        if (pageId === null) {
+            return;
+        }
+
+        if (pagesToRenderWithMatches.some((page) => page.id === pageId)) {
+            onUpdateCurrentMatch(pageId, pagesToRenderWithMatches);
+            pageIdToScrollTo.current = null;
+        }
+    }, [pagesToRenderWithMatches, currentMatchIndex, onUpdateCurrentMatch]);
+
     const pageSearchPartialApi = useMemo(() => {
         if (matches === null || currentMatchIndex === null) {
             return {};
@@ -175,10 +191,13 @@ const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pa
         };
 
         const updateCurrentMatch = (nextCurrentMatchIndex: number) => {
+            const nextMatch = matches[nextCurrentMatchIndex];
             setMatches(matches.map((match, index) => ({ ...match, focused: index === nextCurrentMatchIndex })));
             setCurrentMatchIndex(nextCurrentMatchIndex);
-            const pageIdOfCurrentMatch = matches[nextCurrentMatchIndex].page.id;
-            onUpdateCurrentMatch(pageIdOfCurrentMatch, pagesToRenderWithMatches);
+            // Re-expand the match's ancestors in case they were collapsed (e.g. via "Collapse all"), then scroll to it
+            // once the row is rendered.
+            expandTreeForMatches([nextMatch]);
+            pageIdToScrollTo.current = nextMatch.page.id;
         };
 
         return {
@@ -187,7 +206,7 @@ const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pa
             jumpToNextMatch,
             jumpToPreviousMatch,
         };
-    }, [matches, currentMatchIndex, onUpdateCurrentMatch, pagesToRenderWithMatches]);
+    }, [matches, currentMatchIndex, expandTreeForMatches]);
 
     return { query, setQuery, pagesToRenderWithMatches, ...pageSearchPartialApi };
 };


### PR DESCRIPTION
## Problem

Searching the page tree and then clicking "Collapse all" left the search broken: jumping to the next/previous match only scrolled, it never re-expanded collapsed ancestors, so matches stayed hidden.

## Solution

Navigating between matches now re-expands the current match's ancestors and scrolls to it once its row is rendered.

## Why the deferred scroll

Expanding is a state update, so the target row isn't in the rendered list on the same tick — scrolling to it immediately would find nothing. Instead:

- the match id is stashed in a ref, and
- a `useEffect` performs the scroll on the following render, once the row is present.

The effect no-ops when no scroll is pending, so typing a query still doesn't auto-scroll.

## Screencasts

(recorded by playwright in the cloud session)

**Before**

[pagesearchBEFOREbug.webm](https://github.com/user-attachments/assets/573cd788-90fe-44de-abc9-f20c5fea1846)

**After**

[pagesearchAFTERfixed.webm](https://github.com/user-attachments/assets/b7950ad4-880b-4d0d-9d94-ddd7116c9103)
