### PR TITLE
Deprecate @comet/admin-date-time package

### DIFF
--- a/.changeset/deprecate-admin-date-time-package.md
+++ b/.changeset/deprecate-admin-date-time-package.md
@@ -1,0 +1,9 @@
+---
+"@comet/admin-date-time": minor
+---
+
+Deprecate the `@comet/admin-date-time` package
+
+All of its components now have stable replacements in `@comet/admin`. The remaining exports (`DatePickerNavigation`, `DateFnsLocaleProvider`, `DateFnsLocaleContext` and `useDateFnsLocale`) are now marked as deprecated as well.
+
+See the [migration guide](https://docs.comet-dxp.com/docs/migration-guide/migration-from-v8-to-v9) for how to migrate to the new components in `@comet/admin`.

--- a/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
+++ b/docs/docs/7-migration-guide/migration-from-v8-to-v9.md
@@ -624,7 +624,7 @@ Callers should conditionally render the component instead of passing the `hasCle
 
 ### Replacement of `@comet/admin-date-time`
 
-Most components of `@comet/admin-date-time` are now deprecated and are being replaced by new components in `@comet/admin`.
+The `@comet/admin-date-time` package is deprecated. All of its components have been replaced by new components in `@comet/admin`.
 
 #### Use the new components from `@comet/admin` (recommended)
 
@@ -673,6 +673,23 @@ export const ExampleFields = () => {
         </>
     );
 };
+```
+
+##### Remove `DateFnsLocaleProvider`
+
+The new components from `@comet/admin` are based on MUI X and read the date-fns locale from MUI X's `LocalizationProvider` (`adapterLocale`).
+Once you no longer render any legacy components, the `DateFnsLocaleProvider` (and `useDateFnsLocale`) from `@comet/admin-date-time` are no longer needed and can be removed:
+
+```diff title="src/App.tsx"
+-import { DateFnsLocaleProvider } from "@comet/admin-date-time";
+ import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+ import { LocalizationProvider } from "@mui/x-date-pickers";
+
+ <LocalizationProvider adapterLocale={dateFnsLocale} dateAdapter={AdapterDateFns}>
+-    <DateFnsLocaleProvider value={dateFnsLocale}>
+         {children}
+-    </DateFnsLocaleProvider>
+ </LocalizationProvider>;
 ```
 
 #### Continue using the deprecated components

--- a/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
+++ b/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
@@ -19,6 +19,9 @@ export interface DatePickerNavigationProps
     maxDate: Date;
 }
 
+/**
+ * @deprecated The `@comet/admin-date-time` package is deprecated. Use the date/time components from `@comet/admin` instead.
+ */
 export const DatePickerNavigation = (inProps: DatePickerNavigationProps) => {
     const { focusedDate, changeShownDate, minDate, maxDate, slotProps, ...restProps } = useThemeProps({
         props: inProps,

--- a/packages/admin/admin-date-time/src/timeRangePicker/TimeRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/timeRangePicker/TimeRangePicker.tsx
@@ -57,6 +57,9 @@ const Separator = createComponentSlot(Typography)<TimeRangePickerClassKey>({
     `,
 );
 
+/**
+ * @deprecated Use `TimeRange` from `@comet/admin` instead.
+ */
 export type TimeRange = {
     start: string;
     end: string;

--- a/packages/admin/admin-date-time/src/utils/DateFnsLocaleProvider.tsx
+++ b/packages/admin/admin-date-time/src/utils/DateFnsLocaleProvider.tsx
@@ -1,10 +1,19 @@
 import type { Locale } from "date-fns";
 import { createContext, useContext } from "react";
 
+/**
+ * @deprecated The `@comet/admin-date-time` package is deprecated. Provide the date-fns locale via MUI X's `LocalizationProvider` (`adapterLocale`) from `@mui/x-date-pickers` instead.
+ */
 export const DateFnsLocaleContext = createContext<Locale | undefined>(undefined);
 
+/**
+ * @deprecated The `@comet/admin-date-time` package is deprecated. Provide the date-fns locale via MUI X's `LocalizationProvider` (`adapterLocale`) from `@mui/x-date-pickers` instead.
+ */
 export const DateFnsLocaleProvider = DateFnsLocaleContext.Provider;
 
+/**
+ * @deprecated The `@comet/admin-date-time` package is deprecated. Provide the date-fns locale via MUI X's `LocalizationProvider` (`adapterLocale`) from `@mui/x-date-pickers` instead.
+ */
 export function useDateFnsLocale() {
     return useContext(DateFnsLocaleContext);
 }


### PR DESCRIPTION
All date/time components in `@comet/admin-date-time` now have stable replacements in `@comet/admin`, so the package can be fully deprecated.

- Add `@deprecated` to the remaining un-deprecated exports: `DatePickerNavigation`, `DateFnsLocaleContext`, `DateFnsLocaleProvider`, `useDateFnsLocale` and the `TimeRange` type.
- Extend the v8→v9 migration guide: state that the whole package is deprecated and document replacing `DateFnsLocaleProvider` with MUI X's `LocalizationProvider`.
- Add a changeset.

Marking the package deprecated on npm (via `npm deprecate`) happens at release time.

https://claude.ai/code/session_01NcP9myFJKzWaCRqAe2N3Zz