### PR TITLE
Change v8 release npm tag back to stable-v8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
               uses: dotansimha/changesets-action@v1.5.2
               with:
                   version: pnpm run version
-                  publish: pnpm run publish
+                  publish: pnpm run publish --tag=stable-v8
                   title: "Version Packages (v8)"
                   createGithubReleases: aggregate
                   githubReleaseName: "${{ env.PUBLISHED_VERSION }}"


### PR DESCRIPTION
## Problem

In #5546 the npm dist-tag for v8 releases was temporarily removed, causing packages to be published under the default `latest` tag instead of `stable-v8`.

## Solution

Restore the `--tag=stable-v8` flag on the `publish` step in the v8 release workflow so v8 packages are published under the `stable-v8` dist-tag again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vSwwzDvkE1NacLHadS94q

---
_Generated by [Claude Code](https://claude.ai/code/session_013vSwwzDvkE1NacLHadS94q)_