### PR TITLE
[Backport v8] Fix page search tree expansion after collapse all

### DIFF
--- a/.changeset/fix-page-search-expand-after-collapse-all.md
+++ b/.changeset/fix-page-search-expand-after-collapse-all.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix page search not expanding the tree when navigating between matches after "Collapse all"
+
+Previously, jumping to the next or previous search match only scrolled to the match without expanding its collapsed ancestors. After collapsing the tree via "Collapse all" during an active search, continuing the search revealed nothing. Navigating between matches now re-expands the current match's ancestors before scrolling to it.

--- a/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
+++ b/packages/admin/cms-admin/src/pages/pageSearch/usePageSearch.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 import escapeRegExp from "lodash.escaperegexp";
-import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useState } from "react";
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { type TextMatch } from "../../common/MarkedMatches";
 import { type PageTreePage } from "../pageTree/usePageTree";
@@ -38,6 +38,10 @@ const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pa
     const [matches, setMatches] = useState<PageSearchMatch[] | null>(null);
     const [currentMatchIndex, setCurrentMatchIndex] = useState<number | null>(null);
     const [query, setQuery] = useState("");
+
+    // Page id of a match that should be scrolled to once its tree row is rendered. Scrolling has to be deferred
+    // because navigating to a match may first need to re-expand collapsed ancestors (e.g. after "Collapse all").
+    const pageIdToScrollTo = useRef<string | null>(null);
 
     let domainHost: string | undefined;
 
@@ -157,6 +161,18 @@ const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pa
         [matches, pagesToRender],
     );
 
+    useEffect(() => {
+        const pageId = pageIdToScrollTo.current;
+        if (pageId === null) {
+            return;
+        }
+
+        if (pagesToRenderWithMatches.some((page) => page.id === pageId)) {
+            onUpdateCurrentMatch(pageId, pagesToRenderWithMatches);
+            pageIdToScrollTo.current = null;
+        }
+    }, [pagesToRenderWithMatches, currentMatchIndex, onUpdateCurrentMatch]);
+
     const pageSearchPartialApi = useMemo(() => {
         if (matches === null || currentMatchIndex === null) {
             return {};
@@ -175,10 +191,13 @@ const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pa
         };
 
         const updateCurrentMatch = (nextCurrentMatchIndex: number) => {
+            const nextMatch = matches[nextCurrentMatchIndex];
             setMatches(matches.map((match, index) => ({ ...match, focused: index === nextCurrentMatchIndex })));
             setCurrentMatchIndex(nextCurrentMatchIndex);
-            const pageIdOfCurrentMatch = matches[nextCurrentMatchIndex].page.id;
-            onUpdateCurrentMatch(pageIdOfCurrentMatch, pagesToRenderWithMatches);
+            // Re-expand the match's ancestors in case they were collapsed (e.g. via "Collapse all"), then scroll to it
+            // once the row is rendered.
+            expandTreeForMatches([nextMatch]);
+            pageIdToScrollTo.current = nextMatch.page.id;
         };
 
         return {
@@ -187,7 +206,7 @@ const usePageSearch = ({ tree, siteUrl, setExpandedIds, onUpdateCurrentMatch, pa
             jumpToNextMatch,
             jumpToPreviousMatch,
         };
-    }, [matches, currentMatchIndex, onUpdateCurrentMatch, pagesToRenderWithMatches]);
+    }, [matches, currentMatchIndex, expandTreeForMatches]);
 
     return { query, setQuery, pagesToRenderWithMatches, ...pageSearchPartialApi };
 };


### PR DESCRIPTION
Backport #5953 into v8.

## Verification

- Cherry-picked cleanly (no conflicts).
- Built `@comet/cms-admin` and its workspace dependencies successfully.
- Ran lint for `@comet/cms-admin` (eslint, prettier, tsc) — all clean.
- Could not start the demo stack locally: Docker Hub image pulls (`postgres`, `valkey`, etc.) return `403 Forbidden` in this sandbox's network policy. This is an environment limitation, not related to the change. CI (which has registry access) will run the full Test/Lint pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTrWnw1ZxaxHDFCnCVMJ9y)_