### PR TITLE
admin: Prevent clear button from opening the surrounding picker

### DIFF
--- a/packages/admin/admin/src/common/ClearInputAdornment.tsx
+++ b/packages/admin/admin/src/common/ClearInputAdornment.tsx
@@ -44,7 +44,15 @@ export const ClearInputAdornment = (inProps: ClearInputAdornmentProps) => {
 
     return (
         <Root position={position} ownerState={ownerState} {...slotProps?.root} {...restProps}>
-            <Button onClick={onClick} focusRipple {...slotProps?.buttonBase}>
+            <Button
+                onClick={(event) => {
+                    // Prevent the click from bubbling to the surrounding input, which could trigger its own click handler.
+                    event.stopPropagation();
+                    onClick();
+                }}
+                focusRipple
+                {...slotProps?.buttonBase}
+            >
                 {icon}
             </Button>
         </Root>


### PR DESCRIPTION
Clicking the clear button of a multi-input range picker (e.g. `TimeRangePicker`, `DateTimeRangePicker`) also reopened the picker. MUI's multi-input range field registers an open-on-click handler on the field root, and the clear button is rendered inside it, so the click bubbled up and triggered it.

Stop the click from propagating out of the clear button in `ClearInputAdornment`, so clearing no longer opens the picker. This matches the single-input pickers, where clearing never opened the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Jira: https://vivid-planet.atlassian.net/browse/COM-2203