### PR TITLE
admin: Switch Storybook docgen to react-docgen-typescript

### DIFF
--- a/packages/admin/admin/.storybook/main.ts
+++ b/packages/admin/admin/.storybook/main.ts
@@ -36,6 +36,19 @@ const config: StorybookConfig = {
     addons: ["@storybook/addon-designs", "@storybook/addon-docs", "@storybook/addon-vitest", "storybook-addon-tag-badges"],
     framework: "@storybook/react-vite",
 
+    typescript: {
+        reactDocgen: "react-docgen-typescript",
+        reactDocgenTypescriptOptions: {
+            propFilter: (prop) => {
+                // `react-docgen-typescript` leaves `declarations` empty for some inherited props; read `parent`
+                // instead to find where the prop is declared. https://github.com/storybookjs/storybook/issues/23543
+                const origins = prop.declarations?.length ? prop.declarations : prop.parent ? [prop.parent] : [];
+                const isInheritedFromDependency = origins.length > 0 && origins.every((origin) => origin.fileName.includes("node_modules"));
+                return !isInheritedFromDependency;
+            },
+        },
+    },
+
     viteFinal(viteConfig) {
         return mergeConfig(viteConfig, {
             css: {


### PR DESCRIPTION
Future UI components built on Base UI's `useRender` return a call expression instead of JSX, which the default `react-docgen` engine can't detect, leaving their autodocs prop tables empty.

- **Switch the engine for the whole package, not per component.** 
It reads props from the types, covering `useRender` components too; the alternative — hand-written `argTypes` in every story — does not scale.
- **Show only each component's own props.** 
The engine otherwise adds every prop inherited from base-ui, MUI, or the DOM.