### PR TITLE
Revert "Remove CORS configuration from demo api"

### DIFF
--- a/.env
+++ b/.env
@@ -52,6 +52,7 @@ ADMIN_URL_INTERNAL=http://localhost:$ADMIN_PORT
 API_PORT=4000
 API_URL=$ADMIN_URL/api
 API_URL_INTERNAL=http://localhost:$API_PORT/api
+CORS_ALLOWED_ORIGIN="^http:\/\/(localhost|.*\.dev\.vivid-planet\.cloud|192\.168\.\d{1,3}\.\d{1,3}):\d{2,4}"
 BASIC_AUTH_SYSTEM_USER_PASSWORD=aPasswordWith16Characters
 POST_LOGOUT_REDIRECT_URI=${AUTHPROXY_URL}/oauth2/sign_out?rd=%2F
 

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -101,6 +101,12 @@ export class AppModule {
                             return error;
                         },
                         context: ({ req }: { req: Request }) => ({ ...req }),
+                        cors: {
+                            origin: config.corsAllowedOrigin,
+                            methods: ["GET", "POST"],
+                            credentials: false,
+                            maxAge: 600,
+                        },
                         useGlobalPrefix: true,
                         buildSchemaOptions: {
                             fieldMiddleware: [BlocksTransformerMiddlewareFactory.create(moduleRef)],

--- a/demo/api/src/config/config.ts
+++ b/demo/api/src/config/config.ts
@@ -32,6 +32,7 @@ export function createConfig(processEnv: NodeJS.ProcessEnv) {
         apiUrl: envVars.API_URL,
         apiPort: envVars.API_PORT,
         adminUrl: envVars.ADMIN_URL,
+        corsAllowedOrigin: new RegExp(envVars.CORS_ALLOWED_ORIGIN),
         defaultLocale: "en", // fallback locale
         auth: {
             systemUserPassword: envVars.BASIC_AUTH_SYSTEM_USER_PASSWORD,

--- a/demo/api/src/config/environment-variables.ts
+++ b/demo/api/src/config/environment-variables.ts
@@ -63,6 +63,9 @@ export class EnvironmentVariables {
     API_PORT: number;
 
     @IsString()
+    CORS_ALLOWED_ORIGIN: string;
+
+    @IsString()
     IMGPROXY_SALT: string;
 
     @IsString()

--- a/demo/api/src/main.ts
+++ b/demo/api/src/main.ts
@@ -33,6 +33,12 @@ async function bootstrap(): Promise<void> {
     useContainer(app.select(appModule), { fallbackOnErrors: true });
 
     app.setGlobalPrefix("api");
+    app.enableCors({
+        origin: config.corsAllowedOrigin,
+        methods: ["GET", "POST"],
+        credentials: false,
+        maxAge: 600,
+    });
 
     app.useGlobalFilters(new ExceptionFilter(config.debug));
     app.useGlobalPipes(


### PR DESCRIPTION
Reverts #5906.

We do have cross-origin requests in one situation: a block preview running in the site (on a preview domain) can use a block-loader that runs client-side and loads data directly from the api. That request is cross-origin, so the api must send CORS headers for it.


https://claude.ai/code/session_014z4MSuo3Q7LSBodVA9Bh6Z