### PR TITLE
mail-react: Show custom-render stories' JSX in the Storybook docs panel

### DIFF
--- a/packages/mail-react/.storybook/main.ts
+++ b/packages/mail-react/.storybook/main.ts
@@ -1,9 +1,19 @@
 import type { StorybookConfig } from "@storybook/react-vite";
+import { mergeConfig } from "vite";
 
 const config: StorybookConfig = {
     stories: ["../src/**/*.mdx", "../src/**/*.stories.tsx"],
     addons: ["@storybook/addon-docs", "@storybook/addon-vitest"],
     framework: "@storybook/react-vite",
+    viteFinal: (viteConfig) =>
+        mergeConfig(viteConfig, {
+            build: {
+                // Minifying renames functions, and none of the components used here —
+                // including `@faire/mjml-react`'s — set a `displayName` to survive that, so
+                // the docs "Show code" snippet would print the mangled names.
+                minify: false,
+            },
+        }),
 };
 
 export default config;

--- a/packages/mail-react/.storybook/preview.ts
+++ b/packages/mail-react/.storybook/preview.ts
@@ -5,4 +5,11 @@ export { decorators, initialGlobals } from "../src/storybook/preview.ts";
 export const parameters = {
     ...mailParameters,
     layout: "fullscreen",
+    docs: {
+        source: {
+            // Regenerate the "Show code" snippet from the rendered JSX; the default shows the whole
+            // story object literal for stories with a custom render function.
+            type: "dynamic",
+        },
+    },
 };


### PR DESCRIPTION
Custom-render mail stories showed the whole story object instead of JSX in the "Show code" panel; other stories showed mangled component names in the deployed build.

- **Set `docs.source.type` to `dynamic`.**
  A transform that parsed the render body out of the story's extracted source text instead was rejected as fragile.
- **Apply this globally, not per story.**
  Storybook's `auto` heuristic only switches a story to the dynamic snippet if its `render` function declares a parameter.
  Most stories here would need an unused parameter added just to trigger it — hackier than one global setting.
- **Disable minification for this package's Storybook build via `viteFinal`.**
  Assigning `displayName` to every exported component instead was rejected because it mutates third-party exports.

### Screenshots

| Story | Previously | Now |
|--------|--------|--------|
| **HtmlButton** | <img width="521" height="450" alt="HtmlButton Story Prev" src="https://github.com/user-attachments/assets/48d04b9e-a409-4c2e-856b-e58a999a13e1" /> [story](https://main--69df33e9280a36be495d6521.chromatic.com/?path=/docs/components-htmlbutton--docs) | <img width="521" height="450" alt="HtmlButton Story Now" src="https://github.com/user-attachments/assets/dd7f185e-e04b-4c57-b338-7bd24e787725" /> [story](https://69df33e9280a36be495d6521-mokzequurj.chromatic.com/?path=/docs/components-htmlbutton--docs) |
| **MjmlText** | <img width="609" height="457" alt="MjmlText Story Prev" src="https://github.com/user-attachments/assets/7ae0708a-994b-46a4-80aa-a25f442b7594" /> [story](https://main--69df33e9280a36be495d6521.chromatic.com/?path=/docs/components-mjmltext--docs) | <img width="609" height="457" alt="MjmlText Story Now" src="https://github.com/user-attachments/assets/6ec283eb-d43c-4b86-9013-6481fc149904" /> [story](https://69df33e9280a36be495d6521-mokzequurj.chromatic.com/?path=/docs/components-mjmltext--docs) |