### PR TITLE
Fix dependents list crashing due to invalid visible filter

### DIFF
--- a/.changeset/dependents-list-visible-filter.md
+++ b/.changeset/dependents-list-visible-filter.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix the dependents list crashing due to an invalid `visible` filter
+
+The `DependentsList` initialized the `visible` filter with the string `"true"` instead of the boolean `true`, causing the GraphQL request to fail with a `400 Bad Request` (`Boolean cannot represent a non boolean value`). This made the dependents tab (e.g., on assets) crash with a network error.

--- a/packages/admin/cms-admin/src/dependencies/DependentsList.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependentsList.tsx
@@ -102,7 +102,7 @@ export const DependentsList = ({ query, variables }: DependentsListProps) => {
             queryParamsPrefix: "dependents",
             pageSize,
             initialFilter: {
-                items: [{ field: "visible", operator: "is", value: "true" }],
+                items: [{ field: "visible", operator: "is", value: true }],
             },
         }),
         ...usePersistentColumnState("DependentsList"),


### PR DESCRIPTION
## Problem

Opening the dependents tab (e.g. on an asset) crashed with a "Netzwerkfehler" dialog. The `DamFileDependencies` GraphQL request failed with `400 Bad Request`:

> Variable "$filter" got invalid value "true" at "filter.and[0].visible.equal"; Boolean cannot represent a non boolean value: "true"

## Cause

`DependentsList` initialized the `visible` filter with the **string** `"true"` instead of the boolean `true`. Because it's a preset filter, the value never passes through MUI's `GridFilterInputBoolean` sanitizer (which normally coerces strings to real booleans), so the raw string reached the GraphQL `Boolean` filter field and the API rejected it.

## Fix

Use the boolean `true` for the initial filter value.

Verified in the demo admin: the request now returns `200 OK` and the dependents grid renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)