### PR TITLE
Add InlineActionLogs decorator for relation-level action logging

### DIFF
--- a/.changeset/add-inline-action-logs-decorator.md
+++ b/.changeset/add-inline-action-logs-decorator.md
@@ -1,0 +1,21 @@
+---
+"@comet/cms-api": minor
+---
+
+Add `InlineActionLogs` decorator for action logs
+
+Add an `@InlineActionLogs()` relation decorator to log changes to a one-to-many or many-to-many relation as part of the owning entity's action log instead of producing separate action log entries.
+
+Use it for relations that are edited through the owning entity's form (e.g. assigned colors or tags). Adding, removing, or editing an item of an inline relation now creates a single action log entry on the owning entity, and the relation's items are included in that entry's snapshot. It is often combined with `orphanRemoval: true`, but that is not required.
+
+**Example**
+
+```ts
+@ActionLogs()
+@Entity()
+export class Product {
+    @OneToMany(() => ProductColor, (color) => color.product, { orphanRemoval: true })
+    @InlineActionLogs()
+    colors = new Collection<ProductColor>(this);
+}
+```

--- a/demo/api/src/products/entities/product.entity.ts
+++ b/demo/api/src/products/entities/product.entity.ts
@@ -7,6 +7,7 @@ import {
     EntityInfo,
     FileUpload,
     ImportTargetInterface,
+    InlineActionLogs,
     RequiredPermission,
     RootBlock,
     RootBlockEntity,
@@ -196,6 +197,7 @@ export class Product extends BaseEntity implements ImportTargetInterface {
         //sort: true, //not yet implemented
         input: true, //default is true
     })
+    @InlineActionLogs()
     colors = new Collection<ProductColor>(this);
 
     @OneToMany(() => ProductVariant, (variant) => variant.product, { orphanRemoval: true })

--- a/packages/api/cms-api/src/action-logs/action-logs.subscriber.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.subscriber.ts
@@ -1,10 +1,22 @@
-import { AnyEntity, ChangeSet, ChangeSetType, EntityManager, EventSubscriber, FlushEventArgs, PostgreSqlDriver, raw } from "@mikro-orm/postgresql";
+import {
+    AnyEntity,
+    ChangeSet,
+    ChangeSetType,
+    EntityManager,
+    EventSubscriber,
+    FlushEventArgs,
+    PostgreSqlDriver,
+    raw,
+    Reference,
+    ReferenceKind,
+} from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
 
 import { UserPermissionsStorageService } from "../user-permissions/user-permissions-storage.service";
 import { ACTION_LOGS_METADATA_KEY, ActionLogMetadata } from "./action-logs.decorator";
 import { ActionLogsService } from "./action-logs.service";
 import { ActionLog } from "./entities/action-log.entity";
+import { INLINE_ACTION_LOGS_METADATA_KEY, InlineActionLogsMetadata } from "./inline-action-logs.decorator";
 
 @Injectable()
 export class ActionLogsSubscriber implements EventSubscriber {
@@ -17,11 +29,34 @@ export class ActionLogsSubscriber implements EventSubscriber {
     }
 
     async onFlush(args: FlushEventArgs): Promise<void> {
-        const changeSets = args.uow.getChangeSets();
-        for (const changeSet of changeSets.filter((changeSet) =>
-            Reflect.hasOwnMetadata(ACTION_LOGS_METADATA_KEY, changeSet.entity.constructor.prototype),
-        )) {
-            const actionLog = await this.createLog(changeSet);
+        // Collect all entities that need an action log, deduplicated by entity instance. The value is the entity's own
+        // change set if it has one (required to determine the action type), or undefined when the entity is only logged
+        // because an inline relation changed.
+        const entitiesToLog = new Map<AnyEntity, ChangeSet<AnyEntity> | undefined>();
+
+        for (const changeSet of args.uow.getChangeSets()) {
+            if (this.hasActionLogs(changeSet.entity)) {
+                entitiesToLog.set(changeSet.entity, changeSet);
+            }
+
+            // Editing an item of an inline relation (without adding/removing it) produces a change set for the item but
+            // not a collection update, so resolve the owning entity from the item's back-reference.
+            const inlineRelationOwner = this.getInlineRelationOwner(changeSet.entity);
+            if (inlineRelationOwner && !entitiesToLog.has(inlineRelationOwner)) {
+                entitiesToLog.set(inlineRelationOwner, undefined);
+            }
+        }
+
+        // Adding/removing items of an inline relation results in a collection update on the owning entity.
+        for (const collection of args.uow.getCollectionUpdates()) {
+            const owner = collection.owner;
+            if (this.hasActionLogs(owner) && this.getInlineRelations(owner).includes(collection.property.name) && !entitiesToLog.has(owner)) {
+                entitiesToLog.set(owner, undefined);
+            }
+        }
+
+        for (const [entity, changeSet] of entitiesToLog) {
+            const actionLog = await this.createLog(entity, changeSet);
             if (!actionLog) {
                 continue;
             }
@@ -30,33 +65,28 @@ export class ActionLogsSubscriber implements EventSubscriber {
         }
     }
 
-    async createLog(changeSet: ChangeSet<AnyEntity>): Promise<ActionLog | null> {
-        const entityName = changeSet.entity.constructor.name;
+    async createLog(entity: AnyEntity, changeSet?: ChangeSet<AnyEntity>): Promise<ActionLog | null> {
+        const entityName = entity.constructor.name;
         const entityMetadata = this.entityManager.getMetadata(entityName);
         if (!entityMetadata) {
             return null;
         }
 
-        const actionLogsMetadata: ActionLogMetadata | undefined = Reflect.getMetadata(
-            ACTION_LOGS_METADATA_KEY,
-            changeSet.entity.constructor.prototype,
-        );
-        if (!actionLogsMetadata) {
-            return null;
-        }
-
         if (entityMetadata.primaryKeys.length != 1) {
-            console.error(`entity '${entityMetadata}' doesn't have a single primary key`);
+            console.error(`entity '${entityMetadata.className}' doesn't have a single primary key`);
             return null;
         }
         const user = this.userPermissionsStorageService.get("user");
-        const entityId = changeSet.entity[entityMetadata.primaryKeys[0]];
-        const scope = await this.service.getScopeFromEntity(changeSet.entity);
+        const entityId = entity[entityMetadata.primaryKeys[0]];
+        const scope = await this.service.getScopeFromEntity(entity);
 
         let snapshot: AnyEntity | undefined = undefined;
-        if (changeSet.type !== ChangeSetType.DELETE) {
-            const ignoreFields = entityMetadata.relations.map((entityProperty) => entityProperty.name);
-            snapshot = changeSet.entity.toObject(ignoreFields);
+        if (changeSet?.type !== ChangeSetType.DELETE) {
+            const inlineRelations = this.getInlineRelations(entity);
+            const ignoreFields = entityMetadata.relations
+                .map((entityProperty) => entityProperty.name)
+                .filter((name) => !inlineRelations.includes(name));
+            snapshot = entity.toObject(ignoreFields);
         }
 
         return this.entityManager.create(
@@ -80,5 +110,48 @@ export class ActionLogsSubscriber implements EventSubscriber {
             },
             { persist: false },
         );
+    }
+
+    private hasActionLogs(entity: AnyEntity): boolean {
+        const actionLogsMetadata: ActionLogMetadata | undefined = Reflect.getOwnMetadata(ACTION_LOGS_METADATA_KEY, entity.constructor.prototype);
+        return Boolean(actionLogsMetadata);
+    }
+
+    private getInlineRelations(entity: AnyEntity): InlineActionLogsMetadata {
+        return Reflect.getMetadata(INLINE_ACTION_LOGS_METADATA_KEY, entity.constructor.prototype) ?? [];
+    }
+
+    /**
+     * Returns the owning entity if the given entity is an item of an inline relation of an action-logged entity,
+     * resolved via the item's to-one back-reference (e.g. `ProductColor.product`).
+     */
+    private getInlineRelationOwner(entity: AnyEntity): AnyEntity | undefined {
+        const entityMetadata = this.entityManager.getMetadata(entity.constructor.name);
+        if (!entityMetadata) {
+            return undefined;
+        }
+
+        for (const relation of entityMetadata.relations) {
+            if (relation.kind !== ReferenceKind.MANY_TO_ONE && relation.kind !== ReferenceKind.ONE_TO_ONE) {
+                continue;
+            }
+            const reference = entity[relation.name];
+            if (!reference) {
+                continue;
+            }
+            const owner = Reference.unwrapReference(reference);
+            if (!this.hasActionLogs(owner)) {
+                continue;
+            }
+            const ownerMetadata = this.entityManager.getMetadata(owner.constructor.name);
+            const inlineRelations = this.getInlineRelations(owner);
+            const isInlineRelation = ownerMetadata?.relations.some(
+                (ownerRelation) => inlineRelations.includes(ownerRelation.name) && ownerRelation.mappedBy === relation.name,
+            );
+            if (isInlineRelation) {
+                return owner;
+            }
+        }
+        return undefined;
     }
 }

--- a/packages/api/cms-api/src/action-logs/inline-action-logs.decorator.spec.ts
+++ b/packages/api/cms-api/src/action-logs/inline-action-logs.decorator.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { INLINE_ACTION_LOGS_METADATA_KEY, InlineActionLogs, type InlineActionLogsMetadata } from "./inline-action-logs.decorator";
+
+function getInlineRelations(target: object): InlineActionLogsMetadata | undefined {
+    return Reflect.getMetadata(INLINE_ACTION_LOGS_METADATA_KEY, target);
+}
+
+describe("InlineActionLogs", () => {
+    it("stores the decorated relation name as metadata", () => {
+        class Entity {
+            @InlineActionLogs()
+            colors: unknown[] = [];
+        }
+
+        expect(getInlineRelations(Entity.prototype)).toEqual(["colors"]);
+    });
+
+    it("collects multiple decorated relations", () => {
+        class Entity {
+            @InlineActionLogs()
+            colors: unknown[] = [];
+
+            @InlineActionLogs()
+            tags: unknown[] = [];
+        }
+
+        expect(getInlineRelations(Entity.prototype)).toEqual(["colors", "tags"]);
+    });
+
+    it("does not add metadata to entities without the decorator", () => {
+        class Entity {
+            colors: unknown[] = [];
+        }
+
+        expect(getInlineRelations(Entity.prototype)).toBeUndefined();
+    });
+});

--- a/packages/api/cms-api/src/action-logs/inline-action-logs.decorator.ts
+++ b/packages/api/cms-api/src/action-logs/inline-action-logs.decorator.ts
@@ -1,0 +1,17 @@
+export const INLINE_ACTION_LOGS_METADATA_KEY = "inlineActionLogs";
+
+export type InlineActionLogsMetadata = string[];
+
+/**
+ * Marks a one-to-many or many-to-many relation as inline, meaning changes to its items are logged as part of the
+ * owning entity's action log instead of producing separate action log entries.
+ *
+ * Use this for relations that are edited through the owning entity's form (e.g. assigned colors or tags). It is often
+ * combined with `orphanRemoval: true`, but that is not required.
+ */
+export function InlineActionLogs(): PropertyDecorator {
+    return (target, propertyKey) => {
+        const existingRelations: InlineActionLogsMetadata = Reflect.getOwnMetadata(INLINE_ACTION_LOGS_METADATA_KEY, target) ?? [];
+        Reflect.defineMetadata(INLINE_ACTION_LOGS_METADATA_KEY, [...existingRelations, propertyKey.toString()], target);
+    };
+}

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -4,6 +4,7 @@ export { AccessLogModule } from "./access-log/access-log.module";
 export { ActionLogs } from "./action-logs/action-logs.decorator";
 export { ActionLogsModule } from "./action-logs/action-logs.module";
 export { ActionLogType } from "./action-logs/dto/action-log-type.enum";
+export { InlineActionLogs } from "./action-logs/inline-action-logs.decorator";
 export { DisableCometGuards } from "./auth/decorators/disable-comet-guards.decorator";
 export { GetCurrentUser } from "./auth/decorators/get-current-user.decorator";
 export { CometAuthGuard } from "./auth/guards/comet.guard";


### PR DESCRIPTION
## Summary
Introduces an `@InlineActionLogs()` decorator that allows marking one-to-many and many-to-many relations as "inline," meaning changes to their items are logged as part of the owning entity's action log rather than creating separate entries.

## Key Changes
- **New decorator**: Added `@InlineActionLogs()` to mark relations for inline action logging
- **Enhanced subscriber logic**: Updated `ActionLogsSubscriber` to:
  - Track entities that need logging via a deduplication map
  - Detect when inline relation items are edited (via back-references)
  - Detect when inline relation items are added/removed (via collection updates)
  - Include inline relations in entity snapshots instead of excluding them
- **New test file**: Added comprehensive tests for the decorator's metadata handling
- **Demo usage**: Applied the decorator to `Product.colors` relation as an example
- **Exports**: Added `InlineActionLogs` to the public API exports

## Implementation Details
- Uses a `Map<AnyEntity, ChangeSet | undefined>` to deduplicate entities needing logs, allowing tracking of entities that only changed via inline relations
- Resolves inline relation owners through back-references using `Reference.unwrapReference()`
- Filters out non-inline relations from snapshots to avoid duplication
- Handles three scenarios: direct entity changes, inline item edits, and inline item additions/removals

https://claude.ai/code/session_01Dipd8YpQDvywr1geLvrQMm