### PR TITLE
Make ExternalLinkBlock noFollow field optional to avoid breaking change

### DIFF
--- a/.changeset/external-link-block-no-follow-optional.md
+++ b/.changeset/external-link-block-no-follow-optional.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Make the `noFollow` field of the `ExternalLinkBlock` optional
+
+The `noFollow` field, which was added to the `ExternalLinkBlock` in a previous release, was required. This was a breaking change for existing consumers that create external links without providing `noFollow`. The field is now nullable to avoid the breaking change.

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -1146,7 +1146,7 @@
             {
                 "name": "noFollow",
                 "kind": "Boolean",
-                "nullable": false
+                "nullable": true
             }
         ],
         "inputFields": [
@@ -1163,7 +1163,7 @@
             {
                 "name": "noFollow",
                 "kind": "Boolean",
-                "nullable": false
+                "nullable": true
             }
         ]
     },

--- a/packages/api/brevo-api/block-meta.json
+++ b/packages/api/brevo-api/block-meta.json
@@ -322,7 +322,7 @@
             {
                 "name": "noFollow",
                 "kind": "Boolean",
-                "nullable": false
+                "nullable": true
             }
         ],
         "inputFields": [
@@ -339,7 +339,7 @@
             {
                 "name": "noFollow",
                 "kind": "Boolean",
-                "nullable": false
+                "nullable": true
             }
         ]
     },

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -328,7 +328,7 @@
             {
                 "name": "noFollow",
                 "kind": "Boolean",
-                "nullable": false
+                "nullable": true
             }
         ],
         "inputFields": [
@@ -345,7 +345,7 @@
             {
                 "name": "noFollow",
                 "kind": "Boolean",
-                "nullable": false
+                "nullable": true
             }
         ]
     },

--- a/packages/api/cms-api/src/blocks/externalLink/external-link.block.ts
+++ b/packages/api/cms-api/src/blocks/externalLink/external-link.block.ts
@@ -13,8 +13,8 @@ class ExternalLinkBlockData extends BlockData {
     @BlockField()
     openInNewWindow: boolean;
 
-    @BlockField()
-    noFollow: boolean;
+    @BlockField({ nullable: true })
+    noFollow?: boolean;
 }
 
 class ExternalLinkBlockInput extends BlockInput {
@@ -27,9 +27,10 @@ class ExternalLinkBlockInput extends BlockInput {
     @BlockField()
     openInNewWindow: boolean;
 
+    @IsOptional()
     @IsBoolean()
-    @BlockField()
-    noFollow: boolean;
+    @BlockField({ nullable: true })
+    noFollow?: boolean;
 
     transformToBlockData(): ExternalLinkBlockData {
         return blockInputToData(ExternalLinkBlockData, this);


### PR DESCRIPTION
https://github.com/vivid-planet/comet/pull/5957 added a required `noFollow` field to the `ExternalLinkBlock`. While providing a migration that adds a default value, this is still considered breaking as it requires code changes in the application (e.g., providing a value for `noFollow` in fixtures). Make the field optional to avoid the breaking change.

Note: this is only necessary for the `v8.x.x` backport. The original PR (https://github.com/vivid-planet/comet/pull/5738) targeted v9, so the breaking change is acceptable.

https://claude.ai/code/session_01Uw1f2pPkffJjqjQbTgdjeD