### PR TITLE
[Backport v8] Allow `AffectedScope` to return multiple scopes

### DIFF
--- a/.changeset/add-args-to-scopes-affected-scope.md
+++ b/.changeset/add-args-to-scopes-affected-scope.md
@@ -1,0 +1,11 @@
+---
+"@comet/cms-api": minor
+---
+
+Allow `AffectedScope` to return multiple scopes
+
+The `argsToScope` function can now return `ContentScope[]` in addition to a single `ContentScope`. When multiple scopes are returned, the user must have access to all of them (AND relationship).
+
+```ts
+@AffectedScope((args: MyArgs) => [{ domain: args.fromDomain }, { domain: args.toDomain }])
+```

--- a/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/auth/user-permissions.guard.spec.ts
@@ -726,4 +726,107 @@ describe("UserPermissionsGuard", () => {
             ),
         ).toBe(false);
     });
+
+    it("allows user by AffectedScope returning multiple scopes when user has all scopes", async () => {
+        mockAnnotations({
+            requiredPermission: {
+                requiredPermission: [permissions.p1],
+                options: undefined,
+            },
+            affectedScope: { argsToScope: (args) => [{ a: args.a }, { a: args.b }] },
+        });
+        expect(
+            await guard.canActivate(
+                mockContext({
+                    userPermissions: [
+                        {
+                            permission: permissions.p1,
+                            contentScopes: [{ a: 1 }, { a: 2 }],
+                        },
+                    ],
+                    args: { a: 1, b: 2 },
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it("denies by AffectedScope returning multiple scopes when user is missing any scope", async () => {
+        mockAnnotations({
+            requiredPermission: {
+                requiredPermission: [permissions.p1],
+                options: undefined,
+            },
+            affectedScope: { argsToScope: (args) => [{ a: args.a }, { a: args.b }] },
+        });
+        expect(
+            await guard.canActivate(
+                mockContext({
+                    userPermissions: [
+                        {
+                            permission: permissions.p1,
+                            contentScopes: [{ a: 1 }], // Missing {a: 2}
+                        },
+                    ],
+                    args: { a: 1, b: 2 },
+                }),
+            ),
+        ).toBe(false);
+        expect(
+            await guard.canActivate(
+                mockContext({
+                    userPermissions: [
+                        {
+                            permission: permissions.p1,
+                            contentScopes: [{ a: 2 }], // Missing {a: 1}
+                        },
+                    ],
+                    args: { a: 1, b: 2 },
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it("allows user by AffectedScope returning multiple multidimensional scopes when user has all scopes", async () => {
+        mockAnnotations({
+            requiredPermission: {
+                requiredPermission: [permissions.p1],
+                options: undefined,
+            },
+            affectedScope: {
+                argsToScope: (args) => [
+                    { a: args.a, b: args.b },
+                    { a: args.c, b: args.d },
+                ],
+            },
+        });
+        expect(
+            await guard.canActivate(
+                mockContext({
+                    userPermissions: [
+                        {
+                            permission: permissions.p1,
+                            contentScopes: [
+                                { a: 1, b: "x" },
+                                { a: 2, b: "y" },
+                            ],
+                        },
+                    ],
+                    args: { a: 1, b: "x", c: 2, d: "y" },
+                }),
+            ),
+        ).toBe(true);
+        expect(
+            await guard.canActivate(
+                mockContext({
+                    userPermissions: [
+                        {
+                            permission: permissions.p1,
+                            contentScopes: [{ a: 1, b: "x" }], // Missing {a: 2, b: "y"}
+                        },
+                    ],
+                    args: { a: 1, b: "x", c: 2, d: "y" },
+                }),
+            ),
+        ).toBe(false);
+    });
 });

--- a/packages/api/cms-api/src/user-permissions/content-scope.service.ts
+++ b/packages/api/cms-api/src/user-permissions/content-scope.service.ts
@@ -43,7 +43,12 @@ export class ContentScopeService {
         // AffectedScope
         const affectedScope = this.reflector.getAllAndOverride<AffectedScopeMeta>(AFFECTED_SCOPE_METADATA_KEY, [context.getHandler()]) || undefined;
         if (affectedScope) {
-            contentScopes.push([affectedScope.argsToScope(args) as ContentScope]);
+            const scope = affectedScope.argsToScope(args);
+            if (Array.isArray(scope)) {
+                contentScopes.push(...scope.map((s) => [s]));
+            } else {
+                contentScopes.push([scope]);
+            }
         }
 
         // Scope arg

--- a/packages/api/cms-api/src/user-permissions/decorators/affected-scope.decorator.ts
+++ b/packages/api/cms-api/src/user-permissions/decorators/affected-scope.decorator.ts
@@ -3,11 +3,11 @@ import { SetMetadata } from "@nestjs/common";
 import { type ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
 
 export type AffectedScopeMeta = {
-    argsToScope: (args: Record<string, unknown>) => ContentScope;
+    argsToScope: (args: Record<string, unknown>) => ContentScope | ContentScope[];
 };
 
 export const AFFECTED_SCOPE_METADATA_KEY = "affectedScope";
 
-export const AffectedScope = <T>(argsToScope: (args: T) => ContentScope): MethodDecorator => {
+export const AffectedScope = <T>(argsToScope: (args: T) => ContentScope | ContentScope[]): MethodDecorator => {
     return SetMetadata<string, AffectedScopeMeta>(AFFECTED_SCOPE_METADATA_KEY, { argsToScope: argsToScope as AffectedScopeMeta["argsToScope"] });
 };


### PR DESCRIPTION
Backport of #5835 to `v8.x.x`.

Allow `AffectedScope` to return multiple scopes

The `argsToScope` function can now return `ContentScope[]` in addition to a single `ContentScope`. When multiple scopes are returned, the user must have access to all of them (AND relationship).

Cherry-picked cleanly (no conflicts). Verified: `@comet/cms-api` builds, lints, and its full test suite passes (34/34, including the 3 new tests for this change). Demo API's `AppModule` initializes correctly with this change (verified via `pnpm run console --help`; only fails on DB connection, which is expected without a running Postgres instance in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANtcHCrqsqaJdNQZyGRWpE)_