### PR TITLE
Fix typo in contact import error message

### DIFF
--- a/.changeset/fix-contact-import-error-typo.md
+++ b/.changeset/fix-contact-import-error-typo.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-admin": patch
+---
+
+Fix typo in the contact import error message ("occured" → "occurred")

--- a/packages/admin/brevo-admin/src/common/contactImport/useContactImportFromCsv.tsx
+++ b/packages/admin/brevo-admin/src/common/contactImport/useContactImportFromCsv.tsx
@@ -182,7 +182,7 @@ const ContactImportComponent = ({ scope, targetGroupId, fileInputRef, sendDouble
                 intl.formatMessage({
                     id: "cometBrevoModule.useContactImport.error.defaultMessage",
                     defaultMessage:
-                        "An error occured during the import. Please try again in a while or contact your administrator if the error persists.",
+                        "An error occurred during the import. Please try again in a while or contact your administrator if the error persists.",
                 }),
             );
         }
@@ -278,7 +278,7 @@ const ContactImportComponent = ({ scope, targetGroupId, fileInputRef, sendDouble
                 const userMessage = (
                     <FormattedMessage
                         id="cometBrevoModule.useContactImport.error.defaultMessage"
-                        defaultMessage="An error occured during the import. Please try again in a while or contact your administrator if the error persists."
+                        defaultMessage="An error occurred during the import. Please try again in a while or contact your administrator if the error persists."
                     />
                 );
 


### PR DESCRIPTION
## Summary
Corrects a spelling error in the contact import error message where "occured" has been changed to the correct spelling "occurred".

## Changes
- Fixed typo in error message text in `useContactImportFromCsv.tsx` (2 occurrences)
- Updated both the `intl.formatMessage` call and the `FormattedMessage` component to use the correct spelling

## Details
This is a straightforward spelling correction in user-facing error messages. The change affects the default message displayed when an error occurs during the contact import process.

https://claude.ai/code/session_01F8191rem6iXgL1PUWYjarW