### PR TITLE
Fix dependencies list crashing due to invalid visible filter

### DIFF
--- a/.changeset/dependencies-list-visible-filter.md
+++ b/.changeset/dependencies-list-visible-filter.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix the dependencies list crashing due to an invalid `visible` filter
+
+The `DependenciesList` initialized the `visible` filter with the string `"true"` instead of the boolean `true`, causing the GraphQL request to fail with a `400 Bad Request` (`Boolean cannot represent a non boolean value`). This made the dependencies/dependents tab (e.g., on global content) crash with a network error. This is the counterpart to the earlier fix for `DependentsList`.

--- a/packages/admin/cms-admin/src/dependencies/DependenciesList.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependenciesList.tsx
@@ -102,7 +102,7 @@ export const DependenciesList = ({ query, variables }: DependenciesListProps) =>
             queryParamsPrefix: "dependencies",
             pageSize,
             initialFilter: {
-                items: [{ field: "visible", operator: "is", value: "true" }],
+                items: [{ field: "visible", operator: "is", value: true }],
             },
         }),
         ...usePersistentColumnState("DependenciesList"),


### PR DESCRIPTION
## Description

Follow-up to #5974, which was incomplete: it fixed only `DependentsList`, but the same bug exists in the sibling `DependenciesList` component.

### Problem

Opening a dependents tab backed by `DependenciesList` crashed with a network error. The GraphQL request failed with `400 Bad Request`:

> Variable "$filter" got invalid value "true" at "filter.and[0].visible.equal"; Boolean cannot represent a non boolean value: "true"

### Cause

`DependenciesList` initialized the `visible` filter with the **string** `"true"` instead of the boolean `true`. As a preset filter, the value never passes through MUI's `GridFilterInputBoolean` sanitizer (which coerces strings to real booleans), so the raw string reached the GraphQL `Boolean` filter field and the API rejected it.

`#5974` fixed exactly this in `DependentsList`, but the equivalent bug in `DependenciesList` remained.

### Fix

Use the boolean `true` for the initial filter value, matching the `DependentsList` fix.
