### PR TITLE
Add visibility indicators to dependency lists

### DIFF
--- a/.changeset/dependency-visibility-indicators.md
+++ b/.changeset/dependency-visibility-indicators.md
@@ -4,4 +4,4 @@
 
 Show a visibility indicator for each item in the dependencies and dependents DataGrids
 
-Every row in the dependencies and dependents lists now displays an icon next to its name indicating whether the referenced item is visible or not visible. The lists no longer filter out non-visible items by default, so the visibility of all related content is shown at a glance.
+Every row in the dependencies and dependents lists now displays an icon next to its name indicating whether the referenced item is visible or not visible, so the visibility status of related content is shown at a glance.

--- a/.changeset/dependency-visibility-indicators.md
+++ b/.changeset/dependency-visibility-indicators.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": minor
+---
+
+Show a visibility indicator for each item in the dependencies and dependents DataGrids
+
+Every row in the dependencies and dependents lists now displays an icon next to its name indicating whether the referenced item is visible or not visible. The lists no longer filter out non-visible items by default, so the visibility of all related content is shown at a glance.

--- a/packages/admin/cms-admin/src/dependencies/DependenciesList.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependenciesList.tsx
@@ -102,6 +102,9 @@ export const DependenciesList = ({ query, variables }: DependenciesListProps) =>
         ...useDataGridRemote({
             queryParamsPrefix: "dependencies",
             pageSize,
+            initialFilter: {
+                items: [{ field: "visible", operator: "is", value: "true" }],
+            },
         }),
         ...usePersistentColumnState("DependenciesList"),
     };

--- a/packages/admin/cms-admin/src/dependencies/DependenciesList.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependenciesList.tsx
@@ -26,6 +26,7 @@ import { useContentScope } from "../contentScope/Provider";
 import { DataGrid } from "../dataGrid/DataGrid";
 import type { GQLDependency } from "../graphql.generated";
 import { useDependenciesConfig } from "./dependenciesConfig";
+import { DependencyVisibilityIndicator } from "./DependencyVisibilityIndicator";
 import { getDisplayNameString } from "./getDisplayNameString";
 import type { DependencyInterface } from "./types";
 
@@ -101,9 +102,6 @@ export const DependenciesList = ({ query, variables }: DependenciesListProps) =>
         ...useDataGridRemote({
             queryParamsPrefix: "dependencies",
             pageSize,
-            initialFilter: {
-                items: [{ field: "visible", operator: "is", value: "true" }],
-            },
         }),
         ...usePersistentColumnState("DependenciesList"),
     };
@@ -116,7 +114,11 @@ export const DependenciesList = ({ query, variables }: DependenciesListProps) =>
                 flex: 1,
                 sortBy: "name",
                 renderCell: ({ row }) => (
-                    <GridCellContent primaryText={row.name ?? <FormattedMessage {...messages.unknown} />} secondaryText={row.secondaryInformation} />
+                    <GridCellContent
+                        icon={<DependencyVisibilityIndicator visible={row.visible} />}
+                        primaryText={row.name ?? <FormattedMessage {...messages.unknown} />}
+                        secondaryText={row.secondaryInformation}
+                    />
                 ),
             },
             {

--- a/packages/admin/cms-admin/src/dependencies/DependencyVisibilityIndicator.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependencyVisibilityIndicator.tsx
@@ -1,0 +1,23 @@
+import { Tooltip } from "@comet/admin";
+import { Invisible, Visible } from "@comet/admin-icons";
+import { FormattedMessage } from "react-intl";
+
+interface DependencyVisibilityIndicatorProps {
+    visible: boolean;
+}
+
+export const DependencyVisibilityIndicator = ({ visible }: DependencyVisibilityIndicatorProps) => {
+    return (
+        <Tooltip
+            title={
+                visible ? (
+                    <FormattedMessage id="comet.dependencies.dataGrid.visibleTooltip" defaultMessage="Visible" />
+                ) : (
+                    <FormattedMessage id="comet.dependencies.dataGrid.notVisibleTooltip" defaultMessage="Not visible" />
+                )
+            }
+        >
+            {visible ? <Visible sx={{ color: "success.main" }} /> : <Invisible sx={{ color: "grey.300" }} />}
+        </Tooltip>
+    );
+};

--- a/packages/admin/cms-admin/src/dependencies/DependentsList.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependentsList.tsx
@@ -102,6 +102,9 @@ export const DependentsList = ({ query, variables }: DependentsListProps) => {
         ...useDataGridRemote({
             queryParamsPrefix: "dependents",
             pageSize,
+            initialFilter: {
+                items: [{ field: "visible", operator: "is", value: true }],
+            },
         }),
         ...usePersistentColumnState("DependentsList"),
     };

--- a/packages/admin/cms-admin/src/dependencies/DependentsList.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependentsList.tsx
@@ -26,6 +26,7 @@ import { useContentScope } from "../contentScope/Provider";
 import { DataGrid } from "../dataGrid/DataGrid";
 import type { GQLDependency } from "../graphql.generated";
 import { useDependenciesConfig } from "./dependenciesConfig";
+import { DependencyVisibilityIndicator } from "./DependencyVisibilityIndicator";
 import { getDisplayNameString } from "./getDisplayNameString";
 import type { DependencyInterface } from "./types";
 
@@ -101,9 +102,6 @@ export const DependentsList = ({ query, variables }: DependentsListProps) => {
         ...useDataGridRemote({
             queryParamsPrefix: "dependents",
             pageSize,
-            initialFilter: {
-                items: [{ field: "visible", operator: "is", value: true }],
-            },
         }),
         ...usePersistentColumnState("DependentsList"),
     };
@@ -116,7 +114,11 @@ export const DependentsList = ({ query, variables }: DependentsListProps) => {
                 flex: 1,
                 sortBy: "name",
                 renderCell: ({ row }) => (
-                    <GridCellContent primaryText={row.name ?? <FormattedMessage {...messages.unknown} />} secondaryText={row.secondaryInformation} />
+                    <GridCellContent
+                        icon={<DependencyVisibilityIndicator visible={row.visible} />}
+                        primaryText={row.name ?? <FormattedMessage {...messages.unknown} />}
+                        secondaryText={row.secondaryInformation}
+                    />
                 ),
             },
             {

--- a/packages/admin/cms-admin/src/dependencies/__stories__/DependencyLists.stories.tsx
+++ b/packages/admin/cms-admin/src/dependencies/__stories__/DependencyLists.stories.tsx
@@ -1,0 +1,200 @@
+import { gql, type TypedDocumentNode } from "@apollo/client";
+import { MockedProvider } from "@apollo/client/testing";
+import { Box, Typography } from "@mui/material";
+import type { Meta } from "@storybook/react-vite";
+
+import { CometConfigProvider } from "../../config/CometConfigContext";
+import { DependenciesList } from "../DependenciesList";
+import { DependentsList } from "../DependentsList";
+
+const config: Meta = {
+    title: "dependencies/DependencyLists",
+};
+
+export default config;
+
+const dependenciesConfig = {
+    entityDependencyMap: {
+        Page: {
+            displayName: "Page",
+            resolvePath: async () => "/pages/page",
+        },
+        Link: {
+            displayName: "Link",
+            resolvePath: async () => "/pages/link",
+        },
+        DamFile: {
+            displayName: "Asset",
+            resolvePath: async () => "/assets/file",
+        },
+    },
+};
+
+const dependentsQuery = gql`
+    query DependentsListStory($offset: Int!, $limit: Int!) {
+        item: pageTreeNode(id: "root") {
+            id
+            dependents(offset: $offset, limit: $limit) {
+                nodes {
+                    rootGraphqlObjectType
+                    rootId
+                    rootColumnName
+                    jsonPath
+                    name
+                    secondaryInformation
+                    visible
+                }
+                totalCount
+            }
+        }
+    }
+` as TypedDocumentNode<any, any>;
+
+const dependenciesQuery = gql`
+    query DependenciesListStory($offset: Int!, $limit: Int!) {
+        item: page(id: "root") {
+            id
+            dependencies(offset: $offset, limit: $limit) {
+                nodes {
+                    targetGraphqlObjectType
+                    targetId
+                    rootColumnName
+                    jsonPath
+                    name
+                    secondaryInformation
+                    visible
+                }
+                totalCount
+            }
+        }
+    }
+` as TypedDocumentNode<any, any>;
+
+const dependentNodes = [
+    {
+        rootGraphqlObjectType: "Page",
+        rootId: "1",
+        rootColumnName: "content",
+        jsonPath: "root",
+        name: "Home",
+        secondaryInformation: "/",
+        visible: true,
+    },
+    {
+        rootGraphqlObjectType: "Page",
+        rootId: "2",
+        rootColumnName: "content",
+        jsonPath: "root",
+        name: "About us",
+        secondaryInformation: "/about",
+        visible: true,
+    },
+    {
+        rootGraphqlObjectType: "Page",
+        rootId: "3",
+        rootColumnName: "content",
+        jsonPath: "root",
+        name: "Draft campaign",
+        secondaryInformation: "/campaign",
+        visible: false,
+    },
+    {
+        rootGraphqlObjectType: "Link",
+        rootId: "4",
+        rootColumnName: "content",
+        jsonPath: "root",
+        name: "Footer link",
+        secondaryInformation: "Footer",
+        visible: true,
+    },
+    {
+        rootGraphqlObjectType: "Link",
+        rootId: "5",
+        rootColumnName: "content",
+        jsonPath: "root",
+        name: "Archived promo",
+        secondaryInformation: "Promo",
+        visible: false,
+    },
+];
+
+const dependencyNodes = [
+    {
+        targetGraphqlObjectType: "DamFile",
+        targetId: "10",
+        rootColumnName: "content",
+        jsonPath: "root",
+        name: "hero.jpg",
+        secondaryInformation: "Images",
+        visible: true,
+    },
+    {
+        targetGraphqlObjectType: "Page",
+        targetId: "11",
+        rootColumnName: "content",
+        jsonPath: "root",
+        name: "Contact",
+        secondaryInformation: "/contact",
+        visible: true,
+    },
+    {
+        targetGraphqlObjectType: "Page",
+        targetId: "12",
+        rootColumnName: "content",
+        jsonPath: "root",
+        name: "Unpublished landing page",
+        secondaryInformation: "/landing",
+        visible: false,
+    },
+    {
+        targetGraphqlObjectType: "DamFile",
+        targetId: "13",
+        rootColumnName: "content",
+        jsonPath: "root",
+        name: "old-brochure.pdf",
+        secondaryInformation: "Documents",
+        visible: false,
+    },
+];
+
+const dependentsMock = {
+    request: { query: dependentsQuery },
+    variableMatcher: () => true,
+    result: { data: { item: { id: "root", dependents: { nodes: dependentNodes, totalCount: dependentNodes.length } } } },
+};
+
+const dependenciesMock = {
+    request: { query: dependenciesQuery },
+    variableMatcher: () => true,
+    result: { data: { item: { id: "root", dependencies: { nodes: dependencyNodes, totalCount: dependencyNodes.length } } } },
+};
+
+export const Dependents = {
+    render: () => (
+        <CometConfigProvider graphQLApiUrl="/graphql" apiUrl="" adminUrl="" dependencies={dependenciesConfig}>
+            <MockedProvider mocks={[dependentsMock, dependentsMock, dependentsMock]} addTypename={false}>
+                <Box maxWidth={900}>
+                    <Typography variant="h4" gutterBottom>
+                        Dependents
+                    </Typography>
+                    <DependentsList query={dependentsQuery} variables={{}} />
+                </Box>
+            </MockedProvider>
+        </CometConfigProvider>
+    ),
+};
+
+export const Dependencies = {
+    render: () => (
+        <CometConfigProvider graphQLApiUrl="/graphql" apiUrl="" adminUrl="" dependencies={dependenciesConfig}>
+            <MockedProvider mocks={[dependenciesMock, dependenciesMock, dependenciesMock]} addTypename={false}>
+                <Box maxWidth={900}>
+                    <Typography variant="h4" gutterBottom>
+                        Dependencies
+                    </Typography>
+                    <DependenciesList query={dependenciesQuery} variables={{}} />
+                </Box>
+            </MockedProvider>
+        </CometConfigProvider>
+    ),
+};


### PR DESCRIPTION
## Summary
Add visual indicators to show whether items in the dependencies and dependents lists are visible or not visible. This provides users with at-a-glance information about the visibility status of related content.

## Key Changes
- **New component**: `DependencyVisibilityIndicator` displays a colored icon (green eye for visible, grey crossed-out eye for not visible) with a tooltip
- **Updated `DependenciesList` and `DependentsList`**: added the visibility indicator icon to the name column using `GridCellContent`
- **New Storybook story**: `DependencyLists.stories.tsx` demonstrates both the Dependents and Dependencies list components with mock data

## Implementation Details
- The visibility indicator uses existing `@comet/admin-icons` components (`Visible` and `Invisible`)
- Tooltips are localized with message IDs for internationalization
- The default "visible" filter is kept, so non-visible items are hidden by default; the indicator makes the visibility status clear when the filter is adjusted to show non-visible items
- Both lists follow the same pattern for consistency

## Screenshots

**Dependents list**

<!-- paste screenshot here -->

**Dependencies list**

<!-- paste screenshot here -->

**Tooltip ("Visible" / "Not visible" on hover)**

<!-- paste screenshot here -->

**Narrow width (e.g. DAM file detail split-pane)**

<!-- paste screenshot here -->

https://claude.ai/code/session_01NwsaXzAPoXmkWm36gSzntg