### PR TITLE
admin: Fix separation of multiple selected values in FinalFormSelect

### DIFF
--- a/.changeset/async-select-field-multiple-value-separation.md
+++ b/.changeset/async-select-field-multiple-value-separation.md
@@ -1,0 +1,9 @@
+---
+"@comet/admin": patch
+---
+
+Fix separation of multiple selected values in `FinalFormSelect`
+
+When using `multiple`, the selected values were rendered concatenated without any separator (e.g. `value-2value-1value-3value-4`). They are now separated by a comma, matching the display of `SelectField`.
+
+This affects all fields that render their selected values through the options/`getOptionLabel` path (i.e. without JSX `children`), namely `AsyncSelectField` and any `FinalFormSelect` used with an array value. Within Comet, this also corrects the display of the `targetGroups` and test email address selects in `@comet/brevo-admin` (`SendManagerFields`, `TestEmailCampaignForm`), which consume `FinalFormSelect` and had the same issue.

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -126,7 +126,7 @@ export const FinalFormSelect = <T,>({
             value={Array.isArray(value) ? value.map((i) => getOptionValue(i)) : getOptionValue(value)}
             renderValue={() => {
                 if (Array.isArray(value)) {
-                    return value.map((i) => getOptionLabel(i));
+                    return value.map((i) => getOptionLabel(i)).join(", ");
                 } else {
                     return getOptionLabel(value);
                 }


### PR DESCRIPTION
TIMR: [COM-3067 - AsyncSelectField: mehrere ausgewählte Values werden nicht getrennt dargestellt](https://vivid.timr.com/timr/tasks/649e3173-9f00-4cfe-b942-c7e27320a041)  
JIRA: https://vivid-planet.atlassian.net/browse/COM-3067

## Problem

In `AsyncSelectField` (and any field rendering through `FinalFormSelect`'s options/`getOptionLabel` path), multiple selected values were rendered concatenated without any separator, e.g. `value-2value-1value-3value-4`, while the underlying form state was correct (`["value-2", "value-1", "value-3", "value-4"]`).

The cause: `FinalFormSelect`'s custom `renderValue` returned `value.map((i) => getOptionLabel(i))` — a raw array. React renders array children with no separator. `SelectField` was unaffected because it passes JSX `children`, so `FinalFormSelect` skips the custom `renderValue` and MUI's default multiple-value rendering (which joins labels with `", "`) applies.

## Solution

Join the mapped labels with `", "` in the array branch of `renderValue`, matching MUI's default and `SelectField`'s display:

```tsx
renderValue={() => {
    if (Array.isArray(value)) {
        return value.map((i) => getOptionLabel(i)).join(", ");
    } else {
        return getOptionLabel(value);
    }
}}
```

The single-value (`else`) branch and the `children` path are unchanged, so single selects and `children`-based selects render exactly as before.

## Affected components

Fields that render through the options/`getOptionLabel` path with an array value benefit from this fix:

- `AsyncSelectField` / `FinalFormAsyncSelect` (the reported case) — any `multiple` usage.
- `@comet/brevo-admin` › `SendManagerFields` (`targetGroups`) — `FinalFormSelect` + `multiple` + async options; had the same concatenation bug.
- `@comet/brevo-admin` › `TestEmailCampaignForm` (`testEmails`) — `FinalFormSelect` with an array value; selected values now separate correctly.

Not affected (children path — MUI already comma-joins): `InternalLinkBlock`, `RedirectForm`, `DamFileDownloadLinkBlock`, `createEditPageNode`.
Not affected (single-select, non-array value): `PermissionDialog`, `FileSettingsFields`.

## Reference

- Storybook: AsyncSelectField → "Multiple Without Initial Values"
- [COM-3067](https://vivid-planet.atlassian.net/browse/COM-3067)


## Screenshots

| Before | Now |
| --- | --- |
| <img width="1125" height="500" alt="Screenshot 2026-07-09 at 13 57 52" src="https://github.com/user-attachments/assets/3b9720fd-4c5e-499d-89e0-dbe3c948f487" /> | <img width="875" height="406" alt="Screenshot 2026-07-09 at 15 23 20" src="https://github.com/user-attachments/assets/943d8578-0e79-408d-9a37-3f93087925a4" /> |

[COM-3067]: https://vivid-planet.atlassian.net/browse/COM-3067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ