### PR TITLE
demo: add large-scale scope and user setup for permission testing

### DIFF
--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -118,11 +118,17 @@ export class AppModule {
                 authModule,
                 UserPermissionsModule.forRootAsync({
                     useFactory: (userService: UserService, accessControlService: AccessControlService) => ({
+                        // Generate ~2000 content scopes across 4 dimensions (domain × language × organization × country)
+                        // to test behavior with a large number of scopes. 2 domains × 2 languages × 25 organizations × 20 countries = 2000.
                         availableContentScopes: config.siteConfigs.flatMap((siteConfig) =>
-                            siteConfig.scope.languages.map((language) => ({
-                                scope: { domain: siteConfig.scope.domain, language },
-                                label: { domain: siteConfig.name },
-                            })),
+                            siteConfig.scope.languages.flatMap((language) =>
+                                Array.from({ length: 25 }, (_, orgIndex) => `organization-${orgIndex + 1}`).flatMap((organization) =>
+                                    Array.from({ length: 20 }, (_, countryIndex) => `country-${countryIndex + 1}`).map((country) => ({
+                                        scope: { domain: siteConfig.scope.domain, language, organization, country },
+                                        label: { domain: siteConfig.name },
+                                    })),
+                                ),
+                            ),
                         ),
                         userService,
                         accessControlService,

--- a/demo/api/src/auth/access-control.service.spec.ts
+++ b/demo/api/src/auth/access-control.service.spec.ts
@@ -56,15 +56,18 @@ describe("AccessControlService", () => {
             expect(contentScopes).toEqual(UserPermissions.allContentScopes);
         });
 
-        it("should return limited content scopes for non-admin user", () => {
-            const nonAdminUser = staticUsers[1];
+        it("should return a deterministic subset of content scopes for non-admin user", () => {
+            const nonAdminUser = staticUsers[1]; // id "2"
 
             const contentScopes = service.getContentScopesForUser(nonAdminUser);
 
-            expect(contentScopes).toEqual([{ domain: "main", language: "en" }]);
+            // 2 domains × 2 languages × 3 countries, all mapped to the organization derived from the user id.
+            expect(contentScopes).toHaveLength(12);
+            expect(contentScopes).toContainEqual({ domain: "main", language: "en", organization: "organization-2", country: "country-1" });
+            expect(Array.isArray(contentScopes) && contentScopes.every((scope) => scope.organization === "organization-2")).toBe(true);
         });
 
-        it("should return limited content scopes for unknown non-admin user", () => {
+        it("should fall back to the first organization for a user with a non-numeric id", () => {
             const unknownUser: User = {
                 id: "b26d86a7-32bb-4c84-ab9d-d167dddd40ff",
                 name: "Unknown User",
@@ -74,7 +77,8 @@ describe("AccessControlService", () => {
 
             const contentScopes = service.getContentScopesForUser(unknownUser);
 
-            expect(contentScopes).toEqual([{ domain: "main", language: "en" }]);
+            expect(contentScopes).toHaveLength(12);
+            expect(Array.isArray(contentScopes) && contentScopes.every((scope) => scope.organization === "organization-1")).toBe(true);
         });
     });
 });

--- a/demo/api/src/auth/access-control.service.ts
+++ b/demo/api/src/auth/access-control.service.ts
@@ -14,8 +14,16 @@ export class AccessControlService extends AbstractAccessControlService {
     getContentScopesForUser(user: User): ContentScopesForUser {
         if (user.isAdmin) {
             return UserPermissions.allContentScopes;
-        } else {
-            return [{ domain: "main", language: "en" }];
         }
+        // Assign each non-admin user a deterministic subset of the available content scopes,
+        // so users have (varied) scope assignments to inspect in the user permissions UI.
+        // The organization is derived from the user id (see `availableContentScopes` in app.module.ts for the full set).
+        const userId = parseInt(user.id, 10);
+        const organization = `organization-${Number.isNaN(userId) ? 1 : ((userId - 1) % 25) + 1}`;
+        return ["main", "secondary"].flatMap((domain) =>
+            ["en", "de"].flatMap((language) =>
+                ["country-1", "country-2", "country-3"].map((country) => ({ domain, language, organization, country })),
+            ),
+        );
     }
 }

--- a/demo/api/src/auth/static-users.ts
+++ b/demo/api/src/auth/static-users.ts
@@ -13,4 +13,15 @@ export const staticUsers: User[] = [
         email: "test@test.com",
         isAdmin: false,
     },
+    // Additional non-admin users to fill the user permissions list (e.g. for testing pagination).
+    // Ids must stay sequential because `UserService.getUser` resolves users by `id - 1` array index.
+    ...Array.from({ length: 23 }, (_, index) => {
+        const id = index + 3;
+        return {
+            id: `${id}`,
+            name: `User ${id}`,
+            email: `user${id}@comet-dxp.com`,
+            isAdmin: false,
+        };
+    }),
 ];

--- a/demo/site-configs/site-configs.d.ts
+++ b/demo/site-configs/site-configs.d.ts
@@ -3,6 +3,10 @@ import type { BaseSiteConfig, ExtractPrivateSiteConfig, ExtractPublicSiteConfig 
 export type ContentScope = {
     domain: string;
     language: string;
+    // Additional dimensions used to test behavior with a large number of scopes (see `availableContentScopes` in demo/api app.module.ts).
+    // Optional so existing `{ domain, language }` scope objects keep type-checking.
+    organization?: string;
+    country?: string;
 };
 
 export interface SiteConfig extends BaseSiteConfig {


### PR DESCRIPTION
## Enlarge demo scope and user setup for large-scale testing

### Problem

Some issues (performance and UX in the user permissions area) only surface in projects with a large number of content scopes across several dimensions and many users. The demo previously had only **4 content scopes** (2 domains × 2 languages) and **2 users**, which isn't enough to reproduce or regression-test this behavior.

### Reporoduction

Scale up the demo's scope and user setup so it mirrors a large real-world project:

- Add two optional dimensions — `organization` and `country` — to the demo `ContentScope` type. They're optional so existing two-dimensional (`{ domain, language }`) scope objects across the demo keep type-checking.
- Generate **~2000 content scopes** across 4 dimensions in the user permissions module: 2 domains × 2 languages × 25 organizations × 20 countries.
- Add 23 static users (**25 total**) so the first page of the user permissions list is fully populated.
- Assign each non-admin user a **deterministic 12-scope subset** (both domains, both languages, 3 countries, under one organization derived from the user id), so scope assignments vary across users rather than everyone sharing one scope.

Log in to the admin as **Admin** to get all 2000 scopes in the content-scope selector; the user permissions list now shows 25 users, each with assigned scopes.

### Observed performance with this setup

With ~2000 scopes across 4 dimensions, the following load times were measured:

- **User permissions page (list):** ~16–17s to load
- **User permission detail page:** ~6–7s to load
- **Current user:** ~2s to load

These numbers demonstrate the performance problem this setup is intended to reproduce.