### PR TITLE
Replace hardcoded access-log ignored paths with `DisableAccessLog` decorator

### DIFF
--- a/.changeset/access-log-disable-decorator.md
+++ b/.changeset/access-log-disable-decorator.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Add `DisableAccessLog` decorator to exclude routes from the access log
+
+Annotate a controller or route handler with `@DisableAccessLog()` to prevent the `AccessLogInterceptor` from logging it. This replaces the previously hardcoded list of ignored DAM paths, which relied on brittle route-string matching and stopped excluding the DAM file download route (`/dam/files/:hash/...`) after the Express 5 upgrade changed the route syntax.

--- a/packages/api/cms-api/src/access-log/access-log.interceptor.ts
+++ b/packages/api/cms-api/src/access-log/access-log.interceptor.ts
@@ -1,32 +1,33 @@
 import { CallHandler, ExecutionContext, Inject, Injectable, Logger, NestInterceptor, Optional } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
 import { GqlExecutionContext } from "@nestjs/graphql";
 import { Request } from "express";
 import { GraphQLResolveInfo } from "graphql";
 import { getClientIp } from "request-ip";
 
-import { DamConfig } from "../dam/dam.config";
-import { DAM_CONFIG } from "../dam/dam.constants";
 import { CurrentUser } from "../user-permissions/dto/current-user";
 import { User } from "../user-permissions/interfaces/user";
 import { ACCESS_LOG_CONFIG } from "./access-log.constants";
 import { AccessLogConfig } from "./access-log.module";
+import { DISABLE_ACCESS_LOG_METADATA_KEY } from "./disable-access-log.decorator";
 
 @Injectable()
 export class AccessLogInterceptor implements NestInterceptor {
     protected readonly logger = new Logger(AccessLogInterceptor.name);
-    private ignoredPaths: string[];
 
     constructor(
+        private readonly reflector: Reflector,
         @Optional() @Inject(ACCESS_LOG_CONFIG) private readonly config?: AccessLogConfig,
-        @Optional() @Inject(DAM_CONFIG) private readonly damConfig?: DamConfig,
-    ) {
-        const damBasePath = this.damConfig?.basePath ?? "dam";
-
-        this.ignoredPaths = this.damConfig
-            ? [`/${damBasePath}/images/`, `/${damBasePath}/files/preview`, `/${damBasePath}/files/download`, `/${damBasePath}/files/:hash/`]
-            : [];
-    }
+    ) {}
     intercept(context: ExecutionContext, next: CallHandler) {
+        const disableAccessLog = this.reflector.getAllAndOverride<boolean>(DISABLE_ACCESS_LOG_METADATA_KEY, [
+            context.getHandler(),
+            context.getClass(),
+        ]);
+        if (disableAccessLog) {
+            return next.handle();
+        }
+
         const requestType = context.getType().toString();
 
         const requestData: string[] = [];
@@ -76,13 +77,12 @@ export class AccessLogInterceptor implements NestInterceptor {
             const user = (httpRequest as any).user as CurrentUser;
 
             if (
-                this.ignoredPaths.some((ignoredPath) => httpRequest.route.path.includes(ignoredPath)) ||
-                (this.config &&
-                    this.config.shouldLogRequest &&
-                    !this.config.shouldLogRequest({
-                        user: user,
-                        req: httpRequest,
-                    }))
+                this.config &&
+                this.config.shouldLogRequest &&
+                !this.config.shouldLogRequest({
+                    user: user,
+                    req: httpRequest,
+                })
             ) {
                 ignored = true;
             }

--- a/packages/api/cms-api/src/access-log/disable-access-log.decorator.ts
+++ b/packages/api/cms-api/src/access-log/disable-access-log.decorator.ts
@@ -1,0 +1,5 @@
+import { type CustomDecorator, SetMetadata } from "@nestjs/common";
+
+export const DISABLE_ACCESS_LOG_METADATA_KEY = "disableAccessLog";
+
+export const DisableAccessLog = (): CustomDecorator<string> => SetMetadata(DISABLE_ACCESS_LOG_METADATA_KEY, true);

--- a/packages/api/cms-api/src/dam/files/files.controller.ts
+++ b/packages/api/cms-api/src/dam/files/files.controller.ts
@@ -23,6 +23,7 @@ import { OutgoingHttpHeaders } from "http";
 import { basename, extname } from "path";
 import { Readable } from "stream";
 
+import { DisableAccessLog } from "../../access-log/disable-access-log.decorator";
 import { DisableCometGuards } from "../../auth/decorators/disable-comet-guards.decorator";
 import { GetCurrentUser } from "../../auth/decorators/get-current-user.decorator";
 import { BlobStorageBackendService } from "../../blob-storage/backends/blob-storage-backend.service";
@@ -196,6 +197,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             return { ...replacedFile, fileUrl };
         }
 
+        @DisableAccessLog()
         @Get(`/preview{/:contentHash}/${fileUrl}`)
         async previewFileUrl(
             @Param() { fileId, contentHash }: FileParams,
@@ -220,6 +222,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             return this.streamFile(file, res, { range, overrideHeaders: { "cache-control": "max-age=31536000, private" } }); // Local caches only (1 year)
         }
 
+        @DisableAccessLog()
         @Get(`/download/preview{/:contentHash}/${fileUrl}`)
         async previewDownloadFile(
             @Param() { fileId, contentHash }: FileParams,
@@ -245,6 +248,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             return this.streamFile(file, res, { range, overrideHeaders: { "cache-control": "max-age=31536000, private" } }); // Local caches only (1 year)
         }
 
+        @DisableAccessLog()
         @DisableCometGuards()
         @Get(`/download/:hash{/:contentHash}/${fileUrl}`)
         async downloadFile(
@@ -270,6 +274,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             return this.streamFile(file, res, { range, overrideHeaders: { "cache-control": "max-age=31536000, s-maxage=86400, public" } }); // Public cache, 1 year for browsers, 1 day for proxies/cdn's
         }
 
+        @DisableAccessLog()
         @DisableCometGuards()
         @Get(`/:hash{/:contentHash}/${fileUrl}`)
         async hashedFileUrl(

--- a/packages/api/cms-api/src/dam/images/images.controller.ts
+++ b/packages/api/cms-api/src/dam/images/images.controller.ts
@@ -16,6 +16,7 @@ import { OutgoingHttpHeaders } from "http";
 import mime from "mime";
 import { PassThrough, Readable } from "stream";
 
+import { DisableAccessLog } from "../../access-log/disable-access-log.decorator";
 import { DisableCometGuards } from "../../auth/decorators/disable-comet-guards.decorator";
 import { GetCurrentUser } from "../../auth/decorators/get-current-user.decorator";
 import { BlobStorageBackendService } from "../../blob-storage/backends/blob-storage-backend.service";
@@ -54,6 +55,7 @@ export const createImagesController = ({ damBasePath }: { damBasePath: string })
             @Inject(ACCESS_CONTROL_SERVICE) private accessControlService: AccessControlServiceInterface,
         ) {}
 
+        @DisableAccessLog()
         @Get(`/preview{/:contentHash}/${focusImageUrl}`)
         async previewFocusCroppedImage(
             @Param() params: ImageParams,
@@ -83,6 +85,7 @@ export const createImagesController = ({ damBasePath }: { damBasePath: string })
             });
         }
 
+        @DisableAccessLog()
         @Get(`/preview{/:contentHash}/${smartImageUrl}`)
         async previewSmartCroppedImage(
             @Param() params: ImageParams,
@@ -113,6 +116,7 @@ export const createImagesController = ({ damBasePath }: { damBasePath: string })
             });
         }
 
+        @DisableAccessLog()
         @DisableCometGuards()
         @Get(`/:hash{/:contentHash}/${focusImageUrl}`)
         async focusCroppedImage(@Param() params: HashImageParams, @Headers("Accept") accept: string, @Res() res: Response): Promise<void> {
@@ -134,6 +138,7 @@ export const createImagesController = ({ damBasePath }: { damBasePath: string })
             });
         }
 
+        @DisableAccessLog()
         @DisableCometGuards()
         @Get(`/:hash{/:contentHash}/${smartImageUrl}`)
         async smartCroppedImage(@Param() params: HashImageParams, @Headers("Accept") accept: string, @Res() res: Response): Promise<void> {

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 
 export { AccessLogModule } from "./access-log/access-log.module";
+export { DISABLE_ACCESS_LOG_METADATA_KEY, DisableAccessLog } from "./access-log/disable-access-log.decorator";
 export { DisableCometGuards } from "./auth/decorators/disable-comet-guards.decorator";
 export { GetCurrentUser } from "./auth/decorators/get-current-user.decorator";
 export { CometAuthGuard } from "./auth/guards/comet.guard";


### PR DESCRIPTION
## Description

The `AccessLogInterceptor` excluded high-volume DAM asset-serving routes from the access log via a hardcoded list of DAM path fragments matched against `route.path` with `String.includes`.

- **Problem:** DAM file downloads via `/dam/files/:hash/...` were being access-logged, despite being meant to be excluded.
- **Reason:** The Express 5 / path-to-regexp v8 upgrade changed the optional-param syntax from `/:contentHash?` to `{/:contentHash}`, so the real route path became `/dam/files/:hash{/:contentHash}/...`. The fragment `/dam/files/:hash/` no longer occurs as a substring (the character after `:hash` is now `{`), so the match silently stopped working.
- **Fix / refactor:** Replace the hardcoded path list with a dedicated `@DisableAccessLog()` decorator read via `Reflector` in the interceptor, following the existing `SkipBuild` / `DisableCometGuards` pattern. The DAM serving routes are annotated with it, and the interceptor no longer depends on `DamConfig`.

This preserves the previous exclusion set exactly, decouples the access-log module from the DAM module, and fixes the `:hash` route no longer being excluded. `@DisableAccessLog()` is exported so projects can exclude their own high-volume routes too.

Verified with `build` + `lint` (incl. `tsc`). Runtime verification (hitting DAM routes and checking the logs) is still open.

## Further information

- Task: _n/a — discovered while investigating the access-log behavior_
