### PR TITLE
Fix warnings page crash due to invalid state filter

### DIFF
--- a/.changeset/warnings-page-status-filter.md
+++ b/.changeset/warnings-page-status-filter.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix the warnings page crashing due to an invalid `state` filter
+
+The `WarningsGrid` initialized its default filter with the field `state` instead of `status`, which doesn't exist on the `WarningFilter` input type. This caused the GraphQL request to fail with a `400 Bad Request`, crashing the warnings page (`/system/warnings`).

--- a/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
@@ -80,7 +80,7 @@ function WarningsGridToolbar() {
 export function WarningsGrid() {
     const intl = useIntl();
     const dataGridProps = {
-        ...useDataGridRemote({ initialFilter: { items: [{ field: "state", operator: "is", value: "open" }] } }),
+        ...useDataGridRemote({ initialFilter: { items: [{ field: "status", operator: "is", value: "open" }] } }),
         ...usePersistentColumnState("WarningsGrid"),
     };
     const { messages: warningMessages } = useWarningsConfig();


### PR DESCRIPTION
The `useDataGridRemote` hook in the `WarningsGrid` was being initialized with `{ field: "state", ... }` which doesn't correspond to any field in the `WarningFilter` input type. By correcting this to `{ field: "status", ... }`, the default filter now properly queries for warnings with an "open" status.

https://claude.ai/code/session_01U6L6MzBsxCqFRewKyB4zoD