### PR TITLE
Remove DAM URL filtering from access log interceptor

### DIFF
--- a/.changeset/remove-dam-url-access-log-filter.md
+++ b/.changeset/remove-dam-url-access-log-filter.md
@@ -4,4 +4,4 @@
 
 Remove special handling that excluded DAM URLs from the access log
 
-Previously, requests to DAM routes (images, file preview, download, etc.) were automatically excluded from the access log. These requests are now logged like any other HTTP request. To exclude them, use the `shouldLogRequest` option of the `AccessLogModule`.
+Previously, requests to DAM routes (images, file preview, download, etc.) were automatically excluded from the access log. These requests are now logged like any other HTTP request.

--- a/.changeset/remove-dam-url-access-log-filter.md
+++ b/.changeset/remove-dam-url-access-log-filter.md
@@ -4,4 +4,4 @@
 
 Remove special handling that excluded DAM URLs from the access log
 
-Previously, requests to DAM routes (images, file preview, download, etc.) were automatically excluded from the access log. These requests are now logged like any other HTTP request.
+Previously, requests to DAM routes were excluded from the access log. They are now logged like any other HTTP request.

--- a/.changeset/remove-dam-url-access-log-filter.md
+++ b/.changeset/remove-dam-url-access-log-filter.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Remove special handling that excluded DAM URLs from the access log
+
+Previously, requests to DAM routes (images, file preview, download, etc.) were automatically excluded from the access log. These requests are now logged like any other HTTP request. To exclude them, use the `shouldLogRequest` option of the `AccessLogModule`.

--- a/packages/api/cms-api/src/access-log/access-log.interceptor.ts
+++ b/packages/api/cms-api/src/access-log/access-log.interceptor.ts
@@ -4,8 +4,6 @@ import { Request } from "express";
 import { GraphQLResolveInfo } from "graphql";
 import { getClientIp } from "request-ip";
 
-import { DamConfig } from "../dam/dam.config";
-import { DAM_CONFIG } from "../dam/dam.constants";
 import { CurrentUser } from "../user-permissions/dto/current-user";
 import { User } from "../user-permissions/interfaces/user";
 import { ACCESS_LOG_CONFIG } from "./access-log.constants";
@@ -14,18 +12,9 @@ import { AccessLogConfig } from "./access-log.module";
 @Injectable()
 export class AccessLogInterceptor implements NestInterceptor {
     protected readonly logger = new Logger(AccessLogInterceptor.name);
-    private ignoredPaths: string[];
 
-    constructor(
-        @Optional() @Inject(ACCESS_LOG_CONFIG) private readonly config?: AccessLogConfig,
-        @Optional() @Inject(DAM_CONFIG) private readonly damConfig?: DamConfig,
-    ) {
-        const damBasePath = this.damConfig?.basePath ?? "dam";
+    constructor(@Optional() @Inject(ACCESS_LOG_CONFIG) private readonly config?: AccessLogConfig) {}
 
-        this.ignoredPaths = this.damConfig
-            ? [`/${damBasePath}/images/`, `/${damBasePath}/files/preview`, `/${damBasePath}/files/download`, `/${damBasePath}/files/:hash/`]
-            : [];
-    }
     intercept(context: ExecutionContext, next: CallHandler) {
         const requestType = context.getType().toString();
 
@@ -41,14 +30,7 @@ export class AccessLogInterceptor implements NestInterceptor {
                 return next.handle();
             }
 
-            if (
-                this.config &&
-                this.config.shouldLogRequest &&
-                !this.config.shouldLogRequest({
-                    user: graphqlContext.req.user,
-                    req: graphqlContext.req,
-                })
-            ) {
+            if (this.config?.shouldLogRequest?.({ user: graphqlContext.req.user, req: graphqlContext.req }) === false) {
                 ignored = true;
             }
 
@@ -75,15 +57,7 @@ export class AccessLogInterceptor implements NestInterceptor {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const user = (httpRequest as any).user as CurrentUser;
 
-            if (
-                this.ignoredPaths.some((ignoredPath) => httpRequest.route.path.includes(ignoredPath)) ||
-                (this.config &&
-                    this.config.shouldLogRequest &&
-                    !this.config.shouldLogRequest({
-                        user: user,
-                        req: httpRequest,
-                    }))
-            ) {
+            if (this.config?.shouldLogRequest?.({ user, req: httpRequest }) === false) {
                 ignored = true;
             }
 


### PR DESCRIPTION
Removes the special handling in the access log interceptor that excluded DAM routes from being logged. DAM requests are now logged like any other HTTP request. Requests can still be excluded via the `shouldLogRequest` option.

https://claude.ai/code/session_011xwpGyvBU4U7KweiEJfc7U