### PR TITLE
[Backport v8] Remove DAM URL filtering from access log interceptor

### DIFF
--- a/.changeset/remove-dam-url-access-log-filter.md
+++ b/.changeset/remove-dam-url-access-log-filter.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Remove special handling that excluded DAM URLs from the access log
+
+Previously, requests to DAM routes were excluded from the access log. They are now logged like any other HTTP request.

--- a/packages/api/cms-api/src/access-log/access-log.interceptor.ts
+++ b/packages/api/cms-api/src/access-log/access-log.interceptor.ts
@@ -4,8 +4,6 @@ import { Request } from "express";
 import { GraphQLResolveInfo } from "graphql";
 import { getClientIp } from "request-ip";
 
-import { DamConfig } from "../dam/dam.config";
-import { DAM_CONFIG } from "../dam/dam.constants";
 import { CurrentUser } from "../user-permissions/dto/current-user";
 import { User } from "../user-permissions/interfaces/user";
 import { ACCESS_LOG_CONFIG } from "./access-log.constants";
@@ -14,18 +12,9 @@ import { AccessLogConfig } from "./access-log.module";
 @Injectable()
 export class AccessLogInterceptor implements NestInterceptor {
     protected readonly logger = new Logger(AccessLogInterceptor.name);
-    private ignoredPaths: string[];
 
-    constructor(
-        @Optional() @Inject(ACCESS_LOG_CONFIG) private readonly config?: AccessLogConfig,
-        @Optional() @Inject(DAM_CONFIG) private readonly damConfig?: DamConfig,
-    ) {
-        const damBasePath = this.damConfig?.basePath ?? "dam";
+    constructor(@Optional() @Inject(ACCESS_LOG_CONFIG) private readonly config?: AccessLogConfig) {}
 
-        this.ignoredPaths = this.damConfig
-            ? [`/${damBasePath}/images/`, `/${damBasePath}/files/preview`, `/${damBasePath}/files/download`, `/${damBasePath}/files/:hash/`]
-            : [];
-    }
     intercept(context: ExecutionContext, next: CallHandler) {
         const requestType = context.getType().toString();
 
@@ -41,14 +30,7 @@ export class AccessLogInterceptor implements NestInterceptor {
                 return next.handle();
             }
 
-            if (
-                this.config &&
-                this.config.shouldLogRequest &&
-                !this.config.shouldLogRequest({
-                    user: graphqlContext.req.user,
-                    req: graphqlContext.req,
-                })
-            ) {
+            if (this.config?.shouldLogRequest?.({ user: graphqlContext.req.user, req: graphqlContext.req }) === false) {
                 ignored = true;
             }
 
@@ -73,15 +55,7 @@ export class AccessLogInterceptor implements NestInterceptor {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const user = (httpRequest as any).user as CurrentUser;
 
-            if (
-                this.ignoredPaths.some((ignoredPath) => httpRequest.route.path.includes(ignoredPath)) ||
-                (this.config &&
-                    this.config.shouldLogRequest &&
-                    !this.config.shouldLogRequest({
-                        user: user,
-                        req: httpRequest,
-                    }))
-            ) {
+            if (this.config?.shouldLogRequest?.({ user, req: httpRequest }) === false) {
                 ignored = true;
             }
 


### PR DESCRIPTION
Backport of #5998 to `v8.x.x`.

Removes the special handling in the access log interceptor that excluded DAM routes from being logged. DAM requests are now logged like any other HTTP request. Requests can still be excluded via the `shouldLogRequest` option.

Cherry-picked cleanly from the squash-merge commit (8d46a986f), no conflicts.

**Verified locally:**
- `@comet/cms-api` builds (`tsc -p tsconfig.build.json`)
- ESLint and `tsc --noEmit` pass on the changed file/package
- Confirmed no other DI wiring depends on the removed `DamConfig` injection in `AccessLogInterceptor`


---
_Generated by [Claude Code](https://claude.ai/code/session_01M7xjn9jcSnHyKZv23B2zi1)_