### PR TITLE
[Backport v7] Remove DAM URL filtering from access log interceptor

### DIFF
--- a/.changeset/remove-dam-url-access-log-filter.md
+++ b/.changeset/remove-dam-url-access-log-filter.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": minor
+---
+
+Remove special handling that excluded DAM URLs from the access log
+
+Previously, requests to DAM routes were excluded from the access log. They are now logged like any other HTTP request.

--- a/packages/api/cms-api/src/access-log/access-log.interceptor.ts
+++ b/packages/api/cms-api/src/access-log/access-log.interceptor.ts
@@ -9,8 +9,6 @@ import { User } from "../user-permissions/interfaces/user";
 import { ACCESS_LOG_CONFIG } from "./access-log.constants";
 import { AccessLogConfig } from "./access-log.module";
 
-const IGNORED_ROUTES = ["/dam/images/", "/dam/files/preview", "/dam/files/download", "/dam/files/:hash/"];
-
 @Injectable()
 export class AccessLogInterceptor implements NestInterceptor {
     protected readonly logger = new Logger(AccessLogInterceptor.name);
@@ -32,14 +30,7 @@ export class AccessLogInterceptor implements NestInterceptor {
                 return next.handle();
             }
 
-            if (
-                this.config &&
-                this.config.shouldLogRequest &&
-                !this.config.shouldLogRequest({
-                    user: graphqlContext.req.user,
-                    req: graphqlContext.req,
-                })
-            ) {
+            if (this.config?.shouldLogRequest?.({ user: graphqlContext.req.user, req: graphqlContext.req }) === false) {
                 ignored = true;
             }
 
@@ -63,15 +54,7 @@ export class AccessLogInterceptor implements NestInterceptor {
             const httpRequest = httpContext.getRequest<Request>();
             const user = httpRequest.user as CurrentUser;
 
-            if (
-                IGNORED_ROUTES.some((ignoredPath) => httpRequest.route.path.includes(ignoredPath)) ||
-                (this.config &&
-                    this.config.shouldLogRequest &&
-                    !this.config.shouldLogRequest({
-                        user: user,
-                        req: httpRequest,
-                    }))
-            ) {
+            if (this.config?.shouldLogRequest?.({ user, req: httpRequest }) === false) {
                 ignored = true;
             }
 


### PR DESCRIPTION
Backport of #5998 to `v7.x.x`.

Removes the special handling in the access log interceptor that excluded DAM routes from being logged. DAM requests are now logged like any other HTTP request. Requests can still be excluded via the `shouldLogRequest` option.

**Cherry-pick conflict resolved:** `v7.x.x` still had the older hardcoded `IGNORED_ROUTES` constant (pre-dating the `DamConfig`-based `basePath` approach that only ever existed on `main`). Resolved by applying the same intent as the original PR — removed the DAM URL filtering entirely and kept the simplified `shouldLogRequest` null-safe check.

**Verified locally:**
- `@comet/cms-api` builds (`tsc -p tsconfig.build.json`)
- ESLint, Prettier, and `tsc --noEmit` pass on the changed file/package
- Confirmed no other DI wiring depends on the removed DAM filtering logic in `AccessLogInterceptor`


---
_Generated by [Claude Code](https://claude.ai/code/session_01M7xjn9jcSnHyKZv23B2zi1)_