### PR TITLE
[Backport v8] admin: Fix separation of multiple selected values in FinalFormSelect

### DIFF
--- a/.changeset/async-select-field-multiple-value-separation.md
+++ b/.changeset/async-select-field-multiple-value-separation.md
@@ -1,0 +1,9 @@
+---
+"@comet/admin": patch
+---
+
+Fix separation of multiple selected values in `FinalFormSelect`
+
+When using `multiple`, the selected values were rendered concatenated without any separator (e.g. `value-2value-1value-3value-4`). They are now separated by a comma, matching the display of `SelectField`.
+
+This affects all fields that render their selected values through the options/`getOptionLabel` path (i.e. without JSX `children`), namely `AsyncSelectField` and any `FinalFormSelect` used with an array value. Within Comet, this also corrects the display of the `targetGroups` and test email address selects in `@comet/brevo-admin` (`SendManagerFields`, `TestEmailCampaignForm`), which consume `FinalFormSelect` and had the same issue.

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -136,7 +136,7 @@ export const FinalFormSelect = <T,>({
             value={Array.isArray(value) ? value.map((i) => getOptionValue(i)) : getOptionValue(value)}
             renderValue={() => {
                 if (Array.isArray(value)) {
-                    return value.map((i) => getOptionLabel(i));
+                    return value.map((i) => getOptionLabel(i)).join(", ");
                 } else {
                     return getOptionLabel(value);
                 }


### PR DESCRIPTION
Backport of #5989 to `v8.x.x`.

Cherry-picked cleanly (no conflicts, single commit).

**Verified locally:**
- `@comet/admin` (and its dependency `@comet/admin-icons`) build cleanly.
- `pnpm run lint` (tsc, eslint, prettier) passes for `@comet/admin`.
- Confirmed the fix behaviorally with a temporary React Testing Library render of `FinalFormSelect` with `multiple` + an array value: labels now render as `"Alpha, Beta, Gamma"` instead of the previous concatenated `"AlphaBetaGamma"`. (v8.x.x has no Storybook story for `AsyncSelectField`/`FinalFormSelect` yet, so the original PR's Storybook-based verification wasn't available here; the temporary test was not committed.)