### PR TITLE
cms-admin: Fix hard-to-read text color in DAM drag & drop upload overlay

### DIFF
--- a/.changeset/dam-upload-footer-text-color.md
+++ b/.changeset/dam-upload-footer-text-color.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix hard-to-read text color in the DAM drag & drop upload overlay
+
+The upload overlay (shown when dragging files over a DAM folder) used a dark grey text color on its near-black background, making the text hard to read. It now uses white text for proper contrast.

--- a/packages/admin/cms-admin/src/dam/DataGrid/footer/DamFooter.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/footer/DamFooter.tsx
@@ -16,7 +16,7 @@ const FooterBar = styled(Paper)`
     }
 
     background-color: ${({ theme }) => theme.palette.grey.A400};
-    color: ${({ theme }) => theme.palette.grey.A100};
+    color: ${({ theme }) => theme.palette.common.white};
 
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
TIMR: [COM-3073 - Font Color in Drag&Drop Upload Overlay](https://vivid.timr.com/timr/tasks/e14a1738-fdcf-4f9a-9728-0cd65bb3b75d)  
JIRA: https://vivid-planet.atlassian.net/browse/COM-3073


## Problem

 When dragging files over a folder in the DAM (Asset Manager), a bottom-centered overlay appears reading "Drop files here to upload them to the folder: …". Its text color changed to a dark blue-grey (theme.palette.grey.A100 = #5A697E) sitting on the overlay's near-black background (theme.palette.grey.A400 = #050D1A). The contrast is far too low, so the message is very hard to read.


##  Solution

  Set the overlay text color to white (theme.palette.common.white) so it has proper contrast against the dark background.

  This is the only consumer of the shared FooterBar — the SelectionFooter that previously shared it has since been removed — so no other component is affected.


  Screenshots

  Before — dark grey text on the near-black bar, barely legible

<img width="2400" height="1726" alt="dam-overlay-before-grey-text" src="https://github.com/user-attachments/assets/421d7ed6-2608-426c-b582-ef8225fd62e4" />


  After — white text, fully readable

<img width="2400" height="1726" alt="dam-overlay-after-white-text" src="https://github.com/user-attachments/assets/0b544cfb-c474-4569-a322-c922649cd9dc" />



