### PR TITLE
Deduplicate block index refresh requests within process

### DIFF
--- a/.changeset/dependencies-refresh-advisory-lock-spam.md
+++ b/.changeset/dependencies-refresh-advisory-lock-spam.md
@@ -4,6 +4,6 @@
 
 Prevent `pg_advisory_xact_lock` query spam when refreshing block index dependencies
 
-`DependenciesService.refreshViews()` runs once per resolved `dependents`/`dependencies` field, so a single view (e.g. the DAM "Usages" column) triggers many parallel refreshes. When the last refresh was older than 15 minutes (or none existed), each took the blocking lock path and piled up waiting, holding a database connection.
+`DependenciesService.refreshViews()` runs once per resolved `dependents`/`dependencies` field, so a single view (e.g. the DAM "Usages" column) triggers many parallel refreshes. When the last refresh was older than 15 minutes (or none existed), each took the blocking lock path and piled up waiting, each holding a database connection. This could exhaust the connection pool and surface as `Knex: Timeout acquiring a connection` errors.
 
 Parallel refreshes within a process are now deduplicated into a single in-flight refresh, so at most one advisory lock is taken per instance, while the cross-instance advisory lock still prevents concurrent `REFRESH MATERIALIZED VIEW` runs.

--- a/.changeset/dependencies-refresh-advisory-lock-spam.md
+++ b/.changeset/dependencies-refresh-advisory-lock-spam.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-api": patch
+---
+
+Prevent `pg_advisory_xact_lock` query spam when refreshing block index dependencies
+
+`DependenciesService.refreshViews()` is called once per resolved `dependents`/`dependencies` field, so a single view (e.g. the DAM "Usages" column) triggers many parallel refreshes in the same process. When the last completed refresh was older than 15 minutes (or none existed yet), every one of those calls took the blocking `pg_advisory_xact_lock` path and piled up waiting on the lock, each holding a database connection.
+
+Parallel refreshes within a process are now deduplicated by sharing a single in-flight refresh, so at most one advisory lock is taken per instance while the cross-instance advisory lock still prevents concurrent `REFRESH MATERIALIZED VIEW` runs.

--- a/.changeset/dependencies-refresh-advisory-lock-spam.md
+++ b/.changeset/dependencies-refresh-advisory-lock-spam.md
@@ -4,6 +4,6 @@
 
 Prevent `pg_advisory_xact_lock` query spam when refreshing block index dependencies
 
-`DependenciesService.refreshViews()` is called once per resolved `dependents`/`dependencies` field, so a single view (e.g. the DAM "Usages" column) triggers many parallel refreshes in the same process. When the last completed refresh was older than 15 minutes (or none existed yet), every one of those calls took the blocking `pg_advisory_xact_lock` path and piled up waiting on the lock, each holding a database connection.
+`DependenciesService.refreshViews()` runs once per resolved `dependents`/`dependencies` field, so a single view (e.g. the DAM "Usages" column) triggers many parallel refreshes. When the last refresh was older than 15 minutes (or none existed), each took the blocking lock path and piled up waiting, holding a database connection.
 
-Parallel refreshes within a process are now deduplicated by sharing a single in-flight refresh, so at most one advisory lock is taken per instance while the cross-instance advisory lock still prevents concurrent `REFRESH MATERIALIZED VIEW` runs.
+Parallel refreshes within a process are now deduplicated into a single in-flight refresh, so at most one advisory lock is taken per instance, while the cross-instance advisory lock still prevents concurrent `REFRESH MATERIALIZED VIEW` runs.

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -273,29 +273,25 @@ export class DependenciesService {
             return;
         }
 
-        // Moderately stale (5–15 minutes) — refresh concurrently in the background, caller does not wait.
-        // Very stale (> 15 minutes) or uninitialized — refresh synchronously, caller waits for fresh data.
+        // Moderately stale (5–15 min): background concurrent refresh, caller doesn't wait.
+        // Very stale (> 15 min) or uninitialized: synchronous refresh, caller waits for fresh data.
         const concurrently = lastRefresh != null && new Date(lastRefresh.finishedAt) > subMinutes(now, 15);
 
-        // Deduplicate refreshes within this process: many parallel requests (e.g. one per row of the
-        // DAM "Usages" column) would otherwise each open a transaction and pile up waiting on the
-        // advisory lock. Sharing a single in-flight refresh collapses them, so at most one advisory
-        // lock is taken per instance.
+        // Deduplicate parallel refreshes within this instance (e.g. one per DAM "Usages" row): share a
+        // single in-flight refresh so they don't each open a transaction and pile up on the advisory lock.
         if (!this.runningRefresh) {
             const runningRefresh = refresh({ concurrently }).finally(() => {
                 this.runningRefresh = undefined;
             });
             this.runningRefresh = runningRefresh;
-            // A backgrounded refresh has no awaiter — make sure a failure is logged instead of
-            // becoming an unhandled promise rejection.
+            // A backgrounded refresh has no awaiter — log failures instead of leaving an unhandled rejection.
             runningRefresh.catch((error) => {
                 this.logger.error(`Block index refresh failed: ${error instanceof Error ? error.message : error}`);
             });
         }
 
         if (!concurrently || options?.awaitRefresh) {
-            // Caller waits for fresh data (very stale/uninitialized), or explicitly requested to wait
-            // (CLI command via awaitRefresh).
+            // Wait when synchronous (very stale/uninitialized) or when explicitly requested (CLI awaitRefresh).
             await this.runningRefresh;
         }
     }

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -275,12 +275,12 @@ export class DependenciesService {
 
         // Moderately stale (5–15 min): background concurrent refresh, caller doesn't wait.
         // Very stale (> 15 min) or uninitialized: synchronous refresh, caller waits for fresh data.
-        const concurrently = lastRefresh != null && new Date(lastRefresh.finishedAt) > subMinutes(now, 15);
+        const runRefreshInBackground = lastRefresh != null && new Date(lastRefresh.finishedAt) > subMinutes(now, 15);
 
         // Deduplicate parallel refreshes within this instance (e.g. one per DAM "Usages" row): share a
         // single in-flight refresh so they don't each open a transaction and pile up on the advisory lock.
         if (!this.runningRefresh) {
-            const runningRefresh = refresh({ concurrently }).finally(() => {
+            const runningRefresh = refresh({ concurrently: runRefreshInBackground }).finally(() => {
                 this.runningRefresh = undefined;
             });
             this.runningRefresh = runningRefresh;
@@ -290,7 +290,7 @@ export class DependenciesService {
             });
         }
 
-        if (!concurrently || options?.awaitRefresh) {
+        if (!runRefreshInBackground || options?.awaitRefresh) {
             // Wait when synchronous (very stale/uninitialized) or when explicitly requested (CLI awaitRefresh).
             await this.runningRefresh;
         }

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -28,6 +28,7 @@ const BLOCK_INDEX_REFRESH_LOCK_KEY = 4201;
 export class DependenciesService {
     private connection: Connection;
     private readonly logger = new Logger(DependenciesService.name);
+    private runningRefresh?: Promise<void>;
 
     constructor(
         private readonly discoverService: DiscoverService,
@@ -265,28 +266,37 @@ export class DependenciesService {
             .orderBy("finishedAt", "desc")
             .first();
 
-        if (!lastRefresh) {
-            // No prior refresh exists — first-time initialization, must refresh synchronously
-            await refresh();
+        const now = new Date();
+
+        if (lastRefresh && new Date(lastRefresh.finishedAt) > subMinutes(now, 5)) {
+            // Fresh enough (< 5 minutes) — skip refresh entirely
             return;
         }
 
-        const finishedAt = new Date(lastRefresh.finishedAt);
-        const now = new Date();
+        // Moderately stale (5–15 minutes) — refresh concurrently in the background, caller does not wait.
+        // Very stale (> 15 minutes) or uninitialized — refresh synchronously, caller waits for fresh data.
+        const concurrently = lastRefresh != null && new Date(lastRefresh.finishedAt) > subMinutes(now, 15);
 
-        if (finishedAt > subMinutes(now, 5)) {
-            // Fresh enough (< 5 minutes) — skip refresh entirely
-            return;
-        } else if (finishedAt > subMinutes(now, 15)) {
-            // Moderately stale (5–15 minutes) — refresh concurrently in the background
-            const refreshPromise = refresh({ concurrently: true });
-            if (options?.awaitRefresh) {
-                // Caller wants to wait for the refresh to complete, even if it's concurrent. Only used by CLI command.
-                await refreshPromise;
-            }
-        } else {
-            // Very stale (> 15 minutes) — refresh synchronously, caller waits for fresh data
-            await refresh();
+        // Deduplicate refreshes within this process: many parallel requests (e.g. one per row of the
+        // DAM "Usages" column) would otherwise each open a transaction and pile up waiting on the
+        // advisory lock. Sharing a single in-flight refresh collapses them, so at most one advisory
+        // lock is taken per instance.
+        if (!this.runningRefresh) {
+            const runningRefresh = refresh({ concurrently }).finally(() => {
+                this.runningRefresh = undefined;
+            });
+            this.runningRefresh = runningRefresh;
+            // A backgrounded refresh has no awaiter — make sure a failure is logged instead of
+            // becoming an unhandled promise rejection.
+            runningRefresh.catch((error) => {
+                this.logger.error(`Block index refresh failed: ${error instanceof Error ? error.message : error}`);
+            });
+        }
+
+        if (!concurrently || options?.awaitRefresh) {
+            // Caller waits for fresh data (very stale/uninitialized), or explicitly requested to wait
+            // (CLI command via awaitRefresh).
+            await this.runningRefresh;
         }
     }
 


### PR DESCRIPTION
## Summary

Stop the flood of `pg_advisory_xact_lock` queries from `DependenciesService.refreshViews()` by letting parallel refreshes share a single refresh. This prevents DB connection pool exhaustion.

## Problem

`refreshViews()` runs once for every `dependents`/`dependencies` field in a query. The DAM "Usages" column shows that field for every row, so opening it starts many refreshes at the same time in one API process.

When the last refresh is older than 15 minutes, every one of these calls waits for the same PostgreSQL lock. Each waiting call keeps one database connection open. The connection pool runs out of free connections, and other queries fail with:

```
Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?
```

## Solution

We remember the refresh that is currently running (in a `runningRefresh` field). If a refresh is already running, other calls reuse it instead of starting a new one. So only the first call takes the lock, the others wait for the same result.

## Verification

Tested on the demo app with PostgreSQL query logging, comparing this PR against the commit before it. In every case exactly one `REFRESH MATERIALIZED VIEW` runs and returns the same data. If the data is fresh (less than 5 minutes old), a new burst does nothing. "Stale" means the data is old enough to trigger a refresh.

**Number of locks per burst (stale view)**

| Burst | Before | This PR |
| --- | --- | --- |
| 30 parallel `refreshViews()` | 30 locks on 30 connections, capped at 10 (the whole pool) | 1 lock, 1 connection |
| DAM listing — 13 `dependents` fields at once | 13 locks, capped at 10 connections | 1 lock, 1 connection |

**Speed of `DamItemsList`** — a single request is the same speed as before, because both wait for the one ~16-second refresh. This change is not about making one request faster; it is about not blocking other requests. The benefit shows when many requests run at the same time: before the fix, one burst used up all connections, so other queries had to wait.

| Case | Before | This PR |
| --- | --- | --- |
| One request, very stale (over 15 min) | ~15.5–17 s | ~15.5–16.5 s |
| One request, a bit stale (5–15 min) | ~0.1 s | ~0.07 s |
| One request, fresh (under 5 min) | ~0.07 s | ~0.07 s |
| Another simple query during 8 stale requests | 16.3 s | 0.031 s |

## Multiple API pods

Projects run several API pods at the same time. The refresh is shared across pods too. Two things stop duplicate refreshes:

1. The PostgreSQL advisory lock (`pg_advisory_xact_lock(4201)`). It belongs to the whole database, so only one pod can refresh at a time. This PR does not change it.
2. The new `runningRefresh` field. It stops duplicates inside a single pod.

Test: two processes, each starting 15 refreshes at the same time on a stale view (30 in total).

| Result | Value |
| --- | --- |
| `REFRESH MATERIALIZED VIEW` runs (whole cluster) | 1 |
| Blocking `pg_advisory_xact_lock` queries | 2 (one per pod, not one per call) |

Only one refresh runs for the whole cluster. The number of locks grows with the number of pods (one waiting connection per pod), not with the number of requests. In the "5–15 minutes" case the lock does not block, so other pods skip right away and wait for nothing.

https://claude.ai/code/session_01VcZg8bCPwRGh2JoHj6f6Bo