### PR TITLE
cms-admin: Persist DAM sorting preference across sessions

### DIFF
--- a/.changeset/dam-persist-sort-preference.md
+++ b/.changeset/dam-persist-sort-preference.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Persist the DAM sorting preference across sessions
+
+The Digital Asset Management asset list now remembers the selected sorting (column and direction) in `localStorage` instead of resetting to alphabetical (`name` ascending) on every visit.

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -21,10 +21,12 @@ import {
 import { Info as InfoIcon } from "@comet/admin-icons";
 import { DialogContent, Slide, type SlideProps, Snackbar } from "@mui/material";
 import {
+    type DataGridProps,
     GridColumnHeaderTitle,
     type GridRowClassNameParams,
     type GridRowSelectionModel,
     type GridSlotsComponent,
+    type GridSortModel,
     useGridApiRef,
 } from "@mui/x-data-grid";
 import { type ReactNode, useEffect, useState } from "react";
@@ -178,7 +180,14 @@ const FolderDataGrid = ({
         setUploadTargetFolderName(undefined);
     };
 
-    const dataGridProps = useDataGridRemote({ pageSize: 20, initialSort: [{ field: "name", sort: "asc" }] });
+    const [persistedSortModel, setPersistedSortModel] = useStoredState<GridSortModel>("DamFolderDataGrid-sort", [{ field: "name", sort: "asc" }]);
+
+    const dataGridProps = useDataGridRemote({ pageSize: 20, initialSort: [...persistedSortModel] });
+
+    const handleSortModelChange: NonNullable<DataGridProps["onSortModelChange"]> = (sortModel, details) => {
+        setPersistedSortModel(sortModel);
+        dataGridProps.onSortModelChange?.(sortModel, details);
+    };
 
     const { data: currentFolderData } = useQuery<GQLDamFolderQuery, GQLDamFolderQueryVariables>(damFolderQuery, {
         variables: {
@@ -659,6 +668,7 @@ const FolderDataGrid = ({
                 <DataGrid
                     apiRef={apiRef}
                     {...dataGridProps}
+                    onSortModelChange={handleSortModelChange}
                     rowHeight={58}
                     rows={dataGridData?.damItemsList.nodes ?? []}
                     rowCount={rowCount}


### PR DESCRIPTION
TIMR: [COM-3075 - DAM sorting preference is not persisted across sessions](https://vivid.timr.com/timr/tasks/3b985694-cf03-40c4-a198-7a0bc1763dc4)  
JIRA: https://vivid-planet.atlassian.net/browse/COM-3075

## Problem

The DAM asset list stores its sort state only in the URL query string (via `useDataGridRemote`), falling back to a hard-coded default of alphabetical `name` ascending whenever no `sort` query param is present. As a result, every fresh visit to the Asset Manager (e.g. navigating in from the menu, or in a new session) resets the sort.

Editors who curate assets typically want to work with the newest assets first, and had to re-apply that sort every single time they opened the DAM. 

## Solution

Persist the DAM sort model to `localStorage` using the existing `useStoredState` hook (already used elsewhere in `FolderDataGrid`). The persisted value seeds `initialSort`, so a previously chosen sort is restored on subsequent visits, and every sort change is written back to storage. The default for first-time users remains `name` ascending, so existing behavior is unchanged until the user picks a different sort.

`localStorage` was chosen over `sessionStorage` because the ticket asked for the preference to survive "the session or longer".


Screencast:

https://github.com/user-attachments/assets/a7802a99-f3d1-4b56-8270-6b1cea57689c


<img width="571" height="155" alt="Screenshot 2026-07-16 at 15 18 15" src="https://github.com/user-attachments/assets/871e6e88-6721-49c3-ad29-e8cbc83e7e6c" />


[COM-3075]: https://vivid-planet.atlassian.net/browse/COM-3075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ