### PR TITLE
admin: Fix selected value rendering underneath the end adornment in SelectField

### DIFF
--- a/.changeset/fix-select-clear-button-overlap.md
+++ b/.changeset/fix-select-clear-button-overlap.md
@@ -1,0 +1,8 @@
+---
+"@comet/admin": patch
+---
+
+Fix selected value rendering underneath the end adornment in `SelectField`
+
+Previously, the select reserved a fixed amount of space for the end adornment, which was too small when more than the clear button was rendered (e.g., an error icon).
+Now the reserved space is measured, so long values are always truncated before the first adornment icon.

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -1,12 +1,38 @@
 import { Error } from "@comet/admin-icons";
-import { InputAdornment, LinearProgress, MenuItem, Select, type SelectProps, Typography } from "@mui/material";
-import type { ReactNode } from "react";
+import { InputAdornment, inputBaseClasses, LinearProgress, MenuItem, Select, selectClasses, type SelectProps, Typography } from "@mui/material";
+import { css, styled } from "@mui/material/styles";
+import { type ReactNode, useCallback, useRef, useState } from "react";
 import type { FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 
 import { ClearInputAdornment } from "../common/ClearInputAdornment";
 import type { AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 import { LinearLoadingContainer, MenuItemDisabledOverrideOpacity } from "./FinalFormSelect.sc";
+
+// The rendered adornments (clear button, error icon) change at runtime, so the space the select's text must leave
+// for them cannot be a fixed value (the theme's default only fits the clear button). The adornment is absolutely
+// positioned by the theme; the measured distance between its left edge and the right edge of the input is reserved
+// as padding, so the text can never render underneath the adornment.
+const AdornedSelect = styled(Select, {
+    shouldForwardProp: (prop) => prop !== "endAdornmentWidth",
+})<{ endAdornmentWidth?: number }>(
+    ({ endAdornmentWidth }) => css`
+        ${endAdornmentWidth !== undefined &&
+        endAdornmentWidth > 0 &&
+        css`
+            /* Overrides the fixed "inputAdornedEnd" padding-right from the MuiSelect theme. */
+            & .${selectClasses.select}.${inputBaseClasses.inputAdornedEnd} {
+                padding-right: ${endAdornmentWidth}px;
+            }
+        `}
+    `,
+);
+
+const EndAdornmentContainer = styled(InputAdornment)(
+    ({ theme }) => css`
+        padding-left: ${theme.spacing(2)};
+    `,
+);
 
 export interface FinalFormSelectProps<T> {
     noOptionsText?: ReactNode;
@@ -76,14 +102,34 @@ export const FinalFormSelect = <T,>({
 
     const hasClearableContent = !disabled && (multiple && Array.isArray(value) ? value.length > 0 : value !== undefined && value !== "");
 
-    const endAdornment =
+    const clearAdornment =
         !required && hasClearableContent ? <ClearInputAdornment position="end" onClick={() => onChange(multiple ? [] : undefined)} /> : null;
+
+    const [endAdornmentWidth, setEndAdornmentWidth] = useState<number>();
+    const endAdornmentResizeObserver = useRef<ResizeObserver | undefined>(undefined);
+    const endAdornmentRef = useCallback((node: HTMLDivElement | null) => {
+        endAdornmentResizeObserver.current?.disconnect();
+        endAdornmentResizeObserver.current = undefined;
+
+        if (node) {
+            const measureReservedSpace = () => {
+                const inputRoot = node.closest(`.${inputBaseClasses.root}`);
+                if (inputRoot) {
+                    setEndAdornmentWidth(Math.ceil(inputRoot.getBoundingClientRect().right - node.getBoundingClientRect().left));
+                }
+            };
+            measureReservedSpace();
+            endAdornmentResizeObserver.current = new ResizeObserver(measureReservedSpace);
+            endAdornmentResizeObserver.current.observe(node);
+        } else {
+            setEndAdornmentWidth(undefined);
+        }
+    }, []);
 
     const selectProps = {
         ...rest,
         multiple,
         disabled,
-        endAdornment,
         name,
         onChange,
         onFocus,
@@ -93,9 +139,20 @@ export const FinalFormSelect = <T,>({
 
     if (children) {
         return (
-            <Select {...selectProps} value={value}>
+            <AdornedSelect
+                {...selectProps}
+                endAdornment={
+                    clearAdornment && (
+                        <EndAdornmentContainer position="end" ref={endAdornmentRef}>
+                            {clearAdornment}
+                        </EndAdornmentContainer>
+                    )
+                }
+                endAdornmentWidth={endAdornmentWidth}
+                value={value}
+            >
                 {children}
-            </Select>
+            </AdornedSelect>
         );
     }
 
@@ -106,14 +163,17 @@ export const FinalFormSelect = <T,>({
     const showNoOptions = loading === false && loadingError == null && options.length === 0;
 
     return (
-        <Select
+        <AdornedSelect
             {...selectProps}
+            endAdornmentWidth={endAdornmentWidth}
             endAdornment={
-                <InputAdornment position="end">
-                    {loadingError && <Error color="error" />}
+                (loadingError || clearAdornment) && (
+                    <EndAdornmentContainer position="end" ref={endAdornmentRef}>
+                        {loadingError && <Error color="error" />}
 
-                    {endAdornment}
-                </InputAdornment>
+                        {clearAdornment}
+                    </EndAdornmentContainer>
+                )
             }
             onChange={(event) => {
                 const value = event.target.value;
@@ -170,6 +230,6 @@ export const FinalFormSelect = <T,>({
                         {getOptionLabel(option)}
                     </MenuItem>
                 ))}
-        </Select>
+        </AdornedSelect>
     );
 };

--- a/packages/admin/admin/src/form/__stories__/SelectFieldMultipleEndAdornment.stories.tsx
+++ b/packages/admin/admin/src/form/__stories__/SelectFieldMultipleEndAdornment.stories.tsx
@@ -1,0 +1,185 @@
+import { Box, Typography } from "@mui/material";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { PropsWithChildren } from "react";
+
+import { FinalForm } from "../../FinalForm";
+import { SelectField } from "../../form/fields/SelectField";
+import { Field } from "../Field";
+import { FinalFormSelect } from "../FinalFormSelect";
+
+/**
+ * Layout regression test for the end adornment of a SelectField / FinalFormSelect.
+ *
+ * The clear button and dropdown icon must stay at the right edge of the field and the selected value(s) must never
+ * render underneath them – regardless of how long the selected labels are and which adornments (clear button,
+ * error icon) are rendered. Use the container-width control to test different widths.
+ */
+const config: Meta = {
+    title: "components/form/SelectField/MultipleEndAdornment",
+    argTypes: {
+        containerWidth: {
+            control: { type: "range", min: 200, max: 1000, step: 5 },
+            description: "Container width in px",
+        },
+    },
+    args: {
+        containerWidth: 505,
+    },
+};
+export default config;
+
+interface Option {
+    label: string;
+    value: string;
+}
+
+const longOption: Option = { label: "Supercalifragilisticexpialidocious Chocolate Ice Cream", value: "long" };
+const smallOptions: Option[] = [
+    { label: "Chocolate", value: "chocolate" },
+    { label: "Strawberry", value: "strawberry" },
+    { label: "Vanilla", value: "vanilla" },
+];
+const manyOptions: Option[] = [
+    { label: "Apple", value: "apple" },
+    { label: "Banana", value: "banana" },
+    { label: "Cherry", value: "cherry" },
+    { label: "Date", value: "date" },
+    { label: "Elderberry", value: "elderberry" },
+    { label: "Fig", value: "fig" },
+    { label: "Grape", value: "grape" },
+    { label: "Honeydew", value: "honeydew" },
+];
+const allOptions: Option[] = [longOption, ...smallOptions, ...manyOptions];
+
+const Case = ({ label, children }: PropsWithChildren<{ label: string }>) => {
+    return (
+        <Box sx={{ mb: 3 }}>
+            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                {label}
+            </Typography>
+            {children}
+        </Box>
+    );
+};
+
+interface MultiSelectProps {
+    initialValues: Option[];
+    required?: boolean;
+    disabled?: boolean;
+    loadingError?: Error | null;
+}
+
+const MultiSelect = ({ initialValues, required, disabled, loadingError }: MultiSelectProps) => {
+    return (
+        <FinalForm
+            mode="edit"
+            initialValues={{ field: initialValues }}
+            onSubmit={() => {
+                // not handled
+            }}
+        >
+            {() => (
+                <Field
+                    component={FinalFormSelect}
+                    multiple
+                    name="field"
+                    options={allOptions}
+                    getOptionLabel={(option: Option) => option.label}
+                    getOptionValue={(option: Option) => option.value}
+                    fullWidth
+                    required={required}
+                    disabled={disabled}
+                    loadingError={loadingError ?? null}
+                />
+            )}
+        </FinalForm>
+    );
+};
+
+const SingleSelect = ({ initialValue, loadingError }: { initialValue: Option | null; loadingError?: Error | null }) => {
+    return (
+        <FinalForm
+            mode="edit"
+            initialValues={{ field: initialValue }}
+            onSubmit={() => {
+                // not handled
+            }}
+        >
+            {() => (
+                <Field
+                    component={FinalFormSelect}
+                    name="field"
+                    options={allOptions}
+                    getOptionLabel={(option: Option) => option.label}
+                    getOptionValue={(option: Option) => option.value}
+                    fullWidth
+                    loadingError={loadingError ?? null}
+                />
+            )}
+        </FinalForm>
+    );
+};
+
+const SelectFieldWithOptions = ({ initialValue }: { initialValue: string | null }) => {
+    return (
+        <FinalForm
+            mode="edit"
+            initialValues={{ field: initialValue }}
+            onSubmit={() => {
+                // not handled
+            }}
+        >
+            {() => <SelectField name="field" fullWidth options={allOptions.map(({ label, value }) => ({ label, value }))} />}
+        </FinalForm>
+    );
+};
+
+export const AllCases: StoryObj<{ containerWidth: number }> = {
+    render: ({ containerWidth }) => (
+        <Box sx={{ width: containerWidth, p: 2, border: "1px dashed #ccc" }}>
+            <Typography variant="caption" sx={{ display: "block", mb: 2 }}>
+                Container width: {containerWidth}px
+            </Typography>
+
+            <Case label="Case 1: One long value (multiple)">
+                <MultiSelect initialValues={[longOption]} />
+            </Case>
+
+            <Case label="Case 2: Multiple values filling the row">
+                <MultiSelect initialValues={smallOptions} />
+            </Case>
+
+            <Case label="Case 3: Many values (long joined text)">
+                <MultiSelect initialValues={manyOptions} />
+            </Case>
+
+            <Case label="Case 4: Required (no clear button) with long value">
+                <MultiSelect initialValues={[longOption]} required />
+            </Case>
+
+            <Case label="Case 5: Empty (no values)">
+                <MultiSelect initialValues={[]} />
+            </Case>
+
+            <Case label="Case 6: Disabled with many values">
+                <MultiSelect initialValues={manyOptions} disabled />
+            </Case>
+
+            <Case label="Case 7: Error + clear button (all adornment slots populated)">
+                <MultiSelect initialValues={smallOptions} loadingError={new Error("Failed to load")} />
+            </Case>
+
+            <Case label="Case 8: Single-select with long value">
+                <SingleSelect initialValue={longOption} />
+            </Case>
+
+            <Case label="Case 9: Single-select with error + clear button">
+                <SingleSelect initialValue={longOption} loadingError={new Error("Failed to load")} />
+            </Case>
+
+            <Case label="Case 10: SelectField with options (children path), long value">
+                <SelectFieldWithOptions initialValue={longOption.value} />
+            </Case>
+        </Box>
+    ),
+};


### PR DESCRIPTION
## Problem

`SelectField` / `FinalFormSelect` has the same class of problem as the multi-select `AutocompleteField` in #5434, in a milder form: the end adornment doesn't wrap (the theme already positions it absolutely), but the select reserves a **fixed** `padding-right` (42px via the `inputAdornedEnd` theme override) while the adornment width varies at runtime. As a result, long values render underneath the icons:

- with error icon + clear button, the text paints **12px under the error icon**
- in the `SelectField` children path (`options` prop), the text paints **6px under the clear button**

## Solution

Same approach as #5434: the adornment container's position is **measured** (`ResizeObserver`) and the distance between the input's right edge and the adornment's left edge is reserved as `padding-right` on the select display, so the value text is always truncated (ellipsis) before the first adornment icon — regardless of which adornments (clear button, error icon) are currently visible.

Both render paths (`children`/`options` prop and `options` + `getOptionLabel`) now build the end adornment the same way. When no adornment is rendered, no padding is overridden and the theme default applies.

## Example

New regression story `components/form/SelectField/MultipleEndAdornment` with 10 cases (long value, many values, required, empty, disabled, error + clear, single-select, children path) and a container-width control to test any width — same setup as the story in #5434, so it can be tested on the deploy preview.

## Open TODOs/questions

- Unrelated pre-existing issue noticed while testing (not fixed here, one PR per change): the custom `renderValue` for multiple selects returns an array of labels, which React renders without separators ("ChocolateStrawberryVanilla"). Should be joined with ", " in a follow-up PR.

## Further information

- Same fix pattern as #5434 (multi-select `AutocompleteField`). Once both are merged, the measurement logic could be extracted into a shared internal hook in a follow-up.
- Verified with a Playwright geometry check at 240/320/505/700/1000px container widths: the text content box never extends under an icon, the menu still opens on click, and the clear button clears and then disappears.


---
_Generated by [Claude Code](https://claude.ai/code/session_017r3LhoQaLGMzEs52Dg4SnZ)_