### PR TITLE
[Backport v8] cms-admin: Fix hard-to-read text color in DAM drag & drop upload overlay

### DIFF
--- a/.changeset/dam-upload-footer-text-color.md
+++ b/.changeset/dam-upload-footer-text-color.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix hard-to-read text color in the DAM drag & drop upload overlay
+
+The upload overlay (shown when dragging files over a DAM folder) used a dark grey text color on its near-black background, making the text hard to read. It now uses white text for proper contrast.

--- a/packages/admin/cms-admin/src/dam/DataGrid/footer/DamFooter.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/footer/DamFooter.tsx
@@ -16,7 +16,7 @@ const FooterBar = styled(Paper)`
     }
 
     background-color: ${({ theme }) => theme.palette.grey.A400};
-    color: ${({ theme }) => theme.palette.grey.A100};
+    color: ${({ theme }) => theme.palette.common.white};
 
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
Backport of #6009 to `v8.x.x`.

The upload overlay (shown when dragging files over a DAM folder) used a dark grey text color on its near-black background, making the text hard to read. It now uses white text for proper contrast.

Cherry-picked cleanly (no conflicts, single commit).

**Verified locally:**
- `@comet/cms-admin` (and its dependencies) build cleanly on `v8.x.x`.
- `pnpm run lint` (tsc, eslint, prettier) passes for `@comet/cms-admin`.
- Confirmed the fix behaviorally with a temporary render test of `DamFooter`: computed style resolved to `color: rgb(255, 255, 255)` on `background-color: rgb(5, 13, 26)`, matching the intended white-on-near-black contrast fix. (Temporary test was not committed.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EC1SujTF22wXLifHtY1RyM)_