### PR TITLE
cms-admin: Warn about videos too large for performant delivery

### DIFF
--- a/.changeset/large-video-performance-warning.md
+++ b/.changeset/large-video-performance-warning.md
@@ -1,0 +1,23 @@
+---
+"@comet/cms-admin": minor
+---
+
+Warn editors when videos that are too large for performant delivery are used
+
+Videos are delivered without optimization, so large videos can lead to poor loading performance. A warning is now shown when a video exceeds a configurable file size:
+
+- as a snackbar after uploading it to the DAM
+- as an alert on the DAM asset detail page
+- as an alert in the `DamVideoBlock` when such a video is selected
+
+The threshold defaults to 10 MB and can be configured (or the warning disabled entirely) via the new `videoPerformanceWarningFileSize` option in the `dam` config:
+
+```tsx
+<CometConfigProvider
+    dam={{
+        // ...
+        videoPerformanceWarningFileSize: 25, // warn for videos larger than 25 MB
+        // or set to `false` to disable the warning globally
+    }}
+>
+```

--- a/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
@@ -123,6 +123,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
         return (
             <Box padding={isInPaper ? 3 : 0} pb={0}>
                 <BlocksFinalForm onSubmit={updateState} initialValues={state}>
+                    {state.damFile && isVideoTooLarge(state.damFile) && <VideoPerformanceWarningAlert sx={{ marginBottom: 2 }} />}
                     <Field
                         name="damFile"
                         component={FileField}
@@ -130,7 +131,6 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                         allowedMimetypes={["video/mp4", "video/webm"]}
                         preview={<Video fontSize="large" color="primary" />}
                     />
-                    {state.damFile && isVideoTooLarge(state.damFile) && <VideoPerformanceWarningAlert sx={{ marginTop: 4 }} />}
                     <VideoOptionsFields />
                     <BlockAdminComponentSection title={<FormattedMessage id="comet.blocks.video.previewImage" defaultMessage="Preview Image" />}>
                         <PixelImageBlock.AdminComponent

--- a/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
@@ -6,6 +6,8 @@ import { deepClone } from "@mui/x-data-grid/internals";
 import { defineMessage, FormattedMessage } from "react-intl";
 
 import type { DamVideoBlockData, DamVideoBlockInput } from "../blocks.generated";
+import { useVideoPerformanceWarning } from "../dam/config/damConfig";
+import { VideoPerformanceWarningAlert } from "../dam/VideoPerformanceWarningAlert";
 import { FileField } from "../form/file/FileField";
 import { useBlockAdminComponentPaper } from "./common/BlockAdminComponentPaper";
 import { BlockAdminComponentSection } from "./common/BlockAdminComponentSection";
@@ -116,6 +118,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
 
     AdminComponent: ({ state, updateState }) => {
         const isInPaper = useBlockAdminComponentPaper();
+        const { isVideoTooLarge } = useVideoPerformanceWarning();
 
         return (
             <Box padding={isInPaper ? 3 : 0} pb={0}>
@@ -127,6 +130,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                         allowedMimetypes={["video/mp4", "video/webm"]}
                         preview={<Video fontSize="large" color="primary" />}
                     />
+                    {state.damFile && isVideoTooLarge(state.damFile) && <VideoPerformanceWarningAlert sx={{ marginTop: 4 }} />}
                     <VideoOptionsFields />
                     <BlockAdminComponentSection title={<FormattedMessage id="comet.blocks.video.previewImage" defaultMessage="Preview Image" />}>
                         <PixelImageBlock.AdminComponent

--- a/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/fileUpload/useDamFileUpload.tsx
@@ -1,12 +1,15 @@
 import { useApolloClient } from "@apollo/client";
+import { Alert, useSnackbarApi } from "@comet/admin";
+import { Snackbar } from "@mui/material";
 import { type ReactNode, useCallback, useMemo, useState } from "react";
 import type { Accept, FileRejection } from "react-dropzone";
+import { FormattedMessage } from "react-intl";
 
 import { NetworkError, UnknownError } from "../../../common/errors/errorMessages";
 import { useCometConfig } from "../../../config/CometConfigContext";
 import { replaceByFilenameAndFolder, upload } from "../../../form/file/upload";
 import type { GQLLicenseInput } from "../../../graphql.generated";
-import { useDamBasePath, useDamConfig } from "../../config/damConfig";
+import { useDamBasePath, useDamConfig, useVideoPerformanceWarning } from "../../config/damConfig";
 import { useDamAcceptedMimeTypes } from "../../config/useDamAcceptedMimeTypes";
 import { useDamScope } from "../../config/useDamScope";
 import { clearDamItemCache } from "../../helpers/clearDamItemCache";
@@ -137,6 +140,8 @@ export const useDamFileUpload = (options: UploadDamFileOptions): FileUploadApi =
     const client = useApolloClient();
     const manualDuplicatedFilenamesHandler = useManualDuplicatedFilenamesHandler();
     const scope = useDamScope();
+    const snackbarApi = useSnackbarApi();
+    const { isVideoTooLarge } = useVideoPerformanceWarning();
 
     const { allAcceptedMimeTypes } = useDamAcceptedMimeTypes();
     const accept: Accept = useMemo(() => {
@@ -479,6 +484,24 @@ export const useDamFileUpload = (options: UploadDamFileOptions): FileUploadApi =
         setUploadedSizes({});
 
         addNewlyUploadedItems([...uploadedFolders, ...uploadedFiles]);
+
+        const tooLargeVideoCount = uploadedFiles.filter(
+            ({ file }) => file !== undefined && isVideoTooLarge({ mimetype: file.type, size: file.size }),
+        ).length;
+
+        if (tooLargeVideoCount > 0) {
+            snackbarApi.showSnackbar(
+                <Snackbar autoHideDuration={5000}>
+                    <Alert severity="warning">
+                        <FormattedMessage
+                            id="comet.dam.videoPerformanceWarning.snackbar"
+                            defaultMessage="{count, plural, one {A very large video was uploaded} other {# very large videos were uploaded}}. Videos are delivered without optimization, which can lead to poor loading performance."
+                            values={{ count: tooLargeVideoCount }}
+                        />
+                    </Alert>
+                </Snackbar>,
+            );
+        }
 
         return { hasError: errorOccurred, rejectedFiles: rejectedFiles, uploadedItems: [...uploadedFolders, ...uploadedFiles] };
     };

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.tsx
@@ -28,11 +28,12 @@ import { useDependenciesConfig } from "../../dependencies/dependenciesConfig";
 import { DependentsList } from "../../dependencies/DependentsList";
 import type { GQLFocalPoint, GQLImageCropAreaInput, GQLLicenseInput } from "../../graphql.generated";
 import { useUserPermissionCheck } from "../../userPermissions/hooks/currentUser";
-import { useDamConfig } from "../config/damConfig";
+import { useDamConfig, useVideoPerformanceWarning } from "../config/damConfig";
 import { useDamAcceptedMimeTypes } from "../config/useDamAcceptedMimeTypes";
 import { ArchivedTag } from "../DataGrid/tags/ArchivedTag";
 import { LicenseValidityTags } from "../DataGrid/tags/LicenseValidityTags";
 import { MediaAlternativesGrid } from "../mediaAlternatives/MediaAlternativesGrid";
+import { VideoPerformanceWarningAlert } from "../VideoPerformanceWarningAlert";
 import Duplicates from "./Duplicates";
 import { damFileDependentsQuery, damFileDetailQuery, updateDamFileMutation } from "./EditFile.gql";
 import type { GQLDamFileDetailFragment, GQLDamFileDetailQuery, GQLDamFileDetailQueryVariables } from "./EditFile.gql.generated";
@@ -115,6 +116,7 @@ const EditFileInner = ({ file, id, contentScopeIndicator }: EditFileInnerProps) 
     const acceptedMimeTypes = useDamAcceptedMimeTypes();
     const intl = useIntl();
     const damConfig = useDamConfig();
+    const { isVideoTooLarge } = useVideoPerformanceWarning();
     const apolloClient = useApolloClient();
     const isAllowed = useUserPermissionCheck();
 
@@ -215,6 +217,7 @@ const EditFileInner = ({ file, id, contentScopeIndicator }: EditFileInnerProps) 
                         </ToolbarActions>
                     </Toolbar>
                     <MainContent>
+                        {isVideoTooLarge(file) && <VideoPerformanceWarningAlert sx={{ marginBottom: 4 }} />}
                         <ReactSplit sizes={[initialPreviewWidth, initialBlockListWidth]} minSize={360} gutterSize={40} style={{ display: "flex" }}>
                             <StickyScrollWrapper>
                                 <FilePreview file={file} />

--- a/packages/admin/cms-admin/src/dam/VideoPerformanceWarningAlert.tsx
+++ b/packages/admin/cms-admin/src/dam/VideoPerformanceWarningAlert.tsx
@@ -1,0 +1,19 @@
+import { Alert, type AlertProps } from "@comet/admin";
+import { FormattedMessage } from "react-intl";
+
+type VideoPerformanceWarningAlertProps = Omit<AlertProps, "severity" | "title" | "children">;
+
+export function VideoPerformanceWarningAlert(props: VideoPerformanceWarningAlertProps) {
+    return (
+        <Alert
+            severity="warning"
+            title={<FormattedMessage id="comet.dam.videoPerformanceWarning.title" defaultMessage="Large video file" />}
+            {...props}
+        >
+            <FormattedMessage
+                id="comet.dam.videoPerformanceWarning.text"
+                defaultMessage="This video is very large. Videos are delivered without optimization, which can lead to poor loading performance."
+            />
+        </Alert>
+    );
+}

--- a/packages/admin/cms-admin/src/dam/config/damConfig.ts
+++ b/packages/admin/cms-admin/src/dam/config/damConfig.ts
@@ -17,7 +17,10 @@ export interface DamConfig {
     allowedImageAspectRatios: string[];
     maxSrcResolution: number;
     basePath?: string;
+    videoPerformanceWarningFileSize?: number | false;
 }
+
+const defaultVideoPerformanceWarningFileSize = 10;
 
 export function useDamConfig(): DamConfig {
     const cometConfig = useCometConfig();
@@ -27,6 +30,26 @@ export function useDamConfig(): DamConfig {
     }
 
     return cometConfig.dam;
+}
+
+interface VideoPerformanceWarning {
+    enabled: boolean;
+    maxFileSizeInBytes: number;
+    isVideoTooLarge: (file: { mimetype: string; size: number }) => boolean;
+}
+
+export function useVideoPerformanceWarning(): VideoPerformanceWarning {
+    const { videoPerformanceWarningFileSize } = useDamConfig();
+
+    const enabled = videoPerformanceWarningFileSize !== false;
+    const maxFileSizeInMegabytes =
+        typeof videoPerformanceWarningFileSize === "number" ? videoPerformanceWarningFileSize : defaultVideoPerformanceWarningFileSize;
+    const maxFileSizeInBytes = maxFileSizeInMegabytes * 1024 * 1024;
+
+    const isVideoTooLarge = (file: { mimetype: string; size: number }) =>
+        enabled && file.mimetype.startsWith("video/") && file.size > maxFileSizeInBytes;
+
+    return { enabled, maxFileSizeInBytes, isVideoTooLarge };
 }
 
 export function useDamBasePath(): string {


### PR DESCRIPTION
JIRA: https://vivid-planet.atlassian.net/browse/COM-3053

## Problem

Videos in the DAM are delivered as-is, without any optimization before delivery. When editors upload or use very large videos, the resulting pages can suffer from poor loading performance — but nothing in the admin warns them that this is happening.

## Solution

Show a non-blocking warning whenever a video exceeds a configurable file-size threshold, in the three places an editor encounters such a video:

- as a **snackbar** right after uploading it to the DAM
- as an **alert** on the DAM asset detail page
- as an **alert** in the `DamVideoBlock` when such a video is selected

All three reuse a shared `VideoPerformanceWarningAlert` (severity `warning`) and the existing `Alert`/`Snackbar` styling, so the messaging stays consistent.

The threshold defaults to **10 MB** and is configurable via the new `videoPerformanceWarningFileSize` option in the `dam` config. It can be set to `false` to disable the warning globally — intentionally, so it can be turned off once we add the ability to optimize videos before delivery.


## Screenshots

| After upload (snackbar) | Asset detail page | `DamVideoBlock` |
| --- | --- | --- |
| <img width="1200" height="863" alt="warning-3-upload-snackbar" src="https://github.com/user-attachments/assets/4fc00947-25f0-4007-b926-ad78e4b70641" /> | <img width="1200" height="863" alt="warning-1-dam-detail-page" src="https://github.com/user-attachments/assets/f0002d1c-e84b-4f60-8a4c-bd7f5f0ff697" /> | <img width="1200" height="863" alt="warning-2-dam-video-block" src="https://github.com/user-attachments/assets/4a9d7393-c3f3-4b2c-a060-a26ddfb7bc1c" /> |

