### PR TITLE
[Backport v8] Deduplicate block index refresh requests within process

### DIFF
--- a/.changeset/dependencies-refresh-advisory-lock-spam.md
+++ b/.changeset/dependencies-refresh-advisory-lock-spam.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-api": patch
+---
+
+Prevent `pg_advisory_xact_lock` query spam when refreshing block index dependencies
+
+`DependenciesService.refreshViews()` runs once per resolved `dependents`/`dependencies` field, so a single view (e.g. the DAM "Usages" column) triggers many parallel refreshes. When the last refresh was older than 15 minutes (or none existed), each took the blocking lock path and piled up waiting, each holding a database connection. This could exhaust the connection pool and surface as `Knex: Timeout acquiring a connection` errors.
+
+Parallel refreshes within a process are now deduplicated into a single in-flight refresh, so at most one advisory lock is taken per instance, while the cross-instance advisory lock still prevents concurrent `REFRESH MATERIALIZED VIEW` runs.

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -23,6 +23,7 @@ const BLOCK_INDEX_REFRESH_LOCK_KEY = 4201;
 export class DependenciesService {
     private connection: Connection;
     private readonly logger = new Logger(DependenciesService.name);
+    private runningRefresh?: Promise<void>;
 
     constructor(
         private readonly discoverService: DiscoverService,
@@ -235,28 +236,33 @@ export class DependenciesService {
             .orderBy("finishedAt", "desc")
             .first();
 
-        if (!lastRefresh) {
-            // No prior refresh exists — first-time initialization, must refresh synchronously
-            await refresh();
+        const now = new Date();
+
+        if (lastRefresh && new Date(lastRefresh.finishedAt) > subMinutes(now, 5)) {
+            // Fresh enough (< 5 minutes) — skip refresh entirely
             return;
         }
 
-        const finishedAt = new Date(lastRefresh.finishedAt);
-        const now = new Date();
+        // Moderately stale (5–15 min): background concurrent refresh, caller doesn't wait.
+        // Very stale (> 15 min) or uninitialized: synchronous refresh, caller waits for fresh data.
+        const runRefreshInBackground = lastRefresh != null && new Date(lastRefresh.finishedAt) > subMinutes(now, 15);
 
-        if (finishedAt > subMinutes(now, 5)) {
-            // Fresh enough (< 5 minutes) — skip refresh entirely
-            return;
-        } else if (finishedAt > subMinutes(now, 15)) {
-            // Moderately stale (5–15 minutes) — refresh concurrently in the background
-            const refreshPromise = refresh({ concurrently: true });
-            if (options?.awaitRefresh) {
-                // Caller wants to wait for the refresh to complete, even if it's concurrent. Only used by CLI command.
-                await refreshPromise;
-            }
-        } else {
-            // Very stale (> 15 minutes) — refresh synchronously, caller waits for fresh data
-            await refresh();
+        // Deduplicate parallel refreshes within this instance (e.g. one per DAM "Usages" row): share a
+        // single in-flight refresh so they don't each open a transaction and pile up on the advisory lock.
+        if (!this.runningRefresh) {
+            const runningRefresh = refresh({ concurrently: runRefreshInBackground }).finally(() => {
+                this.runningRefresh = undefined;
+            });
+            this.runningRefresh = runningRefresh;
+            // A backgrounded refresh has no awaiter — log failures instead of leaving an unhandled rejection.
+            runningRefresh.catch((error) => {
+                this.logger.error(`Block index refresh failed: ${error instanceof Error ? error.message : error}`);
+            });
+        }
+
+        if (!runRefreshInBackground || options?.awaitRefresh) {
+            // Wait when synchronous (very stale/uninitialized) or when explicitly requested (CLI awaitRefresh).
+            await this.runningRefresh;
         }
     }
 


### PR DESCRIPTION
Backport of #6011 to `v8.x.x`.

Stops the flood of `pg_advisory_xact_lock` queries from `DependenciesService.refreshViews()` by letting parallel refreshes within a process share a single in-flight refresh, preventing DB connection pool exhaustion (e.g. when the DAM "Usages" column triggers one refresh per row).

Cherry-picked cleanly from the squash-merge commit (`3c28742a4`), no conflicts.

**Verified locally:**
- `@comet/cms-api` type-checks cleanly for the changed file (`tsc --noEmit`); pre-existing unrelated `sharp`/`file-type` errors in the package are environment issues, not introduced by this change.
- ESLint and Prettier pass on the changed files.
- Confirmed the dedup behavior in isolation: 30 parallel calls share exactly one refresh; sequential calls each trigger their own refresh.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WE5DxrhwAvtDdw2c7yhhKC)_