### PR TITLE
replace alert in DamVideoBlock

### DIFF
--- a/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/DamVideoBlock.tsx
@@ -123,6 +123,7 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
         return (
             <Box padding={isInPaper ? 3 : 0} pb={0}>
                 <BlocksFinalForm onSubmit={updateState} initialValues={state}>
+                    {state.damFile && isVideoTooLarge(state.damFile) && <VideoPerformanceWarningAlert sx={{ marginBottom: 2 }} />}
                     <Field
                         name="damFile"
                         component={FileField}
@@ -130,7 +131,6 @@ export const DamVideoBlock: BlockInterface<DamVideoBlockData, State, DamVideoBlo
                         allowedMimetypes={["video/mp4", "video/webm"]}
                         preview={<Video fontSize="large" color="primary" />}
                     />
-                    {state.damFile && isVideoTooLarge(state.damFile) && <VideoPerformanceWarningAlert sx={{ marginTop: 4 }} />}
                     <VideoOptionsFields />
                     <BlockAdminComponentSection title={<FormattedMessage id="comet.blocks.video.previewImage" defaultMessage="Preview Image" />}>
                         <PixelImageBlock.AdminComponent


### PR DESCRIPTION
JIRA: https://vivid-planet.atlassian.net/browse/COM-3053

Replace `VideoPerformanceWarningAlert` for DamVideoBlock

<img width="717" height="760" alt="Screenshot 2026-07-20 at 09 21 37" src="https://github.com/user-attachments/assets/a44ec76a-e81e-44e8-9532-329210890cc7" />
