### PR TITLE
[Backport v8] cms-admin: Persist DAM sorting preference across sessions

### DIFF
--- a/.changeset/dam-persist-sort-preference.md
+++ b/.changeset/dam-persist-sort-preference.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Persist the DAM sorting preference across sessions
+
+The Digital Asset Management asset list now remembers the selected sorting (column and direction) in `localStorage` instead of resetting to alphabetical (`name` ascending) on every visit.

--- a/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
+++ b/packages/admin/cms-admin/src/dam/DataGrid/FolderDataGrid.tsx
@@ -21,10 +21,12 @@ import { Info as InfoIcon } from "@comet/admin-icons";
 import { DialogContent, Slide, type SlideProps, Snackbar } from "@mui/material";
 import {
     DataGrid,
+    type DataGridProps,
     GridColumnHeaderTitle,
     type GridRowClassNameParams,
     type GridRowSelectionModel,
     type GridSlotsComponent,
+    type GridSortModel,
     useGridApiRef,
 } from "@mui/x-data-grid";
 import { type ReactNode, useEffect, useState } from "react";
@@ -177,7 +179,14 @@ const FolderDataGrid = ({
         setUploadTargetFolderName(undefined);
     };
 
-    const dataGridProps = useDataGridRemote({ pageSize: 20, initialSort: [{ field: "name", sort: "asc" }] });
+    const [persistedSortModel, setPersistedSortModel] = useStoredState<GridSortModel>("DamFolderDataGrid-sort", [{ field: "name", sort: "asc" }]);
+
+    const dataGridProps = useDataGridRemote({ pageSize: 20, initialSort: [...persistedSortModel] });
+
+    const handleSortModelChange: NonNullable<DataGridProps["onSortModelChange"]> = (sortModel, details) => {
+        setPersistedSortModel(sortModel);
+        dataGridProps.onSortModelChange?.(sortModel, details);
+    };
 
     const { data: currentFolderData } = useQuery<GQLDamFolderQuery, GQLDamFolderQueryVariables>(damFolderQuery, {
         variables: {
@@ -656,6 +665,7 @@ const FolderDataGrid = ({
                 <DataGrid
                     apiRef={apiRef}
                     {...dataGridProps}
+                    onSortModelChange={handleSortModelChange}
                     rowHeight={58}
                     rows={dataGridData?.damItemsList.nodes ?? []}
                     rowCount={dataGridData?.damItemsList.totalCount ?? undefined}


### PR DESCRIPTION
## Description

Backport of #6012 to `v8.x.x`.

## Further information

- Original PR: #6012

---
_Generated by [Claude Code](https://claude.ai/code/session_0166MuAquhip19CCV9gQBAS6)_