### PR TITLE
Fix client-side crash in `useCookieBotCookieApi` during Cookiebot init

### DIFF
--- a/.changeset/fix-cookiebot-consent-race.md
+++ b/.changeset/fix-cookiebot-consent-race.md
@@ -1,0 +1,8 @@
+---
+"@comet/site-react": patch
+"@comet/site-nextjs": patch
+---
+
+Fix client-side crash in `useCookieBotCookieApi` when Cookiebot is not yet initialized
+
+The hook read `window.Cookiebot.consent` in its initial call, but `window.Cookiebot` exists as soon as the Cookiebot script has run, while `consent` is only populated once Cookiebot fires `CookiebotOnConsentReady`. Calling `Object.keys(consent)` before that threw `TypeError: Cannot convert undefined or null to object`, crashing the client. The initial call is now a no-op until consent is available.

--- a/packages/site/site-react/src/cookies/useCookieBotCookieApi.tsx
+++ b/packages/site/site-react/src/cookies/useCookieBotCookieApi.tsx
@@ -6,7 +6,9 @@ import type { CookieApiHook } from "./CookieApiContext";
 
 type WindowWithCookiebot = Window & {
     Cookiebot: {
-        consent: Record<string, boolean>;
+        // `consent` is only populated once Cookiebot has initialized and fired `CookiebotOnConsentReady`.
+        // `window.Cookiebot` already exists once the script has run, so `consent` must be treated as optional.
+        consent?: Record<string, boolean>;
         renew: () => void;
         [key: string]: unknown;
     };
@@ -23,8 +25,13 @@ export const useCookieBotCookieApi: CookieApiHook = () => {
     useEffect(() => {
         const handleCookieUpdated = () => {
             if (isWindowWithCookiebot(window)) {
-                setInitialized(true);
                 const consentedList = window.Cookiebot.consent;
+                // The initial call can run before Cookiebot has finished initializing, when `consent` is not
+                // yet populated. Calling `Object.keys` on it would throw, so bail out until it's available.
+                if (!consentedList) {
+                    return;
+                }
+                setInitialized(true);
                 setConsentedCookies(Object.keys(consentedList).filter((key) => consentedList[key]));
             }
         };


### PR DESCRIPTION
## Problem

`useCookieBotCookieApi` intermittently crashed the whole client with:

> `TypeError: Cannot convert undefined or null to object`

thrown by `Object.keys(window.Cookiebot.consent)`. It only happened on some page loads — a hard reload (no cache) made it disappear — so it looked flaky.

## Reason

`window.Cookiebot` and its `consent` object are not created at the same time: the object exists as soon as the Cookiebot script has run, but `consent` is only filled in once Cookiebot finishes initializing and fires `CookiebotOnConsentReady`. The hook has a race in that gap:

1. On mount, the effect registers a `CookiebotOnConsentReady` listener **and** calls the handler once immediately (added in #5864, to cover the case where the event fires before the hook mounts).
2. The handler's only guard is `"Cookiebot" in window` — which is already `true` at this point.
3. But `consent` isn't populated yet, so `Object.keys(undefined)` throws and takes down the client.

Whether the immediate call lands inside that gap comes down to timing:

- **Warm cache (crashes):** Cookiebot's script is cached and runs fast, so `window.Cookiebot` already exists when the effect fires — but `consent` is a beat behind. The immediate call hits the gap.
- **Hard reload (works):** the external Cookiebot script is fetched fresh and arrives late, so `window.Cookiebot` doesn't exist yet when the effect fires. The immediate call is a harmless no-op, and the listener later reads a fully-populated `consent`.

## Fix

- Type `consent` as optional (`consent?: Record<string, boolean>`), reflecting that it can be absent before initialization, and null-check it before use.
- **Keep the eager initial call** — it's still required for the case #5864 fixed (the event firing before the hook mounts). The null-check only makes it a safe no-op when it runs before `consent` exists.
- Set `initialized` only once `consent` is actually available (so `CookieSafe` keeps showing its `loading` state until the consent status is genuinely known).

This keeps both orderings working, without reintroducing #5864:

- Event fires **before** mount → the event only fires when consent is ready, so `consent` is already populated; the eager call initializes it.
- Event fires **after** mount → the eager call is a no-op, and the still-registered listener initializes it once the event fires.

Behavior is otherwise unchanged for consumers — the crash is simply removed regardless of cache state.

## How to reproduce

On any site that mounts this hook with Cookiebot loaded (`data-blockingmode="manual"`):

1. Open the page with a **cold cache** (hard reload) → no error: the external Cookiebot script arrives late, so the eager call is a no-op.
2. Reload with a **warm cache** → the client crashes: Cookiebot's cached script has already created `window.Cookiebot`, but `consent` isn't populated yet when the effect's eager call runs.

Verified against a production deployment: cold load clean, warm reload throws the error above. With the fix applied, both paths are clean.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-3086
