### PR TITLE
[Backport v8] Fix client-side crash in `useCookieBotCookieApi` during Cookiebot init

### DIFF
--- a/.changeset/fix-cookiebot-consent-race.md
+++ b/.changeset/fix-cookiebot-consent-race.md
@@ -1,0 +1,8 @@
+---
+"@comet/site-react": patch
+"@comet/site-nextjs": patch
+---
+
+Fix client-side crash in `useCookieBotCookieApi` when Cookiebot is not yet initialized
+
+The hook read `window.Cookiebot.consent` in its initial call, but `window.Cookiebot` exists as soon as the Cookiebot script has run, while `consent` is only populated once Cookiebot fires `CookiebotOnConsentReady`. Calling `Object.keys(consent)` before that threw `TypeError: Cannot convert undefined or null to object`, crashing the client. The initial call is now a no-op until consent is available.

--- a/packages/site/site-react/src/cookies/useCookieBotCookieApi.tsx
+++ b/packages/site/site-react/src/cookies/useCookieBotCookieApi.tsx
@@ -6,7 +6,9 @@ import { type CookieApiHook } from "./CookieApiContext";
 
 type WindowWithCookiebot = Window & {
     Cookiebot: {
-        consent: Record<string, boolean>;
+        // `consent` is only populated once Cookiebot has initialized and fired `CookiebotOnConsentReady`.
+        // `window.Cookiebot` already exists once the script has run, so `consent` must be treated as optional.
+        consent?: Record<string, boolean>;
         renew: () => void;
         [key: string]: unknown;
     };
@@ -23,8 +25,13 @@ export const useCookieBotCookieApi: CookieApiHook = () => {
     useEffect(() => {
         const handleCookieUpdated = () => {
             if (isWindowWithCookiebot(window)) {
-                setInitialized(true);
                 const consentedList = window.Cookiebot.consent;
+                // The initial call can run before Cookiebot has finished initializing, when `consent` is not
+                // yet populated. Calling `Object.keys` on it would throw, so bail out until it's available.
+                if (!consentedList) {
+                    return;
+                }
+                setInitialized(true);
                 setConsentedCookies(Object.keys(consentedList).filter((key) => consentedList[key]));
             }
         };


### PR DESCRIPTION
Backport of #6027 to `v8.x.x`.

Cherry-picked cleanly from the merge commit (94a1d58d), no conflicts.

`useCookieBotCookieApi` intermittently crashed the whole client with `TypeError: Cannot convert undefined or null to object`, thrown by `Object.keys(window.Cookiebot.consent)`. `window.Cookiebot` exists as soon as Cookiebot's script has run, but `consent` is only populated once Cookiebot fires `CookiebotOnConsentReady`. The hook's eager initial call read `consent` before that gap closed on a warm cache, crashing the client. `consent` is now typed as optional and null-checked before use.

**Verified locally:**
- `@comet/site-react` builds (`vite build`)
- ESLint and Prettier pass on the changed file
- `tsc --noEmit` for the package shows only pre-existing failures unrelated to this change (present on `v8.x.x` before this cherry-pick too)
- Wrote a throwaway unit test reproducing the exact warm-cache race (`Cookiebot` present, `consent` undefined) against this branch's code: crashes with the original hook, passes with the backported fix

## Further information

- Original PR: #6027


---
_Generated by [Claude Code](https://claude.ai/code/session_01MuDXNRRpNFT7sjhyGQty4S)_