### PR TITLE
admin: Fix stale variant selector in dev story

### DIFF
--- a/packages/admin/admin/src/future-ui/components/button/__stories__/customization.dev.module.scss
+++ b/packages/admin/admin/src/future-ui/components/button/__stories__/customization.dev.module.scss
@@ -24,7 +24,7 @@
         text-transform: uppercase;
     }
 
-    :global(.cometButton--variantPrimary) {
+    :global(.cometButton)[data-variant="primary"] {
         background: #6750a4;
     }
 


### PR DESCRIPTION
The `ViaWrapperGlobalSelectors` story targeted the `.cometButton--variantPrimary` modifier class, removed when Future UI owner-state styling moved to data attributes (#5936). The selector matched nothing, so the story stopped demonstrating the primary-variant override.