### PR TITLE
admin: Resolve future-ui contract class names in unit tests

### DIFF
--- a/packages/admin/admin/.babelrc.build.json
+++ b/packages/admin/admin/.babelrc.build.json
@@ -1,3 +1,10 @@
 {
-    "ignore": ["**/__stories__/**", "**/*.stories.ts", "**/*.stories.tsx", "src/future-ui/cli/**", "src/future-ui/storybook/**"]
+    "ignore": [
+        "**/__stories__/**",
+        "**/*.stories.ts",
+        "**/*.stories.tsx",
+        "src/future-ui/cli/**",
+        "src/future-ui/cssModules/**",
+        "src/future-ui/storybook/**"
+    ]
 }

--- a/packages/admin/admin/.storybook/main.ts
+++ b/packages/admin/admin/.storybook/main.ts
@@ -1,28 +1,7 @@
-import { createHash } from "node:crypto";
-
 import type { StorybookConfig } from "@storybook/react-vite";
 import { mergeConfig } from "vite";
 
-const futureUiModulePattern = /future-ui\/components\/[^/]+\/([A-Z][A-Za-z0-9]+)\.module\.scss$/;
-const futureUiClassnamePrefix = "comet";
-
-// Produces the stable class names defined by the Future UI class-name contract instead of Vite's default hashed names.
-function generateScopedName(name: string, filename: string): string {
-    const futureUiMatch = filename.match(futureUiModulePattern);
-
-    if (futureUiMatch) {
-        const componentName = futureUiMatch[1];
-
-        if (name === "root") {
-            return `${futureUiClassnamePrefix}${componentName}`;
-        }
-
-        return `${futureUiClassnamePrefix}${componentName}__${name}`;
-    }
-
-    // No class-name contract for modules outside future-ui — fall back to a deterministic, file-scoped name.
-    return `${name}_${createHash("sha1").update(`${filename}::${name}`).digest("hex").slice(0, 5)}`;
-}
+import { generateScopedName } from "../src/future-ui/cssModules/generateScopedName.ts";
 
 const config: StorybookConfig = {
     stories: ["../src/**/*.mdx", "../src/**/__stories__/*.stories.@(js|jsx|mjs|ts|tsx)"],

--- a/packages/admin/admin/src/future-ui/cssModules/generateScopedName.test.ts
+++ b/packages/admin/admin/src/future-ui/cssModules/generateScopedName.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { generateScopedName } from "./generateScopedName";
+
+const buttonModuleFilename = "/project/packages/admin/admin/src/future-ui/components/button/Button.module.scss";
+
+describe("generateScopedName", () => {
+    it("maps `root` in a component module to the component's root class", () => {
+        expect(generateScopedName("root", buttonModuleFilename)).toBe("cometButton");
+    });
+
+    it("maps a part name in a component module to the component's part class", () => {
+        expect(generateScopedName("startIcon", buttonModuleFilename)).toBe("cometButton__startIcon");
+    });
+
+    it("maps a non-contract module deterministically", () => {
+        const storyModuleFilename = "/project/packages/admin/admin/src/future-ui/components/button/__stories__/customization.dev.module.scss";
+
+        expect(generateScopedName("root", storyModuleFilename)).toBe(generateScopedName("root", storyModuleFilename));
+    });
+
+    it("maps the same local name in different non-contract modules to different names", () => {
+        const firstFilename = "/project/packages/admin/admin/src/theme/first.module.scss";
+        const secondFilename = "/project/packages/admin/admin/src/theme/second.module.scss";
+
+        expect(generateScopedName("root", firstFilename)).not.toBe(generateScopedName("root", secondFilename));
+    });
+});

--- a/packages/admin/admin/src/future-ui/cssModules/generateScopedName.ts
+++ b/packages/admin/admin/src/future-ui/cssModules/generateScopedName.ts
@@ -1,0 +1,24 @@
+import { createHash } from "node:crypto";
+
+const futureUiModulePattern = /future-ui\/components\/[^/]+\/([A-Z][A-Za-z0-9]+)\.module\.scss$/;
+const futureUiClassnamePrefix = "comet";
+
+/**
+ * Produces the stable class names defined by the Future UI class-name contract instead of Vite's default hashed names.
+ */
+export function generateScopedName(name: string, filename: string): string {
+    const futureUiMatch = filename.match(futureUiModulePattern);
+
+    if (futureUiMatch) {
+        const componentName = futureUiMatch[1];
+
+        if (name === "root") {
+            return `${futureUiClassnamePrefix}${componentName}`;
+        }
+
+        return `${futureUiClassnamePrefix}${componentName}__${name}`;
+    }
+
+    // No class-name contract for modules outside future-ui — fall back to a deterministic, file-scoped name.
+    return `${name}_${createHash("sha1").update(`${filename}::${name}`).digest("hex").slice(0, 5)}`;
+}

--- a/packages/admin/admin/tsconfig.build.json
+++ b/packages/admin/admin/tsconfig.build.json
@@ -4,6 +4,7 @@
     },
     "exclude": [
         "src/future-ui/cli",
+        "src/future-ui/cssModules",
         "src/future-ui/storybook",
         "**/*.test.tsx",
         "**/*.test.ts",

--- a/packages/admin/admin/vitest.config.ts
+++ b/packages/admin/admin/vitest.config.ts
@@ -3,6 +3,8 @@ import { playwright } from "@vitest/browser-playwright";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
+import { generateScopedName } from "./src/future-ui/cssModules/generateScopedName";
+
 export default defineConfig({
     test: {
         reporters: ["default", "junit"],
@@ -12,10 +14,22 @@ export default defineConfig({
         projects: [
             {
                 plugins: [tsconfigPaths()],
+                css: {
+                    modules: {
+                        generateScopedName,
+                    },
+                },
                 test: {
                     name: "unit",
                     environment: "jsdom",
                     setupFiles: "./vitest.setup.ts",
+                    css: {
+                        include: [/\.module\.scss$/],
+                        modules: {
+                            // "stable" (the default) would override the vite-level generateScopedName above.
+                            classNameStrategy: "scoped",
+                        },
+                    },
                 },
             },
             {


### PR DESCRIPTION
The future-ui styling contract makes emitted class names public API, but the mapping lived in `.storybook/main.ts` and applied only in Storybook. Unit tests saw vitest's own hashed class names instead, so they could not assert the documented public names, and the mapping had no test — a regression in it would silently change the public class names everywhere.

- **The mapping moves to a shared, build-excluded location.**
  Both the Storybook and vitest configs use it, and it configures the CSS-module compiler at build time rather than running in a consumer, so like `cli/` and `storybook/` it stays out of the babel and declaration builds and out of the public exports.
- **The vitest config sets `classNameStrategy: "scoped"` for the unit tests.**
  Without it, vitest generates its own class names and ignores the shared `generateScopedName`, so tests would see hashed names instead of the contract ones.

---

Task: https://vivid-planet.atlassian.net/browse/COM-3078