### PR TITLE
admin: Add Future UI testing convention

### DIFF
--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -164,6 +164,25 @@ const meta = {
 } satisfies Meta<typeof Button>;
 ```
 
+## Testing
+
+Test the behavior and contracts a consumer depends on, not the implementation. Each test protects one such behavior; anything written only for coverage, or that just restates the type checker or the implementation, is left out.
+
+What to test, and with which kind of test:
+
+- **Utility logic** — a unit test (`unit` project, `jsdom`) next to the utility, exercising it directly in isolation.
+- **A component's render contract** — the class names and `data-*` attributes consumers style and target — a unit test next to the component. Assert the contract, not the styles it produces.
+- **A type-only contract** — typing with no runtime behavior, such as slot-prop inference — a compile-time test (`@ts-expect-error` on what must not compile), caught by `tsc`.
+- **Component behavior** — click, keyboard, focus, disabled — a Storybook interaction test (a story's `play` function), run in a real browser.
+
+Not worth a test:
+
+- **That a component renders** — every story already runs as a browser test, so a rendering story is the coverage.
+- **Appearance** — colors, sizes, spacing — reviewed visually in the stories, never asserted.
+- **Dev-local tooling** — CLI scripts, story-only helpers — a failure is loud and local. Exception: code whose regression is silent or reaches consumers, such as the class-name mapping in `cssModules/`.
+
+Run from `packages/admin/admin`: `pnpm run test:unit`, `pnpm run test:storybook`, and `pnpm run test:watch`.
+
 ## Theme
 
 Components read their colors and metrics from CSS custom properties (`var(--comet-button-…)`, `var(--comet-color-…)`, `var(--comet-typography-…)`) with **no fallback** — an unthemed component renders visibly unstyled rather than silently drifting to a default. There is no runtime JS theme object.


### PR DESCRIPTION
Future UI can test the same component through several mechanisms, and without guidance authors duplicate coverage or write tests that mirror the implementation. Documenting which mechanism owns which kind of behavior keeps each test tied to a stated contract.

---

Task: https://vivid-planet.atlassian.net/browse/COM-3078