### PR TITLE
Prevent non-terminating pagination loops in demo site loaders

### DIFF
--- a/demo/site/src/app/[visibility]/[domain]/sitemap.ts
+++ b/demo/site/src/app/[visibility]/[domain]/sitemap.ts
@@ -19,20 +19,21 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         const domain = siteConfig.scope.domain;
         const scope = { domain, language };
 
+        const limit = 50;
+        let offset = 0;
         let totalCount = 0;
-        let currentCount = 0;
 
         do {
             const { paginatedPageTreeNodes } = await graphqlFetch<GQLPrebuildPageDataListSitemapQuery, GQLPrebuildPageDataListSitemapQueryVariables>(
                 pageDataListQuery,
                 {
                     scope,
-                    offset: currentCount,
-                    limit: 50,
+                    offset,
+                    limit,
                 },
             );
             totalCount = paginatedPageTreeNodes.totalCount;
-            currentCount += paginatedPageTreeNodes.nodes.length;
+            offset += limit;
 
             for (const pageTreeNode of paginatedPageTreeNodes.nodes) {
                 if (pageTreeNode) {
@@ -56,7 +57,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
                     }
                 }
             }
-        } while (totalCount > currentCount);
+        } while (offset < totalCount);
     }
 
     return sitemap;

--- a/demo/site/src/common/blocks/PageTreeIndexBlock.loader.ts
+++ b/demo/site/src/common/blocks/PageTreeIndexBlock.loader.ts
@@ -8,7 +8,7 @@ export type LoadedData = Awaited<ReturnType<typeof loader>>;
 
 export const loader = async ({ graphQLFetch, scope }: BlockLoaderOptions<PageTreeIndexBlockData>) => {
     let totalCount = 0;
-    let currentCount = 0;
+    let offset = 0;
     const pageSize = 100;
     const allNodes: PageTreeNode[] = [];
 
@@ -33,15 +33,15 @@ export const loader = async ({ graphQLFetch, scope }: BlockLoaderOptions<PageTre
             `,
             {
                 scope,
-                offset: currentCount,
+                offset,
                 limit: pageSize,
             },
         );
 
         totalCount = paginatedPageTreeNodes.totalCount;
-        currentCount += paginatedPageTreeNodes.nodes.length;
+        offset += pageSize;
         allNodes.push(...paginatedPageTreeNodes.nodes);
-    } while (totalCount > currentCount);
+    } while (offset < totalCount);
 
     return allNodes;
 };

--- a/demo/site/src/middleware/redirectToMainHost.ts
+++ b/demo/site/src/middleware/redirectToMainHost.ts
@@ -39,19 +39,19 @@ async function fetchDomainRedirects(scope: GQLRedirectScopeInput) {
 
         let allNodes: Redirect[] = [];
         let totalCount = 0;
-        let currentCount = 0;
+        let offset = 0;
         do {
             const data = await graphQLFetch<GQLDomainRedirectsQuery, GQLDomainRedirectsQueryVariables>(domainRedirectsQuery, {
                 scope: { domain: scope.domain },
                 filter: { sourceType: { equal: "domain" } },
-                offset: currentCount,
+                offset,
                 limit,
             });
             const nodes = data?.paginatedRedirects?.nodes || [];
             totalCount = data?.paginatedRedirects?.totalCount || 0;
-            currentCount += nodes.length;
+            offset += limit;
             allNodes = allNodes.concat(nodes);
-        } while (currentCount < totalCount);
+        } while (offset < totalCount);
         return allNodes;
     });
 }


### PR DESCRIPTION
## Problem

Several site loaders page through the API to collect all results: they repeatedly request one page of rows at a time until they have fetched every row (`totalCount`). Under production traffic, the site pods occasionally spiked to 100% event loop usage and restarted.

## Reason

The loops tracked progress by counting the rows they received (`currentCount += nodes.length`) and continued while `currentCount < totalCount`. This assumes every page returns as many rows as requested. If a response ever came back with fewer rows than `totalCount` implied — a short/empty page from a partial GraphQL response, or a count/rows mismatch — `currentCount` stopped advancing while still below `totalCount`, so the loop condition never became false.

The result is a tight `await fetch` loop that never terminates: it pins the event loop and holds the request open, with memory growing until the pod restarts. The domain-redirect loop runs in Next.js middleware on every request to an unresolved host, so bot traffic hitting unknown hostnames reliably triggered it.

## Fix

Advance the offset by a fixed page size and stop once `offset >= totalCount`, so the loop always makes progress and terminates regardless of how many rows any single page returns.

Applied to all affected loops:

- `redirectToMainHost.ts` (`fetchDomainRedirects`) — the loop reachable on every request
- `sitemap.ts` and `PageTreeIndexBlock.loader.ts` — same latent bug on cold routes

## Further information

- Task: <!-- add Jira link if there is a ticket -->
