### PR TITLE
Join `EntityInfo` once when building the `block_index_dependencies` materialized view

### DIFF
--- a/.changeset/block-index-dependencies-refresh-single-entityinfo-join.md
+++ b/.changeset/block-index-dependencies-refresh-single-entityinfo-join.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Improve performance of the `block_index_dependencies` materialized view refresh
+
+Resolve the `EntityInfo` of the root and target entity once over the union of all root blocks, instead of joining `EntityInfo` inside each root block's `SELECT`. Previously the `EntityInfo` view (a `UNION` over every entity, including a recursive DAM folder-path CTE) was re-evaluated once per root block, which dominated the refresh cost on large datasets. The refreshed view's columns and contents are unchanged.

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -88,25 +88,15 @@ export class DependenciesService {
                             indexObj->>'blockname'                                              "blockname",
                             indexObj->>'jsonPath'                                               "jsonPath",
                             indexObj->>'visible'                                                "blockVisible",
-                            COALESCE(ei_root."visible", true)                                   "entityVisible",
-                            ((indexObj->>'visible')::boolean AND COALESCE(ei_root."visible", true))  "visible",
                             targetTableData->>'entityName'                                      "targetEntityName",
                             targetTableData->>'graphqlObjectType'                               "targetGraphqlObjectType",
                             targetTableData->>'tableName'                                       "targetTableName",
                             targetTableData->>'primary'                                         "targetPrimaryKey",
-                            dependenciesObj->>'id'                                              "targetId",
-                            ei_root."name"                                                      "rootName",
-                            ei_root."secondaryInformation"                                      "rootSecondaryInformation",
-                            ei_target."name"                                                    "targetName",
-                            ei_target."secondaryInformation"                                    "targetSecondaryInformation"
+                            dependenciesObj->>'id'                                              "targetId"
                         FROM "${metadata.tableName}"
                         CROSS JOIN LATERAL json_array_elements("${metadata.tableName}"."${column}"->'index') indexObj
                         CROSS JOIN LATERAL json_array_elements(indexObj->'dependencies') dependenciesObj
-                        CROSS JOIN LATERAL json_extract_path('${JSON.stringify(targetEntitiesNameData)}', dependenciesObj->>'targetEntityName') targetTableData
-                        LEFT JOIN "EntityInfo" as ei_root ON ei_root."id" = "${metadata.tableName}"."${primary}"::text
-                            AND ei_root."entityName" = '${metadata.name}'
-                        LEFT JOIN "EntityInfo" as ei_target ON ei_target."id" = dependenciesObj->>'id'
-                            AND ei_target."entityName" = dependenciesObj->>'targetEntityName'`;
+                        CROSS JOIN LATERAL json_extract_path('${JSON.stringify(targetEntitiesNameData)}', dependenciesObj->>'targetEntityName') targetTableData`;
 
             indexSelects.push(select);
         }
@@ -116,7 +106,38 @@ export class DependenciesService {
             return;
         }
 
-        const viewSql = indexSelects.join("\n UNION ALL \n");
+        // Resolve the root and target entity's EntityInfo once over the union of all root blocks.
+        // Joining EntityInfo inside each root block's SELECT instead re-evaluates the EntityInfo
+        // view (a UNION over every entity, including a recursive DAM folder-path CTE) once per root
+        // block, which dominates the refresh cost on large datasets.
+        const viewSql = `SELECT
+                        blockIndex."rootId",
+                        blockIndex."rootEntityName",
+                        blockIndex."rootGraphqlObjectType",
+                        blockIndex."rootTableName",
+                        blockIndex."rootColumnName",
+                        blockIndex."rootPrimaryKey",
+                        blockIndex."blockname",
+                        blockIndex."jsonPath",
+                        blockIndex."blockVisible",
+                        COALESCE(ei_root."visible", true)                                            "entityVisible",
+                        ((blockIndex."blockVisible")::boolean AND COALESCE(ei_root."visible", true)) "visible",
+                        blockIndex."targetEntityName",
+                        blockIndex."targetGraphqlObjectType",
+                        blockIndex."targetTableName",
+                        blockIndex."targetPrimaryKey",
+                        blockIndex."targetId",
+                        ei_root."name"                                                              "rootName",
+                        ei_root."secondaryInformation"                                              "rootSecondaryInformation",
+                        ei_target."name"                                                            "targetName",
+                        ei_target."secondaryInformation"                                            "targetSecondaryInformation"
+                    FROM (
+                        ${indexSelects.join("\n UNION ALL \n")}
+                    ) blockIndex
+                    LEFT JOIN "EntityInfo" as ei_root ON ei_root."id" = blockIndex."rootId"::text
+                        AND ei_root."entityName" = blockIndex."rootEntityName"
+                    LEFT JOIN "EntityInfo" as ei_target ON ei_target."id" = blockIndex."targetId"
+                        AND ei_target."entityName" = blockIndex."targetEntityName"`;
 
         console.time("creating block dependency materialized view");
         await this.connection.execute(`DROP MATERIALIZED VIEW IF EXISTS block_index_dependencies`);


### PR DESCRIPTION
## Description

The `block_index_dependencies` materialized view resolves entity-level visibility and the denormalized `name` / `secondaryInformation` columns by joining the `EntityInfo` view for both the root and the target entity.

Previously those two joins were emitted **inside each root block's `SELECT`**. Since `EntityInfo` is a plain (non-materialized) view — a `UNION` over every entity type, including a recursive DAM folder-path CTE — it was re-evaluated once per join per root block (~20 evaluations for the default entity set). This dominated the `REFRESH MATERIALIZED VIEW` cost on large datasets.

This change unions the raw block-index expansions first and applies the two `EntityInfo` joins **once** over the combined result. Because a join distributes over a union, this is algebraically equivalent: the refreshed view's columns, types and contents are unchanged.

## Verification

- **Output unchanged:** same 20 columns in the same order and types (incl. `blockVisible` kept as `text`); 0 row differences vs. the previous definition across all semantic columns.
- **Benchmarked** on a simulated production-scale dataset (millions of block-index entries, a few hundred thousand dependency rows and `EntityInfo` rows). `EntityInfo` evaluations drop from 20 to 2:

  **Measured effect (realistic prod-scale data)**

  | Metric | v8 baseline | v9 before | v9 after (this change) |
  | --- | --- | --- | --- |
  | REFRESH wall-clock (avg ×3) | 23.7 s | 55.3 s | **33.5 s** (−39%) |
  | Sort spill to disk | 0 | 730 MB | **234 MB** (−68%) |
  | Temp-file I/O (written + read) | 0 | 12.1 GB | **3.7 GB** (−69%) |
  | Shared buffers touched | 1.20 GB | 10.35 GB | **4.44 GB** (−57%) |

  What the metrics mean (all from `EXPLAIN (ANALYZE, BUFFERS)`, default `work_mem` = 4 MB):
  - **Sort spill to disk** — sort data that exceeded `work_mem` and had to overflow to temp files. Best proxy for the working RAM the refresh needs: with a large `work_mem` this stays resident instead (~580 MB for "v9 before").
  - **Temp-file I/O** — total bytes written+read to those temp files (sort + hash spills). Disk I/O paid *because* RAM was insufficient; `0` means it all fit in memory.
  - **Shared buffers touched** — volume of page accesses through the cache (not RAM allocated; `shared_buffers` is fixed at 160 MB). A CPU/bandwidth indicator — high values mean the same pages were scanned repeatedly (the ~20× `EntityInfo` re-evaluation).

## Possible follow-up

**Materialize `EntityInfo`** (with a unique index on `(entityName, id)`): the two remaining joins would become cheap indexed lookups against a table scanned once, instead of re-evaluating the recursive view twice. Trade-off: adds an `EntityInfo` refresh step to be ordered before this one.

This could close the remaining gap to the v8 baseline (~34 s → ~24 s) if more headroom is needed.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-3093


---
_Generated by [Claude Code](https://claude.ai/code/session_017vm3B9L2R2cz586T2uYQAL)_