### PR TITLE
admin: Update future-ui to the latest design-token export

### DIFF
--- a/packages/admin/admin/src/future-ui/cli/generateThemeTokens.ts
+++ b/packages/admin/admin/src/future-ui/cli/generateThemeTokens.ts
@@ -33,7 +33,7 @@ interface ModeFile {
 }
 
 type RenderStrategy =
-    | { kind: "scope"; selector: string }
+    | { kind: "scope"; selector: string; mode?: string }
     | { kind: "attribute"; attribute: string }
     | { kind: "responsive"; baseMode: string; breakpointModes: Record<string, string> };
 
@@ -43,13 +43,14 @@ type RenderStrategy =
  * on, and the semantic variables a component references are out of scope at
  * `:root`.
  *
- * `brand` imports only its `default` mode — other brand modes in the export
- * are project-specific and intentionally not imported.
+ * A `scope` collection imports a single mode (`mode`, defaulting to `default`).
+ * `brand` imports only its `dextinity` mode — the other brand modes in the
+ * export belong to separate projects and are intentionally not imported.
  */
 const COLLECTION_RENDER_STRATEGIES: Record<string, RenderStrategy> = {
     primitives: { kind: "scope", selector: ":root" },
     components: { kind: "scope", selector: "[data-comet-color-scheme]" },
-    brand: { kind: "scope", selector: ":root" },
+    brand: { kind: "scope", selector: ":root", mode: "dextinity" },
     semantic: { kind: "attribute", attribute: "data-comet-color-scheme" },
     responsive: { kind: "responsive", baseMode: "mobile", breakpointModes: { desktop: "breakpoint-desktop" } },
 };
@@ -211,8 +212,8 @@ function getModeFile(collection: string, modeFiles: ModeFile[], mode: string): M
     return modeFile;
 }
 
-function renderScope(selector: string, collection: string, modeFiles: ModeFile[]): string {
-    const modeFile = getModeFile(collection, modeFiles, "default");
+function renderScope(selector: string, collection: string, modeFiles: ModeFile[], mode = "default"): string {
+    const modeFile = getModeFile(collection, modeFiles, mode);
     return renderPartialFile([renderSelectorBlock(selector, getTokenEntries(modeFile.tree))]);
 }
 
@@ -332,7 +333,7 @@ async function main(): Promise<void> {
         let contents: string;
         switch (strategy.kind) {
             case "scope":
-                contents = renderScope(strategy.selector, collection, modeFiles);
+                contents = renderScope(strategy.selector, collection, modeFiles, strategy.mode);
                 break;
             case "attribute":
                 contents = renderAttribute(strategy.attribute, modeFiles);

--- a/packages/admin/admin/src/future-ui/components/button/Button.module.scss
+++ b/packages/admin/admin/src/future-ui/components/button/Button.module.scss
@@ -14,13 +14,13 @@
     cursor: pointer;
 
     &[data-variant="primary"] {
-        background: var(--comet-button-variant-primary-default-background);
-        color: var(--comet-button-variant-primary-default-foreground);
+        background: var(--comet-button-color-primary-contained-default-background);
+        color: var(--comet-button-color-primary-contained-default-foreground);
     }
 
     &[data-variant="secondary"] {
-        background: var(--comet-button-variant-secondary-default-background);
-        color: var(--comet-button-variant-secondary-default-foreground);
+        background: var(--comet-button-color-secondary-contained-default-background);
+        color: var(--comet-button-color-secondary-contained-default-foreground);
     }
 
     &[data-disabled] {

--- a/packages/admin/admin/src/future-ui/theme/_components.scss
+++ b/packages/admin/admin/src/future-ui/theme/_components.scss
@@ -79,78 +79,6 @@
         --comet-main-navigation-section-header-hover-foreground: var(--comet-color-foreground-muted);
         --comet-main-navigation-section-header-hover-icon: var(--comet-color-foreground-muted);
 
-        --comet-button-variant-primary-default-background: var(--comet-color-action-primary-default);
-        --comet-button-variant-primary-default-foreground: var(--comet-color-action-primary-foreground);
-        --comet-button-variant-primary-default-border: var(--comet-color-action-primary-default);
-
-        --comet-button-variant-primary-hover-background: var(--comet-color-action-primary-hover);
-        --comet-button-variant-primary-hover-foreground: var(--comet-color-action-primary-foreground);
-        --comet-button-variant-primary-hover-border: var(--comet-color-action-primary-hover);
-
-        --comet-button-variant-primary-active-background: var(--comet-color-action-primary-active);
-        --comet-button-variant-primary-active-foreground: var(--comet-color-action-primary-foreground);
-        --comet-button-variant-primary-active-border: var(--comet-color-action-primary-active);
-
-        --comet-button-variant-primary-focus-background: var(--comet-color-action-primary-default);
-        --comet-button-variant-primary-focus-foreground: var(--comet-color-action-primary-foreground);
-        --comet-button-variant-primary-focus-border: var(--comet-color-action-primary-default);
-
-        --comet-button-variant-primary-disabled-background: var(--comet-color-action-primary-disabled);
-        --comet-button-variant-primary-disabled-foreground: var(--comet-color-foreground-subtle);
-        --comet-button-variant-primary-disabled-border: var(--comet-color-action-primary-disabled);
-
-        --comet-button-variant-primary-loading-background: var(--comet-color-action-primary-default);
-        --comet-button-variant-primary-loading-foreground: var(--comet-color-action-primary-foreground);
-        --comet-button-variant-primary-loading-border: var(--comet-color-action-primary-default);
-
-        --comet-button-variant-secondary-default-background: var(--comet-color-background-default);
-        --comet-button-variant-secondary-default-foreground: var(--comet-color-foreground-default);
-        --comet-button-variant-secondary-default-border: var(--comet-color-border-default);
-
-        --comet-button-variant-secondary-hover-background: var(--comet-color-background-subtle);
-        --comet-button-variant-secondary-hover-foreground: var(--comet-color-foreground-default);
-        --comet-button-variant-secondary-hover-border: var(--comet-color-border-strong);
-
-        --comet-button-variant-secondary-active-background: var(--comet-color-background-muted);
-        --comet-button-variant-secondary-active-foreground: var(--comet-color-foreground-default);
-        --comet-button-variant-secondary-active-border: var(--comet-color-border-strong);
-
-        --comet-button-variant-secondary-focus-background: var(--comet-color-background-default);
-        --comet-button-variant-secondary-focus-foreground: var(--comet-color-foreground-default);
-        --comet-button-variant-secondary-focus-border: var(--comet-color-border-default);
-
-        --comet-button-variant-secondary-disabled-background: var(--comet-color-action-secondary-disabled);
-        --comet-button-variant-secondary-disabled-foreground: var(--comet-color-foreground-subtle);
-        --comet-button-variant-secondary-disabled-border: var(--comet-color-border-subtle);
-
-        --comet-button-variant-secondary-loading-background: var(--comet-color-background-default);
-        --comet-button-variant-secondary-loading-foreground: var(--comet-color-foreground-default);
-        --comet-button-variant-secondary-loading-border: var(--comet-color-border-default);
-
-        --comet-button-variant-tertiary-default-background: var(--comet-color-transparent);
-        --comet-button-variant-tertiary-default-foreground: var(--comet-color-action-tertiary-default);
-        --comet-button-variant-tertiary-default-border: var(--comet-color-transparent);
-
-        --comet-button-variant-tertiary-hover-background: var(--comet-color-action-tertiary-subtle);
-        --comet-button-variant-tertiary-hover-foreground: var(--comet-color-action-tertiary-default);
-        --comet-button-variant-tertiary-hover-border: var(--comet-color-transparent);
-
-        --comet-button-variant-tertiary-active-background: var(--comet-color-background-muted);
-        --comet-button-variant-tertiary-active-foreground: var(--comet-color-action-tertiary-active);
-        --comet-button-variant-tertiary-active-border: var(--comet-color-transparent);
-
-        --comet-button-variant-tertiary-focus-background: var(--comet-color-transparent);
-        --comet-button-variant-tertiary-focus-foreground: var(--comet-color-action-tertiary-default);
-        --comet-button-variant-tertiary-focus-border: var(--comet-color-transparent);
-
-        --comet-button-variant-tertiary-disabled-background: var(--comet-color-transparent);
-        --comet-button-variant-tertiary-disabled-foreground: var(--comet-color-foreground-subtle);
-        --comet-button-variant-tertiary-disabled-border: var(--comet-color-transparent);
-
-        --comet-button-variant-tertiary-loading-background: var(--comet-color-transparent);
-        --comet-button-variant-tertiary-loading-foreground: var(--comet-color-action-tertiary-default);
-        --comet-button-variant-tertiary-loading-border: var(--comet-color-transparent);
-
         --comet-button-type-button-small-font-size: var(--comet-typography-body-sm-size);
         --comet-button-type-button-small-font-line-height: var(--comet-typography-body-sm-line-height);
         --comet-button-type-button-small-font-weight: var(--comet-font-weight-medium);
@@ -313,20 +241,20 @@
         --comet-chip-variant-filled-primary-disabled-border: var(--comet-color-action-primary-disabled);
 
         --comet-chip-variant-filled-error-default-background: var(--comet-color-feedback-danger-default);
-        --comet-chip-variant-filled-error-default-foreground: var(--comet-color-action-danger-foreground);
+        --comet-chip-variant-filled-error-default-foreground: var(--comet-color-action-error-foreground);
         --comet-chip-variant-filled-error-default-border: var(--comet-color-feedback-danger-default);
 
-        --comet-chip-variant-filled-error-hover-background: var(--comet-color-action-danger-hover);
-        --comet-chip-variant-filled-error-hover-foreground: var(--comet-color-action-danger-foreground);
-        --comet-chip-variant-filled-error-hover-border: var(--comet-color-action-danger-hover);
+        --comet-chip-variant-filled-error-hover-background: var(--comet-color-action-error-hover);
+        --comet-chip-variant-filled-error-hover-foreground: var(--comet-color-action-error-foreground);
+        --comet-chip-variant-filled-error-hover-border: var(--comet-color-action-error-hover);
 
         --comet-chip-variant-filled-error-focus-background: var(--comet-color-feedback-danger-default);
-        --comet-chip-variant-filled-error-focus-foreground: var(--comet-color-action-danger-foreground);
+        --comet-chip-variant-filled-error-focus-foreground: var(--comet-color-action-error-foreground);
         --comet-chip-variant-filled-error-focus-border: var(--comet-color-feedback-danger-default);
 
-        --comet-chip-variant-filled-error-disabled-background: var(--comet-color-action-danger-disabled);
+        --comet-chip-variant-filled-error-disabled-background: var(--comet-color-action-error-disabled);
         --comet-chip-variant-filled-error-disabled-foreground: var(--comet-color-foreground-subtle);
-        --comet-chip-variant-filled-error-disabled-border: var(--comet-color-action-danger-disabled);
+        --comet-chip-variant-filled-error-disabled-border: var(--comet-color-action-error-disabled);
 
         --comet-chip-variant-filled-info-default-background: var(--comet-color-feedback-info-default);
         --comet-chip-variant-filled-info-default-foreground: var(--comet-color-foreground-on-accent);
@@ -501,5 +429,293 @@
         --comet-chip-size-small-font-weight: var(--comet-font-weight-medium);
 
         --comet-chip-size-small-font-weight-style: var(--comet-font-weight-medium-style);
+
+        --comet-button-color-primary-contained-default-background: var(--comet-color-action-primary-default);
+        --comet-button-color-primary-contained-default-foreground: var(--comet-color-action-primary-foreground);
+        --comet-button-color-primary-contained-default-border: var(--comet-color-action-primary-default);
+
+        --comet-button-color-primary-contained-hover-background: var(--comet-color-action-primary-hover);
+        --comet-button-color-primary-contained-hover-foreground: var(--comet-color-action-primary-foreground);
+        --comet-button-color-primary-contained-hover-border: var(--comet-color-action-primary-hover);
+
+        --comet-button-color-primary-contained-active-background: var(--comet-color-action-primary-active);
+        --comet-button-color-primary-contained-active-foreground: var(--comet-color-action-primary-foreground);
+        --comet-button-color-primary-contained-active-border: var(--comet-color-action-primary-active);
+
+        --comet-button-color-primary-contained-focus-background: var(--comet-color-action-primary-default);
+        --comet-button-color-primary-contained-focus-foreground: var(--comet-color-action-primary-foreground);
+        --comet-button-color-primary-contained-focus-border: var(--comet-color-action-primary-default);
+
+        --comet-button-color-primary-contained-disabled-background: var(--comet-color-action-primary-disabled);
+        --comet-button-color-primary-contained-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-primary-contained-disabled-border: var(--comet-color-action-primary-disabled);
+
+        --comet-button-color-primary-contained-loading-background: var(--comet-color-action-primary-default);
+        --comet-button-color-primary-contained-loading-foreground: var(--comet-color-action-primary-foreground);
+        --comet-button-color-primary-contained-loading-border: var(--comet-color-action-primary-default);
+
+        --comet-button-color-primary-outlined-default-background: var(--comet-color-transparent);
+        --comet-button-color-primary-outlined-default-foreground: var(--comet-color-action-primary-default);
+        --comet-button-color-primary-outlined-default-border: var(--comet-color-action-primary-default);
+
+        --comet-button-color-primary-outlined-hover-background: var(--comet-color-action-primary-subtle);
+        --comet-button-color-primary-outlined-hover-foreground: var(--comet-color-action-primary-hover);
+        --comet-button-color-primary-outlined-hover-border: var(--comet-color-action-primary-hover);
+
+        --comet-button-color-primary-outlined-active-background: var(--comet-color-action-primary-subtle);
+        --comet-button-color-primary-outlined-active-foreground: var(--comet-color-action-primary-active);
+        --comet-button-color-primary-outlined-active-border: var(--comet-color-action-primary-active);
+
+        --comet-button-color-primary-outlined-focus-background: var(--comet-color-transparent);
+        --comet-button-color-primary-outlined-focus-foreground: var(--comet-color-action-primary-default);
+        --comet-button-color-primary-outlined-focus-border: var(--comet-color-action-primary-default);
+
+        --comet-button-color-primary-outlined-disabled-background: var(--comet-color-transparent);
+        --comet-button-color-primary-outlined-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-primary-outlined-disabled-border: var(--comet-color-border-subtle);
+
+        --comet-button-color-primary-outlined-loading-background: var(--comet-color-transparent);
+        --comet-button-color-primary-outlined-loading-foreground: var(--comet-color-action-primary-default);
+        --comet-button-color-primary-outlined-loading-border: var(--comet-color-action-primary-default);
+
+        --comet-button-color-primary-text-default-background: var(--comet-color-transparent);
+        --comet-button-color-primary-text-default-foreground: var(--comet-color-action-primary-default);
+        --comet-button-color-primary-text-default-border: var(--comet-color-transparent);
+
+        --comet-button-color-primary-text-hover-background: var(--comet-color-action-primary-subtle);
+        --comet-button-color-primary-text-hover-foreground: var(--comet-color-action-primary-hover);
+        --comet-button-color-primary-text-hover-border: var(--comet-color-transparent);
+
+        --comet-button-color-primary-text-active-background: var(--comet-color-action-primary-subtle);
+        --comet-button-color-primary-text-active-foreground: var(--comet-color-action-primary-active);
+        --comet-button-color-primary-text-active-border: var(--comet-color-transparent);
+
+        --comet-button-color-primary-text-focus-background: var(--comet-color-transparent);
+        --comet-button-color-primary-text-focus-foreground: var(--comet-color-action-primary-default);
+        --comet-button-color-primary-text-focus-border: var(--comet-color-transparent);
+
+        --comet-button-color-primary-text-disabled-background: var(--comet-color-transparent);
+        --comet-button-color-primary-text-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-primary-text-disabled-border: var(--comet-color-transparent);
+
+        --comet-button-color-primary-text-loading-background: var(--comet-color-transparent);
+        --comet-button-color-primary-text-loading-foreground: var(--comet-color-action-primary-default);
+        --comet-button-color-primary-text-loading-border: var(--comet-color-transparent);
+
+        --comet-button-color-secondary-contained-default-background: var(--comet-color-action-secondary-default);
+        --comet-button-color-secondary-contained-default-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-contained-default-border: var(--comet-color-action-secondary-default);
+
+        --comet-button-color-secondary-contained-hover-background: var(--comet-color-action-secondary-hover);
+        --comet-button-color-secondary-contained-hover-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-contained-hover-border: var(--comet-color-action-secondary-hover);
+
+        --comet-button-color-secondary-contained-active-background: var(--comet-color-action-secondary-active);
+        --comet-button-color-secondary-contained-active-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-contained-active-border: var(--comet-color-action-secondary-active);
+
+        --comet-button-color-secondary-contained-focus-background: var(--comet-color-action-secondary-default);
+        --comet-button-color-secondary-contained-focus-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-contained-focus-border: var(--comet-color-action-secondary-default);
+
+        --comet-button-color-secondary-contained-disabled-background: var(--comet-color-action-secondary-disabled);
+        --comet-button-color-secondary-contained-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-secondary-contained-disabled-border: var(--comet-color-action-secondary-disabled);
+
+        --comet-button-color-secondary-contained-loading-background: var(--comet-color-action-secondary-default);
+        --comet-button-color-secondary-contained-loading-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-contained-loading-border: var(--comet-color-action-secondary-default);
+
+        --comet-button-color-secondary-outlined-default-background: var(--comet-color-transparent);
+        --comet-button-color-secondary-outlined-default-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-outlined-default-border: var(--comet-color-border-strong);
+
+        --comet-button-color-secondary-outlined-hover-background: var(--comet-color-action-secondary-subtle);
+        --comet-button-color-secondary-outlined-hover-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-outlined-hover-border: var(--comet-color-border-strong);
+
+        --comet-button-color-secondary-outlined-active-background: var(--comet-color-action-secondary-subtle);
+        --comet-button-color-secondary-outlined-active-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-outlined-active-border: var(--comet-color-border-strong);
+
+        --comet-button-color-secondary-outlined-focus-background: var(--comet-color-transparent);
+        --comet-button-color-secondary-outlined-focus-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-outlined-focus-border: var(--comet-color-border-strong);
+
+        --comet-button-color-secondary-outlined-disabled-background: var(--comet-color-transparent);
+        --comet-button-color-secondary-outlined-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-secondary-outlined-disabled-border: var(--comet-color-border-subtle);
+
+        --comet-button-color-secondary-outlined-loading-background: var(--comet-color-transparent);
+        --comet-button-color-secondary-outlined-loading-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-outlined-loading-border: var(--comet-color-border-strong);
+
+        --comet-button-color-secondary-text-default-background: var(--comet-color-transparent);
+        --comet-button-color-secondary-text-default-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-text-default-border: var(--comet-color-transparent);
+
+        --comet-button-color-secondary-text-hover-background: var(--comet-color-action-secondary-subtle);
+        --comet-button-color-secondary-text-hover-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-text-hover-border: var(--comet-color-transparent);
+
+        --comet-button-color-secondary-text-active-background: var(--comet-color-action-secondary-subtle);
+        --comet-button-color-secondary-text-active-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-text-active-border: var(--comet-color-transparent);
+
+        --comet-button-color-secondary-text-focus-background: var(--comet-color-transparent);
+        --comet-button-color-secondary-text-focus-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-text-focus-border: var(--comet-color-transparent);
+
+        --comet-button-color-secondary-text-disabled-background: var(--comet-color-transparent);
+        --comet-button-color-secondary-text-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-secondary-text-disabled-border: var(--comet-color-transparent);
+
+        --comet-button-color-secondary-text-loading-background: var(--comet-color-transparent);
+        --comet-button-color-secondary-text-loading-foreground: var(--comet-color-action-secondary-foreground);
+        --comet-button-color-secondary-text-loading-border: var(--comet-color-transparent);
+
+        --comet-button-color-error-contained-default-background: var(--comet-color-action-error-default);
+        --comet-button-color-error-contained-default-foreground: var(--comet-color-action-error-foreground);
+        --comet-button-color-error-contained-default-border: var(--comet-color-action-error-default);
+
+        --comet-button-color-error-contained-hover-background: var(--comet-color-action-error-hover);
+        --comet-button-color-error-contained-hover-foreground: var(--comet-color-action-error-foreground);
+        --comet-button-color-error-contained-hover-border: var(--comet-color-action-error-hover);
+
+        --comet-button-color-error-contained-active-background: var(--comet-color-action-error-active);
+        --comet-button-color-error-contained-active-foreground: var(--comet-color-action-error-foreground);
+        --comet-button-color-error-contained-active-border: var(--comet-color-action-error-active);
+
+        --comet-button-color-error-contained-focus-background: var(--comet-color-action-error-default);
+        --comet-button-color-error-contained-focus-foreground: var(--comet-color-action-error-foreground);
+        --comet-button-color-error-contained-focus-border: var(--comet-color-action-error-default);
+
+        --comet-button-color-error-contained-disabled-background: var(--comet-color-action-error-disabled);
+        --comet-button-color-error-contained-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-error-contained-disabled-border: var(--comet-color-action-error-disabled);
+
+        --comet-button-color-error-contained-loading-background: var(--comet-color-action-error-default);
+        --comet-button-color-error-contained-loading-foreground: var(--comet-color-action-error-foreground);
+        --comet-button-color-error-contained-loading-border: var(--comet-color-action-error-default);
+
+        --comet-button-color-error-outlined-default-background: var(--comet-color-transparent);
+        --comet-button-color-error-outlined-default-foreground: var(--comet-color-action-error-default);
+        --comet-button-color-error-outlined-default-border: var(--comet-color-action-error-default);
+
+        --comet-button-color-error-outlined-hover-background: var(--comet-color-action-error-subtle);
+        --comet-button-color-error-outlined-hover-foreground: var(--comet-color-action-error-hover);
+        --comet-button-color-error-outlined-hover-border: var(--comet-color-action-error-hover);
+
+        --comet-button-color-error-outlined-active-background: var(--comet-color-action-error-subtle);
+        --comet-button-color-error-outlined-active-foreground: var(--comet-color-action-error-active);
+        --comet-button-color-error-outlined-active-border: var(--comet-color-action-error-active);
+
+        --comet-button-color-error-outlined-focus-background: var(--comet-color-transparent);
+        --comet-button-color-error-outlined-focus-foreground: var(--comet-color-action-error-default);
+        --comet-button-color-error-outlined-focus-border: var(--comet-color-action-error-default);
+
+        --comet-button-color-error-outlined-disabled-background: var(--comet-color-transparent);
+        --comet-button-color-error-outlined-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-error-outlined-disabled-border: var(--comet-color-border-subtle);
+
+        --comet-button-color-error-outlined-loading-background: var(--comet-color-transparent);
+        --comet-button-color-error-outlined-loading-foreground: var(--comet-color-action-error-default);
+        --comet-button-color-error-outlined-loading-border: var(--comet-color-action-error-default);
+
+        --comet-button-color-error-text-default-background: var(--comet-color-transparent);
+        --comet-button-color-error-text-default-foreground: var(--comet-color-action-error-default);
+        --comet-button-color-error-text-default-border: var(--comet-color-transparent);
+
+        --comet-button-color-error-text-hover-background: var(--comet-color-action-error-subtle);
+        --comet-button-color-error-text-hover-foreground: var(--comet-color-action-error-hover);
+        --comet-button-color-error-text-hover-border: var(--comet-color-transparent);
+
+        --comet-button-color-error-text-active-background: var(--comet-color-action-error-subtle);
+        --comet-button-color-error-text-active-foreground: var(--comet-color-action-error-active);
+        --comet-button-color-error-text-active-border: var(--comet-color-transparent);
+
+        --comet-button-color-error-text-focus-background: var(--comet-color-transparent);
+        --comet-button-color-error-text-focus-foreground: var(--comet-color-action-error-default);
+        --comet-button-color-error-text-focus-border: var(--comet-color-transparent);
+
+        --comet-button-color-error-text-disabled-background: var(--comet-color-transparent);
+        --comet-button-color-error-text-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-error-text-disabled-border: var(--comet-color-transparent);
+
+        --comet-button-color-error-text-loading-background: var(--comet-color-transparent);
+        --comet-button-color-error-text-loading-foreground: var(--comet-color-action-error-default);
+        --comet-button-color-error-text-loading-border: var(--comet-color-transparent);
+
+        --comet-button-color-success-contained-default-background: var(--comet-color-action-success-default);
+        --comet-button-color-success-contained-default-foreground: var(--comet-color-action-success-foreground);
+        --comet-button-color-success-contained-default-border: var(--comet-color-action-success-default);
+
+        --comet-button-color-success-contained-hover-background: var(--comet-color-action-success-hover);
+        --comet-button-color-success-contained-hover-foreground: var(--comet-color-action-success-foreground);
+        --comet-button-color-success-contained-hover-border: var(--comet-color-action-success-hover);
+
+        --comet-button-color-success-contained-active-background: var(--comet-color-action-success-active);
+        --comet-button-color-success-contained-active-foreground: var(--comet-color-action-success-foreground);
+        --comet-button-color-success-contained-active-border: var(--comet-color-action-success-active);
+
+        --comet-button-color-success-contained-focus-background: var(--comet-color-action-success-default);
+        --comet-button-color-success-contained-focus-foreground: var(--comet-color-action-success-foreground);
+        --comet-button-color-success-contained-focus-border: var(--comet-color-action-success-default);
+
+        --comet-button-color-success-contained-disabled-background: var(--comet-color-action-success-disabled);
+        --comet-button-color-success-contained-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-success-contained-disabled-border: var(--comet-color-action-success-disabled);
+
+        --comet-button-color-success-contained-loading-background: var(--comet-color-action-success-default);
+        --comet-button-color-success-contained-loading-foreground: var(--comet-color-action-success-foreground);
+        --comet-button-color-success-contained-loading-border: var(--comet-color-action-success-default);
+
+        --comet-button-color-success-outlined-default-background: var(--comet-color-transparent);
+        --comet-button-color-success-outlined-default-foreground: var(--comet-color-action-success-default);
+        --comet-button-color-success-outlined-default-border: var(--comet-color-action-success-default);
+
+        --comet-button-color-success-outlined-hover-background: var(--comet-color-action-success-subtle);
+        --comet-button-color-success-outlined-hover-foreground: var(--comet-color-action-success-hover);
+        --comet-button-color-success-outlined-hover-border: var(--comet-color-action-success-hover);
+
+        --comet-button-color-success-outlined-active-background: var(--comet-color-action-success-subtle);
+        --comet-button-color-success-outlined-active-foreground: var(--comet-color-action-success-active);
+        --comet-button-color-success-outlined-active-border: var(--comet-color-action-success-active);
+
+        --comet-button-color-success-outlined-focus-background: var(--comet-color-transparent);
+        --comet-button-color-success-outlined-focus-foreground: var(--comet-color-action-success-default);
+        --comet-button-color-success-outlined-focus-border: var(--comet-color-action-success-default);
+
+        --comet-button-color-success-outlined-disabled-background: var(--comet-color-transparent);
+        --comet-button-color-success-outlined-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-success-outlined-disabled-border: var(--comet-color-border-subtle);
+
+        --comet-button-color-success-outlined-loading-background: var(--comet-color-transparent);
+        --comet-button-color-success-outlined-loading-foreground: var(--comet-color-action-success-default);
+        --comet-button-color-success-outlined-loading-border: var(--comet-color-action-success-default);
+
+        --comet-button-color-success-text-default-background: var(--comet-color-transparent);
+        --comet-button-color-success-text-default-foreground: var(--comet-color-action-success-default);
+        --comet-button-color-success-text-default-border: var(--comet-color-transparent);
+
+        --comet-button-color-success-text-hover-background: var(--comet-color-action-success-subtle);
+        --comet-button-color-success-text-hover-foreground: var(--comet-color-action-success-hover);
+        --comet-button-color-success-text-hover-border: var(--comet-color-transparent);
+
+        --comet-button-color-success-text-active-background: var(--comet-color-action-success-subtle);
+        --comet-button-color-success-text-active-foreground: var(--comet-color-action-success-active);
+        --comet-button-color-success-text-active-border: var(--comet-color-transparent);
+
+        --comet-button-color-success-text-focus-background: var(--comet-color-transparent);
+        --comet-button-color-success-text-focus-foreground: var(--comet-color-action-success-default);
+        --comet-button-color-success-text-focus-border: var(--comet-color-transparent);
+
+        --comet-button-color-success-text-disabled-background: var(--comet-color-transparent);
+        --comet-button-color-success-text-disabled-foreground: var(--comet-color-foreground-subtle);
+        --comet-button-color-success-text-disabled-border: var(--comet-color-transparent);
+
+        --comet-button-color-success-text-loading-background: var(--comet-color-transparent);
+        --comet-button-color-success-text-loading-foreground: var(--comet-color-action-success-default);
+        --comet-button-color-success-text-loading-border: var(--comet-color-transparent);
     }
 }

--- a/packages/admin/admin/src/future-ui/theme/_primitives.scss
+++ b/packages/admin/admin/src/future-ui/theme/_primitives.scss
@@ -148,5 +148,29 @@
         --comet-font-letter-spacing-tight: -0.25px;
         --comet-font-letter-spacing-normal: 0px;
         --comet-font-letter-spacing-wide: 0.25px;
+
+        --comet-color-violet-50: rgb(249 250 255);
+        --comet-color-violet-100: rgb(239 241 255);
+        --comet-color-violet-200: rgb(216 218 255);
+        --comet-color-violet-300: rgb(189 187 255);
+        --comet-color-violet-400: rgb(158 149 255);
+        --comet-color-violet-500: rgb(129 113 255);
+        --comet-color-violet-600: rgb(102 80 229);
+        --comet-color-violet-700: rgb(80 57 191);
+        --comet-color-violet-800: rgb(59 39 148);
+        --comet-color-violet-900: rgb(40 26 104);
+        --comet-color-violet-950: rgb(26 19 70);
+
+        --comet-color-coral-50: rgb(249 234 229);
+        --comet-color-coral-100: rgb(252 219 209);
+        --comet-color-coral-200: rgb(255 191 168);
+        --comet-color-coral-300: rgb(255 156 123);
+        --comet-color-coral-400: rgb(238 114 72);
+        --comet-color-coral-500: rgb(209 76 23);
+        --comet-color-coral-600: rgb(174 41 0);
+        --comet-color-coral-700: rgb(140 16 0);
+        --comet-color-coral-800: rgb(104 0 0);
+        --comet-color-coral-900: rgb(69 0 0);
+        --comet-color-coral-950: rgb(43 1 0);
     }
 }

--- a/packages/admin/admin/src/future-ui/theme/_semantic.scss
+++ b/packages/admin/admin/src/future-ui/theme/_semantic.scss
@@ -35,19 +35,12 @@
         --comet-color-action-secondary-foreground: var(--comet-brand-color-secondary-100);
         --comet-color-action-secondary-subtle: var(--comet-brand-color-secondary-800);
 
-        --comet-color-action-tertiary-default: var(--comet-brand-color-primary-400);
-        --comet-color-action-tertiary-hover: var(--comet-brand-color-primary-300);
-        --comet-color-action-tertiary-active: var(--comet-brand-color-primary-200);
-        --comet-color-action-tertiary-disabled: var(--comet-brand-color-neutral-700);
-        --comet-color-action-tertiary-subtle: var(--comet-brand-color-primary-900);
-        --comet-color-action-tertiary-foreground: var(--comet-brand-color-primary-400);
-
-        --comet-color-action-danger-default: var(--comet-color-red-400);
-        --comet-color-action-danger-hover: var(--comet-color-red-300);
-        --comet-color-action-danger-active: var(--comet-color-red-200);
-        --comet-color-action-danger-disabled: var(--comet-brand-color-neutral-700);
-        --comet-color-action-danger-subtle: var(--comet-color-red-900);
-        --comet-color-action-danger-foreground: var(--comet-color-white);
+        --comet-color-action-error-default: var(--comet-color-red-300);
+        --comet-color-action-error-hover: var(--comet-color-red-200);
+        --comet-color-action-error-active: var(--comet-color-red-100);
+        --comet-color-action-error-disabled: var(--comet-brand-color-neutral-700);
+        --comet-color-action-error-subtle: var(--comet-color-red-900);
+        --comet-color-action-error-foreground: var(--comet-color-grey-950);
 
         --comet-color-feedback-success-default: var(--comet-color-green-300);
         --comet-color-feedback-success-subtle: var(--comet-color-green-900);
@@ -90,6 +83,13 @@
 
         --comet-focus-ring-width: 2px;
         --comet-focus-ring-offset: 2px;
+
+        --comet-color-action-success-default: var(--comet-color-green-400);
+        --comet-color-action-success-hover: var(--comet-color-green-300);
+        --comet-color-action-success-active: var(--comet-color-green-200);
+        --comet-color-action-success-disabled: var(--comet-brand-color-neutral-700);
+        --comet-color-action-success-subtle: var(--comet-color-green-900);
+        --comet-color-action-success-foreground: var(--comet-color-green-950);
     }
 
     [data-comet-color-scheme="high-contrast"] {
@@ -126,19 +126,12 @@
         --comet-color-action-secondary-foreground: var(--comet-color-white);
         --comet-color-action-secondary-subtle: var(--comet-brand-color-secondary-900);
 
-        --comet-color-action-tertiary-default: var(--comet-brand-color-primary-100);
-        --comet-color-action-tertiary-hover: var(--comet-brand-color-primary-200);
-        --comet-color-action-tertiary-active: var(--comet-brand-color-primary-300);
-        --comet-color-action-tertiary-disabled: var(--comet-brand-color-neutral-700);
-        --comet-color-action-tertiary-subtle: var(--comet-brand-color-neutral-800);
-        --comet-color-action-tertiary-foreground: var(--comet-brand-color-primary-100);
-
-        --comet-color-action-danger-default: var(--comet-color-red-200);
-        --comet-color-action-danger-hover: var(--comet-color-red-100);
-        --comet-color-action-danger-active: var(--comet-color-red-50);
-        --comet-color-action-danger-disabled: var(--comet-brand-color-neutral-700);
-        --comet-color-action-danger-subtle: var(--comet-brand-color-neutral-900);
-        --comet-color-action-danger-foreground: var(--comet-color-black);
+        --comet-color-action-error-default: var(--comet-color-red-200);
+        --comet-color-action-error-hover: var(--comet-color-red-100);
+        --comet-color-action-error-active: var(--comet-color-red-50);
+        --comet-color-action-error-disabled: var(--comet-brand-color-neutral-700);
+        --comet-color-action-error-subtle: var(--comet-brand-color-neutral-900);
+        --comet-color-action-error-foreground: var(--comet-color-black);
 
         --comet-color-feedback-success-default: var(--comet-color-green-200);
         --comet-color-feedback-success-subtle: var(--comet-brand-color-neutral-900);
@@ -181,6 +174,13 @@
 
         --comet-focus-ring-width: 3px;
         --comet-focus-ring-offset: 2px;
+
+        --comet-color-action-success-default: var(--comet-color-green-200);
+        --comet-color-action-success-hover: var(--comet-color-green-100);
+        --comet-color-action-success-active: var(--comet-color-green-50);
+        --comet-color-action-success-disabled: var(--comet-brand-color-neutral-700);
+        --comet-color-action-success-subtle: var(--comet-brand-color-neutral-900);
+        --comet-color-action-success-foreground: var(--comet-color-black);
     }
 
     [data-comet-color-scheme="light"] {
@@ -217,19 +217,12 @@
         --comet-color-action-secondary-foreground: var(--comet-brand-color-secondary-800);
         --comet-color-action-secondary-subtle: var(--comet-brand-color-secondary-50);
 
-        --comet-color-action-tertiary-default: var(--comet-brand-color-primary-500);
-        --comet-color-action-tertiary-hover: var(--comet-brand-color-primary-600);
-        --comet-color-action-tertiary-active: var(--comet-brand-color-primary-700);
-        --comet-color-action-tertiary-disabled: var(--comet-brand-color-neutral-200);
-        --comet-color-action-tertiary-subtle: var(--comet-brand-color-primary-50);
-        --comet-color-action-tertiary-foreground: var(--comet-brand-color-primary-500);
-
-        --comet-color-action-danger-default: var(--comet-color-red-500);
-        --comet-color-action-danger-hover: var(--comet-color-red-600);
-        --comet-color-action-danger-active: var(--comet-color-red-700);
-        --comet-color-action-danger-disabled: var(--comet-brand-color-neutral-200);
-        --comet-color-action-danger-subtle: var(--comet-color-red-50);
-        --comet-color-action-danger-foreground: var(--comet-color-white);
+        --comet-color-action-error-default: var(--comet-color-red-500);
+        --comet-color-action-error-hover: var(--comet-color-red-600);
+        --comet-color-action-error-active: var(--comet-color-red-700);
+        --comet-color-action-error-disabled: var(--comet-brand-color-neutral-200);
+        --comet-color-action-error-subtle: var(--comet-color-red-50);
+        --comet-color-action-error-foreground: var(--comet-color-white);
 
         --comet-color-feedback-success-default: var(--comet-color-green-400);
         --comet-color-feedback-success-subtle: var(--comet-color-green-50);
@@ -272,5 +265,12 @@
 
         --comet-focus-ring-width: 2px;
         --comet-focus-ring-offset: 2px;
+
+        --comet-color-action-success-default: var(--comet-color-green-700);
+        --comet-color-action-success-hover: var(--comet-color-green-800);
+        --comet-color-action-success-active: var(--comet-color-green-900);
+        --comet-color-action-success-disabled: var(--comet-brand-color-neutral-200);
+        --comet-color-action-success-subtle: var(--comet-color-green-50);
+        --comet-color-action-success-foreground: var(--comet-color-white);
     }
 }


### PR DESCRIPTION
The committed theme tokens had drifted from the current design.
Regenerating them from the latest export also required a generator change: the export's brand collection is now split into per-project modes and no longer defines the `default` mode the generator read.

- **`Button` maps both variants to the filled appearance.**
  The filled style is the one the button already had, so `primary` keeps its exact colors while `secondary` shifts to the new action palette, since the tokens no longer define its former neutral colors.

---

Task: https://vivid-planet.atlassian.net/browse/COM-3079