### PR TITLE
Export DamFileAiContentType enum from cms-api

### DIFF
--- a/.changeset/export-dam-file-ai-content-type.md
+++ b/.changeset/export-dam-file-ai-content-type.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Export `DamFileAiContentType` enum

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -185,6 +185,7 @@ export { DAM_CONFIG } from "./dam/dam.constants";
 export { DamModule } from "./dam/dam.module";
 export { CreateFileInput, ImageFileInput, UpdateFileInput } from "./dam/files/dto/file.input";
 export { CreateFolderInput, UpdateFolderInput } from "./dam/files/dto/folder.input";
+export { DamFileAiContentType } from "./dam/files/entities/ai-content-type.enum";
 export { createFileEntity, FileInterface } from "./dam/files/entities/file.entity";
 export { DamFileImage } from "./dam/files/entities/file-image.entity";
 export { createFolderEntity, FolderInterface } from "./dam/files/entities/folder.entity";


### PR DESCRIPTION
## Summary
This PR exports the `DamFileAiContentType` enum from the `@comet/cms-api` package, making it available for public consumption by consumers of the API.

## Changes
- Added export of `DamFileAiContentType` enum from `./dam/files/entities/ai-content-type.enum` in the main index file
- Updated changeset to document this as a patch-level change

## Details
The `DamFileAiContentType` enum was previously defined but not exported from the package's public API. This change makes it accessible to external consumers who need to work with AI content type classifications for DAM files.

https://claude.ai/code/session_01FLyAVVmByAPb5AptaxQRSk