### PR TITLE
[Backport v8] Export DamFileAiContentType enum from cms-api

### DIFF
--- a/.changeset/export-dam-file-ai-content-type.md
+++ b/.changeset/export-dam-file-ai-content-type.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Export `DamFileAiContentType` enum

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -184,6 +184,7 @@ export { DAM_CONFIG } from "./dam/dam.constants";
 export { DamModule } from "./dam/dam.module";
 export { CreateFileInput, ImageFileInput, UpdateFileInput } from "./dam/files/dto/file.input";
 export { CreateFolderInput, UpdateFolderInput } from "./dam/files/dto/folder.input";
+export { DamFileAiContentType } from "./dam/files/entities/ai-content-type.enum";
 export { createFileEntity, FileInterface } from "./dam/files/entities/file.entity";
 export { DamFileImage } from "./dam/files/entities/file-image.entity";
 export { createFolderEntity, FolderInterface } from "./dam/files/entities/folder.entity";


### PR DESCRIPTION
Backport of #6056 to `v8.x.x`.

## Verification

- Cherry-picked cleanly (no conflicts).
- `@comet/cms-api` builds and lints successfully.
- `demo/api` `console --help` starts and initializes `AppModule` correctly (only failure is the expected `ECONNREFUSED` for Postgres, since no DB is running). Since this change is a pure re-export addition with no runtime behavior change, this is sufficient verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSkmEd5BgJEJATnrJRxZto)_