### PR TITLE
Demo: Display only published pages in PageTreeIndexBlock

### DIFF
--- a/demo/site/src/common/blocks/PageTreeIndexBlock.loader.ts
+++ b/demo/site/src/common/blocks/PageTreeIndexBlock.loader.ts
@@ -36,6 +36,7 @@ export const loader = async ({ graphQLFetch, scope }: BlockLoaderOptions<PageTre
                 offset: currentCount,
                 limit: pageSize,
             },
+            { headers: { "x-include-invisible-content": "" } },
         );
 
         totalCount = paginatedPageTreeNodes.totalCount;

--- a/demo/site/src/common/blocks/PageTreeIndexBlock.loader.ts
+++ b/demo/site/src/common/blocks/PageTreeIndexBlock.loader.ts
@@ -22,7 +22,6 @@ export const loader = async ({ graphQLFetch, scope }: BlockLoaderOptions<PageTre
                             name
                             path
                             parentId
-                            visibility
                             scope {
                                 domain
                                 language
@@ -41,7 +40,7 @@ export const loader = async ({ graphQLFetch, scope }: BlockLoaderOptions<PageTre
 
         totalCount = paginatedPageTreeNodes.totalCount;
         currentCount += paginatedPageTreeNodes.nodes.length;
-        allNodes.push(...paginatedPageTreeNodes.nodes.filter((node) => node.visibility === "Published"));
+        allNodes.push(...paginatedPageTreeNodes.nodes);
     } while (totalCount > currentCount);
 
     return allNodes;

--- a/demo/site/src/common/blocks/PageTreeIndexBlock.loader.ts
+++ b/demo/site/src/common/blocks/PageTreeIndexBlock.loader.ts
@@ -22,6 +22,7 @@ export const loader = async ({ graphQLFetch, scope }: BlockLoaderOptions<PageTre
                             name
                             path
                             parentId
+                            visibility
                             scope {
                                 domain
                                 language
@@ -40,7 +41,7 @@ export const loader = async ({ graphQLFetch, scope }: BlockLoaderOptions<PageTre
 
         totalCount = paginatedPageTreeNodes.totalCount;
         currentCount += paginatedPageTreeNodes.nodes.length;
-        allNodes.push(...paginatedPageTreeNodes.nodes);
+        allNodes.push(...paginatedPageTreeNodes.nodes.filter((node) => node.visibility === "Published"));
     } while (totalCount > currentCount);
 
     return allNodes;


### PR DESCRIPTION
The `PageTreeIndexBlock` should only ever list published pages, since it links to pages a visitor can actually open. In the preview, however, `graphQLFetch` sends `x-include-invisible-content: Pages:Unpublished` for every request, so the block's loader also received unpublished nodes and rendered links to them.

The loader now overrides that header with an empty value for its own request. Per-request headers are merged over the preview defaults in `createFetchWithDefaults`, and the API treats the empty header as "no invisible content", so `paginatedPageTreeNodes` returns published pages only — in the preview as well as on the live site.

```ts
const { paginatedPageTreeNodes } = await graphQLFetch<GQLPageTreeIndexDataQuery, GQLPageTreeIndexDataQueryVariables>(
    query,
    { scope, offset: currentCount, limit: pageSize },
    { headers: { "x-include-invisible-content": "" } },
);
```

## Testing

`NewsList` and `Test` were both set to `Unpublished` for testing purposes:
| Before | Now |
|----|----|
| <img width="1728" height="425" alt="Screenshot 2026-07-27 at 17 23 23" src="https://github.com/user-attachments/assets/f59934b3-0d22-478f-a435-363b8823fb40" /> | <img width="1728" height="387" alt="Screenshot 2026-07-27 at 17 22 38" src="https://github.com/user-attachments/assets/a592b7a5-39e0-4616-a827-27ae961f7aab" /> |

## Further information

Task: https://vivid-planet.atlassian.net/browse/COM-2738