### PR TITLE
mail-react: Fix MjmlDivider breaking out of its column

### DIFF
--- a/.changeset/fix-mjml-divider-breaking-out-of-column.md
+++ b/.changeset/fix-mjml-divider-breaking-out-of-column.md
@@ -1,0 +1,9 @@
+---
+"@comet/mail-react": patch
+---
+
+Fix `MjmlDivider` breaking the surrounding layout
+
+A section or column that came after the one holding an `MjmlDivider` rendered outside its wrapper or group instead of inside it. In a section using `disableResponsiveBehavior` (which keeps its columns side-by-side on mobile instead of stacking), the columns' shared wrapper broke, so the following column stacked anyway. In an `MjmlWrapper`, the background stopped after the section holding the divider, so every section below it lost the background.
+
+`MjmlDivider` now wraps its divider `<table>` in an extra row and cell. The class names stay on the `<table>`, so descendant selectors still match — but a selector using a direct-child combinator that expected the table to sit immediately inside the column will need updating, since there's now a `<tr><td>` in between.

--- a/docs/docs/3-features-modules/13-building-html-emails/1-email-basics.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/1-email-basics.md
@@ -40,6 +40,24 @@ When you need to drop into raw HTML outside of a text context — for example, t
 
 ## Common Pitfalls
 
+### Start Raw Content Inside a Column With `<tr>`
+
+`mj-column` wraps every child in its own `<tr><td>` — except `MjmlRaw` content, which goes straight into the column's table unwrapped. A `<table>`, `<div>`, or `<img>` in that position breaks the surrounding layout: the section or column after it renders outside its wrapper or group, and MJML reports no error. Open with a `<tr>` and put your markup in a `<td>`, zeroing that cell's `padding`, `font-size`, and `line-height` so it adds no height of its own:
+
+```tsx
+<MjmlColumn>
+    <MjmlRaw>
+        <tr>
+            <td style={{ padding: 0, fontSize: 0, lineHeight: 0, msoLineHeightRule: "exactly" }}>
+                <HtmlDivider />
+            </td>
+        </tr>
+    </MjmlRaw>
+</MjmlColumn>
+```
+
+This applies to `MjmlColumn` and `MjmlHero`. `MjmlSection` and `MjmlWrapper` already place their children inside a shared cell, so any root element is safe there.
+
 ### Avoid Block-Level HTML Elements Inside Ending Tags
 
 Don't use `<p>`, `<h1>`, `<h2>`, or other block-level HTML elements inside ending tags. They have wildly inconsistent default margins and spacing across email clients and add no rendering value in email HTML. Instead, use `<td>`, `<div>`, and `<span>` for structure, and build your typography hierarchy through `MjmlText`/`HtmlText` [text variants](./2-components-and-theme.md#variants) rather than HTML semantics. If a block-level element is truly unavoidable, always reset its margins explicitly with inline styles (e.g., `style={{ margin: 0 }}`).

--- a/packages/mail-react/src/components/divider/MjmlDivider.tsx
+++ b/packages/mail-react/src/components/divider/MjmlDivider.tsx
@@ -9,7 +9,10 @@ import { HtmlDivider } from "./HtmlDivider.js";
 export type MjmlDividerProps = DividerProps;
 
 /**
- * Themed divider for use inside an `MjmlColumn`.
+ * Themed divider.
+ *
+ * Must be placed within an `MjmlColumn`. For raw HTML context (e.g. inside `MjmlRaw`),
+ * use `HtmlDivider` instead.
  */
 export function MjmlDivider({ variant, height, backgroundColor, backgroundImage, className, style }: MjmlDividerProps): ReactNode {
     const theme = useOptionalTheme();
@@ -17,14 +20,18 @@ export function MjmlDivider({ variant, height, backgroundColor, backgroundImage,
 
     return (
         <MjmlRaw>
-            <HtmlDivider
-                variant={variant}
-                height={height}
-                backgroundColor={backgroundColor}
-                backgroundImage={backgroundImage}
-                className={clsx("mjmlDivider", activeVariant && `mjmlDivider--${activeVariant}`, className)}
-                style={style}
-            />
+            <tr>
+                <td style={{ padding: 0, fontSize: 0, lineHeight: 0, msoLineHeightRule: "exactly" }}>
+                    <HtmlDivider
+                        variant={variant}
+                        height={height}
+                        backgroundColor={backgroundColor}
+                        backgroundImage={backgroundImage}
+                        className={clsx("mjmlDivider", activeVariant && `mjmlDivider--${activeVariant}`, className)}
+                        style={style}
+                    />
+                </td>
+            </tr>
         </MjmlRaw>
     );
 }

--- a/packages/mail-react/src/components/divider/README.md
+++ b/packages/mail-react/src/components/divider/README.md
@@ -1,6 +1,6 @@
 # Divider
 
-MJML's built-in `mj-divider` paints its line via `border-top`, which leaves no room for a gradient overlay and pins consumers to upstream's prop surface. `MjmlDivider` and `HtmlDivider` instead render a `<table>`/`<td>` pair where the colored bar lives in the cell's `background-color`. Height, `backgroundColor`, and `backgroundImage` come from `theme.divider`, or from `defaultDividerStyles` when no `ThemeProvider` is in scope — the `variant` prop is the only thing that requires a theme. A theme `backgroundImage` (typically a gradient) sits on top of the `backgroundColor` fallback so clients that ignore `background-image` still render the solid color.
+MJML's built-in `mj-divider` paints its line via `border-top`, which leaves no room for a gradient overlay and pins consumers to upstream's prop surface. `HtmlDivider` instead renders a `<table>`/`<td>` pair where the colored bar lives in the cell's `background-color`. `MjmlDivider` renders that same table through `MjmlRaw`, wrapped in its own row and cell. Height, `backgroundColor`, and `backgroundImage` come from `theme.divider`, or from `defaultDividerStyles` when no `ThemeProvider` is in scope — the `variant` prop is the only thing that requires a theme. A theme `backgroundImage` (typically a gradient) sits on top of the `backgroundColor` fallback so clients that ignore `background-image` still render the solid color.
 
 ## Non-goals
 

--- a/packages/mail-react/src/components/divider/__stories__/MjmlDivider.stories.tsx
+++ b/packages/mail-react/src/components/divider/__stories__/MjmlDivider.stories.tsx
@@ -1,8 +1,11 @@
 import { MjmlColumn, MjmlSpacer } from "@faire/mjml-react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
 
 import { createTheme } from "../../../theme/createTheme.js";
 import { MjmlSection } from "../../section/MjmlSection.js";
+import { MjmlText } from "../../text/MjmlText.js";
+import { MjmlWrapper } from "../../wrapper/MjmlWrapper.js";
 import { MjmlDivider } from "../MjmlDivider.js";
 
 type Story = StoryObj<typeof MjmlDivider>;
@@ -84,5 +87,72 @@ export const GradientWithFallback: Story = {
         height: 6,
         backgroundColor: "#5B4FC7",
         backgroundImage: "linear-gradient(to right, #5B4FC7, #FF6B6B, #FFD166)",
+    },
+};
+
+const columnClassName = "mjmlDividerStory__column";
+
+/**
+ * A divider must not break the row it sits in. The three colored columns stay side by side; if the
+ * divider's table broke out of its cell, the parser would close the group and section early and the
+ * column after it would stack below instead.
+ */
+export const StaysInsideANonStackingRow: Story = {
+    render: (args) => (
+        <MjmlSection indent disableResponsiveBehavior>
+            <MjmlColumn className={columnClassName} backgroundColor="#cfe3f5">
+                <MjmlText>First</MjmlText>
+            </MjmlColumn>
+            <MjmlColumn className={columnClassName} backgroundColor="#f5e6cf">
+                <MjmlText>Second</MjmlText>
+                <MjmlDivider {...args} />
+            </MjmlColumn>
+            <MjmlColumn className={columnClassName} backgroundColor="#d9f5cf">
+                <MjmlText>Third</MjmlText>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+    play: async ({ canvasElement }) => {
+        const columns = canvasElement.querySelectorAll(`.${columnClassName}`);
+        await expect(columns).toHaveLength(3);
+
+        const containingCells = new Set([...columns].map((column) => column.closest("td")));
+        await expect(containingCells.size).toBe(1);
+    },
+};
+
+const wrapperClassName = "mjmlDividerStory__wrapper";
+
+/**
+ * A wrapper's background has to span every section inside it, including ones after a divider. If the
+ * divider's table broke out of its cell, the section after it would render outside the wrapper
+ * instead of on its background.
+ */
+export const KeepsTheWrapperBackground: Story = {
+    render: (args) => (
+        <MjmlWrapper className={wrapperClassName} backgroundColor="#2d4a6e">
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlSpacer height="16px" />
+                    <MjmlText color="#ffffff">Above the divider</MjmlText>
+                </MjmlColumn>
+            </MjmlSection>
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlDivider {...args} backgroundColor="#ffffff" />
+                </MjmlColumn>
+            </MjmlSection>
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlText color="#ffffff">After the divider</MjmlText>
+                    <MjmlSpacer height="16px" />
+                </MjmlColumn>
+            </MjmlSection>
+        </MjmlWrapper>
+    ),
+    play: async ({ canvasElement }) => {
+        const wrapper = canvasElement.querySelector(`.${wrapperClassName}`);
+        await expect(wrapper).not.toBeNull();
+        await expect(wrapper).toHaveTextContent("After the divider");
     },
 };

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -125,6 +125,24 @@ Always use `theme.breakpoints.*.belowMediaQuery` inside `registerStyles` instead
 
 ## Common Pitfalls
 
+### Start Raw Content Inside a Column With `<tr>`
+
+`mj-column` wraps every child in its own `<tr><td>` — except `MjmlRaw` content, which goes straight into the column's table unwrapped. A `<table>`, `<div>`, or `<img>` in that position breaks the surrounding layout: the section or column after it renders outside its wrapper or group, and MJML reports no error. Open with a `<tr>` and put the markup in a `<td>`, zeroing that cell's `padding`, `font-size`, and `line-height` so it adds no height:
+
+```tsx
+<MjmlColumn>
+    <MjmlRaw>
+        <tr>
+            <td style={{ padding: 0, fontSize: 0, lineHeight: 0, msoLineHeightRule: "exactly" }}>
+                <HtmlDivider />
+            </td>
+        </tr>
+    </MjmlRaw>
+</MjmlColumn>
+```
+
+`MjmlColumn` and `MjmlHero` are both affected — `MjmlSection` and `MjmlWrapper` already place their children inside a shared cell, so any root element is safe there. `MjmlDivider` handles this itself; use it instead of a hand-wrapped `HtmlDivider` whenever you are in an `MjmlColumn`.
+
 ### Avoid Block-Level HTML Elements Inside Ending Tags
 
 Don't use `<p>`, `<h1>`, `<h2>`, or other block-level HTML elements inside ending tags. They have wildly inconsistent default margins and spacing across email clients and add no rendering value in email HTML. Instead, use `<td>`, `<div>`, and `<span>` for structure, and build your typography hierarchy through `MjmlText`/`HtmlText` variants rather than HTML semantics. If a block-level element is truly unavoidable, always reset its margins inline: `style={{ margin: 0 }}`.


### PR DESCRIPTION
Replacing the upstream `mj-divider` re-export with a themed `MjmlRaw` implementation in #5750 introduced a regression: `mj-column` puts raw children straight into its `<tbody>`, without the `<tr><td>` it gives every other child, so the divider's table made the HTML parser close the column's table early. Whatever came after the divider's own section or column — the next section in a wrapper, the next column in a group — then rendered outside that wrapper or group. MJML reports no error, and a lone divider still looks right, so it went unnoticed.

- **`MjmlDivider` supplies the row and cell, instead of `HtmlDivider` rendering a cell as its root.**
  `HtmlDivider` is also meant for use outside any table, where a `<td>` root would be invalid, and only `MjmlDivider` knows its output lands in a column.
- **The class names and the `style` prop still go to the divider's table, not to the new cell.**
  Consumer CSS keeps matching the same element as before, so the added markup changes no styling hook.
- **The wrapper cell has no `height`.**
  A height there would not shrink along with `HtmlDivider`'s mobile-variant CSS, so it would leave white space around the divider on mobile.

| Previously | Now |
|--------|--------|
| <img width="942" height="482" alt="Previously" src="https://github.com/user-attachments/assets/3ba0cee8-8de8-41b8-bd72-4da973beebca" /> | <img width="942" height="464" alt="Now" src="https://github.com/user-attachments/assets/2c8e7bb4-7b6d-4af2-832e-074384156cb1" /> | 

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-11757
Story: https://deploy-preview-6074.storybook.comet-dxp.com/?path=/docs/@comet/mail-react_components-mjmldivider--docs