### PR TITLE
mail-react: Show a short intro when opening Storybook

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/index.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/index.md
@@ -4,6 +4,10 @@ title: Building HTML Emails
 
 `@comet/mail-react` lets you build responsive, themed HTML emails using React components. Under the hood it uses [MJML](https://documentation.mjml.io/) to generate cross-client-compatible HTML. On top of the raw MJML components the library provides a theme system, higher-level wrapper components, a style utility layer, and Storybook integration for live previewing emails during development.
 
+:::note
+Live component previews are available in our [Storybook](https://storybook.comet-dxp.com/?path=/docs/@comet/mail-react_docs-intro--docs).
+:::
+
 :::tip 🤖 Agent Skill `comet-mail-react`
 An agent skill for building HTML emails with `@comet/mail-react` is available. It provides AI coding agents with email development best practices, component patterns, and cross-client compatibility guidance. See [Installing Agent Features](../../4-guides/5-installing-agent-features.md) for setup instructions.
 :::

--- a/packages/mail-react/.storybook/preview.ts
+++ b/packages/mail-react/.storybook/preview.ts
@@ -5,6 +5,11 @@ export { decorators, initialGlobals } from "../src/storybook/preview.ts";
 export const parameters = {
     ...mailParameters,
     layout: "fullscreen",
+    options: {
+        storySort: {
+            order: ["Docs", "*"],
+        },
+    },
     docs: {
         source: {
             // Regenerate the "Show code" snippet from the rendered JSX; the default shows the whole

--- a/packages/mail-react/src/docs/Intro.mdx
+++ b/packages/mail-react/src/docs/Intro.mdx
@@ -1,0 +1,9 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Docs/Intro" />
+
+# @comet/mail-react
+
+`@comet/mail-react` is Comet DXP's library for building responsive, themed HTML emails with React and MJML.
+
+This Storybook is for developing and previewing components in isolation. For the full guide — installation, the theme system, MJML layout rules, and integrating with the Mail Templates Module — see the [Building HTML Emails](https://docs.comet-dxp.com/docs/features-modules/building-html-emails/) documentation.


### PR DESCRIPTION
Previously Storybook opened on whatever story happened to sort first — a random component or example, not an explanation of the package. Add a dedicated "Docs/Intro" page and force it to sort first, so first-time visitors land on a short explanation and a link to the full docs instead of an arbitrary component.

Also link the Building HTML Emails docs page back to the deployed Storybook, so readers can jump to live component previews for quick reference.